### PR TITLE
librelane: 3.0.4 -> 3.0.8

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -25,6 +25,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
   version = "3.0.8";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "librelane";

--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -23,14 +23,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.4";
+  version = "3.0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
     tag = finalAttrs.version;
-    hash = "sha256-y1h2KEbK2rSn54uDuCfH9ouo2FLTFbVxpgOqnR+kwhM=";
+    hash = "sha256-l7zNrx7gSKecBQ/haayJxDfG87477aZzdV64hYsMXO4=";
   };
 
   build-system = [


### PR DESCRIPTION
## Summary

Update librelane from 3.0.4 to 3.0.8.

Changelog: https://github.com/librelane/librelane/releases/tag/3.0.8

## Pre-existing, unrelated blocker

Same as #551828: `librelane` wraps `openroad` into its runtime PATH (`postFixup`), so
building it pulls in `openroad`'s `or-tools` buildInput, which is currently
`meta.broken = true` on the default toolchain (`python3.pythonAtLeast "3.14"`). This is
unrelated to librelane itself and pre-existing on `master` regardless of this bump; see
#551828 for the full diagnosis (real pybind11 2.13.6/Python 3.14 test failure, plus a
second, independent `pkg_resources`/`setuptools` deprecation issue even under Python 3.13).

Verified `librelane` itself (Python packaging, `postInstall`, `wrapProgram`) builds and
wraps cleanly by scoping past the unrelated `or-tools` blocker for local verification
(`or-tools` on python3.13 with its own unrelated `doCheck` skipped) — build succeeded,
`pythonImportsCheckPhase` passed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

**AI disclosure**: this PR description and the git/gh mechanics (branch, commit, push, PR
creation) were drafted/executed with the assistance of Claude Code (Claude Sonnet 5); see
the `Assisted-by:` trailer on the commit. The version bump was produced via `nix-update`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test