### PR TITLE
nixos/eternal-terminal: fix systemd service mis-tracks etserver --daemon; add opt-in telemetry setting; add tomasrivera as maintainer

### DIFF
--- a/nixos/modules/services/networking/eternal-terminal.nix
+++ b/nixos/modules/services/networking/eternal-terminal.nix
@@ -53,6 +53,14 @@ in
           The maximum log size.
         '';
       };
+
+      telemetry = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Collects anonymous usage data and crash reports.
+        '';
+      };
     };
   };
 
@@ -83,6 +91,7 @@ in
             verbose = ${toString cfg.verbosity}
             silent = ${if cfg.silent then "1" else "0"}
             logsize = ${toString cfg.logSize}
+            telemetry = ${lib.boolToString cfg.telemetry}
           ''}";
           Restart = "on-failure";
         };

--- a/nixos/modules/services/networking/eternal-terminal.nix
+++ b/nixos/modules/services/networking/eternal-terminal.nix
@@ -71,8 +71,8 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         serviceConfig = {
-          Type = "forking";
-          ExecStart = "${pkgs.eternal-terminal}/bin/etserver --daemon --cfgfile=${pkgs.writeText "et.cfg" ''
+          Type = "exec";
+          ExecStart = "${pkgs.eternal-terminal}/bin/etserver --logtostdout --cfgfile=${pkgs.writeText "et.cfg" ''
             ; et.cfg : Config file for Eternal Terminal
             ;
 
@@ -85,7 +85,6 @@ in
             logsize = ${toString cfg.logSize}
           ''}";
           Restart = "on-failure";
-          KillMode = "process";
         };
       };
     };

--- a/nixos/modules/services/networking/eternal-terminal.nix
+++ b/nixos/modules/services/networking/eternal-terminal.nix
@@ -92,6 +92,6 @@ in
   };
 
   meta = {
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tomasrivera ];
   };
 }


### PR DESCRIPTION
Closes #550290
 @PearGod if you want to be co-author for the second commit, please specify me your email address to set in the commit message as the fix was described in your issue.

It's my first PR touching a nixos module. I might have done something wrong.

You can find the source for the telemetry option [here](https://github.com/MisterTea/EternalTerminal/blob/master/etc/et.cfg)

No AI/Automation was used for this PR.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
