### PR TITLE
lmdb: 0.9.35 -> 0.9.36

### DIFF
--- a/pkgs/by-name/lm/lmdb/package.nix
+++ b/pkgs/by-name/lm/lmdb/package.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "lmdb";
-  version = "0.9.35";
+  version = "0.9.36";
 
   src = fetchFromGitLab {
     domain = "git.openldap.org";
     owner = "openldap";
     repo = "openldap";
     rev = "LMDB_${version}";
-    sha256 = "sha256-XkOeVqzKojRLojBLkXB0V9lypJnL5ZmGAwutn6aRQIU=";
+    sha256 = "sha256-iOwjUqR2ChCEUDsIFEetVktCD7Mx3R5JgHE+qIhBd5I=";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";


### PR DESCRIPTION
https://github.com/LMDB/lmdb/blob/LMDB_0.9.36/libraries/liblmdb/CHANGES
Let's avoid 1.0 for now.  For example, some projects/users have issues because 1.0 can't use 0.9 DBs and vice versa.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
