### PR TITLE
nixos/quake3-server: add default baseq3

### DIFF
--- a/nixos/modules/services/games/quake3-server.nix
+++ b/nixos/modules/services/games/quake3-server.nix
@@ -21,31 +21,11 @@ let
     ${cfg.extraConfig}
   '';
 
-  defaultBaseq3 = pkgs.requireFile rec {
-    name = "baseq3";
-    hashMode = "recursive";
-    sha256 = "5dd8ee09eabd45e80450f31d7a8b69b846f59738726929298d8a813ce5725ed3";
-    message = ''
-      Unfortunately, we cannot download ${name} automatically.
-      Please purchase a legitimate copy of Quake 3 and change into the installation directory.
-
-      You can either add all relevant files to the nix-store like this:
-      mkdir /tmp/baseq3
-      cp baseq3/pak*.pk3 /tmp/baseq3
-      nix-store --add-fixed sha256 --recursive /tmp/baseq3
-
-      Alternatively you can set services.quake3-server.baseq3 to a path and
-      copy the baseq3 directory into the .q3a subdirectory of that path.
-    '';
-  };
-
   home = pkgs.runCommand "quake3-home" { } ''
     mkdir -p $out/.q3a/baseq3
-
-    for file in ${cfg.baseq3}/*; do
-      ln -s $file $out/.q3a/baseq3/$(basename $file)
+    for file in $(find -L ${cfg.baseq3} -maxdepth 2 -name '*.pk3'); do
+      ln -s "$file" "$out/.q3a/baseq3/$(basename "$file")"
     done
-
     ln -s ${configFile} $out/.q3a/baseq3/nix.cfg
   '';
 in
@@ -86,13 +66,23 @@ in
 
       baseq3 = mkOption {
         type = types.either types.package types.path;
-        default = defaultBaseq3;
-        defaultText = literalMD "Manually downloaded Quake 3 installation directory.";
+        default = pkgs.symlinkJoin {
+          name = "quake3-demo-content";
+          paths = [
+            pkgs.quake3demodata
+            pkgs.quake3pointrelease
+          ];
+        };
+        defaultText = "Freely redistributable Quake 3 demo data (`pak0`) plus the 1.32 point release files (`pak1`-`pak8`), merged together.";
         example = "/var/lib/q3ds";
         description = ''
           Path to the baseq3 files (pak*.pk3). If this is on the nix store (type = package) all .pk3 files should be saved
           in the top-level directory. If this is on another filesystem (e.g /var/lib/baseq3) the .pk3 files are searched in
           $baseq3/.q3a/baseq3/
+
+          Defaults to the freely redistributable demo data (pak0) merged
+          with the 1.32 point release files (pak1-pak8), so the game runs
+          out of the box without owning a retail copy.
         '';
       };
     };


### PR DESCRIPTION
set demo baseq3 files as default for quake3-server so you can run it without needing the full game.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
