### PR TITLE
pkgs/config: remove types.uniq from nixpkgs config options

### DIFF
--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -22,7 +22,7 @@ let
     mkOption (
       removeAttrs args [ "feature" ]
       // {
-        type = args.type or (types.uniq types.bool);
+        type = args.type or types.bool;
         default = args.default or false;
         description = (
           (args.description or ''

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -95,13 +95,11 @@ let
     };
 
     fetchedSourceNameDefault = mkOption {
-      type = types.uniq (
-        types.enum [
-          "source"
-          "versioned"
-          "full"
-        ]
-      );
+      type = types.enum [
+        "source"
+        "versioned"
+        "full"
+      ];
       default = "source";
       description = ''
         This controls the default derivation `name` attribute set by the
@@ -422,13 +420,11 @@ let
     };
 
     recursionMode = mkOption {
-      type = types.uniq (
-        types.enum [
-          "hydra"
-          "eval"
-          "search"
-        ]
-      );
+      type = types.enum [
+        "hydra"
+        "eval"
+        "search"
+      ];
       default = "eval";
       description = ''
         In which way to recurse through Nixpkgs. In most cases you want keep this as the default.


### PR DESCRIPTION
Context: nixos and nixpkgs use different merge behaviors. Nixos implements a custom pre-merge behavior which leads to surprises. 

In the current state wrapping with types.uniq is a no-op for nixos. But not for bare nixpkgs.

 The pre-merge behavior in `nixpkgs.nix` unifies definitions into a single one so 'uniq' never fires.
Enforcing uniq on a bool is also overly restrictive.

This commit relaxes this constraint. So once we enable normal module merging it doesn't cause regressions

Should probably go in after #551178 which contains a test suite.

This should prevent what happend here: https://github.com/NixOS/nixpkgs/pull/523622#issuecomment-5232666064
@SuperSandro2000 reported:

```nix
 error: The option `allowNonSource' is defined multiple times while it's expected to be unique.

 Definition values:
 - In `/nix/store/zh08c04chc1ngacnhj45f75j5ygjrc8g-source/flake.nix': false
    - In `/nix/store/wdzkiqnnyl08x973l469ig6s9fnknz9y-source/modules/base.nix': false
```

Two times the same value; Currently `uniq` is broken, because its undermined by the custom pre-merge logic in 'nixpkgs.nix'
Once we use a regular module `uniq` takes precendence and users get this message. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
