### PR TITLE
{net, disk, sys}watch: add tomasrivera as maintainer, update homepage and changelog, remove versionCheckProgramArg, add optional dependency

### DIFF
--- a/pkgs/by-name/di/diskwatch/package.nix
+++ b/pkgs/by-name/di/diskwatch/package.nix
@@ -3,6 +3,10 @@
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
+
+  # full SMART attribute tables. Else, fallback to basic verified/failing flag from diskutil
+  withSmartmontools ? false,
+  smartmontools,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -21,6 +25,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-MjRU/NDZIbxIXFiU6sdfPfvcszkmbVeDAC0rb+Sz/6s=";
 
   nativeCheckInputs = [ versionCheckHook ];
+
+  buildInputs = lib.optionals withSmartmontools [ smartmontools ];
 
   doInstallCheck = true;
 

--- a/pkgs/by-name/di/diskwatch/package.nix
+++ b/pkgs/by-name/di/diskwatch/package.nix
@@ -31,7 +31,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/matthart1983/diskwatch";
     changelog = "https://github.com/matthart1983/diskwatch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      tomasrivera
+    ];
     mainProgram = "diskwatch";
   };
 })

--- a/pkgs/by-name/di/diskwatch/package.nix
+++ b/pkgs/by-name/di/diskwatch/package.nix
@@ -24,8 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgramArg = [ "-V" ];
-
   meta = {
     description = "Single-host, read-only disk diagnostics TUI";
     homepage = "https://github.com/matthart1983/diskwatch";

--- a/pkgs/by-name/di/diskwatch/package.nix
+++ b/pkgs/by-name/di/diskwatch/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Single-host, read-only disk diagnostics TUI";
-    homepage = "https://github.com/matthart1983/diskwatch";
+    homepage = "https://www.netwatchlabs.com/labs/diskwatch";
     changelog = "https://github.com/matthart1983/diskwatch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ne/netwatch/package.nix
+++ b/pkgs/by-name/ne/netwatch/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Real-time network diagnostics in your terminal.";
-    homepage = "https://github.com/matthart1983/netwatch";
+    homepage = "https://www.netwatchlabs.com/labs/netwatch";
     changelog = "https://github.com/matthart1983/netwatch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "netwatch";

--- a/pkgs/by-name/ne/netwatch/package.nix
+++ b/pkgs/by-name/ne/netwatch/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Real-time network diagnostics in your terminal.";
     homepage = "https://www.netwatchlabs.com/labs/netwatch";
-    changelog = "https://github.com/matthart1983/netwatch/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/matthart1983/netwatch/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "netwatch";
     maintainers = with lib.maintainers; [ tomasrivera ];

--- a/pkgs/by-name/sy/syswatch/package.nix
+++ b/pkgs/by-name/sy/syswatch/package.nix
@@ -29,7 +29,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/matthart1983/syswatch";
     changelog = "https://github.com/matthart1983/syswatch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      tomasrivera
+    ];
     mainProgram = "syswatch";
   };
 })

--- a/pkgs/by-name/sy/syswatch/package.nix
+++ b/pkgs/by-name/sy/syswatch/package.nix
@@ -24,8 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgramArg = [ "-V" ];
-
   meta = {
     description = "Single-host system diagnostics TUI tool";
     homepage = "https://github.com/matthart1983/syswatch";

--- a/pkgs/by-name/sy/syswatch/package.nix
+++ b/pkgs/by-name/sy/syswatch/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Single-host system diagnostics TUI tool";
-    homepage = "https://github.com/matthart1983/syswatch";
+    homepage = "https://www.netwatchlabs.com/labs/syswatch";
     changelog = "https://github.com/matthart1983/syswatch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
I'm already the maintainer for netwatch. I would like to maintain the whole  ecosystem (netwatch, syswatch, diskwatch and [soundwatch](https://github.com/matthart1983/soundwatch) when it will be more mature).

I removed the  versionCheckProgramArg for both syswatch and diskwatch as they already support the default `--version`

For diskwatch
> Prerequisites: Rust 1.75+ (only if building from source). No system dependencies on Linux. macOS calls the standard ioreg, diskutil, and system_profiler binaries — all preinstalled. Optional: smartmontools (brew install smartmontools / apt install smartmontools) for full SMART attribute tables — without it, the SMART tab falls back to the basic verified/failing flag from diskutil. --- https://github.com/matthart1983/diskwatch#install
### Pings
@fabaff for both syswatch and diskwatch




No AI/Automation was used for this PR.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
