### PR TITLE
sessiond-uaccess: init at 0.1.0

### DIFF
--- a/pkgs/by-name/se/sessiond-uaccess/package.nix
+++ b/pkgs/by-name/se/sessiond-uaccess/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  acl,
+  udev,
+  fetchgit,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "sessiond-uaccess";
+  version = "0.1.0";
+
+  cargoHash = "sha256-fdsMnG8a6+6ZCeE16vRkpX4BtJsbngvw4QTB3CNnMIM=";
+
+  src = fetchgit {
+    url = "https://tangled.org/did:plc:dkc53ch7wt7gilra4irpdqol";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZOXS4ZUrIKLmnXpqZ9trmR0of8daqbRSkHFKdEl+Rwg=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    acl
+    udev
+  ];
+
+  postInstall = ''
+    install -d $out/share/sessiond-uaccess
+    cp -r ${finalAttrs.src}/rules $out/share/sessiond-uaccess/
+  '';
+
+  meta = {
+    description = "Dynamic device access manager";
+    homepage = "https://tangled.org/r0chd.pl/sessiond-uaccess";
+    license = lib.licenses.gpl3Only;
+    maintainers = builtins.attrValues { inherit (lib.maintainers) r0chd; };
+    platforms = lib.platforms.linux;
+    mainProgram = "sessiond-uaccess";
+  };
+})


### PR DESCRIPTION
[sessiond-uaccess](https://tangled.org/r0chd.pl/sessiond-uaccess) is a [sessiond](https://tangled.org/r0chd.pl/sessiond) client that manages dynamic device access for active sessions using ACLs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
