### PR TITLE
nim-atlas: unstable-2023-09-22 -> 0.14.12

### DIFF
--- a/pkgs/by-name/ni/nim-atlas/package.nix
+++ b/pkgs/by-name/ni/nim-atlas/package.nix
@@ -5,20 +5,33 @@
   openssl,
 }:
 
+let
+  # Atlas needs the dep in a certain place, easier to download and and place in deps/ folder
+  sat = fetchFromGitHub {
+    owner = "nim-lang";
+    repo = "sat";
+    # The atlas nimble file (https://github.com/nim-lang/atlas/blob/master/atlas.nimble) doesn't
+    # provide a version and upstream sat package has no version tags. This is the latest commit
+    # as of 2026-08-14
+    rev = "9d52513b3c68bfb929dbd687d4fb2836cfee6936";
+    hash = "sha256-y9kFjYFrmVejIE8fSh4AehaNnCO/UISssrnGwwcnJLk=";
+  };
+in
 buildNimPackage (
-  final: prev: {
+  final: prev: rec {
     pname = "atlas";
-    version = "unstable-2023-09-22";
+    version = "0.14.12";
     src = fetchFromGitHub {
       owner = "nim-lang";
       repo = "atlas";
-      rev = "ab22f997c22a644924c1a9b920f8ce207da9b77f";
-      hash = "sha256-TsZ8TriVuKEY9/mV6KR89eFOgYrgTqXmyv/vKu362GU=";
+      rev = "${version}";
+      hash = "sha256-7LPjxqsWlZ0tjsXfMF0q93O9VLDgT+7J20QrJ+1ihDg=";
     };
     buildInputs = [ openssl ];
-    prePatch = ''
-      rm config.nims
-    ''; # never trust a .nims file
+    preConfigure = ''
+      mkdir deps
+      cp -r ${sat} deps/sat
+    '';
     doCheck = false; # tests will clone repos
     meta = final.src.meta // {
       description = "Nim package cloner";


### PR DESCRIPTION
Bumps to latest sources and adds in the single dependency it needs. The JSON lock file was working and atlas was expecting the dep in a certain folder so was easier to just clone

Don't need to delete the config.nims anymore + it contains needed defines like SSL and atomicArc


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
