### PR TITLE
mise: 2026.7.17 -> 2026.8.3

### DIFF
--- a/pkgs/by-name/mi/mise/package.nix
+++ b/pkgs/by-name/mi/mise/package.nix
@@ -22,16 +22,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mise";
-  version = "2026.7.17";
+  version = "2026.8.3";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "mise";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OnuvK0SmRHqMiw14LEuehNKg677XtKyjedgqrg4owlM=";
+    hash = "sha256-tYn54Loo3sSEgRhgu1g5m/t5qL+EKQnvrnfHCuDDbyY=";
   };
 
-  cargoHash = "sha256-Ot5bP4J6KnATOb1Tt2DKOgFTY/urMWcUsFfjbPKnmVc=";
+  cargoHash = "sha256-fzZswzDMIKMx7R53Jxc9m/7I8Bcd2fdPJKmHsjWFqhw=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -97,7 +97,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installManPage ./man/man1/mise.1
 
     substituteInPlace ./completions/{mise.bash,mise.fish,_mise}  \
-      --replace-fail '-p usage' '-p ${lib.getExe usage}' \
+      --replace-fail 'usage &> /dev/null' '${lib.getExe usage} &> /dev/null' \
       --replace-fail 'usage complete-word' '${lib.getExe usage} complete-word'
 
     installShellCompletion \


### PR DESCRIPTION
Updates `mise` from 2026.7.17 to 2026.8.3. See the [v2026.8.3 release](https://github.com/jdx/mise/releases/tag/v2026.8.3) and the [nixpkgs-update log](https://nixpkgs-update-logs.nix-community.org/mise/2026-08-08.log).

The update-bot build completed all 2,483 Rust tests before `postInstall` failed while rewriting the generated Bash completion. Upstream's usage 5 update deliberately regenerated the Bash and Fish guards with `type -P`, while Zsh retained `type -p` ([upstream commit](https://github.com/jdx/mise/commit/80f6b9e4d6b2010f1db1e29af7273c0b987d4ba8)).

The Nixpkgs substitution previously included the shell-specific `-p` flag, so it no longer matched every completion file. This keeps `--replace-fail` but matches the invariant `usage &> /dev/null` portion instead. The existing `usage complete-word` substitution remains unchanged.

Local validation on aarch64-darwin:

- `nix-build --no-out-link -A mise`: 2,443 Rust tests passed; install and fixup completed.
- `nix-build --no-out-link -A mise.tests.version`
- `nix-build --no-out-link -A mise.tests.usageCompat`
- Inspected the installed Bash, Fish, and Zsh completions: every guard and `complete-word` invocation references the Nix-store `usage` executable, with no bare invocation remaining.
- `nixpkgs-review rev HEAD`: one impacted package and one package built.

Automation disclosure: OpenAI Codex (GPT-5) assisted with research, the Nix expression change, validation, and this PR description.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
