### PR TITLE
bottles-unwrapped: disable obs-vkcapture by default and add feature flag

### DIFF
--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -32,6 +32,7 @@
   obs-studio-plugins,
   nix-update-script,
   removeWarningPopup ? false,
+  withObsVkCapture ? false,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -114,13 +115,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
       mangohud
       vmtouch
       fvs2
-      obs-studio-plugins.obs-vkcapture
 
       # Undocumented (subprocess.Popen())
       lsb-release
       pciutils
       procps
-    ];
+    ]
+    ++ lib.optional withObsVkCapture obs-studio-plugins.obs-vkcapture;
 
   pyproject = false;
   dontWrapGApps = true; # prevent double wrapping

--- a/pkgs/by-name/bo/bottles/package.nix
+++ b/pkgs/by-name/bo/bottles/package.nix
@@ -5,6 +5,7 @@
   extraPkgs ? pkgs: [ ],
   extraLibraries ? pkgs: [ ],
   removeWarningPopup ? false,
+  withObsVkCapture ? false,
 }:
 
 let
@@ -17,7 +18,7 @@ let
       pkgs:
       with pkgs;
       [
-        (bottles-unwrapped.override { inherit removeWarningPopup; })
+        (bottles-unwrapped.override { inherit removeWarningPopup withObsVkCapture; })
         # This only allows to enable the toggle, vkBasalt won't work if not installed with environment.systemPackages (or nix-env)
         # See https://github.com/bottlesdevs/Bottles/issues/2401
         vkbasalt


### PR DESCRIPTION
`obs-vkcapture` inflate the package size by a large margin and is entirely optional. This disable support by default while adding a feature flag for users who wants this feature.

With `obs-vkcapture` support:
```bash
nix path-info -Sh /nix/store/cfa7nv53mfs5sr3k7dqh32k55j64l60w-bottles-65.4
/nix/store/cfa7nv53mfs5sr3k7dqh32k55j64l60w-bottles-65.4           5.7 GiB
```

Without `obs-vkcapture` support:
```bash
nix path-info -Sh /nix/store/h203h6c55f1dav47526cfwjzxw99an5a-bottles-65.4
/nix/store/h203h6c55f1dav47526cfwjzxw99an5a-bottles-65.4           3.1 GiB

```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
