### PR TITLE
lemmy: add NGI maintainers and follow packaging guidelines

### DIFF
--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -5,21 +5,20 @@
   utils,
   ...
 }:
-with lib;
 let
   cfg = config.services.lemmy;
   settingsFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     happysalada
     lucasew
   ];
-  meta.teams = [ teams.ngi ];
+  meta.teams = [ lib.teams.ngi ];
   meta.doc = ./lemmy.md;
 
   imports = [
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "lemmy"
       "jwtSecretPath"
@@ -28,92 +27,93 @@ in
 
   options.services.lemmy = {
 
-    enable = mkEnableOption "lemmy a federated alternative to reddit in rust";
+    enable = lib.mkEnableOption "Lemmy, a federated alternative to Reddit";
 
     server = {
-      package = mkPackageOption pkgs "lemmy-server" { };
+      package = lib.mkPackageOption pkgs "lemmy-server" { };
     };
 
     ui = {
-      package = mkPackageOption pkgs "lemmy-ui" { };
+      package = lib.mkPackageOption pkgs "lemmy-ui" { };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 1234;
         description = "Port where lemmy-ui should listen for incoming requests.";
       };
     };
 
-    caddy.enable = mkEnableOption "exposing lemmy with the caddy reverse proxy";
-    nginx.enable = mkEnableOption "exposing lemmy with the nginx reverse proxy";
+    caddy.enable = lib.mkEnableOption "exposing Lemmy with the Caddy reverse proxy";
+    nginx.enable = lib.mkEnableOption "exposing Lemmy with the nginx reverse proxy";
 
     database = {
-      createLocally = mkEnableOption "creation of database on the instance";
+      createLocally = lib.mkEnableOption "creation of a local PostgreSQL database";
 
-      uri = mkOption {
-        type = with types; nullOr str;
+      uri = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
+        example = "postgres:///lemmy?host=/run/postgresql&user=lemmy";
         description = "The connection URI to use. Takes priority over the configuration file if set.";
       };
 
-      uriFile = mkOption {
-        type = with types; nullOr path;
+      uriFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         description = "File which contains the database uri.";
       };
     };
 
-    pictrsApiKeyFile = mkOption {
-      type = with types; nullOr path;
+    pictrsApiKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       default = null;
       description = "File which contains the value of `pictrs.api_key`.";
     };
 
-    smtpPasswordFile = mkOption {
-      type = with types; nullOr path;
+    smtpPasswordFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       default = null;
       description = "File which contains the value of `email.smtp_password`.";
     };
 
-    adminPasswordFile = mkOption {
-      type = with types; nullOr path;
+    adminPasswordFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       default = null;
       description = "File which contains the value of `setup.admin_password`.";
     };
 
-    settings = mkOption {
+    settings = lib.mkOption {
       default = { };
       description = "Lemmy configuration";
 
-      type = types.submodule {
+      type = lib.types.submodule {
         freeformType = settingsFormat.type;
 
-        options.hostname = mkOption {
-          type = types.str;
-          default = null;
-          description = "The domain name of your instance (eg 'lemmy.ml').";
+        options.hostname = lib.mkOption {
+          type = lib.types.str;
+          example = "lemmy.ml";
+          description = "Public domain name of the instance.";
         };
 
-        options.port = mkOption {
-          type = types.port;
+        options.port = lib.mkOption {
+          type = lib.types.port;
           default = 8536;
-          description = "Port where lemmy should listen for incoming requests.";
+          description = "Port where Lemmy should listen for incoming requests.";
         };
 
         options.captcha = {
-          enabled = mkOption {
-            type = types.bool;
+          enabled = lib.mkOption {
+            type = lib.types.bool;
             default = true;
-            description = "Enable Captcha.";
+            description = "Whether to enable captcha.";
           };
-          difficulty = mkOption {
-            type = types.enum [
+          difficulty = lib.mkOption {
+            type = lib.types.enum [
               "easy"
               "medium"
               "hard"
             ];
             default = "medium";
-            description = "The difficultly of the captcha to solve.";
+            description = "Difficulty of the captcha to solve.";
           };
         };
       };
@@ -158,7 +158,7 @@ in
       services.lemmy.settings =
         lib.attrsets.recursiveUpdate
           (
-            mapAttrs (name: mkDefault) {
+            lib.mapAttrs (name: lib.mkDefault) {
               bind = "127.0.0.1";
               tls_enabled = true;
               pictrs = {
@@ -176,7 +176,7 @@ in
               rate_limit.image_per_second = 3600;
             }
             // {
-              database = mapAttrs (name: mkDefault) {
+              database = lib.mapAttrs (name: lib.mkDefault) {
                 user = "lemmy";
                 host = "/run/postgresql";
                 port = 5432;
@@ -193,7 +193,7 @@ in
           );
       # the option name is the id of the credential loaded by LoadCredential
 
-      services.postgresql = mkIf cfg.database.createLocally {
+      services.postgresql = lib.mkIf cfg.database.createLocally {
         enable = true;
         ensureDatabases = [ cfg.settings.database.database ];
         ensureUsers = [
@@ -206,8 +206,8 @@ in
 
       services.pict-rs.enable = true;
 
-      services.caddy = mkIf cfg.caddy.enable {
-        enable = mkDefault true;
+      services.caddy = lib.mkIf cfg.caddy.enable {
+        enable = lib.mkDefault true;
         virtualHosts."${cfg.settings.hostname}" = {
           extraConfig = ''
             handle_path /static/* {
@@ -244,8 +244,8 @@ in
         };
       };
 
-      services.nginx = mkIf cfg.nginx.enable {
-        enable = mkDefault true;
+      services.nginx = lib.mkIf cfg.nginx.enable {
+        enable = lib.mkDefault true;
         virtualHosts."${cfg.settings.hostname}".locations =
           let
             ui = "http://127.0.0.1:${toString cfg.ui.port}";
@@ -295,8 +295,8 @@ in
         }
         {
           assertion =
-            (!(hasAttrByPath [ "federation" ] cfg.settings))
-            && (!(hasAttrByPath [ "federation" "enabled" ] cfg.settings));
+            (!(lib.hasAttrByPath [ "federation" ] cfg.settings))
+            && (!(lib.hasAttrByPath [ "federation" "enabled" ] cfg.settings));
           message = "`services.lemmy.settings.federation` was removed in 0.17.0 and no longer has any effect";
         }
         {
@@ -319,7 +319,7 @@ in
               if cfg.database.uri != null then
                 cfg.database.uri
               else
-                (mkIf (cfg.database.createLocally) "postgres:///lemmy?host=/run/postgresql&user=lemmy");
+                (lib.mkIf cfg.database.createLocally "postgres:///lemmy?host=/run/postgresql&user=lemmy");
           };
 
           documentation = [
@@ -335,7 +335,7 @@ in
 
           # substitute secrets and prevent others from reading the result
           # if somehow $CREDENTIALS_DIRECTORY is not set we fail
-          preStart = mkIf (secrets != { }) ''
+          preStart = lib.mkIf (secrets != { }) ''
             set -u
             umask u=rw,g=,o=
             cd "$CREDENTIALS_DIRECTORY"
@@ -381,7 +381,7 @@ in
         serviceConfig = {
           DynamicUser = true;
           WorkingDirectory = "${cfg.ui.package}";
-          ExecStart = "${pkgs.lib.getExe pkgs.nodejs-slim} ${cfg.ui.package}/dist/js/server.js";
+          ExecStart = "${lib.getExe pkgs.nodejs-slim} ${cfg.ui.package}/dist/js/server.js";
         };
       };
     };

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -11,7 +11,11 @@ let
   settingsFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with maintainers; [ happysalada ];
+  meta.maintainers = with maintainers; [
+    happysalada
+    lucasew
+  ];
+  meta.teams = [ teams.ngi ];
   meta.doc = ./lemmy.md;
 
   imports = [

--- a/nixos/tests/lemmy.nix
+++ b/nixos/tests/lemmy.nix
@@ -6,8 +6,12 @@ let
 in
 {
   name = "lemmy";
-  meta = with lib.maintainers; {
-    maintainers = [ mightyiam ];
+  meta = {
+    maintainers = with lib.maintainers; [
+      mightyiam
+      lucasew
+    ];
+    teams = [ lib.teams.ngi ];
   };
 
   nodes = {

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -84,7 +84,9 @@ rustPlatform.buildRustPackage rec {
       happysalada
       billewanick
       georgyo
+      lucasew
     ];
+    teams = [ lib.teams.ngi ];
     mainProgram = "lemmy_server";
   };
 }

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -14,20 +14,20 @@ let
   pinData = lib.importJSON ./pin.json;
   version = pinData.serverVersion;
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   inherit version;
   pname = "lemmy-server";
 
   src = fetchFromGitHub {
     owner = "LemmyNet";
     repo = "lemmy";
-    rev = version;
+    tag = finalAttrs.version;
     hash = pinData.serverHash;
     fetchSubmodules = true;
   };
 
   preConfigure = ''
-    echo 'pub const VERSION: &str = "${version}";' > crates/utils/src/version.rs
+    echo 'pub const VERSION: &str = "${finalAttrs.version}";' > crates/utils/src/version.rs
   '';
 
   cargoHash = pinData.serverCargoHash;
@@ -69,15 +69,17 @@ rustPlatform.buildRustPackage rec {
 
   # This gets installed automatically by cargoInstallHook,
   # but we don't actually need it, and it leaks a reference to rustc.
-  postInstall = lib.optionals (!stdenv.hostPlatform.isDarwin) ''
+  postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     rm $out/lib/libhtml2md.so
   '';
 
-  passthru.updateScript = ./update.py;
-  passthru.tests.lemmy-server = nixosTests.lemmy;
+  passthru = {
+    updateScript = ./update.py;
+    tests.lemmy-server = nixosTests.lemmy;
+  };
 
   meta = {
-    description = "🐀 Building a federated alternative to reddit in rust";
+    description = "Federated link aggregator and forum";
     homepage = "https://join-lemmy.org/";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
@@ -89,4 +91,4 @@ rustPlatform.buildRustPackage rec {
     teams = [ lib.teams.ngi ];
     mainProgram = "lemmy_server";
   };
-}
+})

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -39,7 +39,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     vips
   ];
 
-  extraBuildInputs = [ libsass ];
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_11;
@@ -75,15 +74,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     done
   '';
 
-  distPhase = "true";
-
   passthru = {
     updateScript = ./update.py;
     tests.lemmy-ui = nixosTests.lemmy;
   };
 
   meta = {
-    description = "Building a federated alternative to reddit in rust";
+    description = "Web frontend for a federated link aggregator";
     homepage = "https://join-lemmy.org/";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -90,7 +90,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       happysalada
       billewanick
       georgyo
+      lucasew
     ];
+    teams = [ lib.teams.ngi ];
     inherit (nodejs.meta) platforms;
   };
 })


### PR DESCRIPTION
NGI packaging follow-up for [ngi-nix/projects#158](https://github.com/ngi-nix/projects/issues/158). Lemmy is already in Nixpkgs; this does not re-init it.

Two commits:

1. Add `lucasew` and `teams.ngi` on `lemmy-server`, `lemmy-ui`, `services.lemmy`, and the NixOS test.
2. Drop the module-level `with lib`, require `settings.hostname` (it was `types.str` with `default = null`), fix `meta.description`, and remove unused `lemmy-ui` attrs (`extraBuildInputs`, `distPhase`).

`update.py` is unchanged.

Assisted-by: Grok Build (xAI Grok 4.6)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test