### PR TITLE
git-vault: init at 1.0.0

### DIFF
--- a/pkgs/by-name/gi/git-vault/package.nix
+++ b/pkgs/by-name/gi/git-vault/package.nix
@@ -1,0 +1,60 @@
+{
+  buildPackages,
+  fetchFromGitHub,
+  gitMinimal,
+  installShellFiles,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-vault";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "roman-16";
+    repo = "git-vault";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PfMiKFLm4yq7Iw4vNlUAblXzBaoz2uMND3hAxxxJZ2U=";
+  };
+
+  cargoHash = "sha256-CmSes391V1/fbSuh2MrESO7J3wzq0pBwMNivog6tKAE=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  postInstall =
+    let
+      gitVault = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/git-vault";
+    in
+    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+      ${gitVault} man "$TMPDIR/man"
+      installManPage "$TMPDIR"/man/*.1
+
+      installShellCompletion --cmd git-vault \
+        --bash <(${gitVault} completions bash) \
+        --fish <(${gitVault} completions fish) \
+        --zsh <(${gitVault} completions zsh)
+    '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Transparent encryption for git that collapses everything it protects into one opaque file";
+    homepage = "https://github.com/roman-16/git-vault";
+    changelog = "https://github.com/roman-16/git-vault/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "git-vault";
+    maintainers = with lib.maintainers; [ roman-16 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
[git-vault](https://github.com/roman-16/git-vault) is transparent encryption for git: secrets stay ordinary files in the worktree, while the repository holds one opaque file that hides their contents as well as their names, paths and directory structure. Plain git commands keep working, and the vault key is wrapped per recipient with [age](https://age-encryption.org).

Notes: the upstream test suite runs in the check phase and needs only `gitMinimal`; man pages and completions come from the built binary, guarded so cross-compilation still works; no `git` wrapper, since git prepends its own `libexec/git-core` to `PATH` for subcommands, hooks and filters, and the `core.fsmonitor` hook installed by `git vault init` runs on every `git status` under a 2 ms upstream budget.

Produced with LLM assistance (pi 0.84.1, claude-opus-5), reviewed and verified by me, per the [automation/AI policy]; the commit carries the `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
