### PR TITLE
postgresqlPackages.pgactive: init at 2.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26521,6 +26521,12 @@
     githubId = 848812;
     name = "Stephan Jau";
   };
+  sjcobb = {
+    email = "sjcobb2003@gmail.com";
+    github = "sjcobb2022";
+    githubId = 68509699;
+    name = "sjcobb";
+  };
   sjfloat = {
     email = "steve+nixpkgs@jonescape.com";
     github = "sjfloat";

--- a/pkgs/servers/sql/postgresql/ext/pgactive.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgactive.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  lib,
+  postgresql,
+  postgresqlBuildExtension,
+  postgresqlTestExtension,
+  pkg-config,
+}:
+postgresqlBuildExtension (finalAttrs: {
+  pname = "pgactive";
+  version = "2.1.8";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "pgactive";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XkGKhNF9ohfWluKYNGvTRSLgoOp6jYzyaL10BIj0igo=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  postPatch = ''
+    touch .distgitrev
+  '';
+
+  buildInputs = postgresql.buildInputs;
+
+  passthru.tests = {
+    extension = postgresqlTestExtension {
+      inherit (finalAttrs) finalPackage;
+
+      # Needed for pgactive to boot successfully.
+      postgresqlExtraSettings = ''
+        shared_preload_libraries = 'pgactive'
+        track_commit_timestamp = 'on'
+        wal_level = 'logical'
+      '';
+
+      sql = ''
+        CREATE EXTENSION pgactive;
+      '';
+    };
+  };
+
+  meta = {
+    description = "Active-active Replication Extension for PostgreSQL";
+    homepage = "https://github.com/aws/pgactive";
+    changelog = "https://github.com/aws/pgactive/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ sjcobb ];
+    platforms = postgresql.meta.platforms;
+    license = lib.licenses.asl20;
+  };
+})


### PR DESCRIPTION
Introduces pgactive which is provides "Active-active Replication Extension for PostgreSQL".

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
