### PR TITLE
fluffychat: fix aarch64 build

### DIFF
--- a/pkgs/by-name/fl/fluffychat/package.nix
+++ b/pkgs/by-name/fl/fluffychat/package.nix
@@ -61,8 +61,6 @@ flutter344.buildFlutterApplication (
         tebriel
         aleksana
       ];
-      # Refer to https://github.com/NixOS/nixpkgs/issues/545995
-      broken = stdenv.hostPlatform.isAarch64;
       badPlatforms = lib.platforms.darwin;
     }
     // lib.optionalAttrs (targetFlutterPlatform == "linux") {
@@ -116,6 +114,32 @@ flutter344.buildFlutterApplication (
             substituteInPlace third_party/CMakeLists.txt \
               --replace-fail "\''${LIBWEBRTC_THIRD_PARTY_DIR}/downloads/\''${LIBWEBRTC_ASSET}.zip" ${libwebrtc}
               ln -s ${libwebrtc} third_party/libwebrtc
+          '';
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir $out
+            cp -r ./* $out/
+
+            runHook postInstall
+          '';
+        };
+    }
+    // lib.optionalAttrs (stdenv.hostPlatform.system == "aarch64-linux") {
+      native_toolchain_cmake =
+        { version, src, ... }:
+        stdenv.mkDerivation {
+          pname = "native_toolchain_cmake";
+          inherit version src;
+          inherit (src) passthru;
+
+          postPatch = ''
+            substituteInPlace cmake/aarch64-linux-gnu.toolchain.cmake \
+              --replace-fail "aarch64-linux-gnu-gcc" "gcc"
+
+            substituteInPlace cmake/aarch64-linux-gnu.toolchain.cmake \
+              --replace-fail "aarch64-linux-gnu-g++" "g++"
           '';
 
           installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes https://github.com/NixOS/nixpkgs/issues/545995 (thanks for the help @qzylinra)

NEEDS TESTING: I was able to compile it but I don't have the setup to test the binary on aarch64-linux.

CC @tebriel  as you were also involved in this previously 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
