### PR TITLE
fastfetch-unwrapped: 2.66.0 -> 2.67.0

### DIFF
--- a/pkgs/by-name/fa/fastfetch-unwrapped/package.nix
+++ b/pkgs/by-name/fa/fastfetch-unwrapped/package.nix
@@ -47,7 +47,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fastfetch-unwrapped";
-  version = "2.66.0";
+  version = "2.67.0";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fastfetch-cli";
     repo = "fastfetch";
     tag = finalAttrs.version;
-    hash = "sha256-ttszEPEywszDGHoYKZYXM2WAUcuOSIj589LeEWxtRaU=";
+    hash = "sha256-IwptETUR3mDVxF7IkBwRMHVqbh8Wl39uiVl6yxXiJmw=";
   };
 
   outputs = [


### PR DESCRIPTION
Updates `fastfetch-unwrapped` from 2.66.0 to 2.67.0.

Changelog: https://github.com/fastfetch-cli/fastfetch/releases/tag/2.67.0

## Things done

- [x] Built `fastfetch-unwrapped` and `fastfetch` on x86_64-linux.