### PR TITLE
prettier: adjust method of loading prettier plugins

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -59,6 +59,10 @@
 
 - `fflogs` has been removed because it was no longer functional. Users should switch to `archon-lite`.
 
+- `prettier`'s `plugins` argument would previously enable plugins explicitly by adding `--plugin <exact_file_path>`. This had the benefit of always enabling the plugin but meant if a `.prettierrc` config file requested a plugin by name e.g. `prettier-plugin-go-template` (like anyone else using prettier outside of nixpkgs would) it [failed to run](https://github.com/NixOS/nixpkgs/issues/341798). If you'd like to preserve the prior functionality please switch to use `plugins-always-on`.
+  - `prettier.override { plugins = [ pkgs.prettier-plugin-go-template ]; }` will work with a `.prettierrc` containing `plugins: [ "prettier-plugin-go-template" ]`.
+  - `prettier.override { plugins-always-on = [ pkgs.prettier-plugin-go-template ]; }` wont work with the above config but will already have loaded the plugin.
+
 - `keycloak.plugins.scim-for-keycloak` has been removed. The upstream open-source project is [end-of-life](https://github.com/Captain-P-Goldfish/scim-for-keycloak) and its last release targets Keycloak 20, which is incompatible with the packaged Keycloak.
 
 - `keycloak.plugins.scim-keycloak-user-storage-spi` has been removed. Upstream has moved the plugin into Keycloak itself as the experimental `ipatuura` federation provider and no longer maintains the standalone repository.

--- a/pkgs/by-name/pr/prettier/load-plugins-from-nixpkgs.patch
+++ b/pkgs/by-name/pr/prettier/load-plugins-from-nixpkgs.patch
@@ -1,0 +1,32 @@
+diff --git a/src/main/plugins/load-plugin.js b/src/main/plugins/load-plugin.js
+index f98d17242..592a944d6 100644
+--- a/src/main/plugins/load-plugin.js
++++ b/src/main/plugins/load-plugin.js
+@@ -1,3 +1,4 @@
++import fs from "node:fs";
+ import path from "node:path";
+ import { pathToFileURL } from "node:url";
+ import { isUrl, toPath } from "url-or-path";
+@@ -19,6 +20,22 @@ async function importPlugin(name, cwd) {
+   }
+ 
+   try {
++    // try load plugins we provide from nixpkgs
++    try {
++      const isDirectory = (path) => {
++        try {
++          return fs.statSync(path).isDirectory();
++        } catch {
++          return false;
++        }
++      };
++      const nppp = process.env.NIXPKGS_PRETTIER_PLUGINS_PATH;
++      if (nppp && isDirectory(nppp)) {
++        return importFromDirectory(name, nppp);
++      }
++    } catch {
++      // nothing
++    }
+     // try local files
+     return await import(pathToFileURL(path.resolve(name)).href);
+   } catch {

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -11,7 +11,15 @@
   stdenv,
   versionCheckHook,
   yarn-berry,
+
+  # providing prettier plugins (can be used in combination):
+  # adding plugins that can be loaded by name via `.prettierrc` config
+  # works better with other non-nix prettier users
+  # e.g. `prettier.override { plugins = [ pkgs.prettier-plugin-go-template ]; }`
   plugins ? [ ],
+  # adding plugins via the `--plugin` flag which will auto load them
+  # e.g. prettier.override { plugins-always-on = [ pkgs.prettier-plugin-go-template ]; }
+  plugins-always-on ? [ ],
 }:
 let
   ## Blame NodeJS
@@ -231,6 +239,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       l0b0
       S0AndS0
+      jk
     ];
   };
 })

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -1,6 +1,7 @@
 {
   fetchFromGitHub,
   fetchPnpmDeps,
+  symlinkJoin,
   lib,
   fetchurl,
   makeBinaryWrapper,
@@ -130,6 +131,12 @@ let
       license = "MIT";
     };
   });
+
+  # plugin dir used for NIXPKGS_PRETTIER_PLUGINS_PATH
+  prettierPlugins = symlinkJoin {
+    name = "prettier-plugins";
+    paths = plugins;
+  };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prettier";
@@ -146,6 +153,9 @@ stdenv.mkDerivation (finalAttrs: {
     # Remove after upstream updates to Yarn 4.14
     # https://github.com/prettier/prettier/blob/main/package.json#L265
     ./yarn-4.14-support.patch
+
+    # allow us to point to and load plugins from nixpkgs
+    ./load-plugins-from-nixpkgs.patch
   ];
 
   missingHashes = ./missing-hashes.json;
@@ -187,10 +197,21 @@ stdenv.mkDerivation (finalAttrs: {
     makeBinaryWrapper "${lib.getExe nodejs}" "$out/bin/prettier" \
       --add-flags "$out/lib/node_modules/prettier/bin/prettier.cjs"
   ''
-  + lib.optionalString (builtins.length plugins > 0) ''
-    wrapProgram $out/bin/prettier --add-flags "${
-      builtins.concatStringsSep " " (lib.map (plugin: "--plugin=${nodeEntryPointOf plugin}") plugins)
-    }";
+  + lib.optionalString ((builtins.length plugins > 0) || (builtins.length plugins-always-on > 0)) ''
+    wrapProgram $out/bin/prettier ${
+      lib.concatStringsSep " " (
+        lib.optional (
+          builtins.length plugins > 0
+        ) "--set NIXPKGS_PRETTIER_PLUGINS_PATH \"${prettierPlugins}/lib/node_modules\""
+        ++
+          lib.optional (builtins.length plugins-always-on > 0)
+            "--add-flags \"${
+              builtins.concatStringsSep " " (
+                lib.map (plugin: "--plugin=${nodeEntryPointOf plugin}") plugins-always-on
+              )
+            }\""
+      )
+    }
   ''
   + ''
     runHook postInstall


### PR DESCRIPTION
- **prettier: adjust method of loading prettier plugins**
  - resolves #341798
- **prettier: add `jk` as maintainer**


Alternatives would be to have a singular `plugins` still and do both the path and the --plugins flag.
Could have a boolean to opt into copying `plugins` -> `plugins-always-on` too.

There doesn't seem to be any explicit problems with loading the plugins twice in both places but there could be cases where people don't expect a config to be loaded yet or temporarily comment it out of the settings etc. so I opted for this method.

Have a release note since it's technically a breaking change, outline how to preserve current behaviour.

cc: @l0b0 @S0AndS0
I've also added myself to the maintainer list, I hope you both don't mind :slightly_smiling_face: 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - Module addition: when adding a new NixOS module.
  - Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
