### PR TITLE
wfuzz: fix build failure

### DIFF
--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -38,6 +38,9 @@ buildPythonPackage (finalAttrs: {
     # replace removed `pipes` stdlib module with `shlex` for Python >= 3.13
     # https://github.com/xmendez/wfuzz/issues/380
     ./python-313-shlex.patch
+    # replace pkg_resources with importlib.resources for Python >= 3.12
+    # https://github.com/xmendez/wfuzz/issues/381
+    ./pkg_resources-importlib.patch
   ];
 
   build-system = [ setuptools ];
@@ -49,7 +52,6 @@ buildPythonPackage (finalAttrs: {
     netaddr # src/wfuzz/plugins/payloads/{iprange,ipnet}.py
     pycurl
     pyparsing
-    setuptools
     six
   ]
   ++ lib.optionals stdenv.hostPlatform.isWindows [ colorama ];

--- a/pkgs/development/python-modules/wfuzz/pkg_resources-importlib.patch
+++ b/pkgs/development/python-modules/wfuzz/pkg_resources-importlib.patch
@@ -1,0 +1,29 @@
+Replace `pkg_resources` with `importlib.resources` for Python >= 3.12.
+
+`pkg_resources` is deprecated and is no longer shipped by setuptools >= 81,
+so importing it breaks `wfuzz.helpers.file_func` outright.
+`importlib.resources.files` is the documented stdlib replacement.
+
+Reported upstream: https://github.com/xmendez/wfuzz/issues/381
+
+diff --git a/src/wfuzz/helpers/file_func.py b/src/wfuzz/helpers/file_func.py
+--- a/src/wfuzz/helpers/file_func.py
++++ b/src/wfuzz/helpers/file_func.py
+@@ -1,7 +1,7 @@
+ import os
+ import sys
+ import re
+-import pkg_resources
++from importlib.resources import files
+
+ from chardet.universaldetector import UniversalDetector
+ import chardet
+@@ -15,7 +15,7 @@ def get_filter_help_file():
+
+     filter_help_text = None
+     try:
+-        fname = pkg_resources.resource_filename("wfuzz", FILTER_HELP_FILE)
++        fname = files("wfuzz").joinpath(FILTER_HELP_FILE)
+         filter_help_text = open(fname).read()
+     except IOError:
+         filter_help_text = open(get_path(FILTER_HELP_DEV_FILE)).read()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
