### PR TITLE
python3Packages.typing-inspection: 0.4.2 -> 0.4.3

### DIFF
--- a/pkgs/development/python-modules/typing-inspection/default.nix
+++ b/pkgs/development/python-modules/typing-inspection/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "typing-inspection";
-  version = "0.4.2";
+  version = "0.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "typing-inspection";
     tag = "v${version}";
-    hash = "sha256-aGScO+FLEJ5IyI6hBqdsiKJRN7vEG36V5131nhVZEbc=";
+    hash = "sha256-jNAMYV9mpUnClLOahQyLisBkOfELcmjKavKJgyxkQr4=";
   };
 
   build-system = [ hatchling ];
@@ -29,12 +29,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # broken by intentional 3.14.7 behavior change
-    # reported upstream: https://github.com/pydantic/typing-inspection/issues/55
-    "test_literal_values_unhashable_type"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/typing-inspection/default.nix
+++ b/pkgs/development/python-modules/typing-inspection/default.nix
@@ -7,7 +7,7 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "typing-inspection";
   version = "0.4.3";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "typing-inspection";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-jNAMYV9mpUnClLOahQyLisBkOfELcmjKavKJgyxkQr4=";
   };
 
@@ -32,10 +32,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/pydantic/typing-inspection/blob/${src.tag}/HISTORY.md";
+    changelog = "https://github.com/pydantic/typing-inspection/blob/${finalAttrs.src.tag}/HISTORY.md";
     description = "Runtime typing introspection tools";
     homepage = "https://github.com/pydantic/typing-inspection";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/pydantic/typing-inspection/blob/v0.4.3/HISTORY.md
Diff: https://github.com/pydantic/typing-inspection/compare/v0.4.2...v0.4.3

Contains a fix for https://github.com/pydantic/typing-inspection/issues/55, which blocked a few thousand jobs in the current `staging-next` cycle and is currently on track to do the same in the upcoming `staging-next-26.05` cycle (reported in https://github.com/NixOS/nixpkgs/issues/550910).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.typing-inspection`
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
