### PR TITLE
nixos/test-driver: honor retry deadlines and propagate OCR timeouts

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -84,6 +84,14 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- The predicate passed to the NixOS test driver's globally exported `retry`
+  helper now receives the remaining timeout in seconds as a `float`, or `None`
+  for an unbounded retry. Previously it received a `last_try` boolean and was
+  called once more after the timeout. Predicates which used `last_try` must be
+  updated for the new contract. A timeout less than or equal to zero now makes
+  no attempt. Explicitly passing `timeout=None` now retries indefinitely; omit
+  `timeout` to use the default timeout of 15 minutes.
+
 - Artalk has been updated to 2.10.0. Its default configuration and data
   directory discovery changed; see the [upstream migration
   guide](https://artalk.js.org/en/guide/releases/v2.10.0.html) when invoking

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -585,20 +585,22 @@ class Driver:
                 if timeout is None:
                     timeout = dt.timedelta(minutes=15)
 
-                def condition(last: bool) -> bool:
-                    if last:
-                        driver.logger.info(
-                            f"Last chance for {self.condition.description}"
-                        )
+                def condition(_timeout: float | None) -> bool:
                     ret = self.condition.check(force=True)
-                    if not ret and not last:
+                    if not ret:
                         driver.logger.info(
                             f"({self.condition.description} failure not fatal yet)"
                         )
                     return ret
 
                 with driver.logger.nested(f"waiting for {self.condition.description}"):
-                    retry(condition, timeout=timeout)
+                    try:
+                        retry(condition, timeout=timeout)
+                    except RequestedAssertionFailed:
+                        driver.logger.info(
+                            f"Timed out waiting for {self.condition.description}"
+                        )
+                        raise
 
         if fun_ is None:
             return Poll

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -106,21 +106,28 @@ def make_command(args: list) -> str:
     return " ".join(map(shlex.quote, (map(str, args))))
 
 
+_DEFAULT_RETRY_TIMEOUT = dt.timedelta(minutes=15)
+
+
 def retry(
-    fn: Callable,
-    timeout_seconds: int | dt.timedelta | None = None,
-    timeout: dt.timedelta | None = None,
+    fn: Callable[[float | None], bool],
+    timeout_seconds: Duration | None = None,
+    timeout: dt.timedelta | None = _DEFAULT_RETRY_TIMEOUT,
 ) -> None:
     """Call the given function repeatedly, with a one second interval between
     retries, until it returns True or a timeout is reached.
 
-    Note that the timeout shown will include the time of the last attempted run.
-
     Has a default timeout of 15 minutes which can be modified.
     The ``timeout_seconds`` argument is deprecated. Use ``timeout`` instead.
+
+    The function receives the time remaining, or None for an unbounded retry.
+    The timeout is checked between calls, so a call which started before the
+    deadline may finish after it.
+    A timeout less than or equal to zero makes no call.
+    Passing ``timeout=None`` retries indefinitely.
     """
     if timeout_seconds is not None:
-        if timeout is not None:
+        if timeout is not _DEFAULT_RETRY_TIMEOUT:
             raise TypeError(
                 "retry() got both 'timeout' and 'timeout_seconds' arguments. Pass only 'timeout'"
             )
@@ -130,23 +137,20 @@ def retry(
             )
         timeout = as_timedelta(timeout_seconds)
 
-    if timeout is None:
-        timeout = dt.timedelta(minutes=15)
     start_time = time.monotonic()
+    deadline = float("inf") if timeout is None else start_time + timeout.total_seconds()
 
-    def elapsed() -> dt.timedelta:
-        return dt.timedelta(seconds=time.monotonic() - start_time)
-
-    while elapsed() < timeout:
-        if fn(False):
+    while (remaining := deadline - time.monotonic()) > 0:
+        if fn(None if timeout is None else remaining):
             return
-        time.sleep(1)
+        if (remaining := deadline - time.monotonic()) > 0:
+            time.sleep(min(1, remaining))
 
-    if not fn(True):
-        raise RequestedAssertionFailed(
-            f"action timed out after {elapsed().total_seconds():.2f} seconds "
-            f"(timeout={timeout.total_seconds()})"
-        )
+    elapsed = time.monotonic() - start_time
+    timeout_display = None if timeout is None else timeout.total_seconds()
+    raise RequestedAssertionFailed(
+        f"action timed out after {elapsed:.2f} seconds (timeout={timeout_display})"
+    )
 
 
 class QemuStartCommand:
@@ -382,7 +386,7 @@ class BaseMachine(ABC):
         """
         _warn_if_numeric_duration(timeout, "wait_for_unit")
 
-        def check_active(_last_try: bool) -> bool:
+        def check_active(_timeout: float | None) -> bool:
             state = self.get_unit_property(unit, "ActiveState", user)
             if state == "failed":
                 raise RequestedAssertionFailed(f'unit "{unit}" reached state "{state}"')
@@ -532,7 +536,7 @@ class BaseMachine(ABC):
         _warn_if_numeric_duration(timeout, "wait_until_succeeds")
         output = ""
 
-        def check_success(_last_try: bool) -> bool:
+        def check_success(_timeout: float | None) -> bool:
             nonlocal output
             status, output = self.execute(command, timeout=timeout)
             return status == 0
@@ -550,7 +554,7 @@ class BaseMachine(ABC):
         _warn_if_numeric_duration(timeout, "wait_until_fails")
         output = ""
 
-        def check_failure(_last_try: bool) -> bool:
+        def check_failure(_timeout: float | None) -> bool:
             nonlocal output
             status, output = self.execute(command, timeout=timeout)
             return status != 0
@@ -589,7 +593,7 @@ class BaseMachine(ABC):
         """
         _warn_if_numeric_duration(timeout, "wait_for_file")
 
-        def check_file(_last_try: bool) -> bool:
+        def check_file(_timeout: float | None) -> bool:
             status, _ = self.execute(f"test -e {filename}")
             return status == 0
 
@@ -608,7 +612,7 @@ class BaseMachine(ABC):
         """
         _warn_if_numeric_duration(timeout, "wait_for_open_port")
 
-        def port_is_open(_last_try: bool) -> bool:
+        def port_is_open(_timeout: float | None) -> bool:
             status, _ = self.execute(f"nc -z {addr} {port}")
             return status == 0
 
@@ -632,7 +636,7 @@ class BaseMachine(ABC):
             "-uU" if is_datagram else "-U",
         ]
 
-        def socket_is_open(_last_try: bool) -> bool:
+        def socket_is_open(_timeout: float | None) -> bool:
             status, _ = self.execute(f"nc {' '.join(nc_flags)} {addr}")
             return status == 0
 
@@ -653,7 +657,7 @@ class BaseMachine(ABC):
         """
         _warn_if_numeric_duration(timeout, "wait_for_closed_port")
 
-        def port_is_closed(_last_try: bool) -> bool:
+        def port_is_closed(_timeout: float | None) -> bool:
             status, _ = self.execute(f"nc -z {addr} {port}")
             return status != 0
 
@@ -956,18 +960,22 @@ class QemuMachine(BaseMachine):
         """
         _warn_if_numeric_duration(timeout, "wait_until_tty_matches")
         matcher = re.compile(regexp)
+        last_text = ""
 
-        def tty_matches(last_try: bool) -> bool:
-            text = self.get_tty_text(tty)
-            if last_try:
-                self.log(
-                    f"Last chance to match /{regexp}/ on TTY{tty}, "
-                    f"which currently contains: {text}"
-                )
-            return len(matcher.findall(text)) > 0
+        def tty_matches(_timeout: float | None) -> bool:
+            nonlocal last_text
+            last_text = self.get_tty_text(tty)
+            return len(matcher.findall(last_text)) > 0
 
         with self.nested(f"waiting for {regexp} to appear on tty {tty}"):
-            retry(tty_matches, as_timedelta(timeout))
+            try:
+                retry(tty_matches, as_timedelta(timeout))
+            except RequestedAssertionFailed:
+                self.log(
+                    f"Timed out matching /{regexp}/ on TTY{tty}. "
+                    f"The last observed contents were: {last_text}"
+                )
+                raise
 
     def dump_tty_contents(self, tty: str) -> None:
         """Debugging: Dump the contents of the TTY<n>"""
@@ -1129,7 +1137,7 @@ class QemuMachine(BaseMachine):
         """
         _warn_if_numeric_duration(timeout, "wait_for_file")
 
-        def check_file(_last_try: bool) -> bool:
+        def check_file(_timeout: float | None) -> bool:
             status, _ = self.execute(f"test -e {filename}")
             return status == 0
 
@@ -1261,19 +1269,25 @@ class QemuMachine(BaseMachine):
         """
         _warn_if_numeric_duration(timeout, "wait_for_text")
 
-        def screen_matches(last_try: bool) -> bool:
-            variants = self.get_screen_text_variants()
-            for text in variants:
+        last_variants: list[str] = []
+
+        def screen_matches(_timeout: float | None) -> bool:
+            nonlocal last_variants
+            last_variants = self.get_screen_text_variants()
+            for text in last_variants:
                 if re.search(regex, text) is not None:
                     return True
-
-            if last_try:
-                self.log(f"Last OCR attempt failed. Text was: {variants}")
 
             return False
 
         with self.nested(f"waiting for {regex} to appear on screen"):
-            retry(screen_matches, as_timedelta(timeout))
+            try:
+                retry(screen_matches, timeout=as_timedelta(timeout))
+            except RequestedAssertionFailed:
+                self.log(
+                    f"OCR timed out. Text from the last attempt was: {last_variants}"
+                )
+                raise
 
     def wait_for_console_text(
         self, regex: str, timeout: Duration | None = None
@@ -1290,7 +1304,7 @@ class QemuMachine(BaseMachine):
         # to match multiline regexes.
         console = io.StringIO()
 
-        def console_matches(_last_try: bool, block: bool = False) -> bool:
+        def console_matches(_timeout: float | None, block: bool = False) -> bool:
             nonlocal console
             try:
                 while True:
@@ -1308,7 +1322,7 @@ class QemuMachine(BaseMachine):
             if timeout is not None:
                 retry(console_matches, as_timedelta(timeout))
             else:
-                console_matches(False, block=True)
+                console_matches(None, block=True)
 
     def get_console_log(self) -> str:
         """
@@ -1471,7 +1485,7 @@ class QemuMachine(BaseMachine):
         """
         _warn_if_numeric_duration(timeout, "wait_for_x")
 
-        def check_x(_last_try: bool) -> bool:
+        def check_x(_timeout: float | None) -> bool:
             cmd = (
                 "journalctl -b SYSLOG_IDENTIFIER=systemd | "
                 + 'grep "Reached target Current graphical"'
@@ -1499,19 +1513,23 @@ class QemuMachine(BaseMachine):
         """
         _warn_if_numeric_duration(timeout, "wait_for_window")
         pattern = re.compile(regexp)
+        last_names: list[str] = []
 
-        def window_is_visible(last_try: bool) -> bool:
-            names = self.get_window_names()
-            if last_try:
-                self.log(
-                    f"Last chance to match {regexp} on the window list,"
-                    + " which currently contains: "
-                    + ", ".join(names)
-                )
-            return any(pattern.search(name) for name in names)
+        def window_is_visible(_timeout: float | None) -> bool:
+            nonlocal last_names
+            last_names = self.get_window_names()
+            return any(pattern.search(name) for name in last_names)
 
         with self.nested("waiting for a window to appear"):
-            retry(window_is_visible, as_timedelta(timeout))
+            try:
+                retry(window_is_visible, as_timedelta(timeout))
+            except RequestedAssertionFailed:
+                self.log(
+                    f"Timed out matching {regexp} on the window list. "
+                    + "The last observed window list was: "
+                    + ", ".join(last_names)
+                )
+                raise
 
     def forward_port(self, host_port: int = 8080, guest_port: int = 80) -> None:
         """

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -1228,7 +1228,7 @@ class QemuMachine(BaseMachine):
                         f"Cannot convert screenshot (pnmtopng returned code {ret.returncode})"
                     )
 
-    def get_screen_text_variants(self) -> list[str]:
+    def get_screen_text_variants(self, timeout: Duration | None = None) -> list[str]:
         """
         Return a list of different interpretations of what is currently
         visible on the machine's screen using optical character
@@ -1236,32 +1236,58 @@ class QemuMachine(BaseMachine):
         specified and is subject to change, but if no exception is raised at
         least one will be returned.
 
+        If timeout is set, preprocessing and all OCR variants share that time
+        budget. A timed-out variant produces an empty string.
+
         ::: {.note}
         This requires [`enableOCR`](#test-opt-enableOCR) to be set to `true`.
         :::
         """
+        _warn_if_numeric_duration(timeout, "get_screen_text_variants")
+        timeout_seconds = None if timeout is None else as_seconds(timeout)
+        start_time = time.monotonic()
         with self._managed_screenshot() as screenshot_path:
-            return perform_ocr_variants_on_screenshot(screenshot_path)
+            remaining = (
+                None
+                if timeout_seconds is None
+                else max(0, timeout_seconds - (time.monotonic() - start_time))
+            )
+            return perform_ocr_variants_on_screenshot(
+                screenshot_path, timeout=remaining
+            )
 
-    def get_screen_text(self) -> str:
+    def get_screen_text(self, timeout: Duration | None = None) -> str:
         """
         Return a textual representation of what is currently visible on the
         machine's screen using optical character recognition.
 
+        If timeout is set, the OCR operation is limited to that many seconds
+        and returns an empty string when it times out.
+
         ::: {.note}
         This requires [`enableOCR`](#test-opt-enableOCR) to be set to `true`.
         :::
         """
+        _warn_if_numeric_duration(timeout, "get_screen_text")
+        timeout_seconds = None if timeout is None else as_seconds(timeout)
+        start_time = time.monotonic()
         with self._managed_screenshot() as screenshot_path:
-            return perform_ocr_on_screenshot(screenshot_path)
+            remaining = (
+                None
+                if timeout_seconds is None
+                else max(0, timeout_seconds - (time.monotonic() - start_time))
+            )
+            return perform_ocr_on_screenshot(screenshot_path, remaining)
 
     def wait_for_text(
-        self, regex: str, timeout: Duration = dt.timedelta(minutes=15)
+        self, regex: str, timeout: Duration | None = dt.timedelta(minutes=15)
     ) -> None:
         """
         Wait until the supplied regular expressions matches the textual
         contents of the screen by using optical character recognition (see
         `get_screen_text` and `get_screen_text_variants`).
+
+        A timeout of None waits indefinitely.
 
         ::: {.note}
         This requires [`enableOCR`](#test-opt-enableOCR) to be set to `true`.
@@ -1271,9 +1297,14 @@ class QemuMachine(BaseMachine):
 
         last_variants: list[str] = []
 
-        def screen_matches(_timeout: float | None) -> bool:
+        def screen_matches(attempt_timeout: float | None) -> bool:
             nonlocal last_variants
-            last_variants = self.get_screen_text_variants()
+            ocr_timeout = (
+                None
+                if attempt_timeout is None
+                else dt.timedelta(seconds=attempt_timeout)
+            )
+            last_variants = self.get_screen_text_variants(ocr_timeout)
             for text in last_variants:
                 if re.search(regex, text) is not None:
                     return True
@@ -1282,7 +1313,10 @@ class QemuMachine(BaseMachine):
 
         with self.nested(f"waiting for {regex} to appear on screen"):
             try:
-                retry(screen_matches, timeout=as_timedelta(timeout))
+                retry(
+                    screen_matches,
+                    timeout=None if timeout is None else as_timedelta(timeout),
+                )
             except RequestedAssertionFailed:
                 self.log(
                     f"OCR timed out. Text from the last attempt was: {last_variants}"

--- a/nixos/lib/test-driver/src/test_driver/machine/ocr.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/ocr.py
@@ -1,30 +1,49 @@
 import os
 import shutil
 import subprocess
+import time
 from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 
 from test_driver.errors import MachineError
 
 
-def perform_ocr_on_screenshot(screenshot_path: Path) -> str:
+def perform_ocr_on_screenshot(
+    screenshot_path: Path, timeout: float | None = None
+) -> str:
     """
     Perform OCR on a screenshot that contains text.
-    Returns a string with all words that could be found.
+    If timeout is set, the OCR operation is limited to that many seconds.
+    Returns a string with all words that could be found, or an empty string if
+    OCR times out.
     """
-    return perform_ocr_variants_on_screenshot(screenshot_path, False)[0]
+    return perform_ocr_variants_on_screenshot(screenshot_path, False, timeout)[0]
 
 
 def perform_ocr_variants_on_screenshot(
-    screenshot_path: Path, variants: bool = True
+    screenshot_path: Path, variants: bool = True, timeout: float | None = None
 ) -> list[str]:
     """
     Same as perform_ocr_on_screenshot but will create variants of the images
     that can lead to more words being detected.
-    Returns a string with words for each variant.
+    If timeout is set, preprocessing and all variants share that time budget.
+    Returns recognized text for each variant. A timed-out variant produces an
+    empty string.
     """
     if shutil.which("tesseract") is None:
         raise MachineError("OCR requested but `tesseract` is not available")
+
+    processed_inversions = (False, True) if variants else ()
+    if timeout is not None and timeout <= 0:
+        return [""] * (1 + len(processed_inversions))
+
+    deadline = None if timeout is None else time.monotonic() + timeout
+
+    def remaining_time() -> float | None:
+        if deadline is None:
+            return None
+        return max(0, deadline - time.monotonic())
 
     # Tesseract runs parallel on up to 4 cores.
     # Docs suggest to run it with OMP_THREAD_LIMIT=1 for hundreds of parallel
@@ -34,21 +53,54 @@ def perform_ocr_variants_on_screenshot(
     cores: int = os.cpu_count() or 1 if nix_cores is None else int(nix_cores)
     workers: int = max(1, int(cores / 4))
 
-    with ThreadPoolExecutor(max_workers=workers) as e:
+    executor = ThreadPoolExecutor(max_workers=workers)
+    try:
         # The idea here is to let the first tesseract call run on the raw image
         # while the other two are preprocessed + tesseracted in parallel
-        future_results: list[Future] = [e.submit(_run_tesseract, screenshot_path)]
-        if variants:
+
+        def tesseract_raw() -> str:
+            worker_timeout = remaining_time()
+            if worker_timeout is not None and worker_timeout <= 0:
+                return ""
+            return _run_tesseract(screenshot_path, worker_timeout)
+
+        future_results: list[Future[str]] = [executor.submit(tesseract_raw)]
+        if processed_inversions:
 
             def tesseract_processed(inverted: bool) -> str:
-                return _run_tesseract(_preprocess_screenshot(screenshot_path, inverted))
+                preprocess_timeout = remaining_time()
+                if preprocess_timeout is not None and preprocess_timeout <= 0:
+                    return ""
+                try:
+                    processed = _preprocess_screenshot(
+                        screenshot_path, inverted, preprocess_timeout
+                    )
+                except subprocess.TimeoutExpired:
+                    return ""
+                return _run_tesseract(
+                    processed,
+                    remaining_time(),
+                )
 
-            future_results.append(e.submit(tesseract_processed, False))
-            future_results.append(e.submit(tesseract_processed, True))
-        return [future.result() for future in future_results]
+            future_results.extend(
+                executor.submit(tesseract_processed, inverted)
+                for inverted in processed_inversions
+            )
+
+        results: list[str] = []
+        for future in future_results:
+            try:
+                results.append(future.result(timeout=remaining_time()))
+            except FuturesTimeoutError:
+                results.append("")
+        return results
+    finally:
+        # Each running worker has the same deadline. Wait for subprocess timeout
+        # cleanup before the screenshot's temporary directory is removed.
+        executor.shutdown(wait=True, cancel_futures=True)
 
 
-def _run_tesseract(image: Path) -> str:
+def _run_tesseract(image: Path, timeout: float | None = None) -> str:
     # tesseract --help-oem
     # OCR Engine modes (OEM):
     #  0|tesseract_only          Legacy engine only.
@@ -57,26 +109,34 @@ def _run_tesseract(image: Path) -> str:
     #  3|default                 Default, based on what is available.
     ocr_engine_mode = 2
 
-    ret = subprocess.run(
-        [
-            "tesseract",
-            image,
-            "-",
-            "--oem",
-            str(ocr_engine_mode),
-            "-c",
-            "debug_file=/dev/null",
-            "--psm",
-            "11",
-        ],
-        capture_output=True,
-    )
+    try:
+        ret = subprocess.run(
+            [
+                "tesseract",
+                image,
+                "-",
+                "--oem",
+                str(ocr_engine_mode),
+                "-c",
+                "debug_file=/dev/null",
+                "--psm",
+                "11",
+            ],
+            capture_output=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return ""
     if ret.returncode != 0:
         raise MachineError(f"OCR failed with exit code {ret.returncode}")
     return ret.stdout.decode("utf-8")
 
 
-def _preprocess_screenshot(screenshot_path: Path, negate: bool = False) -> Path:
+def _preprocess_screenshot(
+    screenshot_path: Path,
+    negate: bool = False,
+    timeout: float | None = None,
+) -> Path:
     if shutil.which("magick") is None:
         raise MachineError("OCR requested but `magick` is not available")
 
@@ -115,6 +175,7 @@ def _preprocess_screenshot(screenshot_path: Path, negate: bool = False) -> Path:
     ret = subprocess.run(
         ["magick", "convert"] + magick_args + [screenshot_path, out_file],
         capture_output=True,
+        timeout=timeout,
     )
 
     if ret.returncode != 0:

--- a/nixos/lib/test-script-prepend.py
+++ b/nixos/lib/test-script-prepend.py
@@ -110,9 +110,9 @@ def polling_condition(
 
 
 def retry(
-    fn: Callable,
-    timeout_seconds: int | dt.timedelta | None = None,
-    timeout: dt.timedelta | None = None,
+    fn: Callable[[float | None], bool],
+    timeout_seconds: int | float | dt.timedelta | None = None,
+    timeout: dt.timedelta | None = dt.timedelta(minutes=15),
 ) -> None:
     pass
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -156,6 +156,7 @@ in
     multi-arch-test = runTest ./nixos-test-driver/multi-arch-test.nix;
     skip-typecheck = runTest ./nixos-test-driver/skip-typecheck.nix;
     console-timeout = runTest ./nixos-test-driver/console-timeout.nix;
+    retry = runTest ./nixos-test-driver/retry.nix;
     options-doc-regression = import ./nixos-test-driver/options-doc-regression.nix { inherit pkgs; };
     driver-timeout =
       pkgs.runCommand "ensure-timeout-induced-failure"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -156,6 +156,7 @@ in
     multi-arch-test = runTest ./nixos-test-driver/multi-arch-test.nix;
     skip-typecheck = runTest ./nixos-test-driver/skip-typecheck.nix;
     console-timeout = runTest ./nixos-test-driver/console-timeout.nix;
+    ocr = runTest ./nixos-test-driver/ocr.nix;
     retry = runTest ./nixos-test-driver/retry.nix;
     options-doc-regression = import ./nixos-test-driver/options-doc-regression.nix { inherit pkgs; };
     driver-timeout =

--- a/nixos/tests/atop.nix
+++ b/nixos/tests/atop.nix
@@ -57,12 +57,10 @@ let
         + ''
           with subtest("atop.service should write some data to /var/log/atop"):
 
-              def has_data_files(last: bool) -> bool:
+              def has_data_files(_remaining: float | None) -> bool:
                   files = int(machine.succeed("ls -1 /var/log/atop | wc -l"))
                   if files == 0:
                       machine.log("Did not find at least one 1 data file")
-                      if not last:
-                          machine.log("Will retry...")
                       return False
                   return True
 
@@ -82,12 +80,10 @@ let
 
           with subtest("atopacct.service should write data to /run/pacct_shadow.d"):
 
-              def has_data_files(last: bool) -> bool:
+              def has_data_files(_remaining: float | None) -> bool:
                   files = int(machine.succeed("ls -1 /run/pacct_shadow.d | wc -l"))
                   if files == 0:
                       machine.log("Did not find at least one 1 data file")
-                      if not last:
-                          machine.log("Will retry...")
                       return False
                   return True
 

--- a/nixos/tests/custom-ca.nix
+++ b/nixos/tests/custom-ca.nix
@@ -144,6 +144,10 @@ let
 
       testScript = ''
         from typing import Tuple
+
+        from test_driver.errors import RequestedAssertionFailed
+
+
         def execute_as(user: str, cmd: str) -> Tuple[int, str]:
             """
             Run a shell command as a specific user.
@@ -156,14 +160,23 @@ let
             Wait until a X11 window of a given user appears.
             """
 
-            def window_is_visible(last_try: bool) -> bool:
-                ret, stdout = execute_as(user, f"xdotool search --onlyvisible --class {cls}")
-                if last_try:
-                    machine.log(f"Last chance to match {cls} on the window list")
+            last_stdout = ""
+
+            def window_is_visible(_remaining: float | None) -> bool:
+                nonlocal last_stdout
+                ret, last_stdout = execute_as(
+                    user, f"xdotool search --onlyvisible --class {cls}"
+                )
                 return ret == 0
 
             with machine.nested("Waiting for a window to appear"):
-                retry(window_is_visible)
+                try:
+                    retry(window_is_visible)
+                except RequestedAssertionFailed:
+                    machine.log(
+                        f"Timed out matching {cls}. Last xdotool output: {last_stdout}"
+                    )
+                    raise
 
 
         machine.start()

--- a/nixos/tests/lomiri-music-app.nix
+++ b/nixos/tests/lomiri-music-app.nix
@@ -106,8 +106,8 @@ in
     startColor: str = "${ocrStartColor}"
 
     # Based on terminal-emulators.nix' check_for_pink
-    def check_for_color(color: str) -> Callable[[bool], bool]:
-        def check_for_color_retry(final=False) -> bool:
+    def check_for_color(color: str) -> Callable[[float | None], bool]:
+        def check_for_color_retry(_remaining: float | None) -> bool:
             with tempfile.NamedTemporaryFile() as tmpin:
                 machine.send_monitor_command("screendump {}".format(tmpin.name))
 
@@ -160,7 +160,7 @@ in
 
         # Ensure pause colours isn't present already
         assert (
-            check_for_color(pauseColor)(True) == False
+            check_for_color(pauseColor)(None) == False
         ), "pauseColor {} was present on the screen before we selected anything!".format(pauseColor)
 
         machine.succeed("xdotool mousemove 25 120 click 1") # Select the track
@@ -173,7 +173,7 @@ in
 
         # Ensure play colours isn't present already
         assert (
-            check_for_color(startColor)(True) == False
+            check_for_color(startColor)(None) == False
         ), "startColor {} was present on the screen before we were expecting it to be!".format(startColor)
 
         machine.succeed("xdotool mousemove 860 480 click 1") # Pause track (only works if app can actually decode the file)

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -90,10 +90,11 @@ let
     from collections.abc import Callable
     import tempfile
     import subprocess
+    import time
 
     # Based on terminal-emulators.nix' check_for_pink
-    def check_for_color(color: str) -> Callable[[bool], bool]:
-      def check_for_color_retry(final=False) -> bool:
+    def check_for_color(color: str) -> Callable[[float | None], bool]:
+      def check_for_color_retry(_remaining: float | None) -> bool:
         with tempfile.NamedTemporaryFile() as tmpin:
           machine.send_monitor_command("screendump {}".format(tmpin.name))
 
@@ -111,25 +112,18 @@ let
 
       return check_for_color_retry
 
-    def check_for_color_continued_presence(color: str) -> Callable[[bool], bool]:
-      colorFunc: Callable[[bool], bool] = check_for_color(color)
-      def check_for_color_continued_presence_retry(final=False) -> bool:
-        colorPresent: bool = colorFunc(final)
+    def ensure_color_continued_presence(color: str, duration: float) -> None:
+      color_func = check_for_color(color)
+      deadline = time.monotonic() + duration
 
-        if final:
-          # If it fails now, retry handles the exception raising.
-          # Otherwise, we passed.
-          return colorPresent
-        else:
-          if colorPresent:
-            # We want retry to continue running us until the timeout, so signal failure.
-            return False
-          else:
-            # Color disappeared
-            raise Exception(
-              "color {} has disappeared from the screen!".format(color)
-            )
-      return check_for_color_continued_presence_retry
+      while True:
+        if not color_func(None):
+          raise Exception(
+            "color {} has disappeared from the screen!".format(color)
+          )
+        if (remaining := deadline - time.monotonic()) <= 0:
+          return
+        time.sleep(min(1, remaining))
 
     def ensure_terminal_running() -> None:
       """
@@ -140,7 +134,7 @@ let
       with machine.nested("Waiting for the screen to have terminalTextColor {} on it:".format(terminalTextColor)):
         retry(check_for_color(terminalTextColor))
       with machine.nested("Ensuring terminalTextColor {} stays present on the screen:".format(terminalTextColor)):
-        retry(fn=check_for_color_continued_presence(terminalTextColor), timeout_seconds=5)
+        ensure_color_continued_presence(terminalTextColor, duration=5)
 
     def change_tty_back_forth(ttynumMain: int, ttynumDiff: int) -> None:
       """
@@ -189,7 +183,7 @@ let
       with machine.nested("Waiting for the screen to have launcherColor {} on it:".format(launcherColor)):
         retry(check_for_color(launcherColor))
       with machine.nested("Ensuring launcherColor {} stays present on the screen:".format(launcherColor)):
-        retry(fn=check_for_color_continued_presence(launcherColor), timeout_seconds=30)
+        ensure_color_continued_presence(launcherColor, duration=30)
 
       # Display "hangs" since qtmir bump? Not sure why. Switch to a different tty and back, and ensure that launcher button is still shown
       change_tty_back_forth(ttynumMain, ttynumDiff)

--- a/nixos/tests/netbird.nix
+++ b/nixos/tests/netbird.nix
@@ -68,7 +68,7 @@
       return ret, output
 
     def wait_until_rcode(node, cmd, rcode=0, retries=30, **kwargs):
-      def check_success(_last_try):
+      def check_success(_remaining):
         nonlocal output
         ret, output = run_with_debug(node, cmd, **kwargs)
         return ret == rcode

--- a/nixos/tests/nixos-test-driver/ocr.nix
+++ b/nixos/tests/nixos-test-driver/ocr.nix
@@ -1,0 +1,86 @@
+{
+  name = "ocr";
+
+  nodes = { };
+
+  testScript = ''
+    import subprocess
+    import threading
+    import time
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from test_driver.machine import ocr
+
+
+    timeout = 0.01
+    expired = subprocess.TimeoutExpired(["tesseract"], timeout)
+    with patch.object(ocr.subprocess, "run", side_effect=expired) as run:
+        assert ocr._run_tesseract(Path("input.png"), timeout) == ""
+        assert run.call_args.kwargs["timeout"] == timeout
+
+    completed = subprocess.CompletedProcess(["tesseract"], 0, stdout=b"text")
+    with patch.object(ocr.subprocess, "run", return_value=completed) as run:
+        assert ocr._run_tesseract(Path("input.png")) == "text"
+        assert run.call_args.kwargs["timeout"] is None
+
+    input_path = Path("input.png")
+    variant_timeouts = {}
+
+    def record_timeout(image: Path, worker_timeout: float | None) -> str:
+        variant_timeouts[image] = worker_timeout
+        return "text"
+
+    def slow_preprocessing(
+        image: Path, inverted: bool, _timeout: float | None
+    ) -> Path:
+        time.sleep(0.03)
+        suffix = "negative" if inverted else "positive"
+        return image.with_name(f"{image.name}.{suffix}")
+
+    with (
+        patch.dict(ocr.os.environ, {"NIX_BUILD_CORES": "12"}),
+        patch.object(ocr.shutil, "which", return_value="/bin/true"),
+        patch.object(ocr, "_run_tesseract", side_effect=record_timeout),
+        patch.object(
+            ocr, "_preprocess_screenshot", side_effect=slow_preprocessing
+        ),
+    ):
+        assert ocr.perform_ocr_variants_on_screenshot(
+            input_path, timeout=0.1
+        ) == ["text", "text", "text"]
+
+    raw_timeout = variant_timeouts[input_path]
+    assert raw_timeout is not None
+    processed_timeouts = [
+        value
+        for path, value in variant_timeouts.items()
+        if path != input_path and value is not None
+    ]
+    assert len(processed_timeouts) == 2
+    assert max(processed_timeouts) < raw_timeout - 0.02
+
+    worker_threads = []
+
+    def slow_worker(_image: Path, _timeout: float | None) -> str:
+        worker_threads.append(threading.current_thread())
+        time.sleep(0.05)
+        return "late"
+
+    with (
+        patch.object(ocr.shutil, "which", return_value="/bin/true"),
+        patch.object(ocr, "_run_tesseract", side_effect=slow_worker),
+    ):
+        assert ocr.perform_ocr_variants_on_screenshot(
+            Path("input.png"), variants=False, timeout=0.01
+        ) == [""]
+
+    assert worker_threads
+    assert all(not worker.is_alive() for worker in worker_threads)
+
+    with patch.object(ocr.shutil, "which", return_value="/bin/true"):
+        assert ocr.perform_ocr_variants_on_screenshot(
+            Path("input.png"), timeout=0
+        ) == ["", "", ""]
+  '';
+}

--- a/nixos/tests/nixos-test-driver/retry.nix
+++ b/nixos/tests/nixos-test-driver/retry.nix
@@ -1,0 +1,56 @@
+{
+  name = "retry";
+
+  nodes = { };
+
+  testScript = ''
+    import datetime as dt
+    import time
+
+    from test_driver.errors import RequestedAssertionFailed
+
+
+    unbounded_arguments = []
+    retry(
+        lambda remaining: unbounded_arguments.append(remaining) or True,
+        timeout=None,
+    )
+    assert unbounded_arguments == [None]
+
+    attempts = 0
+
+    def slow_failure(remaining: float | None) -> bool:
+        global attempts
+        assert remaining is not None and remaining > 0
+        attempts += 1
+        time.sleep(0.05)
+        return False
+
+    with t.assertRaises(RequestedAssertionFailed):
+        retry(slow_failure, timeout=dt.timedelta(seconds=0.01))
+    assert attempts == 1
+
+    late_success_attempts = 0
+
+    def late_success(remaining: float | None) -> bool:
+        global late_success_attempts
+        assert remaining is not None and remaining > 0
+        late_success_attempts += 1
+        time.sleep(0.02)
+        return True
+
+    retry(late_success, timeout=dt.timedelta(seconds=0.01))
+    assert late_success_attempts == 1
+
+    zero_timeout_attempts = 0
+
+    def zero_timeout(_remaining: float | None) -> bool:
+        global zero_timeout_attempts
+        zero_timeout_attempts += 1
+        return True
+
+    with t.assertRaises(RequestedAssertionFailed):
+        retry(zero_timeout, timeout=dt.timedelta(0))
+    assert zero_timeout_attempts == 0
+  '';
+}

--- a/nixos/tests/shadps4.nix
+++ b/nixos/tests/shadps4.nix
@@ -59,8 +59,8 @@
     openorbisColor: str = "#306082"
 
     # Based on terminal-emulators.nix' check_for_pink
-    def check_for_color(color: str) -> Callable[[bool], bool]:
-        def check_for_color_retry(final=False) -> bool:
+    def check_for_color(color: str) -> Callable[[float | None], bool]:
+        def check_for_color_retry(_remaining: float | None) -> bool:
             with tempfile.NamedTemporaryFile() as tmpin:
                 machine.send_monitor_command("screendump {}".format(tmpin.name))
 
@@ -83,7 +83,7 @@
     with subtest("running example works"):
         # Ensure that chosen openorbis logo colour isn't present already
         assert (
-            check_for_color(openorbisColor)(True) == False
+            check_for_color(openorbisColor)(None) == False
         ), "openorbisColor {} was present on the screen before we launched anything!".format(openorbisColor)
 
         machine.succeed("shadps4 /etc/openorbis-sample-packages/OpenOrbis-PNG-Sample/uroot/eboot.bin >&2 &")

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -88,6 +88,8 @@
       import shlex
       import json
 
+      from test_driver.errors import RequestedAssertionFailed
+
       q = shlex.quote
       NODE_GROUPS = ["nodes", "floating_nodes"]
 
@@ -121,16 +123,20 @@
 
 
       def wait_for_window(pattern):
-          def func(last_chance):
-              nodes = (node["name"] for node in walk(swaymsg(type="get_tree")))
+          last_nodes = []
 
-              if last_chance:
-                  nodes = list(nodes)
-                  machine.log(f"Last call! Current list of windows: {nodes}")
+          def func(_remaining):
+              nonlocal last_nodes
+              last_nodes = [
+                  node["name"] for node in walk(swaymsg(type="get_tree"))
+              ]
+              return any(pattern in name for name in last_nodes)
 
-              return any(pattern in name for name in nodes)
-
-          retry(func)
+          try:
+              retry(func)
+          except RequestedAssertionFailed:
+              machine.log(f"Timed out. Last list of windows: {last_nodes}")
+              raise
 
       start_all()
       machine.wait_for_unit("multi-user.target")

--- a/nixos/tests/swayfx.nix
+++ b/nixos/tests/swayfx.nix
@@ -90,6 +90,8 @@
       import shlex
       import json
 
+      from test_driver.errors import RequestedAssertionFailed
+
       q = shlex.quote
       NODE_GROUPS = ["nodes", "floating_nodes"]
 
@@ -123,16 +125,20 @@
 
 
       def wait_for_window(pattern):
-          def func(last_chance):
-              nodes = (node["name"] for node in walk(swaymsg(type="get_tree")))
+          last_nodes = []
 
-              if last_chance:
-                  nodes = list(nodes)
-                  machine.log(f"Last call! Current list of windows: {nodes}")
+          def func(_remaining):
+              nonlocal last_nodes
+              last_nodes = [
+                  node["name"] for node in walk(swaymsg(type="get_tree"))
+              ]
+              return any(pattern in name for name in last_nodes)
 
-              return any(pattern in name for name in nodes)
-
-          retry(func)
+          try:
+              retry(func)
+          except RequestedAssertionFailed:
+              machine.log(f"Timed out. Last list of windows: {last_nodes}")
+              raise
 
       start_all()
       machine.wait_for_unit("multi-user.target")

--- a/nixos/tests/sx.nix
+++ b/nixos/tests/sx.nix
@@ -46,7 +46,7 @@
       machine.wait_for_file(xauthority)
       machine.succeed(f"xauth merge {xauthority}")
 
-      def icewm_is_visible(_last_try: bool) -> bool:
+      def icewm_is_visible(_remaining: float | None) -> bool:
           # sx will set DISPLAY as the TTY number we started, in this case
           # TTY1:
           # https://github.com/Earnestly/sx/blob/master/sx#L41.

--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -196,7 +196,7 @@ mapAttrs (
           import subprocess
 
 
-          def check_for_pink(final=False) -> bool:
+          def check_for_pink(_remaining: float | None = None) -> bool:
               with tempfile.NamedTemporaryFile() as tmpin:
                   machine.send_monitor_command("screendump {}".format(tmpin.name))
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

closes: #302965

`wait_for_text` can exceed its requested timeout without bound when Tesseract takes a pathological amount of time to process one of the screenshot variants. Its timeout was checked only between OCR attempts, so it could not interrupt a blocked subprocess or future wait. The ofborg run linked from #302965 spent 3546.32 seconds in `wait_for_text` before eventually succeeding.

This change starts a shared deadline before screenshot capture, then passes the remaining wait_for_text budget to preprocessing, Tesseract subprocesses and OCR future waits. The raw, positive, and negative variants share one deadline, so work performed by one stage reduces the time available to later stages.

When a variant times out, it contributes an empty string instead of failing the entire OCR attempt. This preserves useful output from variants that completed successfully. Pending futures are cancelled and workers are joined before the screenshot temporary directory is removed.

The underlying `retry` helper now:

- passes the remaining timeout to its predicate
- starts no new predicate call after the deadline
- makes no attempt when the timeout is zero or negative
- treats an explicit `timeout=None` as unbounded

Its in-tree callers, test-script type stub, and 26.11 release notes have been updated accordingly. Public screen-text timeouts follow the `Duration | None` conventions introduced by #542374.

Timeout enforcement remains cooperative for arbitrary synchronous predicates. An attempt started before the deadline may finish afterward and a successful result from that attempt is accepted. The known blocking OCR operations receive the remaining budget and are bounded.

## Reproduction

<details>

<summary>screenshot</summary>

<img width="1024" height="768" alt="ppm" src="https://github.com/user-attachments/assets/f10d78f4-4079-4cdd-9ae3-82efc1557766" />

</details>

A real 1024x768 screenshot produces a 4267x3200 negative variant on which both tesseract 4.1.3 and 5.5.2 remain CPU-bound for more than 120 seconds.

With this change, running the OCR helper with a 20-second timeout completed in 20.037 seconds. The three variants returned text lengths of `[272, 231, 0]`: the raw and positive variants succeeded, while the pathological negative variant timed out cleanly.

This change bounds the problematic OCR work. It does not alter preprocessing, image dimensions, page segmentation mode or the tesseract version.

## Verification

```bash
# new driver tests and the package
nix build --no-link .#nixos-test-driver
nix build --no-link \
  .#nixosTests.nixos-test-driver.retry \
  .#nixosTests.nixos-test-driver.ocr

# the only touched test whose control flow changed
nix build --no-link .#nixosTests.lomiri.desktop-basics

# type check and lint of every other updated test script
nix build --no-link \
  .#nixosTests.atop.defaults.driver \
  .#nixosTests.atop.everything.driver \
  .#nixosTests.atop.atopgpu.driver \
  .#nixosTests.atop.netatop.driver \
  .#nixosTests.custom-ca.firefox.driver \
  .#nixosTests.lomiri-music-app.driver \
  .#nixosTests.shadps4.driver \
  .#nixosTests.sway.driver \
  .#nixosTests.swayfx.driver \
  .#nixosTests.sx.driver \
  .#nixosTests.terminal-emulators.alacritty.driver
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
