### PR TITLE
fwupd: drop valgrind build dep

### DIFF
--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -52,7 +52,6 @@
   readline,
   sqlite,
   tpm2-tss,
-  valgrind,
   xz, # for liblzma
 
   # mesonFlags
@@ -75,7 +74,6 @@
   nix-update-script,
 
   enablePassim ? false,
-  enableValgrind ? lib.meta.availableOn stdenv.hostPlatform valgrind,
 }:
 
 let
@@ -224,9 +222,6 @@ stdenv.mkDerivation (finalAttrs: {
     sqlite
     tpm2-tss
     xz # for liblzma
-  ]
-  ++ lib.optionals enableValgrind [
-    valgrind
   ];
 
   mesonFlags = [
@@ -248,14 +243,12 @@ stdenv.mkDerivation (finalAttrs: {
     # TODO: what should this be?
     (lib.mesonOption "vendor_ids_dir" "${hwdata}/share/hwdata")
     (lib.mesonEnable "umockdev_tests" false)
+    (lib.mesonEnable "valgrind" false)
     # We do not want to place the daemon into lib (cyclic reference)
     "--libexecdir=${placeholder "out"}/libexec"
   ]
   ++ lib.optionals (!enablePassim) [
     (lib.mesonEnable "passim" false)
-  ]
-  ++ lib.optionals (!enableValgrind) [
-    (lib.mesonEnable "valgrind" false)
   ];
 
   # TODO: wrapGAppsHook3 wraps efi capsule even though it is not ELF


### PR DESCRIPTION
This is not actually used anymore upstream, we can drop the option completely once upstream removes it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
