### PR TITLE
tortoisehg: 7.0.1 -> 7.2.2

### DIFF
--- a/pkgs/by-name/to/tortoisehg/package.nix
+++ b/pkgs/by-name/to/tortoisehg/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "7.0.1";
+  version = "7.2.2";
 in
 python3Packages.buildPythonApplication {
   pname = "tortoisehg";
@@ -16,7 +16,7 @@ python3Packages.buildPythonApplication {
 
   src = fetchurl {
     url = "https://www.mercurial-scm.org/release/tortoisehg/targz/tortoisehg-${version}.tar.gz";
-    hash = "sha256-rCDLZ2ppD3Y71c31UNir/1pW1QBJViMP9JdoJiWf0nk=";
+    hash = "sha256-KBLXbiQ2p+mvMM0/U22EQwSj2NIO2i2vI0ZhmF8gc4M=";
   };
 
   build-system = with python3Packages; [ setuptools ];


### PR DESCRIPTION
https://foss.heptapod.net/mercurial/tortoisehg/thg/-/tags/7.2.2
https://foss.heptapod.net/mercurial/tortoisehg/thg/-/compare/7.0.1...7.2.2

Remarks: 
- Revision not yet published on the [project website](https://tortoisehg.bitbucket.io/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
