### PR TITLE
ocamlPackages.tls: 2.1.0 → 2.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchurl,
   buildDunePackage,
+  digestif,
   domain-name,
   fmt,
   logs,
@@ -10,6 +11,7 @@
   mirage-crypto-ec,
   mirage-crypto-pk,
   mirage-crypto-rng,
+  ohex,
   ptime,
   x509,
   ipaddr,
@@ -19,25 +21,27 @@
 
 buildDunePackage (finalAttrs: {
   pname = "tls";
-  version = "2.1.0";
+  version = "2.1.2";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${finalAttrs.version}/tls-${finalAttrs.version}.tbz";
-    hash = "sha256-2nmWB4n6QYtiv4nNUk6ZgVxQEEE7wYnw8zlmuNC4htI=";
+    hash = "sha256-1RlAWHvOlHXJd8WWkEyBedzXhNnvbdmv4+Y0zKlAyfM=";
   };
 
   propagatedBuildInputs = [
+    digestif
     domain-name
     fmt
-    logs
+    ipaddr
     kdf
+    logs
     mirage-crypto
     mirage-crypto-ec
     mirage-crypto-pk
     mirage-crypto-rng
+    ohex
     ptime
     x509
-    ipaddr
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/tls/lwt.nix
+++ b/pkgs/development/ocaml-modules/tls/lwt.nix
@@ -10,8 +10,6 @@ buildDunePackage {
 
   inherit (tls) src meta version;
 
-  minimalOCamlVersion = "4.11";
-
   doCheck = true;
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/tls/miou-unix.nix
+++ b/pkgs/development/ocaml-modules/tls/miou-unix.nix
@@ -3,7 +3,7 @@
   crowbar,
   hxd,
   miou,
-  mirage-crypto-rng-miou-unix,
+  mirage-crypto-rng,
   ohex,
   ptime,
   rresult,
@@ -25,7 +25,7 @@ buildDunePackage {
   checkInputs = [
     crowbar
     hxd
-    mirage-crypto-rng-miou-unix
+    mirage-crypto-rng
     ohex
     ptime
     rresult


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
