### PR TITLE
gtpdoor-scan: init at 0.1

### DIFF
--- a/pkgs/by-name/gt/gtpdoor-scan/package.nix
+++ b/pkgs/by-name/gt/gtpdoor-scan/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  libpcap,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gtpdoor-scan";
+  version = "0.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "haxrob";
+    repo = "gtpdoor-scan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jVF37FzrdkPe7C7pvj73vxHWDJcxiH5UekaM42RNOEg=";
+  };
+
+  vendorHash = "sha256-SSVz4WMi0MCeXkinhiLzyWn3UEmDk+3WwyVkFwAHbzI=";
+
+  buildInputs = [ libpcap ];
+
+  meta = {
+    description = "Network scanner to scan for hosts infected with the GTPDOOR malware";
+    homepage = "https://github.com/haxrob/gtpdoor-scan";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
