### PR TITLE
python3Packages.django-configurations: format to pyproject, enable tests

### DIFF
--- a/pkgs/development/python-modules/django-configurations/default.nix
+++ b/pkgs/development/python-modules/django-configurations/default.nix
@@ -7,41 +7,48 @@
   django,
   django-cache-url,
   fetchPypi,
-  mock,
+  fetchpatch,
   setuptools-scm,
+  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "django-configurations";
   version = "2.5.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-blCDdX4rvfm7eFBWdTa5apNRX2sXUD10ko/2KNsuDpQ=";
   };
 
-  buildInputs = [ setuptools-scm ];
+  patches = [
+    # The `DISABLE_SERVER_SIDE_CURSORS` setting is new to django 6 and without this patch test a dict-equality test fails
+    (fetchpatch {
+      name = "fix-tests.patch";
+      url = "https://github.com/jazzband/django-configurations/commit/63cac8d54eed7267e208556838499e41cb30f658.patch?full_index=1";
+      hash = "sha256-xXDl2fSF+PglDERtp4/SJ8QIoy8zLD8ly4JZoLH8Vco=";
+    })
+  ];
 
-  propagatedBuildInputs = [ django ];
+  build-system = [ setuptools-scm ];
+
+  dependencies = [ django ];
 
   nativeCheckInputs = [
-    mock
     dj-database-url
     dj-email-url
     dj-search-url
     django-cache-url
+    unittestCheckHook
   ];
 
   checkPhase = ''
     export PYTHONPATH=.:$PYTHONPATH
     export DJANGO_SETTINGS_MODULE="tests.settings.main"
     export DJANGO_CONFIGURATION="Test"
-    ${django}/bin/django-admin.py test
+    $out/bin/django-cadmin test -v2
   '';
-
-  # django.core.exceptions.ImproperlyConfigured: django-configurations settings importer wasn't correctly installed
-  doCheck = false;
 
   pythonImportsCheck = [ "configurations" ];
 
@@ -49,7 +56,7 @@ buildPythonPackage rec {
     description = "Helper for organizing Django settings";
     mainProgram = "django-cadmin";
     homepage = "https://django-configurations.readthedocs.io/";
-    license = lib.licenses.bsd0;
+    license = lib.licenses.bsd3;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
Also the license for this one was wrong again somehow. Why do BSD licenses keep getting mixed up? I'll never know.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
