### PR TITLE
nixos/fontconfig: build font caches with the alias configuration

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -48,6 +48,15 @@ let
         pkgs.makeFontsCache {
           inherit fontconfig;
           fontDirectories = config.fonts.packages;
+          # Since fontconfig 2.18.3, the alias configuration determines the
+          # generic family of the aliased fonts in the caches, caches lacking
+          # this classification break generic-family matching for the aliased
+          # fonts.
+          extraConfigFiles = [
+            defaultFontsConf
+            aliases
+          ]
+          ++ lib.optional (cfg.localConf != "") localConf;
         };
       cache = makeCache pkgs.fontconfig;
       cache32 = makeCache pkgs.pkgsi686Linux.fontconfig;

--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -12,6 +12,7 @@ in
 {
   fontconfig ? fontconfig',
   fontDirectories,
+  extraConfigFiles ? [ ],
 }:
 
 let
@@ -33,6 +34,9 @@ runCommand "fc-cache"
     <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
     <fontconfig>
       <include>${fontconfig.out}/etc/fonts/fonts.conf</include>
+      ${lib.concatMapStringsSep "\n  " (
+        file: ''<include ignore_missing="yes">${file}</include>''
+      ) extraConfigFiles}
       <cachedir>$out</cachedir>
     EOF
     cat "${fontDirsPath}" >> fonts.conf


### PR DESCRIPTION
fontconfig 2.18 introduced generic-family matching, which ranks above weakly bound aliases: a font whose cached generic family is unknown loses to any font classified into the requested generic family (typically Noto Sans), even when `fonts.fontconfig.defaultFonts` or `fonts.fontconfig.aliases` prefer it.

Since fontconfig 2.18.3, the alias configuration determines the generic family of the aliased fonts in the caches: every `<alias>`/`<prefer>` pair implicitly generates `<match target="scan">` rules that record the preferred fonts' generic family when a cache is built [1].

The pre-generated system caches were built from the upstream configuration and the font directories alone, so the fonts configured in `52-nixos-default-fonts.conf`, `53-user-aliases.conf` and `local.conf` were never classified, while competing fonts from the upstream presets (`60-latin.conf` etc.) were. The store cache also shadows any cache the user could regenerate, making the aliases ineffective for system fonts, no matter the fontconfig version.

Add an `extraConfigFiles` argument to `makeFontsCache` and pass the default fonts, user aliases and local configuration when generating the caches. This is a no-op for fontconfig <= 2.18.2, where the alias configuration plays no role at scan time.

Related: https://github.com/NixOS/nixpkgs/issues/541553 https://github.com/NixOS/nixpkgs/pull/550238

[1]: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/a4bacb7103d67ce68655dd3140bfaf5c0bd81a17


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
