### PR TITLE
me3: 0.12.1 -> 0.13.0

### DIFF
--- a/pkgs/by-name/me/me3/package.nix
+++ b/pkgs/by-name/me/me3/package.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  version = "0.12.1";
+  version = "0.13.0";
 
   # me3 creates a pipe under /tmp needed by the compat tool subprocess
   steam-run =
@@ -22,10 +22,10 @@ let
     owner = "garyttierney";
     repo = "me3";
     tag = "v${version}";
-    sha256 = "sha256-pGK6A85Xp6NbpYRKJTgi47acv4c8dZgb+Jdmeu8F/uU=";
+    sha256 = "sha256-OgAJGzjt+VDjbyY3uOjX3M5HajXbdoF1YJFAgwiZ03o=";
   };
 
-  cargoHash = "sha256-ss2NkDHfd5NBLGpnZ80UdvO0nn2mGueO0mnlWkog1jc=";
+  cargoHash = "sha256-e6tytA15kY58efmG3mIgZpTTa11Ijwl8u+NIBdYmha8=";
 
   me3-cli = rustPlatform.buildRustPackage (final: {
     inherit cargoHash version src;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
