### PR TITLE
mediagoblin: fix build by overriding setuptools used in paste

### DIFF
--- a/pkgs/by-name/me/mediagoblin/package.nix
+++ b/pkgs/by-name/me/mediagoblin/package.nix
@@ -5,12 +5,18 @@
   gobject-introspection,
   gst_all_1,
   poppler-utils,
-  python3,
+  python3Packages,
   lndir,
 }:
 
 let
-  python = python3;
+  pythonPackages = python3Packages.overrideScope (
+    final: prev: {
+      paste = prev.paste.override { setuptools = prev.setuptools_80; };
+    }
+  );
+
+  inherit (pythonPackages.python) sitePackages;
 
   version = "0.15.0";
   src = fetchFromSourcehut {
@@ -35,7 +41,7 @@ let
     '';
   };
 in
-python.pkgs.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   format = "setuptools";
   pname = "mediagoblin";
   inherit version src;
@@ -53,15 +59,15 @@ python.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     gobject-introspection
-    python3.pkgs.babel
+    pythonPackages.babel
     lndir
   ];
 
-  build-system = with python.pkgs; [
+  build-system = with pythonPackages; [
     setuptools
   ];
 
-  dependencies = with python.pkgs; [
+  dependencies = with pythonPackages; [
     alembic
     babel
     bcrypt
@@ -96,7 +102,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   optional-dependencies =
-    with python.pkgs;
+    with pythonPackages;
     let
       # not really documented in python build system
       gst = with gst_all_1; [
@@ -123,16 +129,16 @@ python.pkgs.buildPythonApplication rec {
   '';
 
   postInstall = ''
-    lndir -silent ${extlib}/node_modules $out/${python.sitePackages}/mediagoblin/static/extlib/
+    lndir -silent ${extlib}/node_modules $out/${sitePackages}/mediagoblin/static/extlib/
 
-    ln -rs $out/${python.sitePackages}/mediagoblin/static/extlib/jquery/dist/jquery.js $out/${python.sitePackages}/mediagoblin/static/js/extlib/jquery.js
-    ln -rs $out/${python.sitePackages}/mediagoblin/static/extlib/leaflet/dist/leaflet.css $out/${python.sitePackages}/mediagoblin/static/extlib/leaflet/leaflet.css
-    ln -rs $out/${python.sitePackages}/mediagoblin/static/extlib/leaflet/dist/leaflet.js $out/${python.sitePackages}/mediagoblin/static/extlib/leaflet/leaflet.js
-    ln -rs $out/${python.sitePackages}/mediagoblin/static/extlib/leaflet/dist/images/ $out/${python.sitePackages}/mediagoblin/static/extlib/leaflet/
+    ln -rs $out/${sitePackages}/mediagoblin/static/extlib/jquery/dist/jquery.js $out/${sitePackages}/mediagoblin/static/js/extlib/jquery.js
+    ln -rs $out/${sitePackages}/mediagoblin/static/extlib/leaflet/dist/leaflet.css $out/${sitePackages}/mediagoblin/static/extlib/leaflet/leaflet.css
+    ln -rs $out/${sitePackages}/mediagoblin/static/extlib/leaflet/dist/leaflet.js $out/${sitePackages}/mediagoblin/static/extlib/leaflet/leaflet.js
+    ln -rs $out/${sitePackages}/mediagoblin/static/extlib/leaflet/dist/images/ $out/${sitePackages}/mediagoblin/static/extlib/leaflet/
   '';
 
   nativeCheckInputs =
-    with python.pkgs;
+    with pythonPackages;
     [
       pytest-forked
       pytest-xdist
@@ -146,7 +152,7 @@ python.pkgs.buildPythonApplication rec {
   pythonImportsCheck = [ "mediagoblin" ];
 
   passthru = {
-    inherit extlib python;
+    inherit extlib pythonPackages;
   };
 
   meta = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
