### PR TITLE
cachix: 1.11.1 -> 1.12.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3416,13 +3416,13 @@ with haskellLib;
 # Manually maintained
 // (
   let
-    version = "1.11.1";
+    version = "1.12.0";
 
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
-      tag = "v${version}";
-      hash = "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=";
+      rev = "e3609f93799354c50e4126d6423ede6dd317e2f2";
+      hash = "sha256-AOhHyBEk8LOiAU9tgmNJPJAKKUVDQFzTNSLe62FPxpY=";
     };
   in
   {
@@ -3441,6 +3441,7 @@ with haskellLib;
         drv.override {
           nix = self.hercules-ci-cnix-store.nixPackage;
           hnix-store-core = self.hnix-store-core_0_8_0_0;
+          hnix-store-nar = self.hnix-store-nar;
         }
       )
     ];

--- a/pkgs/development/haskell-modules/replacements-by-name/hnix-store-nar.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hnix-store-nar.nix
@@ -1,0 +1,79 @@
+{
+  mkDerivation,
+  algebraic-graphs,
+  base,
+  base64-bytestring,
+  bytestring,
+  case-insensitive,
+  cereal,
+  containers,
+  crypton,
+  directory,
+  filepath,
+  hspec,
+  lib,
+  lifted-base,
+  monad-control,
+  mtl,
+  process,
+  tasty,
+  tasty-discover,
+  tasty-hspec,
+  tasty-hunit,
+  tasty-quickcheck,
+  temporary,
+  text,
+  unix,
+  unordered-containers,
+}:
+
+mkDerivation {
+  pname = "hnix-store-nar";
+  version = "0.1.2.0";
+  sha256 = "113cj9dhiw1fj4sdh954l0gpw4l9iycy2xj1ajx76brhsqxrh5r9";
+  libraryHaskellDepends = [
+    algebraic-graphs
+    base
+    bytestring
+    case-insensitive
+    cereal
+    containers
+    directory
+    filepath
+    lifted-base
+    monad-control
+    mtl
+    text
+    unix
+    unordered-containers
+  ];
+  testHaskellDepends = [
+    base
+    base64-bytestring
+    bytestring
+    cereal
+    containers
+    crypton
+    directory
+    filepath
+    hspec
+    process
+    tasty
+    tasty-hspec
+    tasty-hunit
+    tasty-quickcheck
+    temporary
+    text
+    unix
+  ];
+  testToolDepends = [ tasty-discover ];
+  benchmarkHaskellDepends = [
+    base
+    bytestring
+    directory
+    filepath
+  ];
+  homepage = "https://github.com/haskell-nix/hnix-store";
+  description = "NAR file format";
+  license = lib.meta.getLicenseFromSpdxId "Apache-2.0";
+}


### PR DESCRIPTION
https://github.com/cachix/cachix/blob/v1.12.0/cachix/CHANGELOG.md

Assisted-by: OpenAI Codex (GPT-5)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
