### PR TITLE
gxmatcheq-lv2: unpin gcc13, fix build with modern gcc

### DIFF
--- a/pkgs/by-name/gx/gxmatcheq-lv2/package.nix
+++ b/pkgs/by-name/gx/gxmatcheq-lv2/package.nix
@@ -1,20 +1,15 @@
 {
   lib,
   stdenv,
-  gcc13Stdenv,
   fetchFromGitHub,
+  fetchpatch,
   libx11,
   xorgproto,
   cairo,
   lv2,
   pkg-config,
 }:
-let
-  # see: https://github.com/brummer10/GxMatchEQ.lv2/issues/8
-  # Use gcc13 on Linux, but default stdenv (clang) elsewhere
-  buildStdenv = if stdenv.hostPlatform.isLinux then gcc13Stdenv else stdenv;
-in
-buildStdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "GxMatchEQ.lv2";
   version = "0.1";
 
@@ -24,6 +19,22 @@ buildStdenv.mkDerivation (finalAttrs: {
     rev = "V${finalAttrs.version}";
     hash = "sha256-4jg6DYkNRuNuQpOnsZfwJAZljBmBRzS6NcJKjv+r7Ss=";
   };
+
+  patches = [
+    # _LV2UI_Descriptor was mistakenly used instead of LV2UI_Descriptor in one
+    # signature.
+    (fetchpatch {
+      name = "use-lv2ui_descriptor-name.patch";
+      url = "https://github.com/brummer10/GxMatchEQ.lv2/commit/4ca70be32220729a5253c0bb46f5aded5ba3d00a.patch";
+      hash = "sha256-EKlv6UptUpP+LOG7S30L21o0/upeDj6WB1PZ44XtNRU=";
+    })
+  ];
+
+  # without the Xresource.h header, compilation on gcc versions > 13 fails with
+  # gui/gx_matcheq_x11ui.c:360:27: error: implicit declaration of function 'XrmUniqueQuark' [-Wimplicit-function-declaration]
+  postPatch = ''
+    sed -e '1i #include <X11/Xresource.h>' -i gui/gx_matcheq_x11ui.c
+  '';
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
gcc 13 was previously pinned to fix the build, but this was masking real issues. one was fixed upstream, so we fetch the patch, while the other is a missing header that we put in the correct place. this also helps reduce unnecessary pins of old compiler versions and eases their maintenance.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
