### PR TITLE
python3Packages.condense-json: 0.1.3 -> 1.1

### DIFF
--- a/pkgs/development/python-modules/condense-json/default.nix
+++ b/pkgs/development/python-modules/condense-json/default.nix
@@ -34,6 +34,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/simonw/condense-json";
     changelog = "https://github.com/simonw/condense-json/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ josh ];
+    maintainers = with lib.maintainers; [
+      josh
+      dwt
+    ];
   };
 }

--- a/pkgs/development/python-modules/condense-json/default.nix
+++ b/pkgs/development/python-modules/condense-json/default.nix
@@ -4,17 +4,18 @@
   fetchFromGitHub,
   setuptools,
   pytestCheckHook,
+  hypothesis,
 }:
 buildPythonPackage rec {
   pname = "condense-json";
-  version = "0.1.3";
+  version = "1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "condense-json";
     tag = version;
-    hash = "sha256-vMh6GLWqae0Ave3FmrGQuVCgFzYMGCIe76mGNDMrBdU=";
+    hash = "sha256-IBYjDFhbQlZ/17nTo5FvJM7aeadKS5dW7J8IGy4956M=";
   };
 
   build-system = [
@@ -23,6 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    hypothesis
   ];
 
   pythonImportsCheck = [ "condense_json" ];


### PR DESCRIPTION
## Things done

Precursor to updating llm and llm-lmstudio

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
