### PR TITLE
ltesniffer: init at 2.1.0

### DIFF
--- a/pkgs/by-name/lt/ltesniffer/package.nix
+++ b/pkgs/by-name/lt/ltesniffer/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  mkl,
+  uhd,
+  glib,
+  srsran,
+  soapysdr,
+  libbladeRF,
+  boost,
+  fftwFloat,
+  libsysprof-capture,
+  pcre2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ltesniffer";
+  version = "2.1.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "SysSec-KAIST";
+    repo = "LTESniffer";
+    tag = "LTESniffer-v${finalAttrs.version}";
+    hash = "sha256-s5w8v5nrAv2IK4rv7aukcDAXrol5P3wfWceSkCOGEAc=";
+  };
+
+  cmakeFlags = [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
+    "-DCMAKE_PROJECT_NAME=ltesniffer"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    mkl
+    uhd
+    glib
+    srsran
+    soapysdr
+    libbladeRF
+    boost
+    fftwFloat
+    libsysprof-capture
+    pcre2
+  ];
+
+  meta = {
+    description = "Open-source LTE Downlink/Uplink Eavesdropper";
+    homepage = "https://github.com/SysSec-KAIST/LTESniffer";
+    license = lib.licenses.agpl3Only;
+  };
+})


### PR DESCRIPTION
Multiple issues:
- Could NOT find CMNALIB (missing: CMNALIB_LIBRARIES)
- Could NOT find mkl
- libSOAPYSDR not found
- Error: could not find CMAKE_PROJECT_NAME in Cache
- Could NOT find Boost: missing: system (found /nix/store/hl9mnablabykyx4q5dw7a9cdp2m1pclh-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake (found suitable version "1.89.0", minimum required is "1.35"))
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
