### PR TITLE
kextviewr: init at 2.0.0

### DIFF
--- a/pkgs/by-name/ke/kextviewr/package.nix
+++ b/pkgs/by-name/ke/kextviewr/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  makeWrapper,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kextviewr";
+  version = "2.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchzip {
+    url = "https://github.com/objective-see/KextViewr/releases/download/v${finalAttrs.version}/KextViewr_${finalAttrs.version}.zip";
+    hash = "sha256-caTfGRmp8XycOC6+ev1EsDQd4etLVvE9Nb32Nqj27zw=";
+
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R KextViewr.app "$out/Applications/KextViewr.app"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/KextViewr.app/Contents/MacOS/KextViewr $out/bin/kextviewr
+  '';
+
+  dontFixup = true; # Preserve upstream's notarized app bundle and system extension signature.
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "kextviewr";
+    description = "KextViewr is a simple utility that shows you all modules on that are loaded in the OS kernel";
+    longDescription = ''
+      For each loaded kext, it provides information such as their
+      collection (boot, auxiliary, etc.), size, address, and more.
+    '';
+    homepage = "https://objective-see.org/products/kextviewr.html";
+    downloadPage = "https://github.com/objective-see/KextViewr/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/objective-see/KextViewr/releases";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    identifiers = {
+      cpeParts = {
+        vendor = "objective-see";
+        product = "kextviewr";
+        version = finalAttrs.version;
+        target_sw = "macos";
+      };
+      purlParts = {
+        type = "github";
+        namespace = "objective-see";
+        name = "kextviewr";
+        version = finalAttrs.version;
+      };
+    };
+    maintainers = with lib.maintainers; [
+      KristijanZic
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added kextviewr at 2.0.0 from https://objective-see.org/products/kextviewr.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
