### PR TITLE
ouroboros-ai: init at 0.51.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23218,6 +23218,11 @@
     githubId = 39232833;
     name = "Jonas";
   };
+  q00 = {
+    github = "Q00";
+    githubId = 31264094;
+    name = "Q00";
+  };
   q3k = {
     email = "q3k@q3k.org";
     github = "q3k";

--- a/pkgs/by-name/ou/ouroboros-ai/package.nix
+++ b/pkgs/by-name/ou/ouroboros-ai/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ouroboros-ai";
+  version = "0.51.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Q00";
+    repo = "ouroboros";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AhPHsueCU/ZkkHJ+w7nh4cqiWZHbNj1gUU6dE1gv0t0=";
+  };
+
+  # The GitHub tarball has no PKG-INFO or .git, so hatch-vcs cannot
+  # resolve the version on its own.
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  build-system = with python3Packages; [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = with python3Packages; [
+    aiosqlite
+    anyio
+    click
+    jsonschema
+    prompt-toolkit
+    pydantic
+    python-dotenv
+    pyyaml
+    rich
+    sqlalchemy
+    structlog
+    typer
+  ];
+
+  # The test suite drives agent runtimes and writes to a real state directory,
+  # so it is not usable in the sandbox. Check the entry points instead.
+  doCheck = false;
+
+  pythonImportsCheck = [ "ouroboros" ];
+
+  meta = {
+    description = "Specification-first workflow engine that loops AI coding agents until the pinned acceptance spec passes";
+    longDescription = ''
+      Ouroboros runs a Socratic interview to crystallize vague requirements
+      into a pinned acceptance spec, then loops coding agents against it:
+      each iteration is generated, independently verified against the spec,
+      and re-attempted on failure. The verify command and expected output
+      are withheld from the worker contract, so agents cannot overfit to
+      the checker.
+    '';
+    homepage = "https://github.com/Q00/ouroboros";
+    changelog = "https://github.com/Q00/ouroboros/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "ouroboros";
+    maintainers = with lib.maintainers; [ q00 ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds `ouroboros-ai`, a specification-first workflow engine that sits in front of coding agents. It runs an interview before generation, pins the resulting acceptance spec, and verifies the result independently.

- Homepage: https://github.com/Q00/ouroboros
- PyPI: `ouroboros-ai` (sdist available)
- License: MIT
- `requires-python >= 3.12`

**Disclosure:** I work on this project. There is a downstream AUR package but no Nix packaging, and nothing here depends on that.

## Build verification

Built and run in a `nixos/nix` container (aarch64-linux) rather than on a checkout, since this machine has no Nix:

```
nix-build → succeeded
pythonImportsCheckPhase → passed ("Check whether the following modules can be imported: ouroboros")
$out/bin → ooo, ouroboros, ozo
$out/bin/ouroboros --version → Ouroboros version 0.51.1
```

Two things I expected to need work and did not: `hatch-vcs` resolves its version from the sdist's `PKG-INFO`, so no `SETUPTOOLS_SCM_PRETEND_VERSION`, and `sqlalchemy[asyncio]` needed no extra handling.

## Packaging notes

- All twelve runtime dependencies are already in nixpkgs, so no patches: `aiosqlite anyio click jsonschema prompt-toolkit pydantic python-dotenv pyyaml rich sqlalchemy structlog typer`.
- `doCheck = false`. The upstream suite drives real agent runtimes and writes to a state directory, so it is not sandbox-usable. `pythonImportsCheck` covers the import path instead.
- `mainProgram = "ouroboros"`. `pyproject.toml` declares three console scripts (`ooo`, `ouroboros`, `ozo`); `ouroboros` is the canonical one and the other two are a short alias and a subcommand entry point.
- The sha256 was computed from the PyPI digest rather than typed, after I got it wrong by hand the first time.

## Maintainer

Added `q00` to `maintainer-list.nix` (separate commit, per CONTRIBUTING.md) and set `maintainers = with lib.maintainers; [ q00 ];`. Same GitHub account that owns the upstream repo and the PyPI package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
