### PR TITLE
nixos/nftables: switch location of rules to be removed to `/run`

### DIFF
--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -312,7 +312,7 @@ in
             }
             ${cfg.extraDeletions}
           '';
-          deletionsScriptVar = "/var/lib/nftables/deletions.nft";
+          deletionsScriptVar = "/run/nftables/deletions.nft";
           makeDeletions = "${pkgs.nftables}/bin/nft -f ${deletionsScriptVar}";
           ensureDeletions = pkgs.writeShellScript "nftables-ensure-deletions" ''
             touch ${deletionsScriptVar}
@@ -383,7 +383,8 @@ in
             makeDeletions
             cleanupDeletionsScript
           ];
-          StateDirectory = "nftables";
+          RuntimeDirectory = "nftables";
+          RuntimeDirectoryPreserve = true;
         };
       unitConfig.DefaultDependencies = false;
     };


### PR DESCRIPTION
Change the position of the file containing all nftables rules that have to be deleted on stop/reload of the current nftables process from '/var/lib/nftables/deletions.nft` to
`/run/nftables/deletions.nft`.

The list of rules to be deleted is only valid while the service is running and does not need to be persisted.
In cases where users rollback the content of the `/var/lib` directory, for example when restoring data from a backup, they might not notice that they are overwriting the current deletion rules. This might lead to the directory being out-of-sync with the state of nftables.

Following the Filesystem Hierarchy Standard, the `/var/lib` directory is to be used by applications to store state "between invocations and between different instances of the same application. State information should generally remain valid after a reboot."
The `/run` directory is instead intended to store run-time variable data since boot, that is not intended to be backed up and is cleared after reboot.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
