### PR TITLE
n8n: 2.32.6 -> 2.33.7

### DIFF
--- a/pkgs/by-name/n8/n8n/package.nix
+++ b/pkgs/by-name/n8/n8n/package.nix
@@ -27,20 +27,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "n8n";
-  version = "2.32.6";
+  version = "2.33.7";
 
   src = fetchFromGitHub {
     owner = "n8n-io";
     repo = "n8n";
     tag = "n8n@${finalAttrs.version}";
-    hash = "sha256-wWm6vGyJ2I2SBU38gRGaZG2FR5FBxH6V/sWQwn5B4Ac=";
+    hash = "sha256-6QysdmXgSxfJpNaL10HogrnNYEyrxZLdkfgBnRiXWX4=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 4;
-    hash = "sha256-D8CKJxU2RoMjNrqIgGDE3mFBjc0kqFLQzT/DdUpiNmY=";
+    hash = "sha256-Ei/8j+KvhZVgqteA+bqNsL11IMGzWn3OHngDpsEH6jk=";
   };
 
   nativeBuildInputs = [
@@ -104,8 +104,12 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/{bin,lib/n8n}
     cp -r {packages,node_modules} $out/lib/n8n
 
+    # node must be on PATH: in internal runner mode the CLI spawns the
+    # JS task runner via `spawn('node', ...)`, and since 2.33 a failed
+    # spawn crashes n8n instead of being silently ignored
     makeWrapper $out/lib/n8n/packages/cli/bin/n8n $out/bin/n8n \
-      --set N8N_RELEASE_TYPE "stable"
+      --set N8N_RELEASE_TYPE "stable" \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
 
     # JavaScript runner
     makeWrapper ${nodejs}/bin/node $out/bin/n8n-task-runner \


### PR DESCRIPTION
n8n: 2.32.6 -> 2.33.7, and fix internal JS task runner spawn.

Changelog: https://github.com/n8n-io/n8n/compare/n8n%402.32.6...n8n%402.33.7

Supersedes #550691, which fails `nixosTests.n8n`.

Root cause: the n8n CLI launches its internal JS task runner with `spawn('node', ...)` and relies on `node` being on `PATH`. The wrapper never provided it (n8n itself only runs because its shebang is patched to an absolute store path), so the spawn has always failed with ENOENT. Until 2.32.x this was invisible: upstream only listened for the child's `exit` event, and a process that fails to spawn emits `error` but never `exit` — the runner silently never started, which also means the Code node was effectively broken in the default (internal-runner) NixOS setup on earlier versions. n8n 2.33 added an `error` handler that treats a pid-less spawn failure as an exit ([task-runner-process-base.ts](https://github.com/n8n-io/n8n/blob/n8n%402.33.7/packages/cli/src/task-runners/task-runner-process-base.ts)), turning the silent failure into a fatal crash loop.

Fix: prefix the `n8n` wrapper's `PATH` with the nodejs used to build the package. The runner child inherits `PATH` from the n8n process, so this fixes internal runner mode everywhere the package is used, and guarantees the runner uses the same nodejs n8n was built with.

External-mode runners were unaffected, as is the Python runner, which probes its requirements before spawning.

Disclosure per the automation/AI policy: root-cause analysis, the fix, and this PR summary were produced with Claude Code (model Fable 5); reviewed, tested, and submitted by me.

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [x] aarch64-linux
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [x] [NixOS tests] in [nixos/tests]: `nixosTests.n8n` passes, including the previously failing `machine_simple`.
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test