### PR TITLE
dejagnu: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/de/dejagnu/package.nix
+++ b/pkgs/by-name/de/dejagnu/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnu/dejagnu/dejagnu-${finalAttrs.version}.tar.gz";
-    sha256 = "1qx2cv6qkxbiqg87jh217jb62hk3s7dmcs4cz1llm2wmsynfznl7";
+    hash = "sha256-h9rvrNeVi0pp+IxoVtvRY0JhljxBQHnQw3H1ic1mouM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/de/dejagnu/package.nix
+++ b/pkgs/by-name/de/dejagnu/package.nix
@@ -2,6 +2,7 @@
   fetchurl,
   lib,
   stdenv,
+  bashNonInteractive,
   expect,
   makeWrapper,
   updateAutotoolsGnuConfigScriptsHook,
@@ -20,7 +21,12 @@ stdenv.mkDerivation (finalAttrs: {
     updateAutotoolsGnuConfigScriptsHook
     makeWrapper
   ];
-  buildInputs = [ expect ];
+  buildInputs = [
+    bashNonInteractive
+    expect
+  ];
+
+  strictDeps = true;
 
   # dejagnu-1.6.3 can't successfully run tests in source tree:
   #   https://wiki.linuxfromscratch.org/lfs/ticket/4871

--- a/pkgs/by-name/de/dejagnu/package.nix
+++ b/pkgs/by-name/de/dejagnu/package.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${expect}/bin/expect $out/bin/expect
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Framework for testing other programs";
 


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

No change in CA hash of the output.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
