### PR TITLE
treewide: use pname and version in fetchCargoVendor cargoDeps

### DIFF
--- a/pkgs/by-name/am/amberol/package.nix
+++ b/pkgs/by-name/am/amberol/package.nix
@@ -35,8 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "amberol-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     hash = "sha256-OFZd9nKRqXJMHSIIP8tlSNtFAQzk/f/6SBeEvbdPVK0=";
   };
 

--- a/pkgs/by-name/at/atuin-desktop/package.nix
+++ b/pkgs/by-name/at/atuin-desktop/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoRoot = "./.";
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-68yQkgIVpqUo5tOcvxKh6NOkW565V94zHIZeI4q7nNA=";
   };
 

--- a/pkgs/by-name/ch/chance/package.nix
+++ b/pkgs/by-name/ch/chance/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-ObT3l/Exk6UzUGmzCed7mJ7hVzg8CsQIT3fe1RIUfIM=";
   };
 

--- a/pkgs/by-name/cl/clapgrep/package.nix
+++ b/pkgs/by-name/cl/clapgrep/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-iNGYFyAF3Qo6x2VaBsyrLTSYPn6OZ6TWfXDTXqbovhE=";
   };
 

--- a/pkgs/by-name/cu/cutecosmic/package.nix
+++ b/pkgs/by-name/cu/cutecosmic/package.nix
@@ -25,8 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "${finalAttrs.pname}-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     sourceRoot = "${finalAttrs.src.name}/bindings";
     hash = "sha256-+1z0VoxDeOYSmb7BoFSdrwrfo1mmwkxeuEGP+CGFc8Y=";
   };

--- a/pkgs/by-name/de/delineate/package.nix
+++ b/pkgs/by-name/de/delineate/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-G7K3aeSBnKcJHOlQQIHd3Kzoe/ienFVycTWOKOSRhZc=";
   };
 

--- a/pkgs/by-name/dr/drawpile/package.nix
+++ b/pkgs/by-name/dr/drawpile/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-u9fRbxKeQSou9Umw4EaqzzzDiN4zhyfx9sWnlZpfpxU=";
   };
 

--- a/pkgs/by-name/fi/field-monitor/package.nix
+++ b/pkgs/by-name/fi/field-monitor/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-fsrczFhoIilxgZRH2PVXC67YdkMsIjA6zTfix57TTzo=";
   };
 

--- a/pkgs/by-name/fr/fractal/package.nix
+++ b/pkgs/by-name/fr/fractal/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-y3osmwhrB9x2s9V8L9qI1qs2fv2ygynq+mS+cA/KIyA=";
   };
 

--- a/pkgs/by-name/ge/geopard/package.nix
+++ b/pkgs/by-name/ge/geopard/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-g7pHEBrR/tdKP+kuYJ44Py7kaAx0tXcMkC4UdsfSfDQ=";
   };
 

--- a/pkgs/by-name/gi/git-cinnabar/package.nix
+++ b/pkgs/by-name/gi/git-cinnabar/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-IVizzc2dKZ83dz3KBMDDiaFNdnS40cS++k8AywyvakQ=";
   };
 

--- a/pkgs/by-name/gn/gnome-robots/package.nix
+++ b/pkgs/by-name/gn/gnome-robots/package.nix
@@ -32,8 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "gnome-robots-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     hash = "sha256-T3o4zlRLQzrLexSDI9A98bubehYFwJY1zBVUUNmrc9o=";
   };
 

--- a/pkgs/by-name/in/insulator2/package.nix
+++ b/pkgs/by-name/in/insulator2/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     sourceRoot = finalAttrs.src.name + "/backend";
     hash = "sha256-u5WFV7luvqSQQtEJFlN//GH6iNcQpH/o01ME1dPtOB4=";
   };

--- a/pkgs/by-name/ka/kana/package.nix
+++ b/pkgs/by-name/ka/kana/package.nix
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "kana-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     hash = "sha256-3ODkAstBZQE3eqGmRUdm3xyCoBXV41hK4ndxeDK8+Yc=";
   };
 

--- a/pkgs/by-name/ke/key-rack/package.nix
+++ b/pkgs/by-name/ke/key-rack/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-iV9ILi3/Uqi8lDHh1Uf2caz6Kc129CDThnqTN9VfUHc=";
   };
 

--- a/pkgs/by-name/ki/kime/package.nix
+++ b/pkgs/by-name/ki/kime/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-U3SOHZvgyPwv98wY41dnwSCUg+DTkb/LY6woffrAli8=";
   };
 

--- a/pkgs/by-name/kr/krunkit/package.nix
+++ b/pkgs/by-name/kr/krunkit/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-ptMqyCiIJsQfjFyislyc3pR0BGpwnu8Ba3OcQYLJPtM=";
   };
 

--- a/pkgs/by-name/kr/krunvm/package.nix
+++ b/pkgs/by-name/kr/krunvm/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-MRcQ0Vnd3PJqE2q981JpXPjwMUKT4t+RcOvzWptK7PQ=";
   };
 

--- a/pkgs/by-name/la/ladybird/package.nix
+++ b/pkgs/by-name/la/ladybird/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-n0ACVH8NXwe7SIaGFoJ20WIGGR3XjcuLTwPSKGJpT5s=";
   };
 

--- a/pkgs/by-name/li/libchewing/package.nix
+++ b/pkgs/by-name/li/libchewing/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-WPB1IIwKTF9lnkdcgNXcOP6kWIwQcUguUf8Nh5vDA5E=";
   };
 

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -33,8 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "loupe-deps-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     hash = "sha256-I4z5qjX10AUuwk+JdX/1ZU0uCAVPQj8HkEc+n9aMczE=";
   };
 

--- a/pkgs/by-name/me/metronome/package.nix
+++ b/pkgs/by-name/me/metronome/package.nix
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "metronome-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     hash = "sha256-T/x5LpODpKWGA40W1je6jw1DS9attVUK4ZjAnRAyf6k=";
   };
 

--- a/pkgs/by-name/pd/pdns-recursor/package.nix
+++ b/pkgs/by-name/pd/pdns-recursor/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     sourceRoot = "pdns-recursor-${finalAttrs.version}/rec-rust-lib/rust";
     hash = "sha256-0/HLB9wMVQALga7ZJcPSDczjcBinMwQz2vTPep+x8p8=";
   };

--- a/pkgs/by-name/sh/share-preview/package.nix
+++ b/pkgs/by-name/sh/share-preview/package.nix
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "share-preview-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     hash = "sha256-MC5MsoFdeCvF9nIFoYCKoBBpgGysBH36OdmTqbIJt8s=";
   };
 

--- a/pkgs/by-name/st/stratisd/package.nix
+++ b/pkgs/by-name/st/stratisd/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-zA+GEKmg5iV1PaGh0yjNb4h52PH7PwpN53xLV8P9Gac=";
   };
 

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -34,8 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
   cargoDeps = rustPlatform.fetchCargoVendor {
-    name = "${finalAttrs.pname}-${finalAttrs.version}-cargo-deps";
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-03HG8AGe6PJ516zL23iNjGUYmGOZa8NuFljb1ll2pjs=";
   };
 

--- a/pkgs/by-name/ts/tsukimi/package.nix
+++ b/pkgs/by-name/ts/tsukimi/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-lfDPrmCl+Fuf/AG8xiFv00HD76Wy63cBc9Iji7Cw2sw=";
   };
 

--- a/pkgs/by-name/wi/wildcard/package.nix
+++ b/pkgs/by-name/wi/wildcard/package.nix
@@ -29,9 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-hoJsXoPmp0A6oIV1Rm7eXI2U2OIGrStmKzDdPQtI41A=";
-    name = "wildcard-${finalAttrs.version}";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/copykitten/default.nix
+++ b/pkgs/development/python-modules/copykitten/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-Ujed/3vckHMkYaQ1Euj+KaPG4yeERS7HBbl5SzvbOWE=";
   };
 

--- a/pkgs/development/python-modules/django-vcache/default.nix
+++ b/pkgs/development/python-modules/django-vcache/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-tpf0r32wNJ/XCmNutoirTobqKgsEX96s4MsI6+p7KlQ=";
   };
 

--- a/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
+++ b/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-XqXkheK8OEzlLEbq09KMRFxrjJBnFaxvj4rIL2gmydA=";
   };
 

--- a/pkgs/development/python-modules/pycambia/default.nix
+++ b/pkgs/development/python-modules/pycambia/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-w7n/W7PDC3+DPCb//X462mowhEPw0k3HA1raAeu4t/c=";
   };
 

--- a/pkgs/development/python-modules/python-kadmin-rs/default.nix
+++ b/pkgs/development/python-modules/python-kadmin-rs/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-NXPc8hssmMXcmuK15oF5CIV+cUAmRoml6BXYhIkRdvI=";
   };
 

--- a/pkgs/development/python-modules/tlparse/default.nix
+++ b/pkgs/development/python-modules/tlparse/default.nix
@@ -22,8 +22,7 @@ buildPythonPackage (finalAttrs: {
 
   cargoHash = "sha256-q5JaOacChdg57dBL5vQjYd1ht2fBBYnw6+RFIWXYfkY=";
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    name = "${finalAttrs.pname}-${finalAttrs.version}";
+    inherit (finalAttrs) pname version src;
     hash = finalAttrs.cargoHash;
   };
 


### PR DESCRIPTION
I grepped for `fetchCargoVendor` and `inherit (finalAttrs) src;`, and wrote this patch by hand.
I tested this with `nix-build --check` on the following attributes, derived from `.meta.position`s that match any of the touched files:

* `amberol.cargoDeps.vendorStaging`
* `atuin-desktop.cargoDeps.vendorStaging`
* `bcachefs-tools.cargoDeps.vendorStaging`
* `chance.cargoDeps.vendorStaging`
* `clapgrep.cargoDeps.vendorStaging`
* `cutecosmic.cargoDeps.vendorStaging`
* `delineate.cargoDeps.vendorStaging`
* `drawpile.cargoDeps.vendorStaging`
* `drawpile-server-headless.cargoDeps.vendorStaging`
* `field-monitor.cargoDeps.vendorStaging`
* `fractal.cargoDeps.vendorStaging`
* `geopard.cargoDeps.vendorStaging`
* `git-cinnabar.cargoDeps.vendorStaging`
* `gnome-robots.cargoDeps.vendorStaging`
* `gnome-user-share.cargoDeps.vendorStaging`
* `gst_all_1.gst-plugins-rs.cargoDeps.vendorStaging`
* `insulator2.cargoDeps.vendorStaging`
* `kana.cargoDeps.vendorStaging`
* `key-rack.cargoDeps.vendorStaging`
* `kime.cargoDeps.vendorStaging`
* `krunkit.cargoDeps.vendorStaging`
* `krunvm.cargoDeps.vendorStaging`
* `ladybird.cargoDeps.vendorStaging`
* `libchewing.cargoDeps.vendorStaging`
* `libkrun.cargoDeps.vendorStaging`
* `libkrun-sev.cargoDeps.vendorStaging`
* `libkrun-tdx.cargoDeps.vendorStaging`
* `librsvg.cargoDeps.vendorStaging`
* `lldap.cargoDeps.vendorStaging`
* `loupe.cargoDeps.vendorStaging`
* `metronome.cargoDeps.vendorStaging`
* `pdns-recursor.cargoDeps.vendorStaging`
* `python314Packages.copykitten.cargoDeps.vendorStaging`
* `python314Packages.django-vcache.cargoDeps.vendorStaging`
* `python314Packages.pdoc-pyo3-sample-library.cargoDeps.vendorStaging`
* `python314Packages.pycambia.cargoDeps.vendorStaging`
* `python314Packages.python-kadmin-rs.cargoDeps.vendorStaging`
* `python314Packages.tlparse.cargoDeps.vendorStaging`
* `python313Packages.copykitten.cargoDeps.vendorStaging`
* `python313Packages.django-vcache.cargoDeps.vendorStaging`
* `python313Packages.pdoc-pyo3-sample-library.cargoDeps.vendorStaging`
* `python313Packages.pycambia.cargoDeps.vendorStaging`
* `python313Packages.python-kadmin-rs.cargoDeps.vendorStaging`
* `python313Packages.tlparse.cargoDeps.vendorStaging`
* `rutabaga_gfx.cargoDeps.vendorStaging`
* `share-preview.cargoDeps.vendorStaging`
* `stratisd.cargoDeps.vendorStaging`
* `taskwarrior3.cargoDeps.vendorStaging`
* `tsukimi.cargoDeps.vendorStaging`
* `wildcard.cargoDeps.vendorStaging`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
