### PR TITLE
python3Packages.thriftpy2: 0.5.3 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/thriftpy2/default.nix
+++ b/pkgs/development/python-modules/thriftpy2/default.nix
@@ -1,43 +1,38 @@
 {
   lib,
+  aiohttp,
   buildPythonPackage,
   cython,
   fetchFromGitHub,
-  fetchpatch,
+  ijson,
   ply,
-  six,
   setuptools,
-  tornado,
 }:
 
 buildPythonPackage rec {
   pname = "thriftpy2";
-  version = "0.5.3";
+  version = "0.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Thriftpy";
     repo = "thriftpy2";
     tag = "v${version}";
-    hash = "sha256-idUKqpyRj8lq9Aq6vEEeYEawzRPOdNsySnkgfhwPtMc=";
+    hash = "sha256-vbNCPYWO/D+7/UJU/0ATdLzZ4lIPOKeBZ1sgWCdxx/c=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/Thriftpy/thriftpy2/commit/0127d259eb4b96acb060cd158ca709f0597b148c.patch";
-      sha256 = "sha256-UBcbd8NTkPyko1s9jTjKlQ7HprwtyOZS0m66u1CPH3A=";
-    })
-  ];
   build-system = [ setuptools ];
 
   nativeBuildInputs = [ cython ];
 
   dependencies = [
     ply
-    six
-    tornado
+    ijson
   ];
 
+  optional-dependencies = {
+    aiohttp = [ aiohttp ];
+  };
   # Not all needed files seems to be present
   doCheck = false;
 


### PR DESCRIPTION
Diff: https://github.com/Thriftpy/thriftpy2/compare/v0.5.3...v0.7.0

Changelog: https://github.com/Thriftpy/thriftpy2/blob/v0.7.0/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
