### PR TITLE
nixos/tests: support a few more running on darwin + hygiene

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -15,7 +15,8 @@
 # Example callTest that just extracts the derivation from the test:
 #   callTest = t: t.test;
 let
-  inherit (pkgs.lib)
+  inherit (pkgs) lib;
+  inherit (lib)
     isAttrs
     isFunction
     mapAttrs

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -593,9 +593,7 @@ in
   etebase-server = runTest ./etebase-server.nix;
   etesync-dav = runTest ./etesync-dav.nix;
   evcc = runTest ./evcc.nix;
-  extra-initrd = import ./extra-initrd.nix {
-    inherit runTest pkgs;
-  };
+  extra-initrd = import ./extra-initrd.nix { inherit runTest; };
   facter = runTest ./facter;
   fail2ban = runTest ./fail2ban.nix;
   fakeroute = runTest ./fakeroute.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -95,13 +95,38 @@ let
     featureFlags.minimalModules = { };
   };
   evalMinimalConfig = module: nixosLib.evalModules { modules = [ module ]; };
+
+  /**
+    On platforms where NixOS does not run natively, nixosTests is still available
+    as a convenience for running VM tests. This makes them easier to use, and it
+    sidesteps the question of nested virtualisation.
+
+    `runTest` already includes similar logic as part of its [public] interface.
+
+    [public]: https://nixos.org/manual/nixos/stable/#sec-call-nixos-test-outside-nixos
+  */
+  guestPkgs =
+    if pkgs.stdenv.hostPlatform.isLinux then
+      pkgs
+    else
+      let
+        hostToGuest.aarch64-darwin = "aarch64-linux";
+        guestSystem =
+          hostToGuest.${pkgs.stdenv.hostPlatform.system}
+            or (throw "NixOS tests: don't know which Linux guest system to pair with host system ${pkgs.stdenv.hostPlatform.system}.");
+      in
+      import ../.. {
+        system = guestSystem;
+        inherit (pkgs) config overlays;
+      };
+
   evalSystem =
     module:
     import ../lib/eval-config.nix {
       system = null;
       modules = [
         ../modules/misc/nixpkgs/read-only.nix
-        { nixpkgs.pkgs = pkgs; }
+        { nixpkgs.pkgs = guestPkgs; }
         module
       ];
     };
@@ -563,7 +588,7 @@ in
     inherit runTest;
   };
   esphome = runTest ./esphome.nix;
-  etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
+  etc = guestPkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = import ./etcd/default.nix { inherit pkgs runTest; };
   etebase-server = runTest ./etebase-server.nix;
   etesync-dav = runTest ./etesync-dav.nix;
@@ -1055,7 +1080,7 @@ in
   mobilizon = runTest ./mobilizon.nix;
   mod_perl = runTest ./mod_perl.nix;
   modular-service-etc = runTest ./modular-service-etc/test.nix;
-  modularService = pkgs.callPackage ../modules/system/service/systemd/test.nix {
+  modularService = guestPkgs.callPackage ../modules/system/service/systemd/test.nix {
     inherit evalSystem;
   };
   molly-brown = runTest ./molly-brown.nix;
@@ -1653,11 +1678,11 @@ in
   system-services-compliance = recurseIntoAttrs (
     import ./system-services-compliance.nix {
       inherit
-        pkgs
         evalSystem
         runTest
         callTest
         ;
+      pkgs = guestPkgs;
     }
   );
   systemd = runTest ./systemd.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -666,11 +666,11 @@ in
   fontconfig-default-fonts = runTest ./fontconfig-default-fonts.nix;
   forgejo = import ./forgejo.nix {
     inherit runTest;
-    forgejoPackage = pkgs.forgejo;
+    forgejoPackage = guestPkgs.forgejo;
   };
   forgejo-lts = import ./forgejo.nix {
     inherit runTest;
-    forgejoPackage = pkgs.forgejo-lts;
+    forgejoPackage = guestPkgs.forgejo-lts;
   };
   freenet = runTest ./freenet.nix;
   freescout = import ./freescout {
@@ -697,11 +697,11 @@ in
   gancio = runTest ./gancio.nix;
   garage_1 = import ./garage {
     inherit runTest;
-    package = pkgs.garage_1;
+    package = guestPkgs.garage_1;
   };
   garage_2 = import ./garage {
     inherit runTest;
-    package = pkgs.garage_2;
+    package = guestPkgs.garage_2;
   };
   gatus = runTest ./gatus.nix;
   gemstash = import ./gemstash.nix { inherit pkgs runTest; };
@@ -713,7 +713,7 @@ in
   ghostunnel = runTest ./ghostunnel.nix;
   ghostunnel-modular = runTest ./ghostunnel-modular.nix;
   gitdaemon = runTest ./gitdaemon.nix;
-  gitea = handleTest ./gitea.nix { giteaPackage = pkgs.gitea; };
+  gitea = handleTest ./gitea.nix { giteaPackage = guestPkgs.gitea; };
   github-runner = runTest ./github-runner.nix;
   gitlab = import ./gitlab {
     inherit runTest;
@@ -892,7 +892,10 @@ in
   jibri = runTest ./jibri.nix;
   jirafeau = runTest ./jirafeau.nix;
   jitsi-meet = runTest ./jitsi-meet.nix;
-  jool = import ./jool.nix { inherit pkgs runTest; };
+  jool = import ./jool.nix {
+    pkgs = guestPkgs;
+    inherit runTest;
+  };
   jotta-cli = runTest ./jotta-cli.nix;
   k3s = import ./rancher {
     inherit pkgs;
@@ -1430,7 +1433,10 @@ in
       { };
   postfix-tlspol = runTest ./postfix-tlspol.nix;
   postgres-websockets = runTest ./postgres-websockets.nix;
-  postgresql = import ./postgresql { inherit runTest pkgs; };
+  postgresql = import ./postgresql {
+    inherit runTest;
+    pkgs = guestPkgs;
+  };
   postgrest = runTest ./postgrest.nix;
   power-profiles-daemon = runTest ./power-profiles-daemon.nix;
   powerdns = runTest ./powerdns.nix;
@@ -1910,12 +1916,12 @@ in
   whoogle-search = runTest ./whoogle-search.nix;
   wiki-js = runTest ./wiki-js.nix;
   windmill = import ./windmill {
-    inherit pkgs runTest;
-    inherit (pkgs) lib;
+    inherit runTest;
   };
   wine = handleTest ./wine.nix { };
   wireguard = import ./wireguard {
-    inherit pkgs runTest;
+    pkgs = guestPkgs;
+    inherit runTest;
     inherit (pkgs) lib;
   };
   without-nix = runTest ./without-nix.nix;
@@ -1924,7 +1930,7 @@ in
   workout-tracker = runTest ./workout-tracker.nix;
   wpa_supplicant = import ./wpa_supplicant.nix { inherit pkgs runTest; };
   wrappers = runTest ./wrappers.nix;
-  writefreely = import ./web-apps/writefreely.nix { inherit pkgs runTest; };
+  writefreely = import ./web-apps/writefreely.nix { inherit runTest; };
   wstunnel = runTest ./wstunnel.nix;
   xandikos = runTest ./xandikos.nix;
   xautolock = runTest ./xautolock.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1867,7 +1867,7 @@ in
   v2ray = runTest ./v2ray.nix;
   varnish80 = runTest {
     imports = [ ./varnish.nix ];
-    _module.args.package = pkgs.varnish80;
+    _module.args.package = guestPkgs.varnish80;
   };
   vault = runTest ./vault.nix;
   vault-agent = runTest ./vault-agent.nix;
@@ -1885,7 +1885,7 @@ in
   vikunja = runTest ./vikunja.nix;
   vinyl-cache_9 = runTest {
     imports = [ ./vinyl-cache.nix ];
-    _module.args.package = pkgs.vinyl-cache_9;
+    _module.args.package = guestPkgs.vinyl-cache_9;
   };
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1193,7 +1193,7 @@ in
   nginx-status-page = runTest ./nginx-status-page.nix;
   nginx-tmpdir = runTest ./nginx-tmpdir.nix;
   nginx-unix-socket = runTest ./nginx-unix-socket.nix;
-  nginx-variants = import ./nginx-variants.nix { inherit pkgs runTest; };
+  nginx-variants = import ./nginx-variants.nix { inherit runTest; };
   nifi = runTestOn [ "x86_64-linux" ] ./web-apps/nifi.nix;
   nimdow = runTest ./nimdow.nix;
   nipap = runTest ./web-apps/nipap.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -207,8 +207,7 @@ in
   accountsservice = runTest ./accountsservice.nix;
   acl = pkgs.callPackage ./acl.nix { };
   acme = import ./acme/default.nix {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit runTest lib;
   };
   acme-dns = runTest ./acme-dns.nix;
   activation = pkgs.callPackage ../modules/system/activation/test.nix { };
@@ -409,7 +408,7 @@ in
   cloudcompare = import ./cloudcompare.nix { inherit pkgs runTest; };
   cloudlog = runTest ./cloudlog.nix;
   cntr = import ./cntr.nix {
-    inherit (pkgs) lib;
+    inherit lib;
     runTest = runTestOn [
       "aarch64-linux"
       "x86_64-linux"
@@ -584,8 +583,7 @@ in
   ergochat = runTest ./ergochat.nix;
   ersatztv = runTest ./ersatztv.nix;
   espanso = import ./espanso.nix {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   esphome = runTest ./esphome.nix;
   etc = guestPkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
@@ -769,8 +767,7 @@ in
   guix = handleTest ./guix { };
   gvisor = runTest ./gvisor.nix;
   h2o = import ./web-servers/h2o {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   hadoop = import ./hadoop {
     inherit handleTestOn;
@@ -898,8 +895,7 @@ in
   };
   jotta-cli = runTest ./jotta-cli.nix;
   k3s = import ./rancher {
-    inherit pkgs;
-    inherit (pkgs) lib;
+    inherit lib pkgs;
     runTest = runTestOn [
       "aarch64-linux"
       "x86_64-linux"
@@ -942,8 +938,7 @@ in
   kthxbye = runTest ./kthxbye.nix;
   kubernetes = handleTestOn [ "x86_64-linux" ] ./kubernetes { };
   kubo = import ./kubo {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   labgrid = runTest ./labgrid.nix;
   lact = runTest ./lact.nix;
@@ -1057,8 +1052,7 @@ in
   mediamtx = runTest ./mediamtx.nix;
   mediatomb = runTest ./mediatomb.nix;
   mediawiki = import ./mediawiki.nix {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   meilisearch = runTest ./meilisearch.nix;
   memcached = runTest ./memcached.nix;
@@ -1104,8 +1098,7 @@ in
   morph-browser = discoverTests (import ./morph-browser.nix);
   mosquitto = runTest ./mosquitto.nix;
   movim = import ./web-apps/movim {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   mpd = runTest ./mpd.nix;
   mpv = runTest ./mpv.nix;
@@ -1364,8 +1357,7 @@ in
   patroni = handleTestOn [ "x86_64-linux" ] ./patroni.nix { };
   pcsclite = runTest ./pcsclite.nix;
   pdfding = import ./web-apps/pdfding {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   pdns-recursor = runTest ./pdns-recursor.nix;
   pdudaemon = runTest ./pdudaemon.nix;
@@ -1470,8 +1462,7 @@ in
   privoxy = runTest ./privoxy.nix;
   prometheus = import ./prometheus { inherit runTest; };
   prometheus-exporters = import ./prometheus-exporters.nix {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   prosody = runTest ./xmpp/prosody.nix;
   prosody-mysql = handleTest ./xmpp/prosody-mysql.nix { };
@@ -1509,8 +1500,7 @@ in
   rathole = runTest ./rathole.nix;
   rauc = runTest ./rauc.nix;
   reaction = import ./reaction {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   readarr = runTest ./readarr.nix;
   readeck = runTest ./readeck.nix;
@@ -1531,8 +1521,7 @@ in
   retroarch = runTest ./retroarch.nix;
   ringboard = runTest ./ringboard.nix;
   rke2 = import ./rancher {
-    inherit pkgs;
-    inherit (pkgs) lib;
+    inherit lib pkgs;
     runTest = runTestOn [
       "aarch64-linux"
       "x86_64-linux"
@@ -1655,8 +1644,7 @@ in
   sunshine = runTest ./sunshine.nix;
   suricata = runTest ./suricata.nix;
   suwayomi-server = import ./suwayomi-server.nix {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   svnserve = runTest ./svnserve.nix;
   swap-file-btrfs = runTest ./swap-file-btrfs.nix;
@@ -1693,8 +1681,7 @@ in
   systemd-analyze = runTest ./systemd-analyze.nix;
   systemd-binfmt = handleTestOn [ "x86_64-linux" ] ./systemd-binfmt.nix { };
   systemd-boot = import ./systemd-boot.nix {
-    inherit runTest runTestOn;
-    inherit (pkgs) lib;
+    inherit lib runTest runTestOn;
   };
   systemd-bpf = runTest ./systemd-bpf.nix;
   systemd-capsules = runTest ./systemd-capsules.nix;
@@ -1921,8 +1908,7 @@ in
   wine = handleTest ./wine.nix { };
   wireguard = import ./wireguard {
     pkgs = guestPkgs;
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit runTest lib;
   };
   without-nix = runTest ./without-nix.nix;
   wmderland = runTest ./wmderland.nix;
@@ -1948,8 +1934,7 @@ in
   yarr = runTest ./yarr.nix;
   yb = pkgs.callPackage ./yb.nix { inherit (pkgs.yb.passthru) ybPivHarnessTests testFixtures; };
   ydotool = import ./ydotool.nix {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   yggdrasil = runTest ./yggdrasil.nix;
   your_spotify = runTest ./your_spotify.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -109,20 +109,7 @@ let
 
     [public]: https://nixos.org/manual/nixos/stable/#sec-call-nixos-test-outside-nixos
   */
-  guestPkgs =
-    if pkgs.stdenv.hostPlatform.isLinux then
-      pkgs
-    else
-      let
-        hostToGuest.aarch64-darwin = "aarch64-linux";
-        guestSystem =
-          hostToGuest.${pkgs.stdenv.hostPlatform.system}
-            or (throw "NixOS tests: don't know which Linux guest system to pair with host system ${pkgs.stdenv.hostPlatform.system}.");
-      in
-      import ../.. {
-        system = guestSystem;
-        inherit (pkgs) config overlays;
-      };
+  inherit (pkgs) pkgsLinux;
 
   evalSystem =
     module:
@@ -130,7 +117,7 @@ let
       system = null;
       modules = [
         ../modules/misc/nixpkgs/read-only.nix
-        { nixpkgs.pkgs = guestPkgs; }
+        { nixpkgs.pkgs = pkgsLinux; }
         module
       ];
     };
@@ -637,7 +624,7 @@ in
     inherit lib runTest;
   };
   esphome = runTest ./esphome.nix;
-  etc = guestPkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
+  etc = pkgsLinux.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = import ./etcd/default.nix { inherit pkgs runTest; };
   etebase-server = runTest ./etebase-server.nix;
   etesync-dav = runTest ./etesync-dav.nix;
@@ -715,11 +702,11 @@ in
   fontconfig-default-fonts = runTest ./fontconfig-default-fonts.nix;
   forgejo = import ./forgejo.nix {
     inherit runTest;
-    forgejoPackage = guestPkgs.forgejo;
+    forgejoPackage = pkgsLinux.forgejo;
   };
   forgejo-lts = import ./forgejo.nix {
     inherit runTest;
-    forgejoPackage = guestPkgs.forgejo-lts;
+    forgejoPackage = pkgsLinux.forgejo-lts;
   };
   freenet = runTest ./freenet.nix;
   freescout = import ./freescout {
@@ -746,11 +733,11 @@ in
   gancio = runTest ./gancio.nix;
   garage_1 = import ./garage {
     inherit runTest;
-    package = guestPkgs.garage_1;
+    package = pkgsLinux.garage_1;
   };
   garage_2 = import ./garage {
     inherit runTest;
-    package = guestPkgs.garage_2;
+    package = pkgsLinux.garage_2;
   };
   gatus = runTest ./gatus.nix;
   gemstash = import ./gemstash.nix { inherit pkgs runTest; };
@@ -764,7 +751,7 @@ in
   git-pages-modular = runTest ./git-pages.nix;
   gitdaemon = runTest ./gitdaemon.nix;
   gitea = import ./gitea.nix {
-    inherit (pkgs) gitea;
+    inherit (pkgsLinux) gitea;
     inherit runTest;
     inherit lib;
   };
@@ -952,7 +939,7 @@ in
   jirafeau = runTest ./jirafeau.nix;
   jitsi-meet = runTest ./jitsi-meet.nix;
   jool = import ./jool.nix {
-    pkgs = guestPkgs;
+    pkgs = pkgsLinux;
     inherit runTest;
   };
   jotta-cli = runTest ./jotta-cli.nix;
@@ -1149,7 +1136,7 @@ in
   mobilizon = runTest ./mobilizon.nix;
   mod_perl = runTest ./mod_perl.nix;
   modular-service-etc = runTest ./modular-service-etc/test.nix;
-  modularService = guestPkgs.callPackage ../modules/system/service/systemd/test.nix {
+  modularService = pkgsLinux.callPackage ../modules/system/service/systemd/test.nix {
     inherit evalSystem;
   };
   moduleStateRevisions = pkgs.callPackage ./moduleStateRevisions.nix { };
@@ -1521,7 +1508,7 @@ in
   postgres-websockets = runTest ./postgres-websockets.nix;
   postgresql = import ./postgresql {
     inherit runTest;
-    pkgs = guestPkgs;
+    pkgs = pkgsLinux;
   };
   postgrest = runTest ./postgrest.nix;
   power-profiles-daemon = runTest ./power-profiles-daemon.nix;
@@ -1794,7 +1781,7 @@ in
         runTest
         callTest
         ;
-      pkgs = guestPkgs;
+      pkgs = pkgsLinux;
     }
   );
   systemd = runTest ./systemd.nix;
@@ -1987,7 +1974,7 @@ in
   v2ray = runTest ./v2ray.nix;
   varnish80 = runTest {
     imports = [ ./varnish.nix ];
-    _module.args.package = guestPkgs.varnish80;
+    _module.args.package = pkgsLinux.varnish80;
   };
   vault = runTest ./vault.nix;
   vault-agent = runTest ./vault-agent.nix;
@@ -2005,7 +1992,7 @@ in
   vikunja = runTest ./vikunja.nix;
   vinyl-cache_9 = runTest {
     imports = [ ./vinyl-cache.nix ];
-    _module.args.package = guestPkgs.vinyl-cache_9;
+    _module.args.package = pkgsLinux.vinyl-cache_9;
   };
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };
@@ -2037,7 +2024,7 @@ in
     inherit (pkgs) lib;
   };
   wireguard = import ./wireguard {
-    pkgs = guestPkgs;
+    pkgs = pkgsLinux;
     inherit runTest lib;
   };
   without-nix = runTest ./without-nix.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1993,7 +1993,7 @@ in
   v2ray = runTest ./v2ray.nix;
   varnish80 = runTest {
     imports = [ ./varnish.nix ];
-    _module.args.package = pkgs.varnish80;
+    _module.args.package = guestPkgs.varnish80;
   };
   vault = runTest ./vault.nix;
   vault-agent = runTest ./vault-agent.nix;
@@ -2011,7 +2011,7 @@ in
   vikunja = runTest ./vikunja.nix;
   vinyl-cache_9 = runTest {
     imports = [ ./vinyl-cache.nix ];
-    _module.args.package = pkgs.vinyl-cache_9;
+    _module.args.package = guestPkgs.vinyl-cache_9;
   };
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -644,9 +644,7 @@ in
   etebase-server = runTest ./etebase-server.nix;
   etesync-dav = runTest ./etesync-dav.nix;
   evcc = runTest ./evcc.nix;
-  extra-initrd = import ./extra-initrd.nix {
-    inherit runTest pkgs;
-  };
+  extra-initrd = import ./extra-initrd.nix { inherit runTest; };
   facter = runTest ./facter;
   fail2ban = runTest ./fail2ban.nix;
   fakeroute = runTest ./fakeroute.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -99,13 +99,38 @@ let
     featureFlags.minimalModules = { };
   };
   evalMinimalConfig = module: nixosLib.evalModules { modules = [ module ]; };
+
+  /**
+    On platforms where NixOS does not run natively, nixosTests is still available
+    as a convenience for running VM tests. This makes them easier to use, and it
+    sidesteps the question of nested virtualisation.
+
+    `runTest` already includes similar logic as part of its [public] interface.
+
+    [public]: https://nixos.org/manual/nixos/stable/#sec-call-nixos-test-outside-nixos
+  */
+  guestPkgs =
+    if pkgs.stdenv.hostPlatform.isLinux then
+      pkgs
+    else
+      let
+        hostToGuest.aarch64-darwin = "aarch64-linux";
+        guestSystem =
+          hostToGuest.${pkgs.stdenv.hostPlatform.system}
+            or (throw "NixOS tests: don't know which Linux guest system to pair with host system ${pkgs.stdenv.hostPlatform.system}.");
+      in
+      import ../.. {
+        system = guestSystem;
+        inherit (pkgs) config overlays;
+      };
+
   evalSystem =
     module:
     import ../lib/eval-config.nix {
       system = null;
       modules = [
         ../modules/misc/nixpkgs/read-only.nix
-        { nixpkgs.pkgs = pkgs; }
+        { nixpkgs.pkgs = guestPkgs; }
         module
       ];
     };
@@ -614,7 +639,7 @@ in
     inherit runTest;
   };
   esphome = runTest ./esphome.nix;
-  etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
+  etc = guestPkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = import ./etcd/default.nix { inherit pkgs runTest; };
   etebase-server = runTest ./etebase-server.nix;
   etesync-dav = runTest ./etesync-dav.nix;
@@ -1128,7 +1153,7 @@ in
   mobilizon = runTest ./mobilizon.nix;
   mod_perl = runTest ./mod_perl.nix;
   modular-service-etc = runTest ./modular-service-etc/test.nix;
-  modularService = pkgs.callPackage ../modules/system/service/systemd/test.nix {
+  modularService = guestPkgs.callPackage ../modules/system/service/systemd/test.nix {
     inherit evalSystem;
   };
   moduleStateRevisions = pkgs.callPackage ./moduleStateRevisions.nix { };
@@ -1772,11 +1797,11 @@ in
   system-services-compliance = recurseIntoAttrs (
     import ./system-services-compliance.nix {
       inherit
-        pkgs
         evalSystem
         runTest
         callTest
         ;
+      pkgs = guestPkgs;
     }
   );
   systemd = runTest ./systemd.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -249,8 +249,7 @@ in
   accountsservice = runTest ./accountsservice.nix;
   acl = pkgs.callPackage ./acl.nix { };
   acme = import ./acme/default.nix {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit runTest lib;
   };
   acme-dns = runTest ./acme-dns.nix;
   activation = pkgs.callPackage ../modules/system/activation/test.nix { };
@@ -456,7 +455,7 @@ in
   cloudcompare = import ./cloudcompare.nix { inherit pkgs runTest; };
   cloudlog = runTest ./cloudlog.nix;
   cntr = import ./cntr.nix {
-    inherit (pkgs) lib;
+    inherit lib;
     runTest = runTestOn [
       "aarch64-linux"
       "x86_64-linux"
@@ -635,8 +634,7 @@ in
   ergochat = runTest ./ergochat.nix;
   ersatztv = runTest ./ersatztv.nix;
   espanso = import ./espanso.nix {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   esphome = runTest ./esphome.nix;
   etc = guestPkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
@@ -825,8 +823,7 @@ in
   guix = handleTest ./guix { };
   gvisor = runTest ./gvisor.nix;
   h2o = import ./web-servers/h2o {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   hadoop = import ./hadoop {
     inherit handleTestOn;
@@ -960,8 +957,7 @@ in
   };
   jotta-cli = runTest ./jotta-cli.nix;
   k3s = import ./rancher {
-    inherit pkgs;
-    inherit (pkgs) lib;
+    inherit lib pkgs;
     runTest = runTestOn [
       "aarch64-linux"
       "x86_64-linux"
@@ -1013,8 +1009,7 @@ in
   kthxbye = runTest ./kthxbye.nix;
   kubernetes = handleTestOn [ "x86_64-linux" ] ./kubernetes { };
   kubo = import ./kubo {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   kvrocks = runTest ./kvrocks.nix;
   labgrid = runTest ./labgrid.nix;
@@ -1131,8 +1126,7 @@ in
   mediamtx = runTest ./mediamtx.nix;
   mediatomb = runTest ./mediatomb.nix;
   mediawiki = import ./mediawiki.nix {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   meilisearch = runTest ./meilisearch.nix;
   memcached = runTest ./memcached.nix;
@@ -1186,8 +1180,7 @@ in
   morph-browser = discoverTests (import ./morph-browser.nix);
   mosquitto = runTest ./mosquitto.nix;
   movim = import ./web-apps/movim {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   mpd = runTest ./mpd.nix;
   mpv = runTest ./mpv.nix;
@@ -1458,8 +1451,7 @@ in
   patroni = handleTestOn [ "x86_64-linux" ] ./patroni.nix { };
   pcsclite = runTest ./pcsclite.nix;
   pdfding = import ./web-apps/pdfding {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   pdns-recursor = runTest ./pdns-recursor.nix;
   pdudaemon = runTest ./pdudaemon.nix;
@@ -1568,8 +1560,7 @@ in
   privoxy = runTest ./privoxy.nix;
   prometheus = import ./prometheus { inherit runTest; };
   prometheus-exporters = import ./prometheus-exporters.nix {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   prosody = runTest ./xmpp/prosody.nix;
   prosody-mysql = handleTest ./xmpp/prosody-mysql.nix { };
@@ -1609,8 +1600,7 @@ in
   rathole = runTest ./rathole.nix;
   rauc = runTest ./rauc.nix;
   reaction = import ./reaction {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   readarr = runTest ./readarr.nix;
   readeck = runTest ./readeck.nix;
@@ -1631,8 +1621,7 @@ in
   retroarch = runTest ./retroarch.nix;
   ringboard = runTest ./ringboard.nix;
   rke2 = import ./rancher {
-    inherit pkgs;
-    inherit (pkgs) lib;
+    inherit lib pkgs;
     runTest = runTestOn [
       "aarch64-linux"
       "x86_64-linux"
@@ -1760,8 +1749,7 @@ in
   sunshine = runTest ./sunshine.nix;
   suricata = runTest ./suricata.nix;
   suwayomi-server = import ./suwayomi-server.nix {
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit lib runTest;
   };
   svnserve = runTest ./svnserve.nix;
   swap-file-btrfs = runTest ./swap-file-btrfs.nix;
@@ -1813,8 +1801,7 @@ in
   systemd-analyze = runTest ./systemd-analyze.nix;
   systemd-binfmt = handleTestOn [ "x86_64-linux" ] ./systemd-binfmt.nix { };
   systemd-boot = import ./systemd-boot.nix {
-    inherit runTest runTestOn;
-    inherit (pkgs) lib;
+    inherit lib runTest runTestOn;
   };
   systemd-bpf = runTest ./systemd-bpf.nix;
   systemd-capsules = runTest ./systemd-capsules.nix;
@@ -2051,8 +2038,7 @@ in
   };
   wireguard = import ./wireguard {
     pkgs = guestPkgs;
-    inherit runTest;
-    inherit (pkgs) lib;
+    inherit runTest lib;
   };
   without-nix = runTest ./without-nix.nix;
   wmderland = runTest ./wmderland.nix;
@@ -2078,8 +2064,7 @@ in
   yarr = runTest ./yarr.nix;
   yb = pkgs.callPackage ./yb.nix { inherit (pkgs.yb.passthru) ybPivHarnessTests testFixtures; };
   ydotool = import ./ydotool.nix {
-    inherit (pkgs) lib;
-    inherit runTest;
+    inherit lib runTest;
   };
   yggdrasil = runTest ./yggdrasil.nix;
   your_spotify = runTest ./your_spotify.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1281,7 +1281,7 @@ in
   nginx-status-page = runTest ./nginx-status-page.nix;
   nginx-tmpdir = runTest ./nginx-tmpdir.nix;
   nginx-unix-socket = runTest ./nginx-unix-socket.nix;
-  nginx-variants = import ./nginx-variants.nix { inherit pkgs runTest; };
+  nginx-variants = import ./nginx-variants.nix { inherit runTest; };
   nifi = runTestOn [ "x86_64-linux" ] ./web-apps/nifi.nix;
   nimdow = runTest ./nimdow.nix;
   nipap = runTest ./web-apps/nipap.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -717,11 +717,11 @@ in
   fontconfig-default-fonts = runTest ./fontconfig-default-fonts.nix;
   forgejo = import ./forgejo.nix {
     inherit runTest;
-    forgejoPackage = pkgs.forgejo;
+    forgejoPackage = guestPkgs.forgejo;
   };
   forgejo-lts = import ./forgejo.nix {
     inherit runTest;
-    forgejoPackage = pkgs.forgejo-lts;
+    forgejoPackage = guestPkgs.forgejo-lts;
   };
   freenet = runTest ./freenet.nix;
   freescout = import ./freescout {
@@ -748,11 +748,11 @@ in
   gancio = runTest ./gancio.nix;
   garage_1 = import ./garage {
     inherit runTest;
-    package = pkgs.garage_1;
+    package = guestPkgs.garage_1;
   };
   garage_2 = import ./garage {
     inherit runTest;
-    package = pkgs.garage_2;
+    package = guestPkgs.garage_2;
   };
   gatus = runTest ./gatus.nix;
   gemstash = import ./gemstash.nix { inherit pkgs runTest; };
@@ -766,8 +766,9 @@ in
   git-pages-modular = runTest ./git-pages.nix;
   gitdaemon = runTest ./gitdaemon.nix;
   gitea = import ./gitea.nix {
-    inherit pkgs runTest;
-    inherit (pkgs) lib;
+    inherit (pkgs) gitea;
+    inherit runTest;
+    inherit lib;
   };
   gitea-actions-runner = runTest ./gitea-actions-runner.nix;
   github-runner = runTest ./github-runner.nix;
@@ -953,7 +954,10 @@ in
   jibri = runTest ./jibri.nix;
   jirafeau = runTest ./jirafeau.nix;
   jitsi-meet = runTest ./jitsi-meet.nix;
-  jool = import ./jool.nix { inherit pkgs runTest; };
+  jool = import ./jool.nix {
+    pkgs = guestPkgs;
+    inherit runTest;
+  };
   jotta-cli = runTest ./jotta-cli.nix;
   k3s = import ./rancher {
     inherit pkgs;
@@ -1523,7 +1527,10 @@ in
       { };
   postfix-tlspol = runTest ./postfix-tlspol.nix;
   postgres-websockets = runTest ./postgres-websockets.nix;
-  postgresql = import ./postgresql { inherit runTest pkgs; };
+  postgresql = import ./postgresql {
+    inherit runTest;
+    pkgs = guestPkgs;
+  };
   postgrest = runTest ./postgrest.nix;
   power-profiles-daemon = runTest ./power-profiles-daemon.nix;
   powerdns = runTest ./powerdns.nix;
@@ -2036,15 +2043,15 @@ in
   whoogle-search = runTest ./whoogle-search.nix;
   wiki-js = runTest ./wiki-js.nix;
   windmill = import ./windmill {
-    inherit pkgs runTest;
-    inherit (pkgs) lib;
+    inherit runTest;
   };
   wine = import ./wine.nix {
     inherit pkgs runTest;
     inherit (pkgs) lib;
   };
   wireguard = import ./wireguard {
-    inherit pkgs runTest;
+    pkgs = guestPkgs;
+    inherit runTest;
     inherit (pkgs) lib;
   };
   without-nix = runTest ./without-nix.nix;
@@ -2053,7 +2060,7 @@ in
   workout-tracker = runTest ./workout-tracker.nix;
   wpa_supplicant = import ./wpa_supplicant.nix { inherit pkgs runTest; };
   wrappers = runTest ./wrappers.nix;
-  writefreely = import ./web-apps/writefreely.nix { inherit pkgs runTest; };
+  writefreely = import ./web-apps/writefreely.nix { inherit runTest; };
   wstunnel = runTest ./wstunnel.nix;
   xandikos = runTest ./xandikos.nix;
   xautolock = runTest ./xautolock.nix;

--- a/nixos/tests/calibre-server.nix
+++ b/nixos/tests/calibre-server.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   runTest,
-  ...
 }:
 
 let

--- a/nixos/tests/certmgr.nix
+++ b/nixos/tests/certmgr.nix
@@ -1,4 +1,4 @@
-{ runTest, pkgs, ... }:
+{ runTest, pkgs }:
 
 let
   authKey = pkgs.writeText "auth-key" "1234ABCD";

--- a/nixos/tests/etcd/default.nix
+++ b/nixos/tests/etcd/default.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   runTest,
-  ...
 }:
 
 let

--- a/nixos/tests/extra-initrd.nix
+++ b/nixos/tests/extra-initrd.nix
@@ -1,7 +1,4 @@
-{
-  runTest,
-  ...
-}:
+{ runTest }:
 let
   common =
     { config, pkgs, ... }:

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -1,5 +1,5 @@
 {
-  pkgs,
+  gitea,
   lib,
   runTest,
   ...
@@ -28,10 +28,18 @@ let
   ];
   makeGiteaTest =
     type:
-    lib.nameValuePair type (runTest {
-      name = "${pkgs.gitea.pname}-${type}";
+    runTest {
+      imports = [
+        module
+      ];
+      name = "${gitea.pname}-${type}";
+      nodes.server.services.gitea.settings.database = { inherit type; };
+    };
+  module =
+    { config, ... }:
+    {
       meta = {
-        inherit (pkgs.gitea.meta) maintainers;
+        inherit (gitea.meta) maintainers;
       };
 
       nodes = {
@@ -42,7 +50,6 @@ let
             services = {
               gitea = {
                 enable = true;
-                database = { inherit type; };
                 package = pkgs.gitea;
                 metricsTokenFile = (pkgs.writeText "metrics_secret" "fakesecret").outPath;
                 settings = {
@@ -70,7 +77,7 @@ let
 
       testScript =
         let
-          inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+          inherit (import ./ssh-keys.nix config.node.pkgs) snakeOilPrivateKey snakeOilPublicKey;
         in
         /* python */ ''
           GIT_SSH_COMMAND = "ssh -i $HOME/.ssh/privk -o StrictHostKeyChecking=no"
@@ -98,7 +105,7 @@ let
 
           server.succeed(
               "su -l gitea -c 'gpg --homedir /var/lib/gitea/data/home/.gnupg "
-              + "--import ${toString (pkgs.writeText "gitea.key" signingPrivateKey)}'"
+              + "--import ${toString (config.node.pkgs.writeText "gitea.key" signingPrivateKey)}'"
           )
 
           assert "BEGIN PGP PUBLIC KEY BLOCK" in server.succeed("curl http://localhost:3000/api/v1/signing-key.gpg")
@@ -150,7 +157,7 @@ let
                              + 'http://localhost:3000/metrics '
                              + '| grep gitea_accesses')
         '';
-    });
+    };
 in
 
-lib.listToAttrs (map makeGiteaTest supportedDbTypes)
+lib.genAttrs supportedDbTypes makeGiteaTest

--- a/nixos/tests/hadoop/default.nix
+++ b/nixos/tests/hadoop/default.nix
@@ -1,4 +1,4 @@
-{ handleTestOn, package, ... }:
+{ handleTestOn, package }:
 
 {
   all = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop.nix {

--- a/nixos/tests/limine/default.nix
+++ b/nixos/tests/limine/default.nix
@@ -1,6 +1,5 @@
 {
   runTest,
-  ...
 }:
 {
   additionalFiles = runTest ./additional-files.nix;

--- a/nixos/tests/nginx-http3.nix
+++ b/nixos/tests/nginx-http3.nix
@@ -1,4 +1,4 @@
-{ pkgs, runTest, ... }:
+{ pkgs, runTest }:
 let
   hosts = ''
     192.168.2.101 acme.test

--- a/nixos/tests/nginx-variants.nix
+++ b/nixos/tests/nginx-variants.nix
@@ -1,4 +1,4 @@
-{ pkgs, runTest, ... }:
+{ runTest }:
 builtins.listToAttrs (
   map
     (packageName: {

--- a/nixos/tests/nixos-test-driver/options-doc-regression.nix
+++ b/nixos/tests/nixos-test-driver/options-doc-regression.nix
@@ -21,7 +21,6 @@
 
 {
   pkgs,
-  ...
 }:
 let
   evalConfig = import ../../lib/eval-config.nix;

--- a/nixos/tests/rancher/default.nix
+++ b/nixos/tests/rancher/default.nix
@@ -4,7 +4,6 @@
   lib,
   # service/package name to test
   rancherDistro,
-  ...
 }:
 let
   allPackages = lib.filterAttrs (

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -2,7 +2,6 @@
   runTest,
   runTestOn,
   lib,
-  ...
 }:
 
 let

--- a/nixos/tests/varnish.nix
+++ b/nixos/tests/varnish.nix
@@ -1,5 +1,7 @@
-{ pkgs, package, ... }:
+{ config, package, ... }:
 let
+  pkgs = config.node.pkgs;
+
   testPath = pkgs.hello;
 
   # Same stateDir logic as in nixos/modules/services/web-servers/varnish/default.nix

--- a/nixos/tests/vinyl-cache.nix
+++ b/nixos/tests/vinyl-cache.nix
@@ -1,10 +1,11 @@
 {
-  pkgs,
+  config,
   package,
   lib,
   ...
 }:
 let
+  pkgs = config.node.pkgs;
   testPath = pkgs.hello;
 in
 {

--- a/nixos/tests/web-apps/writefreely.nix
+++ b/nixos/tests/web-apps/writefreely.nix
@@ -1,7 +1,4 @@
-{
-  runTest,
-  ...
-}:
+{ runTest }:
 
 let
   writefreelyTest =

--- a/nixos/tests/windmill/default.nix
+++ b/nixos/tests/windmill/default.nix
@@ -1,4 +1,4 @@
-{ runTest, ... }:
+{ runTest }:
 {
   apiIntegration = runTest ./api-integration.nix;
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Problem found during/after modular services meeting https://discourse.nixos.org/t/modular-services-meeting-6-2026-08-07/79408/2
- Not an isolated, so I've applied it more broadly, where I could confirm it to work
- Fix code hygiene as we go

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin (implicitly aarch64-linux, except for the `kvm` parts)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
