### PR TITLE
bencher-cli,dnsi,dnst,flux9s: add meta.changelog; flux9s: enable __structuredAttrs

### DIFF
--- a/pkgs/by-name/be/bencher-cli/package.nix
+++ b/pkgs/by-name/be/bencher-cli/package.nix
@@ -66,6 +66,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       The Nix derivation does not compile the proprietary features.
     '';
     homepage = "https://bencher.dev";
+    changelog = "https://github.com/bencherdev/bencher/releases/tag/v${finalAttrs.version}";
     license =
       if finalAttrs.buildNoDefaultFeatures then
         lib.licenses.OR [

--- a/pkgs/by-name/dn/dnsi/package.nix
+++ b/pkgs/by-name/dn/dnsi/package.nix
@@ -31,6 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Command line tool to investigate the Domain Name System";
     mainProgram = "dnsi";
     homepage = "https://nlnetlabs.nl/projects/domain/dnsi/";
+    changelog = "https://github.com/NLnetLabs/dnsi/blob/v${finalAttrs.version}/Changelog.md";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.skyesoss ];
   };

--- a/pkgs/by-name/dn/dnst/package.nix
+++ b/pkgs/by-name/dn/dnst/package.nix
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Toolset to assist DNS operators with zone and nameserver maintenance";
     mainProgram = "dnst";
     homepage = "https://nlnetlabs.nl/projects/domain/dnst/";
+    changelog = "https://github.com/NLnetLabs/dnst/blob/v${finalAttrs.version}/Changelog.md";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.skyesoss ];
   };

--- a/pkgs/by-name/fl/flux9s/package.nix
+++ b/pkgs/by-name/fl/flux9s/package.nix
@@ -10,6 +10,7 @@
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "flux9s";
   version = "1.0.1";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "dgunzy";
@@ -34,6 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "K9s-inspired terminal UI for monitoring Flux GitOps resources in real-time";
     mainProgram = "flux9s";
     homepage = "https://flux9s.ca/";
+    changelog = "https://github.com/dgunzy/flux9s/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.skyesoss ];
   };


### PR DESCRIPTION
Adds the `meta.changelog` attribute to the packages I maintain.
Also enables `__structuredAttrs` for flux9s.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
