### PR TITLE
hunk: move skills to `$out/share/skills/hunk`

### DIFF
--- a/pkgs/by-name/hu/hunk/package.nix
+++ b/pkgs/by-name/hu/hunk/package.nix
@@ -110,8 +110,8 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm755 hunk $out/bin/hunk
-    mkdir -p $out/share/skills
-    cp -R skills $out/share/skills/$pname
+    mkdir -p $out/share/skills/$pname/hunk-review
+    cp skills/hunk-review/SKILL.md $out/share/skills/$pname/hunk-review/SKILL.md
 
     runHook postInstall
   '';
@@ -130,7 +130,6 @@ stdenv.mkDerivation {
     runHook preInstallCheck
 
     $out/bin/hunk --version | grep -F ${version}
-    test -f $out/share/skills/$pname/hunk-review/SKILL.md
     test -f "$($out/bin/hunk skill path)"
 
     runHook postInstallCheck

--- a/pkgs/by-name/hu/hunk/package.nix
+++ b/pkgs/by-name/hu/hunk/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
       --replace-fail \
         'join("node_modules", "hunkdiff", HUNK_REVIEW_SKILL_RELATIVE_PATH),' \
         'join("node_modules", "hunkdiff", HUNK_REVIEW_SKILL_RELATIVE_PATH),
-    join("share", "skills", "${pname}", "hunk-review", "SKILL.md"),'
+    join("share", "skills", "hunk", "hunk-review", "SKILL.md"),'
   '';
 
   configurePhase = ''
@@ -110,8 +110,8 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm755 hunk $out/bin/hunk
-    mkdir -p $out/share/skills/$pname/hunk-review
-    cp skills/hunk-review/SKILL.md $out/share/skills/$pname/hunk-review/SKILL.md
+    mkdir -p $out/share/skills/hunk/hunk-review
+    cp skills/hunk-review/SKILL.md $out/share/skills/hunk/hunk-review/SKILL.md
 
     runHook postInstall
   '';

--- a/pkgs/by-name/hu/hunk/package.nix
+++ b/pkgs/by-name/hu/hunk/package.nix
@@ -71,6 +71,16 @@ stdenv.mkDerivation {
     writableTmpDirAsHomeHook
   ];
 
+  # Teach `hunk skill path` to find the FHS layout under share/skills/$pname
+  # (https://github.com/NixOS/nixpkgs/issues/547426) instead of $out/skills.
+  postPatch = ''
+    substituteInPlace src/core/paths.ts \
+      --replace-fail \
+        'join("node_modules", "hunkdiff", HUNK_REVIEW_SKILL_RELATIVE_PATH),' \
+        'join("node_modules", "hunkdiff", HUNK_REVIEW_SKILL_RELATIVE_PATH),
+    join("share", "skills", "${pname}", "hunk-review", "SKILL.md"),'
+  '';
+
   configurePhase = ''
     runHook preConfigure
 
@@ -100,9 +110,8 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm755 hunk $out/bin/hunk
-    mkdir -p $out/share/hunk
-    cp -R skills $out/share/hunk/skills
-    ln -s share/hunk/skills $out/skills
+    mkdir -p $out/share/skills
+    cp -R skills $out/share/skills/$pname
 
     runHook postInstall
   '';
@@ -121,6 +130,7 @@ stdenv.mkDerivation {
     runHook preInstallCheck
 
     $out/bin/hunk --version | grep -F ${version}
+    test -f $out/share/skills/$pname/hunk-review/SKILL.md
     test -f "$($out/bin/hunk skill path)"
 
     runHook postInstallCheck


### PR DESCRIPTION
Follow the layout agreed in NixOS/nixpkgs#547426 and drop the `$out/skills` symlink. Patch `paths.ts` so `hunk skill path` still resolves the bundled skill from the share tree.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
