### PR TITLE
obs-studio: expose driver libraries to NVENC probe

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -217,7 +217,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     ''
       qtWrapperArgs+=(
-        --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}"
+        --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}${lib.optionalString stdenv.hostPlatform.isLinux ":/run/opengl-driver/lib"}"
         ''${gappsWrapperArgs[@]}
       )
     ''


### PR DESCRIPTION
`obs-nvenc.so` starts `obs-nvenc-test`, which loads `libnvidia-encode.so.1` dynamically. On NixOS, the plugin itself has the graphics-driver RUNPATH, but the standalone probe does not inherit `/run/opengl-driver/lib`; OBS consequently reports `nvenc_lib` and hides the NVENC encoders.

Extend the existing Linux OBS wrapper's `LD_LIBRARY_PATH` with `/run/opengl-driver/lib`. The probe subprocess then inherits the driver path, while non-Linux wrappers remain unchanged.

Validated on a Quadro RTX 3000 with NVIDIA 595.71.05: the probe detects Turing and reports H.264/HEVC NVENC support; OBS exposes the NVIDIA encoders.

This PR summary was prepared with assistance from OpenAI Codex (GPT-5) and manually reviewed by the contributor.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test
