### PR TITLE
stinkpot: init at 0.1.0

### DIFF
--- a/pkgs/by-name/st/stinkpot/package.nix
+++ b/pkgs/by-name/st/stinkpot/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchgit,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "stinkpot";
+  version = "0.1.0-unstable-2026-08-01";
+  env.CGO_ENABLED = "0";
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+  src = fetchgit {
+    url = "https://tangled.org/oppi.li/stinkpot";
+    rev = "8fa6de51adebb1ddeffbfb3b79c0885c2403575a";
+    hash = "sha256-766l6US0ISPPO7ygPtYryInvLF9wF0q1fWc9IWlSGVY=";
+  };
+
+  vendorHash = "sha256-IVPACl1oWnBKGzcXvG5gzev8MwhzIKNI7zwEKJjhFc8=";
+
+  passthru.updateScript = nix-update-script { };
+  __structuredAttrs = true;
+
+  meta = {
+    description = "sqlite-backed shell history";
+    mainProgram = "stinkpot";
+    homepage = "https://tangled.org/oppi.li/stinkpot";
+    maintainers = [ lib.maintainers.supermarin ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [stinkpot](https://tangled.org/oppi.li/stinkpot), a sqlite3 backed shell history cli.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
