### PR TITLE
nanoboyadvance: 1.8.2 -> 1.8.3

### DIFF
--- a/pkgs/by-name/na/nanoboyadvance/package.nix
+++ b/pkgs/by-name/na/nanoboyadvance/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
+  fetchgit,
   cmake,
   python3Packages,
   libsForQt5,
@@ -22,17 +23,16 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nanoboyadvance";
-  version = "1.8.2";
+  version = "1.8.3";
 
-  src = fetchFromGitHub {
-    owner = "nba-emu";
-    repo = "NanoBoyAdvance";
+  src = fetchgit {
+    url = "https://codeberg.org/nba-emu/NanoBoyAdvance.git";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IH2X0B3HwEG0/wvKacLVPBQad14W0HBy5VFHjk8vgJk=";
   };
 
   patches = [
-    # <https://github.com/nba-emu/NanoBoyAdvance/pull/410>
+    # <https://codeberg.org/nba-emu/NanoBoyAdvance/pull/410>
     ./fix-toml11-4.0.patch
   ];
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Cycle-accurate Nintendo Game Boy Advance emulator";
-    homepage = "https://github.com/nba-emu/NanoBoyAdvance";
+    homepage = "https://codeberg.org/nba-emu/NanoBoyAdvance";
     license = lib.licenses.gpl3Plus;
     mainProgram = "NanoBoyAdvance";
     maintainers = with lib.maintainers; [ tomasajt ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump NanoBoyAdvance, a gameboy emulator, a version. Also I updated how it fetches to reflect that NBA now uses codeberg.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
