### PR TITLE
oxlint: 1.77.0 -> 1.78.0, cleanup

### DIFF
--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -3,8 +3,9 @@
   stdenv,
   fetchFromGitHub,
   fetchPnpmDeps,
+  pnpm_11,
   pnpmConfigHook,
-  pnpm_10,
+  pnpmBuildHook,
   nodejs_24,
   nodejs-slim,
   rustPlatform,
@@ -19,6 +20,9 @@
   darwin,
 }:
 
+let
+  pnpm = pnpm_11;
+in
 # Build with pnpm instead of buildRustPackage because the upstream npm CLI is the
 # JS-plugin-capable runtime. The standalone Rust `oxlint` binary intentionally
 # runs without an external linter, which leaves `jsPlugins` configs inert.
@@ -40,12 +44,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
-    fetcherVersion = 3;
-    hash = "sha256-CjhQyPY9Bsj8g+tVVqfd5i/wKDSeU+geEssEzDsSi1A=";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-fdXk7ODkw9zQSsxGG85We5VKAG8j/NRAcDRWz5zli80=";
   };
 
   dontUseCmakeConfigure = true;
+
+  pnpmWorkspaces = [ "oxlint-app" ];
 
   nativeBuildInputs = [
     cargo
@@ -53,7 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     makeBinaryWrapper
     nodejs_24
     pnpmConfigHook
-    pnpm_10
+    pnpmBuildHook
+    pnpm
     rustPlatform.cargoSetupHook
     rustc
   ];
@@ -73,14 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace "$cli" \
         --replace-fail '"/bin/ps"' '"${darwin.adv_cmds}/bin/ps"'
     done
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-
-    pnpm --workspace-concurrency=1 --filter oxlint-app run build
-
-    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -28,25 +28,25 @@ in
 # runs without an external linter, which leaves `jsPlugins` configs inert.
 stdenv.mkDerivation (finalAttrs: {
   pname = "oxlint";
-  version = "1.77.0";
+  version = "1.78.0";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "oxc";
     tag = "oxlint_v${finalAttrs.version}";
-    hash = "sha256-9l0E4S7xx5UkaPY06Qy21maJiWnwzNAlg/oJDZThqi4=";
+    hash = "sha256-55IzeYx7Bfs40gvfyvbog+QKab5DoXNI1ydc/mcvQDQ=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-AJHfTJe1oyflsjqx128FfZJlqVH1hX2ityAoR9E3rXM=";
+    hash = "sha256-mVk2thsSITIQ6vCQkxBlBvQpPRS0jpWoN+wZ3WJLoJw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-fdXk7ODkw9zQSsxGG85We5VKAG8j/NRAcDRWz5zli80=";
+    hash = "sha256-buM8gRuxi9rrcUVYXHEOnjWpbD4godiNQHAXAUTP7C0=";
   };
 
   dontUseCmakeConfigure = true;

--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -16,6 +16,7 @@
   rust-jemalloc-sys,
   tsgolint,
   versionCheckHook,
+  darwin,
 }:
 
 # Build with pnpm instead of buildRustPackage because the upstream npm CLI is the
@@ -60,6 +61,19 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ rust-jemalloc-sys ];
 
   env.OXC_VERSION = finalAttrs.version;
+
+  # @napi-rs/cli >= 3.8 reads the process start time via `/bin/ps` while
+  # acquiring its filesystem reconciliation lock. The Darwin build sandbox
+  # denies that exec; Node raises it as a synchronous `spawn EPERM` from
+  # execFile, which escapes napi's callback-based error handling. Point the
+  # lookup at a store `ps` so the sandbox allows it. The result is only used
+  # to detect stale lock files.
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    for cli in node_modules/.pnpm/@napi-rs+cli@*/node_modules/@napi-rs/cli/dist/cli.js; do
+      substituteInPlace "$cli" \
+        --replace-fail '"/bin/ps"' '"${darwin.adv_cmds}/bin/ps"'
+    done
+  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -7,7 +7,7 @@
   pnpmConfigHook,
   pnpmBuildHook,
   nodejs_24,
-  nodejs-slim,
+  nodejs-slim_24,
   rustPlatform,
   cargo,
   rustc,
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     chmod +x "$packageRoot/bin/oxlint"
 
-    makeBinaryWrapper "${lib.getExe nodejs-slim}" "$out/bin/oxlint" \
+    makeBinaryWrapper "${lib.getExe nodejs-slim_24}" "$out/bin/oxlint" \
       --add-flags "$packageRoot/bin/oxlint" \
       --prefix PATH : "${lib.makeBinPath [ tsgolint ]}"
 
@@ -107,79 +107,39 @@ stdenv.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    pluginTestDir="$(mktemp -d)"
-    cat > "$pluginTestDir/plugin.mjs" <<'EOF'
-    const plugin = {
+    expectFail() {
+      local needle="$1"; shift
+      local output
+      output="$("$@" 2>&1)" && {
+        printf 'expected `%s` to fail\n%s\n' "$*" "$output" >&2
+        exit 1
+      }
+      grep -Fq "$needle" <<<"$output"
+    }
+
+    cd "$(mktemp -d)"
+
+    cat >plugin.mjs <<'EOF'
+    export default {
       meta: { name: "smoke-plugin" },
       rules: {
         "always-error": {
-          create(context) {
-            return {
-              Program(node) {
-                context.report({ node, message: "plugin-smoke-ok" });
-              },
-            };
-          },
+          create: (context) => ({
+            Program(node) {
+              context.report({ node, message: "plugin-smoke-ok" });
+            },
+          }),
         },
       },
     };
-    export default plugin;
     EOF
-    cat > "$pluginTestDir/.oxlintrc.jsonc" <<'EOF'
-    {
-      "jsPlugins": ["./plugin.mjs"],
-      "rules": {
-        "smoke-plugin/always-error": "error"
-      }
-    }
-    EOF
-    printf 'const value = 1;\n' > "$pluginTestDir/input.js"
+    echo '{"jsPlugins":["./plugin.mjs"],"rules":{"smoke-plugin/always-error":"error"}}' >plugin.jsonc
+    echo 'void 0;' >plugin.js
+    expectFail plugin-smoke-ok "$out/bin/oxlint" -c plugin.jsonc plugin.js
 
-    (
-      cd "$pluginTestDir"
-      set +e
-      pluginOutput="$($out/bin/oxlint input.js 2>&1)"
-      pluginStatus=$?
-      set -e
-      test "$pluginStatus" -ne 0
-      printf '%s\n' "$pluginOutput" | grep -F "plugin-smoke-ok" > /dev/null
-    )
-
-    typeAwareTestDir="$(mktemp -d)"
-    cat > "$typeAwareTestDir/.oxlintrc.jsonc" <<'EOF'
-    {
-      "rules": {
-        "typescript/no-unnecessary-type-assertion": "error"
-      }
-    }
-    EOF
-    cat > "$typeAwareTestDir/tsconfig.json" <<'EOF'
-    {
-      "compilerOptions": {
-        "target": "es2024",
-        "lib": ["ES2024", "DOM"],
-        "module": "es2022",
-        "strict": true,
-        "skipLibCheck": true
-      }
-    }
-    EOF
-    cat > "$typeAwareTestDir/input.ts" <<'EOF'
-    const str: string = "hello";
-    const redundant = str as string;
-
-    export {};
-    EOF
-
-    (
-      cd "$typeAwareTestDir"
-      set +e
-      typeAwareOutput="$($out/bin/oxlint --type-aware input.ts 2>&1)"
-      typeAwareStatus=$?
-      set -e
-      test "$typeAwareStatus" -ne 0
-      printf '%s\n' "$typeAwareOutput" | grep -F "no-unnecessary-type-assertion" > /dev/null
-    )
+    echo 'const s: string = ""; const _: string = s as string;' >type-aware.ts
+    expectFail no-unnecessary-type-assertion \
+      "$out/bin/oxlint" -D typescript/no-unnecessary-type-assertion --type-aware type-aware.ts
 
     runHook postInstallCheck
   '';
@@ -195,6 +155,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ iamanaws ];
     mainProgram = "oxlint";
-    inherit (nodejs-slim.meta) platforms;
+    inherit (nodejs-slim_24.meta) platforms;
   };
 })


### PR DESCRIPTION
Changelog: https://github.com/oxc-project/oxc/releases#release-apps_v1.78.0
Closes https://github.com/NixOS/nixpkgs/issues/551003

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
