### PR TITLE
python3Packages.selenium: disable test_errors_if_not_file on loongarch64-linux

### DIFF
--- a/pkgs/development/python-modules/selenium/default.nix
+++ b/pkgs/development/python-modules/selenium/default.nix
@@ -93,8 +93,8 @@ buildPythonPackage rec {
     # Fails to find browsers during test phase
     "test/selenium"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-    # Unsupported platform/architecture combination: linux/aarch64
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && (!stdenv.hostPlatform.isx86_64)) [
+    # Unsupported platform/architecture combination: linux/{aarch64,loongarch64}
     "test/unit/selenium/webdriver/common/selenium_manager_tests.py::test_errors_if_not_file"
   ];
 


### PR DESCRIPTION
This is @darkyzhou's commit in [loongson-community/nixpkgs](https://github.com/loongson-community/nixpkgs), but I think it's worth upstreaming here. The following is his commit message:

Selenium Manager does not ship a binary for linux/loongarch64, causing test_errors_if_not_file to fail with "Unsupported platform/architecture combination: linux/loongarch64" instead of the expected "Unable to obtain working Selenium Manager binary". This is the same issue already worked around for aarch64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
