### PR TITLE
python3Packages.autoinject: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/autoinject/default.nix
+++ b/pkgs/development/python-modules/autoinject/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  python,
+  pythonOlder,
+  runCommand,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "autoinject";
+  version = "2.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "turnbullerin";
+    repo = "autoinject";
+    # Upstream does not tag releases.
+    rev = "9d29a307ce1ef331e8ded5f8161d0ed2c29cf67e";
+    hash = "sha256-uCUMHNaSwl3/6MeIc1Ztz/2zNTxQQlAbH+GZKm3fynw=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "autoinject" ];
+
+  passthru.tests.integration =
+    runCommand "${finalAttrs.pname}-integration-test"
+      {
+        nativeBuildInputs = [
+          (python.withPackages (_: [ finalAttrs.finalPackage ]))
+        ];
+      }
+      ''
+        python - <<'PY'
+        from autoinject import InjectionManager
+
+        injector = InjectionManager()
+
+        @injector.injectable
+        class Service:
+            value = "injected"
+
+        class Client:
+            @injector.inject
+            def __init__(self, service: Service):
+                self.service = service
+
+        assert Client().service.value == "injected"
+        PY
+
+        touch "$out"
+      '';
+
+  meta = {
+    changelog = "https://github.com/turnbullerin/autoinject/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "Dependency injection framework for Python";
+    homepage = "https://github.com/turnbullerin/autoinject";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lostmsu ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1613,6 +1613,8 @@ self: super: with self; {
 
   autograd-gamma = callPackage ../development/python-modules/autograd-gamma { };
 
+  autoinject = callPackage ../development/python-modules/autoinject { };
+
   autoit-ripper = callPackage ../development/python-modules/autoit-ripper { };
 
   autologging = callPackage ../development/python-modules/autologging { };


### PR DESCRIPTION
Packages [autoinject](https://github.com/turnbullerin/autoinject), a Python dependency-injection framework and a dependency of `graceful-shutdown`.

Upstream does not tag releases, so the source is pinned to the commit that introduced version 2.0.0. The GitHub source is used instead of the PyPI sdist because it includes the complete test fixtures. The package runs the upstream pytest suite, performs an import check, and includes a small downstream-style integration test in `passthru.tests`.

Validation performed:

- Sandboxed build and integration test on x86_64-linux
- Full upstream test suite on CPython 3.11, 3.12, 3.13, 3.14, and 3.15 RC
- `nixpkgs-review wip --staged --no-shell`: `python313Packages.autoinject` and `python314Packages.autoinject` built successfully

A PyPy 3.10 build was attempted, but is currently blocked before `autoinject` builds by an existing `pypy3.10-build` runtime dependency failure (`tomli not installed`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
