### PR TITLE
unifont: stop propagating the bin output to out

### DIFF
--- a/pkgs/by-name/co/console-setup/package.nix
+++ b/pkgs/by-name/co/console-setup/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     bdfresize
     otf2bdf
     perl
-    unifont
+    unifont.bin
   ];
 
   makeFlags = [ "prefix=${placeholder "out"}" ];

--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -55,6 +55,9 @@ stdenv.mkDerivation (finalAttrs: {
     "info"
   ];
 
+  # Don't bloat the font output with tools
+  propagatedBuildOutputs = [ ];
+
   passthru.updateScript = ./update.sh;
 
   meta = {


### PR DESCRIPTION
Before:
```
$ nix-store --query --references /nix/store/6qy18gy0p48wmpbnck5wbi9xlybikm26-unifont-17.0.05
/nix/store/vx1iq0xf9xndaqgxb8j1nvg0xhpf0506-unifont-17.0.05-bin
```

After:
```
$ nix-store --query --references /nix/store/vqampy54ia0zyndnl56ks46gnmjsyvxf-unifont-17.0.05
(no output)
```

See also https://github.com/NixOS/nixpkgs/pull/550059

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
