### PR TITLE
nixos/programs/chromium: support recommended preferences

### DIFF
--- a/nixos/modules/programs/chromium.nix
+++ b/nixos/modules/programs/chromium.nix
@@ -85,7 +85,32 @@ in
       extraOpts = lib.mkOption {
         type = lib.types.attrs;
         description = ''
-          Extra chromium policy options. A list of available policies
+          Extra chromium policy options. These settings are locked and the user cannot change them in the browser later.
+          A list of available policies
+          can be found in the Chrome Enterprise documentation:
+          <https://cloud.google.com/docs/chrome-enterprise/policies/>
+          Make sure the selected policy is supported on Linux and your browser version.
+        '';
+        default = { };
+        example = lib.literalExpression ''
+          {
+            "BrowserSignin" = 0;
+            "SyncDisabled" = true;
+            "PasswordManagerEnabled" = false;
+            "SpellcheckEnabled" = true;
+            "SpellcheckLanguage" = [
+              "de"
+              "en-US"
+            ];
+          }
+        '';
+      };
+
+      extraOptsRecommended = lib.mkOption {
+        type = lib.types.attrs;
+        description = ''
+          Extra chromium policy options in recommended. These are default settings. The user can change them in the browser later if they want to.
+          A list of available policies
           can be found in the Chrome Enterprise documentation:
           <https://cloud.google.com/docs/chrome-enterprise/policies/>
           Make sure the selected policy is supported on Linux and your browser version.
@@ -141,6 +166,9 @@ in
       "chromium/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
         text = builtins.toJSON cfg.extraOpts;
       };
+      "chromium/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
+        text = builtins.toJSON cfg.extraOptsRecommended;
+      };
       "chromium/initial_preferences" = lib.mkIf (cfg.initialPrefs != { }) {
         text = builtins.toJSON cfg.initialPrefs;
       };
@@ -156,12 +184,18 @@ in
       "opt/chrome/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
         text = builtins.toJSON cfg.extraOpts;
       };
+      "opt/chrome/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
+        text = builtins.toJSON cfg.extraOptsRecommended;
+      };
       # for brave
       "brave/policies/managed/default.json" = lib.mkIf (defaultProfile != { }) {
         text = builtins.toJSON defaultProfile;
       };
       "brave/policies/managed/extra.json" = lib.mkIf (cfg.extraOpts != { }) {
         text = builtins.toJSON cfg.extraOpts;
+      };
+      "brave/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
+        text = builtins.toJSON cfg.extraOptsRecommended;
       };
     };
   };


### PR DESCRIPTION

This PR sets the parameters as default values instead of fixed values. 
Before, the parameters were locked and users could not change them. This PR fixes that. Now, users get good default values, but they can also change them later if they want to.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
