### PR TITLE
cnijfilter_4_00: unpin gcc13, pass -std=c90

### DIFF
--- a/pkgs/by-name/cn/cnijfilter_4_00/package.nix
+++ b/pkgs/by-name/cn/cnijfilter_4_00/package.nix
@@ -1,5 +1,5 @@
 {
-  gcc13Stdenv,
+  stdenv,
   lib,
   fetchzip,
   autoconf,
@@ -21,7 +21,6 @@
 */
 
 let
-  stdenv = gcc13Stdenv;
   arch =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       "64"
@@ -67,6 +66,8 @@ stdenv.mkDerivation {
     libusb1
     libxml2
   ];
+
+  env.NIX_CFLAGS_COMPILE = " -std=gnu90";
 
   # patches from https://github.com/tokiclover/bar-overlay/tree/master/net-print/cnijfilter
   patches = [


### PR DESCRIPTION
similar to 698f8c73450fa37cbf015d94d2f447b22717e57b and 334ad35f81097d93d51c7cede18446208c8fb4f5, this doesn't inherently need gcc 13. specifying the standard version is enough, and prevents pulling in compiler versions that are mostly unused.

don't have the right printer to test this with, but this is a simple compilation change and shouldn't affect runtime.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
