### PR TITLE
mullvad-vpn: fix build on macOS

### DIFF
--- a/pkgs/by-name/mu/mullvad-vpn/0001-distribution-configuration.patch
+++ b/pkgs/by-name/mu/mullvad-vpn/0001-distribution-configuration.patch
@@ -1,16 +1,40 @@
 diff --git a/desktop/packages/mullvad-vpn/tasks/distribution.cjs b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
-index 7b2bc36e08..ec027454a2 100644
+index 0a5c668..591849a 100644
 --- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
 +++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
-@@ -28,6 +28,7 @@ function newConfig() {
+@@ -31,6 +31,7 @@ function newConfig() {
      publish: null,
      asar: true,
      compression: noCompression ? 'store' : 'normal',
-+    electronDist: '@electron-dist@',
++    electronDist: process.platform === 'darwin' ? root('electron-dist') : '@electron-dist@',
      extraResources: [
        { from: distAssets('ca.crt'), to: '.' },
        { from: distAssets('relays/relays.json'), to: '.' },
-@@ -180,11 +181,7 @@
+@@ -85,7 +86,8 @@ function newConfig() {
+ 
+     mac: {
++      identity: null,
+       target: {
+-        target: 'pkg',
++        target: 'dir',
+         arch: getMacArch(),
+       },
+       x64ArchFiles:
+@@ -99,13 +100,6 @@ function newConfig() {
+         NSUserNotificationAlertStyle: 'banner',
+       },
+       extraResources: [
+-        { from: distAssets(path.join('${env.BINARIES_PATH}', 'mullvad')), to: '.' },
+-        { from: distAssets(path.join('${env.BINARIES_PATH}', 'mullvad-problem-report')), to: '.' },
+-        { from: distAssets(path.join('${env.BINARIES_PATH}', 'mullvad-daemon')), to: '.' },
+-        { from: distAssets(path.join('${env.BINARIES_PATH}', 'mullvad-setup')), to: '.' },
+-        { from: distAssets('uninstall_macos.sh'), to: './uninstall.sh' },
+-        { from: buildAssets('shell-completions/_mullvad'), to: '.' },
+-        { from: buildAssets('shell-completions/mullvad.fish'), to: '.' },
+       ],
+     },
+ 
+@@ -180,11 +174,7 @@ function newConfig() {
      linux: {
        target: [
          {
@@ -23,7 +47,7 @@ index 7b2bc36e08..ec027454a2 100644
            arch: getLinuxTargetArch(),
          },
        ],
-@@ -185,9 +181,6 @@ function newConfig() {
+@@ -194,9 +184,6 @@ function newConfig() {
        icon: distAssets('icon.icns'),
        extraFiles: [{ from: distAssets('linux/mullvad-gui-launcher.sh'), to: '.' }],
        extraResources: [
@@ -33,7 +57,21 @@ index 7b2bc36e08..ec027454a2 100644
        ],
      },
  
-@@ -494,6 +487,7 @@ function getMacArch() {
+@@ -392,13 +392,2 @@ function packMac() {
+       },
+-      afterAllArtifactBuild: async (_buildResult) => {
+-        // Remove the folder that contains the unpacked app. Electron builder cleans up some of
+-        // these directories and it's changed between versions without a mention in the changelog.
+-        for (const dir of appOutDirs) {
+-          try {
+-            await fs.promises.rm(dir, { recursive: true });
+-          } catch {
+-            // noop
+-          }
+-        }
+-      },
+       afterSign: (context) => {
+@@ -503,6 +496,7 @@ function getMacArch() {
  // than a non-tilde version component
  // https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning
  function getLinuxVersion() {
@@ -41,7 +79,7 @@ index 7b2bc36e08..ec027454a2 100644
    const [version, ...prereleaseParts] = productVersion([]).split('-');
    const [major, minor] = version.split('.');
    const prerelease = prereleaseParts.join('-');
-@@ -509,6 +503,7 @@ function getLinuxVersion() {
+@@ -518,6 +506,7 @@ function getLinuxVersion() {
  // Returns the product version. The `args` argument is optional. Set it to `'semver'`
  // to get the version in semver format.
  function productVersion(extraArgs) {

--- a/pkgs/by-name/mu/mullvad-vpn/package.nix
+++ b/pkgs/by-name/mu/mullvad-vpn/package.nix
@@ -1,6 +1,8 @@
 {
   lib,
   buildNpmPackage,
+  cargo,
+  darwin,
   mullvad,
   nodejs_22,
   replaceVars,
@@ -11,6 +13,9 @@
   makeBinaryWrapper,
   versionCheckHook,
   makeDesktopItem,
+  rustPlatform,
+  rustc,
+  stdenv,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -19,6 +24,8 @@ buildNpmPackage (finalAttrs: {
 
   nodejs = nodejs_22;
   npmDepsHash = "sha256-DWLMf+fHCm3hqKt25vmoZ+uEL90/hEpQS+5k8sBFo/c=";
+  cargoDeps = mullvad.cargoDeps;
+  cargoRoot = "..";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -32,10 +39,18 @@ buildNpmPackage (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    copyDesktopItems
     grpc-tools
-    librsvg
     makeBinaryWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    copyDesktopItems
+    librsvg
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cargo
+    darwin.sigtool
+    rustPlatform.cargoSetupHook
+    rustc
   ];
 
   buildInputs = [
@@ -48,6 +63,12 @@ buildNpmPackage (finalAttrs: {
   # to 'desktop/../dist'.
   postPatch = ''
     cd desktop/
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Electron Builder modifies Electron's Info.plist while packaging, so copy it out of the
+    # read-only Nix store into a writable build directory.
+    cp -r ${electron.dist} ../electron-dist
+    chmod -R u+w ../electron-dist
   '';
 
   # The npmConfigHook only patches executables from the main
@@ -63,29 +84,52 @@ buildNpmPackage (finalAttrs: {
   '';
 
   npmWorkspace = "mullvad-vpn";
-  npmBuildScript = "pack:linux";
+  npmBuildScript = if stdenv.hostPlatform.isDarwin then "pack:mac" else "pack:linux";
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    if stdenv.hostPlatform.isLinux then
+      ''
+        runHook preInstall
 
-    mkdir -p $out/share/mullvad-vpn/
-    cp -r ../dist/*-unpacked/{locales,resources{,.pak}} $out/share/mullvad-vpn/
-    cp ../graphics/icon{-square,}.svg $out/share/mullvad-vpn/resources/
+        mkdir -p $out/share/mullvad-vpn/
+        cp -r ../dist/*-unpacked/{locales,resources{,.pak}} $out/share/mullvad-vpn/
+        cp ../graphics/icon{-square,}.svg $out/share/mullvad-vpn/resources/
 
-    install -D ../graphics/icon.svg $out/share/icons/hicolor/scalable/apps/mullvad-vpn.svg
-    for size in 16 32 48 64 128 256 512 1024; do
-      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
-      rsvg-convert -o $out/share/icons/hicolor/''${size}x''${size}/apps/mullvad-vpn.png -w $size -h $size ../graphics/icon.svg
-    done
+        install -D ../graphics/icon.svg $out/share/icons/hicolor/scalable/apps/mullvad-vpn.svg
+        for size in 16 32 48 64 128 256 512 1024; do
+          mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+          rsvg-convert -o $out/share/icons/hicolor/''${size}x''${size}/apps/mullvad-vpn.png -w $size -h $size ../graphics/icon.svg
+        done
 
-    makeWrapper ${lib.getExe electron} $out/bin/mullvad-vpn \
-        --add-flags $out/share/mullvad-vpn/resources/app.asar \
-        --set MULLVAD_DISABLE_UPDATE_NOTIFICATION 1 \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-        --inherit-argv0
+        makeWrapper ${lib.getExe electron} $out/bin/mullvad-vpn \
+            --add-flags $out/share/mullvad-vpn/resources/app.asar \
+            --set MULLVAD_DISABLE_UPDATE_NOTIFICATION 1 \
+            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+            --inherit-argv0
 
-    runHook postInstall
-  '';
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+
+        mkdir -p "$out/Applications" "$out/bin"
+        cp -r "$NIX_BUILD_TOP"/source/dist/mac*/Mullvad\ VPN.app "$out/Applications/"
+
+        # must be binary wrapper for signing to work
+        wrapBinaryProgram "$out/Applications/Mullvad VPN.app/Contents/MacOS/Mullvad VPN" \
+          --prefix PATH : ${lib.makeBinPath [ mullvad ]}
+
+        makeWrapper "$out/Applications/Mullvad VPN.app/Contents/MacOS/Mullvad VPN" "$out/bin/mullvad-vpn" \
+          --set MULLVAD_DISABLE_UPDATE_NOTIFICATION 1
+
+        # Electron Builder's macOS signing is disabled because it invokes unsupported flags.
+        # Instead, we sign the application executable with nixpkgs' sigtool.
+        codesign --sign - --force \
+          "$out/Applications/Mullvad VPN.app/Contents/MacOS/Mullvad VPN"
+
+        runHook postInstall
+      '';
 
   doCheck = true;
 
@@ -101,16 +145,18 @@ buildNpmPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  desktopItems = lib.singleton (makeDesktopItem {
-    name = "mullvad-vpn";
-    categories = [ "Network" ];
-    comment = "Mullvad VPN client";
-    desktopName = "Mullvad VPN";
-    exec = "mullvad-vpn";
-    icon = "mullvad-vpn";
-    startupWMClass = "Mullvad VPN";
-    terminal = false;
-  });
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+    (makeDesktopItem {
+      name = "mullvad-vpn";
+      categories = [ "Network" ];
+      comment = "Mullvad VPN client";
+      desktopName = "Mullvad VPN";
+      exec = "mullvad-vpn";
+      icon = "mullvad-vpn";
+      startupWMClass = "Mullvad VPN";
+      terminal = false;
+    })
+  ];
 
   passthru.hasMullvadGUI = true;
 


### PR DESCRIPTION
fix the build on macos. this requires some changes to the applied patch, and having different installPhases on macos and linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
