### PR TITLE
postgresqlPackages.libversion: rename from `postgresqlPackages.pg_lib…

### DIFF
--- a/pkgs/servers/sql/postgresql/ext.nix
+++ b/pkgs/servers/sql/postgresql/ext.nix
@@ -23,6 +23,7 @@ in
 // lib.optionalAttrs config.allowAliases {
   cstore_fdw = throw "PostgreSQL extension `cstore_fdw` has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
   pg_embedding = throw "PostgreSQL extension `pg_embedding` has been removed since the project has been abandoned. Upstream's recommendation is to use pgvector instead (https://neon.tech/docs/extensions/pg_embedding#migrate-from-pg_embedding-to-pgvector)";
+  pg_libversion = throw "PostgreSQL extension `pg_embedding` has been renamed to `libversion` due to Upstream's recommendation (https://repology.org/project/pgsql%3Apg-libversion/report)"; # Added 2026-06-12
   pgvecto-rs = throw "PostgreSQL extension `pgvecto-rs` has been removed since the project has been abandoned. Upstream's recommendation is to use vectorchord instead (https://docs.vectorchord.ai/vectorchord/admin/migration.html#from-pgvecto-rs) "; # Added 2026-03-13
   plv8 = throw "PostgreSQL extension `plv8` has been removed due to depending on the insecure NodeJS 20"; # Added 2026-06-13
 }

--- a/pkgs/servers/sql/postgresql/ext/libversion.nix
+++ b/pkgs/servers/sql/postgresql/ext/libversion.nix
@@ -9,7 +9,7 @@
 }:
 
 postgresqlBuildExtension (finalAttrs: {
-  pname = "pg_libversion";
+  pname = "libversion";
   version = "2.0.1";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
…version`

src: https://repology.org/project/pgsql%3Apg-libversion/report

Note: Repology is the upstream in this case.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
