### PR TITLE
[release-26.05] matrix-continuwuity: backport SEC26, matrix-continuwuity: backport SEC28

### DIFF
--- a/pkgs/by-name/ma/matrix-continuwuity/0002-fix-backport-SEC28.patch
+++ b/pkgs/by-name/ma/matrix-continuwuity/0002-fix-backport-SEC28.patch
@@ -1,0 +1,37 @@
+From dcb079931a929880518015794d709f93651154ca Mon Sep 17 00:00:00 2001
+From: Ginger <ginger@gingershaped.computer>
+Date: Tue, 11 Aug 2026 15:59:26 -0400
+Subject: [PATCH 1/2] fix(backport): SEC28
+
+(cherry picked from commit 49a8f6f53b6f86ed6abb8952843cb3a38c530ada)
+---
+ src/service/threepid/mod.rs | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/service/threepid/mod.rs b/src/service/threepid/mod.rs
+index dcc0b58ab..bda80f82e 100644
+--- a/src/service/threepid/mod.rs
++++ b/src/service/threepid/mod.rs
+@@ -112,6 +112,10 @@ pub async fn send_validation_email<Template: MessageTemplate>(
+ 			// If a validation session already exists for this client secret, we can either
+ 			// reuse it with a new token or return early because it's already valid.
+ 			| Some(session) => {
++				if session.email != recipient.email {
++					return Err!(Request(InvalidParam("Wrong email for session.")));
++				}
++
+ 				match session.validation_state {
+ 					| ValidationState::Validated => {
+ 						// If the existing session is already valid, don't send an email.
+@@ -119,7 +123,7 @@ pub async fn send_validation_email<Template: MessageTemplate>(
+ 					},
+ 					| ValidationState::Pending(ref mut token) => {
+ 						// Check ratelimiting for the target address.
+-						if self.ratelimiter.check_key(&recipient.email).is_err() {
++						if self.ratelimiter.check_key(&session.email).is_err() {
+ 							return Err(Error::BadRequest(
+ 								ErrorKind::LimitExceeded { retry_after: None },
+ 								"You're sending emails too fast, try again in a few minutes.",
+-- 
+2.55.0
+

--- a/pkgs/by-name/ma/matrix-continuwuity/0003-fix-backport-SEC26.patch
+++ b/pkgs/by-name/ma/matrix-continuwuity/0003-fix-backport-SEC26.patch
@@ -1,0 +1,132 @@
+From a00a615799bc55bc093a6298735732565aa2b566 Mon Sep 17 00:00:00 2001
+From: Ginger <ginger@gingershaped.computer>
+Date: Tue, 11 Aug 2026 16:35:24 -0400
+Subject: [PATCH 2/2] fix(backport): SEC26
+
+Reviewed-By: timedout <git@nexy7574.co.uk>
+Reviewed-By: Ginger <ginger@gingershaped.computer>
+(cherry picked from commit 700fbe472d4a8385b96f870256bfc00f9a15f809)
+---
+ src/api/server/event_auth.rs | 27 ++++++++++-----------------
+ src/api/server/state.rs      | 13 ++++++++++++-
+ src/api/server/state_ids.rs  | 13 ++++++++++++-
+ 3 files changed, 34 insertions(+), 19 deletions(-)
+
+diff --git a/src/api/server/event_auth.rs b/src/api/server/event_auth.rs
+index a9019e8e7..433e18f46 100644
+--- a/src/api/server/event_auth.rs
++++ b/src/api/server/event_auth.rs
+@@ -1,12 +1,9 @@
+ use std::{borrow::Borrow, iter::once};
+ 
+ use axum::extract::State;
+-use conduwuit::{Err, Error, Result, info, utils::stream::ReadyExt};
++use conduwuit::{Err, Result, Event, info, utils::stream::ReadyExt};
+ use futures::StreamExt;
+-use ruma::{
+-	RoomId,
+-	api::{client::error::ErrorKind, federation::authorization::get_event_authorization},
+-};
++use ruma::api::federation::authorization::get_event_authorization;
+ 
+ use super::AccessCheck;
+ use crate::Ruma;
+@@ -42,25 +39,21 @@ pub(crate) async fn get_event_authorization_route(
+ 		return Err!(Request(NotFound("This server is not participating in that room.")));
+ 	}
+ 
+-	let event = services
++	// The event must be in the room we just authorised access to
++	if !services
+ 		.rooms
+ 		.timeline
+-		.get_pdu_json(&body.event_id)
++		.get_pdu(&body.event_id)
+ 		.await
+-		.map_err(|_| Error::BadRequest(ErrorKind::NotFound, "Event not found."))?;
+-
+-	let room_id_str = event
+-		.get("room_id")
+-		.and_then(|val| val.as_str())
+-		.ok_or_else(|| Error::bad_database("Invalid event in database."))?;
+-
+-	let room_id = <&RoomId>::try_from(room_id_str)
+-		.map_err(|_| Error::bad_database("Invalid room_id in event in database."))?;
++		.is_ok_and(|pdu| pdu.room_id_or_hash() == body.room_id)
++	{
++		return Err!(Request(NotFound("Event not found.")));
++	}
+ 
+ 	let auth_chain = services
+ 		.rooms
+ 		.auth_chain
+-		.event_ids_iter(room_id, once(body.event_id.borrow()))
++		.event_ids_iter(&body.room_id, once(body.event_id.borrow()))
+ 		.ready_filter_map(Result::ok)
+ 		.filter_map(|id| async move { services.rooms.timeline.get_pdu_json(&id).await.ok() })
+ 		.then(|pdu| services.sending.convert_to_outgoing_federation_event(pdu))
+diff --git a/src/api/server/state.rs b/src/api/server/state.rs
+index 5e1ad8ca2..05a008b74 100644
+--- a/src/api/server/state.rs
++++ b/src/api/server/state.rs
+@@ -1,7 +1,7 @@
+ use std::{borrow::Borrow, iter::once};
+ 
+ use axum::extract::State;
+-use conduwuit::{Err, Result, at, err, info, utils::IterStream};
++use conduwuit::{Err, Event, Result, at, err, info, utils::IterStream};
+ use futures::{FutureExt, StreamExt, TryStreamExt};
+ use ruma::{OwnedEventId, api::federation::event::get_room_state};
+ 
+@@ -24,6 +24,17 @@ pub(crate) async fn get_room_state_route(
+ 	.check()
+ 	.await?;
+ 
++	// The event must be in the room we just authorised access to
++	if !services
++		.rooms
++		.timeline
++		.get_pdu(&body.event_id)
++		.await
++		.is_ok_and(|pdu| pdu.room_id_or_hash() == body.room_id)
++	{
++		return Err!(Request(NotFound("Event not found.")));
++	}
++
+ 	if !services
+ 		.rooms
+ 		.state_cache
+diff --git a/src/api/server/state_ids.rs b/src/api/server/state_ids.rs
+index c9dea3116..206f3efc5 100644
+--- a/src/api/server/state_ids.rs
++++ b/src/api/server/state_ids.rs
+@@ -1,7 +1,7 @@
+ use std::{borrow::Borrow, iter::once};
+ 
+ use axum::extract::State;
+-use conduwuit::{Err, Result, at, err, info};
++use conduwuit::{Err, Event, Result, at, err, info};
+ use futures::{StreamExt, TryStreamExt};
+ use ruma::{OwnedEventId, api::federation::event::get_room_state_ids};
+ 
+@@ -25,6 +25,17 @@ pub(crate) async fn get_room_state_ids_route(
+ 	.check()
+ 	.await?;
+ 
++	// The event must be in the room we just authorised access to
++	if !services
++		.rooms
++		.timeline
++		.get_pdu(&body.event_id)
++		.await
++		.is_ok_and(|pdu| pdu.room_id_or_hash() == body.room_id)
++	{
++		return Err!(Request(NotFound("Event not found.")));
++	}
++
+ 	if !services
+ 		.rooms
+ 		.state_cache
+-- 
+2.55.0
+

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -53,6 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   patches = [
     ./0001-fix-backport-SEC10.patch
     ./0002-fix-backport-SEC28.patch
+    ./0003-fix-backport-SEC26.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -52,6 +52,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   patches = [
     ./0001-fix-backport-SEC10.patch
+    ./0002-fix-backport-SEC28.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
- **matrix-continuwuity: backport SEC28**
- **matrix-continuwuity: backport SEC26**

This is a partial backport of https://github.com/NixOS/nixpkgs/pull/551640, backporting a security fix in release v26.7.3 of Continuwuity to v0.5.10.
Original patches:
- https://forgejo.ellis.link/continuwuation/continuwuity/commit/700fbe472d4a8385b96f870256bfc00f9a15f809
- https://forgejo.ellis.link/continuwuation/continuwuity/commit/49a8f6f53b6f86ed6abb8952843cb3a38c530ada

See also: https://forgejo.ellis.link/continuwuation/continuwuity/releases/tag/v26.7.3

Fixes: GHSA-v2x6-m99h-vqxx

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
