### PR TITLE
rsyslog: 8.2512.0 -> 8.2606.0

### DIFF
--- a/pkgs/by-name/rs/rsyslog-light/package.nix
+++ b/pkgs/by-name/rs/rsyslog-light/package.nix
@@ -3,6 +3,7 @@
 }:
 
 rsyslog.override {
+  withLibyaml = false;
   withKrb5 = false;
   withSystemd = false;
   withJemalloc = false;

--- a/pkgs/by-name/rs/rsyslog/package.nix
+++ b/pkgs/by-name/rs/rsyslog/package.nix
@@ -4,11 +4,14 @@
   fetchurl,
   pkg-config,
   autoreconfHook,
+  autoconf-archive,
   libestr,
   json_c,
   zlib,
   docutils,
   libfastjson,
+  withLibyaml ? true,
+  libyaml,
   withKrb5 ? true,
   libkrb5,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
@@ -62,16 +65,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rsyslog";
-  version = "8.2512.0";
+  version = "8.2606.0";
 
   src = fetchurl {
     url = "https://www.rsyslog.com/files/download/rsyslog/rsyslog-${finalAttrs.version}.tar.gz";
-    hash = "sha256-k8UAJdkLbHlfo1DVaj2DK/zkUEPqm9aCQNnCqTlLxik=";
+    hash = "sha256-JXSz8waOaVXrlO9WQ+K2pbhYXMjqp3IJ/1y8Hi5fceU=";
   };
 
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    autoconf-archive
     docutils
   ];
 
@@ -81,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     json_c
     zlib
   ]
+  ++ lib.optional withLibyaml libyaml
   ++ lib.optional withKrb5 libkrb5
   ++ lib.optional withJemalloc jemalloc
   ++ lib.optional withPostgres libpq
@@ -112,6 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-systemdsystemunitdir=\${out}/etc/systemd/system"
     (lib.enableFeature true "largefile")
     (lib.enableFeature true "regexp")
+    (lib.enableFeature withLibyaml "libyaml")
     (lib.enableFeature withKrb5 "gssapi-krb5")
     (lib.enableFeature true "klog")
     (lib.enableFeature true "kmsg")
@@ -157,6 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature false "imsolaris")
     (lib.enableFeature true "imptcp")
     (lib.enableFeature true "impstats")
+    (lib.enableFeature false "impstats-push")
     (lib.enableFeature true "omprog")
     (lib.enableFeature withNet "omudpspoof")
     (lib.enableFeature true "omstdout")


### PR DESCRIPTION
Updates rsyslog to 8.2606.0, fixing CVE-2026-61548.

[Release notes](https://redirect.github.com/rsyslog/rsyslog/releases/tag/v8.2606.0) · [Security advisory](https://redirect.github.com/rsyslog/rsyslog/security/advisories/GHSA-8qmr-c66f-g368)

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
