### PR TITLE
ssss: convert manpage from XML before installing

### DIFF
--- a/pkgs/by-name/ss/ssss/package.nix
+++ b/pkgs/by-name/ss/ssss/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   gmp,
   installShellFiles,
+  xmltoman,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -18,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    xmltoman
     installShellFiles
   ];
 
@@ -27,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preBuild = ''
     sed -e s@/usr/@$out/@g -i Makefile
-    cp ssss.manpage.xml ssss.1
+    xmltoman ssss.manpage.xml >ssss.1
     mkdir -p $out/bin
     echo -e 'install:\n\tcp ssss-combine ssss-split '"$out"'/bin' >>Makefile
   '';

--- a/pkgs/by-name/xm/xmltoman/package.nix
+++ b/pkgs/by-name/xm/xmltoman/package.nix
@@ -3,28 +3,31 @@
   stdenvNoCC,
   fetchFromGitHub,
   perlPackages,
-  perl,
   installShellFiles,
 }:
 
-stdenvNoCC.mkDerivation rec {
+let
+  inherit (perlPackages) perl;
+  perlInputs = with perlPackages; [
+    XMLParser
+    XMLTokeParser
+  ];
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "xmltoman";
   version = "0.6";
 
   src = fetchFromGitHub {
     owner = "atsb";
     repo = "xmltoman";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-EmFdGIeBEcTY0Pqp7BJded9WB/DaXWcMNWh6aTsZlLg=";
   };
 
-  nativeBuildInputs = [
-    perl
-    installShellFiles
-  ];
+  buildInputs = [ perl ] ++ perlInputs;
 
-  buildInputs = [
-    perlPackages.XMLTokeParser
+  nativeBuildInputs = finalAttrs.buildInputs ++ [
+    installShellFiles
   ];
 
   dontBuild = true;
@@ -36,6 +39,11 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out
     perl xmltoman xml/xmltoman.1.xml > xmltoman.1
     perl xmltoman xml/xmlmantohtml.1.xml > xmlmantohtml.1
+
+    sed -e "2i ${
+      lib.concatMapStrings (i: "use lib '${i}/${perl.libPrefix}';") perlInputs
+    }" -i xmltoman xmlmantohtml
+
     install -d $out/bin $out/share/xmltoman
     install -m 0755 xmltoman xmlmantohtml $out/bin
     install -m 0644 xmltoman.dtd xmltoman.css xmltoman.xsl $out/share/xmltoman
@@ -52,4 +60,4 @@ stdenvNoCC.mkDerivation rec {
     mainProgram = "xmltoman";
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
The ssss package includes a manpage that has not been converted from XML to Groff.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
