### PR TITLE
python3Packages.django-contrib-comments: format to pyproject

### DIFF
--- a/pkgs/development/python-modules/django-contrib-comments/default.nix
+++ b/pkgs/development/python-modules/django-contrib-comments/default.nix
@@ -2,24 +2,41 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
+  setuptools,
   django,
+  python,
 }:
 
 buildPythonPackage rec {
   pname = "django-contrib-comments";
   version = "2.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-SN4A8VZ34BaiFq7/IF1uAOQ5HJpXAhNsZBGcRytzVto=";
   };
 
-  propagatedBuildInputs = [ django ];
+  patches = [
+    (fetchpatch {
+      name = "fix-django-issues.patch";
+      url = "https://github.com/django/django-contrib-comments/commit/36bd49060c58eb96e12e42eb098eb63ccaae848e.patch?full_index=1";
+      hash = "sha256-Rs1Vzv+/SLiptrezfYYmCdWLbFVh4s5rsgKJBgq+WHk=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ django ];
+
+  checkPhase = ''
+    ${python.interpreter} tests/runtests.py
+  '';
 
   meta = {
     homepage = "https://github.com/django/django-contrib-comments";
     description = "Code formerly known as django.contrib.comments";
-    license = lib.licenses.bsd0;
+    license = lib.licenses.bsd3;
   };
 }


### PR DESCRIPTION
Enable tests as well

Part of https://github.com/NixOS/nixpkgs/issues/515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
