### PR TITLE
python3Packages.pybraendstofpriser: init at 2.2.0

### DIFF
--- a/pkgs/development/python-modules/pybraendstofpriser/default.nix
+++ b/pkgs/development/python-modules/pybraendstofpriser/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pyprojectVersionPatchHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pybraendstofpriser";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MTrab";
+    repo = "pybraendstofpriser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-U3apX4t4c4Gb14b9KznVJdYmlGyuzjG6fzpseT1v2+U=";
+  };
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ aiohttp ];
+
+  # The test script requires an API key and network access.
+  doCheck = false;
+
+  pythonImportsCheck = [ "pybraendstofpriser" ];
+
+  meta = {
+    description = "Library for fetching fuel prices from Fuelprices.dk API";
+    homepage = "https://github.com/MTrab/pybraendstofpriser";
+    changelog = "https://github.com/MTrab/pybraendstofpriser/releases/tag/${finalAttrs.src.tag}";
+    # Awaiting license clarification from upstream.
+    # https://github.com/MTrab/pybraendstofpriser/issues/44
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2185,7 +2185,8 @@
       ];
     "fuelprices_dk" =
       ps: with ps; [
-      ]; # missing inputs: pybraendstofpriser
+        pybraendstofpriser
+      ];
     "fujitsu_anywair" =
       ps: with ps; [
       ];
@@ -8293,6 +8294,7 @@
     "fronius"
     "frontend"
     "frontier_silicon"
+    "fuelprices_dk"
     "fujitsu_fglair"
     "fully_kiosk"
     "fumis"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14245,6 +14245,8 @@ self: super: with self; {
 
   pybox2d = callPackage ../development/python-modules/pybox2d { };
 
+  pybraendstofpriser = callPackage ../development/python-modules/pybraendstofpriser { };
+
   pybravia = callPackage ../development/python-modules/pybravia { };
 
   pybreaker = callPackage ../development/python-modules/pybreaker { };


### PR DESCRIPTION
- https://pypi.org/project/pybraendstofpriser/
- https://github.com/MTrab/pybraendstofpriser
- https://www.home-assistant.io/integrations/fuelprices_dk/

NOTE: The `LICENSE` file shows a GPL 3 license, but the `pyproject.toml` shows an `MIT` license. I've listed this package as GPL 3 for now (as it is more restrictive) and opened an issue upstream https://github.com/MTrab/pybraendstofpriser/issues/44

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
