### PR TITLE
python3Packages.neopool-modbus: init at 4.5.1

### DIFF
--- a/pkgs/development/python-modules/neopool-modbus/default.nix
+++ b/pkgs/development/python-modules/neopool-modbus/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pymodbus,
+  pytest-asyncio,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "neopool-modbus";
+  version = "4.5.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.13";
+
+  src = fetchFromGitHub {
+    owner = "svasek";
+    repo = "python-neopool-modbus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HF2HqbEgt3bIUZ8MiWtYAht3QBAua/FgMXkppJye6KA=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ pymodbus ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "neopool_modbus" ];
+
+  meta = {
+    description = "Async Python client for Sugar Valley NeoPool / VistaPool / Hidrolife Modbus pool controllers";
+    homepage = "https://github.com/svasek/python-neopool-modbus";
+    changelog = "https://github.com/svasek/python-neopool-modbus/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4528,7 +4528,8 @@
       ];
     "neopool" =
       ps: with ps; [
-      ]; # missing inputs: neopool-modbus
+        neopool-modbus
+      ];
     "ness_alarm" =
       ps: with ps; [
         nessclient
@@ -8629,6 +8630,7 @@
     "nasweb"
     "neato"
     "nederlandse_spoorwegen"
+    "neopool"
     "ness_alarm"
     "nest"
     "netatmo"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11629,6 +11629,8 @@ self: super: with self; {
 
   neo4j = callPackage ../development/python-modules/neo4j { };
 
+  neopool-modbus = callPackage ../development/python-modules/neopool-modbus { };
+
   neoteroi-mkdocs = callPackage ../development/python-modules/neoteroi-mkdocs { };
 
   nessclient = callPackage ../development/python-modules/nessclient { };


### PR DESCRIPTION
- https://pypi.org/project/neopool-modbus/
- https://github.com/svasek/python-neopool-modbus
- https://www.home-assistant.io/integrations/neopool/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
