### PR TITLE
fetchFromTangled: init

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -988,6 +988,20 @@ fetchRadiclePatch {
 }
 ```
 
+## `fetchFromTangled` {#fetchfromtangled}
+
+This is to be used with tangled repositories. `fetchFromTangled` works with
+very similar arguments to `fetchFromGithub`. However, instead of a `owner` and
+`repo`, a `did` argument is expected.
+
+```nix
+fetchFromTangled {
+  did = "did:plc:jj6ajj6duxnlthwtnob4qyuv"; # tranquil.farm/tranquil-pds
+  tag = "v6.6.0";
+  hash = "sha256-cfTsjmK/IMqT5kMKOGpwwWbBlvtrCDOerUJJ8AVI3kY=";
+}
+```
+
 ## `requireFile` {#requirefile}
 
 `requireFile` allows requesting files that cannot be fetched automatically, but whose content is known.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -140,6 +140,9 @@
   "ex-writeShellApplication": [
     "index.html#ex-writeShellApplication"
   ],
+  "fetchfromtangled": [
+    "index.html#fetchfromtangled"
+  ],
   "first-package-go": [
     "index.html#first-package-go"
   ],

--- a/pkgs/build-support/fetchtangled/default.nix
+++ b/pkgs/build-support/fetchtangled/default.nix
@@ -1,0 +1,163 @@
+{
+  lib,
+  repoRevToNameMaybe,
+  fetchgit,
+  fetchzip,
+}@args:
+
+let
+
+  useFetchGitArgsDefault = {
+    deepClone = false;
+    fetchSubmodules = false; # This differs from fetchgit's default
+    fetchLFS = false;
+    forceFetchGit = false;
+    leaveDotGit = null;
+    postCheckout = "";
+    rootDir = "";
+    sparseCheckout = null;
+  };
+  useFetchGitArgsDefaultNullable = {
+    leaveDotGit = false;
+    sparseCheckout = [ ];
+  };
+  useFetchGitargsDefaultNonNull = useFetchGitArgsDefault // useFetchGitArgsDefaultNullable;
+  excludeUseFetchGitArgNames = [
+    "forceFetchGit"
+  ];
+
+  faUseFetchGit = lib.mapAttrs (_: _: true) useFetchGitArgsDefault;
+
+  adjustFunctionArgs = f: lib.setFunctionArgs f (faUseFetchGit // lib.functionArgs f);
+
+  decorate = f: lib.makeOverridable (adjustFunctionArgs f);
+
+  # fetchzip may not be overridable when using external tools, for example nix-prefetch
+  fetchzip =
+    if args.fetchzip ? override then args.fetchzip.override { withUnzip = false; } else args.fetchzip;
+
+in
+
+decorate (
+  {
+    domain ? "tangled.org",
+    did,
+    rev ? null,
+    tag ? null,
+    passthru ? { },
+    meta ? { },
+    ... # For hash agility and additional fetchgit arguments
+  }@args:
+
+  assert lib.assertMsg (lib.xor (tag != null) (
+    rev != null
+  )) "fetchFromTangled requires one of either `rev` or `tag` to be provided (not both).";
+
+  assert lib.assertMsg (lib.strings.hasPrefix "did:" did)
+    "fetchFromTangled requires the `did` key to start with `did:`";
+
+  let
+
+    useFetchGit =
+      lib.mapAttrs (
+        name: nonNullDefault:
+        if args ? ${name} && (useFetchGitArgsDefaultNullable ? ${name} -> args.${name} != null) then
+          args.${name}
+        else
+          nonNullDefault
+      ) useFetchGitargsDefaultNonNull != useFetchGitargsDefaultNonNull;
+
+    useFetchGitArgsWDPassing = lib.overrideExisting (removeAttrs useFetchGitArgsDefault excludeUseFetchGitArgNames) args;
+
+    position = (
+      if args.meta.description or null != null then
+        builtins.unsafeGetAttrPos "description" args.meta
+      else if tag != null then
+        builtins.unsafeGetAttrPos "tag" args
+      else
+        builtins.unsafeGetAttrPos "rev" args
+    );
+
+    baseUrl = "https://${domain}/${did}";
+
+    newMeta =
+      meta
+      // {
+        homepage = meta.homepage or baseUrl;
+        # identifiers = { TODO } // meta.identifiers or { };
+      }
+      // lib.optionalAttrs (position != null) {
+        # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
+        position = "${position.file}:${toString position.line}";
+      };
+
+    passthruAttrs = removeAttrs args (
+      [
+        "domain"
+        "did"
+        "tag"
+        "rev"
+        "fetchSubmodules"
+        "forceFetchGit"
+      ]
+      ++ (if useFetchGit then excludeUseFetchGitArgNames else lib.attrNames faUseFetchGit)
+    );
+
+    # We prefer fetchzip in cases we don't need submodules as the hash
+    # is more stable in that case.
+    fetcher = if useFetchGit then fetchgit else fetchzip;
+
+    fetcherArgs =
+      finalAttrs:
+      passthruAttrs
+      // (
+        if useFetchGit then
+          useFetchGitArgsWDPassing
+          // {
+            inherit tag rev;
+            url = baseUrl;
+            inherit passthru;
+            derivationArgs = {
+              inherit
+                domain
+                did
+                ;
+            };
+          }
+        else
+          let
+            revWithTag = finalAttrs.rev;
+          in
+          {
+            url = "${baseUrl}/archive/${revWithTag}";
+            extension = "tar.gz";
+
+            derivationArgs = {
+              inherit
+                domain
+                did
+                tag
+                ;
+              rev = fetchgit.getRevWithTag {
+                inherit (finalAttrs) tag;
+                rev = finalAttrs.revCustom;
+              };
+              revCustom = rev;
+            };
+
+            passthru = {
+              gitRepoUrl = baseUrl;
+            }
+            // passthru;
+          }
+      )
+      // {
+        name =
+          args.name
+            or (repoRevToNameMaybe finalAttrs.did (lib.revOrTag finalAttrs.revCustom finalAttrs.tag) "tangled");
+        meta = newMeta;
+      };
+  in
+
+  fetcher fetcherArgs
+)

--- a/pkgs/by-name/ls/lsr/package.nix
+++ b/pkgs/by-name/ls/lsr/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   installShellFiles,
-  fetchgit,
+  fetchFromTangled,
   zig_0_14,
   versionCheckHook,
 }:
@@ -16,14 +16,10 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
   strictDeps = true;
 
-  src = fetchgit {
-    url = "https://tangled.sh/@rockorager.dev/lsr";
-    rev = "v${finalAttrs.version}";
-    sparseCheckout = [
-      "src"
-      "docs"
-    ];
-    hash = "sha256-VeB0R/6h9FXSzBfx0IgpGlBz16zQScDSiU7ZvTD/Cds=";
+  src = fetchFromTangled {
+    did = "did:plc:7sufqp5jkgsrtsit7gd5wpo2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Te6GKPnW0XFliSjTI9UhkmT72AEmuUXfO7xNrV01mJk=";
   };
 
   zigDeps = zig.fetchDeps {

--- a/pkgs/by-name/ni/nix-run/nix-run.nix
+++ b/pkgs/by-name/ni/nix-run/nix-run.nix
@@ -2,7 +2,7 @@
   mkDerivation,
   attoparsec,
   base,
-  fetchgit,
+  fetchFromTangled,
   filepath,
   hercules-ci-optparse-applicative,
   hpack,
@@ -15,8 +15,8 @@
 mkDerivation rec {
   pname = "nix-run";
   version = "0.1.0.0-alpha.2";
-  src = fetchgit {
-    url = "https://tangled.org/did:plc:mojgntlezho4qt7uvcfkdndg/nix-run";
+  src = fetchFromTangled {
+    did = "did:plc:jhj73bgwgby7m5sudz5jk6gb";
     tag = version;
     hash = "sha256-vnYD3N32H6eEPLis8eNlglXVY+guP5DDKCf2z7CLzwA=";
   };

--- a/pkgs/by-name/se/sessiond/package.nix
+++ b/pkgs/by-name/se/sessiond/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromTangled,
   linux-pam,
   pkg-config,
   rustPlatform,
@@ -15,8 +15,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-i5F9WJD6hMjgiAM43iR4+ZQKZmwtKhEY8uZ0KleNqE8=";
 
-  src = fetchgit {
-    url = "https://tangled.org/did:plc:vj3bxta3i3cp26nn46yideoh";
+  src = fetchFromTangled {
+    did = "did:plc:vj3bxta3i3cp26nn46yideoh";
     tag = "v${finalAttrs.version}";
     hash = "sha256-8NFNFuolp0zqtBmEeI5ZP4aAmzdUMHNYwvm7esOoS8A=";
   };

--- a/pkgs/by-name/tr/tranquil-pds-frontend/package.nix
+++ b/pkgs/by-name/tr/tranquil-pds-frontend/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenvNoCC,
-  fetchgit,
+  fetchFromTangled,
   nodejs,
   pnpm,
   pnpmConfigHook,
@@ -12,8 +12,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tranquil-frontend";
   version = "0.6.6";
 
-  src = fetchgit {
-    url = "https://tangled.org/tranquil.farm/tranquil-pds";
+  src = fetchFromTangled {
+    did = "did:plc:jj6ajj6duxnlthwtnob4qyuv";
     tag = "v${finalAttrs.version}";
     hash = "sha256-cfTsjmK/IMqT5kMKOGpwwWbBlvtrCDOerUJJ8AVI3kY=";
   };

--- a/pkgs/by-name/tr/tranquil-pds/package.nix
+++ b/pkgs/by-name/tr/tranquil-pds/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchgit,
+  fetchFromTangled,
   rustPlatform,
   pkg-config,
   openssl,
@@ -12,8 +12,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tranquil-pds";
   version = "0.6.6";
 
-  src = fetchgit {
-    url = "https://tangled.org/tranquil.farm/tranquil-pds";
+  src = fetchFromTangled {
+    did = "did:plc:jj6ajj6duxnlthwtnob4qyuv";
     tag = "v${finalAttrs.version}";
     hash = "sha256-cfTsjmK/IMqT5kMKOGpwwWbBlvtrCDOerUJJ8AVI3kY=";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -661,6 +661,8 @@ with pkgs;
   fetchFromRadicle = callPackage ../build-support/fetchradicle { };
   fetchRadiclePatch = callPackage ../build-support/fetchradiclepatch { };
 
+  fetchFromTangled = callPackage ../build-support/fetchtangled { };
+
   fetchgx = callPackage ../build-support/fetchgx { };
 
   fetchItchIo = callPackage ../build-support/fetchitchio { };


### PR DESCRIPTION
[tangled](https://tangled.org/) is a new up and coming git hosting provider. nixpkgs already has a few packages that are hosted on tangled, so it would be nice to add the new fetcher for multiple people to use. the archival url is said to be "mostly" stable at this point even though tangled still being alpha software. the fetcher i've added is mostly a fork of `fetchFromGitHub` with a few alterations since it does not support private data and the url scheme does differ slightly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
