### PR TITLE
python3Packages.ansi2image: patch version

### DIFF
--- a/pkgs/development/python-modules/ansi2image/default.nix
+++ b/pkgs/development/python-modules/ansi2image/default.nix
@@ -20,6 +20,12 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-3nTCWyWfFs1NqUGIvYO3ao9MnOMtrq1fmTihLwSky60=";
   };
 
+  postPatch = ''
+    substituteInPlace ansi2image/__meta__.py \
+      --replace-fail "__version__ = '0.1.4'" "__version__ = '${finalAttrs.version}'" \
+      --replace-fail "__version_tuple__ = version_tuple = (0, 1, 4)" "__version_tuple__ = version_tuple = (${lib.concatStringsSep ", " (lib.splitString "." finalAttrs.version)})"
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [
@@ -35,10 +41,10 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Module to convert ANSI text to an image";
-    mainProgram = "ansi2image";
     homepage = "https://github.com/helviojunior/ansi2image";
     changelog = "https://github.com/helviojunior/ansi2image/blob/${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "ansi2image";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
