### PR TITLE
rhash: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/by-name/rh/rhash/package.nix
+++ b/pkgs/by-name/rh/rhash/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ which ];
   buildInputs = lib.optionals stdenv.hostPlatform.isFreeBSD [ gettext ];
 
+  strictDeps = true;
+
   # configure script is not autotools-based, doesn't support these options
   dontAddStaticConfigureFlags = true;
 

--- a/pkgs/by-name/rh/rhash/package.nix
+++ b/pkgs/by-name/rh/rhash/package.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "rhash";
     repo = "RHash";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-9/kFI38PG3AKsdDqEV/wEzSel9IlQQ/pvOyhU/N/aV0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9/kFI38PG3AKsdDqEV/wEzSel9IlQQ/pvOyhU/N/aV0=";
   };
 
   nativeBuildInputs = [ which ];
@@ -47,6 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (!enableStatic) [
     "install-lib-so-link"
   ];
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://rhash.sourceforge.net/";


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
