### PR TITLE
cudaPackages.nccl: 2.30.7-1 -> 2.31.2-1

### DIFF
--- a/pkgs/development/cuda-modules/packages/nccl.nix
+++ b/pkgs/development/cuda-modules/packages/nccl.nix
@@ -56,7 +56,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   #   newer versions of NCCL than what we provide here.
   version =
     if cudaAtLeast "12.0" then
-      "2.30.7-1"
+      "2.31.2-1"
     else if cudaAtLeast "11.7" then
       "2.28.7-1"
     else if cudaAtLeast "11.6" then
@@ -69,7 +69,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     repo = "nccl";
     tag = "v${finalAttrs.version}";
     hash = getAttr finalAttrs.version {
-      "2.30.7-1" = "sha256-fdiQZweX0jYfGroP0bL5Sfv3+DkCzVBZZLEbPv8aqq8=";
+      "2.31.2-1" = "sha256-G3Nx9pCgSNBYX0CV86ruiNC9aZ9YuZH5hF/WnoOF2mQ=";
       "2.28.7-1" = "sha256-NM19OiBBGmv3cGoVoRLKSh9Y59hiDoei9NIrRnTqWeA=";
       "2.26.6-1" = "sha256-vkWMGXCy+dIpYCecdafmOAGlnfRxIQ5Y2ZQuMjinraI=";
       "2.25.1-1" = "sha256-3snh0xdL9I5BYqdbqdl+noizJoI38mZRVOJChgEE1I8=";

--- a/pkgs/development/python-modules/nccl4py/default.nix
+++ b/pkgs/development/python-modules/nccl4py/default.nix
@@ -12,6 +12,7 @@
   # dependencies
   cuda-core,
   numpy,
+  nvidia-cutlass-dsl,
   packaging,
   pythonOlder,
   typing-extensions,
@@ -23,10 +24,9 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "nccl4py";
-  # `nccl4py` is versioned independently of `nccl` and should be the
-  # same as the contents of
+  # `nccl4py` is versioned independently of `nccl` and should be the same as the contents of
   # `${cudaPackages.nccl.src}/bindings/nccl4py/nccl/_version.py`
-  version = "0.3.1";
+  version = "0.4.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -34,7 +34,7 @@ buildPythonPackage (finalAttrs: {
     owner = "NVIDIA";
     repo = "nccl";
     tag = "nccl4py-v${finalAttrs.version}";
-    hash = "sha256-jpgCUnUWWl2oihtHibgoQRnnXsQC6vlIjVX73i3bVqw=";
+    hash = "sha256-p9z4NlccBdI0auMRzTJtK8VbAOSunLdwKKU0Wn5c6c0=";
   };
   sourceRoot = "${finalAttrs.src.name}/bindings/nccl4py";
 
@@ -102,6 +102,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     cuda-core
     numpy
+    nvidia-cutlass-dsl
     packaging
   ]
   ++ lib.optionals (pythonOlder "3.13") [
@@ -132,6 +133,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python bindings for NCCL";
     homepage = "https://github.com/NVIDIA/nccl/blob/master/bindings/nccl4py/README.md";
+    changelog = "https://github.com/NVIDIA/nccl/releases/tag/${finalAttrs.src.tag}";
     # `cudaPackages.nccl` is BSD3 but the bindings are licensed under
     # Apache License 2.0
     license = lib.licenses.bsd3;


### PR DESCRIPTION
## Things done

Diff: https://github.com/NVIDIA/nccl/compare/v2.30.7-1...v2.31.2-1
Changelog: https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1

cc @NixOS/cuda-maintainers 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
