### PR TITLE
appimage-run{-tests}: set pname and version

### DIFF
--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -30,7 +30,8 @@ let
 in
 buildFHSEnv (
   lib.recursiveUpdate fhsArgs {
-    inherit name;
+    pname = name;
+    version = "0";
 
     targetPkgs = pkgs: [ appimageTools.appimage-exec ] ++ fhsArgs.targetPkgs pkgs ++ extraPkgs pkgs;
     runScript = "appimage-exec.sh";

--- a/pkgs/tools/package-management/appimage-run/test.nix
+++ b/pkgs/tools/package-management/appimage-run/test.nix
@@ -19,6 +19,9 @@ let
 in
 runCommand "appimage-run-tests"
   {
+    inherit (appimage-run) version;
+    pname = "appimage-run-tests";
+
     buildInputs = [
       appimage-run
       glibcLocales
@@ -43,7 +46,7 @@ runCommand "appimage-run-tests"
 
     # Verify desktop entry
     XDG_DATA_DIRS="${appimage-run}/share"
-    [[ "$(xdg-mime query default application/vnd.appimage)" == '${appimage-run.name}.desktop' ]]
+    [[ "$(xdg-mime query default application/vnd.appimage)" == '${appimage-run.pname}.desktop' ]]
 
     set +x
     touch $out


### PR DESCRIPTION
Working towards #485742
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
