### PR TITLE
pico-8: init at 0.2.7

### DIFF
--- a/pkgs/by-name/pi/pico-8/package.nix
+++ b/pkgs/by-name/pi/pico-8/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  makeBinaryWrapper,
+  makeDesktopItem,
+  requireFile,
+  sdl2-compat,
+  stdenv,
+  unzip,
+  wget,
+}:
+let
+  pname = "pico-8";
+  version = "0.2.7";
+
+  src = requireFile rec {
+    name = "${pname}_${version}_amd64.zip";
+    hash = "sha256-7fLOhUdAWFsPmIhO4J1j+auObIdy4BSKkCkntkCMnqo=";
+    message = ''
+      PICO-8 cannot be installed automatically since it requires a license.
+      The archive has to be loaded into the Nix Store manually.
+      In the email from lexaloffle, you should have a link to take you a page to download the application.
+
+      Example: https://www.lexaloffle.com/games.php?page=my&key=abcdefghijklm
+
+      Note you can also find specific versions at:
+       - https://www.lexaloffle.com/games.php?page=archive (requires login)
+
+      1. Visit the download page
+      2. Download the Linux 64-bit archive
+      3. Navigate to the downloaded file and run the following command
+         nix-prefetch-url file://$PWD/${name}
+      4. Re-run the installation
+    '';
+  };
+
+in
+stdenv.mkDerivation (finalAttrs: rec {
+  inherit pname version src;
+
+  desktopItem = makeDesktopItem {
+    name = "${pname}";
+    desktopName = "PICO-8";
+    comment = "Fantasy Console";
+    icon = "${pname}";
+    exec = meta.mainProgram;
+    categories = [ "Development" ];
+  };
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    unzip $src
+
+    runHook postUnpack
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    unzip
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cd pico-8
+
+    patchelf \
+      --add-needed ${sdl2-compat}/lib/libSDL2-2.0.so.0 \
+      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+      pico8
+
+    install -D -m 755 pico8 $out/bin/pico8
+    makeBinaryWrapper $out/bin/pico8 $out/bin/pico8-wrapped \
+      --prefix PATH : ${wget}/bin
+
+    install -D -m 664 pico8.dat $out/bin/pico8.dat
+    install -D -m 444 pico-8_manual.txt $out/share/doc/${pname}/manual.txt
+    install -D -m 444 license.txt $out/share/doc/${pname}/license/license.txt
+    install -D -m 444 lexaloffle-pico8.png $out/share/icons/hicolor/128x128/apps/${pname}.png
+    install -D -m 444 "${desktopItem}/share/applications/"* \
+      -t $out/share/applications/
+
+    runHook postInstall
+  '';
+
+  dontStrip = true;
+
+  meta = {
+    description = "Fantasy console for making, sharing and playing tiny games and other computer programs.";
+    homepage = "https://pico-8.com";
+    license = lib.licenses.unfree;
+    mainProgram = "pico8-wrapped";
+    maintainers = [ lib.maintainers.husjon ];
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
Adds PICO-8 to the repository with desktop entry, license and readme file.
Patches the binary with libSDL2 from sdl2-compat.
Creates wrapper adding wget to `PATH` (used to connect to the PICO-8 BBS for exploring, downloading and playing cartridges)
Set `strictDeps` and `__structuredAttrs` to `true` as requested by nixpkgs-vet.

Note: Due to license requirements, the user is required to prefetch the archive prior to install.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
