### PR TITLE
sv-lang_10: fix build against fmt 12

### DIFF
--- a/pkgs/by-name/sv/sv-lang_10/package.nix
+++ b/pkgs/by-name/sv/sv-lang_10/package.nix
@@ -86,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       sharzy
       carlossless
+      gonsolo
     ];
     mainProgram = "slang";
     platforms = lib.platforms.all;

--- a/pkgs/by-name/sv/sv-lang_10/package.nix
+++ b/pkgs/by-name/sv/sv-lang_10/package.nix
@@ -35,6 +35,15 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace external/CMakeLists.txt --replace-fail \
       'set(mimalloc_min_version "2.2")' \
       'set(mimalloc_min_version "${lib.versions.majorMinor mimalloc.version}")'
+  ''
+  # fmt 12 moved fmt::format's declaration out of the lightweight
+  # fmt/core.h into fmt/format.h (format.h is a strict superset, so this
+  # is safe everywhere it's used). Same fix as upstream slang applied for
+  # 11.0 (commit 5a898b4b9225d281902fcd59fe4732b1561677d2), backported here
+  # since nixpkgs pins slang 10.0 specifically for circt.
+  + ''
+    grep -rl '#include <fmt/core.h>' --include='*.h' --include='*.cpp' . | \
+      xargs sed -i 's|#include <fmt/core.h>|#include <fmt/format.h>|'
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
## Summary

Fixes `sv-lang_10` (the slang 10.0 build pinned specifically for `circt`'s `firtool-1.147.0`),
which currently fails to compile against nixpkgs' pinned `fmt` (12.2.0): `'format' is not a
member of 'fmt'` across several files. Found and diagnosed while bumping other packages in the
Borg toolchain and hitting this as a build blocker for `circt`.

`fmt` 12 moved `fmt::format`'s declaration out of the lightweight `fmt/core.h` into
`fmt/format.h`. `format.h` is a strict superset of `core.h`, so swapping the include is safe
everywhere it's used, and can't remove anything a file was already relying on.

Upstream slang already carries this exact fix for the newer `sv-lang` (11.0) package in
nixpkgs, applied for the same reason via [MikePopoloski/slang@5a898b4](https://github.com/MikePopoloski/slang/commit/5a898b4b9225d281902fcd59fe4732b1561677d22).
`sv-lang_10` pins an older slang release (10.0, required specifically by circt's
`firtool-1.147.0`) that predates that fix and can't just be swapped for 11.0, so this
backports the same one-line-per-file change to the 10.0 source tree via `postPatch`
(verified via `git apply --check` against the upstream commit that most of the individual
hunks apply cleanly to 10.0's tree too, just with slightly different surrounding `#include`
context in a few files, hence backporting as a mechanical `sed` over all affected files
instead of reusing the patch file directly).

## Verification

`nix build .#circt` — previously failed during `sv-lang_10`'s build — now succeeds. `firtool
--version` on the resulting binary reports `1.147.0` as expected.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

**AI disclosure**: this PR description and the git/gh mechanics (branch, commit, push, PR
creation) were drafted/executed with the assistance of Claude Code (Claude Sonnet 5); see the
`Assisted-by:` trailer on each commit. Root-causing (finding the upstream fix commit, testing
patch applicability, identifying the mechanical include-swap pattern) and the fix content were
done with that assistance and verified via the local `circt` build described above.

[NixOS tests]: https://nixos.org/manual/nixos/unstable#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test