### PR TITLE
python3Packages.pyjsparser: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pyjsparser/default.nix
+++ b/pkgs/development/python-modules/pyjsparser/default.nix
@@ -3,13 +3,14 @@
   fetchFromGitHub,
   buildPythonPackage,
   pytestCheckHook,
+  setuptools,
 }:
 
 let
   pyjsparser = buildPythonPackage {
     pname = "pyjsparser";
     version = "2.7.1";
-    format = "setuptools";
+    pyproject = true;
 
     src = fetchFromGitHub {
       owner = "PiotrDabkowski";
@@ -17,6 +18,8 @@ let
       rev = "5465d037b30e334cb0997f2315ec1e451b8ad4c1";
       hash = "sha256-Hqay9/qsjUfe62U7Q79l0Yy01L2Bnj5xNs6427k3Br8=";
     };
+
+    build-system = [ setuptools ];
 
     nativeCheckInputs = [
       pytestCheckHook

--- a/pkgs/development/python-modules/pyjsparser/default.nix
+++ b/pkgs/development/python-modules/pyjsparser/default.nix
@@ -5,37 +5,33 @@
   pytestCheckHook,
   setuptools,
 }:
+buildPythonPackage {
+  pname = "pyjsparser";
+  version = "2.7.1";
+  pyproject = true;
 
-let
-  pyjsparser = buildPythonPackage {
-    pname = "pyjsparser";
-    version = "2.7.1";
-    pyproject = true;
-
-    src = fetchFromGitHub {
-      owner = "PiotrDabkowski";
-      repo = "pyjsparser";
-      rev = "5465d037b30e334cb0997f2315ec1e451b8ad4c1";
-      hash = "sha256-Hqay9/qsjUfe62U7Q79l0Yy01L2Bnj5xNs6427k3Br8=";
-    };
-
-    build-system = [ setuptools ];
-
-    nativeCheckInputs = [
-      pytestCheckHook
-    ];
-
-    # js2py is needed for tests but it's unmaintained and insecure
-    doCheck = false;
-
-    pythonImportsCheck = [ "pyjsparser" ];
-
-    meta = {
-      description = "Fast javascript parser (based on esprima.js)";
-      homepage = "https://github.com/PiotrDabkowski/pyjsparser";
-      license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ onny ];
-    };
+  src = fetchFromGitHub {
+    owner = "PiotrDabkowski";
+    repo = "pyjsparser";
+    rev = "5465d037b30e334cb0997f2315ec1e451b8ad4c1";
+    hash = "sha256-Hqay9/qsjUfe62U7Q79l0Yy01L2Bnj5xNs6427k3Br8=";
   };
-in
-pyjsparser
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # js2py is needed for tests but it's unmaintained and insecure
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyjsparser" ];
+
+  meta = {
+    description = "Fast javascript parser (based on esprima.js)";
+    homepage = "https://github.com/PiotrDabkowski/pyjsparser";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onny ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
