### PR TITLE
coqPackages.CertiRocq: fix build on darwin

### DIFF
--- a/pkgs/development/coq-modules/CertiRocq/default.nix
+++ b/pkgs/development/coq-modules/CertiRocq/default.nix
@@ -1,7 +1,5 @@
 {
   lib,
-  pkgs,
-  pkg-config,
   mkCoqDerivation,
   coq,
   wasmcert,
@@ -45,10 +43,6 @@ mkCoqDerivation {
   };
   releaseRev = v: "v${v}";
 
-  buildInputs = [
-    pkgs.clang
-  ];
-
   propagatedBuildInputs = [
     wasmcert
     compcert
@@ -57,10 +51,17 @@ mkCoqDerivation {
     metarocq-safechecker-plugin
   ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs ./configure.sh
     patchShebangs ./clean_extraction.sh
     patchShebangs ./make_plugin.sh
+
+    # drop after  https://github.com/CertiRocq/certirocq/pull/162
+    substituteInPlace runtime/Makefile \
+      --replace-fail "gcc -I /opt/homebrew/include" '$(CC)'
+    substituteInPlace clean_extraction.sh \
+      --replace-fail "mv aST.ml AST.ml" "mv aST.ml AST.ml.tmp && mv AST.ml.tmp AST.ml" \
+      --replace-fail "mv aST.mli AST.mli" "mv aST.mli AST.mli.tmp && mv AST.mli.tmp AST.mli"
   '';
 
   configurePhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

followup https://github.com/NixOS/nixpkgs/pull/550135

ref https://github.com/CertiRocq/certirocq/pull/162

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
