### PR TITLE
flame: init at 2.4.0, add NixOS module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1680,6 +1680,7 @@
   ./services/web-apps/filebrowser.nix
   ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/firefly-iii.nix
+  ./services/web-apps/flame.nix
   ./services/web-apps/flarum.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freescout.nix

--- a/nixos/modules/services/web-apps/flame.nix
+++ b/nixos/modules/services/web-apps/flame.nix
@@ -1,0 +1,371 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.flame;
+
+  settingsFormat = pkgs.formats.json { };
+
+  # Accepts either a list of strings or a raw semicolon-separated string.
+  schemaToStr = x: if builtins.isList x then lib.concatStringsSep ";" x else x;
+
+  # Needed to prepopulate DB
+  sqlQuote = s: "'" + builtins.replaceStrings [ "'" ] [ "''" ] s + "'";
+
+  seedSql = pkgs.writeText "flame-seed.sql" ''
+    ${lib.optionalString (cfg.apps != [ ] || cfg.categories != [ ]) ''
+      DELETE FROM bookmarks;
+      DELETE FROM categories;
+      DELETE FROM apps;
+    ''}
+    ${lib.concatMapStringsSep "\n" (app: ''
+      INSERT INTO apps (name, url, icon, description, isPinned, createdAt, updatedAt)
+      VALUES (${sqlQuote app.name}, ${sqlQuote app.url}, ${sqlQuote app.icon}, ${sqlQuote app.description}, ${
+        if app.isPinned then "1" else "0"
+      }, datetime('now'), datetime('now'));
+    '') cfg.apps}
+    ${lib.concatMapStringsSep "\n" (cat: ''
+      INSERT INTO categories (name, isPinned, createdAt, updatedAt)
+      VALUES (${sqlQuote cat.name}, ${
+        if cat.isPinned then "1" else "0"
+      }, datetime('now'), datetime('now'));
+      ${lib.concatMapStringsSep "\n" (bm: ''
+        INSERT INTO bookmarks (name, url, icon, categoryId, createdAt, updatedAt)
+        VALUES (${sqlQuote bm.name}, ${sqlQuote bm.url}, ${sqlQuote bm.icon}, (SELECT id FROM categories WHERE name = ${sqlQuote cat.name} ORDER BY id DESC LIMIT 1), datetime('now'), datetime('now'));
+      '') cat.bookmarks}
+    '') cfg.categories}
+  '';
+
+  cssFile = pkgs.writeText "flame-custom.css" cfg.customCSS;
+
+  # Build-time symlink farm of everything Flame ships except data/ and
+  # public/, which are left as empty placeholders here and populated at
+  # runtime (data/ is real state; public/ is refreshed from cfg.package
+  # on every start, since it holds built client assets).
+  appTree = pkgs.runCommand "flame-app-tree" { } ''
+    mkdir -p $out
+    for entry in ${cfg.package}/lib/flame/*; do
+      name=$(basename "$entry")
+      if [ "$name" != data ] && [ "$name" != public ]; then
+        ln -s "$entry" "$out/$name"
+      fi
+    done
+    mkdir -p $out/data $out/public
+  '';
+
+  # WEATHER_API_KEY is deliberately excluded here; it's injected at
+  # runtime from `weatherApiKeyFile` so it never touches the Nix store.
+  settingsFile = settingsFormat.generate "flame-settings.json" (
+    lib.filterAttrs (n: _: n != "weatherApiKeyFile") cfg.settings
+    // lib.optionalAttrs (cfg.settings ? greetingsSchema) {
+      greetingsSchema = schemaToStr cfg.settings.greetingsSchema;
+    }
+    // lib.optionalAttrs (cfg.settings ? daySchema) {
+      daySchema = schemaToStr cfg.settings.daySchema;
+    }
+    // lib.optionalAttrs (cfg.settings ? monthSchema) {
+      monthSchema = schemaToStr cfg.settings.monthSchema;
+    }
+  );
+in
+{
+  meta.maintainers = with lib.maintainers; [ DerGrumpf ];
+
+  options.services.flame = {
+    enable = lib.mkEnableOption "Flame, a self-hosted startpage for your server";
+    package = lib.mkPackageOption pkgs "flame" { };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 5005;
+      description = "Port on which to serve the Flame web interface.";
+    };
+
+    passwordFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to a file containing the password to log in to Flame's settings panel.
+        This is the recommended option as it avoids storing the password in the Nix store.
+        Compatible with sops-nix and agenix.
+      '';
+      example = "/run/secrets/flame-password";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the firewall for the port used by Flame.";
+    };
+
+    customCSS = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        Custom CSS injected into Flame's UI, written to
+        {file}`public/flame.css` on every service start. Can also be used
+        to define a fully custom theme via CSS custom properties — see
+        [Flame's Custom CSS wiki page](https://github.com/pawelmalak/flame/wiki/Custom-CSS).
+      '';
+      example = ''
+        .Home_SettingsButton__Qvn8C {
+          border-radius: 0 !important;
+        }
+      '';
+    };
+
+    categories = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            name = lib.mkOption {
+              type = lib.types.str;
+              description = "Name of the bookmark category.";
+            };
+            isPinned = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Whether the category is pinned by default.";
+            };
+            bookmarks = lib.mkOption {
+              default = [ ];
+              description = "Bookmarks belonging to this category.";
+              type = lib.types.listOf (
+                lib.types.submodule {
+                  options = {
+                    name = lib.mkOption {
+                      type = lib.types.str;
+                      description = "Name of the bookmark.";
+                    };
+                    url = lib.mkOption {
+                      type = lib.types.str;
+                      description = "URL of the bookmark.";
+                    };
+                    icon = lib.mkOption {
+                      type = lib.types.str;
+                      default = "";
+                      description = "Icon name or URL for the bookmark.";
+                    };
+                  };
+                }
+              );
+            };
+          };
+        }
+      );
+      default = [ ];
+      description = ''
+        Bookmark categories and their bookmarks. When non-empty, this
+        fully replaces the contents of Flame's `categories` and
+        `bookmarks` tables on every service start — any bookmarks added
+        through the web UI will not persist across restarts.
+      '';
+      example = [
+        {
+          name = "Dev";
+          bookmarks = [
+            {
+              name = "GitHub";
+              url = "https://github.com";
+            }
+          ];
+        }
+      ];
+    };
+
+    apps = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            name = lib.mkOption {
+              type = lib.types.str;
+              description = "Name of the app.";
+            };
+            url = lib.mkOption {
+              type = lib.types.str;
+              description = "URL of the app.";
+            };
+            icon = lib.mkOption {
+              type = lib.types.str;
+              default = "cancel";
+              description = "Icon name or URL for the app.";
+            };
+            description = lib.mkOption {
+              type = lib.types.str;
+              default = "";
+              description = "Short description shown for the app.";
+            };
+            isPinned = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Whether the app is pinned by default.";
+            };
+          };
+        }
+      );
+      default = [ ];
+      description = ''
+        Applications shown on the dashboard. When non-empty, this fully
+        replaces the contents of Flame's `apps` table on every service
+        start — any apps added through the web UI will not persist
+        across restarts.
+      '';
+      example = [
+        {
+          name = "Router";
+          url = "http://192.168.1.1";
+        }
+      ];
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          weatherApiKeyFile = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = ''
+              Path to a file containing the API key obtained from https://www.weatherapi.com used for
+              Flame's weather widget.
+              Compatible with sops-nix and agenix.
+            '';
+            example = "/run/secrets/flame-weather-api-key";
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Flame settings, written to Flame's settings JSON on every service
+        start. Accepts any key Flame's settings API supports; see
+        [Flame's source](https://github.com/pawelmalak/flame/blob/master/client/src/context/context.js)
+        for the current schema, since Flame does not publish separate
+        settings documentation.
+
+        `greetingsSchema`, `daySchema`, and `monthSchema` accept either a
+        list of strings or a single semicolon-separated string.
+      '';
+      example = {
+        lat = 52.52;
+        long = 13.405;
+        customTitle = "My Dashboard";
+        hideHeader = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services = {
+      flame-seed = lib.mkIf (cfg.apps != [ ] || cfg.categories != [ ]) {
+        description = "Seed Flame apps and bookmarks";
+        after = [ "flame.service" ];
+        requires = [ "flame.service" ];
+        wantedBy = [ "flame.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          DynamicUser = true;
+          StateDirectory = "flame";
+        };
+
+        script = ''
+          for i in $(seq 1 30); do
+            if ${lib.getExe pkgs.sqlite} /var/lib/flame/app/data/db.sqlite \
+               "SELECT 1 FROM sqlite_master WHERE type='table' AND name='apps';" | grep -q 1; then
+              break
+            fi
+            sleep 1
+          done
+          ${lib.getExe pkgs.sqlite} /var/lib/flame/app/data/db.sqlite < ${seedSql}
+        '';
+      };
+
+      flame = {
+        description = "Flame, a self-hosted startpage for your server";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        preStart = ''
+          for entry in ${appTree}/*; do
+            name=$(basename "$entry")
+            if [ "$name" != data ] && [ "$name" != public ]; then
+              ln -sfn "$entry" /var/lib/flame/app/"$name"
+            fi
+          done
+
+          for entry in /var/lib/flame/app/data /var/lib/flame/app/public; do
+            if [ -L "$entry" ]; then
+              rm -f "$entry"
+            fi
+          done
+          mkdir -p /var/lib/flame/app/data/uploads /var/lib/flame/app/public
+
+          if [ ! -f /var/lib/flame/app/data/.secret ]; then
+            ${lib.getExe pkgs.openssl} rand -hex 32 > /var/lib/flame/app/data/.secret
+          fi
+          chmod 644 /var/lib/flame/app/data/.secret
+
+          cp -r ${cfg.package}/lib/flame/public/. /var/lib/flame/app/public/
+          chmod -R u+w /var/lib/flame/app/public
+
+          install -m644 ${cssFile} /var/lib/flame/app/data/flame.css
+
+          ${lib.getExe pkgs.jq} -n --slurpfile base ${cfg.package}/lib/flame/utils/init/initialConfig.json \
+            '$base[0]' > /var/lib/flame/app/data/config.json.tmp
+
+          ${lib.optionalString (cfg.settings.weatherApiKeyFile != null) ''
+            weatherApiKey=$(cat ${cfg.settings.weatherApiKeyFile})
+            ${lib.getExe pkgs.jq} --arg key "$weatherApiKey" '.WEATHER_API_KEY = $key' \
+              ${settingsFile} > /var/lib/flame/app/data/settings-with-key.json
+          ''}
+
+          ${lib.getExe pkgs.jq} -s '.[0] * .[1]' \
+            /var/lib/flame/app/data/config.json.tmp \
+            ${
+              if cfg.settings.weatherApiKeyFile != null then
+                "/var/lib/flame/app/data/settings-with-key.json"
+              else
+                settingsFile
+            } \
+            > /var/lib/flame/app/data/config.json
+          rm -f /var/lib/flame/app/data/config.json.tmp
+          chmod u+w /var/lib/flame/app/data/config.json
+        '';
+
+        serviceConfig = {
+          DynamicUser = true;
+          StateDirectory = [
+            "flame"
+            "flame/app"
+          ];
+          WorkingDirectory = "/var/lib/flame/app";
+          Environment = [
+            "PORT=${toString cfg.port}"
+            "NODE_ENV=production"
+            "VERSION=${cfg.package.version}"
+          ];
+          LoadCredential = [ "flame-password:${cfg.passwordFile}" ];
+          Restart = "always";
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          CapabilityBoundingSet = "";
+        };
+
+        script = ''
+          export PASSWORD="$(cat "$CREDENTIALS_DIRECTORY/flame-password")"
+          exec ${lib.getExe pkgs.nodejs} --preserve-symlinks --preserve-symlinks-main server.js
+        '';
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -629,6 +629,7 @@ in
   firewalld = runTest ./firewalld.nix;
   firezone = runTest ./firezone/firezone.nix;
   fish = runTest ./fish.nix;
+  flame = runTest ./flame.nix;
   flannel = runTestOn [ "x86_64-linux" ] ./flannel.nix;
   flap-alerted = runTest ./flap-alerted.nix;
   flaresolverr = runTest ./flaresolverr.nix;

--- a/nixos/tests/flame.nix
+++ b/nixos/tests/flame.nix
@@ -1,0 +1,68 @@
+{ lib, ... }:
+{
+  name = "flame";
+
+  meta.maintainers = with lib.maintainers; [ DerGrumpf ];
+
+  nodes.machine = {
+    services.flame = {
+      enable = true;
+      passwordFile = "/etc/flame-password";
+
+      apps = [
+        {
+          name = "Test App";
+          url = "http://example.com";
+        }
+      ];
+
+      categories = [
+        {
+          name = "Test Category";
+          bookmarks = [
+            {
+              name = "Nixpkgs";
+              url = "https://github.com/NixOS/nixpkgs";
+            }
+          ];
+        }
+      ];
+
+      settings = {
+        customTitle = "Test Flame";
+        customUnknownKey = "test-value";
+      };
+
+      customCSS = ''
+        body { background: #123456; }
+      '';
+    };
+
+    systemd.tmpfiles.rules = [
+      "f /etc/flame-password 0400 root root - testpassword"
+    ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("flame.service")
+    machine.wait_for_open_port(5005)
+    machine.succeed("curl -f http://localhost:5005/")
+
+    machine.wait_for_unit("flame-seed.service")
+
+    machine.succeed("curl -f http://localhost:5005/api/apps | grep -q 'Test App'")
+    machine.succeed("curl -f http://localhost:5005/api/categories | grep -q 'Test Category'")
+    machine.succeed("curl -f http://localhost:5005/api/categories | grep -q Nixpkgs")
+    machine.succeed("curl -f http://localhost:5005/api/config | grep -q 'Test Flame'")
+    machine.succeed("curl -f http://localhost:5005/flame.css | grep -q '#123456'")
+
+    # Restart resilience
+    machine.succeed("systemctl restart flame.service")
+    machine.wait_for_unit("flame.service")
+    machine.wait_for_open_port(5005)
+    machine.succeed("curl -f http://localhost:5005/api/apps | grep -q 'Test App'")
+
+    # Freeform settings pass-through (unknown key, not explicitly declared)
+    machine.succeed("curl -f http://localhost:5005/api/config | grep -q customUnknownKey")
+  '';
+}

--- a/pkgs/by-name/fl/flame/package.nix
+++ b/pkgs/by-name/fl/flame/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs,
+  python3,
+  autoPatchelfHook,
+  makeWrapper,
+  stdenv,
+  sqlite,
+  nixosTests,
+}:
+let
+  version = "2.4.0";
+
+  flameSrc = fetchFromGitHub {
+    owner = "pawelmalak";
+    repo = "flame";
+    tag = "v${version}";
+    hash = "sha256-Slnft/tDtogjuTnQXus0Mp7y6AlOYjCV1riQ2M9cIc8=";
+  };
+
+  clientDeps = fetchNpmDeps {
+    pname = "flame-client-deps";
+    inherit version;
+    src = flameSrc + "/client";
+    hash = "sha256-IitL0qxu6/3y9x8XkW0dZLjsHTkNeQMHYsaq/LOwvrg=";
+  };
+in
+buildNpmPackage (finalAttrs: {
+  pname = "flame";
+  inherit version;
+  __structuredAttrs = true;
+
+  src = flameSrc;
+
+  nativeBuildInputs = [
+    python3
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    sqlite
+  ];
+
+  npmFlags = [ "--build-from-source" ];
+
+  npmDepsHash = "sha256-YGusqgF8xU6QBB0r0M8V0UZHLuSTdYlYyIMXnov7YEA=";
+
+  dontNpmBuild = true;
+
+  postPatch = ''
+    cat > db/migrations/01_new-config.js <<'EOF'
+    // Neutered for the Nix/NixOS package: this migration only exists to
+    // migrate pre-2.0 SQL-table-based config into config.json for very
+    // old installs. Fresh installs never have that legacy `config`
+    // table, and its unconditional copy of the default config template
+    // over data/config.json would clobber declarative settings applied
+    // by the NixOS module on every first boot.
+    const up = async () => {};
+    const down = async () => {};
+    module.exports = { up, down };
+    EOF
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd client
+    npm ci --cache ${clientDeps} --offline
+    patchShebangs node_modules
+    npm run build
+    cd -
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/flame/{data,public}
+    cp -r . $out/lib/flame
+    cp -r client/build/. $out/lib/flame/public
+    rm -r $out/lib/flame/client
+
+    makeWrapper ${lib.getExe' nodejs "node"} $out/bin/flame \
+      --add-flags $out/lib/flame/server.js
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    nixos = nixosTests.flame;
+  };
+
+  meta = {
+    description = "Self-hosted startpage for your server";
+    homepage = "https://github.com/pawelmalak/flame";
+    license = lib.licenses.mit;
+    mainProgram = "flame";
+    maintainers = with lib.maintainers; [ DerGrumpf ];
+  };
+})


### PR DESCRIPTION
Adds [Flame](https://github.com/pawelmalak/flame), a self-hosted
startpage/dashboard for organizing apps and bookmarks, packaged from the
v2.4.0 release tag.

Also adds a NixOS service module (`services.flame`) with typed options for
the full `config.json` settings surface, declarative `apps`/`categories`/
`bookmarks` seeding, and declarative `customCSS`. Secrets are handled via
`passwordFile` and `settings.weatherApiKeyFile` options only, compatible
with sops-nix and agenix; no plaintext secrets are stored in the Nix store.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled from x86_64-linux via `pkgsCross.aarch64-multiplatform`, not natively tested)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`nixosTests.flame`)
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[Package tests]: https://nixos.org/manual/nixpkgs/unstable/#var-passthru-tests
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automation-and-artificial-intelligence