### PR TITLE
{,python3Packages.}cardimpose: 0.2.1-unstable-2024-12-28 -> 0.2.2

### DIFF
--- a/pkgs/development/python-modules/cardimpose/default.nix
+++ b/pkgs/development/python-modules/cardimpose/default.nix
@@ -1,20 +1,23 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   setuptools,
   pymupdf,
 }:
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "cardimpose";
-  version = "0.2.1-unstable-2024-12-28";
+  version = "0.2.2";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "frsche";
-    repo = "cardimpose";
-    rev = "eb26a9795e20db3e3dd5b62dbcbbad547cb05a55";
-    hash = "sha256-Fel0YOe2D76h+QAon/wxI6EsZhfLca+0ncNi9i888+E=";
+  __structuredAttrs = true;
+
+  # Get source from Pypi as the GitHub repository doesn't have any version
+  # indicators, so there's no way to tell when a new version is available or
+  # what the version should be.
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-fMI2bvsHGYU7nZ9CdaUtWQkNj2MihMEcBCVy8VbE6F0=";
   };
 
   build-system = [ setuptools ];
@@ -38,4 +41,4 @@ buildPythonPackage {
     badPlatforms = pymupdf.meta.badPlatforms or [ ];
     maintainers = [ lib.maintainers.me-and ];
   };
-}
+})


### PR DESCRIPTION
Also enable `__structuredAttrs` and fix the failing `passthru.updateScript` by moving to getting source from PyPI rather than GitHub, since the GitHub repository has no version indicators.

There's no upstream changelog as such, but there's a single change in this release compared to the previous unstable release: <https://github.com/frsche/cardimpose/commit/078a5a70459398e267d0e81726c36e3765c4afdc>.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
