### PR TITLE
python3Packages.lyngdorf: init at 1.4.8

### DIFF
--- a/pkgs/development/python-modules/lyngdorf/default.nix
+++ b/pkgs/development/python-modules/lyngdorf/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  attrs,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "lyngdorf";
+  version = "1.4.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fishloa";
+    repo = "lyngdorf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KasnlVp9Hx4B3NccLL1qaViLJRLKFY41yXu2bz1/8hA=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ attrs ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "lyngdorf" ];
+
+  meta = {
+    description = "Library to control a Lyngdorf A/V processor";
+    homepage = "https://github.com/fishloa/lyngdorf";
+    changelog = "https://github.com/fishloa/lyngdorf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3965,7 +3965,8 @@
       ps: with ps; [
         async-upnp-client
         ifaddr
-      ]; # missing inputs: lyngdorf
+        lyngdorf
+      ];
     "lyric" =
       ps: with ps; [
         aiolyric
@@ -8544,6 +8545,7 @@
     "lupusec"
     "lutron"
     "lutron_caseta"
+    "lyngdorf"
     "lyric"
     "madvr"
     "mailgun"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10060,6 +10060,8 @@ self: super: with self; {
 
   lxst = callPackage ../development/python-modules/lxst { };
 
+  lyngdorf = callPackage ../development/python-modules/lyngdorf { };
+
   lyricwikia = callPackage ../development/python-modules/lyricwikia { };
 
   lz4 = callPackage ../development/python-modules/lz4 { };


### PR DESCRIPTION
- https://pypi.org/project/lyngdorf/
- https://github.com/fishloa/lyngdorf
- https://www.home-assistant.io/integrations/lyngdorf/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
