### PR TITLE
python3Packages.wandb: 0.28.1 -> 0.28.2

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -13,6 +13,9 @@
   ## wandb-xpu
   rustPlatform,
 
+  ## parquet-rust-wrapper
+  cacert,
+
   ## wandb
   buildPythonPackage,
 
@@ -21,6 +24,7 @@
 
   # dependencies
   click,
+  opentelemetry-api,
   packaging,
   platformdirs,
   protobuf,
@@ -76,22 +80,22 @@
 }:
 
 let
-  version = "0.28.1";
+  version = "0.28.2";
   src = fetchFromGitHub {
     owner = "wandb";
     repo = "wandb";
     tag = "v${version}";
-    hash = "sha256-yXsSHyPOh3QXRRkTL4Rj8lLuFjp1LIKfPiacy4+obAk=";
+    hash = "sha256-kmgLHb+1NjStqcjMOYPPU2v2js4m8O3b2OpM6BiSbXI=";
   };
 
   wandb-xpu = rustPlatform.buildRustPackage {
     pname = "wandb-xpu";
-    version = "0.7.0";
+    version = "0.7.1";
     inherit src;
 
     sourceRoot = "${src.name}/xpu";
 
-    cargoHash = "sha256-vB0LZjfnf//U1BXCzvaQBjlXLlGx/4g+emSZWcS+oGU=";
+    cargoHash = "sha256-YKuXtttLam4NmJsJPQH8sFbj1Qs5Gc2uoFJEvTYxkew=";
 
     checkFlags = [
       # fails in sandbox
@@ -116,12 +120,19 @@ let
 
   parquet-rust-wrapper = rustPlatform.buildRustPackage {
     pname = "arrow-rs-wrapper";
-    version = "0.1.0";
+    version = "0.1.1";
     inherit src;
 
     sourceRoot = "${src.name}/parquet-rust-wrapper";
 
-    cargoHash = "sha256-BkeSRbZoehYGHj15KcInugRBvOLXJlh1NqTHhRnNOK8=";
+    cargoHash = "sha256-F68Rvfc04eI/y0Z5tGtQn4zEmqLuMZGZiKEh2HMFi/g=";
+
+    nativeCheckInputs = [
+      # The `httpfile` tests serve a local HTTP server, but reqwest's rustls backend refuses to
+      # build a client at all without system CA certificates.
+      # Its setup hook exports `SSL_CERT_FILE`.
+      cacert
+    ];
 
     # The original build script renames the library:
     # https://github.com/wandb/wandb/blob/v0.26.0/parquet-rust-wrapper/build.sh#L37-L68
@@ -139,15 +150,8 @@ let
     sourceRoot = "${src.name}/core";
 
     postPatch =
-      # Relax the Go toolchain requirement; nixpkgs ships 1.26.2.
-      ''
-        substituteInPlace go.mod \
-          --replace-fail \
-            "go 1.26.4" \
-            "go 1.26.2"
-      ''
       # hardcode the `wandb-xpu` binary path.
-      + ''
+      ''
         substituteInPlace internal/monitor/xpuresourcemanager.go \
           --replace-fail \
             'cmdPath, err := getXPUCmdPath()' \
@@ -234,6 +238,7 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     click
+    opentelemetry-api
     packaging
     platformdirs
     protobuf
@@ -322,6 +327,12 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
+    # The conftest mocks out `read_many_from_queue`, which is the agent loop's only throttle.
+    # It then spins while the child runs, and the `MagicMock` API retains every heartbeat
+    # call (~270MiB/s), OOM-killing the pytest worker.
+    "test_agent_config_whitespace_cli_agent"
+    "test_agent_subprocess_with_import_readline"
+
     # Probably failing because of lack of internet access
     # AttributeError: module 'wandb.sdk.launch.registry' has no attribute 'azure_container_registry'. Did you mean: 'elastic_container_registry'?
     "test_registry_from_uri"
@@ -392,6 +403,7 @@ buildPythonPackage (finalAttrs: {
     "test_log_media_prefixed_with_multiple_slashes"
     "test_log_media_saves_to_run_directory"
     "test_log_media_with_path_traversal"
+    "test_table_logging_mode_incremental_warns_after_100_increments"
 
     # HandleAbandonedError / SystemExit when run in sandbox
     "test_makedirs_raises_oserror__uses_temp_dir"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/wandb/wandb/compare/v0.28.1...v0.28.2
Changelog: https://github.com/wandb/wandb/blob/v0.28.2/CHANGELOG.md

cc @samuela

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test