### PR TITLE
steampipe: 2.3.6 -> 2.4.5

### DIFF
--- a/pkgs/by-name/st/steampipe/package.nix
+++ b/pkgs/by-name/st/steampipe/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "steampipe";
-  version = "2.3.6";
+  version = "2.4.5";
 
   env.CGO_ENABLED = 0;
 
@@ -19,10 +19,10 @@ buildGoModule (finalAttrs: {
     owner = "turbot";
     repo = "steampipe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-b7F3Eo+/vJq8EqWig4O3y2UkqllWhUg38pend/JKeWA=";
+    hash = "sha256-xlMoDT91IrM1+sqAOqQ/Utzu2T0A7tJObCVzlxM9EsE=";
   };
 
-  vendorHash = "sha256-Xu5bxjmFRzABifA6GsvHbwh8CJgKrOlwfNXIH8XYz6s=";
+  vendorHash = "sha256-peqcrkRX6QlXnFl2V+e//ROmpT8HOtRbvzJM9zZUaT8=";
   proxyVendor = true;
 
   postPatch = ''


### PR DESCRIPTION
steampipe: 2.3.6 -> 2.4.5
Diff: https://github.com/turbot/steampipe/compare/v2.3.6...v2.4.5
Changelog: https://github.com/turbot/steampipe/releases/tag/v2.4.5

This update bump the package from 2.3.6 to 2.4.5,which includes fixes for the following CVEs:
- [CVE-2026-27138](https://github.com/advisories/GHSA-ph5j-38mg-j6hp)
- [CVE-2026-27137](https://github.com/advisories/GHSA-7hfw-r8qc-89v4)
- [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8)
- [CVE-2026-34165](https://github.com/advisories/GHSA-jhf3-xxhw-2wpp)
- [CVE-2026-33762](https://github.com/advisories/GHSA-gm2x-2g9h-ccm8)
- [CVE-2026-41889](https://github.com/advisories/GHSA-j88v-2chj-qfwx)
- [CVE-2026-41889](https://github.com/advisories/GHSA-j88v-2chj-qfwx)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
