### PR TITLE
criticalup: init at 1.6.0

### DIFF
--- a/pkgs/by-name/cr/criticalup/package.nix
+++ b/pkgs/by-name/cr/criticalup/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchpatch,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "criticalup";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "ferrocene";
+    repo = "criticalup";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FPHnSp6/26NqJE24Qtd7dbpbFkjYL0Jsrs8k0HZE+Ks=";
+  };
+  cargoHash = "sha256-7sG+qGn2sqawuVFDZ4aXAqxCkBjJdxnts7llJz1o2Hg=";
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  # TODO remove patch with next release after 1.6.0
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/ferrocene/criticalup/pull/184.patch";
+      hash = "sha256-zLEF6KYfOglb9o3hqpAEsYAINFnEAWqQ2Jtax+/8jbs=";
+    })
+  ];
+
+  env.RUSTFLAGS = "--cfg=hyper_unstable_tracing";
+  cargoBuildFlags = [ "--package=criticalup" ];
+
+  # This check fails due to being ran in a temporary subdir.
+  checkFlags = [ "--skip=run::simple_run_command_did_not_run_install" ];
+
+  meta = {
+    description = "Toolchain manager for the safety-critical Rust toolchain Ferrocene, similar to rustup";
+    homepage = "https://criticalup.ferrocene.dev/";
+    changelog = "https://criticalup.ferrocene.dev/changelog.html";
+    license =
+      with lib.licenses;
+      OR [
+        lib.licenses.asl20
+        lib.licenses.mit
+      ];
+    maintainers = with lib.maintainers; [ wucke13 ];
+    mainProgram = "criticalup";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
I think Nix is a prime candidate for toolchain management and development of safety critical systems with Rust. As a first step, I'd like to have the official toolchain manager from Ferrous' Ferrocene available. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
