### PR TITLE
docbook-xsl-*: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -21,12 +21,12 @@ let
     }:
     let
       legacySuffix = lib.optionalString (suffix != "-nons") "-ns";
-      self = stdenv.mkDerivation rec {
+      self = stdenv.mkDerivation (finalAttrs: {
         inherit pname;
         version = "1.79.2";
 
         src = fetchurl {
-          url = "https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F${version}/docbook-xsl${suffix}-${version}.tar.bz2";
+          url = "https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F${finalAttrs.version}/docbook-xsl${suffix}-${finalAttrs.version}.tar.bz2";
           inherit sha256;
         };
 
@@ -50,7 +50,8 @@ let
 
           # Add legacy sourceforge.net URIs to the catalog
           (replaceVars ./catalog-legacy-uris.patch {
-            inherit legacySuffix suffix version;
+            inherit legacySuffix suffix;
+            inherit (finalAttrs) version;
           })
         ]
         ++ lib.optionals withManOptDedupPatch [
@@ -66,7 +67,7 @@ let
         dontBuild = true;
 
         installPhase = ''
-          dst=$out/share/xml/${pname}
+          dst=$out/share/xml/${finalAttrs.pname}
           mkdir -p $dst
           rm -rf RELEASE* README* INSTALL TODO NEWS* BUGS install.sh tools Makefile tests extensions webhelp
           mv * $dst/
@@ -81,8 +82,10 @@ let
 
         passthru.dbtoepub = writeScriptBin "dbtoepub" ''
           #!${bash}/bin/bash
-          exec -a dbtoepub ${ruby}/bin/ruby ${self}/share/xml/${pname}/epub/bin/dbtoepub "$@"
+          exec -a dbtoepub ${ruby}/bin/ruby ${self}/share/xml/${finalAttrs.pname}/epub/bin/dbtoepub "$@"
         '';
+
+        __structuredAttrs = true;
 
         meta = {
           homepage = "https://github.com/docbook/wiki/wiki/DocBookXslStylesheets";
@@ -91,7 +94,7 @@ let
           maintainers = [ ];
           platforms = lib.platforms.all;
         };
-      };
+      });
     in
     self;
 

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -61,6 +61,8 @@ let
 
         propagatedBuildInputs = [ findXMLCatalogs ];
 
+        strictDeps = true;
+
         dontBuild = true;
 
         installPhase = ''


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

No change in CA hashes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
