### PR TITLE
lon: 0.8.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/lo/lon/package.nix
+++ b/pkgs/by-name/lo/lon/package.nix
@@ -1,29 +1,39 @@
 {
   rustPlatform,
   lib,
+  stdenv,
   fetchFromGitHub,
   makeBinaryWrapper,
+  pkg-config,
+  openssl,
   nix-prefetch-git,
   gitMinimal,
+  nix,
   nix-update-script,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lon";
-  version = "0.8.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "nikstur";
     repo = "lon";
     tag = finalAttrs.version;
-    hash = "sha256-bxu83mbdfAeDZYOnjZQYyjTs5WgZS8o6Q2irlzgbYs0=";
+    hash = "sha256-rNQ3RuTYu7gM/pmchuvb/xNeRo/m82M4iZq2g89r3UA=";
   };
 
   sourceRoot = "source/rust/lon";
 
-  cargoHash = "sha256-x+qxn0s64fPJpTG/d0PgzAdzMXegYdnsC1FFFuBpsaI=";
+  cargoHash = "sha256-mbGMStrC2GRMpL0+yr5WpLLZRT+vNDwjufymoRZwuIk=";
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
 
   postInstall = ''
     wrapProgram $out/bin/lon --prefix PATH : ${
@@ -33,6 +43,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ]
     }
   '';
+
+  nativeCheckInputs = [
+    gitMinimal
+    nix-prefetch-git
+    nix
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Added `openssl` dependency as a `buildInput` for linux platforms since `lon`  uses rust package `reqwest`, that uses `native-tls`, which uses `openssl` Added `versionCheckHook`

The `openssl` dependency being only needed for linux is found here:
https://docs.rs/native-tls/latest/native_tls/
"`vendored` - If enabled, the crate will compile and statically link to a vendored copy of OpenSSL. This feature has no effect on Windows and macOS, where OpenSSL is not used."

Upstream also has its own package.nix and it uses `git` instead of `gitMinimal`. Not sure if there is a need to change to `git` or not.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
