### PR TITLE
lib: replace `map (x: x.attr)` with `catAttrs`

### DIFF
--- a/lib/asserts.nix
+++ b/lib/asserts.nix
@@ -7,6 +7,9 @@ let
   inherit (lib.lists)
     filter
     ;
+  inherit (lib.attrsets)
+    catAttrs
+    ;
   inherit (lib.trivial)
     showWarnings
     ;
@@ -192,7 +195,7 @@ rec {
   checkAssertWarn =
     assertions: warnings: val:
     let
-      failedAssertions = map (x: x.message) (filter (x: !x.assertion) assertions);
+      failedAssertions = catAttrs "message" (filter (x: !x.assertion) assertions);
     in
     if failedAssertions != [ ] then
       throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -2,6 +2,7 @@
 
 let
   inherit (builtins)
+    catAttrs
     intersectAttrs
     unsafeGetAttrPos
     ;
@@ -406,7 +407,7 @@ rec {
           ++ [
             {
               name = "all";
-              value = map (x: x.value) outputsList;
+              value = catAttrs "value" outputsList;
             }
           ]
         )

--- a/lib/deprecated/misc.nix
+++ b/lib/deprecated/misc.nix
@@ -241,7 +241,7 @@ let
   # See https://github.com/NixOS/nixpkgs/pull/194391 for details.
   closePropagationFast =
     list:
-    map (x: x.val) (
+    builtins.catAttrs "val" (
       builtins.genericClosure {
         startSet = map (x: {
           key = x.outPath;

--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -14,6 +14,7 @@
 
 let
   inherit (lib)
+    catAttrs
     concatMapStringsSep
     concatStrings
     escape
@@ -409,7 +410,7 @@ rec {
     elems:
     let
       gvarElems = map mkValue elems;
-      tupleType = type.tupleOf (map (e: e.type) gvarElems);
+      tupleType = type.tupleOf (catAttrs "type" gvarElems);
     in
     mkPrimitive tupleType gvarElems
     // {

--- a/lib/meta-types.nix
+++ b/lib/meta-types.nix
@@ -16,6 +16,7 @@ let
     any
     attrNames
     attrValues
+    catAttrs
     concatMap
     isFunction
     isBool
@@ -141,10 +142,10 @@ lib.fix (self: {
     assert all isTypeDef types;
     let
       # Store a list of functions so we don't have to pay the cost of attrset lookups at runtime.
-      funcs = map (t: t.verify) types;
+      funcs = catAttrs "verify" types;
     in
     {
-      name = "union<${concatStringsSep "," (map (t: t.name) types)}>";
+      name = "union<${concatStringsSep "," (catAttrs "name" types)}>";
       verify = v: any (func: func v) funcs;
     };
 
@@ -153,10 +154,10 @@ lib.fix (self: {
     assert all isTypeDef types;
     let
       # Store a list of functions so we don't have to pay the cost of attrset lookups at runtime.
-      funcs = map (t: t.verify) types;
+      funcs = catAttrs "verify" types;
     in
     {
-      name = "intersection<${concatStringsSep "," (map (t: t.name) types)}>";
+      name = "intersection<${concatStringsSep "," (catAttrs "name" types)}>";
       verify = v: all (func: func v) funcs;
     };
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -566,7 +566,7 @@ let
         let
           keyFilter = filter (attrs: !isDisabled modulesPath disabled attrs);
         in
-        map (attrs: attrs.module) (genericClosure {
+        catAttrs "module" (genericClosure {
           startSet = keyFilter modules;
           operator = attrs: keyFilter attrs.modules;
         });
@@ -1148,8 +1148,8 @@ let
     // {
       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
       inherit (res.defsFinal') highestPrio;
-      definitions = map (def: def.value) res.defsFinal;
-      files = map (def: def.file) res.defsFinal;
+      definitions = catAttrs "value" res.defsFinal;
+      files = catAttrs "file" res.defsFinal;
       definitionsWithLocations = res.defsFinal;
       inherit (res) isDefined;
       inherit (res.checkedAndMerged) valueMeta;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -29,6 +29,7 @@ let
     ;
   inherit (lib.attrsets)
     attrByPath
+    catAttrs
     optionalAttrs
     showAttrPath
     ;
@@ -539,7 +540,7 @@ rec {
 
     :::
   */
-  getValues = map (x: x.value);
+  getValues = catAttrs "value";
 
   /**
     Extracts values of all `file` keys of the given list
@@ -561,7 +562,7 @@ rec {
 
     :::
   */
-  getFiles = map (x: x.file);
+  getFiles = catAttrs "file";
 
   # Generate documentation template from the list of option declaration like
   # the set generated with filterOptionSets.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -608,7 +608,7 @@ rec {
     description = "fileset";
     descriptionClass = "noun";
     check = isFileset;
-    merge = loc: defs: unions (map (x: x.value) defs);
+    merge = loc: defs: unions (getValues defs);
     emptyValue.value = empty;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Find replace `map (x: x.y)` with `catAttrs "y"` throughout `lib`.

Leads to less lookups and less intermediate values

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval --expr 'map (x: x.a) (builtins.genList (i: { a = i; }) 999)'</code></summary>

```json
{
  "cpuTime": 0.010325999930500984,
  "envs": {
    "bytes": 33000,
    "elements": 2126,
    "number": 1999
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 160336
  },
  "list": {
    "bytes": 15984,
    "concats": 0,
    "elements": 1998
  },
  "nrAvoided": 1000,
  "nrExprs": 60,
  "nrFunctionCalls": 1998,
  "nrLookups": 1000,
  "nrOpUpdateValuesCopied": 0,
  "nrOpUpdates": 0,
  "nrPrimOpCalls": 2,
  "nrThunks": 3,
  "sets": {
    "bytes": 42032,
    "elements": 1127,
    "number": 1000
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 2461,
    "number": 263
  },
  "time": {
    "cpu": 0.010325999930500984,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 49920,
    "number": 3120
  }
}

```

</details>

<details>
  <summary><code>NIX_SHOW_STATS=1 nix eval --expr 'builtins.catAttrs "a" (builtins.genList (i: { a = i; }) 999)'</code></summary>

```json
{
  "cpuTime": 0.009538000449538231,
  "envs": {
    "bytes": 17016,
    "elements": 1127,
    "number": 1000
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 135568
  },
  "list": {
    "bytes": 15984,
    "concats": 0,
    "elements": 1998
  },
  "nrAvoided": 1001,
  "nrExprs": 59,
  "nrFunctionCalls": 999,
  "nrLookups": 2,
  "nrOpUpdateValuesCopied": 0,
  "nrOpUpdates": 0,
  "nrPrimOpCalls": 2,
  "nrThunks": 2,
  "sets": {
    "bytes": 42032,
    "elements": 1127,
    "number": 1000
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 2461,
    "number": 263
  },
  "time": {
    "cpu": 0.009538000449538231,
    "gc": 0.0,
    "gcFraction": 0.0
  },
  "values": {
    "bytes": 33920,
    "number": 2120
  }
}
```

</details>

Made an exception to use `getValues` in the merge option in `lib.types`, since I saw that was used somewhere above as well. Seems semantically more correct.

`nix-instantiate --eval --strict lib/tests/misc.nix` passes fine, and evaling a random NixOS config `nix eval .#legacyPackages.x86_64-linux.nixosTests._3proxy.nodes.peer0.config.system.build.toplevel` looks fine as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
