### PR TITLE
qq: fix Wayland backend selection

### DIFF
--- a/pkgs/by-name/qq/qq/package.nix
+++ b/pkgs/by-name/qq/qq/package.nix
@@ -190,7 +190,7 @@ else
               libuuid
             ]
           }" \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
           --add-flags ${lib.escapeShellArg commandLineArgs} \
           "''${gappsWrapperArgs[@]}" ${lib.optionalString disableAutoUpdate ''
             \


### PR DESCRIPTION
QQ's bundled Electron runtime does not select the native Wayland backend with
`--ozone-platform-hint=auto`, causing QQ to run through XWayland even in a
Wayland session.

Use `--ozone-platform=wayland` when both `NIXOS_OZONE_WL` and
`WAYLAND_DISPLAY` are set. The existing guards are retained, so native X11
sessions do not receive Wayland-specific arguments.

Manual verification under Hyprland:

- With `NIXOS_OZONE_WL=1` and `WAYLAND_DISPLAY` set, QQ starts with
  `--ozone-platform=wayland` and Hyprland reports `xwayland: false`.
- Without `WAYLAND_DISPLAY`, the wrapper does not inject Wayland arguments;
  QQ can start through XWayland and Hyprland reports `xwayland: true`.
- `NIXPKGS_ALLOW_UNFREE=1 nix-build -A qq --no-out-link` succeeds.

AI disclosure: GPT-5.6 assisted with the change, investigation, testing, and
this pull request description. The resulting change and verification output
were manually reviewed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test