### PR TITLE
throttled: 0.11 -> 0.12.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5289,6 +5289,12 @@
     githubId = 199180;
     name = "Claes Wallin";
   };
+  cktiel = {
+    email = "tiel@tuta.io";
+    github = "cktiel";
+    githubId = 310042450;
+    name = "Artur Cierocki";
+  };
   claes = {
     email = "claes.holmerson@gmail.com";
     github = "claes";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5283,17 +5283,17 @@
     name = "Christian Kruse";
     keys = [ { fingerprint = "BC5D 9F4E F7FB 4382 6056  E834 B8E0 F342 A99A 9D73"; } ];
   };
-  clacke = {
-    email = "claes.wallin@greatsinodevelopment.com";
-    github = "clacke";
-    githubId = 199180;
-    name = "Claes Wallin";
-  };
   cktiel = {
     email = "tiel@tuta.io";
     github = "cktiel";
     githubId = 310042450;
     name = "Artur Cierocki";
+  };
+  clacke = {
+    email = "claes.wallin@greatsinodevelopment.com";
+    github = "clacke";
+    githubId = 199180;
+    name = "Claes Wallin";
   };
   claes = {
     email = "claes.holmerson@gmail.com";

--- a/pkgs/by-name/th/throttled/package.nix
+++ b/pkgs/by-name/th/throttled/package.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/erpalma/throttled";
     license = lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ cktiel ];
   };
 })

--- a/pkgs/by-name/th/throttled/package.nix
+++ b/pkgs/by-name/th/throttled/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "throttled";
-  version = "0.11";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "erpalma";
     repo = "throttled";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-+3ktDkr5hvOfHcch4+mjgJqcuw24UgWTkJqTyDQumyk=";
+    sha256 = "sha256-hwnJO9KEDOizpGcb9NYHYHoEEHKa3PkLt76cKpwgEUs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updated to 0.12.2
Changelogs:
https://github.com/erpalma/throttled/releases#release-v0.12
https://github.com/erpalma/throttled/releases#release-v0.12.1
https://github.com/erpalma/throttled/releases#release-v0.12.2
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
