### PR TITLE
secretspec: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/by-name/se/secretspec-ffi/package.nix
+++ b/pkgs/by-name/se/secretspec-ffi/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  buildPackages,
+  rustPlatform,
+  fetchFromGitHub,
+  cargo-c,
+  nix-update-script,
+  pkg-config,
+  runCommandCC,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "secretspec-ffi";
+  version = "0.19.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cachix";
+    repo = "secretspec";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u6zfPsyLoktLQTE8OEDhK0GtiogOw/3ML4zpDVhSrX0=";
+  };
+
+  cargoHash = "sha256-ogeNTp94FJv7p+eZgrLUK1i63VCHiqHd7BsP+jDMHVc=";
+
+  nativeBuildInputs = [ cargo-c ];
+
+  buildPhase = ''
+    runHook preBuild
+    ${buildPackages.rust.envVars.setEnv} cargo cbuild -p secretspec-ffi -j $NIX_BUILD_CORES \
+      --release --frozen --prefix=${placeholder "out"} \
+      --target ${stdenv.hostPlatform.rust.rustcTarget}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    ${buildPackages.rust.envVars.setEnv} cargo cinstall -p secretspec-ffi -j $NIX_BUILD_CORES \
+      --release --frozen --prefix=${placeholder "out"} \
+      --target ${stdenv.hostPlatform.rust.rustcTarget}
+    runHook postInstall
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ${buildPackages.rust.envVars.setEnv} cargo ctest -p secretspec-ffi -j $NIX_BUILD_CORES \
+      --release --frozen --prefix=${placeholder "out"} \
+      --target ${stdenv.hostPlatform.rust.rustcTarget}
+    runHook postCheck
+  '';
+
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+        versionCheck = true;
+      };
+      smoke =
+        runCommandCC "${finalAttrs.pname}-smoke-test"
+          {
+            nativeBuildInputs = [ pkg-config ];
+            buildInputs = [ finalAttrs.finalPackage ];
+          }
+          ''
+            $CC ${finalAttrs.src}/secretspec-ffi/tests/smoke.c \
+              $(pkg-config --cflags --libs secretspec_ffi) \
+              -o smoke
+            ./smoke
+            touch $out
+          '';
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "C ABI for resolving secrets through SecretSpec";
+    homepage = "https://secretspec.dev";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      domenkozar
+      sandydoo
+    ];
+    pkgConfigModules = [ "secretspec_ffi" ];
+  };
+})

--- a/pkgs/by-name/se/secretspec/package.nix
+++ b/pkgs/by-name/se/secretspec/package.nix
@@ -11,14 +11,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "secretspec";
-  version = "0.18.0";
+  version = "0.19.0";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-4N567/oDMgV81zlusn7TFQcDyWATvpoq879ZL/pzbuU=";
+    hash = "sha256-tpzmzChyyYogebNZZi3LT61MO1HKZW8ln+21CwlqW8M=";
   };
 
-  cargoHash = "sha256-oMoRoKXjaCOER2KvKnLmSh9nKeYErh54IlQPFLHW8sE=";
+  cargoHash = "sha256-VO05AAjBqNVowY2AsyF2W1k4sXWJxOw1U0krs13JS28=";
 
   postPatch = ''
     mkdir -p ../tests/fixtures


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
