### PR TITLE
[release-26.05] libvirt: fix CVE-2026-61478 and CVE-2026-61477

### DIFF
--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -10,6 +10,7 @@
   dnsmasq,
   docutils,
   fetchFromGitLab,
+  fetchpatch,
   gettext,
   glib,
   gnutls,
@@ -133,6 +134,25 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+
+    # CVE-2026-61478
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/68da70aae766c6271b8d3b466374d3cc7d1a8afb.patch";
+      hash = "sha256-praL3I5WOwFwBo/hzm4mcs8POmfmIz+MQEv1XH1OKnw=";
+    })
+    # CVE-2026-61477
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/d44836a1dc6771ac22f69755fc69bf730f0eec87.patch";
+      hash = "sha256-8+DB0CANFixxW/Lf+UoqqWDTuBR+YHBQzoH7WKf8Znw=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/289ffa796d737a79a4c05d07232ebd75def9a12a.patch";
+      hash = "sha256-S1L4ahib7BMiU5z44mPtdT7Yt+Xx9zB6pVVFSCkLfEg=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/cb8974b923e3c40cde96f0c7bceaa638f7f9c72b.patch";
+      hash = "sha256-cAPhjkX2Zb+shuFhKIwNk6N9dzTqiuofBx4fTpA1Bzo=";
+    })
   ]
   ++ lib.optionals enableZfs [
     (replaceVars ./0002-substitute-zfs-and-zpool-commands.patch {


### PR DESCRIPTION
These patches are from the upcoming 12.6 release of libvirt and apply cleanly.

The newer libvirt versions may have mildy breaking changes. I'm not sure what our policy is regarding backporting libvirt updates to releases. If backporting new versions is fine, we can discard this PR.

Relates to #551116.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
