### PR TITLE
or-tools: fix Python 3.14 support, drop broken marker

### DIFF
--- a/pkgs/by-name/or/or-tools/package.nix
+++ b/pkgs/by-name/or/or-tools/package.nix
@@ -246,7 +246,10 @@ stdenv.mkDerivation (finalAttrs: {
       Google's software suite for combinatorial optimization.
     '';
     mainProgram = "fzn-cp-sat";
-    maintainers = with lib.maintainers; [ andersk ];
+    maintainers = with lib.maintainers; [
+      andersk
+      gonsolo
+    ];
     platforms = with lib.platforms; linux ++ darwin;
   };
 })

--- a/pkgs/by-name/or/or-tools/package.nix
+++ b/pkgs/by-name/or/or-tools/package.nix
@@ -109,6 +109,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt \
       --replace-fail 'set(BUILD_protobuf_matchers ON)' 'set(BUILD_protobuf_matchers OFF)'
   ''
+  # pkg_resources was dropped from setuptools and is unused in this file
+  + ''
+    substituteInPlace examples/contrib/check_dependencies.py \
+      --replace-fail 'from pkg_resources import parse_version' ""
+  ''
   # Patches from OpenSUSE:
   # https://build.opensuse.org/projects/science/packages/google-or-tools/files/google-or-tools.spec?expand=1
   + ''
@@ -243,10 +248,5 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "fzn-cp-sat";
     maintainers = with lib.maintainers; [ andersk ];
     platforms = with lib.platforms; linux ++ darwin;
-
-    # Only version 9.15 adds support for Python 3.14: https://github.com/google/or-tools/releases/tag/v9.15
-    # Also this package is tied to pybind 2.13.6, and only 3.0.0 supports Python 3.14: https://github.com/pybind/pybind11/releases/tag/v3.0.0
-    # Also, nix review fails to build python314Packages.ortools
-    broken = python3.pythonAtLeast "3.14";
   };
 })

--- a/pkgs/by-name/or/or-tools/pybind11-2.13.6.nix
+++ b/pkgs/by-name/or/or-tools/pybind11-2.13.6.nix
@@ -6,6 +6,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   ninja,
   setuptools,
@@ -41,8 +42,23 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-SNLdtrOjaC3lGHN9MAqTf51U9EzNKQLyTMNPe0GcdrU=";
   };
 
-  # https://github.com/google/or-tools/commit/7f29b27840436e19b6530d5c7f23eeadd819bd3e
-  patches = [ ./pybind11.patch ];
+  patches = [
+    # From pybind/pybind11#5305, merged upstream.
+    # TODO: remove when updating to a newer pybind11 release.
+    ./pybind11.patch
+    # Python 3.14 support, from pybind/pybind11#5646.
+    (fetchpatch {
+      name = "pybind11-python314-fopen.patch";
+      url = "https://github.com/pybind/pybind11/commit/3bd75bddf966ca32fec6e7d7ffc25630431e8815.patch";
+      includes = [ "include/pybind11/eval.h" ];
+      hash = "sha256-98gdGDUQFM/0el6j+fqyBppOfrjub4Cyxlu7wc7S8SQ=";
+    })
+    (fetchpatch {
+      name = "pybind11-python314-unhashable-message.patch";
+      url = "https://github.com/pybind/pybind11/commit/236b32f5c53665c1b1ea3d70f4a776287dadf863.patch";
+      hash = "sha256-zCapiTpNuPyYepOYmHCRjEFOn8z0UmlT2PmgX59XzM8=";
+    })
+  ];
 
   build-system = [
     cmake


### PR DESCRIPTION
## Summary

Fixes two independent, pre-existing bugs that block building or-tools under Python 3.14
(nixpkgs' current default), found and diagnosed while bumping `openroad`/`librelane` (which
depend on `or-tools`) to their latest releases.

**1. Vendored pybind11 2.13.6 test failure** (`test_return_set_of_unhashable`): Python 3.14
reworded `TypeError`'s unhashable-type message so it no longer *starts with* `"unhashable
type:"` (now embedded mid-message: `"cannot use '...' as a set element (unhashable type:
'...')"`). pybind11's actual behavior is correct and unchanged — only the test assertion was
too strict. Backported the relevant bits of upstream [pybind/pybind11#5646](https://github.com/pybind/pybind11/pull/5646)
to the vendored 2.13.6 copy: the test-assertion loosening, plus the `_Py_fopen_obj` ->
`Py_fopen` rename (3.14 removed the old symbol, would have been a separate latent break).
That PR's other changes (CI/test-infra, a lazy `__annotations__` code path added to pybind11
after 2.13.6) don't apply here and were left out.

**2. `examples/contrib/check_dependencies.py`**: does `from pkg_resources import
parse_version`, which current nixpkgs `setuptools` (83.0.0) no longer provides (upstream
setuptools has deprecated/dropped `pkg_resources`). Checked usage: `parse_version` is never
actually called anywhere in this script — it's dead code — so the import is simply dropped
rather than reached for a `packaging.version.parse` replacement.

With both fixed, dropped the `broken = python3.pythonAtLeast "3.14"` meta marker.

## Verification

- pybind11's own test suite: **1559 assertions in 17 test cases, all passed**.
- or-tools' full ctest suite: **611/611 passed**, including `python_contrib_check_dependencies`.
- `nix build .#or-tools` succeeds with no `NIXPKGS_ALLOW_BROKEN`/`--impure` workarounds needed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

**AI disclosure**: this PR description and the git/gh mechanics (branch, commit, push, PR
creation) were drafted/executed with the assistance of Claude Code (Claude Sonnet 5); see the
`Assisted-by:` trailer on each commit. Root-causing (tracing the actual pybind11 upstream fix,
confirming `parse_version` is unused dead code) and the fix content itself were done with that
assistance and verified via the local builds described above.

[NixOS tests]: https://nixos.org/manual/nixos/unstable#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test