### PR TITLE
haskell.compiler.ghc9142: init at 9.14.1.20260728 [ghc-9.14.2-rc1]

### DIFF
--- a/pkgs/development/compilers/ghc/9.14.2.nix
+++ b/pkgs/development/compilers/ghc/9.14.2.nix
@@ -1,0 +1,5 @@
+import ./common-hadrian.nix {
+  url = "https://downloads.haskell.org/~ghc/9.14.2-rc1/ghc-9.14.1.20260728-src.tar.xz";
+  version = "9.14.1.20260728";
+  sha256 = "015543170af3ca4bf3b2c4112a207b4738be72243883cb0dbbe673bcc316a04f";
+}

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -118,6 +118,7 @@
         # While split sections are now enabled by default in ghc 8.8 for windows,
         # they seem to lead to `too many sections` errors when building base for
         # profiling.
+        # TODO(@alexfmpe): test split sections again with GHC 9.14.2
         ++ (if stdenv.targetPlatform.isWindows then [ "no_split_sections" ] else [ "split_sections" ]);
     in
     baseFlavour + lib.concatMapStrings (t: "+${t}") transformers,
@@ -309,34 +310,21 @@
       ]
 
       # Fix docs build with Sphinx >= 9 https://gitlab.haskell.org/ghc/ghc/-/issues/26810
-      ++
-        lib.optionals
-          (
-            lib.versionOlder version "9.12.4"
-            || (lib.versionAtLeast version "9.14" && lib.versionOlder version "9.15.20260129")
-          )
-          [
-            ./ghc-9.6-or-later-docs-sphinx-9.patch
-          ]
+      ++ lib.optionals (lib.versionOlder version "9.12.4" || version == "9.14.1") [
+        ./ghc-9.6-or-later-docs-sphinx-9.patch
+      ]
 
       # Fixes rts/Types.h missing from the install when targeting javascript
       # See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/15740, krank:ignore-line
       # https://gitlab.haskell.org/ghc/ghc/-/issues/27033. krank:ignore-line
-      ++
-        lib.optionals
-          (
-            version == "9.12.3"
-            # TODO(@sternenseemann): 9.14.2 will likely also have this patch
-            || (lib.versionAtLeast version "9.14" && lib.versionOlder version "9.15.20260127")
-          )
-          [
-            (fetchpatch {
-              name = "ghc-9.12.3-ghcjs-install-rts-types.h.patch";
-              url = "https://gitlab.haskell.org/ghc/ghc/-/commit/5b1be555be4f0989d78c274991c5046d7ac6d25e.patch";
-              hash = "sha256-pv4NDyQ6FlZgmTYZ4Ghis4qggt7nCDMhqGaFxTxVPac=";
-              includes = [ "rts/rts.cabal" ];
-            })
-          ]
+      ++ lib.optionals (version == "9.12.3" || version == "9.14.1") [
+        (fetchpatch {
+          name = "ghc-9.12.3-ghcjs-install-rts-types.h.patch";
+          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/5b1be555be4f0989d78c274991c5046d7ac6d25e.patch";
+          hash = "sha256-pv4NDyQ6FlZgmTYZ4Ghis4qggt7nCDMhqGaFxTxVPac=";
+          includes = [ "rts/rts.cabal" ];
+        })
+      ]
 
       ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; });
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -193,6 +193,14 @@ in
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;
       };
+      ghc9142 = callPackage ../development/compilers/ghc/9.14.2.nix {
+        bootPkgs =
+          # No suitable bindist packaged yet
+          bb.packages.ghc9103;
+        inherit (buildPackages.python3Packages) sphinx;
+        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+        inherit buildTargetLlvmPackages llvmPackages;
+      };
       ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
         bootPkgs =
           # No suitable bindist packaged yet
@@ -300,6 +308,11 @@ in
       ghc9141 = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghc9141;
         ghc = bh.compiler.ghc9141;
+        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.14.x.nix { };
+      };
+      ghc9142 = callPackage ../development/haskell-modules {
+        buildHaskellPackages = bh.packages.ghc9142;
+        ghc = bh.compiler.ghc9142;
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.14.x.nix { };
       };
       ghcHEAD = callPackage ../development/haskell-modules {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -67,7 +67,7 @@ let
     ghc98 = sets.ghc984;
     ghc910 = sets.ghc9103;
     ghc912 = sets.ghc9125;
-    ghc914 = sets.ghc9141;
+    ghc914 = sets.ghc9142;
 
     microhs_0_15 = sets.microhs_0_15_4_0;
     microhs = sets.microhs_0_15;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -547,7 +547,7 @@ let
         compilerNames.ghc910
       ];
       haskell-debugger = [
-        compilerNames.ghc9141
+        compilerNames.ghc9142
       ];
       haskell-language-server = released;
       hoogle = released;
@@ -567,7 +567,7 @@ let
       hashable = released;
       primitive = released;
       scrod = [
-        compilerNames.ghc9141
+        compilerNames.ghc9142
       ];
       semaphore-compat = [
         # Compiler < 9.8 don't have the semaphore-compat core package, but


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @wolfgangwalther

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
