### PR TITLE
discord: respect `DISCORD_USER_DATA_DIR`

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -64,10 +64,12 @@ let
 
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
-    modules_dir="$HOME/Library/Application Support/${configDirName}/${version}/modules"
+    user_data_dir="''${DISCORD_USER_DATA_DIR-$HOME/Library/Application Support}"
+    modules_dir="$user_data_dir''${user_data_dir:+/}${configDirName}/${version}/modules"
     mkdir -p "$modules_dir"
     for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-      ln -sfn "$store_modules/$m" "$modules_dir/$m"
+      rm -rf "$modules_dir/$m"
+      ln -s "$store_modules/$m" "$modules_dir/$m"
     done
     echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
       > "$modules_dir/installed.json"

--- a/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
+++ b/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
@@ -17,10 +17,13 @@ import os
 import sys
 from pathlib import Path
 
-config_home = {
-    "darwin": os.path.join(os.path.expanduser("~"), "Library", "Application Support"),
-    "linux": os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
-}.get(sys.platform, None)
+config_home = os.environ.get("DISCORD_USER_DATA_DIR")
+if config_home is None:
+    config_home = {
+        "darwin": os.path.join(os.path.expanduser("~"), "Library", "Application Support"),
+        "linux": os.environ.get("XDG_CONFIG_HOME")
+        or os.path.join(os.path.expanduser("~"), ".config"),
+    }.get(sys.platform, None)
 
 if config_home is None:
     print("[Nix] Unsupported operating system.")
@@ -28,8 +31,8 @@ if config_home is None:
 
 config_dir_name = "@configDirName@".replace(" ", "") if sys.platform == "darwin" else "@configDirName@"
 
-settings_path = Path(f"{config_home}/{config_dir_name}/settings.json")
-settings_path_temp = Path(f"{config_home}/{config_dir_name}/settings.json.tmp")
+settings_path = Path(config_home) / config_dir_name / "settings.json"
+settings_path_temp = settings_path.with_suffix(".json.tmp")
 
 if os.path.exists(settings_path):
     with settings_path.open(encoding="utf-8") as settings_file:

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -152,7 +152,8 @@ let
   # where Discord's JS moduleUpdater expects them.
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
-    modules_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/${lib.toLower binaryName}/${version}/modules"
+    user_data_dir="''${DISCORD_USER_DATA_DIR-''${XDG_CONFIG_HOME:-$HOME/.config}}"
+    modules_dir="$user_data_dir''${user_data_dir:+/}${lib.toLower binaryName}/${version}/modules"
     rm -rf "$modules_dir"
     mkdir -p "$modules_dir"
     for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/550741

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
