### PR TITLE
confy-tui: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/by-name/co/confy-tui/package.nix
+++ b/pkgs/by-name/co/confy-tui/package.nix
@@ -1,25 +1,23 @@
 {
   lib,
-  python3Packages,
+  rustPlatform,
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonApplication (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "confy-tui";
-  version = "3.0.0";
-  pyproject = true;
+  version = "3.1.0";
+
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "phluxjr";
     repo = "confy";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-yhzmkIPrOckDxoB10RBX5ul/rYzVKtU6l6O1Zm69e9c=";
+    hash = "sha256-nm7ghQ3SbcGXr/cVeCZCI0h9EbvrrMc9/lLP7Rs59Uw=";
   };
 
-  build-system = [
-    python3Packages.hatchling
-  ];
+  cargoHash = "sha256-E4AK2WLwr7GEexM8JncfHoSBQxQ1OuCkro9jEq+9I4s=";
 
   postInstall = ''
     install -Dm644 confy.1 $out/share/man/man1/confy.1


### PR DESCRIPTION
update the package.nix to build for rust rather than python and build the v3.1.0 version

redone because i messed up the commit message

## Things done

- Built on platform:

  - [x] x86_64-linux

  - [ ] aarch64-linux

  - [ ] aarch64-darwin

- Tested, as applicable:

  - [ ] [NixOS tests] in [nixos/tests].

  - [ ] [Package tests] at `passthru.tests`.

  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.

- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.

- Nixpkgs Release Notes

  - [ ] Package update: when the change is major or breaking.

- NixOS Release Notes

  - [ ] Module addition: when adding a new NixOS module.

  - [ ] Module update: when the change is significant.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

- [x] Follows the [automation/AI policy].



[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests

[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage



[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md

[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy

[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests

[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md

[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests

[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

