### PR TITLE
plezy: 2.12.1 -> 2.13.0

### DIFF
--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -27,13 +27,13 @@
 
 let
   pname = "plezy";
-  version = "2.12.1";
+  version = "2.13.0";
 
   src = fetchFromGitHub {
     owner = "edde746";
     repo = "plezy";
     tag = version;
-    hash = "sha256-Ib1ZBKbuan8GfkxKVytQ5Bn0sPKtDR3o4em4h8p78Xk=";
+    hash = "sha256-pSGHB2sN/iySd3WKskvZeBo9H9M3YrsLtfw1LoW15tA=";
   };
 
   simdutf = fetchurl {
@@ -48,7 +48,7 @@ let
   '';
 
   meta = {
-    description = "Modern cross-platform Plex & Jellyfin client built with Flutter";
+    description = "Modern cross-platform Emby, Plex & Jellyfin client built with Flutter";
     homepage = "https://github.com/edde746/plezy";
     mainProgram = "plezy";
     license = lib.licenses.gpl3Only;
@@ -146,7 +146,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/edde746/plezy/releases/download/${version}/plezy-macos.dmg";
-      hash = "sha256-el4w0SXVo3kQi/aRrozl4q8KGs+Y7kCJeQmpV26+Pvk=";
+      hash = "sha256-BF9jKIOzQYpQnJUXD8d2e2GSgIc6ZsjZaqceAc01QI0=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pl/plezy/pubspec.lock.json
+++ b/pkgs/by-name/pl/plezy/pubspec.lock.json
@@ -266,7 +266,7 @@
       "version": "0.4.2"
     },
     "clock": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "clock",
         "sha256": "fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b",


### PR DESCRIPTION
Diff: https://github.com/edde746/plezy/compare/2.12.1...2.13.0
Release: https://github.com/edde746/plezy/releases/tag/2.13.0

Tested basic usage

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
