### PR TITLE
ollama: Make llamaCpp attrs available for overrideAttrs

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -107,18 +107,6 @@ let
 
   cudaPath = lib.removeSuffix "-${cudaMajorVersion}" cudaToolkit;
 
-  # Since v0.30, llama.cpp is consumed via CMake FetchContent rather than
-  # vendored in-tree. Pre-stage the pin (tracks upstream's
-  # `LLAMA_CPP_VERSION` file) so the FetchContent step uses our copy
-  # instead of trying to clone over the network in the sandbox.
-  llamaCppVersion = "b10242";
-  llamaCppSrc = fetchFromGitHub {
-    owner = "ggml-org";
-    repo = "llama.cpp";
-    tag = llamaCppVersion;
-    hash = "sha256-mBqO6h9eiSAXqiHy1H3aK2ACbz1aYagmjAN7IpXNTcw=";
-  };
-
   wrapperOptions = [
     # ollama embeds llama-cpp binaries which actually run the ai models
     # these llama-cpp binaries are unaffected by the ollama binary's DT_RUNPATH
@@ -204,6 +192,18 @@ goBuild (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ]
     ++ lib.optionals enableVulkan vulkanLibs;
 
+  # Since v0.30, llama.cpp is consumed via CMake FetchContent rather than
+  # vendored in-tree. Pre-stage the pin (tracks upstream's
+  # `LLAMA_CPP_VERSION` file) so the FetchContent step uses our copy
+  # instead of trying to clone over the network in the sandbox.
+  llamaCppVersion = "b10242";
+  llamaCppSrc = fetchFromGitHub {
+    owner = "ggml-org";
+    repo = "llama.cpp";
+    tag = finalAttrs.llamaCppVersion;
+    hash = "sha256-mBqO6h9eiSAXqiHy1H3aK2ACbz1aYagmjAN7IpXNTcw=";
+  };
+
   # replace inaccurate version number with actual release version
   postPatch = ''
     substituteInPlace version/version.go \
@@ -225,7 +225,7 @@ goBuild (finalAttrs: {
     # OLLAMA_LLAMA_CPP_SKIP_COMPAT_PATCH=ON to the child build) — the
     # caller has to. The apply-patch.cmake script is idempotent so this
     # is safe to re-run.
-    cp -r ${llamaCppSrc} $TMPDIR/llama-cpp-src
+    cp -r ${finalAttrs.llamaCppSrc} $TMPDIR/llama-cpp-src
     chmod -R +w $TMPDIR/llama-cpp-src
     ( cd $TMPDIR/llama-cpp-src && \
       cmake -DPATCH_DIR=$NIX_BUILD_TOP/source/llama/compat \
@@ -366,7 +366,6 @@ goBuild (finalAttrs: {
   versionCheckKeepEnvironment = "HOME";
 
   passthru = {
-    inherit llamaCppSrc llamaCppVersion;
     tests = {
       inherit ollama;
     }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Make `llamaCppSrc` and `llamaCppVersion` available for `overrideAttrs`.

```nix
# example overlay
_: prev: {
  ollama-cpu = prev.ollama-cpu.overrideAttrs (finalAttrs: prevAttrs: {
    llamaCppVersion = "(new version)";
    llamaCppSrc = prev.fetchFromGitHub {
      inherit (prevAttrs.llamaCppSrc) owner repo;
      tag = finalAttrs.llamaCppVersion;
      hash = "(new hash)";
    };
  });
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
