### PR TITLE
rufin: 0.12.5 -> 0.13.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -42,6 +42,8 @@
 
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.
 
+- `rufin` has been updated from 0.12.5 to 0.13.0. ReplayGain normalization has been replaced by opt-in EBU R128 normalization, and Jellyfin and Navidrome downloads now use Opus instead of MP3. See the [upstream release notes](https://github.com/screwys/Rufin/releases/tag/v0.13.0) for the complete list of changes.
+
 - The existing `wasm32-wasi` target has become `wasm32-wasip1` and `pkgsCross.wasi32` has become `pkgsCross.wasm32-wasip1`, aligning with LLVM's nomenclature. Aliases are in place and old forms will continue to be parsed but there might be some breakage if you're relying on the exact form of these (e.g., in sysroot paths).
 
 - `gotosocial` has been updated to 0.22.0. This release contains a very long database migration, which should not be cancelled or interrupted under any circumstances.

--- a/pkgs/by-name/ru/rufin/package.nix
+++ b/pkgs/by-name/ru/rufin/package.nix
@@ -14,7 +14,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rufin";
-  version = "0.12.5";
+  version = "0.13.0";
 
   __structuredAttrs = true;
 
@@ -22,10 +22,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "screwys";
     repo = "Rufin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QOlDZAVjDgAV1G4+f82TpNbyv+96QGDAUqf5r+A4PuU=";
+    hash = "sha256-xNeANA+qiegxojC3YO0JOMk92Qv+FAFe0/YO4He/I80=";
   };
 
-  cargoHash = "sha256-6u23YZSYYYAcnoOOZiCUCy9rbiOS59Nu4hj3WKhL/B0=";
+  cargoHash = "sha256-UitZfrsvfHkiQUTAq8srstBGRbcuKBn5OJ+WUq1jdqI=";
 
   strictDeps = true;
 
@@ -52,46 +52,35 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoBuildFlags = [
     "-p"
     "rufin"
+    "-p"
+    "xtask"
   ];
 
   doCheck = false;
 
-  postInstall = ''
-    install -Dm644 data/japanese-readings.dic \
-      "$out/share/rufin/japanese-readings.dic"
-    install -Dm644 data/japanese-readings.LICENSE \
-      "$out/share/licenses/rufin/japanese-readings.LICENSE"
-    install -Dm644 data/io.github.screwys.Rufin.desktop \
-      "$out/share/applications/io.github.screwys.Rufin.desktop"
+  installPhase = ''
+    runHook preInstall
+
+    rufin_binary="$(find target -type f -path "*/$cargoBuildType/rufin" -perm -0100 -print -quit)"
+    xtask_binary="$(find target -type f -path "*/$cargoBuildType/xtask" -perm -0100 -print -quit)"
+    if [ -z "$rufin_binary" ] || [ -z "$xtask_binary" ]; then
+      echo "The Rufin or xtask build output is missing." >&2
+      exit 1
+    fi
+    "$xtask_binary" install linux \
+      --binary "$rufin_binary" \
+      --destdir "$out" \
+      --prefix /
     substituteInPlace "$out/share/applications/io.github.screwys.Rufin.desktop" \
       --replace-fail "Exec=rufin" "Exec=$out/bin/rufin"
-    install -Dm644 data/io.github.screwys.Rufin.metainfo.xml \
-      "$out/share/metainfo/io.github.screwys.Rufin.metainfo.xml"
-    install -Dm644 data/icons/hicolor/scalable/apps/io.github.screwys.Rufin.svg \
-      "$out/share/icons/hicolor/scalable/apps/io.github.screwys.Rufin.svg"
-    install -Dm644 -t "$out/share/icons/hicolor/scalable/actions" \
-      data/icons/hicolor/scalable/actions/*.svg
-    install -Dm644 -t "$out/share/icons/hicolor/scalable/status" \
-      data/icons/hicolor/scalable/status/*.svg
-    install -Dm644 -t "$out/share/icons/hicolor/512x512/apps" \
-      data/icons/hicolor/512x512/apps/*.png
-    install -Dm644 -t "$out/share/icons/hicolor/64x64/apps" \
-      data/icons/hicolor/64x64/apps/*.png
 
-    for po_file in crates/localization/locales/*.po; do
-      if [ -f "$po_file" ]; then
-        lang="$(basename "$po_file" .po)"
-        mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
-        msgfmt "$po_file" -o "$out/share/locale/$lang/LC_MESSAGES/rufin.mo"
-      fi
-    done
+    runHook postInstall
   '';
 
   preFixup = ''
     gappsWrapperArgs+=(
       --set-default RUFIN_LOCALEDIR "$out/share/locale"
       --set-default SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
     )
   '';
 

--- a/pkgs/by-name/ru/rufin/package.nix
+++ b/pkgs/by-name/ru/rufin/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   rustPlatform,
   cacert,
@@ -52,8 +53,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoBuildFlags = [
     "-p"
     "rufin"
-    "-p"
-    "xtask"
   ];
 
   doCheck = false;
@@ -62,12 +61,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     runHook preInstall
 
     rufin_binary="$(find target -type f -path "*/$cargoBuildType/rufin" -perm -0100 -print -quit)"
-    xtask_binary="$(find target -type f -path "*/$cargoBuildType/xtask" -perm -0100 -print -quit)"
-    if [ -z "$rufin_binary" ] || [ -z "$xtask_binary" ]; then
-      echo "The Rufin or xtask build output is missing." >&2
-      exit 1
-    fi
-    "$xtask_binary" install linux \
+    cargo run -p xtask --target ${stdenv.buildPlatform.rust.rustcTarget} -- install linux \
       --binary "$rufin_binary" \
       --destdir "$out" \
       --prefix /


### PR DESCRIPTION
Updates Rufin to [0.13.0](https://github.com/screwys/Rufin/releases/tag/v0.13.0). Removes the duplicated GStreamer plugin path and replaces the installation command with repository's generic linux installer so that we do not need to open a manual PR for basic icon and packaging checks in the future. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
