### PR TITLE
circleci-cli: 0.1.38646 -> 1.0.48571

### DIFF
--- a/pkgs/by-name/ci/circleci-cli/package.nix
+++ b/pkgs/by-name/ci/circleci-cli/package.nix
@@ -7,16 +7,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "circleci-cli";
-  version = "0.1.38646";
+  version = "1.0.48571";
 
   src = fetchFromGitHub {
     owner = "CircleCI-Public";
     repo = "circleci-cli";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-n+pt2pGKsRvR4fGDnXypfGB/Xm1euVWjH4fEJSHaHj4=";
+    sha256 = "sha256-doBByvNJG3BIF/+zepBeOm+ZcB+g/nx6W7A8zovJToc=";
   };
 
-  vendorHash = "sha256-K8Nm6lEHergDFMINJuyJn8tw/4cd6gp30nJbddRJCIE=";
+  vendorHash = "sha256-YYyHAGWMiCzjjW1wY9f8IKs0ZICOnA7RWVpruhR9dI8=";
+
+  subPackages = [ "cmd/circleci" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -25,17 +27,17 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/CircleCI-Public/circleci-cli/version.Version=${finalAttrs.version}"
-    "-X github.com/CircleCI-Public/circleci-cli/version.Commit=${finalAttrs.src.rev}"
-    "-X github.com/CircleCI-Public/circleci-cli/version.packageManager=nix"
+    "-X main.version=${finalAttrs.version}"
   ];
 
   postInstall = ''
-    mv $out/bin/circleci-cli $out/bin/circleci
-
     installShellCompletion --cmd circleci \
-      --bash <(HOME=$TMPDIR $out/bin/circleci completion bash --skip-update-check) \
-      --zsh <(HOME=$TMPDIR $out/bin/circleci completion zsh --skip-update-check)
+      --bash <(HOME=$TMPDIR $out/bin/circleci completion bash) \
+      --zsh <(HOME=$TMPDIR $out/bin/circleci completion zsh) \
+      --fish <(HOME=$TMPDIR $out/bin/circleci completion fish)
+
+    HOME=$TMPDIR $out/bin/circleci man --output $TMPDIR/circleci.1
+    installManPage $TMPDIR/circleci.1
   '';
 
   meta = {
@@ -47,6 +49,6 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [ stig ];
     mainProgram = "circleci";
     license = lib.licenses.mit;
-    homepage = "https://circleci.com/";
+    homepage = "https://cli.circleci.com";
   };
 })

--- a/pkgs/by-name/ci/circleci-cli/package.nix
+++ b/pkgs/by-name/ci/circleci-cli/package.nix
@@ -1,8 +1,11 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
+  buildPackages,
   installShellFiles,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -20,7 +23,10 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/circleci" ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    writableTmpDirAsHomeHook
+  ];
 
   doCheck = false;
 
@@ -30,15 +36,20 @@ buildGoModule (finalAttrs: {
     "-X main.version=${finalAttrs.version}"
   ];
 
-  postInstall = ''
-    installShellCompletion --cmd circleci \
-      --bash <(HOME=$TMPDIR $out/bin/circleci completion bash) \
-      --zsh <(HOME=$TMPDIR $out/bin/circleci completion zsh) \
-      --fish <(HOME=$TMPDIR $out/bin/circleci completion fish)
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      installShellCompletion --cmd circleci \
+        --bash <(${emulator} $out/bin/circleci completion bash) \
+        --zsh <(${emulator} $out/bin/circleci completion zsh) \
+        --fish <(${emulator} $out/bin/circleci completion fish)
 
-    HOME=$TMPDIR $out/bin/circleci man --output $TMPDIR/circleci.1
-    installManPage $TMPDIR/circleci.1
-  '';
+      ${emulator} $out/bin/circleci man --output $TMPDIR/circleci.1
+      installManPage $TMPDIR/circleci.1
+    ''
+  );
 
   meta = {
     # Box blurb edited from the AUR package circleci-cli


### PR DESCRIPTION
https://github.com/CircleCI-Public/circleci-cli/releases/tag/v1.0.47571

The 1.x release is a significant rewrite of the CLI. Beyond the version and hash updates, the recipe needed a few structural fixes:

- Added `subPackages = [ "./cmd/circleci" ]` — the new repo layout includes unrelated command packages (`cloudsmith`, `packagecloud`, `virustotal`) that would otherwise also be installed.
- Simplified `ldflags` — the version variable moved to `main.version`; the old `Commit` and `packageManager` vars no longer exist in the new codebase.
- Dropped the `mv circleci-cli → circleci` in `postInstall` — the binary is now built directly as `circleci`.
- Updated `homepage` to `https://cli.circleci.com`.
- Added fish completion and man page generation — both are new capabilities in 1.x.
- Updated `homepage` to `https://cli.circleci.com`.

Release notes: https://github.com/CircleCI-Public/circleci-cli/releases/tag/v1.0.48571

Tested: built on aarch64-darwin, ran `circleci version` and `circleci --help`.

Assisted-by: [Eca](https://eca.dev), in Emacs, with model: anthropic/claude-sonnet-4-5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

NB: the branch name is inconsistent with the package version, since a new version was released before anyone had a chance to review this. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
