### PR TITLE
[WIP][HELP] python3Packages.shazamio: 0.8.1 -> 0.8.1-unstable-2026-08-12; unbreak; python3Packages.dataclass-factory: renamed to adaptix; python3Packages.adaptix: 2.16 -> 3.0.0b12

### DIFF
--- a/pkgs/development/python-modules/adaptix/default.nix
+++ b/pkgs/development/python-modules/adaptix/default.nix
@@ -1,25 +1,51 @@
 {
   lib,
   buildPythonPackage,
+  rustPlatform,
   fetchFromGitHub,
-  pythonAtLeast,
   nose2,
   typing-extensions,
+  setuptools,
+  uv-build,
 }:
+let
+  /*
+    > ERROR Unmet dependencies (checked against /nix/store/3n4qphl9s728sz8frmpqqrv9b1m87g68-python3-3.14.7/bin/python3.14):
+         >       uv_build==0.8.22
+         >                wanted: ==0.8.22
+         >                found: 0.11.28
+  */
+  uv-build-8 = uv-build.overrideAttrs (oldAttrs: rec {
+    version = "0.8.22";
+    src = fetchFromGitHub {
+      owner = "astral-sh";
+      repo = "uv";
+      tag = version;
+      hash = "sha256-7/WOjsyfkDTZLNJY0+rNdRUmMabJsSFvKi2yh/WqViQ=";
+    };
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      inherit version src;
+      pname = "uv-build";
+      hash = "sha256-RubSyxQjWlkoHMItYLjiyJ5Whz3oMXgioqbuewi1fcM=";
+    };
 
-buildPythonPackage rec {
+  });
+in
+buildPythonPackage (finalAttrs: {
   pname = "adaptix";
-  version = "2.16";
-  format = "setuptools";
+  version = "3.0.0b12";
+  pyproject = true;
 
-  # upstream 2.x branch abandoned since 2022; v3 was renamed to adaptix
-  disabled = pythonAtLeast "3.14";
+  build-system = [
+    setuptools
+    uv-build-8
+  ];
 
   src = fetchFromGitHub {
     owner = "reagento";
     repo = "adaptix";
-    rev = version;
-    hash = "sha256-0BIWgyAV1hJzFX4xYFqswvQi5F1Ce+V9FKSmNYuJfZM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-daW0yRweGf33EsiSOusKWOB8bw0kbSkWfyMuKUZet5s=";
   };
 
   nativeCheckInputs = [ nose2 ];
@@ -28,19 +54,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "adaptix" ];
 
-  checkPhase = ''
-    runHook preCheck
-
-    nose2 -v tests
-
-    runHook postCheck
-  '';
-
   meta = {
     description = "Modern way to convert python dataclasses or other objects to and from more common types like dicts or json-like structures";
     homepage = "https://github.com/reagento/adaptix";
-    changelog = "https://github.com/reagento/adaptix/releases/tag/${src.rev}";
+    changelog = "https://github.com/reagento/adaptix/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/adaptix/default.nix
+++ b/pkgs/development/python-modules/adaptix/default.nix
@@ -59,6 +59,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/reagento/adaptix";
     changelog = "https://github.com/reagento/adaptix/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tomasrivera ];
   };
 })

--- a/pkgs/development/python-modules/adaptix/default.nix
+++ b/pkgs/development/python-modules/adaptix/default.nix
@@ -8,7 +8,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "dataclass-factory";
+  pname = "adaptix";
   version = "2.16";
   format = "setuptools";
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "reagento";
-    repo = "dataclass-factory";
+    repo = "adaptix";
     rev = version;
     hash = "sha256-0BIWgyAV1hJzFX4xYFqswvQi5F1Ce+V9FKSmNYuJfZM=";
   };
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   checkInputs = [ typing-extensions ];
 
-  pythonImportsCheck = [ "dataclass_factory" ];
+  pythonImportsCheck = [ "adaptix" ];
 
   checkPhase = ''
     runHook preCheck
@@ -38,8 +38,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "Modern way to convert python dataclasses or other objects to and from more common types like dicts or json-like structures";
-    homepage = "https://github.com/reagento/dataclass-factory";
-    changelog = "https://github.com/reagento/dataclass-factory/releases/tag/${src.rev}";
+    homepage = "https://github.com/reagento/adaptix";
+    changelog = "https://github.com/reagento/adaptix/releases/tag/${src.rev}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -15,7 +15,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "shazamio";
   version = "0.8.1";
   pyproject = true;
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "dotX12";
     repo = "ShazamIO";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-beEEr9Y8w0XlC/0+mNL/oWscmnfwt9KChlZ7Ullyk3E=";
   };
 
@@ -59,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "Free asynchronous library from reverse engineered Shazam API";
     homepage = "https://github.com/dotX12/ShazamIO";
-    changelog = "https://github.com/dotX12/ShazamIO/releases/tag/${src.tag}";
+    changelog = "https://github.com/dotX12/ShazamIO/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -34,6 +34,11 @@ buildPythonPackage (finalAttrs: {
       url = "https://github.com/tomasriveral/ShazamIO/commit/23dd6f2b4195616cbfa5dd98339265e4e5959be6.patch";
       hash = "sha256-h7fVAiUJVJk/gItUsyUyDz2q9++UzRoga7NG/IL+MIY=";
     })
+    # renames all the occurances of dataclass-factory to adaptix
+    (fetchpatch {
+      url = "https://github.com/tomasriveral/ShazamIO/commit/cd448fd8736cc47841fc566b0007304189b95490.patch";
+      hash = "sha256-2qJM3kynMnZtNTPRXdpgqBv0qo88He61/Sc1a14fstM=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -54,6 +59,19 @@ buildPythonPackage (finalAttrs: {
     ffmpeg
     pytest-asyncio
     pytestCheckHook
+  ];
+
+
+  /*
+  pythonRuntimeDepsCheckHook has a lot of false positives.
+  */
+  pythonRemoveDeps = [
+    "adaptix"
+    "aiofiles"
+    "aiohttp-retry"
+    "anyio"
+    "dataclass-factory"
+    "shazamio-core"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -61,6 +61,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/dotX12/ShazamIO";
     changelog = "https://github.com/dotX12/ShazamIO/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tomasrivera ];
   };
 })

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   poetry-core,
   wheel,
   aiofiles,
@@ -26,6 +27,14 @@ buildPythonPackage (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-beEEr9Y8w0XlC/0+mNL/oWscmnfwt9KChlZ7Ullyk3E=";
   };
+
+  patches = [
+    # fixes the version 0.8.0 -> 0.8.1 in the pyproject file
+    (fetchpatch {
+      url = "https://github.com/tomasriveral/ShazamIO/commit/23dd6f2b4195616cbfa5dd98339265e4e5959be6.patch";
+      hash = "sha256-h7fVAiUJVJk/gItUsyUyDz2q9++UzRoga7NG/IL+MIY=";
+    })
+  ];
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   poetry-core,
   wheel,
   aiofiles,
@@ -27,16 +26,6 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-beEEr9Y8w0XlC/0+mNL/oWscmnfwt9KChlZ7Ullyk3E=";
   };
-
-  patches = [
-    # remove poetry and virtualenv from build dependencies as they are not used
-    # https://github.com/dotX12/ShazamIO/pull/71
-    (fetchpatch {
-      name = "remove-unused-build-dependencies.patch";
-      url = "https://github.com/dotX12/ShazamIO/commit/5c61e1efe51c2826852da5b6aa6ad8ce3d4012a9.patch";
-      hash = "sha256-KiU5RVBPnSs5qrReFeTe9ePg1fR7y0NchIIHcQwlPaI=";
-    })
-  ];
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -62,7 +62,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/dotX12/ShazamIO/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
-    # https://github.com/shazamio/ShazamIO/issues/80
-    broken = lib.versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -6,7 +6,7 @@
   wheel,
   aiofiles,
   aiohttp,
-  dataclass-factory,
+  adaptix,
   numpy,
   pydantic,
   pydub,
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     aiofiles
     aiohttp
-    dataclass-factory
+    adaptix
     numpy
     pydantic
     pydub

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -175,6 +175,7 @@ mapAliases {
   cx_oracle = throw "'cx_oracle' has been renamed to/replaced by 'cx-oracle'"; # Converted to throw 2025-10-29
   dalle-mini = throw "'dalle-mini' has been removed due to lack of upstream maintenance"; # added 2026-02-26
   dask-yarn = throw "'dask-yarn' has been removed due to lack of upstream maintenance"; # added 2026-07-06
+  dataclass-factory = warnAlias "'dataclass-factory' has been renamed to/replaced by 'adaptix'" adaptix; # added 2026-08-12
   dataclasses-serialization = throw "'dataclasses-serialization' has been removed due to lack of upstream maintenance."; # added 2026-07-14
   datashape = throw "'datashape' has been removed as it was unmaintained upstream"; # Added 2026-03-22
   datatable = throw "'datatable' has been removed due to lack of upstream maintenance"; # added 2026-02-02

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -75,6 +75,8 @@ self: super: with self; {
 
   adal = callPackage ../development/python-modules/adal { };
 
+  adaptix = callPackage ../development/python-modules/adaptix { };
+
   adax = callPackage ../development/python-modules/adax { };
 
   adax-local = callPackage ../development/python-modules/adax-local { };
@@ -4031,8 +4033,6 @@ self: super: with self; {
   databricks-sql-connector = callPackage ../development/python-modules/databricks-sql-connector { };
 
   dataclass-csv = callPackage ../development/python-modules/dataclass-csv { };
-
-  dataclass-factory = callPackage ../development/python-modules/dataclass-factory { };
 
   dataclass-wizard = callPackage ../development/python-modules/dataclass-wizard { };
 


### PR DESCRIPTION
Context for this PR: #551764
One of the things needed to update `radio-active` is to unbreak shazamio. Shazamio had multiple dependency problems. To solve them, we can just update to an unreleased version. 
> Well, not entirely... One small ~village~ _python dependency_ of indomitable ~Gauls~ _code_ still holds out against ~the invaders~ clean dependencies [^1].

> dataclass-factory-2.16 not supported for interpreter python3.14

It turns out that dataclass-factory had been renamed from 3.0.0 upwards to adaptix. (shazamio hasn't change it's dependencies https://github.com/shazamio/ShazamIO/issues/160) To update this package to 3.0.0b12[^2], I rewrote the build-system with the new `pyproject` and `build-system` with `setuptools` and `uv-build` (this means this PR is technically part of #515974).

> ERROR Unmet dependencies (checked against /nix/store/3n4qphl9s728sz8frmpqqrv9b1m87g68-python3-3.14.7/bin/python3.14):
       >       uv_build==0.8.22
       >                wanted: ==0.8.22
       >                found: 0.11.28

So I overwrote uv_build to 0.8.22. Now, adaptix builds and shazamio builds too...
Except that it fails at checkphase :
```
error: Cannot build '/nix/store/yf0dqs09qjk8pkgfza0wpgacyvwcayrs-python3.14-shazamio-0.8.1-unstable-2026-08-12.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/d6y5w7adk66wvcd5aiwkcvn8ba21pmbm-python3.14-shazamio-0.8.1-unstable-2026-08-12
         /nix/store/hx7g7nfrxvf0mrhmal8fidkp3jibj2q2-python3.14-shazamio-0.8.1-unstable-2026-08-12-dist
       Last 25 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/5w9c63hq0g3vzmmlcrgd20wcb90nqmfr-source
       > source root is source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/tests/test_recognize.py"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > * Building wheel...
       > Successfully built shazamio-0.8.0-py3-none-any.whl
       > Finished creating a wheel...
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for shazamio-0.8.0-py3-none-any.whl
       >   - aiofiles<24.0.0,>=23.2.1 not satisfied by version 25.1.0
       >   - aiohttp-retry not installed
       >   - anyio not installed
       >   - dataclass-factory not installed
       >   - shazamio-core not installed
       For full logs, run:
         nix log /nix/store/yf0dqs09qjk8pkgfza0wpgacyvwcayrs-python3.14-shazamio-0.8.1-unstable-2026-08-12.drv
```
I can't get past this error. It seems more things are broken now.

I didn't found a way to temporarily disable pythonRuntimeDepsCheckHook to just check manually if everything works fine (doCheck=false didn't helped).

It's the first time in one of my PRs, I need to override a version and rename a package. I tried following docs, but I've might done it in the wrong way.

No AI/Automation was used in this PR (It wasn't able to help me correctly).
[^1]: If you don't know the reference, it comes from the comic [Astérix le Gaulois](https://en.wikipedia.org/wiki/Asterix)
[^2]: > Adaptix is ready for production! The beta version only means there may be some backward incompatible changes, so you need to pin a specific version.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
