### PR TITLE
python3Packages.fireworks-ai: 1.2.0 -> 1.2.8

### DIFF
--- a/pkgs/development/python-modules/fireworks-ai/default.nix
+++ b/pkgs/development/python-modules/fireworks-ai/default.nix
@@ -37,7 +37,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "fireworks-ai";
-  version = "1.2.0";
+  version = "1.2.8";
   pyproject = true;
   __structuredAttrs = true;
   strictDeps = true;
@@ -46,7 +46,7 @@ buildPythonPackage (finalAttrs: {
     owner = "fw-ai-external";
     repo = "python-sdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hcJ32r4MnZFBPYf3aT2PhrtXDIYY3EBaE8Y5wH2Sxuw=";
+    hash = "sha256-V3xU/6pmiNVUvMaTWPduoyum9R1IN+Vq36JkIDkAoY4=";
   };
 
   postPatch = ''
@@ -96,6 +96,16 @@ buildPythonPackage (finalAttrs: {
     time-machine
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pytestFlags = [
+    # ResourceWarning: Unclosed client session <aiohttp.client.ClientSession object at 0x7ffff1d48ec0>
+    "-Wignore::ResourceWarning"
+  ];
+
+  disabledTests = [
+    # httpx.TimeoutException: Test timeout error
+    "test_retrying_timeout_errors_doesnt_leak"
+  ];
 
   pythonImportsCheck = [
     "fireworks"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/fw-ai-external/python-sdk/compare/v1.2.0...v1.2.8
Changelog: https://github.com/fw-ai-external/python-sdk/blob/v1.2.8/CHANGELOG.md

cc @sarahec

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test