### PR TITLE
florist: unpin gnat13

### DIFF
--- a/pkgs/by-name/fl/florist/package.nix
+++ b/pkgs/by-name/fl/florist/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
-  gnat13,
-  gnat13Packages,
+  gnat,
+  gnatPackages,
   fetchFromGitHub,
   lib,
 }:
@@ -20,8 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [ "--enable-shared" ];
 
   nativeBuildInputs = [
-    gnat13
-    gnat13Packages.gprbuild
+    gnat
+    gnatPackages.gprbuild
   ];
 
   meta = {


### PR DESCRIPTION
florist has been pinned to gnat 13 since its init in november 2024, but it builds fine with modern gnat and nothing seems to indicate that this pin is necessary, so we remove it. this helps reduce overall compiler version proliferation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
