### PR TITLE
xbstrap: init at 0.36

### DIFF
--- a/pkgs/by-name/xb/xbstrap/package.nix
+++ b/pkgs/by-name/xb/xbstrap/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+  y4,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "xbstrap";
+  version = "0.36";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-k+V+5VEP86Nd99MK9G5zo++B7IFZ2vho3mGCUhKr3GQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace xbstrap/base.py \
+      --replace-fail 'y4_args = ["y4"]' 'y4_args = ["${lib.getBin y4}"]'
+  '';
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    colorama
+    jsonschema
+    pyyaml
+    zstandard
+  ];
+
+  __structuredAttrs = true;
+
+  # has no tests
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/managarm/xbstrap/releases/tag/v${finalAttrs.version}";
+    description = "Build system for OS distributions";
+    homepage = "https://github.com/managarm/xbstrap";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      lzcunt
+    ];
+    mainProgram = "xbstrap";
+  };
+})

--- a/pkgs/by-name/y4/y4/package.nix
+++ b/pkgs/by-name/y4/y4/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "y4";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "managarm";
+    repo = "y4";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Pb7pTTPpRkuH24cnscdmHUpegdkZPyXjHBVUmrd6HlY=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  dependencies = with python3Packages; [
+    jq
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://github.com/managarm/y4/releases/tag/${finalAttrs.src.tag}";
+    description = "Purely functional DSL to process YAML";
+    homepage = "https://github.com/managarm/y4";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      lzcunt
+    ];
+    mainProgram = "y4";
+  };
+})


### PR DESCRIPTION
xbstrap is a meta build system for building OS distributions. It is developed by the Managarm project, tho there are non-Managarm users.

xbstrap recipes can be json or yaml or any DSL that compiles to json or yaml. y4 is a DSL that compiles to yaml. I've also packaged y4 because xbstrap's biggest user, Managarm, uses y4.

y4 repo is missing a LICENSE but I've gotten confirmation from upstream that the LICENSE file missing is unintended and it is licensed MIT. If necessary, this PR can wait until the MIT license is added to the y4 repo (which will likely not be a new release).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
