### PR TITLE
kiro-cli: run all commands through a single FHS environment

### DIFF
--- a/pkgs/by-name/ki/kiro-cli/package.nix
+++ b/pkgs/by-name/ki/kiro-cli/package.nix
@@ -2,8 +2,9 @@
   lib,
   stdenv,
   buildFHSEnv,
-  symlinkJoin,
+  makeWrapper,
   testers,
+  writeShellScript,
   kiro-cli-unwrapped,
   # On Wayland, kiro-cli shells out to wl-clipboard (wl-copy/wl-paste) for
   # clipboard access. Enabling this puts wl-clipboard on the runtime PATH so
@@ -15,45 +16,52 @@
 let
   inherit (kiro-cli-unwrapped) version meta;
 
-  # Each of kiro-cli's user-facing commands, run inside a minimal FHS sandbox.
+  # All of kiro-cli's user-facing commands run inside one minimal FHS sandbox.
   # The sandbox provides a standard /lib64/ld-linux-x86-64.so.2 plus libgcc_s/
   # libstdc++ (via stdenv.cc.cc.lib), so the generic-glibc `bun` that
   # kiro-cli-chat extracts at runtime just works — no binary patching of the
   # extracted asset, and no build-time execution of the tool.
-  fhsFor =
-    executableName:
-    buildFHSEnv {
-      pname = executableName;
-      inherit version;
-      inherit executableName;
-      runScript = executableName;
+  #
+  # buildFHSEnv provides a single entry point per environment, so instead of
+  # building one environment per command (which would give kiro-cli, kiro-cli-chat
+  # and kiro-cli-term separate derivations, each with its own unfree license and
+  # each requiring its own entry in the unfree allowlist), we build a single
+  # environment whose entry point dispatches to whichever command is passed to
+  # it, and expose one thin wrapper per command via `extraInstallCommands`.
+  # This keeps the unfree allowlist to two entries (`kiro-cli` and
+  # `kiro-cli-unwrapped`) instead of four. The three binaries ship in the same
+  # upstream artifact and share the same runtime needs, so there is no
+  # per-command sandbox to lose.
+  fhsenv = buildFHSEnv {
+    pname = "kiro-cli";
+    inherit version;
 
-      targetPkgs =
-        pkgs:
-        [
-          kiro-cli-unwrapped
-          pkgs.stdenv.cc.cc.lib # libstdc++.so.6, libgcc_s.so.1 for the extracted bun
-        ]
-        ++ lib.optional waylandSupport pkgs.wl-clipboard;
+    runScript = writeShellScript "kiro-cli" ''
+      command="$1"
+      shift
+      exec "$command" "$@"
+    '';
 
-      meta = meta // {
-        mainProgram = executableName;
-      };
-    };
-in
-# Darwin ships a normal .app bundle with no embedded-bun problem, so it needs
-# no FHS sandbox; hand back the unwrapped derivation under the public name.
-if stdenv.hostPlatform.isLinux then
-  symlinkJoin {
-    name = "kiro-cli-${version}";
-    # Preserve the strictDeps = true that the unwrapped derivation exposes, so
-    # the top-level attribute keeps it too (nixpkgs-vet NPV-165).
-    strictDeps = true;
-    paths = map fhsFor [
-      "kiro-cli"
-      "kiro-cli-chat"
-      "kiro-cli-term"
-    ];
+    targetPkgs =
+      pkgs:
+      [
+        kiro-cli-unwrapped
+        pkgs.stdenv.cc.cc.lib # libstdc++.so.6, libgcc_s.so.1 for the extracted bun
+      ]
+      ++ lib.optional waylandSupport pkgs.wl-clipboard;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    extraInstallCommands = ''
+      mkdir -p $out/libexec/kiro-cli
+      mv $out/bin/kiro-cli $out/libexec/kiro-cli/kiro-cli-wrapper
+
+      for command in kiro-cli kiro-cli-chat kiro-cli-term; do
+        makeWrapper "$out/libexec/kiro-cli/kiro-cli-wrapper" "$out/bin/$command" \
+          --add-flags "$command"
+      done
+    '';
+
     passthru = {
       unwrapped = kiro-cli-unwrapped;
       tests.version = testers.testVersion {
@@ -64,7 +72,15 @@ if stdenv.hostPlatform.isLinux then
         inherit version;
       };
     };
-    inherit meta;
-  }
+
+    meta = meta // {
+      mainProgram = "kiro-cli";
+    };
+  };
+in
+# Darwin ships a normal .app bundle with no embedded-bun problem, so it needs
+# no FHS sandbox; hand back the unwrapped derivation under the public name.
+if stdenv.hostPlatform.isLinux then
+  fhsenv
 else
   kiro-cli-unwrapped.overrideAttrs { pname = "kiro-cli"; }


### PR DESCRIPTION
kiro-cli currently builds one FHS environment per sub-command
(kiro-cli, kiro-cli-chat, kiro-cli-term). Since buildFHSEnv supports a
single entry point per environment, that gives each command its own
derivation — each carrying its own unfree license and each requiring
its own entry in the `allowUnfreePredicate` allowlist — alongside
`kiro-cli-unwrapped`, for four predicate names in total.

All three binaries ship in the same upstream artifact and need the same
runtime environment, so one sandbox is enough. The environment's entry
script dispatches to whichever command is passed to it, and
`extraInstallCommands` exposes one thin wrapper per command in
`$out/bin` (the same approach as `aja-desktop-software`). This reduces
the unfree allowlist to two names (`kiro-cli` and `kiro-cli-unwrapped`)
while keeping the unfree license truthful on the unwrapped derivation.

Assisted-by: DeepSeek V4 Flash / Neuralwatt / Pi coding agent


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
