### PR TITLE
chatgpt: add Linux support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1658,6 +1658,12 @@
     githubId = 382798;
     name = "amfl";
   };
+  amielke = {
+    email = "gentoo-os@amielke.de";
+    github = "amielke";
+    githubId = 289922;
+    name = "Andreas Mielke";
+  };
   aminechikhaoui = {
     email = "amine.chikhaoui91@gmail.com";
     github = "AmineChikhaoui";

--- a/pkgs/by-name/ch/chatgpt/chatgpt-launcher.sh
+++ b/pkgs/by-name/ch/chatgpt/chatgpt-launcher.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Arch Linux Contributors
+# SPDX-License-Identifier: 0BSD
+
+set -euo pipefail
+
+app_root="@APP_ROOT@"
+app_version="@APP_VERSION@"
+
+user_flags=()
+ozone_flags=()
+
+config_home="${XDG_CONFIG_HOME:-}"
+if [[ -z "${config_home}" && -n "${HOME:-}" ]]; then
+  config_home="${HOME}/.config"
+fi
+
+if [[ -n "${config_home}" && -f "${config_home}/codex-flags.conf" ]]; then
+  while IFS= read -r flag_line || [[ -n "${flag_line}" ]]; do
+    flag_line="${flag_line%%#*}"
+    read -r -a flag_parts <<<"${flag_line}"
+    user_flags+=("${flag_parts[@]}")
+  done <"${config_home}/codex-flags.conf"
+fi
+
+# The bundled plugins live in the immutable Nix store. ChatGPT copies their
+# file modes into ~/.codex, which makes its staging directories read-only.
+# Use OpenAI's resource-path override with a small writable per-version cache.
+cache_home="${XDG_CACHE_HOME:-${HOME}/.cache}"
+cache_base="${cache_home}/openai-codex-desktop/${app_version}"
+cache_resources="${cache_base}/resources"
+
+source_plugins="${app_root}/resources/plugins/openai-bundled"
+target_plugins="${cache_resources}/plugins/openai-bundled"
+
+refresh_cache=false
+
+if [[ ! -f "${target_plugins}/.bundle-id" ]]; then
+  refresh_cache=true
+elif ! cmp -s \
+  "${source_plugins}/.bundle-id" \
+  "${target_plugins}/.bundle-id"; then
+  refresh_cache=true
+fi
+
+if [[ "${refresh_cache}" == true ]]; then
+  tmp_cache="${cache_base}.tmp.$$"
+
+  rm -rf "${tmp_cache}"
+  mkdir -p "${tmp_cache}/resources/plugins"
+
+  cp -a \
+    "${source_plugins}" \
+    "${tmp_cache}/resources/plugins/"
+
+  chmod -R u+w "${tmp_cache}"
+
+  if [[ -d "${cache_base}" ]]; then
+    chmod -R u+w "${cache_base}" 2>/dev/null || true
+    rm -rf "${cache_base}"
+  fi
+
+  mv "${tmp_cache}" "${cache_base}"
+fi
+
+export CODEX_ELECTRON_BUNDLED_PLUGINS_RESOURCES_PATH="${cache_resources}"
+
+# Use native Wayland rendering in Wayland sessions. Chromium's automatic Ozone
+# selection can otherwise fall back to XWayland.
+if [[ "${XDG_SESSION_TYPE:-}" == wayland || -n "${WAYLAND_DISPLAY:-}" ]]; then
+  ozone_flags=(--ozone-platform=wayland)
+fi
+
+# Explicit user settings override the automatic Wayland selection.
+for flag in "${user_flags[@]}" "$@"; do
+  case "${flag}" in
+    --ozone-platform=*|--ozone-platform-hint=*)
+      ozone_flags=()
+      ;;
+  esac
+done
+
+exec "${app_root}/ChatGPT" \
+  "${ozone_flags[@]}" \
+  "${user_flags[@]}" \
+  "$@"

--- a/pkgs/by-name/ch/chatgpt/package.nix
+++ b/pkgs/by-name/ch/chatgpt/package.nix
@@ -1,47 +1,203 @@
 {
   lib,
+  stdenv,
   stdenvNoCC,
   fetchurl,
   _7zz,
   undmg,
+  autoPatchelfHook,
+  dpkg,
+  makeWrapper,
+  alsa-lib,
+  at-spi2-core,
+  cairo,
+  dbus,
+  expat,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  cups,
+  libdrm,
+  libglvnd,
+  libnotify,
+  libusb1,
+  libxcb,
+  libxkbcommon,
+  mesa,
+  nspr,
+  nss,
+  openssl,
+  pango,
+  systemd,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  xdg-utils,
+  xz,
 }:
 
 let
-  source = import ./source.nix;
-in
-stdenvNoCC.mkDerivation {
-  pname = "chatgpt";
-  inherit (source) version;
+  darwinSource = import ./source.nix;
+  linuxSource = import ./source-linux.nix;
 
-  src = fetchurl source.src;
-
-  nativeBuildInputs = [
-    undmg
-  ];
-
-  sourceRoot = ".";
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p "$out/Applications"
-    mkdir -p "$out/bin"
-    cp -a ChatGPT.app "$out/Applications"
-    ln -s "$out/Applications/ChatGPT.app/Contents/MacOS/ChatGPT" "$out/bin/ChatGPT"
-
-    runHook postInstall
-  '';
-
-  passthru.updateScript = ./update.sh;
-
-  meta = {
+  commonMeta = {
     description = "Desktop application for ChatGPT";
-    homepage = "https://openai.com/chatgpt/desktop/";
-    changelog = "https://help.openai.com/en/articles/9703738-macos-app-release-notes";
+    homepage = "https://" + "openai.com/chatgpt/desktop/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ wattmto ];
-    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ amielke wattmto ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    mainProgram = "ChatGPT";
   };
-}
+in
+if stdenv.hostPlatform.isDarwin then
+  stdenvNoCC.mkDerivation {
+    pname = "chatgpt";
+    inherit (darwinSource) version;
+
+    src = fetchurl darwinSource.src;
+
+    nativeBuildInputs = [
+      undmg
+    ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/Applications"
+      mkdir -p "$out/bin"
+      cp -a ChatGPT.app "$out/Applications"
+      ln -s "$out/Applications/ChatGPT.app/Contents/MacOS/ChatGPT" "$out/bin/ChatGPT"
+
+      runHook postInstall
+    '';
+
+    passthru.updateScript = ./update.sh;
+
+
+    meta = commonMeta // {
+      changelog = "https://" + "help.openai.com/en/articles/9703738-macos-app-release-notes";
+      platforms = lib.platforms.darwin;
+      mainProgram = "ChatGPT";
+    };
+  }
+else
+  let
+    source =
+      linuxSource.sources.${stdenv.hostPlatform.system}
+        or (throw "chatgpt: unsupported Linux platform ${stdenv.hostPlatform.system}");
+  in
+  stdenv.mkDerivation {
+    pname = "chatgpt";
+    inherit (linuxSource) version;
+
+    src = fetchurl source;
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+    ];
+
+    autoPatchelfIgnoreMissingDeps = [
+      "libc.musl-x86_64.so.1"
+      "libQt5Core.so.5"
+      "libQt5Gui.so.5"
+      "libQt5Widgets.so.5"
+      "libQt6Core.so.6"
+      "libQt6Gui.so.6"
+      "libQt6Widgets.so.6"
+    ];
+
+    buildInputs = [
+      alsa-lib
+      at-spi2-core
+      cairo
+      dbus
+      expat
+      gdk-pixbuf
+      glib
+      gtk3
+      cups
+      libdrm
+      libglvnd
+      libnotify
+      libusb1
+      libxcb
+      libxkbcommon
+      mesa
+      nspr
+      nss
+      openssl
+      pango
+      systemd
+      libx11
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxrandr
+      xz
+      stdenv.cc.cc.lib
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      dpkg-deb -x "$src" source
+
+      runHook postUnpack
+    '';
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/bin" "$out/lib" "$out/share"
+
+      cp -r source/usr/lib/chatgpt "$out/lib/"
+
+      if [ -d source/usr/share ]; then
+        cp -r source/usr/share/. "$out/share/"
+      fi
+
+      install -Dm644 \
+        source/usr/share/pixmaps/chatgpt.png \
+        "$out/share/icons/hicolor/1024x1024/apps/chatgpt.png"
+
+      install -Dm755 ${./chatgpt-launcher.sh} "$out/bin/chatgpt"
+
+      substituteInPlace "$out/bin/chatgpt" \
+        --replace-fail "@APP_ROOT@" "$out/lib/chatgpt" \
+        --replace-fail "@APP_VERSION@" "${linuxSource.version}"
+
+      wrapProgram "$out/bin/chatgpt" \
+        --prefix PATH : ${lib.makeBinPath [ xdg-utils ]}
+
+      ln -s chatgpt "$out/bin/codex-desktop"
+
+      if [ -d "$out/share/applications" ]; then
+        for desktop in "$out"/share/applications/*.desktop; do
+          [ -e "$desktop" ] || continue
+          substituteInPlace "$desktop" \
+            --replace-warn "/usr/bin/chatgpt" "$out/bin/chatgpt"
+        done
+      fi
+
+      runHook postInstall
+    '';
+
+    passthru.updateScript = ./update-linux.sh;
+
+    meta = commonMeta // {
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      mainProgram = "chatgpt";
+    };
+  }

--- a/pkgs/by-name/ch/chatgpt/source-linux.nix
+++ b/pkgs/by-name/ch/chatgpt/source-linux.nix
@@ -1,0 +1,19 @@
+{
+  version = "26.803.81509";
+
+  sources = {
+    x86_64-linux = {
+      url =
+        "https://"
+        + "persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_amd64.deb";
+      hash = "sha256-qb+Ro2j598Tuo4CCqfuPtGuNAFtxmm13FdLloZgsOOs=";
+    };
+
+    aarch64-linux = {
+      url =
+        "https://"
+        + "persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_arm64.deb";
+      hash = "sha256-84/MGU7KmrAyfcEMkjQGgernfF11Fk33ADhM4q2sy8E=";
+    };
+  };
+}

--- a/pkgs/by-name/ch/chatgpt/update-linux.sh
+++ b/pkgs/by-name/ch/chatgpt/update-linux.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl dpkg nix
+
+set -euo pipefail
+
+BASE_URL="https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+AMD64_URL="$BASE_URL/chatgpt_amd64.deb"
+ARM64_URL="$BASE_URL/chatgpt_arm64.deb"
+
+curl -L "$AMD64_URL" -o "$TMPDIR/chatgpt_amd64.deb"
+curl -L "$ARM64_URL" -o "$TMPDIR/chatgpt_arm64.deb"
+
+VERSION="$(dpkg-deb -f "$TMPDIR/chatgpt_amd64.deb" Version)"
+ARM_VERSION="$(dpkg-deb -f "$TMPDIR/chatgpt_arm64.deb" Version)"
+
+if [[ "$VERSION" != "$ARM_VERSION" ]]; then
+  echo "Version mismatch: amd64=$VERSION arm64=$ARM_VERSION" >&2
+  exit 1
+fi
+
+AMD64_HASH="$(nix hash file --type sha256 --sri "$TMPDIR/chatgpt_amd64.deb")"
+ARM64_HASH="$(nix hash file --type sha256 --sri "$TMPDIR/chatgpt_arm64.deb")"
+
+SOURCE_NIX="$(dirname "${BASH_SOURCE[0]}")/source-linux.nix"
+
+cat > "$SOURCE_NIX" <<EOF2
+{
+  version = "$VERSION";
+
+  sources = {
+    x86_64-linux = {
+      url =
+        "https://"
+        + "persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_amd64.deb";
+      hash = "$AMD64_HASH";
+    };
+
+    aarch64-linux = {
+      url =
+        "https://"
+        + "persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_arm64.deb";
+      hash = "$ARM64_HASH";
+    };
+  };
+}
+EOF2


### PR DESCRIPTION
Adds Linux support to the existing `chatgpt` package using OpenAI's official
Linux `.deb` distributions.

The existing macOS package remains supported and keeps its current update
mechanism.

Linux packaging includes:

- x86_64-linux and aarch64-linux sources
- Electron runtime dependencies and auto-patchelf integration
- native Wayland selection in Wayland sessions while retaining X11 support
- support for user-defined Ozone flags
- writable per-version cache for bundled ChatGPT/Codex plugins, since resources
  copied directly from the immutable Nix store otherwise retain read-only modes
- desktop entry and official application icon integration
- `xdg-utils` in the runtime PATH
- separate Linux update script for the official amd64 and arm64 builds

I also add myself as a maintainer while retaining @wattmto as the existing
maintainer.

### Testing

On x86_64-linux:

- `nix build .#chatgpt`
- `nix-build -A chatgpt --arg config '{ allowUnfree = true; }'`
- application starts successfully
- `chatgpt --version` executes successfully
- desktop entry and application icon work
- bundled plugin cache is writable and functional
- application exits cleanly via File -> Quit
- native Wayland launch tested

For aarch64-linux:

- official OpenAI arm64 `.deb` inspected
- package architecture verified as AArch64
- package derivation evaluates successfully
- not built or executed on AArch64 hardware

The Linux updater was run successfully against the current official amd64 and
arm64 downloads and reproduced the current version and hashes.

LLM assistance is disclosed in the commit trailers.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
