### PR TITLE
home-assistant-custom-components.econet300: init at 1.3.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/econet300/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/econet300/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  version = "1.3.0";
+  domain = "econet300";
+  owner = "jontofront";
+
+  src = fetchFromGitHub {
+    owner = "jontofront";
+    repo = "ecoNET-300-Home-Assistant-Integration";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-E5C0onRXNlzxwqz/Z653CRi/xT8FA+uOWiwOX3rkdlg=";
+  };
+
+  meta = {
+    changelog = "https://github.com/jontofront/ecoNET-300-Home-Assistant-Integration/releases/tag/v${finalAttrs.version}";
+    description = "Home Assistant component for Plum ecoNET300 devices";
+    homepage = "https://github.com/jontofront/ecoNET-300-Home-Assistant-Integration";
+    maintainers = with lib.maintainers; [ implr ];
+    license = lib.licenses.unfree;
+  };
+})


### PR DESCRIPTION
This is a HA integration for local control of [Plum](https://plum.pl/en/home/) [ecoNET](https://hvac.plum.pl/en/product/econet-300/) devices. These are controllers for home HVAC, like heat pumps. \
The [chosen repo](https://github.com/jontofront/ecoNET-300-Home-Assistant-Integration) is for a fork which still receives updates.

note: The source repository does not have a license. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
