### PR TITLE
auto-patchelf: add `--relativize-rpath` arg

### DIFF
--- a/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
@@ -240,6 +240,35 @@ def find_first_matching_rpath_with_origin(binary: Path, lib_dir: Path, rpaths: l
             return Path(rpath)
     return None
 
+
+def relativize_rpath_to_origin(*, binary_path: Path, rpath_entries: list[Path], containing_path: Path) -> list[Path]:
+    """
+    Rewrite absolute RPATH entries to use $ORIGIN when the entry sits
+    under containing_path (the --paths entry the binary was found
+    under).
+
+    The resulting RPATH is relocatable: as long as the directory layout
+    within containing_path is preserved, the whole tree can be moved
+    and the binary will still find its dependencies.
+
+    Entries that already contain $ORIGIN are left untouched.
+    Entries outside containing_path are also left absolute.
+    """
+    containing_norm: Path = Path(os.path.normpath(containing_path))
+    new_rpath_entries: list[Path] = []
+    for entry in rpath_entries:
+        if "$ORIGIN" in entry.as_posix():
+            new_rpath_entries.append(entry)
+            continue
+        entry_norm: Path = Path(os.path.normpath(entry))
+        if not entry_norm.is_relative_to(containing_norm):
+            new_rpath_entries.append(entry)
+            continue
+        rel = os.path.relpath(entry_norm, binary_path.parent)
+        new_rpath_entries.append(Path("$ORIGIN") / rel)
+    return new_rpath_entries
+
+
 class Event(Protocol):
     """Protocol for loggable events that occur during the auto-patchelf process."""
     def to_human_readable_str(self) -> str: ...
@@ -317,7 +346,18 @@ class Logger:
 
 
 
-def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], append_rpaths: list[Path] = [], keep_libc: bool = False, preserve_origin: bool = False, extra_args: list[str] = []) -> list[Dependency]:
+def auto_patchelf_file(
+    *,
+    logger: Logger,
+    runtime_deps: list[Path],
+    append_rpaths: list[Path] = [],
+    keep_libc: bool = False,
+    preserve_origin: bool = False,
+    relativize_rpath: bool = False,
+    extra_args: list[str] = [],
+    path: Path,
+    containing_path: Path
+) -> list[Dependency]:
     try:
         with open_elf(path) as elf:
 
@@ -436,6 +476,9 @@ def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], app
             if "$ORIGIN" in existing_rpath:
                 rpath.append(Path(existing_rpath))
 
+    if relativize_rpath:
+        rpath = relativize_rpath_to_origin(binary_path=path, rpath_entries=rpath, containing_path=containing_path)
+
     # Dedup the rpath
     rpath_str = ":".join(dict.fromkeys(map(Path.as_posix, rpath)))
 
@@ -458,6 +501,7 @@ def auto_patchelf(
         append_rpaths: list[Path] = [],
         keep_libc: bool = False,
         preserve_origin: bool = False,
+        relativize_rpath: bool = False,
         add_existing: bool = True,
         extra_args: list[str] = []) -> None:
 
@@ -472,9 +516,20 @@ def auto_patchelf(
     populate_cache(lib_dirs)
 
     dependencies = []
-    for path in chain.from_iterable(glob(p, '*', recursive) for p in paths_to_patch):
-        if not path.is_symlink() and path.is_file():
-            dependencies += auto_patchelf_file(logger, path, runtime_deps, append_rpaths, keep_libc, preserve_origin, extra_args)
+    for containing_path in paths_to_patch:
+        for path in glob(containing_path, '*', recursive):
+            if not path.is_symlink() and path.is_file():
+                dependencies += auto_patchelf_file(
+                    logger=logger,
+                    runtime_deps=runtime_deps,
+                    append_rpaths=append_rpaths,
+                    keep_libc=keep_libc,
+                    preserve_origin=preserve_origin,
+                    relativize_rpath=relativize_rpath,
+                    extra_args=extra_args,
+                    path=path,
+                    containing_path=containing_path
+                )
 
     missing = [dep for dep in dependencies if not dep.found]
 
@@ -561,6 +616,12 @@ def main() -> None:
         help="When possible, replace absolute RPATH entries with original $ORIGIN entries that resolve to the same directory.",
     )
     parser.add_argument(
+        "--relativize-rpath",
+        dest="relativize_rpath",
+        action="store_true",
+        help="Rewrite absolute RPATH entries to use $ORIGIN when the binary and the entry live under the same --paths root, so the patched tree is relocatable.",
+    )
+    parser.add_argument(
         "--ignore-existing",
         dest="add_existing",
         action="store_false",
@@ -597,6 +658,7 @@ def main() -> None:
         append_rpaths=args.append_rpaths,
         keep_libc=args.keep_libc,
         preserve_origin=args.preserve_origin,
+        relativize_rpath=args.relativize_rpath,
         add_existing=args.add_existing,
         extra_args=args.extra_args)
 

--- a/pkgs/test/auto-patchelf-hook-relativize-rpath/default.nix
+++ b/pkgs/test/auto-patchelf-hook-relativize-rpath/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  tests,
+  autoPatchelfHook,
+  patchelf,
+  python3,
+}:
+
+let
+  foo = tests.stdenv-inputs.foo;
+
+  # Produce a tree containing lib/{baz.so,libs/foo.so},
+  # with src/lib/libbaz.so calling code from src/lib/libs/libfoo.so.
+  # These have absolute paths.
+  baz-bundle = stdenv.mkDerivation {
+    name = "baz-bundle";
+
+    buildCommand = ''
+      mkdir -p $out/lib/libs
+      cp ${(lib.getDev foo)}/lib/libfoo.so $out/lib/libs/
+
+      mkdir -p $out/lib/
+      $CC -shared -lfoo -L$out/lib/libs -o $out/lib/libbaz.so ${./lib-baz.c}
+    '';
+
+    # No references to the foo store path.
+    disallowedReferences = [
+      (lib.getDev foo)
+    ];
+  };
+
+  # Make baz-bundle relocatable, by running autopatchelf with the `--relativize-rpath` flag.
+  # This will replace the `RPATH` of `$out/lib/libbaz.so` from `$out/lib/libs` to `$ORIGIN/libs`.
+  baz-bundle-relocatable = stdenv.mkDerivation {
+    name = "baz-bundle-relocatable";
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+    ];
+
+    autoPatchelfFlags = [ "--relativize-rpath" ];
+
+    dontUnpack = true;
+
+    # we don't set buildCommand because we want to ensure fixupPhase
+    # (containing autoPatchelfHook) is run.
+    installPhase = ''
+      mkdir -p $out
+      cp -R ${baz-bundle}/lib $out/lib
+    '';
+
+    # Now these two .so files refer neither to `baz-bundle`, nor contain self-references.
+    disallowedReferences = [
+      baz-bundle
+      "out"
+    ];
+  };
+
+in
+# Pretend a user consumed `baz-bundle-relocatable` as an artifact,
+# copied to ./libs/baz-bundle, and calls `baz` from `libbaz.so` from their code.
+# Ensure this works, which requires `baz()` to still be able to find `foo()`.
+stdenv.mkDerivation {
+  name = "auto-patchelf-hook-relativize-rpath";
+  nativeBuildInputs = [
+    patchelf
+    python3
+  ];
+
+  buildCommand = ''
+    mkdir -p libs/baz-bundle
+    cp -R ${baz-bundle-relocatable}/lib/* libs/baz-bundle/
+
+    echo "RPATHs:"
+    echo -n "libs/baz-bundle/libbaz.so:     "
+    patchelf --print-rpath libs/baz-bundle/libbaz.so
+    echo -n "libs/baz-bundle/lib/libfoo.so: "
+    patchelf --print-rpath libs/baz-bundle/libs/libfoo.so
+
+    cp ${./main.py} main.py
+    python main.py |& tee /dev/stderr | grep -q "foo returned 42"
+
+    touch $out
+  '';
+
+  meta.platforms = lib.platforms.linux;
+}

--- a/pkgs/test/auto-patchelf-hook-relativize-rpath/lib-baz.c
+++ b/pkgs/test/auto-patchelf-hook-relativize-rpath/lib-baz.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+extern unsigned int foo(void);
+
+extern unsigned int baz(void)
+{
+    fprintf(stderr, "about to call foo()\n");
+    fprintf(stderr, "foo returned %d\n", foo());
+    return 0;
+}

--- a/pkgs/test/auto-patchelf-hook-relativize-rpath/main.py
+++ b/pkgs/test/auto-patchelf-hook-relativize-rpath/main.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import ctypes
+
+lib_path = Path(__file__).parent / "libs/baz-bundle/libbaz.so"
+lib = ctypes.CDLL(str(lib_path))
+
+lib.baz.restype = ctypes.c_uint
+lib.baz.argtypes = []
+
+lib.baz()

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -247,6 +247,8 @@ in
 
   auto-patchelf-hook-preserve-origin = callPackage ./auto-patchelf-hook-preserve-origin { };
 
+  auto-patchelf-hook-relativize-rpath = callPackage ./auto-patchelf-hook-relativize-rpath { };
+
   # Accumulate all passthru.tests from arrayUtilities into a single attribute set.
   arrayUtilities = recurseIntoAttrs (
     concatMapAttrs (


### PR DESCRIPTION
This adds a `--relativize-rpath` flag, which infers `$ORIGIN` for a shared object's RUNPATH entries if the object and entry both fall under a path provided to auto-patchelf via `--paths`.

Sometimes Python wheels distribute shared objects in multiple directories, where the objects in one directory depend on shared objects in another directory. The RUNPATH entries that declare where to find the dependent objects are usually provided as absolute paths, which breaks if the objects are moved around.

It then adds a test where we making use of this flag. It produces an output containing two `.so` files `auto-patchelf`'ed to use relative rpaths, and shows how these can be freely moved around and loaded as long as that subtree is kept the same.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
