### PR TITLE
p11-kit: enable structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/by-name/p1/p11-kit/package.nix
+++ b/pkgs/by-name/p1/p11-kit/package.nix
@@ -14,14 +14,14 @@
   libintl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "p11-kit";
   version = "0.26.2";
 
   src = fetchFromGitHub {
     owner = "p11-glue";
     repo = "p11-kit";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-qFanbp0KPc6+CN4s5mMQNduzcxt/SrMcYWvIMZ0XnGY=";
     fetchSubmodules = true;
   };
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # Install sample config files to $out/etc even though they will be loaded from /etc.
     substituteInPlace p11-kit/meson.build \
-      --replace 'install_dir: prefix / p11_system_config' "install_dir: '$out/etc/pkcs11'"
+      --replace-fail 'install_dir: prefix / p11_system_config' "install_dir: '$out/etc/pkcs11'"
   '';
 
   preCheck = ''
@@ -81,6 +81,8 @@ stdenv.mkDerivation rec {
       export FAKED_MODE=1
     fi
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Library for loading and sharing PKCS#11 modules";
@@ -91,8 +93,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://p11-glue.github.io/p11-glue/p11-kit.html";
     changelog = [
-      "https://github.com/p11-glue/p11-kit/raw/${version}/NEWS"
-      "https://github.com/p11-glue/p11-kit/releases/tag/${version}"
+      "https://github.com/p11-glue/p11-kit/raw/${finalAttrs.version}/NEWS"
+      "https://github.com/p11-glue/p11-kit/releases/tag/${finalAttrs.version}"
     ];
     platforms = lib.platforms.all;
     badPlatforms = [
@@ -101,6 +103,6 @@ stdenv.mkDerivation rec {
     ];
     license = lib.licenses.bsd3;
     mainProgram = "p11-kit";
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "p11-kit_project" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "p11-kit_project" finalAttrs.version;
   };
-}
+})


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

CA hashes of the outputs are unchanged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
