### PR TITLE
yopass: init at 14.9.0

### DIFF
--- a/pkgs/by-name/yo/yopass/package.nix
+++ b/pkgs/by-name/yo/yopass/package.nix
@@ -1,0 +1,57 @@
+{
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  lib,
+}:
+let
+  version = "14.9.0";
+  src = fetchFromGitHub {
+    owner = "jhaals";
+    repo = "yopass";
+    tag = version;
+    hash = "sha256-YZeSGcQcAsOmIwhhVpGN7bxlNGsWIJNAwUBxJM/7314=";
+  };
+
+  website = callPackage ./website.nix { inherit src version; };
+in
+buildGoModule (finalAttrs: {
+  inherit version src;
+  pname = "yopass";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  vendorHash = "sha256-mR17QPGZNJ9Vx6y6mExvZDKReVxdUif8aQ6VMfKVgcM=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  subPackages = [
+    "cmd/yopass"
+    "cmd/yopass-server"
+  ];
+
+  checkFlags = [
+    # Disable tests that require network access
+    "-skip=TestSecretNotFoundError"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/yopass-server \
+      --add-flags "--asset-path ${website}"
+  '';
+
+  meta = {
+    description = "Secure sharing of secrets, passwords and files";
+    homepage = "https://github.com/jhaals/yopass";
+    changelog = "https://github.com/jhaals/yopass/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      ivarmedi
+      fraggerfox
+    ];
+    mainProgram = "yopass";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/yo/yopass/website.nix
+++ b/pkgs/by-name/yo/yopass/website.nix
@@ -1,0 +1,35 @@
+{
+  fetchYarnDeps,
+  nodejs-slim,
+  src,
+  stdenv,
+  version,
+  yarnBuildHook,
+  yarnConfigHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yopass-website";
+  inherit version;
+
+  src = src + "/website";
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-x3ouozoDreaeeqoh8osXOqEYphy6vTalLMjQt5vowkg=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs-slim
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mv dist $out
+
+    runHook postInstall
+  '';
+})


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


Import [yopass](https://github.com/jhaals/yopass) into nixpkgs.
- The original [PR](https://github.com/NixOS/nixpkgs/pull/442730) got stuck in review process and the author has not responded for two weeks.
- I have added myself also as a co-maintainer for this package because of this.
- In a follow up PR I intend to add the nix module to help configure the server side of this package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
