### PR TITLE
treewide: enable strictDeps and structuredAttrs for various low-level packages

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -1037,6 +1037,8 @@ stdenvNoCC.mkDerivation {
       apple-sdk.__spliced.buildTarget or apple-sdk;
   };
 
+  __structuredAttrs = true;
+
   meta =
     let
       cc_ = optionalAttrs (cc != null) cc;

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -180,6 +180,8 @@ stdenv.mkDerivation {
       ;
   };
 
+  __structuredAttrs = true;
+
   meta =
     let
       pkg-config_ = optionalAttrs (pkg-config != null) pkg-config;

--- a/pkgs/by-name/ar/argp-standalone/package.nix
+++ b/pkgs/by-name/ar/argp-standalone/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/argp-standalone/argp-standalone";
     description = "Standalone version of arguments parsing functions from Glibc";

--- a/pkgs/by-name/ar/argp-standalone/package.nix
+++ b/pkgs/by-name/ar/argp-standalone/package.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
+  strictDeps = true;
+
   doCheck = true;
 
   meta = {

--- a/pkgs/by-name/as/asciidoc/package.nix
+++ b/pkgs/by-name/as/asciidoc/package.nix
@@ -151,7 +151,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "asciidoc-py";
     repo = "asciidoc-py";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-td3C7xTWfSzdo9Bbz0dHW2oPaCQYmUE9H2sUFfg5HH0=";
   };
 
@@ -319,6 +319,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
     runHook postCheck
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Text-based document generation system";

--- a/pkgs/by-name/au/auto-patchelf/package.nix
+++ b/pkgs/by-name/au/auto-patchelf/package.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Automatically patch ELF binaries using patchelf";
     mainProgram = "auto-patchelf";

--- a/pkgs/by-name/au/autoconf-archive/package.nix
+++ b/pkgs/by-name/au/autoconf-archive/package.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ xz ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Archive of autoconf m4 macros";
     homepage = "https://www.gnu.org/software/autoconf-archive/";

--- a/pkgs/by-name/bi/bison/package.nix
+++ b/pkgs/by-name/bi/bison/package.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
   # TODO: enable doInstallCheck unconditionally when fixed upstream.
   doInstallCheck = !stdenv.cc.isClang;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/bison/";
     description = "Yacc-compatible parser generator";

--- a/pkgs/by-name/bi/bison/package.nix
+++ b/pkgs/by-name/bi/bison/package.nix
@@ -28,10 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     "host"
   ];
 
-  # there's a /bin/sh shebang in bin/yacc which when no strictDeps is patched with the build stdenv shell
-  # however when cross-compiling it would still be patched with the build stdenv shell which would be wrong
-  # cannot add bash to buildInputs due to infinite recursion
-  strictDeps = stdenv.hostPlatform != stdenv.buildPlatform;
+  strictDeps = true;
 
   nativeBuildInputs = [
     m4
@@ -39,6 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];
+
+  # there's a /bin/sh shebang in bin/yacc which when no strictDeps is patched with the build stdenv shell
+  # however when cross-compiling it would still be patched with the build stdenv shell which would be wrong
+  # cannot add bash to buildInputs due to infinite recursion
+  postFixup = lib.optionalString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
+    patchShebangs --build $out/bin/yacc
+  '';
 
   enableParallelBuilding = true;
   # tests are flaky / timing sensitive on FreeBSD

--- a/pkgs/by-name/bl/bluez-headers/package.nix
+++ b/pkgs/by-name/bl/bluez-headers/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -rv lib/* "$out/include/"
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://bluez.github.io/";
     description = "Official Linux Bluetooth protocol stack";

--- a/pkgs/by-name/bl/bluez-headers/package.nix
+++ b/pkgs/by-name/bl/bluez-headers/package.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
   dontConfigure = true;
   dontBuild = true;
 
+  strictDeps = true;
+
   installPhase = ''
     mkdir -p $out/include/
     cp -rv lib/* "$out/include/"

--- a/pkgs/by-name/br/brotli/package.nix
+++ b/pkgs/by-name/br/brotli/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
+  strictDeps = true;
+
   cmakeFlags = lib.optional staticOnly "-DBUILD_SHARED_LIBS=OFF";
 
   outputs = [

--- a/pkgs/by-name/br/brotli/package.nix
+++ b/pkgs/by-name/br/brotli/package.nix
@@ -62,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script { };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/google/brotli";
     changelog = "https://github.com/google/brotli/blob/${finalAttrs.src.tag}/CHANGELOG.md";

--- a/pkgs/by-name/by/byacc/package.nix
+++ b/pkgs/by-name/by/byacc/package.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-thjF+0TC9fBIhD25D30bJPePR7B5E8jHuoyULT6ySwA=";
   };
 
+  strictDeps = true;
+
   configureFlags = [
     # change yacc to byacc
     "--program-transform-name='s,^,b,'"

--- a/pkgs/by-name/by/byacc/package.nix
+++ b/pkgs/by-name/by/byacc/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/bin/byacc $out/bin/yacc
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://invisible-island.net/byacc/byacc.html";
     description = "Berkeley YACC";

--- a/pkgs/by-name/ca/cacert/package.nix
+++ b/pkgs/by-name/ca/cacert/package.nix
@@ -249,5 +249,7 @@ stdenv.mkDerivation {
       };
   };
 
+  __structuredAttrs = true;
+
   inherit meta;
 }

--- a/pkgs/by-name/ca/cacert/package.nix
+++ b/pkgs/by-name/ca/cacert/package.nix
@@ -70,6 +70,8 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ buildcatrust ];
 
+  strictDeps = true;
+
   buildPhase = ''
     mkdir unbundled hashed
     buildcatrust \

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -208,6 +208,8 @@ stdenv.mkDerivation (finalAttrs: {
     ignoredVersions = "-"; # -rc1 and friends
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://cmake.org/";
     description = "Cross-platform, open-source build system generator";

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -124,6 +124,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional cursesUI ncurses
     ++ lib.optional qt5UI qtbase;
 
+  strictDeps = true;
+
   # bootstrap is not autoconf and rejects --enable-static/--disable-shared
   # FIXME: rebuild avoidance, drop optionalDrvAttr in staging
   dontAddStaticConfigureFlags = lib.optionalDrvAttr stdenv.hostPlatform.isStatic true;

--- a/pkgs/by-name/cu/cunit/package.nix
+++ b/pkgs/by-name/cu/cunit/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "057j82da9vv4li4z5ri3227ybd18nzyq81f6gsvhifs5z0vr3cpm";
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Unit Testing Framework for C";
 

--- a/pkgs/by-name/cu/cunit/package.nix
+++ b/pkgs/by-name/cu/cunit/package.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ libtool ];
 
+  strictDeps = true;
+
   src = fetchurl {
     url = "mirror://sourceforge/cunit/CUnit/${finalAttrs.version}/CUnit-${finalAttrs.version}.tar.bz2";
     sha256 = "057j82da9vv4li4z5ri3227ybd18nzyq81f6gsvhifs5z0vr3cpm";

--- a/pkgs/by-name/da/dash/package.nix
+++ b/pkgs/by-name/da/dash/package.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "http://gondor.apana.org.au/~herbert/dash/";
     description = "POSIX-compliant implementation of /bin/sh that aims to be as small as possible";

--- a/pkgs/by-name/de/dejagnu/package.nix
+++ b/pkgs/by-name/de/dejagnu/package.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ expect ];
 
+  strictDeps = true;
+
   # dejagnu-1.6.3 can't successfully run tests in source tree:
   #   https://wiki.linuxfromscratch.org/lfs/ticket/4871
   preConfigure = ''

--- a/pkgs/by-name/de/dejagnu/package.nix
+++ b/pkgs/by-name/de/dejagnu/package.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${expect}/bin/expect $out/bin/expect
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Framework for testing other programs";
 

--- a/pkgs/by-name/di/diffutils/package.nix
+++ b/pkgs/by-name/di/diffutils/package.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
   # If no explicit coreutils is given, use the one from stdenv.
   buildInputs = [ coreutils ];
 
+  strictDeps = true;
+
   # Disable stack-related gnulib tests on x86_64-darwin because they have problems running under
   # Rosetta 2: test-c-stack hangs, test-sigsegv-catch-stackoverflow and test-sigaction fail.
   # Disable all gnulib tests when building on Darwin due to test-nl_langinfo-mt failure

--- a/pkgs/by-name/di/diffutils/package.nix
+++ b/pkgs/by-name/di/diffutils/package.nix
@@ -12,12 +12,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "diffutils";
   version = "3.12";
 
   src = fetchurl {
-    url = "mirror://gnu/diffutils/diffutils-${version}.tar.xz";
+    url = "mirror://gnu/diffutils/diffutils-${finalAttrs.version}.tar.xz";
     hash = "sha256-fIt/n8hgkUH96pzs6FJJ0whiQ5H/Yd7a9Sj8szdyff0=";
   };
 
@@ -80,6 +80,8 @@ stdenv.mkDerivation rec {
   # Test failure on QEMU only (#300550)
   doCheck = !stdenv.buildPlatform.isRiscV64;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/diffutils/diffutils.html";
     description = "Commands for showing the differences between files (diff, cmp, etc.)";
@@ -90,4 +92,4 @@ stdenv.mkDerivation rec {
       helsinki-Jo
     ];
   };
-}
+})

--- a/pkgs/by-name/dn/dns-root-data/package.nix
+++ b/pkgs/by-name/dn/dns-root-data/package.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation {
     cp ${./root.ds} $out/root.ds
   '';
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.iana.org/domains/root/files";
     description = "DNS root data including root hints and DNSSEC root trust anchor + key";

--- a/pkgs/by-name/ed/ed/package.nix
+++ b/pkgs/by-name/ed/ed/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/ed/";
     description = "GNU implementation of the standard Unix editor";

--- a/pkgs/by-name/el/elfutils/package.nix
+++ b/pkgs/by-name/el/elfutils/package.nix
@@ -146,6 +146,8 @@ stdenv.mkDerivation (finalAttrs: {
     rev-prefix = "elfutils-";
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://sourceware.org/elfutils/";
     description = "Set of utilities to handle ELF objects";

--- a/pkgs/by-name/el/elfutils/package.nix
+++ b/pkgs/by-name/el/elfutils/package.nix
@@ -113,6 +113,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];
 
+  strictDeps = true;
+
   hardeningDisable = [ "strictflexarrays3" ];
 
   configureFlags = [

--- a/pkgs/by-name/ex/expand-response-params/package.nix
+++ b/pkgs/by-name/ex/expand-response-params/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation {
     mv expand-response-params${stdenv.hostPlatform.extensions.executable} $prefix/bin/
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Internal tool used by the nixpkgs wrapper scripts for processing response files";
     longDescription = ''

--- a/pkgs/by-name/ex/expat/package.nix
+++ b/pkgs/by-name/ex/expat/package.nix
@@ -72,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://github.com/libexpat/libexpat/blob/${tagFor finalAttrs.version}/expat/Changes";
     homepage = "https://libexpat.github.io/";

--- a/pkgs/by-name/fo/fortify-headers/package.nix
+++ b/pkgs/by-name/fo/fortify-headers/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./restore-macros.patch
   ];
 
+  strictDeps = true;
+
   dontBuild = true;
 
   installPhase = ''
@@ -35,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater {
     url = "git://git.2f30.org/fortify-headers";
   };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Standalone header-based fortify-source implementation";

--- a/pkgs/by-name/gd/gdbm/package.nix
+++ b/pkgs/by-name/gd/gdbm/package.nix
@@ -65,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/gdbm/";
     description = "GNU dbm key/value database library";

--- a/pkgs/by-name/gd/gdbm/package.nix
+++ b/pkgs/by-name/gd/gdbm/package.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
 
+  strictDeps = true;
+
   hardeningDisable = [ "strictflexarrays3" ];
 
   configureFlags = [ (lib.enableFeature true "libgdbm-compat") ];

--- a/pkgs/by-name/ge/getopt/package.nix
+++ b/pkgs/by-name/ge/getopt/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
     "CC:=$(CC)"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
     platforms = lib.platforms.unix;
     homepage = "http://frodo.looijaard.name/project/getopt";

--- a/pkgs/by-name/ge/getopt/package.nix
+++ b/pkgs/by-name/ge/getopt/package.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
   # attempt to use C library functions without declaring them, which is raised as an error.
   env.NIX_CFLAGS_COMPILE = "-D__GNU_LIBRARY__";
 
+  strictDeps = true;
+
   makeFlags = [
     "WITHOUT_GETTEXT=1"
     "LIBCGETOPT=0"

--- a/pkgs/by-name/gn/gnu-config/package.nix
+++ b/pkgs/by-name/gn/gnu-config/package.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Attempt to guess a canonical system name";
     homepage = "https://savannah.gnu.org/projects/config";

--- a/pkgs/by-name/gn/gnugrep/package.nix
+++ b/pkgs/by-name/gn/gnugrep/package.nix
@@ -15,16 +15,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-let
-  version = "3.12";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnugrep";
-  inherit version;
+  version = "3.12";
 
   src = fetchurl {
-    url = "mirror://gnu/grep/grep-${version}.tar.xz";
+    url = "mirror://gnu/grep/grep-${finalAttrs.version}.tar.xz";
     hash = "sha256-JkmyfA6Q5jLq3NdXvgbG6aT0jZQd5R58D4P/dkCKB7k=";
   };
 
@@ -39,13 +35,9 @@ stdenv.mkDerivation {
   # - on Musl: https://github.com/NixOS/nixpkgs/pull/228714
   # - on x86_64-darwin: https://github.com/NixOS/nixpkgs/pull/228714#issuecomment-1576826330
   # - when building on Darwin (cross-compilation): test-nl_langinfo-mt fails
-  postPatch =
-    if stdenv.hostPlatform.isMusl || stdenv.buildPlatform.isDarwin then
-      ''
-        sed -i 's:gnulib-tests::g' Makefile.in
-      ''
-    else
-      null;
+  postPatch = lib.optionalString (stdenv.hostPlatform.isMusl || stdenv.buildPlatform.isDarwin) ''
+    substituteInPlace Makefile.in --replace-fail "gnulib-tests" ""
+  '';
 
   nativeCheckInputs = [
     perl
@@ -120,7 +112,7 @@ stdenv.mkDerivation {
     teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     mainProgram = "grep";
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version // {
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version // {
       product = "grep";
     };
   };
@@ -128,4 +120,4 @@ stdenv.mkDerivation {
   passthru = {
     inherit pcre2;
   };
-}
+})

--- a/pkgs/by-name/gn/gnugrep/package.nix
+++ b/pkgs/by-name/gn/gnugrep/package.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation {
   ]
   ++ lib.optional (!stdenv.hostPlatform.isWindows) runtimeShellPackage;
 
+  strictDeps = true;
+
   # cygwin: FAIL: multibyte-white-space
   # freebsd: FAIL mb-non-UTF8-performance
   # x86_64-darwin: fails 'stack-overflow' tests on Rosetta 2 emulator

--- a/pkgs/by-name/gn/gnugrep/package.nix
+++ b/pkgs/by-name/gn/gnugrep/package.nix
@@ -99,6 +99,8 @@ stdenv.mkDerivation {
     NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/grep/";
     description = "GNU implementation of the Unix grep command";

--- a/pkgs/by-name/gn/gnum4/package.nix
+++ b/pkgs/by-name/gn/gnum4/package.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isMinGW "CFLAGS=-fno-stack-protector";
 
+  __structuredAttrs = true;
+
   meta = {
     description = "GNU M4, a macro processor";
     longDescription = ''

--- a/pkgs/by-name/gn/gnumake/package.nix
+++ b/pkgs/by-name/gn/gnumake/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnu/make/make-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-3Rb7HWe/q3mnL16DkHNcSePo5wtJRaFasfgd23hlj7M=";
+    hash = "sha256-3Rb7HWe/q3mnL16DkHNcSePo5wtJRaFasfgd23hlj7M=";
   };
 
   # To update patches:
@@ -81,6 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
     # make sure that the override doesn't break bootstrapping
     gnumakeWithGuile = gnumake.override { guileSupport = true; };
   };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Tool to control the generation of non-source files from sources";

--- a/pkgs/by-name/gn/gnupatch/package.nix
+++ b/pkgs/by-name/gn/gnupatch/package.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "GNU Patch, a program to apply differences to files";
     mainProgram = "patch";

--- a/pkgs/by-name/gn/gnutls/package.nix
+++ b/pkgs/by-name/gn/gnutls/package.nix
@@ -58,12 +58,12 @@ let
   util-linux = util-linuxMinimal;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnutls";
   version = "3.8.13";
 
   src = fetchurl {
-    url = "mirror://gnupg/gnutls/v${lib.versions.majorMinor version}/gnutls-${version}.tar.xz";
+    url = "mirror://gnupg/gnutls/v${lib.versions.majorMinor finalAttrs.version}/gnutls-${finalAttrs.version}.tar.xz";
     hash = "sha256-/+2Owb8JwkJtTxSq43feR1O1PlN9aF5gTpmosWypyX4=";
   };
 
@@ -217,6 +217,8 @@ stdenv.mkDerivation rec {
     static = pkgsStatic.gnutls;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "GNU Transport Layer Security Library";
 
@@ -238,6 +240,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ vcunat ];
     platforms = lib.platforms.all;
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;
   };
-}
+})

--- a/pkgs/by-name/gn/gnutls/package.nix
+++ b/pkgs/by-name/gn/gnutls/package.nix
@@ -173,6 +173,8 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ nettle ];
 
+  strictDeps = true;
+
   inherit doCheck;
   # stdenv's `NIX_SSL_CERT_FILE=/no-cert-file.crt` breaks tests.
   # Also empty files won't work, and we want to avoid potentially impure /etc/

--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "google";
     repo = "googletest";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-HIHMxAUR4bjmFLoltJeIAVSulVQ6kVuIT2Ku+lwAx/4=";
   };
 
@@ -63,6 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_CXX_STANDARD=${cxx_standard}"
   ]
   ++ lib.optional withAbseil "-DGTEST_HAS_ABSL=ON";
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Google's framework for writing C++ tests";

--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     re2
   ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
   ]

--- a/pkgs/by-name/gt/gtk-doc/package.nix
+++ b/pkgs/by-name/gt/gtk-doc/package.nix
@@ -14,7 +14,7 @@
   dblatex,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "gtk-doc";
   version = "1.36.1";
 
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "gtk-doc";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-8hB43BCAtT1B7/ak2i0FAlYD3Kb4rNCWfsJ+wqGu3FA=";
   };
 
@@ -85,12 +85,14 @@ python3.pkgs.buildPythonApplication rec {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://gitlab.gnome.org/GNOME/gtk-doc/-/blob/${src.tag}/NEWS";
+    changelog = "https://gitlab.gnome.org/GNOME/gtk-doc/-/blob/${finalAttrs.src.tag}/NEWS";
     description = "Tools to extract documentation embedded in GTK and GNOME source code";
     homepage = "https://gitlab.gnome.org/GNOME/gtk-doc";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ pSub ];
     teams = [ lib.teams.gnome ];
   };
-}
+})

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -3,7 +3,6 @@
   lib,
   stdenv,
   fetchurl,
-  nixos,
   testers,
   versionCheckHook,
   hello,

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
   ];
 
+  strictDeps = true;
+
   doCheck = true;
 
   doInstallCheck = true;

--- a/pkgs/by-name/he/help2man/package.nix
+++ b/pkgs/by-name/he/help2man/package.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     chmod +x $out/bin/help2man
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Generate man pages from `--help' output";
     mainProgram = "help2man";

--- a/pkgs/by-name/jq/jq/package.nix
+++ b/pkgs/by-name/jq/jq/package.nix
@@ -117,6 +117,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://github.com/jqlang/jq/releases/tag/jq-${finalAttrs.version}";
     description = "Lightweight and flexible command-line JSON processor";

--- a/pkgs/by-name/js/json_c/package.nix
+++ b/pkgs/by-name/js/json_c/package.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeBool "BUILD_APPS" false)
   ];

--- a/pkgs/by-name/js/json_c/package.nix
+++ b/pkgs/by-name/js/json_c/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "json-c";
     repo = "json-c";
-    rev = "json-c-0.18-20240915";
+    tag = "json-c-0.18-20240915";
     hash = "sha256-UyMXr8Vc6kDOx1/lD2YKPiHdaTotXAF9ak0yQuwrSUA=";
   };
 
@@ -28,6 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_APPS" false)
   ];
+
+  __structuredAttrs = true;
 
   meta = {
     description = "JSON implementation in C";

--- a/pkgs/by-name/ke/keyutils/package.nix
+++ b/pkgs/by-name/ke/keyutils/package.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = lib.optionals stdenv.hostPlatform.isStatic [ "NO_SOLIB=1" ];
 
+  strictDeps = true;
+
   outputs = [
     "out"
     "lib"

--- a/pkgs/by-name/ke/keyutils/package.nix
+++ b/pkgs/by-name/ke/keyutils/package.nix
@@ -70,6 +70,8 @@ stdenv.mkDerivation (finalAttrs: {
     "USRLIBDIR=$(lib)/lib"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://people.redhat.com/dhowells/keyutils/";
     description = "Tools used to control the Linux kernel key management system";

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -142,6 +142,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "http://libarchive.org";
     description = "Multi-format archive and compression library";

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -108,6 +108,8 @@ stdenv.mkDerivation (finalAttrs: {
     acl
   ];
 
+  strictDeps = true;
+
   hardeningDisable = [
     "strictflexarrays3"
   ]

--- a/pkgs/by-name/li/libedit/package.nix
+++ b/pkgs/by-name/li/libedit/package.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
   ];
 
+  strictDeps = true;
+
   # GCC automatically include `stdc-predefs.h` while Clang does not do this by
   # default. While Musl is ISO 10646 compliant, it does not define
   # __STDC_ISO_10646__.

--- a/pkgs/by-name/li/libedit/package.nix
+++ b/pkgs/by-name/li/libedit/package.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
       xargs sed -i -e 's,-lncurses[a-z]*,-L${ncurses.out}/lib -lncursesw,g'
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "http://www.thrysoee.dk/editline/";
     changelog = "https://www.thrysoee.dk/editline/#changelog";

--- a/pkgs/by-name/li/libev/package.nix
+++ b/pkgs/by-name/li/libev/package.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
       "LDFLAGS+=-lws2_32"
     ]);
 
+  __structuredAttrs = true;
+
   meta = {
     description = "High-performance event loop/event model with lots of features";
     homepage = "https://software.schmorp.de/pkg/libev.html";

--- a/pkgs/by-name/li/libev/package.nix
+++ b/pkgs/by-name/li/libev/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
 
+  strictDeps = true;
+
   configureFlags = lib.optional static "LDFLAGS=-static";
 
   makeFlags =

--- a/pkgs/by-name/li/libevent/package.nix
+++ b/pkgs/by-name/li/libevent/package.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     lib.optional sslSupport openssl ++ lib.optional stdenv.hostPlatform.isCygwin findutils;
 
+  strictDeps = true;
+
   doCheck = false; # needs the net
 
   postInstall = lib.optionalString sslSupport ''

--- a/pkgs/by-name/li/libevent/package.nix
+++ b/pkgs/by-name/li/libevent/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Don't define BIO_get_init() for LibreSSL 3.5+
     (fetchpatch {
       url = "https://github.com/libevent/libevent/commit/883630f76cbf512003b81de25cd96cb75c6cf0f9.patch";
-      sha256 = "sha256-VPJqJUAovw6V92jpqIXkIR1xYGbxIWxaHr8cePWI2SU=";
+      hash = "sha256-VPJqJUAovw6V92jpqIXkIR1xYGbxIWxaHr8cePWI2SU=";
     })
   ];
 
@@ -71,6 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   enableParallelBuilding = true;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Event notification library";

--- a/pkgs/by-name/li/libffiReal/package.nix
+++ b/pkgs/by-name/li/libffiReal/package.nix
@@ -73,6 +73,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Foreign function call interface library";
     longDescription = ''

--- a/pkgs/by-name/li/libgcrypt/package.nix
+++ b/pkgs/by-name/li/libgcrypt/package.nix
@@ -16,12 +16,12 @@
 
 assert enableCapabilities -> stdenv.hostPlatform.isLinux;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgcrypt";
   version = "1.12.2";
 
   src = fetchurl {
-    url = "mirror://gnupg/libgcrypt/${pname}-${version}.tar.bz2";
+    url = "mirror://gnupg/libgcrypt/libgcrypt-${finalAttrs.version}.tar.bz2";
     hash = "sha256-fOM8JJIiGgQ2+WqFACFenz49y1/SanV81BXnqEO6vV4=";
   };
 
@@ -118,13 +118,15 @@ stdenv.mkDerivation rec {
     inherit gnupg libotr rsyslog;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/libgcrypt/";
-    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=${pname}.git;a=blob;f=NEWS;hb=refs/tags/${pname}-${version}";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob;f=NEWS;hb=refs/tags/libgcrypt-${finalAttrs.version}";
     description = "General-purpose cryptographic library";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
     maintainers = [ ];
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" finalAttrs.version;
   };
-}
+})

--- a/pkgs/by-name/li/libgpg-error/package.nix
+++ b/pkgs/by-name/li/libgpg-error/package.nix
@@ -102,6 +102,8 @@ stdenv.mkDerivation (
 
     doCheck = true; # not cross
 
+    __structuredAttrs = true;
+
     meta = {
       homepage = "https://www.gnupg.org/software/libgpg-error/index.html";
       changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=NEWS;hb=refs/tags/libgpg-error-${version}";

--- a/pkgs/by-name/li/libgpg-error/package.nix
+++ b/pkgs/by-name/li/libgpg-error/package.nix
@@ -81,6 +81,8 @@ stdenv.mkDerivation (
       gettext
     ];
 
+    strictDeps = true;
+
     postConfigure =
       # For some reason, /bin/sh on OpenIndiana leads to this at the end of the
       # `config.status' run:

--- a/pkgs/by-name/li/libidn/package.nix
+++ b/pkgs/by-name/li/libidn/package.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
 
+  strictDeps = true;
+
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = {

--- a/pkgs/by-name/li/libidn/package.nix
+++ b/pkgs/by-name/li/libidn/package.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://codeberg.org/libidn/libidn/src/tag/v${finalAttrs.version}/NEWS";
     homepage = "https://www.gnu.org/software/libidn/";

--- a/pkgs/by-name/li/libmpc/package.nix
+++ b/pkgs/by-name/li/libmpc/package.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true; # not cross;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for multiprecision complex arithmetic with exact rounding";
 

--- a/pkgs/by-name/li/libpfm/package.nix
+++ b/pkgs/by-name/li/libpfm/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Helper library to program the performance monitoring events";
     longDescription = ''

--- a/pkgs/by-name/li/libpfm/package.nix
+++ b/pkgs/by-name/li/libpfm/package.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = lib.optional stdenv.hostPlatform.isMinGW windows.libgnurx;
 
+  strictDeps = true;
+
   meta = {
     description = "Helper library to program the performance monitoring events";
     longDescription = ''

--- a/pkgs/by-name/li/libpsl/package.nix
+++ b/pkgs/by-name/li/libpsl/package.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     libxslt
   ];
 
+  strictDeps = true;
+
   propagatedBuildInputs = [
     publicsuffix-list
   ];

--- a/pkgs/by-name/li/libpsl/package.nix
+++ b/pkgs/by-name/li/libpsl/package.nix
@@ -85,6 +85,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "C library for the Publix Suffix List";
     longDescription = ''

--- a/pkgs/by-name/li/libssh2/package.nix
+++ b/pkgs/by-name/li/libssh2/package.nix
@@ -126,6 +126,8 @@ stdenv.mkDerivation (finalAttrs: {
     curl = (curl.override { scpSupport = true; }).tests.withCheck;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Client-side C library implementing the SSH2 protocol";
     homepage = "https://www.libssh2.org";

--- a/pkgs/by-name/li/libssh2/package.nix
+++ b/pkgs/by-name/li/libssh2/package.nix
@@ -114,6 +114,8 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [ openssl ]; # see Libs: in libssh2.pc
   buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64;
 
+  strictDeps = true;
+
   passthru.tests = {
     inherit
       aria2

--- a/pkgs/by-name/li/libtasn1/package.nix
+++ b/pkgs/by-name/li/libtasn1/package.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit gnutls samba qemu;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/libtasn1/";
     description = "ASN.1 library";

--- a/pkgs/by-name/li/libtasn1/package.nix
+++ b/pkgs/by-name/li/libtasn1/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
     perl
   ];
 
+  strictDeps = true;
+
   doCheck = true;
   preCheck =
     if stdenv.hostPlatform.isDarwin then "export DYLD_LIBRARY_PATH=`pwd`/lib/.libs" else null;

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -162,6 +162,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
+  strictDeps = true;
+
   # This is part of the Darwin bootstrap, so we don’t always get
   # `libutil.dylib` automatically propagated through the SDK.
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -211,6 +211,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Multi-platform support library with a focus on asynchronous I/O";
     homepage = "https://libuv.org/";

--- a/pkgs/by-name/li/libxslt/package.nix
+++ b/pkgs/by-name/li/libxslt/package.nix
@@ -97,6 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://gitlab.gnome.org/GNOME/libxslt";
     description = "C library and tools to do XSL transformations";

--- a/pkgs/by-name/lz/lzip/package.nix
+++ b/pkgs/by-name/lz/lzip/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
   strictDeps = true;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.nongnu.org/lzip/lzip.html";
     description = "Lossless data compressor based on the LZMA algorithm";

--- a/pkgs/by-name/lz/lzo/package.nix
+++ b/pkgs/by-name/lz/lzo/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Real-time data (de)compression library";
     longDescription = ''

--- a/pkgs/by-name/lz/lzo/package.nix
+++ b/pkgs/by-name/lz/lzo/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://www.oberhumer.com/opensource/lzo/download/lzo-${finalAttrs.version}.tar.gz";
-    sha256 = "0wm04519pd3g8hqpjqhfr72q8qmbiwqaxcs3cndny9h86aa95y60";
+    hash = "sha256-wPiSlDIIJm+bZUOzrjCPq2KExckOYnkxRG+0m0IhoHI=";
   };
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];

--- a/pkgs/by-name/ma/mailcap/package.nix
+++ b/pkgs/by-name/ma/mailcap/package.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-mkAyIC/A0rCFj0GxZzianP5SrCTsKC5kebkHZTGd4RM=";
   };
 
+  strictDeps = true;
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/ma/mailcap/package.nix
+++ b/pkgs/by-name/ma/mailcap/package.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests.nginx-mime = nixosTests.nginx-mime;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Helper application and MIME type associations for file types";
     homepage = "https://pagure.io/mailcap";

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -14,7 +14,7 @@
   zlib,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "meson";
   version = "1.10.2";
   format = "setuptools";
@@ -22,7 +22,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mesonbuild";
     repo = "meson";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-3Zeavn6aW6920gM7yE73Ms1RPCP2GjX9IUL9YGmISfY=";
   };
 
@@ -176,6 +176,8 @@ python3.pkgs.buildPythonApplication rec {
   setupHook = ./setup-hook.sh;
   env.hostPlatform = stdenv.targetPlatform.system;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://mesonbuild.com";
     description = "Open source, fast and friendly build system made in Python";
@@ -193,5 +195,5 @@ python3.pkgs.buildPythonApplication rec {
     maintainers = with lib.maintainers; [ qyliss ];
     inherit (python3.meta) platforms;
   };
-}
+})
 # TODO: a more Nixpkgs-tailoired test suite

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -106,6 +106,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     libblocksruntime
   ];
 
+  strictDeps = true;
+
   checkPhase = lib.concatStringsSep "\n" (
     [
       "runHook preCheck"

--- a/pkgs/by-name/mp/mpdecimal/package.nix
+++ b/pkgs/by-name/mp/mpdecimal/package.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
     echo -n $cxx >> $dev/nix-support/propagated-build-inputs
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for arbitrary precision decimal floating point arithmetic";
 

--- a/pkgs/by-name/mp/mpdecimal/package.nix
+++ b/pkgs/by-name/mp/mpdecimal/package.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ autoreconfHook ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   postInstall = ''

--- a/pkgs/by-name/mp/mpfr/package.nix
+++ b/pkgs/by-name/mp/mpfr/package.nix
@@ -12,14 +12,14 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "4.2.2";
   pname = "mpfr";
 
   src = fetchurl {
     urls = [
-      "https://www.mpfr.org/${pname}-${version}/${pname}-${version}.tar.xz"
-      "mirror://gnu/mpfr/${pname}-${version}.tar.xz"
+      "https://www.mpfr.org/mpfr-${finalAttrs.version}/mpfr-${finalAttrs.version}.tar.xz"
+      "mirror://gnu/mpfr/mpfr-${finalAttrs.version}.tar.xz"
     ];
     hash = "sha256-tnugOD736KhWNzTi6InvXsPDuJigHQD6CmhprYHGzgE=";
   };
@@ -67,9 +67,11 @@ stdenv.mkDerivation rec {
       # Expect the text in format of '<title>GNU MPFR version 4.1.1</title>'
       new_version="$(curl -s https://www.mpfr.org/mpfr-current/ |
           pcre2grep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
-      update-source-version ${pname} "$new_version"
+      update-source-version ${finalAttrs.pname} "$new_version"
     '';
   };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://www.mpfr.org/";
@@ -92,4 +94,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/mu/musl-fts/package.nix
+++ b/pkgs/by-name/mu/musl-fts/package.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/by-name/mu/musl-fts/package.nix
+++ b/pkgs/by-name/mu/musl-fts/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "void-linux";
     repo = "musl-fts";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "Azw5qrz6OKDcpYydE6jXzVxSM5A8oYWAztrHr+O/DOE=";
   };
 
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   enableParallelBuilding = true;
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://github.com/void-linux/musl-fts";

--- a/pkgs/by-name/mu/musl-obstack/package.nix
+++ b/pkgs/by-name/mu/musl-obstack/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/by-name/mu/musl-obstack/package.nix
+++ b/pkgs/by-name/mu/musl-obstack/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "void-linux";
     repo = "musl-obstack";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-oydS7FubUniMHAUWfg84OH9+CZ0JCrTXy7jzwOyJzC8=";
   };
 
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   enableParallelBuilding = true;
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://github.com/void-linux/musl-obstack";

--- a/pkgs/by-name/mu/musl/package.nix
+++ b/pkgs/by-name/mu/musl/package.nix
@@ -176,6 +176,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.linuxHeaders = linuxHeaders;
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     description = "Efficient, small, quality libc implementation";
     homepage = "https://musl.libc.org/";

--- a/pkgs/by-name/ng/nghttp2/package.nix
+++ b/pkgs/by-name/ng/nghttp2/package.nix
@@ -77,6 +77,8 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals enablePython [ python3 ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   configureFlags = [

--- a/pkgs/by-name/ng/nghttp2/package.nix
+++ b/pkgs/by-name/ng/nghttp2/package.nix
@@ -42,12 +42,12 @@ assert enableHpack -> enableApp;
 assert enableHttp3 -> enableApp;
 assert enableJemalloc -> enableApp;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nghttp2";
   version = "1.69.0";
 
   src = fetchurl {
-    url = "https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.bz2";
+    url = "https://github.com/nghttp2/nghttp2/releases/download/v${finalAttrs.version}/nghttp2-${finalAttrs.version}.tar.bz2";
     hash = "sha256-PxhfWxw+d4heuc8/LE2ksan3OiS/WVe4KRg60Tf4Lcg=";
   };
 
@@ -118,6 +118,8 @@ stdenv.mkDerivation rec {
     inherit curl libsoup_3;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "HTTP/2 C library and tools";
     longDescription = ''
@@ -131,10 +133,10 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://nghttp2.org/";
-    changelog = "https://github.com/nghttp2/nghttp2/releases/tag/v${version}";
+    changelog = "https://github.com/nghttp2/nghttp2/releases/tag/v${finalAttrs.version}";
     # News articles with changes summary can be found here: https://nghttp2.org/blog/archives/
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_SHARED_LIB" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "ENABLE_STATIC_LIB" stdenv.hostPlatform.isStatic)

--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit curl;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/ngtcp2/nghttp3";
     changelog = "https://github.com/ngtcp2/nghttp3/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/ni/ninja/package.nix
+++ b/pkgs/by-name/ni/ninja/package.nix
@@ -114,6 +114,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Small build system with a focus on speed";
     mainProgram = "ninja";

--- a/pkgs/by-name/ni/ninja/package.nix
+++ b/pkgs/by-name/ni/ninja/package.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
     libxslt.bin
   ];
 
+  strictDeps = true;
+
   patches = [
     ./0001-spawn-sh-instead-of-bin-sh.patch
   ]

--- a/pkgs/by-name/on/oniguruma/package.nix
+++ b/pkgs/by-name/on/oniguruma/package.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
   outputBin = "dev"; # onig-config
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  strictDeps = true;
+
   configureFlags = [ "--enable-posix-api=yes" ];
 
   meta = {

--- a/pkgs/by-name/on/oniguruma/package.nix
+++ b/pkgs/by-name/on/oniguruma/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Note: do not use fetchpatch or fetchFromGitHub to keep this package available in __bootPackages
   src = fetchurl {
     url = "https://github.com/kkos/oniguruma/releases/download/v${finalAttrs.version}/onig-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-Klz8WuJZ5Ol/hraN//wVLNr/6U4gYLdwy4JyONdp/AU=";
+    hash = "sha256-Klz8WuJZ5Ol/hraN//wVLNr/6U4gYLdwy4JyONdp/AU=";
   };
 
   outputs = [
@@ -27,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   configureFlags = [ "--enable-posix-api=yes" ];
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://github.com/kkos/oniguruma";

--- a/pkgs/by-name/p1/p11-kit/package.nix
+++ b/pkgs/by-name/p1/p11-kit/package.nix
@@ -14,14 +14,14 @@
   libintl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "p11-kit";
   version = "0.26.2";
 
   src = fetchFromGitHub {
     owner = "p11-glue";
     repo = "p11-kit";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-qFanbp0KPc6+CN4s5mMQNduzcxt/SrMcYWvIMZ0XnGY=";
     fetchSubmodules = true;
   };
@@ -82,6 +82,8 @@ stdenv.mkDerivation rec {
     fi
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for loading and sharing PKCS#11 modules";
     longDescription = ''
@@ -91,8 +93,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://p11-glue.github.io/p11-glue/p11-kit.html";
     changelog = [
-      "https://github.com/p11-glue/p11-kit/raw/${version}/NEWS"
-      "https://github.com/p11-glue/p11-kit/releases/tag/${version}"
+      "https://github.com/p11-glue/p11-kit/raw/${finalAttrs.version}/NEWS"
+      "https://github.com/p11-glue/p11-kit/releases/tag/${finalAttrs.version}"
     ];
     platforms = lib.platforms.all;
     badPlatforms = [
@@ -101,6 +103,6 @@ stdenv.mkDerivation rec {
     ];
     license = lib.licenses.bsd3;
     mainProgram = "p11-kit";
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "p11-kit_project" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "p11-kit_project" finalAttrs.version;
   };
-}
+})

--- a/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
+++ b/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
@@ -77,6 +77,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''rm -f "$out"/bin/*-pkg-config''; # clean the duplicate file
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Tool that allows packages to find out information about other packages";
     homepage = "http://pkg-config.freedesktop.org/wiki/";

--- a/pkgs/by-name/pu/publicsuffix-list/package.nix
+++ b/pkgs/by-name/pu/publicsuffix-list/package.nix
@@ -18,6 +18,8 @@ stdenvNoCC.mkDerivation {
 
   dontBuild = true;
 
+  strictDeps = true;
+
   installPhase = ''
     runHook preInstall
 
@@ -27,6 +29,8 @@ stdenvNoCC.mkDerivation {
   '';
 
   passthru.updateScript = unstableGitUpdater { };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://publicsuffix.org/";

--- a/pkgs/by-name/re/re2c/package.nix
+++ b/pkgs/by-name/re/re2c/package.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
+  strictDeps = true;
+
   doCheck = true;
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/re/re2c/package.nix
+++ b/pkgs/by-name/re/re2c/package.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Tool for writing very fast and very flexible scanners";
     homepage = "https://re2c.org";

--- a/pkgs/by-name/rh/rhash/package.nix
+++ b/pkgs/by-name/rh/rhash/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ which ];
   buildInputs = lib.optionals stdenv.hostPlatform.isFreeBSD [ gettext ];
 
+  strictDeps = true;
+
   # configure script is not autotools-based, doesn't support these options
   dontAddStaticConfigureFlags = true;
 

--- a/pkgs/by-name/rh/rhash/package.nix
+++ b/pkgs/by-name/rh/rhash/package.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "rhash";
     repo = "RHash";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-9/kFI38PG3AKsdDqEV/wEzSel9IlQQ/pvOyhU/N/aV0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9/kFI38PG3AKsdDqEV/wEzSel9IlQQ/pvOyhU/N/aV0=";
   };
 
   nativeBuildInputs = [ which ];
@@ -47,6 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (!enableStatic) [
     "install-lib-so-link"
   ];
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://rhash.sourceforge.net/";

--- a/pkgs/by-name/st/strace/package.nix
+++ b/pkgs/by-name/st/strace/package.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
     rev-prefix = "v";
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://strace.io/";
     description = "System call tracer for Linux";

--- a/pkgs/by-name/st/strace/package.nix
+++ b/pkgs/by-name/st/strace/package.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   # libunwind for -k.

--- a/pkgs/by-name/sw/swig/package.nix
+++ b/pkgs/by-name/sw/swig/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "swig";
     repo = "swig";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-jsi83v9sg0n5kUfDACqdNAS2VuLSyxv+pe2LRcO4Khc=";
   };
 
@@ -42,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   enableParallelBuilding = true;
+
+  __structuredAttrs = true;
 
   meta = {
     changelog = "https://github.com/swig/swig/blob/${finalAttrs.src.rev}/CHANGES.current";

--- a/pkgs/by-name/tz/tzdata/package.nix
+++ b/pkgs/by-name/tz/tzdata/package.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   propagatedBuildOutputs = [ ];
 
+  strictDeps = true;
+
   makeFlags = [
     "TOPDIR=${placeholder "out"}"
     "TZDIR=${placeholder "out"}/share/zoneinfo"
@@ -112,6 +114,8 @@ stdenv.mkDerivation (finalAttrs: {
   # Upstream provides patches very quickly, we just need to apply them until the next
   # minor releases.
   passthru.tests = postgresql;
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "http://www.iana.org/time-zones";

--- a/pkgs/by-name/un/unbound/package.nix
+++ b/pkgs/by-name/un/unbound/package.nix
@@ -234,6 +234,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Validating, recursive, and caching DNS resolver";
     license = lib.licenses.bsd3;

--- a/pkgs/by-name/un/unbound/package.nix
+++ b/pkgs/by-name/un/unbound/package.nix
@@ -99,6 +99,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withDoQ [ ngtcp2 ]
   ++ lib.optionals withPythonModule [ python ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   configureFlags = [

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -7,12 +7,14 @@
   libnatspec,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "unzip";
   version = "6.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/infozip/unzip${lib.replaceStrings [ "." ] [ "" ] version}.tar.gz";
+    url = "mirror://sourceforge/infozip/unzip${
+      lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }.tar.gz";
     sha256 = "0dxx11knh3nk95p2gg2ak777dd11pr7jx5das2g49l262scrcv83";
   };
 
@@ -107,6 +109,8 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "http://www.info-zip.org";
     description = "Extraction utility for archives compressed in .zip format";
@@ -115,4 +119,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ RossComputerGuy ];
     mainProgram = "unzip";
   };
-}
+})

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -73,6 +73,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ bzip2 ];
   buildInputs = [ bzip2 ] ++ lib.optional enableNLS libnatspec;
 
+  strictDeps = true;
+
   makefile = "unix/Makefile";
 
   env = {

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -171,6 +171,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals ncursesSupport [ ncurses ]
   ++ lib.optionals systemdSupport [ systemdLibs ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   postInstall = ''

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -231,6 +231,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.kernel.org/pub/linux/utils/util-linux/";
     description = "Set of system utilities for Linux";

--- a/pkgs/by-name/zl/zlib-ng/package.nix
+++ b/pkgs/by-name/zl/zlib-ng/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "zlib-ng";
     repo = "zlib-ng";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-6GlHCnx9dQtmViPnvHnMS+l9Z+g6M8ynrSxLhLtmAKU=";
   };
 
@@ -45,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DINSTALL_UTILS=OFF"
   ]
   ++ lib.optionals withZlibCompat [ "-DZLIB_COMPAT=ON" ];
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Zlib data compression library for the next generation systems";

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ unzip ];
   propagatedNativeBuildInputs = [ findXMLCatalogs ];
 
+  strictDeps = true;
+
   unpackPhase = ''
     mkdir -p $out/xml/dtd/docbook
     cd $out/xml/dtd/docbook

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     branch = version;
     platforms = lib.platforms.unix;

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -21,12 +21,12 @@ let
     }:
     let
       legacySuffix = lib.optionalString (suffix != "-nons") "-ns";
-      self = stdenv.mkDerivation rec {
+      self = stdenv.mkDerivation (finalAttrs: {
         inherit pname;
         version = "1.79.2";
 
         src = fetchurl {
-          url = "https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F${version}/docbook-xsl${suffix}-${version}.tar.bz2";
+          url = "https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F${finalAttrs.version}/docbook-xsl${suffix}-${finalAttrs.version}.tar.bz2";
           inherit sha256;
         };
 
@@ -50,7 +50,8 @@ let
 
           # Add legacy sourceforge.net URIs to the catalog
           (replaceVars ./catalog-legacy-uris.patch {
-            inherit legacySuffix suffix version;
+            inherit legacySuffix suffix;
+            inherit (finalAttrs) version;
           })
         ]
         ++ lib.optionals withManOptDedupPatch [
@@ -66,7 +67,7 @@ let
         dontBuild = true;
 
         installPhase = ''
-          dst=$out/share/xml/${pname}
+          dst=$out/share/xml/${finalAttrs.pname}
           mkdir -p $dst
           rm -rf RELEASE* README* INSTALL TODO NEWS* BUGS install.sh tools Makefile tests extensions webhelp
           mv * $dst/
@@ -81,8 +82,10 @@ let
 
         passthru.dbtoepub = writeScriptBin "dbtoepub" ''
           #!${bash}/bin/bash
-          exec -a dbtoepub ${ruby}/bin/ruby ${self}/share/xml/${pname}/epub/bin/dbtoepub "$@"
+          exec -a dbtoepub ${ruby}/bin/ruby ${self}/share/xml/${finalAttrs.pname}/epub/bin/dbtoepub "$@"
         '';
+
+        __structuredAttrs = true;
 
         meta = {
           homepage = "https://github.com/docbook/wiki/wiki/DocBookXslStylesheets";
@@ -91,7 +94,7 @@ let
           maintainers = [ ];
           platforms = lib.platforms.all;
         };
-      };
+      });
     in
     self;
 

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -61,6 +61,8 @@ let
 
         propagatedBuildInputs = [ findXMLCatalogs ];
 
+        strictDeps = true;
+
         dontBuild = true;
 
         installPhase = ''

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -320,6 +320,8 @@ pipe
         depsTargetTarget
         ;
 
+      strictDeps = true;
+
       preConfigure = (callFile ./common/pre-configure.nix { }) + ''
         ln -sf ${libxcrypt}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
       '';

--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -95,6 +95,8 @@ let
       updateAutotoolsGnuConfigScriptsHook
     ];
 
+    strictDeps = true;
+
     cmakeFlags = [
       # Projects with tablegen-like tools.
       "-DLLVM_ENABLE_PROJECTS=${

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -252,7 +252,10 @@ stdenv.mkDerivation (
       ]
       ++ lib.optional stdenv.hostPlatform.isSunOS "-Dcc=gcc"
       ++ lib.optional enableThreading "-Dusethreads"
-      ++ lib.optional (!enableCrypt) "-A clear:d_crypt_r"
+      ++ lib.optionals (!enableCrypt) [
+        "-A"
+        "clear:d_crypt_r"
+      ]
       ++ lib.optionals (stdenv.hostPlatform.isFreeBSD && crossCompiling && enableCrypt) [
         # https://github.com/Perl/perl5/issues/22295
         # configure cannot figure out that we have crypt automatically, but we really do
@@ -410,6 +413,8 @@ stdenv.mkDerivation (
       wrapProgram $mini/bin/perl --prefix PERL5LIB : \
         "$mini/lib/perl5/cross_perl/${version}:$out/lib/perl5/${version}:$out/lib/perl5/${version}/$runtimeArch"
     ''; # */
+
+    __structuredAttrs = true;
 
     meta = {
       homepage = "https://www.perl.org/";

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -366,6 +366,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ buildInputs;
 
+  strictDeps = true;
+
   prePatch = optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace configure --replace-fail '`/usr/bin/arch`' '"i386"'
   '';

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -133,6 +133,8 @@ let
       maintainers = with lib.maintainers; [ agbrooks ];
     };
 
+    __structuredAttrs = true;
+
     passthru = rec {
       inherit release version;
       isTcl9 = lib.versions.major version == "9";

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -46,6 +46,8 @@ let
       zlib
     ];
 
+    strictDeps = true;
+
     preConfigure = ''
       cd unix
     '';

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gettext ];
 
+  strictDeps = true;
+
   postPatch = ''
     for script in install-sh include/install-sh; do
       patchShebangs $script

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -10,12 +10,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "attr";
   version = "2.6.0";
 
   src = fetchurl {
-    url = "mirror://savannah/attr/attr-${version}.tar.gz";
+    url = "mirror://savannah/attr/attr-${finalAttrs.version}.tar.gz";
     hash = "sha256-1C+jdFExgLtIyxGkZpb0iCQOUST/HmrYiwq/9waYVhI=";
   };
 
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
   # See nixos/tests/attr.nix
   doCheck = false;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://savannah.nongnu.org/projects/attr/";
     description = "Library and tools for manipulating extended attributes";
@@ -47,6 +49,6 @@ stdenv.mkDerivation rec {
     badPlatforms = lib.platforms.microblaze;
     license = lib.licenses.gpl2Plus;
     teams = [ lib.teams.security-review ];
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "attr_project" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "attr_project" finalAttrs.version;
   };
-}
+})

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -12,12 +12,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gettext";
   version = "1.0";
 
   src = fetchurl {
-    url = "mirror://gnu/gettext/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/gettext/gettext-${finalAttrs.version}.tar.gz";
     hash = "sha256-hdmbecmBpASHTALgNCF2z3XHaY4rUf5BAxz2Um2XTxo=";
   };
   patches = [
@@ -103,6 +103,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   enableParallelChecking = false; # fails sometimes
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Well integrated set of translation tools and documentation";
 
@@ -135,4 +137,4 @@ stdenv.mkDerivation rec {
 
 // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
   makeFlags = [ "CFLAGS=-D_FORTIFY_SOURCE=0" ];
-}
+})

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     "gl_cv_func_wcwidth_works=yes"
   ];
 
+  makeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "CFLAGS=-D_FORTIFY_SOURCE=0"
+  ];
+
   postPatch = ''
     # Older versions of gettext come with a copy of `extern-inline.m4` that is not compatible with clang 18.
     # When a project uses gettext + autoreconfPhase, autoreconfPhase will invoke `autopoint -f`, which will
@@ -133,8 +137,4 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
   };
-}
-
-// lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-  makeFlags = [ "CFLAGS=-D_FORTIFY_SOURCE=0" ];
 })

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -347,6 +347,8 @@ stdenv.mkDerivation (
 
       doCheck = false; # fails
 
+      __structuredAttrs = true;
+
       meta =
 
         {

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -14,19 +14,19 @@
 # files.
 
 let
-  inherit (lib) optional;
+  inherit (lib) optionals;
 in
 
 let
-  self = stdenv.mkDerivation rec {
+  self = stdenv.mkDerivation (finalAttrs: {
     pname = "gmp${lib.optionalString cxx "-with-cxx"}";
     version = "6.3.0";
 
     src = fetchurl {
       # we need to use bz2, others aren't in bootstrapping stdenv
       urls = [
-        "mirror://gnu/gmp/gmp-${version}.tar.bz2"
-        "ftp://ftp.gmplib.org/pub/gmp-${version}/gmp-${version}.tar.bz2"
+        "mirror://gnu/gmp/gmp-${finalAttrs.version}.tar.bz2"
+        "ftp://ftp.gmplib.org/pub/gmp-${finalAttrs.version}/gmp-${finalAttrs.version}.tar.bz2"
       ];
       hash = "sha256-rCghGnz7YJuuLiyNYFjWbI/pZDT3QM9v4uR7AA0cIMs=";
     };
@@ -65,17 +65,26 @@ let
       # broken on multicore CPUs). Avoid this impurity.
       "--build=${stdenv.buildPlatform.config}"
     ]
-    ++ optional (cxx && stdenv.hostPlatform.isDarwin) "CPPFLAGS=-fexceptions"
-    ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.is64bit) "ABI=64"
+    ++ optionals (cxx && stdenv.hostPlatform.isDarwin) [
+      "CPPFLAGS=-fexceptions"
+    ]
+    ++ optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.is64bit) [
+      "ABI=64"
+    ]
     # to build a .dll on windows, we need --disable-static + --enable-shared
     # see https://gmplib.org/manual/Notes-for-Particular-Systems.html
-    ++ optional (!withStatic && stdenv.hostPlatform.isPE) "--disable-static --enable-shared";
+    ++ optionals (!withStatic && stdenv.hostPlatform.isPE) [
+      "--disable-static"
+      "--enable-shared"
+    ];
 
     doCheck = true; # not cross;
 
     dontDisableStatic = withStatic;
 
     enableParallelBuilding = true;
+
+    __structuredAttrs = true;
 
     meta = {
       homepage = "https://gmplib.org/";
@@ -112,6 +121,6 @@ let
       platforms = lib.platforms.all;
       maintainers = with lib.maintainers; [ coolcuber ];
     };
-  };
+  });
 in
 self

--- a/pkgs/development/libraries/isl/generic.nix
+++ b/pkgs/development/libraries/isl/generic.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation {
 
   makeFlags = lib.optional stdenv.hostPlatform.isPE "LDFLAGS=-no-undefined";
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://libisl.sourceforge.io/";
     license = lib.licenses.lgpl21;

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -10,13 +10,13 @@
 
 # assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform != stdenv.buildPlatform; # TODO: improve on cross
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libiconv";
   version = "1.19";
 
   src = fetchurl {
-    url = "mirror://gnu/libiconv/${pname}-${version}.tar.gz";
-    sha256 = "sha256-iN2WqMBGTsoUT8eRrmDNMc2O54Mh5nOX4l/AlcShmqY=";
+    url = "mirror://gnu/libiconv/libiconf-${finalAttrs.version}.tar.gz";
+    hash = "sha256-iN2WqMBGTsoUT8eRrmDNMc2O54Mh5nOX4l/AlcShmqY=";
   };
 
   enableParallelBuilding = true;
@@ -84,7 +84,9 @@ stdenv.mkDerivation rec {
   # remove after gnulib is updated
   ++ lib.optional stdenv.hostPlatform.isCygwin "gl_cv_clean_version_stddef=yes";
 
-  passthru = { inherit setupHooks; };
+  passthru = { inherit (finalAttrs) setupHooks; };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Iconv(3) implementation";
@@ -108,4 +110,4 @@ stdenv.mkDerivation rec {
     # This library is not needed on GNU platforms.
     hydraPlatforms = with lib.platforms; cygwin ++ darwin ++ freebsd;
   };
-}
+})

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   # https://git.savannah.gnu.org/cgit/config.git/commit/?id=e4786449e1c26716e3f9ea182caf472e4dbc96e0
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
 
+  strictDeps = true;
+
   # https://github.com/NixOS/nixpkgs/pull/192630#discussion_r978985593
   hardeningDisable = lib.optional (stdenv.hostPlatform.libc == "bionic") "fortify";
 

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -14,12 +14,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libidn2";
   version = "2.3.8";
 
   src = fetchurl {
-    url = "https://ftp.gnu.org/gnu/libidn/libidn2-${version}.tar.gz";
+    url = "https://ftp.gnu.org/gnu/libidn/libidn2-${finalAttrs.version}.tar.gz";
     hash = "sha256-9VeRG/YXFiHh9y/zX1sYJbs1tS7UUyXc3ukx5dPAeHo=";
   };
 
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ libunistring ] ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/libidn/#libidn2";
     description = "Free software implementation of IDNA2008 and TR46";
@@ -65,6 +67,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ fpletz ];
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;
   };
-}
+})

--- a/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
+++ b/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
@@ -4,7 +4,6 @@
   libidn2,
   libunistring,
   runCommandLocal,
-  patchelf,
 }:
 # Construct a copy of libidn2.* where all (transitive) libc references (in .bin)
 # get replaced by a new one, so that there's no reference to bootstrap tools.

--- a/pkgs/development/libraries/libmicrohttpd/generic.nix
+++ b/pkgs/development/libraries/libmicrohttpd/generic.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
   # Disabled because the tests can time-out.
   doCheck = false;
 
+  __structuredAttrs = true;
+
   meta =
 
     {

--- a/pkgs/development/libraries/libmicrohttpd/generic.nix
+++ b/pkgs/development/libraries/libmicrohttpd/generic.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
     libintl
   ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   preCheck = ''

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -5,7 +5,6 @@
   libiconv,
   libiconvReal,
   updateAutotoolsGnuConfigScriptsHook,
-  darwin,
 }@args:
 
 let

--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "libunwind";
     repo = "libunwind";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ed+FUPApDxNHxznXMhiTeNr8yRxRDSCyJJdIhouGNho=";
   };
 
@@ -65,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     package = finalAttrs.finalPackage;
     versionCheck = true;
   };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://www.nongnu.org/libunwind";

--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ autoreconfHook ];
 
+  strictDeps = true;
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   perl,
   # Update the enabled crypt scheme ids in passthru when the enabled hashes change
   enableHashes ? "strong",

--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -62,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     perl
   ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
 
   doCheck = true;

--- a/pkgs/development/libraries/libxml2/common.nix
+++ b/pkgs/development/libraries/libxml2/common.nix
@@ -153,6 +153,8 @@ stdenv'.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://gitlab.gnome.org/GNOME/libxml2";
     description = "XML parsing library for C";

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -259,6 +259,8 @@ stdenv.mkDerivation (finalAttrs: {
     execer cannot bin/{reset,tput,tset}
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/ncurses/";
     description = "Free software emulation of curses in SVR4 and more";

--- a/pkgs/development/libraries/nettle/generic.nix
+++ b/pkgs/development/libraries/nettle/generic.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation {
 
   patches = lib.optional (stdenv.hostPlatform.system == "i686-cygwin") ./cygwin.patch;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Cryptographic library";
 

--- a/pkgs/development/libraries/nettle/generic.nix
+++ b/pkgs/development/libraries/nettle/generic.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ gnum4 ];
   propagatedBuildInputs = [ gmp ];
 
+  strictDeps = true;
+
   configureFlags =
     # runtime selection of HW-accelerated code; it's default since 3.7
     [ "--enable-fat" ]

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit curl;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/ngtcp2/ngtcp2";
     changelog = "https://github.com/ngtcp2/ngtcp2/releases/tag/v${finalAttrs.version}";

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withJemalloc jemalloc;
 
+  strictDeps = true;
+
   cmakeFlags = [
     # The examples try to link against `ngtcp2_crypto_ossl` and `ngtcp2` libraries.
     # This works in the dynamic case where the targets have the same name, but not here where they're suffixed with `_static`.

--- a/pkgs/development/libraries/ngtcp2/gnutls.nix
+++ b/pkgs/development/libraries/ngtcp2/gnutls.nix
@@ -11,14 +11,14 @@
   curlWithGnuTls,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
   version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = "ngtcp2";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BBV4nNtSWQOFuwVOeH3LJEUeF7v4LVhGbfcrkroBAvc=";
   };
 
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
     inherit curlWithGnuTls;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/ngtcp2/ngtcp2";
     description = "Effort to implement RFC9000 QUIC protocol";
@@ -52,7 +54,7 @@ stdenv.mkDerivation rec {
       vcunat # for knot-dns
     ];
   };
-}
+})
 
 /*
   Why split from ./default.nix?

--- a/pkgs/development/libraries/ngtcp2/gnutls.nix
+++ b/pkgs/development/libraries/ngtcp2/gnutls.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ gnutls ];
 
+  strictDeps = true;
+
   configureFlags = [ "--with-gnutls=yes" ];
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/readline/7.0.nix
+++ b/pkgs/development/libraries/readline/7.0.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-std=gnu17";
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for interactive line editing";
 

--- a/pkgs/development/libraries/readline/8.3.nix
+++ b/pkgs/development/libraries/readline/8.3.nix
@@ -97,6 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/lib/libreadline.so* $out/lib/libreadline.so
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for interactive line editing";
 

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation rec {
     ncurses
   ];
 
+  strictDeps = true;
+
   # required for aarch64 but applied for all arches for simplicity
   preConfigure = ''
     patchShebangs configure

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -26,18 +26,18 @@ let
   archiveVersion = import ./archive-version.nix lib;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sqlite${lib.optionalString interactive "-interactive"}";
   version = "3.53.3";
 
   # nixpkgs-update: no auto update
   # NB! Make sure to update ./tools.nix src (in the same directory).
   src = fetchurl {
-    url = "https://sqlite.org/2026/sqlite-src-${archiveVersion version}.zip";
+    url = "https://sqlite.org/2026/sqlite-src-${archiveVersion finalAttrs.version}.zip";
     hash = "sha256-u4C/ijv/wZJBzoq6WkvHTpw5gAE8sLXw8JdqmVFpQq8=";
   };
   docsrc = fetchurl {
-    url = "https://sqlite.org/2026/sqlite-doc-${archiveVersion version}.zip";
+    url = "https://sqlite.org/2026/sqlite-doc-${archiveVersion finalAttrs.version}.zip";
     hash = "sha256-Fo+Zhph2vPTbjZPvoqSDqcgVNlN9AZAMWM110KZ8yic=";
   };
 
@@ -130,7 +130,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $doc/share/doc
     unzip $docsrc
-    mv sqlite-doc-${archiveVersion version} $doc/share/doc/sqlite
+    mv sqlite-doc-${archiveVersion finalAttrs.version} $doc/share/doc/sqlite
   '';
 
   # SQLite’s tests are unreliable on Darwin. Sometimes they run successfully, but often they do not.
@@ -158,8 +158,12 @@ stdenv.mkDerivation rec {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
-    changelog = "https://www.sqlite.org/releaselog/${lib.replaceStrings [ "." ] [ "_" ] version}.html";
+    changelog = "https://www.sqlite.org/releaselog/${
+      lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
+    }.html";
     description = "Self-contained, serverless, zero-configuration, transactional SQL database engine";
     downloadPage = "https://sqlite.org/download.html";
     homepage = "https://www.sqlite.org/";
@@ -169,6 +173,6 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.security-review ];
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     pkgConfigModules = [ "sqlite3" ];
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "sqlite" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "sqlite" finalAttrs.version;
   };
-}
+})

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -161,6 +161,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit minizip;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://zlib.net";
     description = "Lossless data-compression library";

--- a/pkgs/development/python-modules/bootstrap/build/default.nix
+++ b/pkgs/development/python-modules/bootstrap/build/default.nix
@@ -37,6 +37,9 @@ let
 
           runHook postInstall
         '';
+
+        strictDeps = true;
+        __structuredAttrs = true;
       }
       // attrs
     );

--- a/pkgs/development/python-modules/bootstrap/flit-core/default.nix
+++ b/pkgs/development/python-modules/bootstrap/flit-core/default.nix
@@ -31,4 +31,7 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
 }

--- a/pkgs/development/python-modules/bootstrap/installer/default.nix
+++ b/pkgs/development/python-modules/bootstrap/installer/default.nix
@@ -31,4 +31,7 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
 }

--- a/pkgs/development/python-modules/bootstrap/packaging/default.nix
+++ b/pkgs/development/python-modules/bootstrap/packaging/default.nix
@@ -28,4 +28,7 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
 }

--- a/pkgs/development/tools/misc/autoconf/2.69.nix
+++ b/pkgs/development/tools/misc/autoconf/2.69.nix
@@ -6,12 +6,12 @@
   perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "autoconf";
   version = "2.69";
 
   src = fetchurl {
-    url = "mirror://gnu/autoconf/autoconf-${version}.tar.xz";
+    url = "mirror://gnu/autoconf/autoconf-${finalAttrs.version}.tar.xz";
     sha256 = "113nlmidxy9kjr45kg9x3ngar4951mvag1js2a3j8nxcz34wxsv4";
   };
 
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = false; # fails
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/autoconf/";
     description = "Part of the GNU Build System";
@@ -59,4 +61,4 @@ stdenv.mkDerivation rec {
 
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tools/misc/autoconf/2.69.nix
+++ b/pkgs/development/tools/misc/autoconf/2.69.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ m4 ];
 
+  strictDeps = true;
+
   # Work around a known issue in Cygwin.  See
   # http://thread.gmane.org/gmane.comp.sysutils.autoconf.bugs/6822 for
   # details.

--- a/pkgs/development/tools/misc/autoconf/2.69.nix
+++ b/pkgs/development/tools/misc/autoconf/2.69.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnu/autoconf/autoconf-${finalAttrs.version}.tar.xz";
-    sha256 = "113nlmidxy9kjr45kg9x3ngar4951mvag1js2a3j8nxcz34wxsv4";
+    hash = "sha256-ZOvOyfisWySHElqGp3YNJZGsnh09vVlIljP53mKldoQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -12,7 +12,7 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "autoconf";
   version = "2.73";
   outputs = [
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnu/autoconf/autoconf-${version}.tar.xz";
+    url = "mirror://gnu/autoconf/autoconf-${finalAttrs.version}.tar.xz";
     hash = "sha256-n9ZyschCX6wvpn+gR3uZCYcmi5D/NtXwFtrle+DWtS4=";
   };
 
@@ -57,6 +57,8 @@ stdenv.mkDerivation rec {
     export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/autoconf/";
     description = "Part of the GNU Build System";
@@ -75,4 +77,4 @@ stdenv.mkDerivation rec {
 
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tools/misc/automake/automake-1.16.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.16.x.nix
@@ -7,12 +7,12 @@
   updateAutotoolsGnuConfigScriptsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "automake";
   version = "1.16.5";
 
   src = fetchurl {
-    url = "mirror://gnu/automake/automake-${version}.tar.xz";
+    url = "mirror://gnu/automake/automake-${finalAttrs.version}.tar.xz";
     sha256 = "0sdl32qxdy7m06iggmkkvf7j520rmmgbsjzbm7fgnxwxdp6mh7gh";
   };
 
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
   # "fixed" path in generated files!
   dontPatchShebangs = true;
 
+  __structuredAttrs = true;
+
   meta = {
     branch = "1.16";
     homepage = "https://www.gnu.org/software/automake/";
@@ -48,4 +50,4 @@ stdenv.mkDerivation rec {
     '';
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tools/misc/automake/automake-1.16.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.16.x.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnu/automake/automake-${finalAttrs.version}.tar.xz";
-    sha256 = "0sdl32qxdy7m06iggmkkvf7j520rmmgbsjzbm7fgnxwxdp6mh7gh";
+    hash = "sha256-8B1YzW2dd/vcqetLvV6tGYgij9tz1veiAfX41rEYtGk=";
   };
 
   strictDeps = true;

--- a/pkgs/development/tools/misc/automake/automake-1.18.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.18.x.nix
@@ -7,12 +7,12 @@
   updateAutotoolsGnuConfigScriptsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "automake";
   version = "1.18.1";
 
   src = fetchurl {
-    url = "mirror://gnu/automake/automake-${version}.tar.xz";
+    url = "mirror://gnu/automake/automake-${finalAttrs.version}.tar.xz";
     hash = "sha256-FoqjYyeDUbia9WaERI9SWlvOUHnQtoQr2RD90/FkaIc=";
   };
 
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
   # "fixed" path in generated files!
   dontPatchShebangs = true;
 
+  __structuredAttrs = true;
+
   meta = {
     branch = "1.18";
     homepage = "https://www.gnu.org/software/automake/";
@@ -48,4 +50,4 @@ stdenv.mkDerivation rec {
     '';
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tools/misc/binutils/2.38/default.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/default.nix
@@ -263,6 +263,8 @@ stdenv.mkDerivation {
     isGNU = true;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Tools for manipulating binaries (linker, assembler, etc.)";
     longDescription = ''

--- a/pkgs/development/tools/misc/binutils/2.38/libbfd.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/libbfd.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for manipulating containers of machine code";
     longDescription = ''

--- a/pkgs/development/tools/misc/binutils/2.38/libopcodes.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/libopcodes.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library from binutils for manipulating machine code";
     homepage = "https://www.gnu.org/software/binutils/";

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -278,7 +278,7 @@ stdenv.mkDerivation (finalAttrs: {
     for target in ${lib.escapeShellArgs allGasTargets}; do
       mkdir "$NIX_BUILD_TOP/build-$target"
       env -C "$NIX_BUILD_TOP/build-$target" \
-        "$configureScript" $configureFlags "''${configureFlagsArray[@]}" \
+        "$configureScript" "''${configureFlags[@]}" \
         --enable-gas --program-prefix "$target-"  --target "$target"
     done
   '';
@@ -293,7 +293,7 @@ stdenv.mkDerivation (finalAttrs: {
   postBuild = lib.optionalString withAllTargets ''
     for target in ${lib.escapeShellArgs allGasTargets}; do
       make -C "$NIX_BUILD_TOP/build-$target" -j"$NIX_BUILD_CORES" \
-        $makeFlags "''${makeFlagsArray[@]}" $buildFlags "''${buildFlagsArray[@]}" \
+        "''${makeFlags[@]}" "''${buildFlags[@]}" \
         TARGET-gas=as-new all-gas
     done
   '';
@@ -328,7 +328,7 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString withAllTargets ''
       for target in ${lib.escapeShellArgs allGasTargets}; do
         make -C "$NIX_BUILD_TOP/build-$target/gas" -j"$NIX_BUILD_CORES" \
-          $makeFlags "''${makeFlagsArray[@]}" $installFlags "''${installFlagsArray[@]}" \
+          "''${makeFlags[@]}" "''${installFlags[@]}" \
           install-exec-bindir
       done
     ''
@@ -353,6 +353,8 @@ stdenv.mkDerivation (finalAttrs: {
         --wildcards '*'/include/plugin-api.h
     '';
   };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Tools for manipulating binaries (linker, assembler, etc.)";

--- a/pkgs/development/tools/misc/binutils/libbfd.nix
+++ b/pkgs/development/tools/misc/binutils/libbfd.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
     inherit (binutils-unwrapped-all-targets) src dev plugin-api-header;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for manipulating containers of machine code";
     longDescription = ''

--- a/pkgs/development/tools/misc/binutils/libopcodes.nix
+++ b/pkgs/development/tools/misc/binutils/libopcodes.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
     inherit (binutils-unwrapped-all-targets) dev;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library from binutils for manipulating machine code";
     homepage = "https://www.gnu.org/software/binutils/";

--- a/pkgs/development/tools/misc/libtool/default.nix
+++ b/pkgs/development/tools/misc/libtool/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ m4 ];
   buildInputs = [ perl ];
 
+  strictDeps = true;
+
   # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the
   # "fixed" path in generated files!
   dontPatchShebangs = true;

--- a/pkgs/development/tools/misc/libtool/default.nix
+++ b/pkgs/development/tools/misc/libtool/default.nix
@@ -6,12 +6,12 @@
   perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtool";
   version = "1.5.26";
 
   src = fetchurl {
-    url = "mirror://gnu/${pname}/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/libtool/libtool-${finalAttrs.version}.tar.gz";
     sha256 = "029ggq5kri1gjn6nfqmgw4w920gyfzscjjxbsxxidal5zqsawd8w";
   };
 
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   # "fixed" path in generated files!
   dontPatchShebangs = true;
   dontFixLibtool = true;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Generic library support script";
@@ -45,4 +47,4 @@ stdenv.mkDerivation rec {
 
     mainProgram = "libtool";
   };
-}
+})

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -13,12 +13,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtool";
   version = "2.6.2";
 
   src = fetchurl {
-    url = "mirror://gnu/libtool/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/libtool/libtool-${finalAttrs.version}.tar.gz";
     hash = "sha256-JK2zqprgNccPq6NEr1fXMhXriSgQRa9sfM0wd1H4sL8=";
   };
 
@@ -68,6 +68,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "GNU Libtool, a generic library support script";
     longDescription = ''
@@ -85,4 +87,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "libtool";
   };
-}
+})

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -9,13 +9,13 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "patchelf";
   version = "0.15.2";
 
   src = fetchurl {
-    url = "https://github.com/NixOS/${pname}/releases/download/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-F3RfVkFZyOIo/EEtplogSLhGxLa0Igt3y/IkFuAvLXw=";
+    url = "https://github.com/NixOS/patchelf/releases/download/${finalAttrs.version}/patchelf-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-F3RfVkFZyOIo/EEtplogSLhGxLa0Igt3y/IkFuAvLXw=";
   };
 
   strictDeps = true;
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   # fails 8 out of 24 tests, problems when loading libc.so.6
   doCheck = stdenv.name == "stdenv-linux";
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/NixOS/patchelf";
     license = lib.licenses.gpl3Plus;
@@ -35,4 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -141,6 +141,8 @@ stdenv.mkDerivation {
     done
   '';
 
+  __structuredAttrs = true;
+
   meta = meta // {
     branch = version;
   };

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ m4 ];
 
+  strictDeps = true;
+
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     ac_cv_func_malloc_0_nonnull=yes
     ac_cv_func_realloc_0_nonnull=yes

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -10,13 +10,13 @@
   m4,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "flex";
   version = "2.5.35";
 
   src = fetchurl {
     url = "https://github.com/westes/flex/archive/flex-${
-      lib.replaceStrings [ "." ] [ "-" ] version
+      lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     }.tar.gz";
     sha256 = "0wh06nix8bd4w1aq4k2fbbkdq5i30a9lxz3xczf3ff28yy0kfwzm";
   };
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails 2 out of 46 tests
 
+  __structuredAttrs = true;
+
   meta = {
     branch = "2.5.35";
     homepage = "https://flex.sourceforge.net/";
@@ -56,4 +58,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -54,6 +54,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison ];
   propagatedBuildInputs = [ m4 ];
 
+  strictDeps = true;
+
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     export ac_cv_func_malloc_0_nonnull=yes
     export ac_cv_func_realloc_0_nonnull=yes

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -13,12 +13,12 @@
 # dependency during bootstrap. Useful when gcc is built from snapshot
 # or from a git tree (flex lexers are not pre-generated there).
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "flex";
   version = "2.6.4";
 
   src = fetchurl {
-    url = "https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz";
+    url = "https://github.com/westes/flex/releases/download/v${finalAttrs.version}/flex-${finalAttrs.version}.tar.gz";
     sha256 = "15g9bv236nzi665p9ggqjlfn4dwck5835vf0bbw2cz7h5c1swyp8";
   };
 
@@ -71,10 +71,12 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/flex $out/bin/lex
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/westes/flex";
     description = "Fast lexical analyser generator";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -108,7 +108,7 @@ let
       # Skip clean on darwin, case-sensitivity issues.
       buildPhase =
         lib.optionalString (!stdenvNoCC.buildPlatform.isDarwin) ''
-          make mrproper $makeFlags
+          make mrproper "''${makeFlags[@]}"
         ''
         + (
           if stdenvNoCC.hostPlatform.isAndroid then
@@ -118,12 +118,12 @@ let
             ''
           else
             ''
-              make headers $makeFlags
+              make headers "''${makeFlags[@]}"
             ''
         );
 
       checkPhase = ''
-        make headers_check $makeFlags
+        make headers_check "''${makeFlags[@]}"
       '';
 
       # The following command requires rsync:
@@ -143,6 +143,8 @@ let
       '';
 
       inherit passthru;
+
+      __structuredAttrs = true;
 
       meta = {
         description = "Header files and scripts for Linux kernel";

--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -5,13 +5,13 @@
   fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "net-tools";
   version = "2.10";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-smJDWlJB6Jv6UcPKvVEzdTlS96e3uT8y4Iy52W9YDWk=";
+    url = "mirror://sourceforge/net-tools/net-tools-${finalAttrs.version}.tar.xz";
+    hash = "sha256-smJDWlJB6Jv6UcPKvVEzdTlS96e3uT8y4Iy52W9YDWk=";
   };
 
   patches = [
@@ -46,10 +46,12 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "http://net-tools.sourceforge.net/";
     description = "Set of tools for controlling the network subsystem in Linux";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
     "man"
   ];
 
+  strictDeps = true;
+
   meta = {
     homepage = "http://net-tools.sourceforge.net/";
     description = "Set of tools for controlling the network subsystem in Linux";

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -261,6 +261,8 @@ lib.warnIf (withDocs != null)
       });
     };
 
+    __structuredAttrs = true;
+
     meta = {
       homepage = "https://www.gnu.org/software/bash/";
       description =

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -520,12 +520,13 @@ in
 
         # TODO(amjoseph): It is not yet entirely clear why this is necessary.
         # Something strange is going on with xgcc and libstdc++ on pkgsMusl.
-        patchelf = super.patchelf.overrideAttrs (
-          previousAttrs:
-          lib.optionalAttrs super.stdenv.hostPlatform.isMusl {
-            NIX_CFLAGS_COMPILE = (previousAttrs.NIX_CFLAGS_COMPILE or "") + " -static-libstdc++";
-          }
-        );
+        patchelf = super.patchelf.overrideAttrs (previousAttrs: {
+          env =
+            previousAttrs.env or { }
+            // lib.optionalAttrs super.stdenv.hostPlatform.isMusl {
+              NIX_CFLAGS_COMPILE = (previousAttrs.env.NIX_CFLAGS_COMPILE or "") + " -static-libstdc++";
+            };
+        });
 
       };
     }

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -853,7 +853,6 @@ in
               inherit (self)
                 stdenv
                 runCommandLocal
-                patchelf
                 libunistring
                 ;
             };

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -505,6 +505,7 @@ in
             dontUnpack = true;
             dontBuild = true;
             strictDeps = true;
+            __structuredAttrs = true;
             # We wouldn't need to *copy* all, but it's easier and the result is temporary anyway.
             installPhase = ''
               mkdir -p "$out"/bin

--- a/pkgs/stdenv/linux/stage0.nix
+++ b/pkgs/stdenv/linux/stage0.nix
@@ -70,6 +70,7 @@ if minbootSupported then
             ln -s ${libcPackage}/lib $out/lib
             ln -s ${libcPackage}/include $out/include
           '';
+          __structuredAttrs = true;
           passthru.isFromBootstrapFiles = true;
         };
         gcc-unwrapped = compilerPackage;
@@ -157,6 +158,7 @@ else
           + lib.optionalString (localSystem.libc == "musl") ''
             ln -s ${bootstrapTools}/include-libc $out/include
           '';
+          __structuredAttrs = true;
           passthru.isFromBootstrapFiles = true;
         };
         gcc-unwrapped = bootstrapTools;

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (
 
     src = fetchurl {
       url = "https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz";
-      sha256 = "sha256-q1oDF27hBtPw+pDjgdpHjdrkBZGBU8yiSOaCzQxKImk=";
+      hash = "sha256-q1oDF27hBtPw+pDjgdpHjdrkBZGBU8yiSOaCzQxKImk=";
     };
 
     patchFlags = [ "-p0" ];
@@ -73,6 +73,8 @@ stdenv.mkDerivation (
     '';
 
     passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+    __structuredAttrs = true;
 
     meta = {
       description = "High-quality data compression program";

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ runtimeShellPackage ];
 
+  strictDeps = true;
+
   makeFlags = [
     "SHELL=/bin/sh"
     "GREP=grep"

--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -89,6 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests.makecheck = gzip.overrideAttrs { doCheck = true; };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/gzip/";
     description = "GNU zip compression program";

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
   buildInputs = lib.optional stdenv.hostPlatform.isUnix bashNonInteractive;
 
+  strictDeps = true;
+
   patches = [
     # This patches makes sure we do not attempt to use the MD5 implementation
     # of the host platform when running the tests

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "zstd";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
   };
 
@@ -145,6 +145,8 @@ stdenv.mkDerivation (finalAttrs: {
       pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
     };
   };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Zstandard real-time compression algorithm";

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -34,12 +34,12 @@
 
 assert guiSupport -> !enableMinimal;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnupg";
   version = "2.4.9";
 
   src = fetchurl {
-    url = "mirror://gnupg/gnupg/${pname}-${version}.tar.bz2";
+    url = "mirror://gnupg/gnupg/gnupg-${finalAttrs.version}.tar.bz2";
     hash = "sha256-3RerLpoE/XnTnYU/WZy8hSBi3bmrUqTd60F2/YswKWQ=";
   };
 
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     # in the patch file.
     ./static.patch
   ]
-  ++ lib.map (v: "${freepgPatches}/STABLE-BRANCH-2-4-freepg/" + v) [
+  ++ lib.map (v: "${finalAttrs.freepgPatches}/STABLE-BRANCH-2-4-freepg/" + v) [
     "0002-gpg-accept-subkeys-with-a-good-revocation-but-no-sel.patch"
     "0003-gpg-allow-import-of-previously-known-keys-even-witho.patch"
     "0004-tests-add-test-cases-for-import-without-uid.patch"
@@ -206,9 +206,11 @@ stdenv.mkDerivation rec {
 
   passthru.tests = nixosTests.gnupg;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://gnupg.org";
-    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=${pname}.git;a=blob;f=NEWS;hb=refs/tags/${pname}-${version}";
+    changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=NEWS;hb=refs/tags/gnupg-${finalAttrs.version}";
     description = "Modern release of the GNU Privacy Guard, a GPL OpenPGP implementation";
     license = lib.licenses.gpl3Plus;
     longDescription = ''
@@ -229,6 +231,6 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     mainProgram = "gpg";
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" finalAttrs.version;
   };
-}
+})

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -76,6 +76,8 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals withTpm2Tss [ tpm2-tss ];
 
+  strictDeps = true;
+
   # FreePG (https://freepg.org) is a set of commonly-used patches for GnuPG that
   # have not been merged upstream. It is used by Arch Linux, Debian, Fedora and
   # NixOS, and is maintained by Andrew Gallagher.

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -24,12 +24,12 @@
 
 assert (doCheck && stdenv.hostPlatform.isLinux) -> glibcLocales != null;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gawk" + lib.optionalString interactive "-interactive";
   version = "5.4.1";
 
   src = fetchurl {
-    url = "mirror://gnu/gawk/gawk-${version}.tar.xz";
+    url = "mirror://gnu/gawk/gawk-${finalAttrs.version}.tar.xz";
     hash = "sha256-B/b3NCt/6+QxP8LCVCrZPWT+IK2HFyABCfEFqCb1/Tc=";
   };
 
@@ -105,6 +105,8 @@ stdenv.mkDerivation rec {
       ln -s gawk.1 "''${!outputMan}"/share/man/man1/awk.1
     '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/gawk/";
     description = "GNU implementation of the Awk programming language";
@@ -129,4 +131,4 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "gawk";
   };
-}
+})

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -6,13 +6,13 @@
   perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnused";
   version = "4.10";
 
   src = fetchurl {
-    url = "mirror://gnu/sed/sed-${version}.tar.xz";
-    sha256 = "sha256-uOchgrLslqNXTimYxHt6qmTMIM4ADY6awxPMB87PKMc=";
+    url = "mirror://gnu/sed/sed-${finalAttrs.version}.tar.xz";
+    hash = "sha256-uOchgrLslqNXTimYxHt6qmTMIM4ADY6awxPMB87PKMc=";
   };
 
   outputs = [
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     PERL = "missing";
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://www.gnu.org/software/sed/";
     description = "GNU sed, a batch stream editor";
@@ -53,4 +55,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ mic92 ];
     mainProgram = "sed";
   };
-}
+})

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation rec {
     updateAutotoolsGnuConfigScriptsHook
     perl
   ];
+
+  strictDeps = true;
+
   preConfigure = "patchShebangs ./build-aux/help2man";
 
   # Prevents attempts of running 'help2man' on cross-built binaries.


### PR DESCRIPTION
A big move towards having `strictDeps` and `structuredAttrs` enabled on the paths to 

* tests.stdenv
* pkgsi686Linux.tests.stdenv
* pkgsMusl.tests.stdenv
* gccgo
* pkgsi686Linux.gccgo
* hello
* pkgsi686Linux.hello
* pkgsMusl.hello
* dust
* pkgsi686Linux.dust
* pkgsMusl.dust

as tested via `nixpkgs-review` (and by me rebuilding my system configurations with `strictDepsByDefault` and `structuredAttrsByDefault` enabled). A number of low-level builders need to be adapted with more care than these packages, for which required changes are more limited in scope.

This PR is not intended to be merged (unless some brave soul wants to take responsibility for that - it should Just Work, but it would be harder to debug if it doesn't), but as a centralized PR I can link to for the individual package PRs.

Currently re-running nixpkgs-review because staging moved between pre-testing and making this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
