### PR TITLE
python3Packages.pykerberos: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pykerberos/default.nix
+++ b/pkgs/development/python-modules/pykerberos/default.nix
@@ -6,13 +6,13 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pykerberos";
   version = "1.2.4";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-nXAevY/FlsmdMVXVukWBO9WQjSbvg7oK3SUO22IqvtQ=";
   };
 
@@ -31,4 +31,4 @@ buildPythonPackage rec {
     description = "High-level interface to Kerberos";
     license = lib.licenses.asl20;
   };
-}
+})

--- a/pkgs/development/python-modules/pykerberos/default.nix
+++ b/pkgs/development/python-modules/pykerberos/default.nix
@@ -3,17 +3,20 @@
   fetchPypi,
   buildPythonPackage,
   krb5-c, # C krb5 library, not PyPI krb5
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pykerberos";
   version = "1.2.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-nXAevY/FlsmdMVXVukWBO9WQjSbvg7oK3SUO22IqvtQ=";
   };
+
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [ krb5-c ]; # for krb5-config
 

--- a/pkgs/development/python-modules/pykerberos/default.nix
+++ b/pkgs/development/python-modules/pykerberos/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "High-level interface to Kerberos";
+    homepage = "https://github.com/02strich/pykerberos";
     license = lib.licenses.asl20;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
