### PR TITLE
Revert "openvox: set __structuredAttrs and __strictDeps to true with an override"

### DIFF
--- a/pkgs/by-name/op/openvox/package.nix
+++ b/pkgs/by-name/op/openvox/package.nix
@@ -6,7 +6,8 @@
   ruby_3_4,
   testers,
 }:
-((bundlerApp.override { ruby = ruby_3_4; }) {
+
+(bundlerApp.override { ruby = ruby_3_4; }) {
   pname = "openvox";
   gemdir = ./.;
   exes = [ "puppet" ];
@@ -28,11 +29,4 @@
     mainProgram = "puppet";
     maintainers = with lib.maintainers; [ skyethepinkcat ];
   };
-}).overrideAttrs
-  # Workaround `bundlerApp` not specifying `__structuredAttrs = true` and `strictDeps = true` for its result package.
-  {
-    # TODO(@ShamrockLee, @skyethepinkcat): Revert/remove after PR #539303 lands on the master branch.
-    __structuredAttrs = true;
-    # TODO(@ShamrockLee, @skyethepinkcat): Revert/remove after PR #540069 lands on the master branch.
-    strictDeps = true;
-  }
+}


### PR DESCRIPTION
This reverts commit 5778a66cc7961a5471712f9b812bcd265485150f, which was a temporary fix until #539303 #540069 were merged.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
