### PR TITLE
vector-blf: init at 2.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -875,6 +875,12 @@
     githubId = 6055037;
     name = "Alexander Hirner";
   };
+  AhmedAmr = {
+    email = "ahmedamr24680@gmail.com";
+    github = "AhmedAmrNabil";
+    githubId = 43810060;
+    name = "Ahmed Amr";
+  };
   ahoneybun = {
     email = "aaronhoneycutt@proton.me";
     github = "ahoneybun";

--- a/pkgs/by-name/ve/vector-blf/001-fix-cstdint-include.patch
+++ b/pkgs/by-name/ve/vector-blf/001-fix-cstdint-include.patch
@@ -1,0 +1,24 @@
+diff --git a/src/Vector/BLF/FileStatistics.h b/src/Vector/BLF/FileStatistics.h
+index 2e507c2..6fc25b8 100644
+--- a/src/Vector/BLF/FileStatistics.h
++++ b/src/Vector/BLF/FileStatistics.h
+@@ -6,6 +6,7 @@
+ 
+ #include <Vector/BLF/platform.h>
+ 
++#include <cstdint>
+ #include <array>
+ 
+ #include <Vector/BLF/AbstractFile.h>
+diff --git a/src/Vector/BLF/ObjectHeaderBase.h b/src/Vector/BLF/ObjectHeaderBase.h
+index 4fb9407..b72ed6d 100644
+--- a/src/Vector/BLF/ObjectHeaderBase.h
++++ b/src/Vector/BLF/ObjectHeaderBase.h
+@@ -10,6 +10,7 @@
+ 
+ #include <Vector/BLF/vector_blf_export.h>
+ 
++#include <cstdint>
+ namespace Vector {
+ namespace BLF {
+ 

--- a/pkgs/by-name/ve/vector-blf/002-fix-pkg-config-file.patch
+++ b/pkgs/by-name/ve/vector-blf/002-fix-pkg-config-file.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Vector/BLF/Vector_BLF.pc.in b/src/Vector/BLF/Vector_BLF.pc.in
+index b3cb36f..0e20bf8 100644
+--- a/src/Vector/BLF/Vector_BLF.pc.in
++++ b/src/Vector/BLF/Vector_BLF.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @PROJECT_NAME@
+ Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@

--- a/pkgs/by-name/ve/vector-blf/003-fix-boost-cmake.patch
+++ b/pkgs/by-name/ve/vector-blf/003-fix-boost-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 82da81b..750d075 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,7 +45,7 @@ if(OPTION_RUN_CPPCHECK)
+ endif()
+ if(OPTION_BUILD_TESTS)
+     enable_testing()
+-    find_package(Boost 1.55 COMPONENTS system filesystem unit_test_framework REQUIRED)
++    find_package(Boost 1.55 CONFIG REQUIRED COMPONENTS filesystem unit_test_framework)
+ endif()
+ if(OPTION_ADD_LCOV)
+     find_package(LCOV REQUIRED)

--- a/pkgs/by-name/ve/vector-blf/package.nix
+++ b/pkgs/by-name/ve/vector-blf/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  zlib,
+  boost,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vector-blf";
+  version = "2.4.2";
+
+  src = fetchFromGitHub {
+    owner = "Technica-Engineering";
+    repo = "vector_blf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KtAvSkDs8/ZvZ9r0EjQIstMa4RHOdKDDE+ia4hGP8aA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  checkInputs = [
+    boost
+  ];
+
+  patches = [
+    ./001-fix-cstdint-include.patch
+    ./002-fix-pkg-config-file.patch
+    ./003-fix-boost-cmake.patch
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "OPTION_RUN_DOXYGEN" false)
+    (lib.cmakeBool "OPTION_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = true;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Library to access Binary Log File (BLF) files";
+    homepage = "https://github.com/Technica-Engineering/vector_blf";
+    changelog = "https://github.com/Technica-Engineering/vector_blf/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      AhmedAmr
+    ];
+    teams = with lib.teams; [ ngi ];
+    platforms = lib.platforms.all;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the `vector-blf` library (Binary Log File support from Vector Informatik).

This package is a dependency of KDE Labplot and is being packaged as part of the work to bring Labplot into nixpkgs / NGI Forge.

Homepage: https://github.com/Technica-Engineering/vector_blf

This work is done as part of Summer of Nix 2026.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
