### PR TITLE
wg-access-server: 0.13.0 -> 1.0.0

### DIFF
--- a/nixos/tests/wg-access-server.nix
+++ b/nixos/tests/wg-access-server.nix
@@ -1,34 +1,42 @@
 {
-  pkgs,
   lib,
-  kernelPackages ? null,
+  config,
   ...
 }:
+let
+  keys = import ./wireguard/snakeoil-keys.nix;
+in
 {
   name = "wg-access-server";
-  meta = with pkgs.lib.maintainers; {
+  meta = with lib.maintainers; {
     maintainers = [ xanderio ];
   };
 
   nodes = {
-    server = {
+    server = { pkgs, ... }: {
       services.wg-access-server = {
         enable = true;
         settings = {
           adminUsername = "admin";
+          enableMetadata = true;
         };
         secretsFile = (
           pkgs.writers.writeYAML "secrets.yaml" {
             adminPassword = "hunter2";
+            wireguard.privateKey = keys.peer0.privateKey;
           }
         );
       };
     };
   };
 
-  testScript = ''
-    start_all()
+  testScript =
+    # python
+    ''
+      start_all()
 
-    server.wait_for_unit("wg-access-server.service")
-  '';
+      server.wait_for_unit("wg-access-server.service")
+      server.wait_for_open_port(8000)
+      assert "${config.nodes.server.services.wg-access-server.package.version}" in server.succeed("curl -L http://localhost:8000/metrics | grep wg_access_server_build_info")
+    '';
 }

--- a/pkgs/by-name/wg/wg-access-server/package.nix
+++ b/pkgs/by-name/wg/wg-access-server/package.nix
@@ -6,22 +6,22 @@
   makeWrapper,
   iptables,
   nixosTests,
-  nodejs_22,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "wg-access-server";
-  version = "0.13.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "freifunkMUC";
     repo = "wg-access-server";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-x4QNEn5SR6D1YIiv+mKnQlZ94jZ7BrdIxiLxBqhtBjg=";
+    hash = "sha256-NnIvVgshrvZiSsXXCjluTAVy9T0MthP9uJHJaK0QHWU=";
   };
 
   proxyVendor = true; # darwin/linux hash mismatch
-  vendorHash = "sha256-pjQeF1+1gr/0pF76KNdK7GDX3pYBTqqY3xbJeMLsJIM=";
+  vendorHash = "sha256-mcyQtBS9185GQJIKbO/92v8bxrF4xVyqKbeWYem8QF4=";
 
   env.CGO_ENABLED = 1;
 
@@ -38,9 +38,7 @@ buildGoModule (finalAttrs: {
     inherit (finalAttrs) version src;
     pname = "wg-access-server-ui";
 
-    nodejs = nodejs_22;
-
-    npmDepsHash = "sha256-UntV5+9E2lyp8IQGKbbnBNdd0JLvM5NsfkLvCSOgyGo=";
+    npmDepsHash = "sha256-2jFr3W1XwiN2q2YUzWAMB6yDIz8Gp9qwQYG2QlFf6vY=";
 
     sourceRoot = "${finalAttrs.src.name}/website";
 
@@ -66,6 +64,12 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     tests = { inherit (nixosTests) wg-access-server; };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "-s"
+        "ui"
+      ];
+    };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
