### PR TITLE
hdrhistogram_c: fix pkgsStatic build

### DIFF
--- a/pkgs/by-name/hd/hdrhistogram_c/package.nix
+++ b/pkgs/by-name/hd/hdrhistogram_c/package.nix
@@ -32,6 +32,20 @@ stdenv.mkDerivation (finalAttrs: {
     validatePkgConfig
   ];
 
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isStatic [
+    (lib.cmakeBool "HDR_HISTOGRAM_BUILD_SHARED" false)
+    # Examples and tests depend on the shared library target; skip them in
+    # static builds (tests still run for the regular pkgs.hdrhistogram_c build).
+    (lib.cmakeBool "HDR_HISTOGRAM_BUILD_PROGRAMS" false)
+  ];
+
+  # The .pc file always references -lhdr_histogram, but in static builds only
+  # libhdr_histogram_static.a is produced. Provide a symlink so pkg-config
+  # consumers find the right archive.
+  postInstall = lib.optionalString stdenv.hostPlatform.isStatic ''
+    ln -s $out/lib/libhdr_histogram_static.a $out/lib/libhdr_histogram.a
+  '';
+
   doCheck = true;
 
   passthru = {


### PR DESCRIPTION
`pkgsStatic` uses a fully static musl toolchain (`crtbeginT.o`) which cannot
link shared objects. The upstream `CMakeLists` uses its own
`HDR_HISTOGRAM_BUILD_SHARED` option (not `BUILD_SHARED_LIBS`) to build both
libraries unconditionally, causing a linker failure.

Disable shared library and programs builds for static targets. Add a
`postInstall` symlink `libhdr_histogram.a -> libhdr_histogram_static.a` so
that the installed pkg-config file (`-lhdr_histogram`) resolves correctly.

Fixes: https://github.com/NixOS/nixpkgs/issues/549561
Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
