### PR TITLE
python3Packages.iso4217parse: init at 0.6.2

### DIFF
--- a/pkgs/development/python-modules/iso4217parse/default.nix
+++ b/pkgs/development/python-modules/iso4217parse/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  poetry-core,
+  fetchpatch,
+  pytest-cov-stub,
+  pytestCheckHook,
+  iso3166,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "iso4217parse";
+  version = "0.6.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tammoippen";
+    repo = "iso4217parse";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DPuauUTgBlw82W7AvoVNuqiE4ToXy8EmHZM40YXR+CA=";
+  };
+
+  patches = [
+    # Switch to poetry-core, https://github.com/tammoippen/iso4217parse/pull/20
+    ./use-poetry-core.patch
+  ];
+
+  build-system = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [
+    "iso4217parse"
+  ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+    iso3166
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Parse currencies (symbols and codes) from and to ISO4217";
+    homepage = "https://github.com/tammoippen/iso4217parse";
+    changelog = "https://github.com/tammoippen/iso4217parse/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dwoffinden ];
+  };
+})

--- a/pkgs/development/python-modules/iso4217parse/default.nix
+++ b/pkgs/development/python-modules/iso4217parse/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  poetry-core,
+  fetchpatch,
+  pytest-cov-stub,
+  pytestCheckHook,
+  iso3166,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "iso4217parse";
+  version = "0.6.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tammoippen";
+    repo = "iso4217parse";
+    # need unreleased https://github.com/tammoippen/iso4217parse/pull/20
+    rev = "4b1e1ae9c4e800b232f5f2a9a866db80be82cd6d";
+    hash = "sha256-pFCvJEBnCeUIrYe8ebl+dxSZpYtClSIR7V74vdddmg4=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [
+    "iso4217parse"
+  ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+    iso3166
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Parse currencies (symbols and codes) from and to ISO4217";
+    homepage = "https://github.com/tammoippen/iso4217parse";
+    changelog = "https://github.com/tammoippen/iso4217parse/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dwoffinden ];
+  };
+})

--- a/pkgs/development/python-modules/iso4217parse/use-poetry-core.patch
+++ b/pkgs/development/python-modules/iso4217parse/use-poetry-core.patch
@@ -1,0 +1,21 @@
+From 16fcf2b986f3e6a56152a94e8079aebe626f4fcb Mon Sep 17 00:00:00 2001
+From: Daniel Woffinden <daw@hey.com>
+Date: Wed, 12 Aug 2026 16:13:09 +0100
+Subject: [PATCH] use poetry-core
+
+---
+ pyproject.toml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 852ee34..846a848 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -41,5 +41,5 @@ pytest-cov = "*"
+ ruff = "*"
+ 
+ [build-system]
+-requires = ["poetry>=0.12"]
+-build-backend = "poetry.masonry.api"
++requires = ["poetry-core"]
++build-backend = "poetry.core.masonry.api"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8308,6 +8308,8 @@ self: super: with self; {
 
   iso4217 = callPackage ../development/python-modules/iso4217 { };
 
+  iso4217parse = callPackage ../development/python-modules/iso4217parse { };
+
   iso8601 = callPackage ../development/python-modules/iso8601 { };
 
   isocodes = callPackage ../development/python-modules/isocodes { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8545,6 +8545,8 @@ self: super: with self; {
 
   iso4217 = callPackage ../development/python-modules/iso4217 { };
 
+  iso4217parse = callPackage ../development/python-modules/iso4217parse { };
+
   iso639-lang = callPackage ../development/python-modules/iso639-lang { };
 
   iso8601 = callPackage ../development/python-modules/iso8601 { };


### PR DESCRIPTION
Brings in https://github.com/tammoippen/iso4217parse/pull/20 as a patch for poetry-core


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
