### PR TITLE
aegisbpf: init at 0.10.0-unstable-2026-08-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8481,6 +8481,11 @@
     name = "Alexandre Iooss";
     keys = [ { fingerprint = "2D37 1AD2 7E2B BC77 97E1  B759 6C79 278F 3FCD CC02"; } ];
   };
+  erenari = {
+    github = "ErenAri";
+    githubId = 67584761;
+    name = "Eren Arı";
+  };
   ereslibre = {
     email = "ereslibre@ereslibre.es";
     matrix = "@ereslibre:matrix.org";

--- a/pkgs/by-name/ae/aegisbpf/package.nix
+++ b/pkgs/by-name/ae/aegisbpf/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  bpftools,
+  libbpf,
+  elfutils,
+  zlib,
+  zstd,
+  linuxHeaders,
+  llvmPackages_18,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aegisbpf";
+  version = "0.9.0-unstable-2026-08-12";
+
+  src = fetchFromGitHub {
+    owner = "ErenAri";
+    repo = "Aegis-BPF";
+    rev = "d0fa0012faef63a885bd6316630d5896bd56a4b4";
+    hash = "sha256-DwhxjcDM6eZ2Dzi6uGigLUSEfKYjRehLfrW5jVqZiMs=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    # Unwrapped LLVM-18 clang builds the BPF object with exactly `-target bpf`:
+    # the stdenv cc-wrapper injects hardening flags (e.g. -fzero-call-used-regs)
+    # the bpf target rejects, and newer LLVM regresses BPF stack usage past the
+    # 512-byte verifier limit. LLVM 18 matches upstream's tested clang matrix.
+    llvmPackages_18.clang-unwrapped
+    bpftools
+  ];
+
+  buildInputs = [
+    libbpf
+    elfutils
+    zlib
+    zstd # elfutils' libelf.pc requires libzstd
+    linuxHeaders # asm-generic/* UAPI headers for the BPF object
+  ];
+
+  # Unwrapped clang has no default system-header search path; hand it the kernel
+  # UAPI headers. The userspace C++ build uses the normal stdenv cc.
+  env.CPATH = "${linuxHeaders}/include";
+
+  cmakeFlags = [
+    # Pre-generated CO-RE header (upstream ships one) => hermetic BPF build with
+    # no /sys/kernel/btf dependency.
+    (lib.cmakeFeature "VMLINUX_H" "${finalAttrs.src}/packaging/nix/vmlinux.x86_64.h")
+    (lib.cmakeBool "BUILD_TESTING" false)
+    (lib.cmakeBool "ENABLE_RUST_PARSER_LINK" false)
+    (lib.cmakeBool "STATIC_LIBBPF" false)
+  ];
+
+  # Upstream installs two system-config files to absolute /etc paths; redirect
+  # them under $out for a hermetic install.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'DESTINATION /etc/default' 'DESTINATION ${placeholder "out"}/etc/default' \
+      --replace-fail 'DESTINATION /etc/aegisbpf' 'DESTINATION ${placeholder "out"}/etc/aegisbpf'
+  '';
+
+  meta = {
+    description = "BPF-LSM runtime security agent with race-free in-kernel enforcement";
+    homepage = "https://github.com/ErenAri/Aegis-BPF";
+    changelog = "https://github.com/ErenAri/Aegis-BPF/blob/${finalAttrs.src.rev}/docs/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ erenari ];
+    mainProgram = "aegisbpf";
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
Adds `aegisbpf`, a BPF-LSM runtime-security agent (file/network policy enforcement with race-free in-kernel `-EPERM`, OCSF output) — upstream: https://github.com/ErenAri/Aegis-BPF. New leaf package under `pkgs/by-name/ae/aegisbpf/` (x86_64-linux), plus a maintainer entry.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of the binary in `./result/bin/` (`aegisbpf version` runs).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

## Automation/AI disclosure

Per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy): this package was produced with **AI assistance (Claude Code, model `claude-opus-4-8`)** under my direction; the commits carry an `Assisted-by: Claude Code (claude-opus-4-8)` trailer. I (@ErenAri) am the responsible person accountable for this contribution and will answer review questions directly.

Confidence in correctness was established through automated verification (as the policy permits in lieu of full manual review): the package builds hermetically in a `nixos/nix` sandbox with **no network and no `/sys/kernel/btf`** access, producing a working binary (`aegisbpf version`), and `nixpkgs-vet` + the eval/build CI pass. The packaged upstream project (AegisBPF) is my own.

Apologies for overwriting the template on the first submission — restored here.
