### PR TITLE
ngtcp2{,-gnutls}: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit curl;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/ngtcp2/ngtcp2";
     changelog = "https://github.com/ngtcp2/ngtcp2/releases/tag/v${finalAttrs.version}";

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withJemalloc jemalloc;
 
+  strictDeps = true;
+
   cmakeFlags = [
     # The examples try to link against `ngtcp2_crypto_ossl` and `ngtcp2` libraries.
     # This works in the dynamic case where the targets have the same name, but not here where they're suffixed with `_static`.

--- a/pkgs/development/libraries/ngtcp2/gnutls.nix
+++ b/pkgs/development/libraries/ngtcp2/gnutls.nix
@@ -11,14 +11,14 @@
   curlWithGnuTls,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
   version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = "ngtcp2";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BBV4nNtSWQOFuwVOeH3LJEUeF7v4LVhGbfcrkroBAvc=";
   };
 
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
     inherit curlWithGnuTls;
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/ngtcp2/ngtcp2";
     description = "Effort to implement RFC9000 QUIC protocol";
@@ -52,7 +54,7 @@ stdenv.mkDerivation rec {
       vcunat # for knot-dns
     ];
   };
-}
+})
 
 /*
   Why split from ./default.nix?

--- a/pkgs/development/libraries/ngtcp2/gnutls.nix
+++ b/pkgs/development/libraries/ngtcp2/gnutls.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [ gnutls ];
 
+  strictDeps = true;
+
   configureFlags = [ "--with-gnutls=yes" ];
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
