### PR TITLE
walls: init at 0.13.4

### DIFF
--- a/pkgs/by-name/wa/walls/package.nix
+++ b/pkgs/by-name/wa/walls/package.nix
@@ -14,6 +14,7 @@
   libappindicator,
   libdbusmenu-gtk3,
   nix-update-script,
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -40,6 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ pkg-config ];
 
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     gtk3
     gdk-pixbuf
@@ -58,12 +61,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip"
     "tui_with_pty_exits_cleanly_on_quit"
   ];
-
-  # Config/state paths expand under HOME; point at TMPDIR in the sandbox.
-  preCheck = ''
-    export HOME="$TMPDIR/walls-test-home"
-    mkdir -p "$HOME"
-  '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/share/icons/hicolor/scalable/apps $out/share/applications

--- a/pkgs/by-name/wa/walls/package.nix
+++ b/pkgs/by-name/wa/walls/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  xdg-terminal-exec,
+  gtk3,
+  gdk-pixbuf,
+  cairo,
+  pango,
+  glib,
+  atk,
+  libappindicator,
+  libdbusmenu-gtk3,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "walls";
+  version = "0.13.4";
+
+  src = fetchFromGitHub {
+    owner = "willfish";
+    repo = "walls";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6c4NdXGPsDFqlLLMH2BL0MpoQpZiLxJnWMzWKN1bO84=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-WZK3QkeBqDkH/5m9mqhyJQDKZoA6LfEuFbMRImJN4oQ=";
+
+  cargoBuildFlags = [
+    "-p"
+    "walls"
+    "-p"
+    "walls-tray"
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gtk3
+    gdk-pixbuf
+    cairo
+    pango
+    glib
+    atk
+    libappindicator
+    libdbusmenu-gtk3
+  ];
+
+  # PTY integration test is unreliable in the Nix build sandbox.
+  cargoTestFlags = [
+    "--workspace"
+    "--"
+    "--skip"
+    "tui_with_pty_exits_cleanly_on_quit"
+  ];
+
+  # Config/state paths expand under HOME; point at TMPDIR in the sandbox.
+  preCheck = ''
+    export HOME="$TMPDIR/walls-test-home"
+    mkdir -p "$HOME"
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/share/icons/hicolor/scalable/apps $out/share/applications
+    cp assets/icons/walls-tray.svg $out/share/icons/hicolor/scalable/apps/walls.svg
+    substitute assets/applications/walls.desktop.in $out/share/applications/walls.desktop \
+      --replace-fail '@walls@' "$out/bin/walls" \
+      --replace-fail '@xdg-terminal-exec@' "${lib.getExe xdg-terminal-exec}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wallpaper manager with Wallhaven sources, CLI/TUI, and tray";
+    homepage = "https://github.com/willfish/walls";
+    changelog = "https://github.com/willfish/walls/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ willfish ];
+    mainProgram = "walls";
+    # Upstream CI builds the flake package on x86_64/aarch64 Linux and Darwin
+    # (tray GTK deps are Linux-only; Darwin still produces walls + walls-tray).
+    # x86_64-darwin is dropped in nixpkgs 26.11; platforms.darwin is aarch64-only there.
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description

Add [walls](https://github.com/willfish/walls), a wallpaper manager with:

- CLI + keyboard-first TUI + system tray (`walls`, `walls-tray`)
- Wallhaven and local library sources
- Apply backends for COSMIC, GNOME-family, KDE, XFCE, sway/Hyprland, and feh/nitrogen fallback (Linux desktops)

Packaged with `rustPlatform.buildRustPackage` from the `v0.13.4` tag under `pkgs/by-name/wa/walls`.

### Platforms

`meta.platforms` is **Linux + Darwin** (Hydra-supported systems: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`). Upstream flake CI also builds those three plus `x86_64-darwin` on the project side; nixpkgs 26.11 no longer evaluates `x86_64-darwin`.

| System | `meta.platforms` | Built / tested for this PR |
|--------|------------------|----------------------------|
| `x86_64-linux` | yes | yes — local sandbox `nix-build -A walls` |
| `aarch64-linux` | yes | not yet in this PR (ofborg / Hydra) |
| `aarch64-darwin` | yes | not yet in this PR (ofborg / Hydra) |

Linux-only: GTK/AppIndicator tray native deps and desktop entry/icon install. Darwin still builds `walls` and `walls-tray` without those inputs.

Upstream multi-arch packaging job: [willfish/walls CI](https://github.com/willfish/walls/blob/main/.github/workflows/ci.yml).

## Things done



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [`nix.conf` manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and &#34;core&#34; functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/tree/master/pkgs/test)
  - based on changes in [utils](https://github.com/NixOS/nixpkgs/tree/master/pkgs/utils), [lib](https://github.com/NixOS/nixpkgs/tree/master/lib), [min-kernel](https://github.com/NixOS/nixpkgs/tree/master/pkgs/os-specific/linux/kernel/common-config.nix), or core packages like [systemd](https://github.com/NixOS/nixpkgs/tree/master/pkgs/os-specific/linux/systemd)
- [ ] Tested compilation of all packages that depend on this change using `nixpkgs-review`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] [Fits CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Tested (this PR, x86_64-linux)

- `nix-build -A walls` (sandbox)
- Workspace cargo tests (PTY integration test skipped in sandbox)
- `./result/bin/walls --help` and `./result/bin/walls -V` → `walls 0.13.4`
- Desktop entry and icon installed under `$out/share`

I am the upstream author and listed as package maintainer (`willfish`).

### Automation/AI disclosure

OpenAI Codex using `gpt-5.6-sol` assisted with all content in this contribution, including the package expression, commit message, and PR description. I drove the intent and remained actively involved in the decisions, taste, and wording. I manually reviewed the final contribution and established confidence through the sandbox build, workspace tests, binary smoke tests, and installed-asset checks listed above.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments
[pull requests you find important]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#how-to-get-your-pull-requests-merged