### PR TITLE
python3Packages.google-health-api: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/google-health-api/default.nix
+++ b/pkgs/development/python-modules/google-health-api/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  cryptography,
+  fetchFromGitHub,
+  google-auth,
+  google-auth-oauthlib,
+  mashumaro,
+  pytest-aiohttp,
+  pytest-asyncio,
+  pytestCheckHook,
+  pythonOlder,
+  requests,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "google-health-api";
+  version = "0.8.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.14";
+
+  src = fetchFromGitHub {
+    owner = "allenporter";
+    repo = "python-google-health-api";
+    tag = finalAttrs.version;
+    hash = "sha256-EyHQ2pNjz1GjwxgogyYCnr+oyloqJe6Qa2KhonW4xwY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    google-auth
+    google-auth-oauthlib
+    mashumaro
+    requests
+  ];
+
+  optional-dependencies.webhook = [ cryptography ];
+
+  nativeCheckInputs = [
+    cryptography
+    pytest-aiohttp
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "google_health_api" ];
+
+  meta = {
+    description = "Asynchronous, type-safe Python client library for the Google Health API";
+    homepage = "https://github.com/allenporter/python-google-health-api";
+    changelog = "https://github.com/allenporter/python-google-health-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2417,7 +2417,8 @@
       ];
     "google_health" =
       ps: with ps; [
-      ]; # missing inputs: google-health-api
+        google-health-api
+      ];
     "google_mail" =
       ps: with ps; [
         google-api-python-client
@@ -8329,6 +8330,7 @@
     "google_cloud"
     "google_drive"
     "google_generative_ai_conversation"
+    "google_health"
     "google_mail"
     "google_photos"
     "google_pubsub"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7072,6 +7072,8 @@ self: super: with self; {
 
   google-geo-type = callPackage ../development/python-modules/google-geo-type { };
 
+  google-health-api = callPackage ../development/python-modules/google-health-api { };
+
   google-i18n-address = callPackage ../development/python-modules/google-i18n-address { };
 
   google-maps-routing = callPackage ../development/python-modules/google-maps-routing { };


### PR DESCRIPTION
- https://pypi.org/project/google-health-api/
- https://github.com/allenporter/python-google-health-api
- https://www.home-assistant.io/integrations/google_health/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
