### PR TITLE
pitchfork: init at 2.23.0

### DIFF
--- a/pkgs/by-name/pi/pitchfork/package.nix
+++ b/pkgs/by-name/pi/pitchfork/package.nix
@@ -7,7 +7,6 @@
   pnpmConfigHook,
   rustPlatform,
   stdenv,
-  ...
 }:
 
 let

--- a/pkgs/by-name/pi/pitchfork/package.nix
+++ b/pkgs/by-name/pi/pitchfork/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  rustPlatform,
+  stdenv,
+  ...
+}:
+
+let
+  pnpm = pnpm_10;
+in
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    webui = stdenv.mkDerivation {
+      pname = "${finalAttrs.pname}-webui";
+      inherit (finalAttrs) version src;
+
+      sourceRoot = "${finalAttrs.src.name}/ui";
+      pnpmDeps = finalAttrs.pnpmDeps;
+
+      nativeBuildInputs = [
+        nodejs
+        pnpm
+        pnpmConfigHook
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        pnpm build
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -r dist/. $out/
+
+        runHook postInstall
+      '';
+    };
+  in
+  {
+    pname = "pitchfork";
+    version = "2.23.0";
+
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "jdx";
+      repo = "pitchfork";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-P3N4YquQPJ+xr/M6foK9r2EDKjOsslRVMU3aIsJr04U=";
+    };
+
+    cargoHash = "sha256-jNf0dTsZgS8CWBrGu+o1d11Nil9OgsLykxNkGxTd9aY=";
+
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      inherit (finalAttrs) pname src version;
+      hash = finalAttrs.cargoHash;
+    };
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      inherit pnpm;
+      sourceRoot = "${finalAttrs.src.name}/ui";
+      fetcherVersion = 3;
+      hash = "sha256-zh0JlHe6NDpsuDKsGq5Eto8Rx7gGLc7ayxV/NIhm4EQ=";
+    };
+
+    preBuild = ''
+      mkdir -p ui/dist
+      cp -r ${webui}/. ui/dist/
+    '';
+
+    doCheck = false;
+
+    meta = {
+      homepage = "https://pitchfork.jdx.dev";
+      description = "Daemons with DX";
+      changelog = "https://github.com/jdx/pitchfork/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+      license = lib.licenses.mit;
+      mainProgram = "pitchfork";
+      maintainers = with lib.maintainers; [ esteve ];
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[pitchfork](https://pitchfork.jdx.dev/) is a tool for managing daemons written in Rust, by the author of [mise](https://mise.jdx.dev/). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).