### PR TITLE
tcl*: enable strictDeps and structuredAttrs, modernize

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -101,6 +101,8 @@
   `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
   Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.
 
+- `tcl.mkTclDerivation` now enables `strictDeps` and `__structuredAttrs`.
+
 - `pdns` has been updated from `5.0.x` to `5.1.x`. Please be sure to review the [Upgrade Notes](https://doc.powerdns.com/authoritative/upgrading.html#to-5-1-0) before upgrading. Namely LUA record updates are no longer allowed by default, and the embedded webserver no longer includes a `access-control-allow-origin: *` header by default.
 
 - LibreOffice upstream switched from Fresh/Still stable branches to a single Stable branch; `libreoffice` and `libreoffice-qt` work as before, but more specific aliases like `libreoffice-fresh` should be replaced.

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -493,7 +493,7 @@ When using native compilation, `stdenv` is lenient towards incorrect placement o
 
 While convenient for getting to a package quickly, this behavior can break cross-compilation. Adding `strictDeps = true` as a parameter to `mkDerivation` or any of its language specific wrappers disables this behavior.
 
-The specialized `build*` functions for dlang, emacs, go, nim, ocaml, python, and rust enable this option by default.
+The specialized `build*` functions for dlang, emacs, go, nim, ocaml, python, rust, and `tcl.mkTclDerivation` enable this option by default.
 
 ## Attributes {#ssec-stdenv-attributes}
 

--- a/pkgs/by-name/el/eltclsh/package.nix
+++ b/pkgs/by-name/el/eltclsh/package.nix
@@ -9,13 +9,13 @@
   tk,
 }:
 
-tcl.mkTclDerivation rec {
+tcl.mkTclDerivation (finalAttrs: {
   pname = "eltclsh";
   version = "1.20";
 
   src = fetchgit {
     url = "https://git.openrobots.org/robots/eltclsh.git";
-    rev = "eltclsh-${version}";
+    tag = "eltclsh-${finalAttrs.version}";
     hash = "sha256-kNUT190DkY+NNUmBwHfSxgBLbSyc0MutVDLsRh7kFDE=";
   };
 
@@ -46,4 +46,4 @@ tcl.mkTclDerivation rec {
     maintainers = with lib.maintainers; [ iwanb ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/na/nagelfar/package.nix
+++ b/pkgs/by-name/na/nagelfar/package.nix
@@ -6,14 +6,14 @@
   tk,
 }:
 
-tcl.mkTclDerivation rec {
+tcl.mkTclDerivation (finalAttrs: {
   pname = "nagelfar";
   version = "1.3.5";
 
   src = fetchurl {
     url = "https://sourceforge.net/projects/nagelfar/files/Rel_${
-      lib.replaceString "." "" version
-    }/nagelfar${lib.replaceString "." "" version}.tar.gz";
+      lib.replaceString "." "" finalAttrs.version
+    }/nagelfar${lib.replaceString "." "" finalAttrs.version}.tar.gz";
     hash = "sha256-O6+SD7NLc+MgZxGDZdB02FkpjivON0itlFhiS+zoWyM=";
   };
 
@@ -43,4 +43,4 @@ tcl.mkTclDerivation rec {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.nat-418 ];
   };
-}
+})

--- a/pkgs/by-name/na/nagelfar/package.nix
+++ b/pkgs/by-name/na/nagelfar/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchurl,
+  bashNonInteractive,
   tcl,
   tclPackages,
   tk,
@@ -18,6 +19,7 @@ tcl.mkTclDerivation (finalAttrs: {
   };
 
   buildInputs = [
+    bashNonInteractive
     tcl
     tclPackages.tcllib
     tk

--- a/pkgs/by-name/re/remind/package.nix
+++ b/pkgs/by-name/re/remind/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchzip,
   gitUpdater,
+  bashNonInteractive,
   tk,
   tclPackages,
   tcl,
@@ -22,6 +23,10 @@ tcl.mkTclDerivation (finalAttrs: {
     url = "https://dianne.skoll.ca/projects/remind/download/remind-${finalAttrs.version}.tar.gz";
     hash = "sha256-R6kceXLzg5CRMYAgMyhnmKxWT49ayXIFm/IpXuDgl8I=";
   };
+
+  buildInputs = [
+    bashNonInteractive
+  ];
 
   propagatedBuildInputs = lib.optionals withGui [
     tclPackages.tcllib

--- a/pkgs/by-name/re/remind/package.nix
+++ b/pkgs/by-name/re/remind/package.nix
@@ -14,12 +14,12 @@
       true,
 }:
 
-tcl.mkTclDerivation rec {
+tcl.mkTclDerivation (finalAttrs: {
   pname = "remind";
   version = "06.02.10";
 
   src = fetchzip {
-    url = "https://dianne.skoll.ca/projects/remind/download/remind-${version}.tar.gz";
+    url = "https://dianne.skoll.ca/projects/remind/download/remind-${finalAttrs.version}.tar.gz";
     hash = "sha256-R6kceXLzg5CRMYAgMyhnmKxWT49ayXIFm/IpXuDgl8I=";
   };
 
@@ -38,11 +38,13 @@ tcl.mkTclDerivation rec {
       --replace-fail 'set Rem2PDF "rem2pdf"' "set Rem2PDF \"$out/bin/rem2pdf\""
   '';
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     # On Darwin setenv and unsetenv are defined in stdlib.h from libSystem
-    "-DHAVE_SETENV"
-    "-DHAVE_UNSETENV"
-  ]);
+    NIX_CFLAGS_COMPILE = toString [
+      "-DHAVE_SETENV"
+      "-DHAVE_UNSETENV"
+    ];
+  };
 
   passthru.updateScript = gitUpdater {
     ignoredVersions = "-BETA";
@@ -60,4 +62,4 @@ tcl.mkTclDerivation rec {
     mainProgram = "remind";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/sc/scid-vs-pc/package.nix
+++ b/pkgs/by-name/sc/scid-vs-pc/package.nix
@@ -10,19 +10,18 @@
   makeDesktopItem,
 }:
 
-tcl.mkTclDerivation rec {
+tcl.mkTclDerivation (finalAttrs: {
   pname = "scid-vs-pc";
   version = "4.27";
 
   src = fetchurl {
-    url = "mirror://sourceforge/scidvspc/scid_vs_pc-${version}.tgz";
+    url = "mirror://sourceforge/scidvspc/scid_vs_pc-${finalAttrs.version}.tgz";
     hash = "sha256-aWN1w46dOW7VMACs8huvUsACtk3ggIS6BZ51BM9k+VM=";
   };
 
   postPatch = ''
     substituteInPlace configure Makefile.conf \
-      --replace "~/.fonts" "$out/share/fonts/truetype/Scid" \
-      --replace "which fc-cache" "false"
+      --replace-fail "~/.fonts" "$out/share/fonts/truetype/Scid"
   '';
 
   nativeBuildInputs = [
@@ -55,7 +54,7 @@ tcl.mkTclDerivation rec {
     name = "scid-vs-pc";
     desktopName = "Scid vs. PC";
     genericName = "Chess Database";
-    comment = meta.description;
+    comment = finalAttrs.meta.description;
     icon = "scid";
     exec = "scid";
     categories = [
@@ -72,4 +71,4 @@ tcl.mkTclDerivation rec {
     maintainers = [ lib.maintainers.paraseba ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/sc/scid-vs-pc/package.nix
+++ b/pkgs/by-name/sc/scid-vs-pc/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchurl,
   tcl,
+  bashNonInteractive,
   tk,
   libx11,
   zlib,
@@ -29,6 +30,7 @@ tcl.mkTclDerivation (finalAttrs: {
     which
   ];
   buildInputs = [
+    bashNonInteractive
     tk
     libx11
     zlib

--- a/pkgs/by-name/sc/scid/package.nix
+++ b/pkgs/by-name/sc/scid/package.nix
@@ -9,20 +9,20 @@
   zlib,
 }:
 
-tcl.mkTclDerivation rec {
+tcl.mkTclDerivation (finalAttrs: {
   pname = "scid";
   version = "5.0.2";
 
   src = fetchFromGitHub {
     owner = "benini";
     repo = "scid";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-5WGZm7EwhZAMKJKxj/OOIFOJIgPBcc6/Bh4xVAlia4Y=";
   };
 
   postPatch = ''
     substituteInPlace configure \
-      --replace "set var(INSTALL) {install_mac}" ""
+      --replace-fail "set var(INSTALL) {install_mac}" ""
   '';
 
   nativeBuildInputs = [
@@ -55,4 +55,4 @@ tcl.mkTclDerivation rec {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/sc/scid/package.nix
+++ b/pkgs/by-name/sc/scid/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   tcl,
+  bashNonInteractive,
   tk,
   libx11,
   zlib,
@@ -30,6 +31,7 @@ tcl.mkTclDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    bashNonInteractive
     tk
     libx11
     zlib

--- a/pkgs/by-name/tc/tcl2048/package.nix
+++ b/pkgs/by-name/tc/tcl2048/package.nix
@@ -6,12 +6,12 @@
   runtimeShell,
 }:
 
-tcl.mkTclDerivation rec {
+tcl.mkTclDerivation (finalAttrs: {
   pname = "tcl2048";
   version = "0.4.0";
 
   src = fetchurl {
-    url = "https://raw.githubusercontent.com/dbohdan/2048.tcl/v${version}/2048.tcl";
+    url = "https://raw.githubusercontent.com/dbohdan/2048.tcl/v${finalAttrs.version}/2048.tcl";
     sha256 = "53f5503efd7f029b2614b0f9b1e3aac6c0342735a3c9b811d74a5135fee3e89e";
   };
 
@@ -31,4 +31,4 @@ tcl.mkTclDerivation rec {
     mainProgram = "2048";
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -129,6 +129,8 @@ let
         ''}
       '';
 
+    __structuredAttrs = true;
+
     meta = {
       description = "Tcl scripting language";
       homepage = "https://www.tcl.tk/";

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -4,6 +4,7 @@
   callPackage,
   makeSetupHook,
   runCommand,
+  bashNonInteractive,
   tzdata,
   zip,
   zlib,
@@ -42,9 +43,14 @@ let
       zip
     ];
 
-    buildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
+    buildInputs = [
+      bashNonInteractive
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "9.0") [
       zlib
     ];
+
+    strictDeps = true;
 
     preConfigure = ''
       cd unix

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  baseInterp = stdenv.mkDerivation rec {
+  baseInterp = stdenv.mkDerivation (finalAttrs: {
     pname = "tcl";
     inherit version src;
 
@@ -31,10 +31,10 @@ let
 
     postPatch = ''
       substituteInPlace library/clock.tcl \
-        --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
-        --replace "/usr/share/lib/zoneinfo" "" \
-        --replace "/usr/lib/zoneinfo" "" \
-        --replace "/usr/local/etc/zoneinfo" ""
+        --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
+        --replace-fail "/usr/share/lib/zoneinfo" "" \
+        --replace-fail "/usr/lib/zoneinfo" "" \
+        --replace-fail "/usr/local/etc/zoneinfo" ""
     ''
     + extraPatch;
 
@@ -139,41 +139,44 @@ let
       maintainers = with lib.maintainers; [ agbrooks ];
     };
 
-    passthru = rec {
-      inherit release version;
-      isTcl9 = lib.versions.major version == "9";
-      libPrefix = "tcl${release}";
-      libdir = "lib/${libPrefix}";
-      tclPackageHook = callPackage (
-        { buildPackages }:
-        makeSetupHook {
-          name = "tcl-package-hook";
-          propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
-          meta = {
-            inherit (meta) maintainers platforms;
-            license = lib.licenses.mit;
-          };
-        } ./tcl-package-hook.sh
-      ) { };
-      tclRequiresCheckHook = callPackage (
-        { buildPackages }:
-        makeSetupHook {
-          name = "tcl-requires-check-hook";
-          propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
-          meta = {
-            inherit (meta) maintainers platforms;
-            license = lib.licenses.mit;
-          };
-        } ./tcl-requires-check-hook.sh
-      ) { };
-      # verify that Tcl's clock library can access tzdata
-      tests.tzdata = runCommand "${pname}-test-tzdata" { } ''
-        ${baseInterp}/bin/tclsh <(echo "set t [clock scan {2004-10-30 05:00:00} \
-                                      -format {%Y-%m-%d %H:%M:%S} \
-                                      -timezone :America/New_York]") > $out
-      '';
-    };
-  };
+    passthru =
+      let
+        libPrefix = "tcl${release}";
+      in
+      {
+        inherit release version libPrefix;
+        isTcl9 = lib.versions.major version == "9";
+        libdir = "lib/${libPrefix}";
+        tclPackageHook = callPackage (
+          { buildPackages }:
+          makeSetupHook {
+            name = "tcl-package-hook";
+            propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
+            meta = {
+              inherit (finalAttrs.meta) maintainers platforms;
+              license = lib.licenses.mit;
+            };
+          } ./tcl-package-hook.sh
+        ) { };
+        tclRequiresCheckHook = callPackage (
+          { buildPackages }:
+          makeSetupHook {
+            name = "tcl-requires-check-hook";
+            propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
+            meta = {
+              inherit (finalAttrs.meta) maintainers platforms;
+              license = lib.licenses.mit;
+            };
+          } ./tcl-requires-check-hook.sh
+        ) { };
+        # verify that Tcl's clock library can access tzdata
+        tests.tzdata = runCommand "${finalAttrs.pname}-test-tzdata" { } ''
+          ${baseInterp}/bin/tclsh <(echo "set t [clock scan {2004-10-30 05:00:00} \
+                                        -format {%Y-%m-%d %H:%M:%S} \
+                                        -timezone :America/New_York]") > $out
+        '';
+      };
+  });
 
   mkTclDerivation = callPackage ./mk-tcl-derivation.nix { tcl = baseInterp; };
 

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -7,7 +7,7 @@
 
 let
   inherit (tcl) stdenv;
-  inherit (lib) getBin optionalAttrs;
+  inherit (lib) getExe' optionalAttrs;
 
   defaultTclPkgConfigureFlags = [
     "--with-tcl=${tcl}/lib"
@@ -72,7 +72,7 @@ lib.extendMkDerivation {
             configureFlags;
 
         env = {
-          TCLSH = "${getBin tcl}/bin/tclsh";
+          TCLSH = "${getExe' tcl "tclsh"}";
         }
         // args.env or { };
 

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -76,6 +76,8 @@ lib.extendMkDerivation {
         }
         // args.env or { };
 
+        __structuredAttrs = true;
+
         meta = {
           platforms = tcl.meta.platforms;
         }

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -56,6 +56,8 @@ lib.extendMkDerivation {
 
         propagatedBuildInputs = args.propagatedBuildInputs or [ ] ++ [ tcl ];
 
+        strictDeps = true;
+
         # Run tests after install, at which point we've done all TCLLIBPATH setup
         doCheck = false;
         doInstallCheck = args.doCheck or (args.doInstallCheck or false);

--- a/pkgs/development/tcl-modules/by-name/bw/bwidget/package.nix
+++ b/pkgs/development/tcl-modules/by-name/bw/bwidget/package.nix
@@ -5,21 +5,21 @@
   tk,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "bwidget";
   version = "1.10.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/tcllib/bwidget-${version}.tar.gz";
-    sha256 = "sha256-61sCvsua+Iv3SldHhd4eMpzzCjZ5EVMJOnkRT6xRw60=";
+    url = "mirror://sourceforge/tcllib/bwidget-${finalAttrs.version}.tar.gz";
+    hash = "sha256-61sCvsua+Iv3SldHhd4eMpzzCjZ5EVMJOnkRT6xRw60=";
   };
 
   dontBuild = true;
   propagatedBuildInputs = [ tk ];
 
   installPhase = ''
-    mkdir -p "$out/lib/bwidget${version}"
-    cp -R *.tcl lang images "$out/lib/bwidget${version}"
+    mkdir -p "$out/lib/bwidget${finalAttrs.version}"
+    cp -R *.tcl lang images "$out/lib/bwidget${finalAttrs.version}"
   '';
 
   meta = {
@@ -29,4 +29,4 @@ mkTclDerivation rec {
     license = lib.licenses.tcltk;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/cf/cffi/package.nix
+++ b/pkgs/development/tcl-modules/by-name/cf/cffi/package.nix
@@ -15,8 +15,6 @@ mkTclDerivation (finalAttrs: {
     hash = "sha256-IcoDZu2P+yafntDNeDZS3NSwFuRgZgIBZCLhCdIY+6g=";
   };
 
-  strictDeps = true;
-
   patches = [
     # https://github.com/apnadkarni/tclh/pull/2
     ./efscorrupted-euclean.patch

--- a/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
@@ -40,8 +40,6 @@ tcl.mkTclDerivation (finalAttrs: {
 
   __structuredAttrs = true;
 
-  strictDeps = true;
-
   postInstall = ''
     tclWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ tcl ]})
     ${lib.optionalString stdenv.hostPlatform.isDarwin "tclWrapperArgs+=(--prefix DYLD_LIBRARY_PATH : $out/lib/expect${finalAttrs.version})"}

--- a/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
@@ -38,8 +38,6 @@ tcl.mkTclDerivation (finalAttrs: {
     makeWrapper
   ];
 
-  __structuredAttrs = true;
-
   postInstall = ''
     tclWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ tcl ]})
     ${lib.optionalString stdenv.hostPlatform.isDarwin "tclWrapperArgs+=(--prefix DYLD_LIBRARY_PATH : $out/lib/expect${finalAttrs.version})"}

--- a/pkgs/development/tcl-modules/by-name/in/incrtcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/in/incrtcl/package.nix
@@ -7,12 +7,12 @@
   tcl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "incrtcl";
   version = "4.2.3";
 
   src = fetchurl {
-    url = "mirror://sourceforge/incrtcl/%5BIncr%20Tcl_Tk%5D-source/3.4/itcl${version}.tar.gz";
+    url = "mirror://sourceforge/incrtcl/%5BIncr%20Tcl_Tk%5D-source/3.4/itcl${finalAttrs.version}.tar.gz";
     hash = "sha256-idOs2GXP3ZY7ECtF+K9hg5REyK6sQ0qk+666gUQPjCY=";
   };
 
@@ -24,10 +24,10 @@ mkTclDerivation rec {
 
   postInstall = ''
     rmdir $out/bin
-    mv $out/lib/itcl${version}/* $out/lib
-    ln -s libitcl${version}${stdenv.hostPlatform.extensions.sharedLibrary} \
-      $out/lib/libitcl${lib.versions.major version}${stdenv.hostPlatform.extensions.sharedLibrary}
-    rmdir $out/lib/itcl${version}
+    mv $out/lib/itcl${finalAttrs.version}/* $out/lib
+    ln -s libitcl${finalAttrs.version}${stdenv.hostPlatform.extensions.sharedLibrary} \
+      $out/lib/libitcl${lib.versions.major finalAttrs.version}${stdenv.hostPlatform.extensions.sharedLibrary}
+    rmdir $out/lib/itcl${finalAttrs.version}
   '';
 
   setupHook = writeText "setup-hook.sh" ''
@@ -48,4 +48,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ thoughtpolice ];
     broken = tcl.isTcl9;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/it/itktcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/it/itktcl/package.nix
@@ -7,12 +7,12 @@
   incrtcl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "itk-tcl";
   version = "4.1.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/incrtcl/%5BIncr%20Tcl_Tk%5D-source/3.4/itk${version}.tar.gz";
+    url = "mirror://sourceforge/incrtcl/%5BIncr%20Tcl_Tk%5D-source/3.4/itk${finalAttrs.version}.tar.gz";
     hash = "sha256-2mRhmSIu/cTYyZWThjyNKHRC6lqGh/lUYNbp5yQxycc=";
   };
 
@@ -30,10 +30,10 @@ mkTclDerivation rec {
 
   postInstall = ''
     rmdir $out/bin
-    mv $out/lib/itk${version}/* $out/lib
-    ln -s libitk${version}${stdenv.hostPlatform.extensions.sharedLibrary} \
-      $out/lib/libitk${lib.versions.major version}${stdenv.hostPlatform.extensions.sharedLibrary}
-    rmdir $out/lib/itk${version}
+    mv $out/lib/itk${finalAttrs.version}/* $out/lib
+    ln -s libitk${finalAttrs.version}${stdenv.hostPlatform.extensions.sharedLibrary} \
+      $out/lib/libitk${lib.versions.major finalAttrs.version}${stdenv.hostPlatform.extensions.sharedLibrary}
+    rmdir $out/lib/itk${finalAttrs.version}
   '';
 
   outputs = [
@@ -49,4 +49,4 @@ mkTclDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/mu/mustache-tcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/mu/mustache-tcl/package.nix
@@ -5,14 +5,14 @@
   tcllib,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "mustache-tcl";
   version = "1.1.3.4";
 
   src = fetchFromGitHub {
     owner = "ianka";
     repo = "mustache.tcl";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-apM57LEZ0Y9hXcEPWrKYOoTVtP5QSqiaQrjTHQc3pc4=";
   };
 
@@ -33,4 +33,4 @@ mkTclDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ nat-418 ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/pd/pdf4tcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/pd/pdf4tcl/package.nix
@@ -4,12 +4,14 @@
   fetchzip,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "pdf4tcl";
   version = "0.9.4";
 
   src = fetchzip {
-    url = "mirror://sourceforge/pdf4tcl/pdf4tcl${lib.replaceStrings [ "." ] [ "" ] version}.tar.gz";
+    url = "mirror://sourceforge/pdf4tcl/pdf4tcl${
+      lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }.tar.gz";
     hash = "sha256-lmSt0UQDfUef8S7zevAvvbeWB/vd6jLbKz7Y5A7xJm4=";
   };
 
@@ -26,4 +28,4 @@ mkTclDerivation rec {
     license = lib.licenses.tcltk;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/ru/ruff/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ru/ruff/package.nix
@@ -5,12 +5,12 @@
   tcllib,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "ruff";
   version = "2.4.2";
 
   src = fetchzip {
-    url = "mirror://sourceforge/magicsplat/ruff/ruff-${version}.tgz";
+    url = "mirror://sourceforge/magicsplat/ruff/ruff-${finalAttrs.version}.tgz";
     hash = "sha256-BeO0YtFDSg3e0ehdcpbojAw6WsInkiiHh01I0bYOkRY=";
   };
 
@@ -41,4 +41,4 @@ mkTclDerivation rec {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tcl-lmdb/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcl-lmdb/package.nix
@@ -5,14 +5,14 @@
   lmdb,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tcl-lmdb";
   version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "ray2501";
     repo = "tcl-lmdb";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-HrR8VQ9cE9jkESqvKkLnYbZLErUVxau2z8xcFImH9lc=";
   };
 
@@ -32,4 +32,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tcl-opencl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcl-opencl/package.nix
@@ -7,14 +7,14 @@
   vectcl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tcl-opencl";
   version = "0.8";
 
   src = fetchFromGitHub {
     owner = "ray2501";
     repo = "tcl-opencl";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-nVqHWP6YbWbOAJsz0+4xYkOW3zWVmwhOI421Ak+8E3Q=";
   };
 
@@ -37,4 +37,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tclcsv/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclcsv/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tclcsv";
   version = "2.4.3";
 
   src = fetchzip {
-    url = "mirror://sourceforge/tclcsv/tclcsv${version}-src.tar.gz";
+    url = "mirror://sourceforge/tclcsv/tclcsv${finalAttrs.version}-src.tar.gz";
     hash = "sha256-bNRMgIyUSy4TnOGq9FPCXr79NIkcRfy2SqO5/i+DC/w=";
   };
 
@@ -21,4 +21,4 @@ mkTclDerivation rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tclcurl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclcurl/package.nix
@@ -6,14 +6,14 @@
   tcl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tclcurl";
   version = "7.22.1";
 
   src = fetchFromGitHub {
     owner = "flightaware";
     repo = "tclcurl-fa";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-XQuP+SiqvGX3ckBShUxsGBADjV3QdvYpU4hW6LMbMMQ=";
   };
 
@@ -32,4 +32,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     broken = tcl.isTcl9;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tclcurl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclcurl/package.nix
@@ -17,10 +17,11 @@ mkTclDerivation (finalAttrs: {
     hash = "sha256-XQuP+SiqvGX3ckBShUxsGBADjV3QdvYpU4hW6LMbMMQ=";
   };
 
-  buildInputs = [ curl ];
+  nativeBuildInputs = [
+    curl # for curl-config
+  ];
 
-  # Uses curl-config
-  strictDeps = false;
+  buildInputs = [ curl ];
 
   makeFlags = [ "LDFLAGS=-lcurl" ];
 

--- a/pkgs/development/tcl-modules/by-name/tc/tcllib/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcllib/package.nix
@@ -6,12 +6,12 @@
   withCritcl ? true,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tcllib";
   version = "2.0";
 
   src = fetchzip {
-    url = "mirror://sourceforge/tcllib/tcllib-${version}.tar.gz";
+    url = "mirror://sourceforge/tcllib/tcllib-${finalAttrs.version}.tar.gz";
     hash = "sha256-LoY6y7p9n1dXk4eSa/HuyA4bIXa0rN7F2OGESk2tROI=";
   };
 
@@ -35,4 +35,4 @@ mkTclDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tcllib/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcllib/package.nix
@@ -4,6 +4,7 @@
   mkTclDerivation,
   critcl,
   withCritcl ? true,
+  bashNonInteractive,
 }:
 
 mkTclDerivation (finalAttrs: {
@@ -16,6 +17,10 @@ mkTclDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = lib.optional withCritcl critcl;
+
+  buildInputs = [
+    bashNonInteractive
+  ];
 
   buildFlags = [ "all" ] ++ lib.optional withCritcl "critcl";
 

--- a/pkgs/development/tcl-modules/by-name/tc/tclmagick/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclmagick/package.nix
@@ -18,6 +18,10 @@ mkTclDerivation (finalAttrs: {
 
   sourceRoot = finalAttrs.src.name + "/TclMagick";
 
+  nativeBuildInputs = [
+    graphicsmagick # for GraphicsMagickWand-config script
+  ];
+
   buildInputs = [
     graphicsmagick
     tk

--- a/pkgs/development/tcl-modules/by-name/tc/tclmagick/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclmagick/package.nix
@@ -7,16 +7,16 @@
   tk,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tclmagick";
   version = "1.3.43";
 
   src = fetchzip {
-    url = "mirror://sourceforge/graphicsmagick/GraphicsMagick-${version}.tar.xz";
+    url = "mirror://sourceforge/graphicsmagick/GraphicsMagick-${finalAttrs.version}.tar.xz";
     hash = "sha256-CpZztiBF0HqH4XWIAyE9IbZVpBcgrDzyASv47wTneQ0=";
   };
 
-  sourceRoot = src.name + "/TclMagick";
+  sourceRoot = finalAttrs.src.name + "/TclMagick";
 
   buildInputs = [
     graphicsmagick
@@ -37,4 +37,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     broken = tcl.isTcl9;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tclreadline/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclreadline/package.nix
@@ -10,14 +10,14 @@
   tk,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tclreadline";
   version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "flightaware";
     repo = "tclreadline";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-6FIQJsAm28jPIfNG+7xsMlCJSLw9JStOVzDemw2P+EI=";
   };
 
@@ -67,4 +67,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tcltls/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcltls/package.nix
@@ -6,13 +6,13 @@
   tcl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tcltls";
   version = "1.7.22";
 
   src = fetchurl {
-    url = "https://core.tcl-lang.org/tcltls/uv/tcltls-${version}.tar.gz";
-    sha256 = "sha256-6E4reideyCxKqp0bH5eG2+Q1jIFekXU5/+f2Z/9Lw7Q=";
+    url = "https://core.tcl-lang.org/tcltls/uv/tcltls-${finalAttrs.version}.tar.gz";
+    hash = "sha256-6E4reideyCxKqp0bH5eG2+Q1jIFekXU5/+f2Z/9Lw7Q=";
   };
 
   buildInputs = [ openssl ];
@@ -31,4 +31,4 @@ mkTclDerivation rec {
     platforms = lib.platforms.unix;
     broken = tcl.isTcl9;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tcludp/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcludp/package.nix
@@ -5,13 +5,13 @@
   tcl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tcludp";
   version = "1.0.11";
 
   src = fetchfossil {
     url = "https://core.tcl-lang.org/tcludp";
-    rev = "ver_" + lib.replaceStrings [ "." ] [ "_" ] version;
+    rev = "ver_" + lib.replaceString "." "_" finalAttrs.version;
     hash = "sha256-PckGwUqL2r5KJEet8sS4U504G63flX84EkQEkQdMifY=";
   };
 
@@ -38,4 +38,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     broken = tcl.isTcl9;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tc/tclx/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclx/package.nix
@@ -4,21 +4,21 @@
   mkTclDerivation,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tclx";
   version = "8.6.3";
 
   src = fetchFromGitHub {
     owner = "flightaware";
     repo = "tclx";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-bzLF6qOF9o24joWnGR7B4S+Doj7zv9iTh/mo50iFbUs=";
   };
 
   # required in order for tclx to properly detect tclx.tcl at runtime
   postInstall =
     let
-      majorMinorVersion = lib.versions.majorMinor version;
+      majorMinorVersion = lib.versions.majorMinor finalAttrs.version;
     in
     ''
       ln -s $prefix/lib/tclx${majorMinorVersion} $prefix/lib/tclx${majorMinorVersion}/tclx${majorMinorVersion}
@@ -33,4 +33,4 @@ mkTclDerivation rec {
       fgaz
     ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/td/tdom/package.nix
+++ b/pkgs/development/tcl-modules/by-name/td/tdom/package.nix
@@ -7,12 +7,12 @@
   pkg-config,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tdom";
   version = "0.9.6";
 
   src = fetchzip {
-    url = "https://tdom.org/downloads/tdom-${version}-src.tgz";
+    url = "https://tdom.org/downloads/tdom-${finalAttrs.version}-src.tgz";
     hash = "sha256-zN855tb9JQUtcB7K1DeAjUBrqhoNH44KbeHwp3qewqw=";
   };
 
@@ -37,4 +37,4 @@ mkTclDerivation rec {
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tk/tkimg/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tk/tkimg/package.nix
@@ -8,12 +8,12 @@
   zlib,
 }:
 
-tcl.mkTclDerivation rec {
+tcl.mkTclDerivation (finalAttrs: {
   pname = "tkimg";
   version = "2.1.1";
 
   src = fetchzip {
-    url = "mirror://sourceforge/tkimg/tkimg/Img-${version}.tar.gz";
+    url = "mirror://sourceforge/tkimg/tkimg/Img-${finalAttrs.version}.tar.gz";
     hash = "sha256-TRtE2/BVrYgkdKtbF06UjLvokokgLGQ/EKDLxhz2Ckw=";
   };
 
@@ -37,4 +37,4 @@ tcl.mkTclDerivation rec {
     platforms = lib.platforms.unix;
     badPlatforms = lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/tk/tkimg/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tk/tkimg/package.nix
@@ -23,6 +23,10 @@ tcl.mkTclDerivation (finalAttrs: {
     "--with-tkinclude=${tk.dev}/include"
   ];
 
+  nativeBuildInputs = [
+    tcllib # for dtplite
+  ];
+
   buildInputs = [
     libx11
     tcllib

--- a/pkgs/development/tcl-modules/by-name/ve/vectcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ve/vectcl/package.nix
@@ -5,14 +5,14 @@
   tcl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "vectcl";
   version = "0.3";
 
   src = fetchFromGitHub {
     owner = "auriocus";
     repo = "VecTcl";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-nPs16Jy6KMEdupWJNhgYqosuW5Dlpb/dxxTrLpRbYf0=";
   };
 
@@ -25,4 +25,4 @@ mkTclDerivation rec {
     license = lib.licenses.tcltk;
     broken = tcl.isTcl9;
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/ya/yajl-tcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ya/yajl-tcl/package.nix
@@ -18,8 +18,6 @@ mkTclDerivation (finalAttrs: {
     hash = "sha256-MKm/cfZxPoxpsHuZf9qSXZXzdFbDb7IGeJgMHGh9bcE=";
   };
 
-  strictDeps = true;
-
   nativeBuildInputs = [
     autoreconfHook
     pkg-config

--- a/pkgs/development/tcl-modules/by-name/ya/yajl-tcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ya/yajl-tcl/package.nix
@@ -7,14 +7,14 @@
   yajl,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "yajl-tcl";
   version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "flightaware";
     repo = "yajl-tcl";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-MKm/cfZxPoxpsHuZf9qSXZXzdFbDb7IGeJgMHGh9bcE=";
   };
 
@@ -37,8 +37,8 @@ mkTclDerivation rec {
   meta = {
     description = "Tcl bindings for Yet Another JSON Library";
     homepage = "https://github.com/flightaware/yajl-tcl";
-    changelog = "https://github.com/flightaware/yajl-tcl/blob/${src.tag}/ChangeLog";
+    changelog = "https://github.com/flightaware/yajl-tcl/blob/${finalAttrs.src.tag}/ChangeLog";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/development/tcl-modules/by-name/ze/zesty/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ze/zesty/package.nix
@@ -6,14 +6,14 @@
   nix-update-script,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "zesty";
   version = "0.2";
 
   src = fetchFromGitHub {
     owner = "nico-robert";
     repo = "zesty";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-1K3E9rQAXEXegLjp2mZTzwyDXq3lMpDr0DB4I+ACH08=";
   };
 
@@ -38,4 +38,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tcl-modules/critcl/default.nix
+++ b/pkgs/development/tcl-modules/critcl/default.nix
@@ -6,14 +6,14 @@
   tcllib,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "critcl";
   version = "3.3.1";
 
   src = fetchFromGitHub {
     owner = "andreas-kupries";
     repo = "critcl";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-LBTAuwTrvwj42vo/TXVSUK8euxHgvSLai23e1jmhMso=";
   };
 
@@ -45,4 +45,4 @@ mkTclDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/tcl-modules/critcl/default.nix
+++ b/pkgs/development/tcl-modules/critcl/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   mkTclDerivation,
+  bashNonInteractive,
   tcl,
   tcllib,
 }:
@@ -18,6 +19,7 @@ mkTclDerivation (finalAttrs: {
   };
 
   buildInputs = [
+    bashNonInteractive
     tcl
     tcllib
   ];

--- a/pkgs/development/tcl-modules/dbus/default.nix
+++ b/pkgs/development/tcl-modules/dbus/default.nix
@@ -6,12 +6,12 @@
   dbus,
 }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "dbus";
   version = "4.1";
 
   src = fetchzip {
-    url = "https://chiselapp.com/user/schelte/repository/dbus/uv/dbus-${version}.tar.gz";
+    url = "https://chiselapp.com/user/schelte/repository/dbus/uv/dbus-${finalAttrs.version}.tar.gz";
     hash = "sha256-8VIw475Q9kRh6UV6FxWCXKLKasqM1z58ed0rMgzEX3I=";
   };
 
@@ -29,4 +29,4 @@ mkTclDerivation rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})


### PR DESCRIPTION
In the process of moving towards having `strictDeps` and `structuredAttrs` enabled in all of nixpkgs I encountered a number of tcl-related changes that needed to be made in the process of testing https://github.com/NixOS/nixpkgs/pull/551108 (or rather, an extended version of it that also updates various builders). Low-level changes are mostly caused by `tclPackages.except` (dependency of `dejagnu`) gaining `__structuredAttrs`, and the changes to the tcl interpreter itself (because `tclPacakges.except` sees that).

However, the tcl package set as a whole is rather small and contains many leaf packages, so it seems feasible to update and modernize the whole thing in one go.

I've [tested all packages that use `mkTclDerivation` individually via `nixpkgs-review` - based on master instead of staging](https://github.com/NixOS/nixpkgs/pull/551143#issuecomment-5240886809).

Can we get this merged in one go or should I split this up into individual PRs anyway? The exciting stuff happens from "[tcl.mkTclDerivation: enable strictDeps, fix and clean affected packages](https://github.com/NixOS/nixpkgs/pull/551143/commits/c947aa10e06250c82997f9f19a0990fbc90d04fb)" onward, only pretty simple modernization before that point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
