### PR TITLE
ocamlPackages.luv-0-5-12: drop

### DIFF
--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -8,59 +8,47 @@
   file,
 }:
 
-let
-  generic =
-    {
-      version,
-      sha256,
-    }:
-    buildDunePackage (finalAttrs: {
-      pname = "luv";
-      inherit version;
+buildDunePackage (finalAttrs: {
+  pname = "luv";
+  version = "0.5.14";
 
-      src = fetchurl {
-        url = "https://github.com/aantron/luv/releases/download/${finalAttrs.version}/luv-${finalAttrs.version}.tar.gz";
-        inherit sha256;
-      };
-
-      patches = lib.optional (lib.versionOlder version "0.5.14") ./incompatible-pointer-type-fix.diff;
-
-      postConfigure = ''
-        substituteInPlace "src/c/vendor/configure/ltmain.sh" --replace-fail /usr/bin/file file
-      '';
-
-      nativeBuildInputs = [ file ];
-      propagatedBuildInputs = [
-        ctypes
-        result
-      ];
-      checkInputs = [ alcotest ];
-      doCheck = true;
-
-      meta = {
-        homepage = "https://github.com/aantron/luv";
-        description = "Binding to libuv: cross-platform asynchronous I/O";
-        # MIT-licensed, extra licenses apply partially to libuv vendor
-        license = with lib.licenses; [
-          mit
-          bsd2
-          bsd3
-          cc-by-sa-40
-        ];
-        maintainers = with lib.maintainers; [
-          locallycompact
-          sternenseemann
-        ];
-      };
-    });
-in
-{
-  luv-0-5-12 = generic {
-    version = "0.5.12";
-    sha256 = "sha256-dp9qCIYqSdROIAQ+Jw73F3vMe7hnkDe8BgZWImNMVsA=";
+  src = fetchurl {
+    url = "https://github.com/aantron/luv/releases/download/${finalAttrs.version}/luv-${finalAttrs.version}.tar.gz";
+    hash =
+      {
+        "0.5.14" = "sha256-jgG0pQyIds3ZjY4kXAaHxNxNiDrtFhrZxazh+x/arpk=";
+        "0.5.12" = "sha256-dp9qCIYqSdROIAQ+Jw73F3vMe7hnkDe8BgZWImNMVsA=";
+      }
+      ."${finalAttrs.version}";
   };
-  luv = generic {
-    version = "0.5.14";
-    sha256 = "sha256-jgG0pQyIds3ZjY4kXAaHxNxNiDrtFhrZxazh+x/arpk=";
+
+  patches = lib.optional (lib.versionOlder finalAttrs.version "0.5.14") ./incompatible-pointer-type-fix.diff;
+
+  postConfigure = ''
+    substituteInPlace "src/c/vendor/configure/ltmain.sh" --replace-fail /usr/bin/file file
+  '';
+
+  nativeBuildInputs = [ file ];
+  propagatedBuildInputs = [
+    ctypes
+    result
+  ];
+  checkInputs = [ alcotest ];
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/aantron/luv";
+    description = "Binding to libuv: cross-platform asynchronous I/O";
+    # MIT-licensed, extra licenses apply partially to libuv vendor
+    license = with lib.licenses; [
+      mit
+      bsd2
+      bsd3
+      cc-by-sa-40
+    ];
+    maintainers = with lib.maintainers; [
+      locallycompact
+      sternenseemann
+    ];
   };
-}
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1175,12 +1175,7 @@ let
 
         lutils = callPackage ../development/ocaml-modules/lutils { };
 
-        inherit
-          (callPackage ../development/ocaml-modules/luv {
-          })
-          luv-0-5-12
-          luv
-          ;
+        luv = callPackage ../development/ocaml-modules/luv { };
 
         lwd = callPackage ../development/ocaml-modules/lwd { };
 
@@ -2375,6 +2370,11 @@ let
         gd4o = throw "ocamlPackages.gd4o is not maintained, use ocamlPackages.gd instead";
         hol_light = pkgs.hol_light; # Added 2026-06-02
         lablgtk-extras = throw "lablgtk-extras has been removed as it depends on sourceview2, which has been removed from nixpkgs"; # Added 2026-08-11
+        luv-0-5-12 = luv.overrideAttrs (_: {
+          # Added 2026-08-11
+          version = "0.5.12";
+          __intentionallyOverridingVersion = true;
+        });
         mirage-bootvar-unix = throw "ocamlPackages.mirage-bootvar-unix has been removed, superseded by ocamlPackages.mirage-bootvar"; # Added 2026-08-18
         mirage-bootvar-xen = throw "ocamlPackages.mirage-bootvar-xen has been removed, superseded by ocamlPackages.mirage-bootvar"; # Added 2026-08-18
         notty = throw "2026-05-05: notty is no longer maintained, use notty-community instead";


### PR DESCRIPTION
The last use of this attribute has been removed in #508350.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
