### PR TITLE
zfp: remove `cudatoolkit`, modernize

### DIFF
--- a/pkgs/by-name/zf/zfp/package.nix
+++ b/pkgs/by-name/zf/zfp/package.nix
@@ -28,6 +28,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   version = "1.0.1";
 
   __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "LLNL";
@@ -42,19 +43,21 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ./python312.patch
   ];
 
-  nativeBuildInputs = [ cmake ] ++ lib.optionals enableCuda [ cudaPackages.cuda_nvcc ];
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ lib.optionals enableCuda [ cudaPackages.cuda_nvcc ]
+  ++ lib.optionals enableFortran [ gfortran ]
+  ++ lib.optionals enablePython (
+    with python3Packages;
+    [
+      cython
+      numpy
+      python
+    ]
+  );
 
-  buildInputs =
-    lib.optionals enableCuda [ cudaPackages.cuda_cudart ]
-    ++ lib.optionals enableFortran [ gfortran ]
-    ++ lib.optionals enablePython (
-      with python3Packages;
-      [
-        cython
-        numpy
-        python
-      ]
-    );
+  buildInputs = lib.optionals enableCuda [ cudaPackages.cuda_cudart ];
 
   propagatedBuildInputs = lib.optionals (enableOpenMP && effectiveStdenv.cc.isClang) [
     llvmPackages.openmp

--- a/pkgs/by-name/zf/zfp/package.nix
+++ b/pkgs/by-name/zf/zfp/package.nix
@@ -1,6 +1,5 @@
 {
   cmake,
-  cudatoolkit,
   fetchFromGitHub,
   gfortran,
   lib,
@@ -43,10 +42,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ./python312.patch
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ lib.optionals enableCuda [ cudaPackages.cuda_nvcc ];
 
   buildInputs =
-    lib.optionals enableCuda [ cudatoolkit ]
+    lib.optionals enableCuda [ cudaPackages.cuda_cudart ]
     ++ lib.optionals enableFortran [ gfortran ]
     ++ lib.optionals enablePython (
       with python3Packages;

--- a/pkgs/by-name/zf/zfp/package.nix
+++ b/pkgs/by-name/zf/zfp/package.nix
@@ -16,6 +16,7 @@
   enableOpenMP ? true,
   enablePython ? true,
   enableUtilities ? true,
+  versionCheckHook,
 }@inputs:
 
 let
@@ -97,6 +98,9 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   checkFlags = lib.optionals (bitStreamWordSize != 64) [
     "ARGS=\"--exclude-regex testzfp\""
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   passthru.tests = {
     cmake-config = testers.hasCmakeConfigModules {


### PR DESCRIPTION
- **zfp: remove `cudatoolkit`**
- **zfp: enable strictDeps**
- **zfp: add versionCheckHook**
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
