### PR TITLE
reticulum-go: 0.9.6 -> 1.0.1

### DIFF
--- a/pkgs/by-name/re/reticulum-go/package.nix
+++ b/pkgs/by-name/re/reticulum-go/package.nix
@@ -3,11 +3,12 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "reticulum-go";
-  version = "0.9.6";
+  version = "1.0.1";
   strictDeps = true;
   __structuredAttrs = true;
 
@@ -15,14 +16,8 @@ buildGoModule (finalAttrs: {
     owner = "Quad4-Software";
     repo = "Reticulum-Go";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Rji6MJQAN48zKsLHQS8ukbi9pWjHPEbezXJu/700HZs=";
+    hash = "sha256-QPf8MymZUW8DbYYgE1hGqKNQJNunyigJMgh/tYJaW1k=";
   };
-
-  # TODO: Remove this when https://github.com/NixOS/nixpkgs/pull/527289 has landed in `master`
-  postPatch = ''
-    substituteInPlace go.mod \
-      --replace-fail "1.26.4" "1.26.3"
-  '';
 
   vendorHash = null;
 
@@ -31,10 +26,14 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
+    "-X main.defaultVersion=${finalAttrs.version}"
   ];
 
   # Required for some tests on darwin.
   __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Bump `reticulum-go` from 0.9.6 to 1.0.1

Injected the version via ldflags and added `versionCheckHook`

https://github.com/NixOS/nixpkgs/pull/527289 has since been merged, so `postPatch` was removed.

Without the `-X` ldflag `--version` cmd would output as `dev`. See source:
https://github.com/Quad4-Software/Reticulum-Go/blob/v1.0.1/cmd/reticulum-go/version.go

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
