### PR TITLE
3x-ui: init at 3.6.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1145,6 +1145,7 @@
   ./services/network-filesystems/webdav.nix
   ./services/network-filesystems/yandex-disk.nix
   ./services/networking/3proxy.nix
+  ./services/networking/3x-ui.nix
   ./services/networking/acme-dns.nix
   ./services/networking/adguardhome.nix
   ./services/networking/alice-lg.nix

--- a/nixos/modules/services/networking/3x-ui.nix
+++ b/nixos/modules/services/networking/3x-ui.nix
@@ -1,0 +1,129 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services._3x-ui;
+
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    ;
+in
+{
+  options.services._3x-ui = {
+    enable = mkEnableOption "3x-ui";
+
+    port = mkOption {
+      description = "Port for control panal, null for self-managed";
+      type = types.nullOr types.port;
+      default = null;
+    };
+
+    openFirewall = mkEnableOption "open firewall ports for 3x-ui";
+
+    dataDir = mkOption {
+      description = "Directory for service data";
+      type = types.path;
+      default = "/var/lib/3x-ui";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "_3x-ui";
+      description = "User account under which 3x-ui runs";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "_3x-ui";
+      description = "Group under which 3x-ui runs";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.proxydetox;
+      defaultText = "pkgs._3x-ui";
+      description = "The 3x-ui derivation to use";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = (cfg.port != null) || !cfg.openFirewall;
+        message = "Port is unknown for firewall opening";
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 _3x-ui _3x-ui -"
+      "d ${cfg.dataDir}/bin 0755 _3x-ui _3x-ui -"
+      "d ${cfg.dataDir}/logs 0755 _3x-ui _3x-ui -"
+    ];
+
+    systemd.services._3x-ui = {
+      description = "3x-ui control panel";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = ''
+        ln -sf ${getExe pkgs.xray} ${cfg.dataDir}/bin/xray-linux-amd64
+      ''
+      + (
+        if cfg.port != null then
+          ''
+            ${getExe pkgs._3x-ui} setting -port ${toString cfg.port}
+          ''
+        else
+          ""
+      );
+
+      environment = {
+        XUI_DB_FOLDER = cfg.dataDir;
+        XUI_BIN_FOLDER = "${cfg.dataDir}/bin";
+        XUI_LOG_FOLDER = "${cfg.dataDir}/logs";
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.user;
+        Restart = "on-failure";
+
+        ExecStart = "${getExe pkgs._3x-ui}";
+
+        AmbientCapabilities = [
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_ADMIN"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_ADMIN"
+        ];
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf (cfg.openFirewall && (cfg.port != null)) [ cfg.port ];
+
+    users.users = mkIf (cfg.user == "_3x-ui") {
+      _3x-ui = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "_3x-ui") {
+      _3x-ui = { };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    maxmosk
+  ];
+}

--- a/pkgs/by-name/_3/_3x-ui/package.nix
+++ b/pkgs/by-name/_3/_3x-ui/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  buildNpmPackage,
+}:
+let
+  version = "3.6.0";
+
+  src = fetchFromGitHub {
+    owner = "MHSanaei";
+    repo = "3x-ui";
+    tag = "v${version}";
+    hash = "sha256-RZYerYLOOSlWSULwMF1JnY6S0FImzN5SDX/Y+FJnvvg=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "3x-ui-frontend";
+    inherit version;
+
+    src = "${src}/frontend";
+
+    npmDepsHash = "sha256-95+XlMIyJHu1OHE+2X+RyvJeKVUGcMvgXIdeFhCiBl0=";
+
+    preBuild = ''
+      mkdir -p ../internal/web/
+      cp -r ${src}/internal/web/translation ../internal/web/translation
+    '';
+
+    installPhase = ''
+      cp -r ../internal/web/dist $out/
+    '';
+  };
+in
+buildGoModule {
+  pname = "3x-ui";
+  inherit version src;
+  vendorHash = "sha256-WP8WYdVdleBTXYiHc7Kc9/EMzyVp/HKNc7ewzpg2o1M=";
+
+  __structuredAttrs = true;
+
+  preBuild = ''
+    cp -r ${frontend} internal/web/dist
+  '';
+
+  meta = with lib; {
+    description = "Xray panel supporting multi-protocol multi-user";
+    homepage = "https://github.com/MHSanaei/3x-ui";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.maxmosk ];
+  };
+}


### PR DESCRIPTION
Xray panel supporting multi-protocol multi-user expire day & traffic & IP limit (Vmess, Vless, Trojan, ShadowSocks, Wireguard, Hysteria, Tunnel, Mixed, HTTP, Tun, MTProto).

Widely used for securing connection and bypassing DPI inspection/intrusion.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
