### PR TITLE
claude-code: 2.1.227 -> 2.1.228

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-nPQnGuBJPTKb53nb7iuUy7WeR+h2AdSvKc6mTDQaRk4=";
+          hash = "sha256-sz5etvOsW+IL+ma5lVwgXAfdZXOaBDPyshIyjOCid/U=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-5EcopowbIsvylvdCp9nNhT+Jb7AyqjB9lxuFjgohMaU=";
+          hash = "sha256-IN1IIVuthrJ65opzxAINTwXgkDKztnNabRTwVqSmTCU=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-P3RpxruQPenyThhs9NpYk5UebRAhCIUxHHp0+C6hEr8=";
+          hash = "sha256-89Hle3ekVbjWxTLnW38YKcOk3ieDpXMq08g6XaDzZhs=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.227";
+      version = "2.1.228";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.227",
-  "commit": "5ecc7d5389d8b682652d0ea32eadd3e0eb537ee8",
-  "buildDate": "2026-08-10T19:04:57Z",
+  "version": "2.1.228",
+  "commit": "4a2077e9c39676b5c335919018dda18f476a7f70",
+  "buildDate": "2026-08-11T01:54:41Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "7432511ba3be818e01f23f6eef8630d214a8b618451e188c3c7d61a987eef6c7",
-      "size": 285046400
+      "checksum": "43484b1352cef03a08346f36ef0437755b1aad646ab9313ce187857b794b7247",
+      "size": 289298144
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "14484fb9a0480b6b638230685a7d9a248a5339b384a162e0df127e4a4a07249b",
-      "size": 294700704
+      "checksum": "7852f1ae0efb64d46d77a57d8852daddc4a6ffb58aeda6267bd3f3428adc09b3",
+      "size": 298977312
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "db47335532cbcab67a4b3ab16d8f3f77976bf85d53c7d79f8296538aa22bfce6",
-      "size": 300923832
+      "checksum": "2664006219497bf7021ac43156519cd42eda64ceb2a66f434ecab83e7831f942",
+      "size": 305118136
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "6832dc3f1797b890b71116e5f2dbbf9a83fd3d0498c235b4b0f9cd0e6e499ad6",
-      "size": 304282632
+      "checksum": "d535985e6941a3eb00179ccd7f52ceb0c6623a0305a518ebc4e6514f84a94c99",
+      "size": 308521992
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "8284d20a5d61e71502e69836b1598ba03f688f4d8de6c22105055fbf0af118f6",
-      "size": 294237544
+      "checksum": "1b8034fb30c90ea7471d6403bc610cb5173b7dedab3a92e89f6a91430c481876",
+      "size": 298431848
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "da7b62210da0000c09c7c29b217e166ccc66dad4c79c9e2bc8d52fc7b66f590d",
-      "size": 298885712
+      "checksum": "0285be21af52692e5d1ea2199171b45fc85d9ca62fb4a2d9f2c244c2bbca8de7",
+      "size": 303129168
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "a5d8bcc6549cf99a2ea35451f8034a12f0db919e63334477c72d42fc8e0d5c09",
-      "size": 292227232
+      "checksum": "841efce70b048ae03c752f79000cb6be5c2c2c4d0478f3eaaa762494ade9daf5",
+      "size": 296308896
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "68935d2c971ad417e90f1d5bb503c8773b218c7f7049fe35e502f0180232ff18",
-      "size": 286900384
+      "checksum": "e1d23400b3eef8f7b2ddde782ce4d3153aa88b5397d0f42813b8abbe0b47cbcd",
+      "size": 290981024
     }
   },
   "sdkCompat": {


### PR DESCRIPTION
Update claude-code and vscode-extensions.anthropic.claude-code to 2.1.228.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

> [!NOTE]
> Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard `maintainers/scripts/update.nix` script; the change was built locally and validated across arches via `nixpkgs-review`, and reviewed by a human (@markus1189) before being marked ready.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
