### PR TITLE
python3Packages.pypdf: 6.14.2 -> 6.15.0

### DIFF
--- a/pkgs/by-name/pd/pdfding/package.nix
+++ b/pkgs/by-name/pd/pdfding/package.nix
@@ -140,6 +140,7 @@ python.pkgs.buildPythonPackage (finalAttrs: {
     "huey"
     "nh3"
     "psycopg2-binary"
+    "pypdf"
     "pypdfium2"
   ];
 

--- a/pkgs/development/python-modules/pypdf/default.nix
+++ b/pkgs/development/python-modules/pypdf/default.nix
@@ -12,9 +12,11 @@
   myst-parser,
 
   # optionals
+  arabic-reshaper,
   cryptography,
   fonttools,
   pillow,
+  python-bidi,
 
   # tests
   fpdf2,
@@ -24,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "pypdf";
-  version = "6.14.2";
+  version = "6.15.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -33,7 +35,7 @@ buildPythonPackage rec {
     tag = version;
     # fetch sample files used in tests
     fetchSubmodules = true;
-    hash = "sha256-h7JuQTTUZ5tWoAhixjp+grDVA3JQ8PbHcMBzIyCMOJU=";
+    hash = "sha256-e39xclCnXlX4oagx4TnFCf99VKdJZeM2Kc3set1KXuo=";
   };
 
   outputs = [
@@ -55,10 +57,14 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = rec {
-    full = crypto ++ fonts ++ image;
+    full = crypto ++ fonts ++ image ++ rtl_text;
     crypto = [ cryptography ];
     fonts = [ fonttools ];
     image = [ pillow ];
+    rtl_text = [
+      arabic-reshaper
+      python-bidi
+    ];
   };
 
   pythonImportsCheck = [ "pypdf" ];


### PR DESCRIPTION
Updates pypdf to 6.15.0, fixing CVE-2026-71870 and CVE-2026-71852.

Upstream release: [6.15.0](https://redirect.github.com/py-pdf/pypdf/releases/tag/6.15.0)

fixes #551113

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
