### PR TITLE
plemoljp, plemoljp-{nf,hs}: fix updateScript, 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/by-name/pl/plemoljp-hs/package.nix
+++ b/pkgs/by-name/pl/plemoljp-hs/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchzip {
     url = "https://github.com/yuru7/PlemolJP/releases/download/v${finalAttrs.version}/PlemolJP_HS_v${finalAttrs.version}.zip";
-    hash = "sha256-V21T8ktNZE4nq3SH6aN9iIJHmGTkZuMsvT84yHbwSqI=";
+    hash = "sha256-ebBPun8CVHBOxs3c9SNHvT8lP1YqUH4DhBLAZk6NOrE=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/pl/plemoljp-nf/package.nix
+++ b/pkgs/by-name/pl/plemoljp-nf/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchzip {
     url = "https://github.com/yuru7/PlemolJP/releases/download/v${finalAttrs.version}/PlemolJP_NF_v${finalAttrs.version}.zip";
-    hash = "sha256-m8zR9ySl88DnVzG4fKJtc9WjSLDMLU4YDX+KXhcP2WU=";
+    hash = "sha256-7DVWDxciW5pEuaIdIinibwPi7QjNsQBPFq/wtP+fTeg=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/pl/plemoljp/package.nix
+++ b/pkgs/by-name/pl/plemoljp/package.nix
@@ -3,6 +3,8 @@
   stdenvNoCC,
   fetchzip,
   nix-update-script,
+  plemoljp-hs,
+  plemoljp-nf,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -26,8 +28,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    inherit plemoljp-hs plemoljp-nf;
+
     updateScript = nix-update-script {
-      extraArgs = [ "--version-regex=^v([0-9.]+)$" ];
+      extraArgs = [
+        "--version-regex=^v([0-9.]+)$"
+        "--subpackage"
+        "plemoljp-hs"
+        "--subpackage"
+        "plemoljp-nf"
+      ];
     };
   };
 

--- a/pkgs/by-name/pl/plemoljp/package.nix
+++ b/pkgs/by-name/pl/plemoljp/package.nix
@@ -9,11 +9,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plemoljp";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchzip {
     url = "https://github.com/yuru7/PlemolJP/releases/download/v${finalAttrs.version}/PlemolJP_v${finalAttrs.version}.zip";
-    hash = "sha256-R4zC1pnM72FVqBQ5d03z8vyVccsM163BE15m2hdEnSA=";
+    hash = "sha256-X4DUAU7uicWtm8o3L9HmfU9By1YMnnjVrVU0iyw273A=";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- I made a mistake when refining the updater. The current code does not update hashes in subpackages: https://github.com/NixOS/nixpkgs/pull/459967.
- Replacing to `installFonts` in another PR  https://github.com/NixOS/nixpkgs/pull/505755

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
