### PR TITLE
nixos/niri: add an option to control inclusion of gnome-keyring

### DIFF
--- a/nixos/modules/programs/wayland/niri.nix
+++ b/nixos/modules/programs/wayland/niri.nix
@@ -16,6 +16,10 @@ in
     useNautilus = lib.mkEnableOption "Nautilus as file-chooser for xdg-desktop-portal-gnome" // {
       default = true;
     };
+
+    useGnomeKeyring = lib.mkEnableOption "GNOME Keyring as a secret service" // {
+      default = true;
+    };
   };
 
   config = lib.mkIf cfg.enable (
@@ -43,7 +47,7 @@ in
 
           # Recommended by upstream
           # https://github.com/YaLTeR/niri/wiki/Important-Software#portals
-          gnome.gnome-keyring.enable = lib.mkDefault true;
+          gnome.gnome-keyring.enable = lib.mkIf cfg.useGnomeKeyring (lib.mkDefault true);
         };
 
         systemd.packages = [ cfg.package ];
@@ -71,7 +75,7 @@ in
             "org.freedesktop.impl.portal.Access" = "gtk";
             "org.freedesktop.impl.portal.FileChooser" = lib.mkIf (!cfg.useNautilus) "gtk";
             "org.freedesktop.impl.portal.Notification" = "gtk";
-            "org.freedesktop.impl.portal.Secret" = "gnome-keyring";
+            "org.freedesktop.impl.portal.Secret" = lib.mkIf cfg.useGnomeKeyring "gnome-keyring";
           };
 
           # Recommended by upstream, required for screencast support


### PR DESCRIPTION
This makes the inclusion of gnome-keyring configurable via an option.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] It works on my machine.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- NixOS Release Notes
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. (no automation or ai used)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
