### PR TITLE
bibata-modern-catppuccin-mocha-blue: init at 0-unstable-2026-08-10

### DIFF
--- a/pkgs/by-name/bi/bibata-modern-catppuccin-mocha-blue/package.nix
+++ b/pkgs/by-name/bi/bibata-modern-catppuccin-mocha-blue/package.nix
@@ -1,0 +1,29 @@
+{
+    lib,
+    stdenvNoCC,
+    fetchurl,
+}:
+
+stdenvNoCC.mkDerivation {
+    pname = "bibata-modern-catppuccin-mocha-blue";
+    version = "unstable-2026-08-10";
+
+    src = fetchurl {
+      url =
+      "https://github.com/dimunyx/Bibata-Modern-Catppuccin-Mocha-Blue/raw/refs/heads/main/pkgs/Bibata-Modern-Catppuccin-Mocha-Blue.tar.xz";
+      hash = "sha256-gNdBFXAaaeRKIgYM8Nwl8X+Wupa3CLHeJ49A35/Ams8=";
+    };
+
+    installPhase = ''
+      install -dm 0755 "$out/share/icons"
+      tar -xJf "$src" -C "$out/share/icons"
+    '';
+
+    meta = {
+      description = "Bibata Modern Catppuccin Mocha Blue cursor theme";
+      homepage = "https://github.com/dimunyx/Bibata-Modern-Catppuccin-Mocha-Blue";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.linux;
+      maintainers = [ ];
+    };
+}

--- a/pkgs/by-name/bi/bibata-modern-catppuccin-mocha-blue/package.nix
+++ b/pkgs/by-name/bi/bibata-modern-catppuccin-mocha-blue/package.nix
@@ -1,29 +1,28 @@
 {
-    lib,
-    stdenvNoCC,
-    fetchurl,
+  lib,
+  stdenvNoCC,
+  fetchurl,
 }:
 
 stdenvNoCC.mkDerivation {
-    pname = "bibata-modern-catppuccin-mocha-blue";
-    version = "unstable-2026-08-10";
+  pname = "bibata-modern-catppuccin-mocha-blue";
+  version = "unstable-2026-08-10";
 
-    src = fetchurl {
-      url =
-      "https://github.com/dimunyx/Bibata-Modern-Catppuccin-Mocha-Blue/raw/refs/heads/main/pkgs/Bibata-Modern-Catppuccin-Mocha-Blue.tar.xz";
-      hash = "sha256-gNdBFXAaaeRKIgYM8Nwl8X+Wupa3CLHeJ49A35/Ams8=";
-    };
+  src = fetchurl {
+    url = "https://github.com/dimunyx/Bibata-Modern-Catppuccin-Mocha-Blue/raw/refs/heads/main/pkgs/Bibata-Modern-Catppuccin-Mocha-Blue.tar.xz";
+    hash = "sha256-gNdBFXAaaeRKIgYM8Nwl8X+Wupa3CLHeJ49A35/Ams8=";
+  };
 
-    installPhase = ''
-      install -dm 0755 "$out/share/icons"
-      tar -xJf "$src" -C "$out/share/icons"
-    '';
+  installPhase = ''
+    install -dm 0755 "$out/share/icons"
+    tar -xJf "$src" -C "$out/share/icons"
+  '';
 
-    meta = {
-      description = "Bibata Modern Catppuccin Mocha Blue cursor theme";
-      homepage = "https://github.com/dimunyx/Bibata-Modern-Catppuccin-Mocha-Blue";
-      license = lib.licenses.gpl3Only;
-      platforms = lib.platforms.linux;
-      maintainers = [ ];
-    };
+  meta = {
+    description = "Bibata Modern Catppuccin Mocha Blue cursor theme";
+    homepage = "https://github.com/dimunyx/Bibata-Modern-Catppuccin-Mocha-Blue";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+  };
 }

--- a/pkgs/by-name/bi/bibata-modern-catppuccin-mocha-blue/package.nix
+++ b/pkgs/by-name/bi/bibata-modern-catppuccin-mocha-blue/package.nix
@@ -8,6 +8,9 @@ stdenvNoCC.mkDerivation {
   pname = "bibata-modern-catppuccin-mocha-blue";
   version = "unstable-2026-08-10";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchurl {
     url = "https://github.com/dimunyx/Bibata-Modern-Catppuccin-Mocha-Blue/raw/refs/heads/main/pkgs/Bibata-Modern-Catppuccin-Mocha-Blue.tar.xz";
     hash = "sha256-gNdBFXAaaeRKIgYM8Nwl8X+Wupa3CLHeJ49A35/Ams8=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
