### PR TITLE
claude-code: 2.1.226 -> 2.1.227

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-V5hoHOxaROmgK7f308cURYRO0mUwIe7VUY84X4sbzKc=";
+          hash = "sha256-nPQnGuBJPTKb53nb7iuUy7WeR+h2AdSvKc6mTDQaRk4=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-SsCaPataxJ/kpWAogWfXKbqgaIL9aPzRAmSEJ5wg22c=";
+          hash = "sha256-5EcopowbIsvylvdCp9nNhT+Jb7AyqjB9lxuFjgohMaU=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-WVRaa1G64FBdXJbaOAA/tbE1HIKdmbnq8sdP86IwWo8=";
+          hash = "sha256-P3RpxruQPenyThhs9NpYk5UebRAhCIUxHHp0+C6hEr8=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.226";
+      version = "2.1.227";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,53 +1,51 @@
 {
-  "version": "2.1.226",
-  "commit": "e140b3281c1e8d834468889bd0a5c3fd2f15507c",
-  "buildDate": "2026-08-08T01:00:56Z",
+  "version": "2.1.227",
+  "commit": "5ecc7d5389d8b682652d0ea32eadd3e0eb537ee8",
+  "buildDate": "2026-08-10T19:04:57Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "013a1cf17df5ff1dcc189d5d6fd3fdd5f097ddc3cd41aa9992e99805574febbe",
-      "size": 279661952
+      "checksum": "7432511ba3be818e01f23f6eef8630d214a8b618451e188c3c7d61a987eef6c7",
+      "size": 285046400
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "773b095876f13ddb8336bfae202a57c62e358b1882746f1d55e3680601a32c59",
-      "size": 289284768
+      "checksum": "14484fb9a0480b6b638230685a7d9a248a5339b384a162e0df127e4a4a07249b",
+      "size": 294700704
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "feb715ee066d02a400c9d83941592f11c8e8fa6628c1e3c14262bc529f950498",
-      "size": 294566840
+      "checksum": "db47335532cbcab67a4b3ab16d8f3f77976bf85d53c7d79f8296538aa22bfce6",
+      "size": 300923832
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "4e9bec1177ce9690e8bd988b710ac24105e70da428dd094c5adcbbe786a55555",
-      "size": 297831432
+      "checksum": "6832dc3f1797b890b71116e5f2dbbf9a83fd3d0498c235b4b0f9cd0e6e499ad6",
+      "size": 304282632
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "8c58e37c14e09f0be1b5b42e1fc4f409f1124ccc584a8633b99b7e8e63d79bd0",
-      "size": 287880552
+      "checksum": "8284d20a5d61e71502e69836b1598ba03f688f4d8de6c22105055fbf0af118f6",
+      "size": 294237544
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "d199d62f2ce2fca6138256f788ecd6157cacc40edb3b50ce22b8f974f816111a",
-      "size": 292438608
+      "checksum": "da7b62210da0000c09c7c29b217e166ccc66dad4c79c9e2bc8d52fc7b66f590d",
+      "size": 298885712
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "cec4e772e8237357554a8a5a86f821db9081e9fb05499bc4e5fd14b73f48708c",
-      "size": 287053472
+      "checksum": "a5d8bcc6549cf99a2ea35451f8034a12f0db919e63334477c72d42fc8e0d5c09",
+      "size": 292227232
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "6512422580a1f705301f7a1f6cebe436b207ed4f8a3fc23caf23295b7e8745bd",
-      "size": 281726112
+      "checksum": "68935d2c971ad417e90f1d5bb503c8773b218c7f7049fe35e502f0180232ff18",
+      "size": 286900384
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.185",
-      "0.3.186",
       "0.3.187",
       "0.3.190",
       "0.3.191",
@@ -73,9 +71,11 @@
       "0.3.216",
       "0.3.217",
       "0.3.218",
+      "0.3.219",
       "0.3.220",
       "0.3.221",
-      "0.3.222"
+      "0.3.222",
+      "0.3.226"
     ],
     "harnessSchema": 1
   }


### PR DESCRIPTION
Update claude-code and vscode-extensions.anthropic.claude-code to 2.1.227.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

> [!NOTE]
> Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard `maintainers/scripts/update.nix` script; the change was built locally and validated across arches via `nixpkgs-review`, and reviewed by a human (@markus1189) before being marked ready.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
