### PR TITLE
libnfc-nci: 2.4.1-unstable-2024-08-05 -> 2.4.1-unstable-2026-08-11

### DIFF
--- a/pkgs/by-name/li/libnfc-nci/package.nix
+++ b/pkgs/by-name/li/libnfc-nci/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libnfc-nci";
-  version = "2.4.1-unstable-2024-08-05";
+  version = "2.4.1-unstable-2026-08-11";
 
   src = fetchFromGitHub {
     owner = "StarGate01";
     repo = "linux_libnfc-nci";
-    rev = "7ce9c8aad0e37850a49b6d8dcc22ae5c783268e7";
-    sha256 = "sha256-iSvDiae+A2hUok426Lj5TMn3Q9G+vH1G0jajP48PehQ=";
+    rev = "1ed3cced60d3c7c5bb08486d54db322ac099a3dd";
+    sha256 = "sha256-eIYey7N3CWomEDYQ8OVdx/f6vZN+TavYhNMiYh5KJPo=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Libtool 2.6 (e7fc5f5) stopped propagating `dependency_libs` from `.la` files to avoid overlinking on ELF systems. This exposed a pre-existing bug in `linux_libnfc-nci`: `-Bstatic` was set in `AM_LDFLAGS`, which prevented `libstdc++.so` from appearing in `libnfc_nci_linux.so`'s `DT_NEEDED`. As a result, `nfcDemoApp` failed to link and `pcscd` failed to load `libifdnfc-nci.so` at runtime with an undefined C++ RTTI symbol.

The fix was applied upstream (StarGate01/linux_libnfc-nci@1ed3cce): removing `-Bstatic` so libtool builds the shared library cleanly with `libstdc++.so` properly recorded as a runtime dependency. This updates `libnfc-nci` to that commit and fixes `ifdnfc-nci` transitively.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
