### PR TITLE
mobile-config-firefox: 4.6.0 -> 5.4.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/mobile-config.nix
+++ b/pkgs/applications/networking/browsers/firefox/mobile-config.nix
@@ -10,27 +10,18 @@ let
     domain = "gitlab.postmarketos.org";
     owner = "postmarketOS";
     repo = "mobile-config-firefox";
-    rev = "4.6.0";
-    hash = "sha256-tISfxN/04spgtKStkkn+zlCtFU6GbtwuZubqpGN2olA=";
+    rev = "5.4.1";
+    hash = "sha256-MyhGl1gIjDtNUMLoHz15l5RaJWDcTeBgZl0Gb8WHcUg=";
   };
   mobileConfigDir = runCommand "mobile-config-firefox" { } ''
-    mkdir -p $out/mobile-config-firefox/{common,userChrome,userContent}
-
-    cp ${pkg}/src/common/*.css $out/mobile-config-firefox/common/
-    cp ${pkg}/src/userChrome/*.css $out/mobile-config-firefox/userChrome/
-    cp ${pkg}/src/userContent/*.css $out/mobile-config-firefox/userContent/
-
-    (cd $out/mobile-config-firefox && find common -name "*.css" | sort) >> $out/mobile-config-firefox/userChrome.files
-    (cd $out/mobile-config-firefox && find common -name "*.css" | sort) >> $out/mobile-config-firefox/userContent.files
-
-    (cd $out/mobile-config-firefox && find userChrome -name "*.css" | sort) > $out/mobile-config-firefox/userChrome.files
-    (cd $out/mobile-config-firefox && find userContent -name "*.css" | sort) > $out/mobile-config-firefox/userContent.files
-
+    mkdir -p $out
+    cp -r ${pkg}/src/modules/. $out/
+    cp -r ${pkg}/src/themes $out/
   '';
 
   mobileConfigAutoconfig = runCommand "mobile-config-autoconfig.js" { } ''
     substitute ${pkg}/src/mobile-config-autoconfig.js $out \
-      --replace "/etc/mobile-config-firefox" "${mobileConfigDir}/mobile-config-firefox"
+      --replace-fail "/usr/lib/mobile-config-firefox" "${mobileConfigDir}"
   '';
 
   mobileConfigPrefs = runCommand "mobile-config-prefs.js" { } ''


### PR DESCRIPTION
It's mostly broken for the current firefox, so updating it to the latest version:

<img width="945" height="1650" alt="Screenshot_20260812_113317" src="https://github.com/user-attachments/assets/ee456ffe-5a75-45a6-a06c-ad12e645ea81" />

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
