### PR TITLE
tcl: fix Windows build targets

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -4,6 +4,7 @@
   callPackage,
   makeSetupHook,
   runCommand,
+  tcl,
   tzdata,
   zip,
   zlib,
@@ -37,18 +38,26 @@ let
     ''
     + extraPatch;
 
-    nativeBuildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
-      # Only used to detect the presence of zlib. Could be replaced with a stub.
-      zip
-    ];
+    nativeBuildInputs =
+      lib.optionals (lib.versionAtLeast version "9.0") [
+        # Only used to detect the presence of zlib. Could be replaced with a stub.
+        zip
+      ]
+      ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) tcl;
 
     buildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
       zlib
     ];
 
-    preConfigure = ''
-      cd unix
-    '';
+    preConfigure =
+      if stdenv.hostPlatform.isWindows then
+        ''
+          cd win
+        ''
+      else
+        ''
+          cd unix
+        '';
 
     # Note: pre-9.0 flags are temporarily interspersed to avoid a mass rebuild.
     configureFlags =
@@ -111,15 +120,19 @@ let
       let
         dllExtension = stdenv.hostPlatform.extensions.sharedLibrary;
         staticExtension = stdenv.hostPlatform.extensions.staticLibrary;
+        exeExtension = stdenv.hostPlatform.extensions.executable;
+        # Windows tags files as e.g. tclsh86.exe instead of tclsh8.6
+        binRelease =
+          if stdenv.hostPlatform.isWindows then (builtins.replaceStrings [ "." ] [ "" ] release) else release;
       in
       ''
         make install-private-headers
-        ln -s $out/bin/tclsh${release} $out/bin/tclsh
-        if [[ -e $out/lib/libtcl${release}${staticExtension} ]]; then
-          ln -s $out/lib/libtcl${release}${staticExtension} $out/lib/libtcl${staticExtension}
+        ln -s $out/bin/tclsh${binRelease}${exeExtension} $out/bin/tclsh${exeExtension}
+        if [[ -e $out/lib/libtcl${binRelease}${staticExtension} ]]; then
+          ln -s $out/lib/libtcl${binRelease}${staticExtension} $out/lib/libtcl${staticExtension}
         fi
-        ${lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-          ln -s $out/lib/libtcl${release}${dllExtension} $out/lib/libtcl${dllExtension}
+        ${lib.optionalString (!stdenv.hostPlatform.isStatic && !stdenv.hostPlatform.isWindows) ''
+          ln -s $out/lib/libtcl${binRelease}${dllExtension} $out/lib/libtcl${dllExtension}
         ''}
       '';
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
