### PR TITLE
 nixos-render-doc: add support for tables

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/asciidoc.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/asciidoc.py
@@ -56,12 +56,14 @@ class AsciiDocRenderer(Renderer):
     _parstack: list[Par]
     _list_stack: list[List]
     _attrspans: list[str]
+    _table_row_has_cell: bool
 
     def __init__(self, manpage_urls: Mapping[str, str]):
         super().__init__(manpage_urls)
         self._parstack = [ Par("\n\n", "====") ]
         self._list_stack = []
         self._attrspans = []
+        self._table_row_has_cell = False
 
     def _enter_block(self, is_list: bool) -> None:
         self._parstack.append(Par("\n+\n" if is_list else "\n\n", self._parstack[-1].block_delim + "="))
@@ -215,3 +217,41 @@ class AsciiDocRenderer(Renderer):
         return self._list_open(token, '.')
     def ordered_list_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         return self._list_close()
+    def table_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        aligns = []
+        for j in range(i + 1, len(tokens)):
+            if tokens[j].type == 'thead_close':
+                break
+            elif tokens[j].type == 'th_open':
+                style = cast(str, tokens[j].attrs.get('style', 'left')).removeprefix('text-align:')
+                aligns.append({'left': '<', 'center': '^', 'right': '>'}[style])
+        cols = ",".join(aligns)
+        pbreak = self._break(True)
+        return f'{pbreak}[cols="{cols}",options="header"]\n|==='
+    def table_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "\n|===\n"
+    def thead_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def thead_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "\n"
+    def tr_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        self._table_row_has_cell = False
+        return "\n"
+    def tr_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def _table_cell_open(self) -> str:
+        sep = " " if self._table_row_has_cell else ""
+        self._table_row_has_cell = True
+        return f"{sep}| "
+    def th_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return self._table_cell_open()
+    def th_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def tbody_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def tbody_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def td_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return self._table_cell_open()
+    def td_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
@@ -26,6 +26,7 @@ class CommonMarkRenderer(Renderer):
     _parstack: list[Par]
     _link_stack: list[str]
     _list_stack: list[List]
+    _table_header_count: int
 
     def __init__(self, manpage_urls: Mapping[str, str], admonition_style: AdmonitionStyle = AdmonitionStyle.PLAIN):
         super().__init__(manpage_urls)
@@ -228,3 +229,29 @@ class CommonMarkRenderer(Renderer):
         if title := cast(str, token.attrs.get('title', '')):
             title = ' "' + title.replace('"', '\\"') + '"'
         return f'![{token.content}]({token.attrs["src"]}{title})'
+    # Markdown tables aren't supported in base CommonMark,
+    # but raw HTML tables are for some inexplicable reason
+    def table_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "\n<table>\n"
+    def table_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "</table>\n"
+    def thead_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "<thead>\n"
+    def thead_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "</thead>\n"
+    def tr_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "<tr>\n"
+    def tr_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "</tr>\n"
+    def th_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "<th>"
+    def th_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "</th>\n"
+    def tbody_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "<tbody>\n"
+    def tbody_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "</tbody>\n"
+    def td_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "<td>"
+    def td_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "</td>\n"

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manpage.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manpage.py
@@ -85,6 +85,9 @@ class ManpageRenderer(Renderer):
     _do_parbreak_stack: list[bool]
     _list_stack: list[List]
     _font_stack: list[str]
+    _in_table_cell: bool
+    _table_cell_content: Optional[str]
+    _table_row_cells: list[str]
 
     def __init__(self, manpage_urls: Mapping[str, str], href_targets: dict[str, str]):
         super().__init__(manpage_urls)
@@ -93,11 +96,21 @@ class ManpageRenderer(Renderer):
         self._do_parbreak_stack = []
         self._list_stack = []
         self._font_stack = []
+        self._in_table_cell = False
+        self._table_cell_content = None
+        self._table_row_cells = []
 
     def _join_block(self, ls: Iterable[str]) -> str:
         return "\n".join([ l for l in ls if len(l) ])
     def _join_inline(self, ls: Iterable[str]) -> str:
         return _normalize_space(super()._join_inline(ls))
+
+    def renderInline(self, tokens: Sequence[Token]) -> str:
+        result = super().renderInline(tokens)
+        if self._in_table_cell:
+            self._table_cell_content = result
+            return ""
+        return result
 
     def _enter_block(self) -> None:
         self._do_parbreak_stack.append(False)
@@ -286,3 +299,51 @@ class ManpageRenderer(Renderer):
     def ordered_list_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         self._list_stack.pop()
         return ""
+    def table_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        aligns = []
+        for j in range(i + 1, len(tokens)):
+            if tokens[j].type == 'thead_close':
+                break
+            elif tokens[j].type == 'th_open':
+                style = cast(str, tokens[j].attrs.get('style', 'left')).removeprefix('text-align:')
+                aligns.append({'left': 'l', 'center': 'c', 'right': 'r'}[style])
+        header_spec = " ".join(f"{a}b" for a in aligns)
+        body_spec = " ".join(aligns)
+        return (
+            ".RS 4\n"
+            ".TS\n"
+            "allbox;\n"
+            f"{header_spec}\n"
+            f"{body_spec} ."
+        )
+    def table_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ".TE\n.RE"
+    def thead_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def thead_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def tbody_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def tbody_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return ""
+    def tr_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        self._table_row_cells = []
+        return ""
+    def tr_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return "\t".join(self._table_row_cells) or "\\&"
+    def _table_cell_open(self) -> str:
+        self._in_table_cell = True
+        self._table_cell_content = None
+        return ""
+    def _table_cell_close(self) -> str:
+        self._in_table_cell = False
+        self._table_row_cells.append(self._table_cell_content or "")
+        return ""
+    def th_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return self._table_cell_open()
+    def th_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return self._table_cell_close()
+    def td_open(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return self._table_cell_open()
+    def td_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        return self._table_cell_close()

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/options.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/options.py
@@ -255,7 +255,7 @@ class ManpageConverter(BaseConverter[OptionsManpageRenderer]):
         return []
 
     def finalize(self) -> str:
-        result = []
+        result = ["'\\\" t"]
 
         if self._header is not None:
             result += self._header

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_md.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_md.py
@@ -65,4 +65,8 @@ deflist
 
 more stuff in same deflist
 : foo
+
+| this | is    |
+|------|-------|
+| a    | table |
 """

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_asciidoc.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_asciidoc.py
@@ -1,4 +1,5 @@
 import nixos_render_docs as nrd
+import textwrap
 
 from sample_md import sample1
 
@@ -41,6 +42,117 @@ b
 +
 f
 """
+
+def test_table_two_columns() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key | value |
+      |-----|-------|
+      | foo | bar   |
+    """)) == (
+        '\n\n'
+        '[cols="<,<",options="header"]\n'
+        '|===\n'
+        '| key | value\n'
+        '\n'
+        '| foo | bar\n'
+        '|===\n'
+    )
+
+def test_table_many_columns() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | d | l | m |
+      |---|---|---|
+      | a | b | c |
+      | x | y | z |
+    """)) == (
+        '\n\n'
+        '[cols="<,<,<",options="header"]\n'
+        '|===\n'
+        '| d | l | m\n'
+        '\n'
+        '| a | b | c\n'
+        '| x | y | z\n'
+        '|===\n'
+    )
+
+def test_table_single_column() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key |
+      |-----|
+      | foo |
+    """)) == (
+        '\n\n'
+        '[cols="<",options="header"]\n'
+        '|===\n'
+        '| key\n'
+        '\n'
+        '| foo\n'
+        '|===\n'
+    )
+
+def test_table_column_alignment() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | l | c | r |
+      |:--|:-:|--:|
+      | a | b | c |
+    """)) == (
+        '\n\n'
+        '[cols="<,^,>",options="header"]\n'
+        '|===\n'
+        '| l | c | r\n'
+        '\n'
+        '| a | b | c\n'
+        '|===\n'
+    )
+
+def test_table_empty_cell() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key |
+      |-----|
+      |     |
+    """)) == (
+        '\n\n'
+        '[cols="<",options="header"]\n'
+        '|===\n'
+        '| key\n'
+        '\n'
+        '| \n'
+        '|===\n'
+    )
+    assert c._render(textwrap.dedent("""
+      | a | b |
+      |---|---|
+      |   | x |
+    """)) == (
+        '\n\n'
+        '[cols="<,<",options="header"]\n'
+        '|===\n'
+        '| a | b\n'
+        '\n'
+        '|  | x\n'
+        '|===\n'
+    )
+
+def test_table_escapes_content() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key   | value        |
+      |-------|--------------|
+      | a-b   | *em* \\| `c` |
+    """)) == (
+        '\n\n'
+        '[cols="<,<",options="header"]\n'
+        '|===\n'
+        '| key | value\n'
+        '\n'
+        '| a-b | __em__ {vbar} ``c``\n'
+        '|===\n'
+    )
 
 def test_full() -> None:
     c = Converter({ 'man(1)': 'http://example.org' })

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_asciidoc.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_asciidoc.py
@@ -266,4 +266,12 @@ text
 
 
 more stuff in same deflist:: {empty}foo
+
+
+[cols="<,<",options="header"]
+|===
+| this | is
+
+| a | table
+|===
 """

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
@@ -220,7 +220,22 @@ some nested anchors
 
  - *‌more stuff in same deflist‌*
    
-   foo""".replace(' ', ' ')
+   foo
+<table>
+<thead>
+<tr>
+<th>this</th>
+<th>is</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>a</td>
+<td>table</td>
+</tr>
+</tbody>
+</table>
+""".replace(' ', ' ')
 
 def test_images() -> None:
     c = Converter({})

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_html.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_html.py
@@ -269,4 +269,24 @@ def test_full() -> None:
            <p>foo</p>
           </dd>
          </dl>
+        </div>
+        <div class="informaltable">
+          <table class="informaltable" border="1">
+            <colgroup>
+              <col align="left" />
+              <col align="left" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th align="left">this</th>
+                <th align="left">is</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left">a</td>
+                <td align="left">table</td>
+              </tr>
+            </tbody>
+          </table>
         </div>""")

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manpage.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manpage.py
@@ -1,4 +1,5 @@
 import nixos_render_docs as nrd
+import textwrap
 
 from sample_md import sample1
 
@@ -35,6 +36,139 @@ def test_dedup_links() -> None:
     c._renderer.link_footnotes = []
     assert c._render("[a](link) [b](link)") == "\\fBa\\fR[1]\\fR \\fBb\\fR[1]\\fR"
     assert c._renderer.link_footnotes == ['link']
+
+def test_table_two_columns() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key | value |
+      |-----|-------|
+      | foo | bar   |
+    """)) == (
+        ".RS 4\n"
+        ".TS\n"
+        "allbox;\n"
+        "lb lb\n"
+        "l l .\n"
+        "key\tvalue\n"
+        "foo\tbar\n"
+        ".TE\n"
+        ".RE"
+    )
+
+def test_table_many_columns() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | d | l | m |
+      |---|---|---|
+      | a | b | c |
+      | x | y | z |
+    """)) == (
+        ".RS 4\n"
+        ".TS\n"
+        "allbox;\n"
+        "lb lb lb\n"
+        "l l l .\n"
+        "d\tl\tm\n"
+        "a\tb\tc\n"
+        "x\ty\tz\n"
+        ".TE\n"
+        ".RE"
+    )
+
+def test_table_single_column() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key |
+      |-----|
+      | foo |
+    """)) == (
+        ".RS 4\n"
+        ".TS\n"
+        "allbox;\n"
+        "lb\n"
+        "l .\n"
+        "key\n"
+        "foo\n"
+        ".TE\n"
+        ".RE"
+    )
+
+def test_table_column_alignment() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | l | c | r |
+      |:--|:-:|--:|
+      | a | b | c |
+    """)) == (
+        ".RS 4\n"
+        ".TS\n"
+        "allbox;\n"
+        "lb cb rb\n"
+        "l c r .\n"
+        "l\tc\tr\n"
+        "a\tb\tc\n"
+        ".TE\n"
+        ".RE"
+    )
+
+def test_table_header_shown() -> None:
+    c = Converter({})
+    assert "HEADER" in c._render(textwrap.dedent("""
+      | HEADER |
+      |--------|
+      | body   |
+    """))
+
+def test_table_empty_cell() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key |
+      |-----|
+      |     |
+    """)) == (
+        ".RS 4\n"
+        ".TS\n"
+        "allbox;\n"
+        "lb\n"
+        "l .\n"
+        "key\n"
+        "\\&\n"
+        ".TE\n"
+        ".RE"
+    )
+    assert c._render(textwrap.dedent("""
+      | a | b |
+      |---|---|
+      |   | x |
+    """)) == (
+        ".RS 4\n"
+        ".TS\n"
+        "allbox;\n"
+        "lb lb\n"
+        "l l .\n"
+        "a\tb\n"
+        "\tx\n"
+        ".TE\n"
+        ".RE"
+    )
+
+def test_table_escapes_content() -> None:
+    c = Converter({})
+    assert c._render(textwrap.dedent("""
+      | key   | value    |
+      |-------|----------|
+      | a-b   | *em* `c` |
+    """)) == (
+        ".RS 4\n"
+        ".TS\n"
+        "allbox;\n"
+        "lb lb\n"
+        "l l .\n"
+        "key\tvalue\n"
+        "a\\-b\t\\fIem\\fR \\fR\\(oqc\\(cq\\fP\n"
+        ".TE\n"
+        ".RE"
+    )
 
 def test_full() -> None:
     c = Converter({ 'man(1)': 'http://example.org' })

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manpage.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manpage.py
@@ -312,4 +312,13 @@ more stuff in same deflist
 .RS 4
 foo
 .RE
+.RE
+.RS 4
+.TS
+allbox;
+lb lb
+l l .
+this\tis
+a\ttable
+.TE
 .RE"""

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
@@ -16,6 +16,11 @@ def test_option_headings() -> None:
         content='', markup='#', info='', meta={}, block=True, hidden=False
     )
 
+def test_options_manpage_tbl_cookie() -> None:
+    c = nixos_render_docs.options.ManpageConverter('local', None, None)
+    c.add_options({})
+    assert c.finalize().startswith('\'\\" t\n')
+
 def test_options_commonmark() -> None:
     c = nixos_render_docs.options.CommonMarkConverter({}, 'local')
     with Path('tests/sample_options_simple.json').open() as f:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/pull/509450 (now reverted) added a nixos option with a markdown table in its description. While the HTML renderer handled it correctly, the rest of them failed because they didn't have implementations. This adds support for tables so that if this happens again, it'll work correctly, and so that the new pattern that https://github.com/NixOS/nixpkgs/pull/509450 introduced can use tables, if desired.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
