### PR TITLE
matrix-continuwuity: 26.7.2 -> 26.7.3

### DIFF
--- a/nixos/tests/matrix/continuwuity.nix
+++ b/nixos/tests/matrix/continuwuity.nix
@@ -29,7 +29,7 @@ in
             import asyncio
 
             from mautrix.client import Client
-            from mautrix.types import EventType, RoomFilter
+            from mautrix.types import EventType, RoomFilter, Filter
 
 
             async def main() -> None:
@@ -66,7 +66,7 @@ in
                     received.set()
 
                 client.add_event_handler(EventType.ROOM_MESSAGE, on_message)
-                sync_task = client.start(RoomFilter(rooms=[room_id]))
+                sync_task = client.start(Filter(room=RoomFilter(rooms=[room_id])))
 
                 await client.send_text(room_id, msg)
 

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -17,17 +17,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-continuwuity";
-  version = "26.7.2";
+  version = "26.7.3";
 
   src = fetchFromGitea {
     domain = "forgejo.ellis.link";
     owner = "continuwuation";
     repo = "continuwuity";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uE38tYYgze2q4hgW1mzk5CLTD3ezAwCnj+RQOmZtCdw=";
+    hash = "sha256-Uj4fcHoTiQ/G5vyEnSOatjdqaUquGSlOxeTt32F2xew=";
   };
 
-  cargoHash = "sha256-DZsRr0Xt/7HnlNCZfXK4dUILK/uEOnSD+r26OxvycD0=";
+  cargoHash = "sha256-6C4dXm9+m2sKA4m1YXocifX4ss61s6/L2FeXzfkowMs=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
- **nixos/tests/matrix-continuwuity: wrap sync filter in filter data class**
- **matrix-continuwuity: 26.7.2 -> 26.7.3**

Release notes: https://forgejo.ellis.link/continuwuation/continuwuity/releases/tag/v26.7.3
Changelog: https://forgejo.ellis.link/continuwuation/continuwuity/src/commit/v26.7.3/CHANGELOG.md
Diff: https://forgejo.ellis.link/continuwuation/continuwuity/compare/v26.7.2...v26.7.3

Fixes: GHSA-v2x6-m99h-vqxx

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
