### PR TITLE
cargo-bp: init at 0.6.1

### DIFF
--- a/pkgs/by-name/ca/cargo-bp/package.nix
+++ b/pkgs/by-name/ca/cargo-bp/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  installShellFiles,
+  ...
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargo-bp";
+  version = "0.6.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "battery-pack-rs";
+    repo = "battery-pack";
+    tag = "cargo-bp-v${finalAttrs.version}";
+    hash = "sha256-9hfr0wF5m3rME0gHlZ50OHZzUPseS1rJsbGAwIRNcE8=";
+  };
+
+  cargoHash = "sha256-SxUKCYMqQLY3qWKoRLKfOV4qzfjUb9nD2y03Zmnn3nA=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  buildAndTestSubdir = "src/cargo-bp";
+
+  # Integration tests spawn cargo commands that fail in the Nix sandbox
+  doCheck = false;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd cargo-bp \
+      --bash <($out/bin/cargo-bp bp completions bash) \
+      --zsh <($out/bin/cargo-bp bp completions zsh) \
+      --fish <($out/bin/cargo-bp bp completions fish)
+  '';
+
+  meta = {
+    description = "CLI for creating and managing battery packs (cargo bp)";
+    longDescription = ''
+      A battery pack bundles everything you need to get started in
+      an area: curated crates, documentation, examples, and templates.
+
+      Think of it like an addition to the standard library targeting
+      a particular use case, like building a CLI tool or web server.
+    '';
+    homepage = "https://github.com/battery-pack-rs/battery-pack";
+    changelog = "https://github.com/battery-pack-rs/battery-pack/releases/tag/cargo-bp-v${finalAttrs.version}";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ yusufraji ];
+    mainProgram = "cargo-bp";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
