### PR TITLE
python3Packages.arviz: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/arviz-base/default.nix
+++ b/pkgs/development/python-modules/arviz-base/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  arviz,
   fetchFromGitHub,
 
   # build-system
@@ -24,7 +25,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz-base";
-  version = "1.2.0";
+  inherit (arviz) version;
   pyproject = true;
   __structuredAttrs = true;
 
@@ -32,7 +33,7 @@ buildPythonPackage (finalAttrs: {
     owner = "arviz-devs";
     repo = "arviz-base";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IMS5t+ezAoALBxk0PnX7G+DFNfYW20Qd+/M2p1IzktA=";
+    hash = "sha256-viGjQrAeelzC7DBqMA4kltBllDAXJvymWdntOMYapEA=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/arviz-plots/default.nix
+++ b/pkgs/development/python-modules/arviz-plots/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
+  arviz,
   fetchFromGitHub,
 
   # build-system
@@ -41,7 +42,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz-plots";
-  version = "1.2.0";
+  inherit (arviz) version;
   pyproject = true;
   __structuredAttrs = true;
 
@@ -49,7 +50,7 @@ buildPythonPackage (finalAttrs: {
     owner = "arviz-devs";
     repo = "arviz-plots";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-C08HLWnCixreeMj5imN7iOnYgYUZZ3+XG0lPExL4O1c=";
+    hash = "sha256-FHhF/spTt1KPVG45Dtdkf/C41VbOU+CXUSoeCfOWR50=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/arviz-stats/default.nix
+++ b/pkgs/development/python-modules/arviz-stats/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  arviz,
   fetchFromGitHub,
 
   # build-system
@@ -38,7 +39,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz-stats";
-  version = "1.2.0";
+  inherit (arviz) version;
   pyproject = true;
   __structuredAttrs = true;
 
@@ -46,7 +47,7 @@ buildPythonPackage (finalAttrs: {
     owner = "arviz-devs";
     repo = "arviz-stats";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KA36JGqgsYs5fF1AndsTBkXQ6U/duoebDQ1TOEmaCSc=";
+    hash = "sha256-Kg112pr5Jx3SDYOsrPL6AhRuzSPiUnRw4xpuANfF02Y=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz";
-  version = "1.2.0";
+  version = "1.3.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -25,7 +25,7 @@ buildPythonPackage (finalAttrs: {
     owner = "arviz-devs";
     repo = "arviz";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pbYc9ofBTAZ9e7IqAgHXT0EXhbQzovSdc6X3SysAKhw=";
+    hash = "sha256-YQ+0dUXl432cTtBJCNzekHtTiA+c25Q/1P2iqHj+TXk=";
   };
 
   build-system = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/arviz-devs/arviz/compare/v1.2.0...v1.3.0
Changelog: https://github.com/arviz-devs/arviz/blob/v1.3.0/CHANGELOG.md

cc @OmnipotentEntity

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test