### PR TITLE
qemu: 11.0.3 -> 11.1.0

### DIFF
--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -258,7 +258,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals brlttySupport [ brltty ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
 
-  dontUseMesonConfigure = true; # meson's configurePhase isn't compatible with qemu build
+  # QEMU uses Meson and Ninja but still wants Make to be the entrypoint.
+  dontUseMesonConfigure = true;
+  dontUseNinjaBuild = true;
+  dontUseNinjaCheck = true;
+  dontUseNinjaInstall = true;
   dontAddStaticConfigureFlags = true;
 
   outputs = [ "out" ] ++ lib.optional enableDocs "doc" ++ lib.optional guestAgentSupport "ga";
@@ -304,6 +308,8 @@ stdenv.mkDerivation (finalAttrs: {
     mv VERSION QEMU_VERSION
     substituteInPlace configure \
       --replace-fail '$source_path/VERSION' '$source_path/QEMU_VERSION'
+    substituteInPlace Makefile \
+      --replace-fail '$(SRC_PATH)/VERSION' '$(SRC_PATH)/QEMU_VERSION'
     substituteInPlace meson.build \
       --replace-fail "'VERSION'" "'QEMU_VERSION'"
     substituteInPlace docs/conf.py \
@@ -384,7 +390,6 @@ stdenv.mkDerivation (finalAttrs: {
     # <https://github.com/NixOS/nixpkgs/issues/83667>
     rm -f $out/nix-support/propagated-build-inputs
   '';
-  preBuild = "cd build";
 
   # tests can still timeout on slower systems
   doCheck = false;
@@ -396,37 +401,37 @@ stdenv.mkDerivation (finalAttrs: {
   preCheck = ''
     # time limits are a little meagre for a build machine that's
     # potentially under load.
-    substituteInPlace ../tests/unit/meson.build \
+    substituteInPlace tests/unit/meson.build \
       --replace 'timeout: slow_tests' 'timeout: 50 * slow_tests'
-    substituteInPlace ../tests/qtest/meson.build \
+    substituteInPlace tests/qtest/meson.build \
       --replace 'timeout: slow_qtests' 'timeout: 50 * slow_qtests'
-    substituteInPlace ../tests/fp/meson.build \
+    substituteInPlace tests/fp/meson.build \
       --replace 'timeout: 90)' 'timeout: 300)'
 
     # point tests towards correct binaries
-    substituteInPlace ../tests/unit/test-qga.c \
+    substituteInPlace tests/unit/test-qga.c \
       --replace '/bin/bash' "$(type -P bash)" \
       --replace '/bin/echo' "$(type -P echo)"
-    substituteInPlace ../tests/unit/test-io-channel-command.c \
+    substituteInPlace tests/unit/test-io-channel-command.c \
       --replace '/bin/socat' "$(type -P socat)"
 
     # combined with a long package name, some temp socket paths
     # can end up exceeding max socket name len
-    substituteInPlace ../tests/qtest/bios-tables-test.c \
+    substituteInPlace tests/qtest/bios-tables-test.c \
       --replace 'qemu-test_acpi_%s_tcg_%s' '%s_%s'
 
     # get-fsinfo attempts to access block devices, disallowed by sandbox
     sed -i -e '/\/qga\/get-fsinfo/d' -e '/\/qga\/blacklist/d' \
-      ../tests/unit/test-qga.c
+      tests/unit/test-qga.c
 
     # xattrs are not allowed in the sandbox
-    substituteInPlace ../tests/qtest/virtio-9p-test.c \
+    substituteInPlace tests/qtest/virtio-9p-test.c \
       --replace-fail mapped-xattr mapped-file
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # skip test that stalls on darwin, perhaps due to subtle differences
     # in fifo behaviour
-    substituteInPlace ../tests/unit/meson.build \
+    substituteInPlace tests/unit/meson.build \
       --replace "'test-io-channel-command'" "#'test-io-channel-command'"
   '';
 

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -405,15 +405,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace 'timeout: slow_tests' 'timeout: 50 * slow_tests'
     substituteInPlace tests/qtest/meson.build \
       --replace 'timeout: slow_qtests' 'timeout: 50 * slow_qtests'
-    substituteInPlace tests/fp/meson.build \
-      --replace 'timeout: 90)' 'timeout: 300)'
-
-    # point tests towards correct binaries
-    substituteInPlace tests/unit/test-qga.c \
-      --replace '/bin/bash' "$(type -P bash)" \
-      --replace '/bin/echo' "$(type -P echo)"
-    substituteInPlace tests/unit/test-io-channel-command.c \
-      --replace '/bin/socat' "$(type -P socat)"
 
     # combined with a long package name, some temp socket paths
     # can end up exceeding max socket name len

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -143,11 +143,11 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString nixosTestRunner "-for-vm-tests"
     + lib.optionalString toolsOnly "-utils"
     + lib.optionalString userOnly "-user";
-  version = "11.0.3";
+  version = "11.1.0";
 
   src = fetchurl {
     url = "https://download.qemu.org/qemu-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2l/P/DJ2KCBWi4KO1DCnKIZNNNULbS8wNYWXdgy7BSM=";
+    hash = "sha256-buHRph9oISR2snEIwm2l9EncCbYm1C+CeboNwuCPqFg=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -402,14 +402,14 @@ stdenv.mkDerivation (finalAttrs: {
     # time limits are a little meagre for a build machine that's
     # potentially under load.
     substituteInPlace tests/unit/meson.build \
-      --replace 'timeout: slow_tests' 'timeout: 50 * slow_tests'
+      --replace-fail 'timeout: slow_tests' 'timeout: 50 * slow_tests'
     substituteInPlace tests/qtest/meson.build \
-      --replace 'timeout: slow_qtests' 'timeout: 50 * slow_qtests'
+      --replace-fail 'timeout: slow_qtests' 'timeout: 50 * slow_qtests'
 
     # combined with a long package name, some temp socket paths
     # can end up exceeding max socket name len
     substituteInPlace tests/qtest/bios-tables-test.c \
-      --replace 'qemu-test_acpi_%s_tcg_%s' '%s_%s'
+      --replace-fail 'qemu-test_acpi_%s_tcg_%s' '%s_%s'
 
     # get-fsinfo attempts to access block devices, disallowed by sandbox
     sed -i -e '/\/qga\/get-fsinfo/d' -e '/\/qga\/blacklist/d' \
@@ -423,7 +423,7 @@ stdenv.mkDerivation (finalAttrs: {
     # skip test that stalls on darwin, perhaps due to subtle differences
     # in fifo behaviour
     substituteInPlace tests/unit/meson.build \
-      --replace "'test-io-channel-command'" "#'test-io-channel-command'"
+      --replace-fail "'test-io-channel-command'" "#'test-io-channel-command'"
   '';
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.


### PR DESCRIPTION
QEMU assumes Make is used for all of these, and the Ninja targets might not do the things one would expect.  For example, in current QEMU rcs, ninja check runs tests that are disabled when run via make check (and seem like they are not intended to be run widely).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
