### PR TITLE
strace: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/st/strace/package.nix
+++ b/pkgs/by-name/st/strace/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   perl,
+  bashNonInteractive,
   libunwind,
   buildPackages,
   gitUpdater,
@@ -30,14 +31,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  # libunwind for -k.
-  # On RISC-V platforms, LLVM's libunwind implementation is unsupported by strace.
-  # The build will silently fall back and -k will not work on RISC-V.
   buildInputs = [
+    bashNonInteractive # for strace-log-merge shebang
+    # libunwind for -k.
+    # On RISC-V platforms, LLVM's libunwind implementation is unsupported by strace.
+    # The build will silently fall back and -k will not work on RISC-V.
     libunwind
   ]
   # -kk
   ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform elfutils) elfutils;
+
+  strictDeps = true;
 
   configureFlags = [
     "--enable-mpers=check"

--- a/pkgs/by-name/st/strace/package.nix
+++ b/pkgs/by-name/st/strace/package.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl ];
 
-  enableParallelBuilding = true;
-
   buildInputs = [
     bashNonInteractive # for strace-log-merge shebang
     # libunwind for -k.
@@ -41,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   # -kk
   ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform elfutils) elfutils;
 
+  enableParallelBuilding = true;
   strictDeps = true;
 
   configureFlags = [
@@ -53,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://github.com/strace/strace.git";
     rev-prefix = "v";
   };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://strace.io/";


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
