### PR TITLE
postgresqlPackages.pglite_fusion: init at 0.0.7

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pglite_fusion.nix
+++ b/pkgs/servers/sql/postgresql/ext/pglite_fusion.nix
@@ -1,0 +1,72 @@
+{
+  buildPgrxExtension,
+  cargo-pgrx_0_18_0,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  postgresql,
+  postgresqlTestExtension,
+}:
+buildPgrxExtension (finalAttrs: {
+  inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_18_0;
+
+  pname = "pglite_fusion";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "frectonz";
+    repo = "pglite-fusion";
+    tag = finalAttrs.version;
+    hash = "sha256-/BUA3bxp/5di6R574VtAaWqhMWrJYyt2Me3pMBtk76s=";
+  };
+
+  cargoHash = "sha256-954nNwdMDE9tVOvql/fMR8J1pIq64AdKiKlBjl0yqRI=";
+
+  # pgrx tests try to install the extension into the postgresql nix store
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  passthru.tests.extension = postgresqlTestExtension {
+    inherit (finalAttrs) finalPackage;
+    sql = ''
+      CREATE EXTENSION pglite_fusion;
+
+      CREATE TABLE people (
+        name     TEXT NOT NULL,
+        database SQLITE DEFAULT init_sqlite($sqlite$CREATE TABLE todos (task TEXT)$sqlite$)
+      );
+
+      INSERT INTO people VALUES ('frectonz');
+
+      UPDATE people
+      SET database = execute_sqlite(
+        database,
+        $sqlite$INSERT INTO todos VALUES ('solve multitenancy')$sqlite$
+      )
+      WHERE name = 'frectonz';
+    '';
+    asserts = [
+      {
+        query = ''
+          SELECT get_sqlite_text(sqlite_row, 0)
+          FROM query_sqlite(
+            (SELECT database FROM people WHERE name = 'frectonz'),
+            'SELECT * FROM todos'
+          )
+        '';
+        expected = "'solve multitenancy'";
+        description = "todo stored in the embedded SQLite database can be read back";
+      }
+    ];
+  };
+
+  meta = {
+    description = "PostgreSQL extension for embedding an SQLite database in a column";
+    homepage = "https://github.com/frectonz/pglite-fusion";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ frectonz ];
+    platforms = postgresql.meta.platforms;
+  };
+})


### PR DESCRIPTION
[pglite-fusion](https://github.com/frectonz/pglite-fusion) is a PostgreSQL extension that allows you to define columns on tables as `SQLITE` and gives you a set of function to read and write to the SQLite databases on each row of that given table.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
