### PR TITLE
photogimp: init at 3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31504,6 +31504,11 @@
       { fingerprint = "D2A8 A906 ACA7 B6D6 575E 9A2F 3A49 5054 6EA6 9E5C"; }
     ];
   };
+  Yonnix = {
+    github = "Yonnix";
+    githubId = 116506223;
+    name = "Yonnix";
+  };
   yoquec = {
     email = "alvaro.viejo@yoquec.com";
     github = "yoquec";

--- a/pkgs/by-name/ph/photogimp/package.nix
+++ b/pkgs/by-name/ph/photogimp/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gimp,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "photogimp";
+  version = "3.1";
+  src = fetchFromGitHub {
+    owner = "Diolinux";
+    repo = "PhotoGIMP";
+    tag = finalAttrs.version;
+    hash = "sha256-524lsDRmahWXXP9/cfk2ia+7K6xNFTdoYXO8UUsLP/o=";
+  };
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace .config/GIMP/3.0/theme.css \
+      --replace-fail "file:///app/" "file://${gimp}/"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/photogimp
+    cp -r .config/GIMP/3.0/. $out/share/photogimp/
+
+    mkdir -p $out/share/icons
+    cp -r .local/share/icons/. $out/share/icons/
+
+    makeWrapper ${gimp}/bin/gimp $out/bin/photogimp \
+      --run '
+        PHOTOGIMP_DIR="''${XDG_CONFIG_HOME:-$HOME/.config}/PhotoGIMP/3.0"
+        if [ ! -d "$PHOTOGIMP_DIR" ]; then
+          mkdir -p "$PHOTOGIMP_DIR"
+          cp -r --no-preserve=mode '"$out"'/share/photogimp/* "$PHOTOGIMP_DIR/"
+          chmod -R +w "$PHOTOGIMP_DIR"
+        fi
+        export GIMP3_DIRECTORY="$PHOTOGIMP_DIR"
+      '
+
+    runHook postInstall
+  '';
+  desktopItems = [
+    (makeDesktopItem {
+      name = "photogimp";
+      exec = "photogimp %U";
+      icon = "photogimp";
+      comment = "A patch for GIMP 3+ for Adobe Photoshop users";
+      desktopName = "PhotoGIMP";
+      genericName = "Image Editor";
+      categories = [
+        "Graphics"
+        "2DGraphics"
+        "RasterGraphics"
+      ];
+    })
+  ];
+  meta = {
+    description = "A patch for GIMP 3+ for Adobe Photoshop users";
+    homepage = "https://github.com/Diolinux/PhotoGIMP";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "photogimp";
+    maintainers = with lib.maintainers; [ Yonnix ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Resolves #350520

### Description

This package add [PhotoGIMP](https://github.com/Diolinux/PhotoGIMP) 3.1, a patch made for GIMP 3+ that adapts the interface, keyboard shortcuts, tools layouts  to mimic the workflow like Adobe Photoshop users.

- created a new package `pkgs/by-name/ph/photogimp/package.nix`
-  added a wrapper script to automatically configure the user configuration in `~/.config/PhotoGIMP/3.0` with write permissions
- added a patch for hardcoded specific Flatpak path in `theme.css` to point to GIMP nix store path
-  Added deskop laucnher and photoGIMP icon as well

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
