### PR TITLE
python3Packages.ww-manager: init at 2.1.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31432,6 +31432,12 @@
     github = "yechielw";
     githubId = 41305372;
   };
+  yefada = {
+    name = "Chi Ye";
+    email = "yezhidezhangh@163.com";
+    github = "YeFaDa";
+    githubId = 261456766;
+  };
   yelite = {
     name = "Lite Ye";
     email = "yelite958@gmail.com";

--- a/pkgs/development/python-modules/ww-manager/default.nix
+++ b/pkgs/development/python-modules/ww-manager/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  typer,
+  certifi,
+  rich,
+  typing-extensions,
+  pythonOlder,
+  testers,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "ww-manager";
+  version = "2.1.12";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "timetetng";
+    repo = "wutheringwaves-cli-manager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1BYcPAzsFVUHXHqPKOLrQwTEJcX4OIxAkJDMN3BNS3M=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    certifi
+    rich
+    typer
+    typing-extensions
+  ];
+
+  # upstream ships no tests
+  doCheck = false;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "ww --version";
+  };
+
+  pythonImportsCheck = [
+    "ww_manager"
+  ];
+
+  meta = {
+    description = "Wuthering Waves CLI Manager";
+    homepage = "https://github.com/timetetng/wutheringwaves-cli-manager";
+    changelog = "https://github.com/timetetng/wutheringwaves-cli-manager/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.yefada ];
+    mainProgram = "ww";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10964,4 +10964,6 @@ with pkgs;
   };
 
   feishin-web = feishin.override { webVersion = true; };
+
+  ww-manager = python3Packages.toPythonApplication python3Packages.ww-manager;
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22379,6 +22379,8 @@ self: super: with self; {
 
   wurlitzer = callPackage ../development/python-modules/wurlitzer { };
 
+  ww-manager = callPackage ../development/python-modules/ww-manager { };
+
   wxpython = callPackage ../development/python-modules/wxpython/4.2.nix {
     wxGTK = pkgs.wxwidgets_3_2.override { withWebKit = true; };
   };


### PR DESCRIPTION
## Summary

Adds `ww-manager`, a command-line manager for the Wuthering Waves game client (designed for Linux users to manage downloads, verification, and fast server switching).

- **Homepage:** https://github.com/timetetng/wutheringwaves-cli-manager
- **PyPI:** https://pypi.org/project/ww-manager/

This is a new package. It builds successfully locally, and the CLI tool `ww` works as expected.
Assisted-by: Deepseeek Website

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation disclosure
This pull request was created with the assistance of AI website (chat.deepseek.com) solely for researching the latest nixpkgs Python packaging syntax and template formatting requirements. The final package expression was written and verified manually, and all changes have been tested locally.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
