### PR TITLE
python3Packages.llama-cpp-python: unpin gcc13 for cuda

### DIFF
--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  gcc13Stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -35,10 +34,7 @@
   cudaPackages ? { },
 
 }:
-let
-  stdenvTarget = if cudaSupport then gcc13Stdenv else stdenv;
-in
-buildPythonPackage.override { stdenv = stdenvTarget; } rec {
+buildPythonPackage rec {
   pname = "llama-cpp-python";
   version = "0.3.23";
   pyproject = true;
@@ -126,7 +122,7 @@ buildPythonPackage.override { stdenv = stdenvTarget; } rec {
       rev-prefix = "v";
       allowedVersions = "^[.0-9]+$";
     };
-    tests = lib.optionalAttrs stdenvTarget.hostPlatform.isLinux {
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
       withCuda = llama-cpp-python.override {
         cudaSupport = true;
       };


### PR DESCRIPTION
this appears to no longer be necessary, as `pkgsCuda.python3Packages.llama-cpp-python` builds fine. this helps reduce proliferation of old compiler versions. originally introduced in 6d15d203b6824564b072d8f55fe9eed1c6f7911e.

## Things done

- Built on platform:
  - [x] x86_64-linux (`python3Packages.llama-cpp-python`, `pkgsCuda.python3Packages.llama-cpp-python`)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
