### PR TITLE
pureref: add updateScript

### DIFF
--- a/pkgs/by-name/pu/pureref/package.nix
+++ b/pkgs/by-name/pu/pureref/package.nix
@@ -6,53 +6,92 @@
   curl,
   gnugrep,
   cacert,
-  dpkg,
+  writeShellScript,
+  blockNetwork ? false,
 }:
 let
+  pname = "pureref";
   version = "2.1.3";
-  deb =
-    runCommand "PureRef-${version}_x64"
+  homepage = "https://www.pureref.com";
+
+  kindCurl = ''curl -s -A "nixpkgs/Please contact maintainers if there is an issue"'';
+  downloadKeyCmd = ''${kindCurl} "${homepage}/download.php" | grep '%3D%3D' | cut -d '"' -f2'';
+  archiveUrl =
+    v: k: "${homepage}/files/build.php?build=LINUX64.Appimage&version=${v}&downloadKey=${k}";
+
+  src =
+    runCommand "PureRef-${version}.AppImage"
       {
         nativeBuildInputs = [
           curl
           gnugrep
           cacert
-          dpkg
         ];
-        outputHash = "sha256-7S0nnEwtGKKKNPZL2pb5Z8bKKB5eWvymSS2pQo9cJa0=";
-        outputHashMode = "recursive";
+        outputHash = "sha256-N5iyT/WFOFBZdfjHX6lZD2EqiOmTdYQEf2YIlN2o7/M=";
+        outputHashMode = "flat";
       }
       ''
-        key="$(curl -A 'nixpkgs/Please contact maintainer if there is an issue' "https://www.pureref.com/download.php" --silent | grep '%3D%3D' | cut -d '"' -f2)"
-        curl -L "https://www.pureref.com/files/build.php?build=LINUX64.deb&version=${version}&downloadKey=$key" --output $name.deb
-        dpkg-deb -x $name.deb $out
-        chmod 755 $out
+        key="$(${downloadKeyCmd})"
+        curl -L "${archiveUrl version "$key"}" --output $out
       '';
+
+  archive = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
-  pname = "pureref";
-  inherit version;
+  inherit pname version src;
 
   nativeBuildInputs = [ makeWrapper ];
 
-  src = "${deb}/usr/bin/PureRef";
-
   extraInstallCommands = ''
     mv $out/bin/pureref $out/bin/PureRef
-    cp -r ${deb}/usr/share $out
-    wrapProgram $out/bin/PureRef --set QT_QPA_PLATFORM xcb
+    ln -s $out/bin/PureRef $out/bin/pureref
+    cp -r ${archive}/usr/share $out
+    wrapProgram $out/bin/PureRef \
+      --set QT_QPA_PLATFORM xcb \
+      --unset QT_STYLE_OVERRIDE \
+      --set FONTCONFIG_FILE /etc/fonts/fonts.conf
+  ''
+  + lib.optionalString blockNetwork ''
+    sed -i 's|--die-with-parent|--unshare-net\n --die-with-parent|' $out/bin/.PureRef-wrapped
+  '';
+
+  passthru.updateScript = writeShellScript "update-pureref" ''
+    set -eux
+    package_nix="${toString ./package.nix}"
+
+    echo "Fetching latest version..."
+    version=$(${kindCurl} "${homepage}/buildfinder.php" | sed -n 's/.*PureRef-\([0-9.]*\)_.*/\1/p')
+
+    if [ -z "$version" ]; then
+      echo "Failed to find version, contact nixpkgs maintainers"
+      exit 1
+    else
+      echo "Found new version: $version"
+    fi
+
+    echo "Computing hash..."
+    key=$(${downloadKeyCmd})
+    url="${archiveUrl "$version" "$key"}"
+    hash=$(nix-prefetch-url --type sha256 --name "PureRef-$version.AppImage" "$url")
+    sri=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+
+    echo "Updating version in $package_nix to $version"
+    sed -i "s|version = \".*\"|version = \"$version\"|" "$package_nix"
+    echo "Updating hash in $package_nix to $sri"
+    sed -i "s|outputHash = \".*\"|outputHash = \"$sri\"|" "$package_nix"
   '';
 
   meta = {
     description = "Reference Image Viewer";
-    homepage = "https://www.pureref.com";
+    inherit homepage;
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       elnudev
       husjon
+      lnk3
     ];
     platforms = [ "x86_64-linux" ];
-    mainProgram = "PureRef";
+    mainProgram = "pureref";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 }


### PR DESCRIPTION
## Changes

- Add passthru.updateScript for automated updates
- Switch source from .deb to .AppImage (Type 2)
- Add blockNetwork sandbox option
- Add lnk3 to maintainers

```
 $ ./result/bin/pureref
QApplication: invalid style override 'kvantum' passed, ignoring it.
    Available styles: Windows, Fusion
Fontconfig error: Cannot load default config file: No such file: (null) 
```
- Unset QT_STYLE_OVERRIDE to prevent unbundled plugins to not be found
- Set FONTCONFIG_FILE to the FHS path


## Test

I tested the update script.
- Reverted the version to `2.0.3`
```diff
$ git diff --unified=0
diff --git a/pkgs/by-name/pu/pureref/package.nix b/pkgs/by-name/pu/pureref/package.nix
index 528c179e55b5..d3c0d2fdd2eb 100644
--- a/pkgs/by-name/pu/pureref/package.nix
+++ b/pkgs/by-name/pu/pureref/package.nix
@@ -14 +14 @@ let
-  version = "2.1.3";
+  version = "2.0.3";
@@ -30 +30 @@ let
-        outputHash = "sha256-N5iyT/WFOFBZdfjHX6lZD2EqiOmTdYQEf2YIlN2o7/M=";
+        outputHash = "sha256-0iR1cP2sZvWWqKwRAwq6L/bmIBSYHKrlI8u8V2hANfM=";
```
- Built `2.0.3`
```bash
$ NIXPKGS_ALLOW_UNFREE=1 nix-build -A pureref
/nix/store/l18a2gvnf578qacabr4jy5ryvdv4kyqa-pureref-2.0.3
```

- Run update script and got `2.1.3` and it's hash updated
```bash
$ nix-update pureref --use-update-script
$ nix-instantiate --eval --json --strict /nix/store/crvfdgi07s4106xw8ygnb7kg4hz0l9pn-nix-update-1.15.1/lib/python3.13/site-packages/nix_update/eval.nix --argstr importPath ~/nixpkgs.git/pureref --argstr attribute '["pureref"]' --arg isFlake false --arg sanitizePositions true
$ nix-shell --extra-experimental-features 'flakes nix-command' ~/nixpkgs.git/pureref/maintainers/scripts/update.nix --argstr package pureref --argstr skip-prompt true
this derivation will be built:
  /nix/store/4r5jyf6wwzpvbkah2qsn925l0s6qmikw-packages.json.drv
building '/nix/store/4r5jyf6wwzpvbkah2qsn925l0s6qmikw-packages.json.drv'...

Going to be running update for following packages:
 - pureref-2.0.3


Running update for:
Enqueuing group of 1 packages
 - pureref-2.0.3: UPDATING ...
 - pureref-2.0.3: DONE.

Packages updated!
$ nix-instantiate --eval --json --strict /nix/store/crvfdgi07s4106xw8ygnb7kg4hz0l9pn-nix-update-1.15.1/lib/python3.13/site-packages/nix_update/eval.nix --argstr importPath ~/nixpkgs.git/pureref --argstr attribute '["pureref"]' --arg isFlake false --arg sanitizePositions true
Package maintainers:
  - Elnu (@ElnuDev)
  - Jon Erling Hustadnes (@husjon)
  - Luca Ruperto (@lnk3)
$ git -C ~/nixpkgs.git/pureref diff -- ~/nixpkgs.git/pureref/pkgs/by-name/pu/pureref
No changes detected, skipping remaining steps
$ git diff --unified=0
```

- Built `2.1.3`
```bash
$ NIXPKGS_ALLOW_UNFREE=1 nix-build -A pureref
/nix/store/mzg59x9iqq01wc12ivhzk5wcyznsscck-pureref-2.1.3
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Ran `nixpkgs-hammering` on this package.
- [x] Ran `nixpkgs-lint` on this checkout.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test