### PR TITLE
python3.pkgs.iodata: 1.0.0a4 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/iodata/default.nix
+++ b/pkgs/development/python-modules/iodata/default.nix
@@ -11,22 +11,28 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
-  pname = "iodata";
-  version = "1.0.0a4";
+buildPythonPackage (finalAttrs: {
+  pname = "qc-iodata";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "theochem";
     repo = "iodata";
-    tag = "v${version}";
-    hash = "sha256-ld6V+/8lg4Du6+mHU5XuXXyMpWwyepXurerScg/bf2Q=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ly5nEqgxCt5uU+UNQx/7zgrh+w1Plngarw29+Ns68ts=";
   };
 
   build-system = [
     setuptools
     setuptools-scm
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail \
+      'addopts = "-n auto -W error --strict-markers"' \
+      'addopts = "-n auto --strict-markers"'
+  '';
 
   dependencies = [
     numpy
@@ -41,6 +47,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTestPaths = [ "tools/test_harmonics.py" ];
+
   meta = {
     description = "Python library for reading, writing, and converting computational chemistry file formats and generating input files";
     mainProgram = "iodata-convert";
@@ -48,4 +56,4 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl3Only;
     maintainers = [ lib.maintainers.sheepforce ];
   };
-}
+})


### PR DESCRIPTION
Updates IOData to the latest version and fixes build issues. https://github.com/theochem/iodata/releases/tag/v1.0.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
