### PR TITLE
{grub2,console-setup}: make work with upstream unifont structure

### DIFF
--- a/pkgs/by-name/co/console-setup/package.nix
+++ b/pkgs/by-name/co/console-setup/package.nix
@@ -26,6 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     bdfresize
     otf2bdf
     perl
+    unifont
   ];
 
   makeFlags = [ "prefix=${placeholder "out"}" ];
@@ -35,8 +36,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs .
     substituteInPlace Fonts/Makefile --replace-fail '/usr/share/fonts/truetype/dejavu/' '${dejavu_fonts}/share/fonts/truetype/'
-    ln -s ${unifont}/share/fonts/unifont.bdf Fonts/bdf
-    substituteInPlace Fonts/Makefile --replace-fail 'rm -f $(fntdir)/bdf/unifont.bdf' ""
+    substituteInPlace Fonts/Makefile --replace-fail '/usr/share/unifont/' '${unifont.doc}/share/unifont/'
   '';
 
   preBuild = "make -j$NIX_BUILD_CORES bdf";

--- a/pkgs/by-name/gr/grub2/package.nix
+++ b/pkgs/by-name/gr/grub2/package.nix
@@ -670,7 +670,7 @@ stdenv.mkDerivation rec {
 
     ./bootstrap --no-git --gnulib-srcdir=${gnulib}
 
-    substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
+    substituteInPlace ./configure --replace-fail '/usr/share/fonts' '${unifont}/share/fonts'
   ''
   # build-grub-mkfont is built & run during build, need to find freetype for buildPlatform
   + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''


### PR DESCRIPTION
This makes these packages build correctly, with the changes to unifont.

Fixes https://github.com/NixOS/nixpkgs/pull/550059#issuecomment-5236187739

Also tested in combination with #551008 that `nixosTests.installer.simple` works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
