### PR TITLE
treewide: fix eval on unsupported systems Part 2

### DIFF
--- a/pkgs/by-name/fu/furmark/package.nix
+++ b/pkgs/by-name/fu/furmark/package.nix
@@ -47,9 +47,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "furmark";
-  version =
-    versions.${stdenv.hostPlatform.system}
-      or (throw "Furmark is not available on ${stdenv.hostPlatform.system}");
+  version = versions.${stdenv.hostPlatform.system} or versions.x86_64-linux;
 
   src = fetchurl sources.${stdenv.hostPlatform.system};
 

--- a/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
+++ b/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
@@ -143,6 +143,10 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     maintainers = with lib.maintainers; [
       messemar
     ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/pg/pgsql-tools/package.nix
+++ b/pkgs/by-name/pg/pgsql-tools/package.nix
@@ -77,7 +77,11 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Backend service for PostgreSQL server tools, offering features such as connection management, query execution with result set handling, and language service support via the VS Code protocol";
     changelog = "https://github.com/microsoft/pgsql-tools/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     maintainers = with lib.maintainers; [ liberodark ];
     mainProgram = "ossdbtoolsservice_main";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/su/sunshine/package.nix
+++ b/pkgs/by-name/su/sunshine/package.nix
@@ -319,6 +319,10 @@ stdenv'.mkDerivation (finalAttrs: {
       devusb
       anish
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
   };
 })

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -819,7 +819,12 @@ stdenv.mkDerivation {
     homepage = "https://github.com/apple/swift";
     teams = [ lib.teams.swift ];
     license = lib.licenses.asl20;
-    platforms = with lib.platforms; linux ++ darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
     # Swift doesn't support 32-bit Linux, unknown on other platforms.
     badPlatforms = lib.platforms.i686;
     timeout = 86400; # 24 hours.

--- a/pkgs/development/python-modules/tritonclient/default.nix
+++ b/pkgs/development/python-modules/tritonclient/default.nix
@@ -69,6 +69,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/triton-inference-server/client";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ happysalada ];
-    platforms = lib.platforms.linux;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
