### PR TITLE
make-derivation: get rid of nested lists, cleanup derivation logic

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -14,7 +14,6 @@ let
     attrNames
     concatLists
     concatMap
-    concatMapStrings
     concatMapStringsSep
     concatStringsSep
     elem
@@ -486,31 +485,23 @@ let
           actualValue;
       outputs' = if separateDebugInfo' then outputs ++ [ "debug" ] else outputs;
 
-      checkDependencyList = checkDependencyList' [ ];
-      checkDependencyList' =
-        positions: name: deps:
+      checkDependencyList =
+        name: deps:
         if all isSingularDependency deps then
           deps
         else
-          # iterate again with the index if an invalid type was passed, or we
-          # need to recurse into a sublist. making sublists take longer is
-          # worth it, since nobody uses them and handling them makes normal
-          # dependencies slower
+          # iterate again with the index if an invalid type was passed
           seq (foldl' (
             index: dep:
             if isSingularDependency dep then
               index + 1
             else if isList dep then
-              warn
-                ''
-                  Dependency of package '${attrs.name or attrs.pname}' uses a nested list in attribute '${name}'.
-                  This is deprecated as of Nixpkgs release 26.05, and support will
-                  be removed in a future nixpkgs release.''
-                (seq (checkDependencyList' ([ index ] ++ positions) name dep) (index + 1))
+              throw ''
+                Dependency of package '${attrs.name or attrs.pname}' uses a nested list in attribute '${name}'.
+                Support for these is removed as of Nixpkgs release 26.11. Dependency lists should instead be
+                concatenated together using '++' or 'builtins.concatLists'.''
             else
-              throw "Dependency is not of a valid type: ${
-                concatMapStrings (ix: "element ${toString ix} of ") ([ index ] ++ positions)
-              }${name} for ${attrs.name or attrs.pname}"
+              throw "Dependency is not of a valid type: element ${toString index} of ${name} for ${attrs.name or attrs.pname}"
           ) 1 deps) deps;
     in
     if

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -77,6 +77,7 @@ let
     "trivialautovarinit"
     "zerocallusedregs"
   ];
+  isErroneous = flag: !elem flag knownHardeningFlags;
 
   removedOrReplacedAttrNames = [
     "checkInputs"
@@ -511,8 +512,6 @@ let
                 concatMapStrings (ix: "element ${toString ix} of ") ([ index ] ++ positions)
               }${name} for ${attrs.name or attrs.pname}"
           ) 1 deps) deps;
-
-      isErroneous = flag: !elem flag knownHardeningFlags;
     in
     if
       # Check if any hardening flag is erroneous

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -10,7 +10,7 @@ lib:
 let
   # Lib attributes are inherited to the lexical scope for performance reasons.
   inherit (lib)
-    all
+    any
     attrNames
     concatLists
     concatMap
@@ -27,8 +27,8 @@ let
     isAttrs
     isBool
     isDerivation
-    isInt
     isFunction
+    isInt
     isList
     isPath
     isString
@@ -39,7 +39,6 @@ let
     optionalString
     optionals
     remove
-    seq
     splitString
     subtractLists
     toFunction
@@ -49,7 +48,6 @@ let
     unsafeGetAttrPos
     warn
     zipAttrsWith
-    any
     ;
 
   inherit (lib.generators) toPretty;
@@ -133,8 +131,6 @@ let
     ./default-builder.sh
   ];
 
-  isSingularDependency = dep: dep == null || isDerivation dep || isString dep || isPath dep;
-
   cachedOutputChecks = {
     out = { };
   };
@@ -151,6 +147,56 @@ let
       unsafeDiscardStringContext drv.outPath
     else
       drv;
+
+  # types that don't actually have an output, but are still valid and coercible
+  # to a string
+  nonDrvButValid = dep: isPath dep || dep == null || isString dep;
+  makeDependencyOutputs =
+    splicedName: commonName: pname: deps:
+    map (
+      dep:
+      # NOTE: this shows up as an extremely hot path in the profiler. This seems
+      # to be mainly a limitation of lazy evaluation, as this is where most
+      # derivations are are first evaluated. However, it may be possible to
+      # eliminate some of these checks or move them elsewhere
+      if dep.type or null == "derivation" then
+        getDev (dep.__spliced.${splicedName} or dep)
+      else if nonDrvButValid dep then
+        dep
+      else
+        # iterate again with the index if an invalid type was passed to generate
+        # the error message
+        foldl' (
+          index: dep:
+          if dep.type or null == "derivation" || nonDrvButValid dep then
+            index + 1
+          else
+            throw "Dependency is not of a valid type: element ${toString index} of ${commonName} for package ${pname}"
+            + (
+              if isList dep then
+                ''
+                  was a nested list.
+                  Support for these is removed as of Nixpkgs release 26.11. Dependency lists should instead be
+                  concatenated together using '++' or 'builtins.concatLists'.''
+              else
+                ""
+            )
+        ) 1 deps
+
+    ) deps;
+
+  makeBuildBuild = makeDependencyOutputs "buildBuild" "depsBuildBuild";
+  makePropagatedBuildBuild = makeDependencyOutputs "buildBuild" "depsBuildBuildPropagated";
+  makeBuildHost = makeDependencyOutputs "buildHost" "nativeBuildInputs";
+  makePropagatedBuildHost = makeDependencyOutputs "buildHost" "nativeBuildInputs";
+  makeBuildTarget = makeDependencyOutputs "buildTarget" "depsBuildTarget";
+  makePropagatedBuildTarget = makeDependencyOutputs "buildTarget" "depsBuildTargetPropagated";
+  makeHostHost = makeDependencyOutputs "hostHost" "depsHostHost";
+  makePropagatedHostHost = makeDependencyOutputs "hostHost" "depsHostHostPropagated";
+  makeHostTarget = makeDependencyOutputs "hostTarget" "buildInputs";
+  makePropagatedHostTarget = makeDependencyOutputs "hostTarget" "propagatedBuildInputs";
+  makeTargetTarget = makeDependencyOutputs "targetTarget" "depsTargetTarget";
+  makePropagatedTargetTarget = makeDependencyOutputs "targetTarget" "depsTargetTargetPropagated";
 
   makeOutputChecks =
     attrs:
@@ -484,25 +530,6 @@ let
         else
           actualValue;
       outputs' = if separateDebugInfo' then outputs ++ [ "debug" ] else outputs;
-
-      checkDependencyList =
-        name: deps:
-        if all isSingularDependency deps then
-          deps
-        else
-          # iterate again with the index if an invalid type was passed
-          seq (foldl' (
-            index: dep:
-            if isSingularDependency dep then
-              index + 1
-            else if isList dep then
-              throw ''
-                Dependency of package '${attrs.name or attrs.pname}' uses a nested list in attribute '${name}'.
-                Support for these is removed as of Nixpkgs release 26.11. Dependency lists should instead be
-                concatenated together using '++' or 'builtins.concatLists'.''
-            else
-              throw "Dependency is not of a valid type: element ${toString index} of ${name} for ${attrs.name or attrs.pname}"
-          ) 1 deps) deps;
     in
     if
       # Check if any hardening flag is erroneous
@@ -539,44 +566,16 @@ let
 
         outputs = outputs';
 
-        buildBuildOutputs =
-          if depsBuildBuild == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.buildBuild or drv) (
-              checkDependencyList "depsBuildBuild" depsBuildBuild
-            );
+        pname = attrs.pname or attrs.name;
+
+        buildBuildOutputs = if depsBuildBuild == [ ] then [ ] else makeBuildBuild pname depsBuildBuild;
         buildHostOutputs =
-          if nativeBuildInputs' == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.buildHost or drv) (
-              checkDependencyList "nativeBuildInputs" nativeBuildInputs'
-            );
-        buildTargetOutputs =
-          if depsBuildTarget == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.buildTarget or drv) (
-              checkDependencyList "depsBuildTarget" depsBuildTarget
-            );
-        hostHostOutputs =
-          if depsHostHost == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost);
-        hostTargetOutputs =
-          if buildInputs' == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs');
+          if nativeBuildInputs' == [ ] then [ ] else makeBuildHost pname nativeBuildInputs';
+        buildTargetOutputs = if depsBuildTarget == [ ] then [ ] else makeBuildTarget pname depsBuildTarget;
+        hostHostOutputs = if depsHostHost == [ ] then [ ] else makeHostHost pname depsHostHost;
+        hostTargetOutputs = if buildInputs' == [ ] then [ ] else makeHostTarget pname buildInputs';
         targetTargetOutputs =
-          if depsTargetTarget == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.targetTarget or drv) (
-              checkDependencyList "depsTargetTarget" depsTargetTarget
-            );
+          if depsTargetTarget == [ ] then [ ] else makeTargetTarget pname depsTargetTarget;
         allDependencies = concatLists [
           buildBuildOutputs
           buildHostOutputs
@@ -590,44 +589,26 @@ let
           if depsBuildBuildPropagated == [ ] then
             [ ]
           else
-            map (drv: getDev drv.__spliced.buildBuild or drv) (
-              checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated
-            );
+            makePropagatedBuildBuild pname depsBuildBuildPropagated;
         propagatedBuildHostOutputs =
           if propagatedNativeBuildInputs == [ ] then
             [ ]
           else
-            map (drv: getDev drv.__spliced.buildHost or drv) (
-              checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs
-            );
+            makePropagatedBuildHost pname propagatedNativeBuildInputs;
         propagatedBuildTargetOutputs =
           if depsBuildTargetPropagated == [ ] then
             [ ]
           else
-            map (drv: getDev drv.__spliced.buildTarget or drv) (
-              checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated
-            );
+            makePropagatedBuildTarget pname depsBuildTargetPropagated;
         propagatedHostHostOutputs =
-          if depsHostHostPropagated == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.hostHost or drv) (
-              checkDependencyList "depsHostHostPropagated" depsHostHostPropagated
-            );
+          if depsHostHostPropagated == [ ] then [ ] else makePropagatedHostHost pname depsHostHostPropagated;
         propagatedHostTargetOutputs =
-          if propagatedBuildInputs == [ ] then
-            [ ]
-          else
-            map (drv: getDev drv.__spliced.hostTarget or drv) (
-              checkDependencyList "propagatedBuildInputs" propagatedBuildInputs
-            );
+          if propagatedBuildInputs == [ ] then [ ] else makePropagatedHostTarget pname propagatedBuildInputs;
         propagatedTargetTargetOutputs =
           if depsTargetTargetPropagated == [ ] then
             [ ]
           else
-            map (drv: getDev drv.__spliced.targetTarget or drv) (
-              checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated
-            );
+            makePropagatedTargetTarget pname depsTargetTargetPropagated;
         allPropagatedDependencies = concatLists [
           propagatedBuildBuildOutputs
           propagatedBuildHostOutputs


### PR DESCRIPTION
We've had nested lists warning for a full cycle. We now start throwing on them, which makes it easier to do the next commit - moving our logic for typechecking dependencies and getting their outputs to the same step. This is a _very_ hot function -- accounting for 18% of the eval of `pkgs.firefox` -- so care is taken to do things as performantly as possible. Granted, I have a hunch that a lot of those numbers are just limitations of our function-based stack-profiler, but what can I say?

## Benchmarking

Stats diff for pkgs.firefox:

```json
{
  "attrset": {
    "lookups": "-0.16%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": null
  },
  "parser": {
    "expressions": "-0.03%"
  },
  "memoryBytes": {
    "envs": "-4.25%",
    "list": null,
    "sets": null,
    "symbols": "+0.04%",
    "values": "-0.51%",
    "total": "-0.44%"
  },
  "speed": {
    "primops": "-1.99%",
    "functionCalls": "-6.75%",
    "thunksMade": "-1.14%",
    "thunksAvoided": "-2.05%"
  }
}
```

And real-time diff:
```
Benchmark 1: nix-instantiate --eval -A firefox.outPath
  Time (mean ± σ):      1.197 s ±  0.017 s    [User: 0.941 s, System: 0.220 s]
  Range (min … max):    1.172 s …  1.244 s    20 runs
Benchmark 2: nix-instantiate --eval -A firefox.outPath
  Time (mean ± σ):      1.184 s ±  0.009 s    [User: 0.935 s, System: 0.216 s]
  Range (min … max):    1.169 s …  1.206 s    20 runs
```

## Optimizations that didn't work out

1. Calling `map makeBuildBuild buildInputs'`, instead of passing the whole list to `makeBuildBuild` and mapping on it there. Would've saved a function call. For error message purposes, we need to know the index of the build input - so the dependency list needs to be passed fully to iterate again.
2. Avoiding splicing logic when we're not doing crosscomp. I tried defining `isCross = !lib.systems.equals hostPlatform targetPlatform`. However, this seemed to create an infrec on building firefox (now you see why I use it as my test case!). It also _probably_ wouldn't save any noticeable time, since the implementation of `or` for attrset lookups is fairly simple.
3. Defining `makeDependencies` inside the normal make-derivation logic rather than outside of it. We need to pass pname for error message purposes, but if we were in a context where `attrs` was accessible, this wouldn't be a problem. However, then we wouldn't be able to partially apply the attribute names, so we end up calling with an extra string regardless.
4. Inlining `getDev`. This would be difficult given point 2.

## An optimization we could try in the future

Some dependencies are always included by certain builders, and therefore get checked a bazillion times. Testing on my own config as an example (these numbers were similar for `pkgs.firefox`, I just wanted something larger):
```
   1151 trace: python-catch-conflicts-hook
   1185 trace: pypa-build-hook.sh
   1185 trace: python-runtime-deps-check-hook.sh
   1268 trace: pkg-config-wrapper
   1309 trace: pypa-install-hook
   1315 trace: python-output-dist-hook
   1327 trace: python-namespaces-hook.sh
   1336 trace: python-remove-bin-bytecode-hook
   1336 trace: python-remove-tests-dir-hook
   1340 trace: python-imports-check-hook.sh
   1342 trace: ensure-newer-sources-hook
   1351 trace: wrap-python-hook
   2505 trace: null
   3164 trace: python3
   6631 trace: curl
```
These are all the instances over 1000, and make up 27% of all the dependencies. curl is notably from fetchurl, and the rest are mostly from python. We could improve this by adding sepcial attributes like `__defaultBuildInputs` that would be read in setup.sh and concatenated to the normal lists. This would improve eval performance for mkDerivation wrappers, since they could pre-apply the `getDev` check for these. Something to think about, if this function is as critical as the eval profiler says it is.

Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
