### PR TITLE
qrc: init at 0.9.0

### DIFF
--- a/pkgs/by-name/qr/qrc/package.nix
+++ b/pkgs/by-name/qr/qrc/package.nix
@@ -1,0 +1,29 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "qrc";
+  version = "0.9.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fumiyas";
+    repo = "qrc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-d0WGfdPC61PFLkxYFs+rdQnUUnR/gkYFyblOvdIUkl8=";
+  };
+
+  vendorHash = "sha256-u30FC0Agx/vnXWqXgF2LcaDjnbZn2tj2yNyB6KfgjV0=";
+
+  meta = {
+    homepage = "https://github.com/fumiyas/qrc";
+    description = "QR code generator for text terminals";
+    maintainers = with lib.maintainers; [ yarn ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.mit;
+    mainProgram = "qrc";
+  };
+})


### PR DESCRIPTION
https://github.com/fumiyas/qrc

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
