### PR TITLE
microbin: 2.0.4 -> 2.1.4

### DIFF
--- a/pkgs/by-name/mi/microbin/package.nix
+++ b/pkgs/by-name/mi/microbin/package.nix
@@ -1,67 +1,27 @@
 {
   fetchFromGitHub,
-  fetchpatch,
   lib,
   oniguruma,
   openssl,
   pkg-config,
   rustPlatform,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "microbin";
-  version = "2.0.4";
+  version = "2.1.4";
 
   src = fetchFromGitHub {
     owner = "szabodanika";
     repo = "microbin";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-fsRpqSYDsuV0M6Xar2GVoyTgCPT39dcKJ6eW4YXCkQ0=";
+    hash = "sha256-ipSMiUJgbZ0kijGs7Ok8bRTGdFzygIPEY6ZuJ/eRb9s=";
   };
 
-  cargoHash = "sha256-cQyb9KpmdJ2DB395Ce24JX8YcMLQn3fmeYZUo72L38s=";
+  cargoHash = "sha256-vvSQfXu67RNBXzfDIE2rcfUOcAfTACaVRvSBBITJ9gY=";
 
-  patches = [
-    # Prefix some URLs with args.public_path_as_str() by PeterUpfold
-    # https://github.com/szabodanika/microbin/pull/194
-    # MicroBin returns wrong URLs on deployments with non-root URLs.
-    (fetchpatch {
-      name = "0001-fixup-explicit-urls.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..df062134cbaf3fd0ebcb67af8453a4c66844cd13.patch";
-      hash = "sha256-h13FBuzu2O4AwdhRHF5EX5LaKyPeWJAcaV6SGTaYzTg=";
-    })
-
-    # Minor fixups by LuK1337
-    # https://github.com/szabodanika/microbin/pull/211
-    # Fixup styling, password protected and private pastas.
-    (fetchpatch {
-      name = "0002-minor-fixups.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..3b0c025e9b6dc1ca69269541940bdb53032a048a.patch";
-      hash = "sha256-cZB/jx5d6F+C4xOn49TQ1at/Z4ov26efo9PTtWEdCHw=";
-    })
-
-    # Fix MICROBIN_ETERNAL_PASTA by SouthFox-D
-    # https://github.com/szabodanika/microbin/pull/215
-    # MICROBIN_ETERNAL_PASTA config doesn't work without this.
-    (fetchpatch {
-      name = "0003-fix-microbin-eternal-pasta.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..c7c846c64344b8d51500aa9a4b2e9a92de8d09d8.patch";
-      hash = "sha256-gCio73Jt0F7YCFtQxtf6pPBDLNcyOAcfSsiyjLFzEzY=";
-    })
-
-    # Fix raw pastes returning 404 by GizmoTjaz
-    # https://github.com/szabodanika/microbin/pull/218
-    # Existing pastas return code 404 even when they exist.
-    (fetchpatch {
-      name = "0004-fix-raw-pastas-returning-404.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..e789901520824d4bf610d28923097affe85ead7d.patch";
-      hash = "sha256-R47ozwu/FD1kCu5nx4Gf1cOFeLVFdS67K8RNDygwoZM=";
-    })
-  ];
-
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     oniguruma

--- a/pkgs/by-name/mi/microbin/package.nix
+++ b/pkgs/by-name/mi/microbin/package.nix
@@ -33,6 +33,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     RUSTONIG_SYSTEM_LIBONIG = true;
   };
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Tiny, self-contained, configurable paste bin and URL shortener written in Rust";
     homepage = "https://github.com/szabodanika/microbin";


### PR DESCRIPTION
- **microbin: 2.0.4 -> 2.1.4** (https://github.com/szabodanika/microbin/releases/tag/v2.1.4)
- **microbin: setup auto updates**

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6a4c48a454e52fe47f73a862e37eb27843647873`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>microbin</li>
  </ul>
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
