### PR TITLE
ark: set R_LIBS_SITE to fix detection of installed packages

### DIFF
--- a/pkgs/by-name/ar/ark/package.nix
+++ b/pkgs/by-name/ar/ark/package.nix
@@ -38,10 +38,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = false;
 
   # Ark loads R dynamically at runtime, locating it via `R_HOME` or by running
-  # `R RHOME`. Put R on PATH so the kernel works out of the box.
+  # `R RHOME`. Put R on PATH so the kernel works out of the box. Also set
+  # R_LIBS_SITE so that ark can find installed packages.
   postInstall = ''
     wrapProgram $out/bin/ark \
-      --suffix PATH : ${lib.makeBinPath [ R ]}
+      --suffix PATH : ${lib.makeBinPath [ R ]} \
+      --prefix R_LIBS_SITE : "$(${lib.getExe' R "Rscript"} -e 'cat(Sys.getenv("R_LIBS_SITE"))')"
   '';
 
   meta = {


### PR DESCRIPTION
The original version of `ark` didn't correctly pick up installed packages, i.e. if you did an override of R with something like `rWrapper.override { packages = [...]; }`.

CC @Th1nkK1D, this should fix the problem we've been discussing in https://github.com/NixOS/nixpkgs/pull/471079.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
