### PR TITLE
klayout: 0.30.8 -> 0.30.10

### DIFF
--- a/pkgs/by-name/kl/klayout/package.nix
+++ b/pkgs/by-name/kl/klayout/package.nix
@@ -19,15 +19,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "klayout";
-  version = "0.30.8";
+  version = "0.30.10";
 
   src = fetchFromGitHub {
     owner = "KLayout";
     repo = "klayout";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RjMH6hrc0jyCLgG1D6cztBp5Fb3W5HgTxVTfI2bxgCs=";
+    hash = "sha256-ruM9+aD0k5RRpHMAzNNGtU5Xb2rmzz6yIsxxyHVcwRs=";
   };
 
+  __structuredAttrs = true;
   strictDeps = true;
 
   postPatch = ''

--- a/pkgs/by-name/kl/klayout/package.nix
+++ b/pkgs/by-name/kl/klayout/package.nix
@@ -129,6 +129,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.klayout.de/";
     changelog = "https://www.klayout.de/development.html#${finalAttrs.version}";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.gonsolo ];
   };
 })


### PR DESCRIPTION
## Summary

Update klayout from 0.30.8 to 0.30.10 and add myself as maintainer.

Changelog: https://www.klayout.de/development.html#0.30.10

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

**AI disclosure**: this PR description and the git/gh mechanics (branch, commit, push, PR creation) were drafted/executed with the assistance of Claude Code (Claude Sonnet 5); see the `Assisted-by:` trailer on the commit. The version bump and maintainer addition themselves were made by hand.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test