### PR TITLE
rPackages: strip dynamic libraries and binaries

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -25,7 +25,7 @@ let
 
   buildRPackage = pkgs.callPackage ./generic-builder.nix {
     inherit R;
-    inherit (pkgs) gettext gfortran;
+    inherit (pkgs) gettext;
   };
 
   # Generates package templates given per-repository settings

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -5,7 +5,6 @@
   xvfb-run,
   util-linux,
   gettext,
-  gfortran,
   libiconv,
 }:
 
@@ -17,6 +16,12 @@
 
 stdenv.mkDerivation (
   {
+    __structuredAttrs = true;
+    outputChecks.out.disallowedReferences = [
+      stdenv.cc
+      stdenv.cc.cc
+    ];
+
     buildInputs =
       buildInputs
       ++ [
@@ -28,7 +33,6 @@ stdenv.mkDerivation (
         xvfb-run
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        gfortran
         libiconv
       ];
 
@@ -70,6 +74,11 @@ stdenv.mkDerivation (
       $rCommand CMD INSTALL --built-timestamp='1970-01-01 00:00:00 UTC' $installFlags --configure-args="$configureFlags" -l $out/library .
       runHook postInstall
     '';
+
+    stripDebugList = [
+      "library/${attrs.pname}/libs"
+      "library/${attrs.pname}/bin"
+    ];
 
     postFixup = ''
       if test -e $out/nix-support/propagated-build-inputs; then


### PR DESCRIPTION
Reapply https://github.com/NixOS/nixpkgs/pull/542871 with a twist

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
