### PR TITLE
openscadPackages.bosl: init at unstable-2023-02-19

### DIFF
--- a/pkgs/development/openscad-packages/bosl/default.nix
+++ b/pkgs/development/openscad-packages/bosl/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildOpenSCADPackage,
+  fetchFromGitHub,
+}:
+
+buildOpenSCADPackage (finalAttrs: {
+  pname = "bosl";
+  version = "unstable-2023-02-19";
+  libName = "BOSL";
+
+  installTargets = [ "*.scad" ];
+
+  src = fetchFromGitHub {
+    owner = "revarbat";
+    repo = "BOSL";
+    rev = "4ce427a8a38786e5f74b728c1e33d9fe7d4904d2";
+    hash = "sha256-24vqGt0TPe09K1WTP8fDX2Wx4MlsDnigzx7Ha0mXCOg=";
+  };
+
+  meta = {
+    description = "The Belfry OpenScad Library - A library of tools, shapes, and helpers to make OpenScad easier to use.";
+    homepage = "https://github.com/revarbat/BOSL";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ xoconoch ];
+  };
+})

--- a/pkgs/top-level/openscad-packages.nix
+++ b/pkgs/top-level/openscad-packages.nix
@@ -12,5 +12,6 @@ lib.makeScope newScope (
   lib.recurseIntoAttrs {
     buildOpenSCADPackage = self.callPackage ../build-support/build-openscad-package { };
     openscad = openscadOrig.override { openscadPackages = self; };
+    bosl = self.callPackage ../development/openscad-packages/bosl { };
   }
 )


### PR DESCRIPTION
As per suggestion in https://github.com/NixOS/nixpkgs/pull/551689#issuecomment-5260707692, BOSL v1 gets added alongside BOSL v2. This version of the library seems to be unmaintained, so I just put the latest commit and called it unstable. Test shell:

```nix
let
  pkgs = import ./default.nix { };
in
pkgs.mkShell {
  buildInputs = [
    (pkgs.openscadPackages.openscad.withPackages (ps: [ ps.bosl ]))
  ];
  shellHook = ''
    openscad -o test.3mf - <<EOF
    include <BOSL/constants.scad>
    use <BOSL/shapes.scad>

    cuboid(40);

    EOF
    rm test.3mf
  '';
}
```

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
