### PR TITLE
python3Packages.django-crossdomainmedia: format to pyproject

### DIFF
--- a/pkgs/development/python-modules/django-crossdomainmedia/default.nix
+++ b/pkgs/development/python-modules/django-crossdomainmedia/default.nix
@@ -2,16 +2,16 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   django,
   pytestCheckHook,
   pytest-django,
-  python,
 }:
 
 buildPythonPackage {
   pname = "django-crossdomainmedia";
   version = "0.0.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stefanw";
@@ -23,14 +23,18 @@ buildPythonPackage {
     hash = "sha256-nwFUm+cxokZ38c5D77z15gIO/kg49oRACOl6+eGGEtQ=";
   };
 
+  build-system = [ setuptools ];
+
   dependencies = [ django ];
 
-  checkPhase = ''
-    ${python.interpreter} manage.py test
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-django
+  ];
 
-  # django.core.exceptions.ImproperlyConfigured: Requested setting DEBUG, but settings are not configured.
-  # pythonImportsCheck = [ "crossdomainmedia" ];
+  env.DJANGO_SETTINGS_MODULE = "tests.settings";
+
+  enabledTestPaths = [ "tests/tests.py" ];
 
   meta = {
     description = "Django application to retrieve user's IP address";


### PR DESCRIPTION
Run tests with pytest as well

Part of https://github.com/NixOS/nixpkgs/issues/515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
