### PR TITLE
llvmPackages.flang: fix failing builds for LLVM 22 & 23

### DIFF
--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -476,21 +476,15 @@ makeScopeWithSplicing' {
         # Standalone flang still resolves driver/option definitions via the
         # installed libclang package, so keep flang-specific driver backports
         # in a private libclang variant instead of patching the flang source
-        # tree. The `-Xflang` diagnostic improvement applies to every
-        # supported standalone-flang version (20+); the other two backports
-        # are only needed up to LLVM 21 because upstream merged equivalent
-        # behaviour into LLVM 22.
+        # tree.
         flangDriverPatches =
-          lib.optionals (lib.versionAtLeast metadata.release_version "20") [
-            (metadata.getVersionFile "flang/use-xflang-in-diagnostics.patch")
-          ]
-          ++
-            lib.optionals
-              (lib.versionAtLeast metadata.release_version "20" && lib.versionOlder metadata.release_version "22")
-              [
-                (metadata.getVersionFile "flang/warn-on-fbuiltin-and-fno-builtin.patch")
-                (metadata.getVersionFile "flang/accept-and-ignore-some-gfortran-optimization-flags.patch")
-              ];
+          lib.optionals
+            (lib.versionAtLeast metadata.release_version "20" && lib.versionOlder metadata.release_version "22")
+            [
+              (metadata.getVersionFile "flang/use-xflang-in-diagnostics.patch")
+              (metadata.getVersionFile "flang/warn-on-fbuiltin-and-fno-builtin.patch")
+              (metadata.getVersionFile "flang/accept-and-ignore-some-gfortran-optimization-flags.patch")
+            ];
         flangLibclang =
           if flangDriverPatches == [ ] then
             self.libclang

--- a/pkgs/development/compilers/llvm/common/flang-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang-rt/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
         cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
         cp -r ${monorepoSrc}/flang "$out"
         cp -r ${monorepoSrc}/runtimes "$out"
+        cp -r ${monorepoSrc}/libc/ "$out"
       '';
 
   sourceRoot = "${finalAttrs.src.name}/runtimes";

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -135,6 +135,7 @@
   "flang/use-xflang-in-diagnostics.patch" = [
     {
       after = "20";
+      before = "22";
       path = ../21;
     }
   ];


### PR DESCRIPTION
One patch doesn't need to be applied anymore and flang 23 needs include files from the libc subfolder.

flang 20 does not compile due to a mlir patch not applying.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
