### PR TITLE
rtmpdump, tinyalsa, libnice: adopt and fix packaging issues

### DIFF
--- a/pkgs/by-name/li/libnice/package.nix
+++ b/pkgs/by-name/li/libnice/package.nix
@@ -122,5 +122,6 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl21
       mpl11
     ];
+    maintainers = with lib.maintainers; [ tmarkus ];
   };
 })

--- a/pkgs/by-name/li/libnice/package.nix
+++ b/pkgs/by-name/li/libnice/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  testers,
   fetchurl,
   fetchpatch,
   meson,
@@ -106,6 +107,8 @@ stdenv.mkDerivation (finalAttrs: {
   # see https://github.com/NixOS/nixpkgs/pull/53293#issuecomment-453739295
   doCheck = false;
 
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
   meta = {
     changelog = "https://gitlab.freedesktop.org/libnice/libnice/-/blob/${finalAttrs.version}/NEWS";
     description = "GLib ICE implementation";
@@ -117,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
       It provides a GLib-based library, libnice and a Glib-free library,
       libstun as well as GStreamer elements.'';
     homepage = "https://libnice.freedesktop.org/";
+    pkgConfigModules = [ "nice" ];
     platforms = lib.platforms.unix;
     license = with lib.licenses; [
       lgpl21

--- a/pkgs/by-name/li/libnice/package.nix
+++ b/pkgs/by-name/li/libnice/package.nix
@@ -2,8 +2,9 @@
   lib,
   stdenv,
   testers,
-  fetchurl,
+  fetchFromGitLab,
   fetchpatch,
+  nix-update-script,
   meson,
   ninja,
   pkg-config,
@@ -35,9 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals enableDocumentation [ "devdoc" ];
 
-  src = fetchurl {
-    url = "https://libnice.freedesktop.org/releases/libnice-${finalAttrs.version}.tar.gz";
-    hash = "sha256-YY/E6N45O3GbFkHB2O7AGCbU050VrekmedIhx/Xk5w0=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "libnice";
+    repo = "libnice";
+    tag = finalAttrs.version;
+    hash = "sha256-UPppE5kBois0jJwsHKefBC8iTfSIkPZXV6XnUBnEFn8=";
   };
 
   patches = [
@@ -107,7 +111,10 @@ stdenv.mkDerivation (finalAttrs: {
   # see https://github.com/NixOS/nixpkgs/pull/53293#issuecomment-453739295
   doCheck = false;
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
 
   meta = {
     changelog = "https://gitlab.freedesktop.org/libnice/libnice/-/blob/${finalAttrs.version}/NEWS";

--- a/pkgs/by-name/li/libnice/package.nix
+++ b/pkgs/by-name/li/libnice/package.nix
@@ -6,16 +6,21 @@
   meson,
   ninja,
   pkg-config,
-  python3,
-  gobject-introspection,
-  gtk-doc,
-  docbook_xsl,
-  docbook_xml_dtd_412,
   glib,
   gupnp-igd,
   gst_all_1,
   gnutls,
+  enableDocumentation ? stdenv.buildPlatform == stdenv.hostPlatform,
+  gtk-doc,
+  docbook_xsl,
+  docbook_xml_dtd_412,
   graphviz,
+  python3,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  buildPackages,
+  gobject-introspection,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
   ]
-  ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+  ++ lib.optionals enableDocumentation [ "devdoc" ];
 
   src = fetchurl {
     url = "https://libnice.freedesktop.org/releases/libnice-${finalAttrs.version}.tar.gz";
@@ -51,18 +56,26 @@ stdenv.mkDerivation (finalAttrs: {
     ./musl.patch
   ];
 
+  # specifies <1.30, but also works with later versions
+  postPatch = ''
+    substituteInPlace docs/reference/libnice/meson.build \
+      --replace-fail "version: '<1.30', " ""
+  '';
+
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    python3
+  ]
+  ++ lib.optionals withIntrospection [
     gobject-introspection
-
-    # documentation
+  ]
+  ++ lib.optionals enableDocumentation [
     gtk-doc
     docbook_xsl
     docbook_xml_dtd_412
     graphviz
+    python3
   ];
 
   buildInputs = [
@@ -76,11 +89,18 @@ stdenv.mkDerivation (finalAttrs: {
     glib
   ];
 
-  mesonFlags = [
-    "-Dgtk_doc=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "enabled" else "disabled"}"
-    "-Dintrospection=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "enabled" else "disabled"}"
-    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-  ];
+  mesonFlags = lib.mapAttrsToList lib.mesonEnable {
+    gtk_doc = enableDocumentation;
+    introspection = withIntrospection;
+
+    # requires many dependencies and probably not useful for our users
+    examples = false;
+    tests = finalAttrs.finalPackage.doCheck;
+
+    gstreamer = true;
+
+    glib_debug = false;
+  };
 
   # Tests are flaky
   # see https://github.com/NixOS/nixpkgs/pull/53293#issuecomment-453739295

--- a/pkgs/by-name/rt/rtmpdump/package.nix
+++ b/pkgs/by-name/rt/rtmpdump/package.nix
@@ -90,6 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "rtmpdump";
     pkgConfigModules = [ "librtmp" ];
     platforms = lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tmarkus ];
   };
 })

--- a/pkgs/by-name/rt/rtmpdump/package.nix
+++ b/pkgs/by-name/rt/rtmpdump/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchgit,
+  testers,
+  versionCheckHook,
   zlib,
   gnutlsSupport ? false,
   gnutls,
@@ -12,7 +14,7 @@
 
 assert (gnutlsSupport || opensslSupport);
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rtmpdump";
   version = "2.6";
 
@@ -22,6 +24,18 @@ stdenv.mkDerivation {
     rev = "6f6bb1353fc84f4cc37138baa99f586750028a01";
     hash = "sha256-rwMA9eougKnkpG+fe6vZIwOBt2CC1d9qI9a079EbE5o=";
   };
+
+  postPatch = ''
+    for file in rtmp{dump.1,gw.8}{,.html} librtmp/librtmp.3{,.html}; do
+      substituteInPlace "$file" \
+        --replace-fail "RTMPDump v2.4" "RTMPDump v${finalAttrs.version}"
+    done
+
+    for file in Makefile librtmp/Makefile; do
+      substituteInPlace "$file" \
+        --replace-fail "VERSION=v2.4" "VERSION=v${finalAttrs.version}"
+    done
+  '';
 
   preBuild = ''
     makeFlagsArray+=(CC="$CC")
@@ -44,18 +58,38 @@ stdenv.mkDerivation {
   ]
   ++ lib.optional opensslSupport openssl;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--help";
+  doInstallCheck = true;
+
   outputs = [
     "out"
     "dev"
   ];
 
+  # incdir hardcoded to ${prefix}/include, but we move includes to -dev
+  # pkg-config version field is specified without "v" prefix
+  postFixup = ''
+    substituteInPlace $dev/lib/pkgconfig/librtmp.pc \
+      --replace-fail 'incdir=''${prefix}/include' "incdir=$dev/include" \
+      --replace-fail 'Version: v${finalAttrs.version}' 'Version: ${finalAttrs.version}'
+  '';
+
   separateDebugInfo = true;
+
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
 
   meta = {
     description = "Toolkit for RTMP streams";
     homepage = "https://rtmpdump.mplayerhq.hu/";
+    changelog = "https://rtmpdump.mplayerhq.hu/ChangeLog";
     license = lib.licenses.gpl2Plus;
+    mainProgram = "rtmpdump";
+    pkgConfigModules = [ "librtmp" ];
     platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ti/tinyalsa/package.nix
+++ b/pkgs/by-name/ti/tinyalsa/package.nix
@@ -1,43 +1,49 @@
 {
   lib,
   stdenv,
+  testers,
   fetchFromGitHub,
-  cmake,
+  meson,
+  ninja,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tinyalsa";
-  version = "unstable-2022-06-05";
+  version = "2.0.0-unstable-2026-07-27";
 
   src = fetchFromGitHub {
     owner = "tinyalsa";
     repo = "tinyalsa";
-    rev = "3d70d227e7dfd1be6f8f420a5aae164a2b4126e0";
-    hash = "sha256-RHeF3VShy+LYFtJK+AEU7swIr5/rnpg2fdllnH9cFCk=";
+    rev = "9fab97ca07184371ecad81154d1dadb09d0fa7cf";
+    hash = "sha256-+/wz0pwyF1kulUA5kjFGVOwbSkunEU+WzsZf/UsCEVk=";
   };
 
+  separateDebugInfo = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "dev"
+    "bin"
+  ];
+
   nativeBuildInputs = [
-    cmake
+    meson
+    ninja
   ];
 
-  cmakeFlags = [
-    "-DTINYALSA_USES_PLUGINS=ON"
-  ];
-
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=sign-compare"
-  ];
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 3.1)" "cmake_minimum_required(VERSION 3.10)"
-  '';
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = false;
+  };
 
   meta = {
     homepage = "https://github.com/tinyalsa/tinyalsa";
     description = "Tiny library to interface with ALSA in the Linux kernel";
     license = lib.licenses.mit;
+    pkgConfigModules = [ "tinyalsa" ];
     maintainers = [ ];
     platforms = with lib.platforms; linux;
   };
-}
+})

--- a/pkgs/by-name/ti/tinyalsa/package.nix
+++ b/pkgs/by-name/ti/tinyalsa/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tiny library to interface with ALSA in the Linux kernel";
     license = lib.licenses.mit;
     pkgConfigModules = [ "tinyalsa" ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tmarkus ];
     platforms = with lib.platforms; linux;
   };
 })

--- a/pkgs/by-name/ti/tinyalsa/package.nix
+++ b/pkgs/by-name/ti/tinyalsa/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   testers,
+  unstableGitUpdater,
   fetchFromGitHub,
   meson,
   ninja,
@@ -33,9 +34,14 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
-  passthru.tests.pkg-config = testers.hasPkgConfigModules {
-    package = finalAttrs.finalPackage;
-    versionCheck = false;
+  passthru = {
+    updateScript = unstableGitUpdater {
+      tagPrefix = "v";
+    };
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = false;
+    };
   };
 
   meta = {


### PR DESCRIPTION
Originally part of #549902, but split out because these changes are technically independent and the original PR got a little too big.

* Adopt rtmpdump, tinyalsa and libnice
* fix some pkg-config related packaging issues and add pkg-config meta tests where applicable
* refactor mesonFlags in libnice
* tinyalsa has a meson build system that works better and produces proper pkg-config files
* libnice documentation didn't actually build because of a gtk-doc version constraint, but it also works with our packaged version, so just patch the version constraint out
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
