### PR TITLE
python3Packages.pygeosphere-warnings: init at 0.1.2

### DIFF
--- a/pkgs/development/python-modules/pygeosphere-warnings/default.nix
+++ b/pkgs/development/python-modules/pygeosphere-warnings/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pygeosphere-warnings";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tklecka";
+    repo = "pygeosphere-warnings";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AQ2TQk5N+S4bW0OmrZj0la2UMIdpmxBUCMhbIkszm3g=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pygeosphere_warnings" ];
+
+  meta = {
+    description = "Asynchronous Python client for the GeoSphere Austria Warn API";
+    homepage = "https://github.com/tklecka/pygeosphere-warnings";
+    changelog = "https://github.com/tklecka/pygeosphere-warnings/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2322,7 +2322,8 @@
       ];
     "geosphere_austria_warnings" =
       ps: with ps; [
-      ]; # missing inputs: pygeosphere-warnings
+        pygeosphere-warnings
+      ];
     "ghost" =
       ps: with ps; [
         aioghost
@@ -8314,6 +8315,7 @@
     "geofency"
     "geonetnz_quakes"
     "geonetnz_volcano"
+    "geosphere_austria_warnings"
     "ghost"
     "gios"
     "github"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14730,6 +14730,8 @@ self: super: with self; {
 
   pygeocodio = callPackage ../development/python-modules/pygeocodio { };
 
+  pygeosphere-warnings = callPackage ../development/python-modules/pygeosphere-warnings { };
+
   pygerber = callPackage ../development/python-modules/pygerber { };
 
   pygetwindow = callPackage ../development/python-modules/pygetwindow { };


### PR DESCRIPTION
- https://pypi.org/project/pygeosphere-warnings/
- https://github.com/tklecka/pygeosphere-warnings
- https://www.home-assistant.io/integrations/geosphere_austria_warnings/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
