### PR TITLE
nixos/auto-upgrade: add networkRetries option for network probing

### DIFF
--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -193,6 +193,18 @@ in
         '';
       };
 
+      networkRetries = lib.mkOption {
+        type = lib.types.ints.unsigned;
+        default = 6;
+        example = 0;
+        description = ''
+          Number of network connectivity probe attempts with exponential
+          backoff.
+
+          Setting this to `0` disables network probing.
+        '';
+      };
+
     };
 
   };
@@ -237,7 +249,49 @@ in
         cfg.runGarbageCollection && config.nix.enable
       ) "nix-gc.service";
 
-      serviceConfig.Type = "oneshot";
+      serviceConfig = {
+        ExecStartPre = lib.mkIf (cfg.networkRetries > 0) (
+          lib.getExe (
+            pkgs.writeShellApplication {
+              name = "nixos-upgrade-wait-network";
+              runtimeEnv.max_retries = cfg.networkRetries;
+
+              runtimeInputs = [
+                config.nix.package
+                pkgs.curl
+              ];
+
+              text = ''
+                sleep=1
+
+                for ((current_retries = 1; current_retries <= max_retries; current_retries++)); do
+                  if ${
+                    if cfg.flake != null then
+                      "nix --extra-experimental-features 'nix-command flakes' flake metadata ${lib.escapeShellArg (lib.head (lib.splitString "#" cfg.flake))}"
+                    else
+                      "curl --fail --location ${
+                        if cfg.channel != null then lib.escapeShellArg cfg.channel else "https://channels.nixos.org"
+                      }"
+                  } >/dev/null 2>&1; then
+                    exit 0
+                  fi
+
+                  if ((current_retries < max_retries)); then
+                    echo "warning: network endpoint unreachable; retrying in ''${sleep}s (attempt $current_retries/$max_retries)..."
+                    sleep "$sleep"
+                    ((sleep *= 2))
+                  fi
+                done
+
+                echo "error: network endpoint unreachable after $max_retries attempts"
+                exit 1
+              '';
+            }
+          )
+        );
+
+        Type = "oneshot";
+      };
 
       environment =
         config.nix.envVars


### PR DESCRIPTION
```
Add the system.autoUpgrade.networkRetries option for network probing
with exponential backoff to prevent immediate failures when waking up
from suspend or booting without network.

Closes: https://github.com/NixOS/nixpkgs/issues/73945
```

Aside from the trivial happy path with `system.autoUpgrade.flake`, this patch has barely been tested. Considering this patch enables this feature by default for practical reasons and touches critical infrastructure code, it should be thoroughly tested before merging.

This PR is primarily a PoC to tangibly progress https://github.com/NixOS/nixpkgs/issues/73945.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
