### PR TITLE
ocamlPackages.xkbcommon: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/xkbcommon/default.nix
+++ b/pkgs/development/ocaml-modules/xkbcommon/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  alcotest,
+  dune-configurator,
+  buildDunePackage,
+  libxkbcommon,
+  pkg-config,
+}:
+buildDunePackage {
+  pname = "xkbcommon";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "talex5";
+    repo = "xkbcommon";
+    rev = "bcb74feb2a32a41e612ef28c26755181a9ddcff9";
+    hash = "sha256-tyR+X6H7F9U7ylnxoGulmQEe5VANvb0vKqitFT+zxUc=";
+  };
+
+  minimalOCamlVersion = "4.14";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dune-configurator
+    libxkbcommon
+  ];
+
+  checkInputs = [
+    alcotest
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "OCaml bindings to libxkbcommon";
+    homepage = "https://github.com/talex5/xkbcommon";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ricardomaps ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2295,6 +2295,8 @@ let
 
         xenstore_transport = callPackage ../development/ocaml-modules/xenstore_transport { };
 
+        xkbcommon = callPackage ../development/ocaml-modules/xkbcommon { };
+
         xml-light = callPackage ../development/ocaml-modules/xml-light { };
 
         xmlm = callPackage ../development/ocaml-modules/xmlm { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
