### PR TITLE
openttd: support darwin

### DIFF
--- a/pkgs/by-name/op/openttd/package.nix
+++ b/pkgs/by-name/op/openttd/package.nix
@@ -34,6 +34,7 @@
   alsa-lib,
   libjack2,
   makeWrapper,
+  makeBinaryWrapper,
   buildPackages,
   versionCheckHook,
 }:
@@ -65,6 +66,8 @@ let
       install -Dm555 src/settingsgen/settingsgen -t $out/bin
     '';
   });
+
+  darwinOutputContents = "Applications/OpenTTD.app/Contents";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openttd";
@@ -79,6 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     makeWrapper
+    makeBinaryWrapper
   ]
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     crossTools
@@ -98,18 +102,29 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     pcre2
   ]
-  ++ lib.optionals withFluidSynth [
-    fluidsynth
-    soundfont-fluid
-    libsndfile
-    flac
-    libogg
-    libvorbis
-    libopus
-    libmpg123
-    pulseaudio
-    alsa-lib
-    libjack2
+  ++ lib.optionals withFluidSynth (
+    [
+      fluidsynth
+      soundfont-fluid
+      libsndfile
+      flac
+      libogg
+      libvorbis
+      libopus
+      libmpg123
+      libjack2
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      pulseaudio
+    ]
+  );
+
+  cmakeFlags = [
+    (lib.cmakeBool "OPTION_USE_ASSERTS" false)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/${darwinOutputContents}/Resources"
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -121,17 +136,33 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/music/fluidsynth.cpp \
       --replace-fail "/usr/share/soundfonts/default.sf2" \
                      "${soundfont-fluid}/share/soundfonts/${soundfont-name}.sf2"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace cmake/PackageBundle.cmake \
+      --replace-fail 'fixup_bundle(\"\''${CMAKE_INSTALL_PREFIX}/../MacOS/openttd\"  \"\" \"\")' \
+                     '# fixup_bundle disabled for Nix builds'
   '';
 
   postInstall =
+    let
+      basesetDirectory =
+        if stdenv.hostPlatform.isDarwin then
+          "$out/${darwinOutputContents}/Resources/baseset"
+        else
+          "$out/share/games/openttd/baseset";
+    in
     lib.optionalString withOpenGFX ''
-      cp ${opengfx}/*.tar $out/share/games/openttd/baseset
+      cp ${opengfx}/*.tar ${basesetDirectory}
     ''
     + lib.optionalString withOpenSFX ''
-      cp ${opensfx}/*.tar $out/share/games/openttd/baseset
+      cp ${opensfx}/*.tar ${basesetDirectory}
     ''
     + lib.optionalString withOpenMSX ''
-      tar -xf ${openmsx}/*.tar -C $out/share/games/openttd/baseset
+      tar -xf ${openmsx}/*.tar -C ${basesetDirectory}
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/bin
+      makeBinaryWrapper $out/${darwinOutputContents}/MacOS/openttd $out/bin/openttd
     '';
 
   meta = {
@@ -150,7 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.openttd.org/";
     changelog = "https://cdn.openttd.org/openttd-releases/${finalAttrs.version}/changelog.md";
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [
       jcumming
       fpletz


### PR DESCRIPTION
Adds Darwin support to the OpenTTD package, along with small changes such as disabling assertions. Also affects the JGRPP patched package.

Tested on macOS 14.8.7.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
