### PR TITLE
slang-server: init at 0.2.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8646,6 +8646,12 @@
     githubId = 330292;
     name = "Evan Richter";
   };
+  evanwporter = {
+    email = "evanwporter@gmail.com";
+    github = "evanwporter";
+    githubId = 115374841;
+    name = "Evan Porter";
+  };
   evax = {
     email = "nixos@evax.fr";
     github = "evax";

--- a/pkgs/by-name/sl/slang-server/package.nix
+++ b/pkgs/by-name/sl/slang-server/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  clang-tools,
+  cmake,
+  ninja,
+  pkg-config,
+  python3,
+
+  # buildInputs
+  openssl,
+  zlib,
+  fmt,
+  boost,
+  tomlplusplus,
+
+  # tests
+  versionCheckHook,
+
+  # passthru
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "slang-server";
+  version = "0.2.10";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hudson-trading";
+    repo = "slang-server";
+    tag = "v${finalAttrs.version}";
+    # slang-server vendors its dependencies via submodules
+    fetchSubmodules = true;
+    hash = "sha256-hyKiEtUpLkXYbwh9KKDc26EgZbC1bvf0hV5tM8p5vVU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    # Pick up the `clang-scan-deps` wrapper for CMake; see:
+    # https://github.com/NixOS/nixpkgs/issues/452260
+    clang-tools
+  ];
+
+  buildInputs = [
+    boost
+    fmt
+    openssl
+    tomlplusplus
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SLANG_SERVER_INCLUDE_TESTS" false)
+    (lib.cmakeBool "SLANG_INCLUDE_TESTS" false)
+    (lib.cmakeBool "SLANG_USE_MIMALLOC" false)
+    (lib.cmakeBool "SLANG_USE_SYSTEM_BOOST" true)
+    (lib.cmakeBool "SLANG_SERVER_USE_SYSTEM_FMT" true)
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "SystemVerilog language server";
+    homepage = "https://github.com/hudson-trading/slang-server";
+    changelog = "https://github.com/hudson-trading/slang-server/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.evanwporter ];
+    platforms = lib.platforms.unix;
+    mainProgram = "slang-server";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [slang-server](https://github.com/hudson-trading/slang-server)--a system verilog language server--to nixpkgs.

Companion PR: #551675

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
