### PR TITLE
nmtrust: 0.1.1 -> 0.2.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -114,6 +114,12 @@
 
 - `services.pid-fan-controller` no longer provides deep configuration rewriting and adheres now fully to RFC42.
 
+- `services.nmtrust` binds units by their full unit name. An entry such as `"mailsync.timer"` previously bound `mailsync.service`, leaving the timer firing in every trust state; entries are now routed to the option set owning their type, and unbindable types are rejected at evaluation time.
+
+- `services.nmtrust` now forces `wantedBy` on bound units, which are controlled by the trust targets alone. A unit declaring its own `wantedBy` elsewhere stayed needed in every trust state, so the binding silently did nothing.
+
+- `services.nmtrust` ignores loopback when evaluating trust. Counting NetworkManager-managed `lo` put every host in the mixed branch, which `mixedPolicy = "untrusted"` resolved to untrusted, so the trusted state was unreachable and trusted-bound units never ran. They now start as intended, and an explicit `lo` exclusion is no longer needed.
+
 - The `extraArgs` and `check` arguments to `nixos/lib/eval-config.nix` (and therefore to `lib.nixosSystem`) have been removed after being deprecated with a warning since 2021. Passing them is now an evaluation error. Instead of `extraArgs`, set `config._module.args`; instead of `check = false`, set `config._module.check = false`. The `extraArgs` attribute on the resulting configuration has been removed as well.
 
 - Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.
@@ -173,6 +179,10 @@
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
+
+- `services.nmtrust` units can be bound to any trust state through a `states` list, not just the trusted one, so a unit can run precisely when the network is *not* trusted — a VPN, or a stricter resolver. `allowOffline` is kept as sugar, leaving existing configurations unchanged. `evalFailurePolicy = "offline"` is now rejected alongside untrusted-bound units, since it would drop a VPN while still on a hostile network.
+
+- `services.nmtrust` no longer blocks activation on the units a trust target starts, which previously stalled `nixos-rebuild` for as long as a bound backup or VPN took to run, with no error.
 
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 

--- a/nixos/modules/services/networking/nmtrust.nix
+++ b/nixos/modules/services/networking/nmtrust.nix
@@ -17,18 +17,152 @@ let
 
   userNames = builtins.attrNames cfg.userUnits;
 
+  # Unit names across all users, deduplicated: systemd.user.* is
+  # system-wide, so the same unit named by two users is one unit.
+  sharedUserUnitNames = lib.unique (
+    lib.concatMap (username: builtins.attrNames cfg.userUnits.${username}) userNames
+  );
+
   # The package reads config from /etc/nmtrust/config at runtime
   trustHelper = pkgs.nmtrust;
 
-  # Trust target names
-  trustTargets = [
-    "nmtrust-trusted"
-    "nmtrust-untrusted"
-    "nmtrust-offline"
+  # Trust states, and the target names derived from them
+  trustStates = [
+    "trusted"
+    "untrusted"
+    "offline"
   ];
+
+  trustTargets = map (state: "nmtrust-${state}") trustStates;
+
+  # Fully-qualified target unit names, used to tell nmtrust's own
+  # dependencies apart from foreign ones in assertions.
+  trustTargetUnits = map (t: "${t}.target") trustTargets;
 
   # Generate Conflicts= for a target (all other trust targets)
   conflictsFor = target: map (t: "${t}.target") (builtins.filter (t: t != target) trustTargets);
+
+  # Unit types nmtrust can bind, mapped to the NixOS option set that owns
+  # them. NixOS appends the type suffix itself, so "backup.timer" has to
+  # be routed to systemd.timers.backup — putting it in systemd.services
+  # would silently bind backup.service and leave the timer firing in
+  # every trust state.
+  unitTypeOptions = {
+    service = "services";
+    timer = "timers";
+    socket = "sockets";
+    path = "paths";
+  };
+
+  # Every unit type systemd knows. Used to tell a real type suffix apart
+  # from a dot inside a unit name (dbus-org.freedesktop.resolve1 must not
+  # be read as a ".resolve1" unit). No entry is a suffix of another, so
+  # at most one can match.
+  allUnitTypes = [
+    "service"
+    "socket"
+    "device"
+    "mount"
+    "automount"
+    "swap"
+    "target"
+    "path"
+    "timer"
+    "slice"
+    "scope"
+  ];
+
+  # "backup.timer" -> { type = "timer"; base = "backup"; optionSet = "timers"; }
+  # A name with no recognized type suffix is treated as a service, which
+  # is both the previous behaviour and NixOS's own convention for
+  # systemd.services attribute names. A unit whose name genuinely ends in
+  # another type's suffix can be disambiguated by spelling out .service
+  # ("archive.timer.service" -> systemd.services."archive.timer").
+  #
+  # `bindable` is false for unit types nmtrust cannot bind and for a name
+  # that is nothing but a suffix (".timer"). Both are rejected by an
+  # assertion and skipped when generating config.
+  splitUnitName =
+    name:
+    let
+      matched = builtins.filter (t: lib.hasSuffix ".${t}" name) allUnitTypes;
+      type = if matched == [ ] then "service" else builtins.head matched;
+      base = if matched == [ ] then name else lib.removeSuffix ".${type}" name;
+      optionSet = unitTypeOptions.${type} or null;
+    in
+    {
+      inherit type base optionSet;
+      bindable = optionSet != null && base != "";
+    };
+
+  bindableUnitTypes = builtins.attrNames unitTypeOptions;
+
+  # States a unit entry resolves to; allowOffline is sugar for adding
+  # "offline" to states.
+  unitStates = unitCfg: lib.unique (unitCfg.states ++ lib.optional unitCfg.allowOffline "offline");
+
+  # Every binding that names the untrusted state, labelled for error
+  # messages. Used to reject the fail-open evalFailurePolicy combination.
+  untrustedBoundUnits =
+    lib.filter (n: builtins.elem "untrusted" (unitStates cfg.systemUnits.${n})) (
+      builtins.attrNames cfg.systemUnits
+    )
+    ++ lib.concatMap (
+      username:
+      map (n: "${username}:${n}") (
+        lib.filter (n: builtins.elem "untrusted" (unitStates cfg.userUnits.${username}.${n})) (
+          builtins.attrNames cfg.userUnits.${username}
+        )
+      )
+    ) userNames;
+
+  # { "backup.timer" = [ states ]; ... }
+  #   -> { timers = { backup = [ states ]; }; ... }
+  # Two entries can land on the same unit (e.g. "foo" and "foo.service"),
+  # so states are unioned rather than overwritten.
+  byOptionSet =
+    statesByName:
+    lib.foldl' (
+      acc: unitName:
+      let
+        u = splitUnitName unitName;
+        existing = acc.${u.optionSet} or { };
+      in
+      if !u.bindable then
+        acc
+      else
+        acc
+        // {
+          ${u.optionSet} = existing // {
+            ${u.base} = lib.unique ((existing.${u.base} or [ ]) ++ statesByName.${unitName});
+          };
+        }
+    ) { } (builtins.attrNames statesByName);
+
+  # systemUnits, grouped by the option set each unit belongs to.
+  systemUnitsByOptionSet = byOptionSet (lib.mapAttrs (_: unitStates) cfg.systemUnits);
+
+  # userUnits merged across users first — systemd.user.* is system-wide,
+  # so per-user differences in states/allowOffline are resolved by taking
+  # the most permissive value (the unit runs in any state some user
+  # asked for) — then grouped the same way.
+  userUnitsByOptionSet = byOptionSet (
+    lib.foldl' (
+      acc: username:
+      lib.foldl' (
+        acc': unitName:
+        acc'
+        // {
+          ${unitName} = lib.unique (
+            (acc'.${unitName} or [ ]) ++ unitStates cfg.userUnits.${username}.${unitName}
+          );
+        }
+      ) acc (builtins.attrNames cfg.userUnits.${username})
+    ) { } userNames
+  );
+
+  # Overrides for one option set, e.g. mkBoundUnits userUnitsByOptionSet "timers"
+  mkBoundUnits = grouped: optionSet: lib.mapAttrs (_: mkUnitOverrides) (grouped.${optionSet} or { });
 
   # Uses StopWhenUnneeded instead of PartOf to avoid same-transaction
   # issues: when transitioning between targets that both want a unit
@@ -36,29 +170,147 @@ let
   # old target would stop the unit before WantedBy on the new target
   # can restart it. StopWhenUnneeded only stops the unit when NO
   # active target wants it.
-  mkUnitOverrides =
-    unitName: unitCfg:
+  #
+  # wantedBy is mkForce'd for two reasons. Most units worth binding are
+  # already `wantedBy = [ "multi-user.target" ]` in the module that
+  # defines them; left in place, that keeps the unit "needed" in every
+  # trust state and silently reduces the binding to a no-op. Forcing it
+  # also means a user's own `wantedBy = lib.mkForce [ ]` merges with this
+  # definition at equal priority (list definitions at the winning
+  # priority are concatenated) instead of clobbering the trust binding.
+  mkUnitOverrides = states: {
+    unitConfig.StopWhenUnneeded = true;
+    wantedBy = lib.mkForce (map (state: "nmtrust-${state}.target") states);
+  };
+
+  # Options shared by systemUnits and userUnits entries.
+  unitSubmodule = lib.types.submodule {
+    options = {
+      states = lib.mkOption {
+        type = lib.types.nonEmptyListOf (lib.types.enum trustStates);
+        default = [ "trusted" ];
+        example = [ "untrusted" ];
+        description = ''
+          Trust states in which this unit should run. The unit is bound to
+          the corresponding `nmtrust-<state>.target`s and stops in every
+          state not listed.
+
+          The default `[ "trusted" ]` runs the unit only on trusted
+          networks. Use `[ "untrusted" ]` for the inverse case — a unit
+          that should run only on networks you do not control, such as a
+          VPN or Tailscale bring-up unit. Listing all three states means
+          the unit always runs, which makes the binding pointless.
+        '';
+      };
+
+      allowOffline = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether this unit should also run when offline. Shorthand for
+          adding `"offline"` to {option}`states`; the two are unioned.
+        '';
+      };
+    };
+  };
+
+  # StopWhenUnneeded= only stops a unit when nothing *active* needs it.
+  # Foreign wantedBy is handled by mkForce above, but requiredBy and
+  # upheldBy are contributed to other units' Requires=/Upholds= and
+  # cannot be overridden from here — they keep the unit running in every
+  # trust state and silently reduce the binding to a no-op. Catch them at
+  # eval time rather than letting the binding quietly do nothing.
+  foreignDeps = unit: lib.subtractLists trustTargetUnits (unit.requiredBy ++ unit.upheldBy);
+
+  mkForeignDepAssertion =
+    {
+      unit,
+      optionPath,
+      attrPath,
+    }:
     let
-      targets = [
-        "nmtrust-trusted.target"
-      ]
-      ++ lib.optional unitCfg.allowOffline "nmtrust-offline.target";
+      foreign = foreignDeps unit;
     in
     {
-      unitConfig.StopWhenUnneeded = true;
-      wantedBy = targets;
+      assertion = foreign == [ ];
+      message =
+        "${optionPath} is also pulled in by ${lib.concatStringsSep ", " foreign} "
+        + "via requiredBy/upheldBy. nmtrust stops units with StopWhenUnneeded=, which "
+        + "only takes effect when nothing active needs the unit, so it would stay "
+        + "running in every trust state and the trust binding would have no effect. "
+        + "Clear the other dependency, e.g. ${attrPath}.requiredBy = lib.mkForce [ ]; "
+        + "(nmtrust force-overrides wantedBy itself, so plain WantedBy= dependencies "
+        + "from other modules need no action).";
     };
+
+  mkUnitNameAssertion =
+    { unitName, optionPath }:
+    let
+      u = splitUnitName unitName;
+    in
+    if u.base == "" then
+      {
+        assertion = false;
+        message = "${optionPath} has no unit name before the .${u.type} suffix.";
+      }
+    else
+      {
+        assertion = u.optionSet != null;
+        message =
+          "${optionPath} names a .${u.type} unit, which nmtrust cannot bind. "
+          + "Only ${lib.concatMapStringsSep ", " (t: ".${t}") bindableUnitTypes} units "
+          + "can be bound to a trust target. If this is a service whose name ends in "
+          + "\".${u.type}\", spell out the suffix: \"${unitName}.service\".";
+      };
+
+  # Assertions for one collection of unit names, resolved against the
+  # option set each unit actually belongs to (systemd.timers for a
+  # .timer, and so on).
+  mkUnitAssertions =
+    {
+      unitNames,
+      optionPathFor,
+      systemdPath,
+    }:
+    lib.concatMap (
+      unitName:
+      let
+        u = splitUnitName unitName;
+        optionPath = optionPathFor unitName;
+      in
+      [ (mkUnitNameAssertion { inherit unitName optionPath; }) ]
+      ++ lib.optional u.bindable (mkForeignDepAssertion {
+        unit = lib.getAttrFromPath (
+          systemdPath
+          ++ [
+            u.optionSet
+            u.base
+          ]
+        ) config;
+        inherit optionPath;
+        attrPath = "${lib.concatStringsSep "." systemdPath}.${u.optionSet}.${u.base}";
+      })
+    ) unitNames;
 
   # NM dispatcher script
   dispatcherScript = pkgs.writeShellScript "nmtrust-dispatcher" ''
     case "$2" in
       up|down|vpn-up|vpn-down|connectivity-change)
-        ${config.systemd.package}/bin/systemd-run \
+        # A debounce collision ("already exists") is expected -- the pending
+        # run evaluates current state, so it covers this event too. Anything
+        # else must reach the journal: discarding stderr wholesale made a
+        # dispatcher that had stopped scheduling look like a quiet network.
+        if ! err=$(${config.systemd.package}/bin/systemd-run \
           --no-block \
           --on-active=1s \
           --unit=nmtrust-apply-debounce \
           ${config.systemd.package}/bin/systemctl start nmtrust-apply.service \
-          2>/dev/null || true
+          2>&1); then
+          case "$err" in
+            *"already exists"*) ;;
+            *) echo "nmtrust: could not schedule apply after '$2': $err" >&2 ;;
+          esac
+        fi
         ;;
     esac
   '';
@@ -79,7 +331,7 @@ in
       default = [ ];
       description = ''
         List of NetworkManager profile names from
-        {option}`networking.networkmanager.ensureProfiles`.
+        networking.networkmanager.ensureProfiles.
         UUIDs are resolved at evaluation time.
       '';
     };
@@ -91,7 +343,7 @@ in
       default = [ ];
       description = ''
         Additional trusted connection UUIDs not managed via
-        {option}`networking.networkmanager.ensureProfiles`.
+        networking.networkmanager.ensureProfiles.
         Must be valid UUID format.
       '';
     };
@@ -104,7 +356,16 @@ in
         fnmatch(3) with FNM_NOESCAPE. Connection names are treated as
         literal strings (no backslash interpretation).
         Matching connections are ignored when computing trust state.
+
+        Loopback is always ignored and needs no entry here. A VPN tunnel
+        does, so that it cannot feed back into the trust state that
+        started it.
       '';
+      example = [
+        "virbr*"
+        "docker*"
+        "tailscale0"
+      ];
     };
 
     mixedPolicy = lib.mkOption {
@@ -127,55 +388,57 @@ in
       default = "untrusted";
       description = ''
         How to handle trust evaluation failures (D-Bus errors, NM
-        unavailable). `"untrusted"` (default) is fail-closed: trusted-only
-        units stop. `"offline"` allows units with
-        {option}`allowOffline` to run.
+        unavailable). "untrusted" (default) is fail-safe: trusted-only
+        units stop, and units bound to the untrusted state activate.
+        "offline" resolves to the offline state instead, allowing units
+        with `allowOffline` to run.
+
+        "offline" is rejected when any unit is bound to the untrusted
+        state, because it would stop those units on a failure — dropping
+        a VPN while you may still be on an untrusted network.
       '';
     };
 
     systemUnits = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options.allowOffline = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            description = "Whether this unit should also run when offline.";
-          };
-        }
-      );
+      type = lib.types.attrsOf unitSubmodule;
       default = { };
+      example = lib.literalExpression ''
+        {
+          "my-sync.service" = { };
+          "mailsync.timer" = { };
+          "backup.service" = { allowOffline = true; };
+          "mullvad-connect.service" = { states = [ "untrusted" ]; };
+        }
+      '';
       description = ''
-        System units to bind to the trusted network target.
-        Keys are systemd unit names.
+        System units to bind to the trust targets. Keys are systemd unit
+        names; each entry selects the trust states the unit runs in via
+        {option}`states` (default `[ "trusted" ]`).
+
+        `.service`, `.timer`, `.socket` and `.path` units are supported,
+        and each is routed to the option set that owns it — a
+        `"backup.timer"` entry binds `systemd.timers.backup`, not the
+        service it triggers. A name with no type suffix is treated as a
+        `.service`.
       '';
     };
 
     userUnits = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.attrsOf (
-          lib.types.submodule {
-            options.allowOffline = lib.mkOption {
-              type = lib.types.bool;
-              default = false;
-              description = "Whether this unit should also run when offline.";
-            };
-          }
-        )
-      );
+      type = lib.types.attrsOf (lib.types.attrsOf unitSubmodule);
       default = { };
       example = lib.literalExpression ''
         {
           alice = {
             "etesync-dav.service" = { };
             "syncthing.service" = { allowOffline = true; };
+            "personal-vpn.service" = { states = [ "untrusted" ]; };
           };
         }
       '';
       description = ''
-        Per-user units to bind to the trusted network target.
+        Per-user units to bind to the trust targets.
         Outer keys are usernames, inner keys are systemd unit names.
-        Users must have linger enabled
-        ({option}`users.users.<name>.linger`).
+        Users must have linger enabled (users.users.<name>.linger = true).
       '';
     };
   };
@@ -207,6 +470,22 @@ in
             + "but no matching networking.networkmanager.ensureProfiles entry with a UUID exists.";
         }) cfg.trustedConnections)
       ++
+        # evalFailurePolicy = "offline" is fail-open for untrusted-bound units
+        [
+          {
+            assertion = cfg.evalFailurePolicy != "offline" || untrustedBoundUnits == [ ];
+            message =
+              "services.nmtrust.evalFailurePolicy = \"offline\" cannot be combined with "
+              + "units bound to the untrusted state (${lib.concatStringsSep ", " untrustedBoundUnits}). "
+              + "On an evaluation failure the offline policy resolves to the offline state, "
+              + "which stops untrusted-bound units — so a transient D-Bus error would drop a "
+              + "VPN while you may still be on an untrusted network. That is fail-open, and "
+              + "it is the opposite of why the unit is bound to untrusted in the first place. "
+              + "Use the default evalFailurePolicy = \"untrusted\", which activates those units "
+              + "on failure instead.";
+          }
+        ]
+      ++
         # userUnits -> user existence
         (map (username: {
           assertion = config.users.users ? ${username};
@@ -228,7 +507,25 @@ in
             + "ensure the user's systemd instance is running for trust-based unit management. "
             + "Note: enabling linger causes ALL of this user's enabled user services to run "
             + "persistently, not just trust-managed units.";
-        }) (builtins.filter (u: config.users.users ? ${u}) userNames));
+        }) (builtins.filter (u: config.users.users ? ${u}) userNames))
+      ++
+        # systemUnits -> bindable unit type, and no foreign dependency
+        # defeating StopWhenUnneeded
+        (mkUnitAssertions {
+          unitNames = builtins.attrNames cfg.systemUnits;
+          optionPathFor = unitName: "services.nmtrust.systemUnits.\"${unitName}\"";
+          systemdPath = [ "systemd" ];
+        })
+      ++
+        # userUnits -> same checks, deduplicated across users
+        (mkUnitAssertions {
+          unitNames = sharedUserUnitNames;
+          optionPathFor = unitName: "services.nmtrust.userUnits.*.\"${unitName}\"";
+          systemdPath = [
+            "systemd"
+            "user"
+          ];
+        });
 
     # --- Helper package on PATH ---
 
@@ -297,84 +594,60 @@ in
 
     # --- System unit overrides + services ---
 
-    # Strip .service/.timer/.socket suffixes — NixOS appends them automatically
-    systemd.services =
-      lib.mapAttrs' (name: value: {
-        name = lib.removeSuffix ".service" (lib.removeSuffix ".timer" (lib.removeSuffix ".socket" name));
-        value = mkUnitOverrides name value;
-      }) cfg.systemUnits
-      // {
-        nmtrust-apply = {
-          description = "Evaluate and apply network trust state";
-          after = [ "NetworkManager.service" ];
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart = "${trustHelper}/bin/nmtrust apply";
-            Restart = "on-failure";
-            RestartSec = "5";
-            ProtectSystem = "strict";
-            ReadWritePaths = [ "/run/nmtrust" ];
-            ProtectHome = true;
-            NoNewPrivileges = true;
-            PrivateTmp = true;
-          };
-        };
-        nmtrust-eval = {
-          description = "Evaluate network trust state on boot";
-          wantedBy = [ "network-online.target" ];
-          wants = [ "network-online.target" ];
-          after = [
-            "NetworkManager.service"
-            "network-online.target"
-          ];
-          restartTriggers = [
-            config.environment.etc."nmtrust/config".source
-          ];
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            ExecStart = "${trustHelper}/bin/nmtrust apply";
-            Restart = "on-failure";
-            RestartSec = "5";
-            ProtectSystem = "strict";
-            ReadWritePaths = [ "/run/nmtrust" ];
-            ProtectHome = true;
-            NoNewPrivileges = true;
-            PrivateTmp = true;
-          };
+    # Each bound unit is routed to the option set that owns its type;
+    # NixOS appends the type suffix back on.
+    systemd.timers = mkBoundUnits systemUnitsByOptionSet "timers";
+    systemd.sockets = mkBoundUnits systemUnitsByOptionSet "sockets";
+    systemd.paths = mkBoundUnits systemUnitsByOptionSet "paths";
+
+    systemd.services = mkBoundUnits systemUnitsByOptionSet "services" // {
+      nmtrust-apply = {
+        description = "Evaluate and apply network trust state";
+        after = [ "NetworkManager.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${trustHelper}/bin/nmtrust apply";
+          Restart = "on-failure";
+          RestartSec = "5";
+          ProtectSystem = "strict";
+          ReadWritePaths = [ "/run/nmtrust" ];
+          ProtectHome = true;
+          NoNewPrivileges = true;
+          PrivateTmp = true;
         };
       };
+      nmtrust-eval = {
+        description = "Evaluate network trust state on boot";
+        wantedBy = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        after = [
+          "NetworkManager.service"
+          "network-online.target"
+        ];
+        restartTriggers = [
+          config.environment.etc."nmtrust/config".source
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "${trustHelper}/bin/nmtrust apply";
+          Restart = "on-failure";
+          RestartSec = "5";
+          ProtectSystem = "strict";
+          ReadWritePaths = [ "/run/nmtrust" ];
+          ProtectHome = true;
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+        };
+      };
+    };
 
     # --- User unit overrides ---
 
-    # When the same unit appears under multiple users, union their wantedBy
-    # lists. systemd.user.services is system-wide, so per-user allowOffline
-    # differences are resolved by taking the most permissive value (any
-    # true wins).
-    systemd.user.services = lib.foldl' (
-      acc: username:
-      lib.foldl' (
-        acc': unitName:
-        let
-          strippedName = lib.removeSuffix ".service" (
-            lib.removeSuffix ".timer" (lib.removeSuffix ".socket" unitName)
-          );
-          incoming = mkUnitOverrides unitName cfg.userUnits.${username}.${unitName};
-          existing = acc'.${strippedName} or null;
-        in
-        acc'
-        // {
-          ${strippedName} =
-            if existing == null then
-              incoming
-            else
-              existing
-              // {
-                wantedBy = lib.unique (existing.wantedBy ++ incoming.wantedBy);
-              };
-        }
-      ) acc (builtins.attrNames cfg.userUnits.${username})
-    ) { } userNames;
+    systemd.user.services = mkBoundUnits userUnitsByOptionSet "services";
+    systemd.user.timers = mkBoundUnits userUnitsByOptionSet "timers";
+    systemd.user.sockets = mkBoundUnits userUnitsByOptionSet "sockets";
+    systemd.user.paths = mkBoundUnits userUnitsByOptionSet "paths";
 
     # --- NM dispatcher ---
 

--- a/pkgs/by-name/nm/nmtrust/package.nix
+++ b/pkgs/by-name/nm/nmtrust/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation {
   pname = "nmtrust";
-  version = "0.1.1";
+  version = "0.2.0";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "brett";
     repo = "nmtrust-nix";
-    rev = "v0.1.1";
-    hash = "sha256-niCbYxeunNxfkM/HEUiMAvwiholR0nmEPqssOOl9Qvo=";
+    rev = "v0.2.0";
+    hash = "sha256-vn1Kwy8vrXyOqj4kfiYHXH3VgMwP8jIDXSP0jAbNWRU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!-- PR title: nmtrust: 0.1.1 -> 0.2.0 -->

Module and trust-evaluation fixes. 

**Fixes**

- A `"foo.timer"` entry bound `foo.service` and left the timer firing in every trust state. Entries now route to the systemd option set that owns their unit type (`.timer` → `timers`, `.socket` → `sockets`, `.path` → `paths`), and unbindable types are rejected at evaluation time.
- `wantedBy` is now forced. A unit that declared its own `wantedBy` elsewhere stayed needed in every trust state, so `StopWhenUnneeded` never fired and the binding was a silent no-op.
- Loopback is ignored when evaluating trust. NetworkManager manages `lo`, so it was active on every boot and never trusted, putting every host in the mixed branch — which `mixedPolicy = "untrusted"` resolves to untrusted. The trusted state was therefore unreachable and trusted-bound units never ran.
- Trust targets are started with `--no-block`. `systemctl start` waits for the whole transaction, so a bound backup or VPN held `nmtrust-apply`/`nmtrust-eval` open for its entire runtime and stalled `nixos-rebuild` with no error — both are `Type=oneshot`, whose `TimeoutStartSec` defaults to infinity.
- The NetworkManager dispatcher reports scheduling failures instead of discarding all stderr.

**New**

- Units can be bound to any trust state through a `states` list, not just the trusted one, so a unit can run precisely when the network is *not* trusted — a VPN, or a stricter resolver. `allowOffline` is kept as sugar and unioned with it, so existing configurations are unchanged.
- `evalFailurePolicy = "offline"` is rejected alongside untrusted-bound units, since it would stop a VPN while still on a hostile network.

Backward-incompatible changes are documented in the 26.11 release notes.

Changelog: https://github.com/brett/nmtrust-nix/releases/tag/v0.2.0


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] — `nixosTests.nmtrust`
  - [x] [Package tests] at `passthru.tests`

Claude Code (Claude Opus 5) was used for:
- Drafting the PR message
- Reviewing code changes for security and correctness
- Assisting in testing



