### PR TITLE
openrct2: support darwin, add schrobingus as maintainer

### DIFF
--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -199,21 +199,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    runHook preInstall
-    mkdir -p $out/{Applications,bin,share}
-    cp -R OpenRCT2.app $out/Applications/
-    makeBinaryWrapper $out/Applications/OpenRCT2.app/Contents/MacOS/openrct2 $out/bin/openrct2
-    cp openrct2-cli $out/bin/openrct2-cli
-    ln -s $out/Applications/OpenRCT2.app/Contents/Resources $out/share/openrct2
-    runHook postInstall
-  '';
-
-  postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    wrapProgram $out/bin/openrct2 \
-      ${lib.optionalString (rct1Path != null) "--add-flags '--rct1-data-path=\"${rct1Path}\"'"} \
-      ${lib.optionalString (rct2Path != null) "--add-flags '--rct2-data-path=\"${rct2Path}\"'"}
-  '';
+  postInstall =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        mkdir -p $out/{Applications,bin,share}
+        cp -R OpenRCT2.app $out/Applications/
+        makeBinaryWrapper $out/Applications/OpenRCT2.app/Contents/MacOS/openrct2 $out/bin/openrct2
+        cp openrct2-cli $out/bin/openrct2-cli
+        ln -s $out/Applications/OpenRCT2.app/Contents/Resources $out/share/openrct2
+      ''
+    else
+      ''
+        wrapProgram $out/bin/openrct2 \
+          ${lib.optionalString (rct1Path != null) "--add-flags '--rct1-data-path=\"${rct1Path}\"'"} \
+          ${lib.optionalString (rct2Path != null) "--add-flags '--rct2-data-path=\"${rct2Path}\"'"}
+      '';
 
   meta = {
     description = "Open source re-implementation of RollerCoaster Tycoon 2";

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -26,6 +26,7 @@
   libvorbis,
   libzip,
   makeWrapper,
+  makeBinaryWrapper,
   nlohmann_json,
   openssl,
   pkg-config,
@@ -88,6 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     unzip
     makeWrapper
+    makeBinaryWrapper
     versionCheckHook
   ];
 
@@ -124,6 +126,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "DOWNLOAD_OPENSFX" false)
     (lib.cmakeBool "DOWNLOAD_TITLE_SEQUENCES" false)
     (lib.cmakeBool "DISABLE_DISCORD_RPC" (!withDiscordRpc))
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    (lib.cmakeBool "MACOS_USE_DEPENDENCIES" false)
+    (lib.cmakeBool "MACOS_BUNDLE" true)
   ];
 
   postUnpack = ''
@@ -132,6 +138,56 @@ stdenv.mkDerivation (finalAttrs: {
     unzip -o ${finalAttrs.passthru.assets.openmusic} -d $sourceRoot/data
     unzip -o ${finalAttrs.passthru.assets.opensfx} -d $sourceRoot/data
     unzip -o ${finalAttrs.passthru.assets.title-sequences} -d $sourceRoot/data/sequence
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    mkdir -p $sourceRoot/build/object $sourceRoot/build/sequence
+    unzip -o ${finalAttrs.passthru.assets.objects} -d $sourceRoot/build/object
+    unzip -o ${finalAttrs.passthru.assets.title-sequences} -d $sourceRoot/build/sequence
+    unzip -o ${finalAttrs.passthru.assets.opensfx} -d $sourceRoot/build
+    unzip -o ${finalAttrs.passthru.assets.openmusic} -d $sourceRoot/build
+    printf '%s' "${finalAttrs.passthru.assets.objects.url}" > $sourceRoot/build/object/objects.zip.zipversion
+    printf '%s' "${finalAttrs.passthru.assets.title-sequences.url}" > $sourceRoot/build/sequence/title-sequences.zip.zipversion
+    printf '%s' "${finalAttrs.passthru.assets.opensfx.url}" > $sourceRoot/build/opensound.zip.zipversion
+    printf '%s' "${finalAttrs.passthru.assets.openmusic.url}" > $sourceRoot/build/openmusic.zip.zipversion
+  '';
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    # MACOS_BUNDLE (to build a .APP) is tied to MACOS_USE_DEPENDENCIES by default.
+    # Decouple the two variables so that we can use resources downloaded from Nix.
+    sed -i \
+      -e 's/^CMAKE_DEPENDENT_OPTION(MACOS_BUNDLE.*/option(MACOS_BUNDLE "Build macOS application bundle (OpenRCT2.app)" ON)/' \
+      -e '/"MACOS_USE_DEPENDENCIES; NOT DISABLE_GUI" OFF)/d' \
+      CMakeLists.txt
+    sed -i '/^if (MACOS_USE_DEPENDENCIES)$/i include(cmake/download.cmake)' CMakeLists.txt
+
+    # Clang 21 on Nixpkgs will provide a broken Foundation module, as of now.
+    # The Apple Obj-C modules requested are not explicitly required, so drop them.
+    sed -i 's/-x objective-c++ -fmodules/-x objective-c++/' \
+      src/openrct2/CMakeLists.txt \
+      src/openrct2-ui/CMakeLists.txt
+
+    # `fixup_bundle` will inherit mismatched dependencies relative to compilation.
+    # Hence, disable `fixup_bundle` for Darwin builds.
+    substituteInPlace src/openrct2-ui/CMakeLists.txt \
+        --replace-fail 'fixup_bundle(''${CMAKE_BINARY_DIR}/''${MACOS_APP_NAME} \"\" \"\")' \
+                       '# fixup_bundle disabled for Nix builds'
+
+    # sdl2-compat is the default for SDL2 in Nixpkgs, which has issues on Darwin.
+    # Set OpenGL as the default renderer in Darwin to bypass them.
+    substituteInPlace src/openrct2/config/Config.cpp \
+        --replace-fail 'DrawingEngine::SoftwareWithHardwareDisplay, Enum_DrawingEngine)' \
+                       'DrawingEngine::OpenGL, Enum_DrawingEngine)'
+
+    # Wrapping with --rct*-data-path will not work on Darwin for OpenRCT2.app.
+    # This simply sets that data path as the default in source, if defined.
+    ${lib.optionalString (rct1Path != null) ''
+      substituteInPlace src/openrct2/config/Config.cpp \
+          --replace-fail 'GetString("rct1_path", "")' 'GetString("rct1_path", "${rct1Path}")'
+    ''}
+    ${lib.optionalString (rct2Path != null) ''
+      substituteInPlace src/openrct2/config/Config.cpp \
+          --replace-fail 'GetString("rct2_path", "")' 'GetString("rct2_path", "${rct2Path}")'
+    ''}
   '';
 
   preConfigure =
@@ -147,7 +203,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  postInstall = ''
+  installPhase = lib.optionalString stdenv.isDarwin ''
+    runHook preInstall
+    mkdir -p $out/Applications $out/bin $out/share
+    cp -R OpenRCT2.app $out/Applications/
+    makeBinaryWrapper $out/Applications/OpenRCT2.app/Contents/MacOS/openrct2 $out/bin/openrct2
+    cp openrct2-cli $out/bin/openrct2-cli
+    ln -s $out/Applications/OpenRCT2.app/Contents/Resources $out/share/openrct2
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (!stdenv.isDarwin) ''
     wrapProgram $out/bin/openrct2 \
       ${lib.optionalString (rct1Path != null) "--add-flags '--rct1-data-path=\"${rct1Path}\"'"} \
       ${lib.optionalString (rct2Path != null) "--add-flags '--rct2-data-path=\"${rct2Path}\"'"}
@@ -183,7 +249,7 @@ stdenv.mkDerivation (finalAttrs: {
       kylerisse
     ];
     mainProgram = "openrct2";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };
 })

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -127,31 +127,27 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "DOWNLOAD_TITLE_SEQUENCES" false)
     (lib.cmakeBool "DISABLE_DISCORD_RPC" (!withDiscordRpc))
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeBool "MACOS_USE_DEPENDENCIES" false)
     (lib.cmakeBool "MACOS_BUNDLE" true)
   ];
 
   postUnpack = ''
-    mkdir -p $sourceRoot/data/{object,sequence}
-    unzip -o ${finalAttrs.passthru.assets.objects} -d $sourceRoot/data/object
-    unzip -o ${finalAttrs.passthru.assets.openmusic} -d $sourceRoot/data
-    unzip -o ${finalAttrs.passthru.assets.opensfx} -d $sourceRoot/data
-    unzip -o ${finalAttrs.passthru.assets.title-sequences} -d $sourceRoot/data/sequence
+    export OPENRCT2_ASSETS_DIR=$sourceRoot/${if stdenv.hostPlatform.isDarwin then "build" else "data"}
+    mkdir -p $OPENRCT2_ASSETS_DIR/{object,sequence}
+    unzip -o ${finalAttrs.passthru.assets.objects} -d $OPENRCT2_ASSETS_DIR/object
+    unzip -o ${finalAttrs.passthru.assets.openmusic} -d $OPENRCT2_ASSETS_DIR
+    unzip -o ${finalAttrs.passthru.assets.opensfx} -d $OPENRCT2_ASSETS_DIR
+    unzip -o ${finalAttrs.passthru.assets.title-sequences} -d $OPENRCT2_ASSETS_DIR/sequence
   ''
-  + lib.optionalString stdenv.isDarwin ''
-    mkdir -p $sourceRoot/build/object $sourceRoot/build/sequence
-    unzip -o ${finalAttrs.passthru.assets.objects} -d $sourceRoot/build/object
-    unzip -o ${finalAttrs.passthru.assets.title-sequences} -d $sourceRoot/build/sequence
-    unzip -o ${finalAttrs.passthru.assets.opensfx} -d $sourceRoot/build
-    unzip -o ${finalAttrs.passthru.assets.openmusic} -d $sourceRoot/build
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     printf '%s' "${finalAttrs.passthru.assets.objects.url}" > $sourceRoot/build/object/objects.zip.zipversion
     printf '%s' "${finalAttrs.passthru.assets.title-sequences.url}" > $sourceRoot/build/sequence/title-sequences.zip.zipversion
     printf '%s' "${finalAttrs.passthru.assets.opensfx.url}" > $sourceRoot/build/opensound.zip.zipversion
     printf '%s' "${finalAttrs.passthru.assets.openmusic.url}" > $sourceRoot/build/openmusic.zip.zipversion
   '';
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # MACOS_BUNDLE (to build a .APP) is tied to MACOS_USE_DEPENDENCIES by default.
     # Decouple the two variables so that we can use resources downloaded from Nix.
     sed -i \
@@ -162,9 +158,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Clang 21 on Nixpkgs will provide a broken Foundation module, as of now.
     # The Apple Obj-C modules requested are not explicitly required, so drop them.
-    sed -i 's/-x objective-c++ -fmodules/-x objective-c++/' \
-      src/openrct2/CMakeLists.txt \
-      src/openrct2-ui/CMakeLists.txt
+    substituteInPlace src/{openrct2,openrct2-ui}/CmakeLists.txt \
+        --replace-fail '-x objective-c++ -fmodules' \
+                       '-x objective-c++'
 
     # `fixup_bundle` will inherit mismatched dependencies relative to compilation.
     # Hence, disable `fixup_bundle` for Darwin builds.
@@ -203,9 +199,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  installPhase = lib.optionalString stdenv.isDarwin ''
+  installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
     runHook preInstall
-    mkdir -p $out/Applications $out/bin $out/share
+    mkdir -p $out/{Applications,bin,share}
     cp -R OpenRCT2.app $out/Applications/
     makeBinaryWrapper $out/Applications/OpenRCT2.app/Contents/MacOS/openrct2 $out/bin/openrct2
     cp openrct2-cli $out/bin/openrct2-cli
@@ -213,7 +209,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postInstall = lib.optionalString (!stdenv.isDarwin) ''
+  postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     wrapProgram $out/bin/openrct2 \
       ${lib.optionalString (rct1Path != null) "--add-flags '--rct1-data-path=\"${rct1Path}\"'"} \
       ${lib.optionalString (rct2Path != null) "--add-flags '--rct2-data-path=\"${rct2Path}\"'"}

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -243,6 +243,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       keenanweaver
       kylerisse
+      schrobingus
     ];
     mainProgram = "openrct2";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;


### PR DESCRIPTION
Adds Darwin support to the OpenRCT2 package. 

Due to the structure of .APP on Mac and no viable wrapper option, `rct1Path` and `rct2Path` had to be patched directly into the source as defaults for Darwin specifically, rather than wrapped into the output (still preserved for Linux / non-Darwin).

Tested on macOS 14.8.7.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
