### PR TITLE
lxrandr: force-enable gtk3

### DIFF
--- a/pkgs/by-name/lx/lxrandr/package.nix
+++ b/pkgs/by-name/lx/lxrandr/package.nix
@@ -4,10 +4,8 @@
   fetchFromGitHub,
   pkg-config,
   intltool,
-  gtk2,
   libx11,
   xrandr,
-  withGtk3 ? false,
   gtk3,
   autoreconfHook,
   libxslt,
@@ -29,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--enable-man"
-  ]
-  ++ lib.optional withGtk3 "--enable-gtk3";
+    "--enable-gtk3"
+  ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -47,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libx11
     xrandr
-    (if withGtk3 then gtk3 else gtk2)
+    gtk3
   ];
 
   meta = {


### PR DESCRIPTION
We're getting rid of GTK2, so we force on GTK3 support.

Part of #410814
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
