### PR TITLE
python3Packages.pqc-audit: init at 0.2.0

### DIFF
--- a/pkgs/by-name/pq/pqc-scanner/package.nix
+++ b/pkgs/by-name/pq/pqc-scanner/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: python3Packages.toPythonApplication python3Packages.pqc-audit

--- a/pkgs/development/python-modules/pqc-audit/default.nix
+++ b/pkgs/development/python-modules/pqc-audit/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  jsonschema,
+  mcp,
+  nix-update-script,
+  pytestCheckHook,
+  rich,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pqc-audit";
+  version = "0.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rauleteee";
+    repo = "pqc-scanner";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QzkytPYDVwoiISgsNhEbbWPLGRz9JKwiFbX2H5HtosI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ rich ];
+
+  optional-dependencies = {
+    mcp = [ mcp ];
+  };
+
+  nativeCheckInputs = [
+    jsonschema
+    mcp
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pqc_scanner" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Library to scan and audit PQC implementations for known vulnerabilities";
+    homepage = "https://github.com/rauleteee/pqc-scanner";
+    changelog = "https://github.com/rauleteee/pqc-scanner/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "pqc-scanner";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13610,6 +13610,8 @@ self: super: with self; {
 
   pq = callPackage ../development/python-modules/pq { };
 
+  pqc-audit = callPackage ../development/python-modules/pqc-audit { };
+
   praat-parselmouth = callPackage ../development/python-modules/praat-parselmouth { };
 
   prana-api-client = callPackage ../development/python-modules/prana-api-client { };


### PR DESCRIPTION
Library to scan and audit PQC implementations for known vulnerabilities

https://github.com/rauleteee/pqc-scanner

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
