### PR TITLE
python3Packages.flask-dramatiq: 0.6.0 -> 0.8.0; python3Packages.periodiq: 0.13.0 -> 0.14.0; fittrackee: 0.11.2 -> 1.3.4

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -446,6 +446,8 @@ gnuradioMinimal.override {
 
 - `mold` is now wrapped by default.
 
+- `fittrackee` 1.0.0 now requires postgres with postgis. The [upgrade guide](https://docs.fittrackee.org/en/upgrading-to-1.0.0.html) has steps to prepare for this upgrade.
+
 - The `neovim` package and module now disable by default the `python3` and `ruby` providers, unused by most users and reducing closure size from 365MiB to 240MiB. Host provider executables are not exposed anymore along with the neovim wrapper. You can still refer to those using the neovim provider variables (e.g., `python3_host_prog`).
 
 - `canokey-qemu` support for `qemu` was restored (although disabled by default), after being marked as broken since nixpkgs 25.11. Please note that the format of canokey files has changed, and that some data created with older canokey-qemu release cannot be read by the current version. See the [documentation](https://github.com/canokeys/canokey-qemu/tree/v1?tab=readme-ov-file#compatibility-warning) for details.

--- a/pkgs/by-name/fi/fittrackee/0001-pytest-Parametrize-compatability-with-9.1.1.patch
+++ b/pkgs/by-name/fi/fittrackee/0001-pytest-Parametrize-compatability-with-9.1.1.patch
@@ -1,0 +1,34 @@
+From 4fa9323aa6c029049848bf619b11fc790d9cecc2 Mon Sep 17 00:00:00 2001
+From: Chris Moultrie <tebriel@frodux.in>
+Date: Sun, 9 Aug 2026 18:08:21 -0400
+Subject: [PATCH] pytest: Parametrize compatability with 9.1.1
+
+---
+ fittrackee/tests/workouts/test_workouts_model.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/fittrackee/tests/workouts/test_workouts_model.py b/fittrackee/tests/workouts/test_workouts_model.py
+index 077a8a86e..ca4175a6f 100644
+--- a/fittrackee/tests/workouts/test_workouts_model.py
++++ b/fittrackee/tests/workouts/test_workouts_model.py
+@@ -1199,7 +1199,7 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
+         )
+ 
+     @pytest.mark.parametrize(
+-        "input_args,",
++        "input_args",
+         [
+             {"light": False},
+             {"light": False, "with_equipments": True},
+@@ -1226,7 +1226,7 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
+             equipment_bike_user_1.serialize(current_user=user_1)
+         ]
+ 
+-    @pytest.mark.parametrize("input_args,", [{}, {"light": True}])
++    @pytest.mark.parametrize("input_args", [{}, {"light": True}])
+     def test_serializer_does_not_return_equipments(
+         self,
+         app: Flask,
+-- 
+2.54.0
+

--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -11,22 +11,27 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "fittrackee";
-  version = "1.3.3";
+  version = "1.3.4";
   pyproject = true;
 
   src = fetchFromCodeberg {
     owner = "FitTrackee";
     repo = "FitTrackee";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XWR9gg52pfg0lHoFikQ2wVhvkPCTjTTndBYqBzYPB8s=";
+    hash = "sha256-PN+YHRKvsAgTaSm4dl2t5voRxbgIo+yoieMfGEuE0oI=";
   };
+
+  patches = [
+    # https://codeberg.org/FitTrackee/FitTrackee/pulls/1205
+    ./0001-pytest-Parametrize-compatability-with-9.1.1.patch
+  ];
 
   makeCacheWritable = true;
   npmRoot = "fittrackee_client";
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-HEgof2ln+mBxM63Dv8Lc/bfx3ozoJCRYYyJOz6jh+Vs=";
+    hash = "sha256-kN/J7hIeEcnCKaramIPhoBsbBg32VgF372f9KOPi+nY=";
     sourceRoot = "${finalAttrs.src.name}/fittrackee_client";
   };
 

--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -1,49 +1,51 @@
 {
-  fetchFromGitHub,
+  fetchFromCodeberg,
+  fetchNpmDeps,
   lib,
   stdenv,
+  nodejs_24,
+  npmHooks,
   postgresql,
   postgresqlTestHook,
   python3Packages,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "fittrackee";
-  version = "0.11.2";
+  version = "1.3.3";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "SamR1";
+  src = fetchFromCodeberg {
+    owner = "FitTrackee";
     repo = "FitTrackee";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-A9gebHxNCpYUUIm7IjyySojIIyuTxfYCUeUufpUM1iA=";
+    hash = "sha256-XWR9gg52pfg0lHoFikQ2wVhvkPCTjTTndBYqBzYPB8s=";
   };
+
+  makeCacheWritable = true;
+  npmRoot = "fittrackee_client";
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-HEgof2ln+mBxM63Dv8Lc/bfx3ozoJCRYYyJOz6jh+Vs=";
+    sourceRoot = "${finalAttrs.src.name}/fittrackee_client";
+  };
+
+  nativeBuildInputs = [
+    nodejs_24
+    npmHooks.npmConfigHook
+  ];
+
+  preBuild = ''
+    pushd fittrackee_client
+    npm run build-only
+    popd
+  '';
 
   build-system = [
     python3Packages.poetry-core
   ];
 
-  # The upstream project changed the behavior of the CLI when --set-admin and --set-role are used together.
-  # Previously, it would raise an error, but now it issues a deprecation warning.
-  # This patch updates the test assertion to expect the new deprecation warning message.
-  # See upstream commit 6eda1b6119b3e41bdf8896e74b4a07d3c9e97609.
-  postPatch = ''
-    substituteInPlace fittrackee/tests/users/test_users_commands.py \
-      --replace '"--set-admin and --set-role can not be used together."' '"WARNING: --set-admin is deprecated. Please use --set-role option instead."'
-  '';
-
-  pythonRelaxDeps = [
-    "authlib"
-    "fitdecode"
-    "flask"
-    "flask-limiter"
-    "flask-migrate"
-    "nh3"
-    "lxml"
-    "pyopenssl"
-    "pytz"
-    "sqlalchemy"
-    "xmltodict"
-  ];
+  pythonRelaxDeps = true;
 
   dependencies =
     with python3Packages;
@@ -53,21 +55,31 @@ python3Packages.buildPythonApplication (finalAttrs: {
       click
       dramatiq
       dramatiq-abort
+      feedgenerator
       fitdecode
       flask
+      flask-babel
       flask-bcrypt
       flask-dramatiq
       flask-limiter
       flask-migrate
       flask-sqlalchemy
+      geoalchemy2
+      geopandas
       gpxpy
       gunicorn
       humanize
       jsonschema
+      lxml
+      mistune
       nh3
+      numpy
+      pandas
       psycopg2-binary
       pyjwt
       pyopenssl
+      pyproj
+      python-magic
       pytz
       shortuuid
       sqlalchemy
@@ -76,7 +88,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
       xmltodict
     ]
     ++ dramatiq.optional-dependencies.redis
-    ++ flask-limiter.optional-dependencies.redis;
+    ++ flask-limiter.optional-dependencies.redis
+    ++ geoalchemy2.optional-dependencies.shapely
+    ++ staticmap3.optional-dependencies.filecache;
 
   pythonImportsCheck = [ "fittrackee" ];
 
@@ -84,7 +98,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pytestCheckHook
     freezegun
     postgresqlTestHook
-    postgresql
+    (postgresql.withPackages (ps: with ps; [ postgis ]))
     time-machine
   ];
 
@@ -93,6 +107,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   postgresqlTestSetupPost = ''
+    echo "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" | PGUSER=postgres psql test_db
     export DATABASE_TEST_URL=postgresql://$PGUSER/$PGDATABASE?host=$PGHOST
   '';
 
@@ -105,8 +120,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Self-hosted outdoor activity tracker";
-    homepage = "https://github.com/SamR1/FitTrackee";
-    changelog = "https://github.com/SamR1/FitTrackee/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    homepage = "https://docs.fittrackee.org/";
+    changelog = "https://codeberg.org/FitTrackee/FitTrackee/src/tag/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       tebriel

--- a/pkgs/development/python-modules/flask-dramatiq/default.nix
+++ b/pkgs/development/python-modules/flask-dramatiq/default.nix
@@ -2,11 +2,13 @@
   lib,
   buildPythonPackage,
   dramatiq,
-  fetchFromGitLab,
+  fetchFromGitHub,
   flask-migrate,
+  flask-sqlalchemy,
   flask,
+  httpx,
   periodiq,
-  poetry-core,
+  hatchling,
   postgresql,
   postgresqlTestHook,
   psycopg2,
@@ -16,35 +18,33 @@
   requests,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "flask-dramatiq";
-  version = "0.6.0";
+  version = "0.8.0";
   pyproject = true;
 
-  src = fetchFromGitLab {
-    owner = "bersace";
+  src = fetchFromGitHub {
+    owner = "pallets-eco";
     repo = "flask-dramatiq";
-    rev = "840209e9bf582b4dda468e8bba515f248f3f8534";
-    hash = "sha256-qjV1zyVzHPXMt+oUeGBdP9XVlbcSz2MF9Zygj543T4w=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Gt9yynbmFWMISP1U0jRjU6oY3ImrLxYa2D0xf0llCEg=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'poetry>=0.12' 'poetry-core' \
-      --replace 'poetry.masonry.api' 'poetry.core.masonry.api'
-
     patchShebangs --build ./example.py
   '';
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   pythonRelaxDeps = [ "dramatiq" ];
 
   dependencies = [ dramatiq ];
 
   nativeCheckInputs = [
+    flask-sqlalchemy
     flask
     flask-migrate
+    httpx
     periodiq
     postgresql
     postgresqlTestHook
@@ -54,7 +54,8 @@ buildPythonPackage {
     pytestCheckHook
     requests
   ]
-  ++ dramatiq.optional-dependencies.rabbitmq;
+  ++ dramatiq.optional-dependencies.rabbitmq
+  ++ dramatiq.optional-dependencies.watch;
 
   postgresqlTestSetupPost = ''
     substituteInPlace config.py \
@@ -72,8 +73,8 @@ buildPythonPackage {
 
   meta = {
     description = "Adds Dramatiq support to your Flask application";
-    homepage = "https://gitlab.com/bersace/flask-dramatiq";
+    homepage = "https://github.com/pallets-eco/flask-dramatiq";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ traxys ];
   };
-}
+})

--- a/pkgs/development/python-modules/periodiq/default.nix
+++ b/pkgs/development/python-modules/periodiq/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
-  poetry-core,
+  uv-build,
   dramatiq,
   pendulum,
   setuptools,
@@ -13,27 +13,28 @@
 
 buildPythonPackage rec {
   pname = "periodiq";
-  version = "0.13.0";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "bersace";
     repo = "periodiq";
     tag = "v${version}";
-    hash = "sha256-Pyh/T3/HGPYyaXjyM0wkQ1V7p5ibqxE1Q62QwCIJ8To=";
+    hash = "sha256-XYQ0cR0gdiX7GePqpMDG/Ml0CK+SBcNbsNB99FZ/D3I=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail 'poetry>=0.12' 'poetry-core' \
-      --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api'
+      --replace-fail "uv_build>=0.11,<0.12" uv_build
   '';
 
-  pythonRelaxDeps = [ "dramatiq" ];
+  pythonRelaxDeps = [
+    "dramatiq"
+  ];
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ uv-build ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     dramatiq
     pendulum
     setuptools


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/444673
- https://github.com/NixOS/nixpkgs/pull/550914

Because Fittrackee <= 1.3.3 is vulnerable to https://github.com/SamR1/FitTrackee/security/advisories/GHSA-rc38-72q6-pc7w

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
