### PR TITLE
mostrix: init at 0.2.3

### DIFF
--- a/pkgs/by-name/mo/mostrix/log-to-home-dir.patch
+++ b/pkgs/by-name/mo/mostrix/log-to-home-dir.patch
@@ -1,0 +1,28 @@
+diff --git a/src/main.rs b/src/main.rs
+index ead056d..4e1b46d 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -149,6 +149,14 @@ fn setup_logger(level: &str) -> Result<(), fern::InitError> {
+         "error" => log::LevelFilter::Error,
+         _ => log::LevelFilter::Info, // Default to Info for invalid values
+     };
++    let log_path = match dirs::home_dir() {
++        Some(home) => {
++            let app_dir = home.join(format!(".{}", env!("CARGO_PKG_NAME")));
++            std::fs::create_dir_all(&app_dir)?;
++            app_dir.join("app.log")
++        }
++        None => std::path::PathBuf::from("app.log"),
++    };
+     Dispatch::new()
+         .format(|out, message, record| {
+             out.finish(format_args!(
+@@ -159,7 +167,7 @@ fn setup_logger(level: &str) -> Result<(), fern::InitError> {
+             ))
+         })
+         .level(log_level)
+-        .chain(fern::log_file("app.log")?) // Guarda en logs/app.log
++        .chain(fern::log_file(&log_path)?)
+         .apply()?;
+     Ok(())
+ }

--- a/pkgs/by-name/mo/mostrix/package.nix
+++ b/pkgs/by-name/mo/mostrix/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  perl,
+  makeWrapper,
+  stdenv,
+  wayland,
+  libxkbcommon,
+  libxcb,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mostrix";
+  version = "0.2.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MostroP2P";
+    repo = "mostrix";
+    tag = "v${version}";
+    hash = "sha256-zKzPP+GRVLAon1ULDWOhcDjM/E4VAIsmnDethCoyL/w=";
+  };
+
+  cargoHash = "sha256-9mcSTB4guSrniQH0N9B+0//lpjLRoUWbaw22NZ9ps2U=";
+
+  patches = [
+    # write app.log to ~/.mostrix instead of read-only nix store
+    ./log-to-home-dir.patch
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    # aws-lc-sys (pulled in transitively via rustls/nostr-sdk) builds its
+    # vendored C sources with cmake, and uses perl for the asm generators.
+    cmake
+    perl
+    makeWrapper
+  ];
+
+  # sqlite (via libsqlite3-sys "bundled") is compiled from vendored C sources,
+  # so no system sqlite is required at build time.
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    wayland
+    libxkbcommon
+    libxcb
+  ];
+
+  # Some tests initialize the SQLite database under $HOME/.mostrix, which is
+  # unwritable in the build sandbox.
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # TODO: add versionCheckHook once upstream has a --version flag.
+
+  # arboard dlopens the Wayland/X11 clipboard backends at runtime; make the
+  # libraries discoverable so copy/paste works outside a dev shell.
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/mostrix \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs}
+  '';
+
+  meta = {
+    description = "Mostro TUI client for peer-to-peer Bitcoin trading over Nostr";
+    homepage = "https://github.com/MostroP2P/mostrix";
+    changelog = "https://github.com/MostroP2P/mostrix/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ekzyis ];
+    mainProgram = "mostrix";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
This adds [mostrix](https://github.com/MostroP2P/mostrix), a Mostro TUI client, to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
