### PR TITLE
nixos/test-driver: make `get_tty_text` handle CP437 chars correctly 

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -943,10 +943,11 @@ class QemuMachine(BaseMachine):
         """
         Get the output printed to a given TTY.
         """
-        status, output = self.execute(
-            f"fold -w$(stty -F /dev/tty{tty} size | awk '{{print $2}}') /dev/vcs{tty}"
-        )
-        return output
+        _, size = self.execute(f"stty -F /dev/tty{tty} size")
+        cols = int(size.split()[1])
+        _, b64 = self.execute(f"base64 -w0 /dev/vcsu{tty}")
+        text = base64.b64decode(b64).decode("utf-32-le")
+        return "\n".join(text[i : i + cols] for i in range(0, len(text), cols))
 
     def wait_until_tty_matches(
         self, tty: str, regexp: str, timeout: Duration = dt.timedelta(minutes=15)

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -972,7 +972,7 @@ class QemuMachine(BaseMachine):
 
     def dump_tty_contents(self, tty: str) -> None:
         """Debugging: Dump the contents of the TTY<n>"""
-        self.execute(f"fold -w 80 /dev/vcs{tty} | systemd-cat")
+        self.log(self.get_tty_text(tty))
 
     def _execute(
         self,


### PR DESCRIPTION
Previous implementation would send `/dev/vcs<n>` bytes into  `fold`, where `vcs` devices would produce font-dependent glyph indices. While this worked fine for the most part, `fold` could be confused by VGA text mode characters and shift the line cutoff incorrectly.

The side effect of this shifting is that the result returned by `get_tty_text` would have `\n` added inbetween words that should not be split, which in turn could break `wait_until_tty_matches` because the string you were expecting suddenly had a newline in it.

Consuming text from  `/dev/vcsu<n>` instead leaves us with predictable UTF-32 output.

Found this thanks to a piece of software with some crazy ascii (?) art.

Built a few nixos tests that uses `wait_until_tty_matches` as a smoke test: `nix build .#nixosTests.auth-mysql .#nixosTests.systemd-homed .#nixosTests.fscrypt .#nixosTests.kerberos.heimdal`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
