### PR TITLE
whisrs: init at 0.1.24

### DIFF
--- a/pkgs/by-name/wh/whisrs/package.nix
+++ b/pkgs/by-name/wh/whisrs/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  cmake,
+  installShellFiles,
+  llvmPackages,
+  pkg-config,
+
+  alsa-lib,
+  libxkbcommon,
+
+  nix-update-script,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "whisrs";
+  version = "0.1.24";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "y0sif";
+    repo = "whisrs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-X0bU3UJYXrwWMVIOrzMENl2VsVHcDYcHCKkQWWvTY6s=";
+  };
+
+  cargoHash = "sha256-z4oBV0VdzszGIWc6O0om2lvKXuDOWRgbC8YbEBFsj6o=";
+
+  nativeBuildInputs = [
+    cmake
+    installShellFiles
+    llvmPackages.clang
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libxkbcommon
+  ];
+
+  postInstall = ''
+    installManPage contrib/whisrs.1 contrib/whisrsd.1
+    install -Dm644 contrib/whisrs.service -t $out/lib/systemd/user
+  '';
+
+  versionCheckProgram = "${placeholder "out"}/bin/whisrsd";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Voice-to-text dictation daemon that types transcriptions into the focused window";
+    homepage = "https://github.com/y0sif/whisrs";
+    license = lib.licenses.mit;
+    mainProgram = "whisrs";
+    maintainers = with lib.maintainers; [ otavio ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Supersedes #545837 (closed in favour of this one): it was opened at 0.1.20 and upstream has since released 0.1.24.

`whisrs` is a Linux-native voice-to-text dictation daemon written in Rust. You press a hotkey, speak, and the transcription is typed directly into the focused window via `uinput` or the Wayland virtual-keyboard protocol. It ships six transcription backends — Groq, Deepgram (REST and streaming), OpenAI (REST and Realtime), and offline whisper.cpp.

Homepage: https://github.com/y0sif/whisrs

**Despite the name, this is unrelated to the existing `whisper-*` packages.** It is not OpenAI's Whisper model or a wrapper around it. Nixpkgs already has `whisper-cpp`, `openai-whisper`, `whisper-ctranslate2` and friends; `whisrs` is a dictation daemon that can *optionally* use whisper.cpp as one of its six backends (via the default `local-whisper` cargo feature, which vendors and builds whisper.cpp through `whisper-rs`/bindgen — hence the `cmake` + `clang` + `bindgenHook` inputs).

The package installs two binaries, `whisrs` (CLI) and `whisrsd` (daemon), plus the upstream man pages and a systemd user unit.

Upstream's `contrib/99-whisrs.rules` is **deliberately not installed**. It grants `/dev/uinput` to the `input` group, whereas NixOS manages uinput through `hardware.uinput.enable`, which uses the `uinput` group. Because the rule would sort after the `99-local.rules` that `services.udev.extraRules` generates, activating it via `services.udev.packages` would override that group and could break an otherwise working setup. NixOS users should enable `hardware.uinput.enable` and add themselves to the `uinput` group instead; nothing in nixpkgs or systemd grants uinput access by default (systemd's `70-uaccess.rules` tags only `rfkill` in the `misc` subsystem).

This is the package only — no NixOS module is included in this PR.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Notes on the above:

- `nixpkgs-review rev HEAD` on x86_64-linux: 1 package added, 1 package built, 0 failed.
- Upstream's own test suite runs during `checkPhase` in the sandbox with no workarounds: 409 tests (302 + 106 + 1) pass.
- `versionCheckHook` is wired up and passes. It is pointed at `whisrsd` via `versionCheckProgram` rather than at `meta.mainProgram`: since 0.1.21 the daemon answers `--version` instead of starting up, and that is the behaviour worth guarding. `whisrs` was additionally smoke-tested by hand.
- Only x86_64-linux was built; `meta.platforms` is `lib.platforms.linux` since nothing in the source is arch-specific, but I have not verified aarch64-linux.

Assisted-by: Claude Code (claude-opus-5)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



