### PR TITLE
proton-ge-bin: GE-Proton11-3 -> GE-Proton11-5, add support for aarch64-linux

### DIFF
--- a/pkgs/by-name/dw/dwproton-bin/package.nix
+++ b/pkgs/by-name/dw/dwproton-bin/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenvNoCC,
   fetchzip,
   writeScript,
   proton-ge-bin,
@@ -9,26 +10,29 @@
 proton-ge-bin.overrideAttrs (
   finalAttrs: _: {
     inherit steamDisplayName;
+    inherit (finalAttrs.passthru.variants.${stdenvNoCC.hostPlatform.system}) src toolName;
 
     pname = "dwproton-bin";
     version = "dwproton-11.0-12";
 
-    src = fetchzip {
-      url = "https://dawn.wine/dawn-winery/dwproton/releases/download/${finalAttrs.version}/${finalAttrs.version}-x86_64.tar.xz";
-      hash = "sha256-NGyrXQcA+k87SnowFd41uq49luI32fZENTwFTma7NpI=";
+    passthru = {
+      variants = {
+        "x86_64-linux" = {
+          toolName = "${finalAttrs.version}-x86_64";
+          src = fetchzip {
+            url = "https://dawn.wine/dawn-winery/dwproton/releases/download/${finalAttrs.version}/${finalAttrs.version}-x86_64.tar.xz";
+            hash = "sha256-NGyrXQcA+k87SnowFd41uq49luI32fZENTwFTma7NpI=";
+          };
+        };
+      };
+
+      updateScript = writeScript "update-dwproton" ''
+        #!/usr/bin/env nix-shell
+        #!nix-shell -i bash -p curl jq common-updater-scripts
+        version=$(curl -sL "https://dawn.wine/api/v1/repos/dawn-winery/dwproton/tags?page=1\&limit=1" | jq -r .[0].name)
+        update-source-version dwproton-bin "$version"
+      '';
     };
-
-    preFixup = ''
-      substituteInPlace "$steamcompattool/compatibilitytool.vdf" \
-        --replace-fail "${finalAttrs.version}" "${steamDisplayName}"
-    '';
-
-    passthru.updateScript = writeScript "update-dwproton" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl jq common-updater-scripts
-      version=$(curl -sL "https://dawn.wine/api/v1/repos/dawn-winery/dwproton/tags?page=1\&limit=1" | jq -r .[0].name)
-      update-source-version dwproton-bin "$version"
-    '';
 
     meta = {
       description = ''

--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -3,18 +3,21 @@
   stdenvNoCC,
   fetchzip,
   writeScript,
+  steamDisplayName ? null,
+}:
+assert
+  steamDisplayName == null
+  || throw "proton-ge-bin: The `steamDisplayName` interface has been changed to an attribute, which is overridable using `overrideAttrs`.";
+
+stdenvNoCC.mkDerivation (finalAttrs: {
   # Can be overridden to alter the display name in steam
   # This could be useful if multiple versions should be installed together
-  steamDisplayName ? "GE-Proton",
-}:
-stdenvNoCC.mkDerivation (finalAttrs: {
+  steamDisplayName = "GE-Proton";
+
   pname = "proton-ge-bin";
   version = "GE-Proton11-5";
 
-  src = fetchzip {
-    url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}-x86_64.tar.gz";
-    hash = "sha256-Sbyi5zXMhPIKSotvL5LEZ2dbDoLpXRcCyuY9TsnBnus=";
-  };
+  inherit (finalAttrs.passthru.variants.${stdenvNoCC.hostPlatform.system}) src toolName;
 
   dontUnpack = true;
   dontConfigure = true;
@@ -42,24 +45,45 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   preFixup = ''
     substituteInPlace "$steamcompattool/compatibilitytool.vdf" \
-      --replace-fail "${finalAttrs.version}" "${steamDisplayName}"
+      --replace-fail "$toolName" "$steamDisplayName"
   '';
 
-  /*
-    We use the created releases, and not the tags, for the update script as nix-update loads releases.atom
-    that contains both. Sometimes upstream pushes the tags but the GitHub releases don't get created due to
-    CI errors. Last time this happened was on 8-33, where a tag was created but no releases were created.
-    As of 2024-03-13, there have been no announcements indicating that the CI has been fixed, and thus
-    we avoid nix-update-script and use our own update script instead.
-    See: <https://github.com/NixOS/nixpkgs/pull/294532#issuecomment-1987359650>
-  */
-  passthru.updateScript = writeScript "update-proton-ge" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl jq common-updater-scripts
-    repo="https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases"
-    version="$(curl -sL "$repo" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output)"
-    update-source-version proton-ge-bin "$version"
-  '';
+  passthru = {
+    variants = {
+      "x86_64-linux" = {
+        toolName = "${finalAttrs.version}-x86_64";
+        src = fetchzip {
+          url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}-x86_64.tar.gz";
+          hash = "sha256-Sbyi5zXMhPIKSotvL5LEZ2dbDoLpXRcCyuY9TsnBnus=";
+        };
+      };
+      "aarch64-linux" = {
+        toolName = "${finalAttrs.version}-aarch64";
+        src = fetchzip {
+          url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}-aarch64.tar.gz";
+          hash = "sha256-fS4N2ip8IvhMfrJsfHnrq+zA/41qJd6kbLQ0+5lZ5uE=";
+        };
+      };
+    };
+
+    /*
+      We use the created releases, and not the tags, for the update script as nix-update loads releases.atom
+      that contains both. Sometimes upstream pushes the tags but the GitHub releases don't get created due to
+      CI errors. Last time this happened was on 8-33, where a tag was created but no releases were created.
+      As of 2024-03-13, there have been no announcements indicating that the CI has been fixed, and thus
+      we avoid nix-update-script and use our own update script instead.
+      See: <https://github.com/NixOS/nixpkgs/pull/294532#issuecomment-1987359650>
+    */
+    updateScript = writeScript "update-proton-ge" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq common-updater-scripts
+      repo="https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases"
+      version="$(curl -sL "$repo" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output)"
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        update-source-version proton-ge-bin "$version" --ignore-same-version --source-key="variants.$platform.src"
+      done
+    '';
+  };
 
   meta = {
     description = ''
@@ -75,7 +99,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       Scrumplex
       shawn8901
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = builtins.attrNames finalAttrs.passthru.variants;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -9,11 +9,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "proton-ge-bin";
-  version = "GE-Proton11-3";
+  version = "GE-Proton11-5";
 
   src = fetchzip {
-    url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-    hash = "sha256-RiCmnUKeZRhPUCgm7fsROKFkAl37+/tYkA47tQtkIF4=";
+    url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}-x86_64.tar.gz";
+    hash = "sha256-Sbyi5zXMhPIKSotvL5LEZ2dbDoLpXRcCyuY9TsnBnus=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
Changelog: https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/GE-Proton11-4
Diff: https://github.com/GloriousEggroll/proton-ge-custom/compare/GE-Proton11-3...GE-Proton11-5

Built on both `x86_64-linux` and `aarch64-linux` (with binfmt), but only tested on `x86_64-linux`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
