### PR TITLE
incus-spawn: update for git-remote-isx needs to ignore same hash

### DIFF
--- a/pkgs/by-name/in/incus-spawn/package.nix
+++ b/pkgs/by-name/in/incus-spawn/package.nix
@@ -102,7 +102,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           echo "incus-spawn is already at $NEW_VERSION"
           exit 0
       fi
-      update-source-version incus-spawn "$NEW_VERSION" --source-key="git-remote-isx"
+      update-source-version incus-spawn "$NEW_VERSION" --source-key="git-remote-isx" --ignore-same-hash
       for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
         update-source-version incus-spawn "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
       done


### PR DESCRIPTION
Ignore same hash updating `git-remote-isx` since this is just a script and it might not change between versions. This fix should unlock the bot to run updates, (see [latest failure](https://nixpkgs-update-logs.nix-community.org/incus-spawn/2026-08-05.log)).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [n/a] [NixOS tests] in [nixos/tests]. (CLI tool, no NixOS module)
  - [x] [Package tests] at `passthru.tests`.
  - [n/a] Tests in [lib/tests] or [pkgs/test] for functions and core functionality. (CLI tool, no NixOS module)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [n/a] Package update: when the change is major or breaking. (CLI tool, no NixOS module)
- NixOS Release Notes
  - [n/a] Module addition: when adding a new NixOS module. (CLI tool, no NixOS module)
  - [n/a] Module update: when the change is significant. (CLI tool, no NixOS module)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test