### PR TITLE
_1password-cli: 2.34.1 -> 2.38.1

### DIFF
--- a/pkgs/by-name/_1/_1password-cli/package.nix
+++ b/pkgs/by-name/_1/_1password-cli/package.nix
@@ -24,13 +24,13 @@ let
     if extension == "zip" then fetchzip args else fetchurl args;
 
   pname = "1password-cli";
-  version = "2.34.1";
+  version = "2.38.1";
   sources = {
-    aarch64-linux = fetch "linux_arm64" "sha256-uEukRq71eeayvNguD9XepvP1Br5AkE2Ag/Chv2idf4A=" "zip";
-    i686-linux = fetch "linux_386" "sha256-p/F3YZLJnlimrVE2qxTHvIB4m47kuwhoCWTC40VIvMs=" "zip";
-    x86_64-linux = fetch "linux_amd64" "sha256-oAABMlwwv5X91TT6FK2aPpg+e2CvmHT1rqIVRTjQNCQ=" "zip";
+    aarch64-linux = fetch "linux_arm64" "sha256-RmpJkrrLrKwbmbw50+sTg0aFa0+M2EFPZ6+QSc3aV5M=" "zip";
+    i686-linux = fetch "linux_386" "sha256-hnpVsbNgofmfw/XobVZ2MnbGIcAjxH1MvVJNc5T1kuk=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-k268YiTC/2MJZhVqMI/e9bsrf4Sr4Wj8M/h/hbmmcqY=" "zip";
     aarch64-darwin =
-      fetch "apple_universal" "sha256-vp1Y1M6DUanx1CAVhLrqgBovwws6Y/5jOgnwTZE8Hhc="
+      fetch "apple_universal" "sha256-pLlEsqCL5j9QCuLkQxK/Mmz647lKbCYhOUiPch2MMuE="
         "pkg";
   };
   platforms = builtins.attrNames sources;

--- a/pkgs/by-name/_1/_1password-cli/update.sh
+++ b/pkgs/by-name/_1/_1password-cli/update.sh
@@ -27,7 +27,7 @@ replace_sha() {
   sed -i "s|\"$1\" \"sha256-.\{44\}\"|\"$1\" \"$2\"|" "$NIX_DRV"
 }
 
-CLI_VERSION="$(curl -Ls https://app-updates.agilebits.com/product_history/CLI2 | xq -q 'h3' | head -n1)"
+CLI_VERSION="$(curl -Ls https://app-updates.agilebits.com/product_history/CLI2 | xq -q 'article:not(.beta) h3' | head -n1)"
 
 CLI_LINUX_AARCH64_SHA256=$(fetch_linux "$CLI_VERSION" "linux_arm64")
 CLI_LINUX_I686_SHA256=$(fetch_linux "$CLI_VERSION" "linux_386")


### PR DESCRIPTION
Restricts the updater to stable releases and updates `_1password-cli` to 2.38.1.

Supersedes #542758.

## Things done

- [x] Verified the updater reruns cleanly
- [x] Built on x86_64-linux
- [x] Built on i686-linux
- [x] Built on aarch64-linux
- [x] Built on aarch64-darwin