### PR TITLE
`runCommand`: add `finalAttrs`

### DIFF
--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -3,6 +3,35 @@
 Nixpkgs provides a variety of wrapper functions that help build commonly useful derivations.
 Like [`stdenv.mkDerivation`](#sec-using-stdenv), each of these build helpers creates a derivation, but the arguments passed are different (usually simpler) from those required by `stdenv.mkDerivation`.
 
+## Arguments with finalAttrs {#trivial-builder-finalAttrs}
+
+In parameters that reference this section, you may either pass the value itself,
+or a function that produces it.
+When it's a function the argument value is [`finalAttrs`] from [`mkDerivation`].
+
+Typically both the *attributes* and *script* arguments support this, simultaneously if needed.
+
+::: {.example #ex-trivial-builder-finalAttrs}
+# Using `finalAttrs` in a build helper
+
+```nix
+runCommand "hi" (finalAttrs: { passthru.exe = "${finalAttrs.finalPackage}/bin/hi"; }) ''
+  mkdir -p $out/bin
+  substitute ${./hi.foo} $out/bin/hi --replace-fail "@foo@" ${lib.getExe foo}
+''
+```
+
+This creates a package with an executable script that's in the standard `bin/` directory,
+but also convenient to interpolate without reliance on `$PATH`, e.g assuming the result of the above is in binding `hi`:
+```nix
+''
+  echo START_GREETING
+  ${hi.exe} --rude
+  echo END_GREETING
+''
+```
+
+:::
 
 ## `runCommandWith` {#trivial-builder-runCommandWith}
 
@@ -23,8 +52,10 @@ runCommandWith :: {
   name :: name;
   stdenv? :: Derivation;
   runLocal? :: Bool;
-  derivationArgs? :: { ... };
-} -> String -> Derivation
+  derivationArgs? :: { ... } | finalAttrs@{ finalPackage :: Derivation, ... } -> { ... };
+}
+  -> (String | finalAttrs@{ finalPackage :: Derivation, ... } -> String)
+  -> Derivation
 ```
 
 ### Inputs {#trivial-builder-runCommandWith-Inputs}
@@ -47,10 +78,10 @@ runCommandWith :: {
 `stdenv` (Derivation)
 :   The [standard environment](#chap-stdenv) to use, defaulting to `pkgs.stdenv`.
 
-`derivationArgs` (Attribute set)
+`derivationArgs` (Attribute set *or* [function from `finalAttrs`](#trivial-builder-finalAttrs))
 :   Additional arguments for [`mkDerivation`](#sec-using-stdenv).
 
-`buildCommand` (String)
+`buildCommand` (String *or* [function from `finalAttrs`](#trivial-builder-finalAttrs))
 :   Shell commands to run in the derivation builder.
 
     ::: {.note}
@@ -109,10 +140,10 @@ While the type signature(s) differ from [`runCommandWith`], individual arguments
 `name` (String)
 :   The derivation's name
 
-`derivationArgs` (Attribute set)
+`derivationArgs` (Attribute set *or* [function from `finalAttrs`](#trivial-builder-finalAttrs))
 :   Additional parameters passed to [`mkDerivation`]
 
-`buildCommand` (String)
+`buildCommand` (String *or* [function from `finalAttrs`](#trivial-builder-finalAttrs))
 :   The command(s) run to build the derivation.
 
 
@@ -902,3 +933,6 @@ produces an output path `/nix/store/<hash>-runtime-references` containing
 
 but none of `hello`'s dependencies because those are not referenced directly
 by `hi`'s output.
+
+[`finalAttrs`]: #mkderivation-recursive-attributes
+[`mkDerivation`]: #sec-using-stdenv

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -140,6 +140,9 @@
   "ex-testEqualArrayOrMap-test-function-add-cowbell": [
     "index.html#ex-testEqualArrayOrMap-test-function-add-cowbell"
   ],
+  "ex-trivial-builder-finalAttrs": [
+    "index.html#ex-trivial-builder-finalAttrs"
+  ],
   "ex-writeShellApplication": [
     "index.html#ex-writeShellApplication"
   ],
@@ -980,6 +983,9 @@
   ],
   "treefmt": [
     "index.html#treefmt"
+  ],
+  "trivial-builder-finalAttrs": [
+    "index.html#trivial-builder-finalAttrs"
   ],
   "typst": [
     "index.html#typst",

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -140,6 +140,9 @@
   "ex-testEqualArrayOrMap-test-function-add-cowbell": [
     "index.html#ex-testEqualArrayOrMap-test-function-add-cowbell"
   ],
+  "ex-trivial-builder-finalAttrs": [
+    "index.html#ex-trivial-builder-finalAttrs"
+  ],
   "ex-writeShellApplication": [
     "index.html#ex-writeShellApplication"
   ],
@@ -998,6 +1001,9 @@
   ],
   "treefmt": [
     "index.html#treefmt"
+  ],
+  "trivial-builder-finalAttrs": [
+    "index.html#trivial-builder-finalAttrs"
   ],
   "typst": [
     "index.html#typst",

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -71,7 +71,6 @@ rec {
       stdenv ? defaultStdenv,
       # whether to build this derivation locally instead of substituting
       runLocal ? false,
-      # extra arguments to pass to stdenv.mkDerivation
       derivationArgs ? { },
       # name of the resulting derivation
       name,
@@ -79,22 +78,24 @@ rec {
     }:
     buildCommand:
     stdenv.mkDerivation (
+      finalAttrs:
+      let
+        userAttrs = lib.toFunction derivationArgs finalAttrs;
+      in
       {
         enableParallelBuilding = true;
-        inherit buildCommand name;
-        passAsFile = defaultPassAsFile ++ (derivationArgs.passAsFile or [ ]);
-        ${if !derivationArgs ? meta then "pos" else null} =
+        inherit name;
+        buildCommand = lib.toFunction buildCommand finalAttrs;
+        passAsFile = defaultPassAsFile ++ (userAttrs.passAsFile or [ ]);
+        ${if !userAttrs ? meta then "pos" else null} =
           let
-            args = builtins.attrNames derivationArgs;
+            args = builtins.attrNames userAttrs;
           in
-          if builtins.length args > 0 then
-            builtins.unsafeGetAttrPos (builtins.head args) derivationArgs
-          else
-            null;
+          if builtins.length args > 0 then builtins.unsafeGetAttrPos (builtins.head args) userAttrs else null;
         ${if runLocal then "preferLocalBuild" else null} = true;
         ${if runLocal then "allowSubstitutes" else null} = false;
       }
-      // removeAttrs derivationArgs removedNames
+      // removeAttrs userAttrs removedNames
     );
 
   # Docs in doc/build-helpers/trivial-build-helpers.chapter.md

--- a/pkgs/build-support/trivial-builders/test/default.nix
+++ b/pkgs/build-support/trivial-builders/test/default.nix
@@ -26,6 +26,7 @@ recurseIntoAttrs {
   overriding = callPackage ../test-overriding.nix { };
   inherit references;
   requireFile = callPackage ./requireFile.nix { };
+  runCommand = callPackage ./runCommand.nix { };
   writeCBin = callPackage ./writeCBin.nix { };
   writeClosure-union = callPackage ./writeClosure-union.nix {
     inherit (references) samples;

--- a/pkgs/build-support/trivial-builders/test/runCommand.nix
+++ b/pkgs/build-support/trivial-builders/test/runCommand.nix
@@ -1,0 +1,25 @@
+{ lib, runCommand, ... }:
+
+lib.recurseIntoAttrs {
+
+  runCommandBasic = runCommand "hi" { greeting = "hello"; } ''
+    [[ $greeting == hello ]] || echo wtf
+    touch $out
+  '';
+
+  runCommandFinalAttrs =
+    runCommand "hi-finalAttrs"
+      (finalAttrs: {
+        message = finalAttrs.greeting;
+        greeting = "hello";
+      })
+      (
+        finalAttrs:
+        assert finalAttrs.message == "hello";
+        ''
+          [[ $message == hello ]] || echo wtf
+          touch $out
+        ''
+      );
+
+}

--- a/pkgs/build-support/trivial-builders/test/runCommand.nix
+++ b/pkgs/build-support/trivial-builders/test/runCommand.nix
@@ -1,0 +1,25 @@
+{ lib, runCommand, ... }:
+
+lib.recurseIntoAttrs {
+
+  runCommandBasic = runCommand "hi" { greeting = "hello"; } ''
+    [[ $greeting == hello ]] || { echo wtf; exit 1; }
+    touch $out
+  '';
+
+  runCommandFinalAttrs =
+    runCommand "hi-finalAttrs"
+      (finalAttrs: {
+        message = finalAttrs.greeting;
+        greeting = "hello";
+      })
+      (
+        finalAttrs:
+        assert finalAttrs.message == "hello";
+        ''
+          [[ $message == hello ]] || { echo wtf; exit 1; }
+          touch $out
+        ''
+      );
+
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A useful little nugget when you need it.
The example is a bit silly.
The real motiviation is https://github.com/NixOS/nixpkgs/pull/551391
The correct thing wrt overriding should be straighforward, so that it makes things like this go smoother.
Or more insidious correctness issue: https://github.com/NixOS/nixpkgs/pull/551387
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] `pkgs.tests.trivial-builders.runCommand` :new: 
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
