### PR TITLE
tesla_auth: init at 0.15.0

### DIFF
--- a/pkgs/by-name/te/tesla_auth/package.nix
+++ b/pkgs/by-name/te/tesla_auth/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  wrapGAppsHook3,
+  webkitgtk_4_1,
+  xdotool,
+  gtk3,
+  cairo,
+  pango,
+  gdk-pixbuf,
+  glib,
+  libsoup_3,
+  openssl,
+  glib-networking,
+  nss,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tesla_auth";
+  version = "0.15.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "adriankumpf";
+    repo = "tesla_auth";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nidbHxvvvmL0PAh+nNLlYBYM5riGdt4pL4w4UxdEdV0=";
+  };
+
+  cargoHash = "sha256-TkqxzB6ufCFbibVCFM4dI2ZNQpGneNNR7j73YTgI+hE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    xdotool
+    gtk3
+    cairo
+    pango
+    gdk-pixbuf
+    glib
+    libsoup_3
+    openssl
+    glib-networking
+    nss
+  ];
+
+  env.STATIC_VCRUNTIME_NO_BUILD = "1";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Securely generate API tokens for third-party access to your Tesla";
+    homepage = "https://github.com/adriankumpf/tesla_auth";
+    license = lib.licenses.mit;
+    mainProgram = "tesla_auth";
+    maintainers = with lib.maintainers; [ brianmay ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
