### PR TITLE
bind: fix riscv64-linux build

### DIFF
--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -121,6 +121,12 @@ stdenv.mkDerivation (finalAttrs: {
   preCheck = ''
     # skip timezone-related tests, they are flaky inside the nix sandbox
     sed -i '/^ISC_TEST_ENTRY(isc_time_formatISO8601L/d' tests/isc/time_test.c
+  ''
+  + lib.optionalString stdenv.hostPlatform.isRiscV64 ''
+    # lock benchmarks exceed the 300s test watchdog on slower hardware
+    sed -i '/^ISC_TEST_ENTRY(isc_mutex_benchmark/d' tests/isc/mutex_test.c
+    sed -i '/^ISC_TEST_ENTRY_CUSTOM(isc_rwlock_benchmark/d' tests/isc/rwlock_test.c
+    sed -i '/^ISC_TEST_ENTRY(isc_spinlock_benchmark/d' tests/isc/spinlock_test.c
   '';
 
   postFixup = ''


### PR DESCRIPTION
Fix :

```
bind> ============================================
bind>    BIND 9.20.26: tests/isc/test-suite.log
bind> ============================================
bind> 
bind> # TOTAL: 47
bind> # PASS:  44
bind> # SKIP:  0
bind> # XFAIL: 0
bind> # FAIL:  3
bind> # XPASS: 0
bind> # ERROR: 0
bind> 
bind> System information (uname -a): Linux 7.2.0-rc6 #1-NixOS SMP PREEMPT Tue Jan 1 00:00:00 UTC 1980 riscv64
bind> 
bind> .. contents:: :depth: 2
bind> 
bind> FAIL: mutex_test
bind> ================
bind> 
bind> [==========] tests: Running 2 test(s).
bind> [ RUN      ] isc_mutex
bind> [       OK ] isc_mutex
bind> [ RUN      ] isc_mutex_benchmark
bind> PID 55034 exceeded run time limit, sending SIGABRT
bind> FAIL mutex_test (exit status: 124)
bind> 
bind> FAIL: rwlock_test
bind> =================
bind> 
bind> [==========] tests: Running 5 test(s).
bind> [ RUN      ] isc_rwlock_rdlock
bind> [       OK ] isc_rwlock_rdlock
bind> [ RUN      ] isc_rwlock_wrlock
bind> [       OK ] isc_rwlock_wrlock
bind> [ RUN      ] isc_rwlock_tryupgrade
bind> [       OK ] isc_rwlock_tryupgrade
bind> [ RUN      ] isc_rwlock_trylock
bind> [       OK ] isc_rwlock_trylock
bind> [ RUN      ] isc_rwlock_benchmark
bind> PID 58012 exceeded run time limit, sending SIGABRT
bind> FAIL rwlock_test (exit status: 124)
bind> 
bind> FAIL: spinlock_test
bind> ===================
bind> 
bind> [==========] tests: Running 2 test(s).
bind> [ RUN      ] isc_spinlock
bind> [       OK ] isc_spinlock
bind> [ RUN      ] isc_spinlock_benchmark
bind> PID 58535 exceeded run time limit, sending SIGABRT
bind> FAIL spinlock_test (exit status: 124)
bind> 
bind> ============================================================================
bind> Testsuite summary for BIND 9.20.26
bind> ============================================================================
bind> # TOTAL: 47
bind> # PASS:  44
bind> # SKIP:  0
bind> # XFAIL: 0
bind> # FAIL:  3
bind> # XPASS: 0
bind> # ERROR: 0
```

Related to : https://github.com/NixOS/nixpkgs/pull/536032

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
