### PR TITLE
swsim: init at 0-unstable-2026-05-02

### DIFF
--- a/pkgs/by-name/sw/swicc/package.nix
+++ b/pkgs/by-name/sw/swicc/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gcc,
+  cmake,
+}:
+
+stdenv.mkDerivation {
+  pname = "swicc";
+  version = "0-unstable-2026-05-02";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tomasz-lisowski";
+    repo = "swicc";
+    rev = "2b9c3257816fdd97f7673f3f6eebed0541202047";
+    hash = "sha256-7+kxrZY165aJsVSAZgmcNlazDA8JmK4qdU6DD+ptAUc=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    gcc
+    cmake
+  ];
+
+  configurePhase = ''
+    make main-dbg
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -v ./build/libswicc.a $out/lib
+    cp -rv ./include $out
+  '';
+
+  meta = {
+    description = "Framework for creating smart cards";
+    homepage = "https://github.com/tomasz-lisowski/swicc";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+}

--- a/pkgs/by-name/sw/swsim/package.nix
+++ b/pkgs/by-name/sw/swsim/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gcc,
+  cmake,
+  swicc,
+}:
+
+stdenv.mkDerivation {
+  pname = "swsim";
+  version = "0-unstable-2026-05-02";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tomasz-lisowski";
+    repo = "swsim";
+    rev = "281da8c63398ece9a5126cad969674f4f413ab63";
+    hash = "sha256-cfbd9YV3odbXZ1TsbgHaYEiCmFan86fdSGoKAe4HbGI=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    gcc
+    cmake
+    swicc
+  ];
+
+  configurePhase = ''
+    make main-dbg
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v ./build/swsim.elf $out/bin/swsim
+  '';
+
+  meta = {
+    description = "Software SIM card";
+    homepage = "https://github.com/tomasz-lisowski/swsim";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ felbinger ];
+    mainProgram = "swsim";
+  };
+}


### PR DESCRIPTION
[versionCheckHook](https://github.com/NixOS/nixpkgs/blob/master/doc/hooks/versionCheckHook.section.md) cannot be used because even though this is not released yet the programs version is v0.0.1.

There seams to be another issue: Failed to load/generate disk: error.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
