### PR TITLE
sketchybar-app-font: 2.0.71 -> 2.0.72

### DIFF
--- a/pkgs/by-name/sk/sketchybar-app-font/package.nix
+++ b/pkgs/by-name/sk/sketchybar-app-font/package.nix
@@ -10,13 +10,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "sketchybar-app-font";
-  version = "2.0.71";
+  version = "2.0.72";
 
   src = fetchFromGitHub {
     owner = "kvndrsslr";
     repo = "sketchybar-app-font";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Xyj2yPU7Sd6WTWHrVAmx2JGGvUihM5jq79yXbLUz9Qk=";
+    hash = "sha256-FTyElxbUs8Vu7dvjv9dyAWWq+wuOUn8MjK8QgCUnuOA=";
   };
 
   pnpmDeps = fetchPnpmDeps {


### PR DESCRIPTION
Updates `sketchybar-app-font` from 2.0.71 to 2.0.72.

Changelog: https://github.com/kvndrsslr/sketchybar-app-font/releases/tag/v2.0.72

## Things done

- [x] Built `sketchybar-app-font` on x86_64-linux.