### PR TITLE
python3Packages.pytest-forked: 1.6.0 -> 1.7.5

### DIFF
--- a/pkgs/development/python-modules/pytest-forked/default.nix
+++ b/pkgs/development/python-modules/pytest-forked/default.nix
@@ -4,71 +4,43 @@
   buildPythonPackage,
   pythonAtLeast,
   fetchFromGitHub,
-  fetchpatch2,
   setuptools,
   setuptools-scm,
-  wheel,
-  py,
   pytest,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-forked";
-  version = "1.6.0";
+  version = "1.7.5";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-forked";
-    tag = "v${version}";
-    hash = "sha256-owkGwF5WQ17/CXwTsIYJ2AgktekRB4qhtsDxR0LCI/k=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RPuJAukcfVjZHZQ+a/bxADhY3BJKmSe3S/6eHUG3kYQ=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      # https://github.com/pytest-dev/pytest-forked/actions
-      name = "pytest8-compat.patch";
-      url = "https://github.com/pytest-dev/pytest-forked/commit/b2742322d39ebda97d5170922520f3bb9c73f614.patch";
-      hash = "sha256-tTRW0p3tOotQMtjjJ6RUKdynsAnKRz0RAV8gAUHiNNA=";
-    })
-    # https://github.com/pytest-dev/pytest-forked/pull/96
-    ./pytest9-compat.patch
-  ];
-
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     setuptools-scm
-    wheel
   ];
 
   buildInputs = [ pytest ];
 
-  propagatedBuildInputs = [ py ];
-
   nativeCheckInputs = [
-    py
     pytestCheckHook
   ];
-
-  disabledTests =
-    if (pythonAtLeast "3.12" && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) then
-      [
-        # non reproducible test failure on hydra, works on community builder
-        # https://hydra.nixos.org/build/252537267
-        "test_xfail"
-      ]
-    else
-      null;
 
   setupHook = ./setup-hook.sh;
 
   meta = {
-    changelog = "https://github.com/pytest-dev/pytest-forked/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/pytest-dev/pytest-forked/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     description = "Run tests in isolated forked subprocesses";
     homepage = "https://github.com/pytest-dev/pytest-forked";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/pytest-dev/pytest-forked/compare/v1.6.0...v1.7.5

Changelog: https://github.com/pytest-dev/pytest-forked/blob/refs/tags/v1.7.5/CHANGELOG.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
