### PR TITLE
cpio: patch CVE-2026-66484, CVE-2026-66485, and CVE-2026-66486

### DIFF
--- a/pkgs/by-name/cp/cpio/package.nix
+++ b/pkgs/by-name/cp/cpio/package.nix
@@ -2,7 +2,9 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   autoreconfHook,
+  texinfo,
 
   # for passthru.tests
   git,
@@ -20,7 +22,29 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-k3YQuXwymh7JJoVT+3gAN7z/8Nz/6XJevE/ZwaqQdds=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  patches = [
+    (fetchpatch {
+      name = "CVE-2026-66484.patch";
+      url = "https://git.savannah.gnu.org/cgit/cpio.git/patch/?id=e2b9cbdd3354d2b1569b7390d1bc15c1930559ad";
+      hash = "sha256-WjphVpMaI/ePg8MTZx+vvilKzpRAAzhAFwCwrbsPLRE=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-66485.patch";
+      url = "https://git.savannah.gnu.org/cgit/cpio.git/patch/?id=3cd514031371d8aeeaf2048aa10103e02831aaa9";
+      hash = "sha256-YDlROEYYlZERNzzlx1cQD29gV5IrU01aVcZ/sKpWrRo=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-66486.patch";
+      url = "https://git.savannah.gnu.org/cgit/cpio.git/patch/?id=2ff9600c9ef32e88759843cdbde74c8db5ae9b30";
+      excludes = [ "NEWS" ];
+      hash = "sha256-qi9/9xhKnIyPpji63RgzbnnHZsJgwRnQVMaMiLxQipk=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    texinfo # for makeinfo
+  ];
 
   separateDebugInfo = true;
 


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/551385
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
