### PR TITLE
cyan-skillfish-governor-smu: init at 0.4.12

### DIFF
--- a/pkgs/by-name/cy/cyan-skillfish-governor-smu/package.nix
+++ b/pkgs/by-name/cy/cyan-skillfish-governor-smu/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libdrm,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cyan-skillfish-governor-smu";
+  version = "0.4.12";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "filippor";
+    repo = "cyan-skillfish-governor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yer2MlLnj9lx2cEBeYqAktbx0BqQEK/eFPiga5gXCr8=";
+  };
+
+  cargoHash = "sha256-zlAVGLGnub2Gc0Bkzb5GU9NBAJ2YWLhIG8JOa+1wHx8=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libdrm ];
+
+  env.CYAN_SKILLFISH_GOVERNOR_VERSION = finalAttrs.version;
+
+  postInstall = ''
+    install -Dm755 scripts/cyan-skillfish-performance-mode \
+      $out/bin/cyan-skillfish-performance-mode
+
+    install -Dm644 com.cyanskillfish.Governor.conf \
+      $out/share/dbus-1/system.d/com.cyanskillfish.Governor.conf
+
+    install -Dm644 default-config.toml \
+      $out/share/cyan-skillfish-governor-smu/default-config.toml
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "SMU-based GPU governor for the AMD Cyan Skillfish APU (ASRock BC-250)";
+    homepage = "https://github.com/filippor/cyan-skillfish-governor";
+    changelog = "https://github.com/filippor/cyan-skillfish-governor/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ liberodark ];
+    mainProgram = "cyan-skillfish-governor-smu";
+  };
+})


### PR DESCRIPTION
https://github.com/filippor/cyan-skillfish-governor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
