### PR TITLE
pantheon: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation {
   ]
   ++ selectedPlugs;
 
-  passAsFile = [ "paths" ];
-
   nativeBuildInputs = [
     glib
     lndir
@@ -52,7 +50,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out
-    for i in $(cat $pathsPath); do
+    for i in "''${paths[@]}"; do
       lndir -silent $i $out
     done
 
@@ -67,6 +65,8 @@ stdenv.mkDerivation {
       --set SWITCHBOARD_PLUGS_PATH "$out/lib/switchboard-3"
     )
   '';
+
+  __structuredAttrs = true;
 
   inherit (switchboard) meta;
 }

--- a/pkgs/desktops/pantheon/desktop/wingpanel/wrapper.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/wrapper.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation {
   ]
   ++ selectedIndicators;
 
-  passAsFile = [ "paths" ];
-
   nativeBuildInputs = [
     glib
     wrapGAppsHook3
@@ -48,7 +46,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out
-    for i in $(cat $pathsPath); do
+    for i in "''${paths[@]}"; do
       ${lndir}/bin/lndir -silent $i $out
     done
   '';
@@ -59,6 +57,8 @@ stdenv.mkDerivation {
       --set SWITCHBOARD_PLUGS_PATH "${switchboard-with-plugs}/lib/switchboard-3"
     )
   '';
+
+  __structuredAttrs = true;
 
   inherit (wingpanel) meta;
 }


### PR DESCRIPTION
`passAsFile` doesn't work if `__structuredAttrs` is enabled (which setting nixpkgs is moving towards), but if it is we can access the array directly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
