### PR TITLE
jrl-cmakemodules: 2.2.4 -> 2.3.0

### DIFF
--- a/pkgs/by-name/jr/jrl-cmakemodules-scripts/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules-scripts/package.nix
@@ -1,5 +1,6 @@
 {
   jrl-cmakemodules,
+  gitMinimal,
   python3Packages,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -21,6 +22,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   nativeCheckInputs = [
+    gitMinimal
     python3Packages.pytest-mock
     python3Packages.pytestCheckHook
   ];

--- a/pkgs/by-name/jr/jrl-cmakemodules/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules/package.nix
@@ -16,7 +16,10 @@
 
   # tests
   catch2_3,
+  cppad,
+  gmp,
   matio,
+  mpfr,
   python3Packages,
   simde,
   suitesparse,
@@ -32,13 +35,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jrl-cmakemodules";
-  version = "2.2.4";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "jrl-umi3218";
     repo = "jrl-cmakemodules";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ty6PSQfIQK9jE9gaop2Rc+4uT0dG42A90+yU3pViLI0=";
+    hash = "sha256-PjEE/JIb6gegW5fqKiFgN0th8Fi58Pe0u5qrdIz2Rm8=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -52,7 +55,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [
     catch2_3
+    cppad
+    gmp
     matio
+    mpfr
     python3Packages.boost
     python3Packages.nanobind
     python3Packages.numpy
@@ -78,6 +84,10 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeFeature "DOXYGEN_HTML_FORMULA_FORMAT" "svg")
       (lib.cmakeFeature "DOXYGEN_HTML_OUTPUT" "doxygen-html")
       (lib.cmakeBool "DOXYGEN_USE_MATHJAX" false)
+      (lib.cmakeBool "JRL_CMAKEMODULES_ENABLE_TEST_CPPAD" true)
+      (lib.cmakeBool "JRL_CMAKEMODULES_ENABLE_TEST_CPPADCG" false) # wait for #390728
+      (lib.cmakeBool "JRL_CMAKEMODULES_ENABLE_TEST_GMP" true)
+      (lib.cmakeBool "JRL_CMAKEMODULES_ENABLE_TEST_MPFR" true)
     ];
   };
 


### PR DESCRIPTION
fix https://hydra.nixos.org/build/341531295/log/tail:
```python
=========================== short test summary info ============================
FAILED test_jrl_release.py::test_discover_package_roots_respects_gitignore - FileNotFoundError: [Errno 2] No such file or directory: 'git'
FAILED test_jrl_release.py::test_discover_package_roots_skips_submodules - FileNotFoundError: [Errno 2] No such file or directory: 'git'
FAILED test_jrl_release.py::test_git_submodule_dirs_empty_without_gitmodules - FileNotFoundError: [Errno 2] No such file or directory: 'git'
======================== 3 failed, 112 passed in 1.02s =========================
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
