### PR TITLE
jellyfin-plugin-dlna: init at 11.0.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5349,6 +5349,11 @@
     githubId = 71959829;
     name = "Cleeyv";
   };
+  clement-songis = {
+    github = "clement-songis";
+    githubId = 45465110;
+    name = "Clément Songis";
+  };
   clementpoiret = {
     email = "poiret.clement@outlook.fr";
     github = "clementpoiret";

--- a/pkgs/by-name/je/jellyfin-plugin-dlna/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-dlna/nuget-deps.json
@@ -1,0 +1,262 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authorization",
+    "version": "8.0.10",
+    "hash": "sha256-VeUAe/OoV2zNDaiSKSv7tXR5barJzLbxS96DUb9bAz8="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Metadata",
+    "version": "8.0.10",
+    "hash": "sha256-SxnMOWJGgUUQyKaRezJQwMUt4eMfWjnhmfk8pldYGNA="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "2.0.0",
+    "hash": "sha256-Eg1MES40kzkGW9tZmjaKtbWI00Kbv7fLJQmjrigjxqk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "2.0.0",
+    "hash": "sha256-H1rEnq/veRWvmp8qmUsrQkQIcVlKilUNzmmKsxJ0md8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.2",
+    "hash": "sha256-cHpe8X2BgYa5DzulZfq24rg8O2K5Lmq2OiLhoyAVgJc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "2.0.0",
+    "hash": "sha256-EMvaXxGzueI8lT97bYJQr0kAj1IK0pjnAcWN82hTnzw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "8.0.2",
+    "hash": "sha256-AjcldddddtN/9aH9pg7ClEZycWtFHLi9IPe1GGhNQys="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "2.0.0",
+    "hash": "sha256-q44LtMvyNEKSvgERvA+BrasKapP92Sc91QR4u2TJ9/Y="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "8.0.0",
+    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-dlna/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-dlna/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  writers,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "jellyfin-plugin-dlna";
+  # Upstream tags releases `vN`, but the assembly and the published artifact
+  # are versioned `N.0.0.0`, which is also what Jellyfin compares plugin
+  # folders and manifests against.
+  version = "11.0.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-dlna";
+    tag = "v${lib.versions.major finalAttrs.version}";
+    hash = "sha256-2elz1x3+MDqPskqAcsH5iflB16+YClXK1b+D2oti0XA=";
+  };
+
+  projectFile = "Jellyfin.Plugin.Dlna.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_9_0;
+
+  # src/Directory.Build.Props hardcodes 0.0.0.0; upstream's CI passes the real
+  # version on the command line. Without this the assembly reports 0.0.0.0 and
+  # Jellyfin's plugin manager treats every rebuild as the same version.
+  dotnetBuildFlags = [ "-p:Version=${finalAttrs.version}" ];
+
+  # A plugin is a library: there is nothing to wrap, and the default
+  # `executables = null` would try to install every project as a binary.
+  executables = [ ];
+
+  # Jellyfin discovers plugins by enumerating the subdirectories of its
+  # `plugins` folder and reading `meta.json` from each. The versioned
+  # `Name_Version` folder is a legacy fallback that upstream documents as being
+  # phased out, so the manifest is what we ship.
+  postInstall =
+    let
+      # Mirrors upstream's build.yaml, which is what the official repository
+      # manifest is generated from.
+      meta = {
+        category = "General";
+        description = "Adds DLNA capability to Jellyfin";
+        guid = "33eba9cd-7da1-4720-967f-dd7dae7b74a1";
+        name = "DLNA";
+        overview = "DLNA Service";
+        owner = "jellyfin";
+        # The plugin is skipped at startup unless the running server is at
+        # least this version, so it has to track build.yaml rather than the
+        # jellyfin package.
+        targetAbi = "10.11.9.0";
+        version = finalAttrs.version;
+        status = "Active";
+        # Nothing here is allowed to auto-update: the store is read-only, and
+        # an update would be lost on the next rebuild anyway.
+        autoUpdate = false;
+        assemblies = [
+          "Jellyfin.Plugin.Dlna.dll"
+          "Jellyfin.Plugin.Dlna.Model.dll"
+          "Jellyfin.Plugin.Dlna.Playback.dll"
+          "Rssdp.dll"
+        ];
+        timestamp = "1970-01-01T00:00:00Z";
+      };
+      metaFile = (writers.writeJSON "meta.json" meta);
+    in
+    ''
+      plugin="$out/lib/jellyfin/plugins/${finalAttrs.passthru.pluginName}"
+      mkdir -p "$plugin"
+
+      for dll in ${lib.concatStringsSep " " meta.assemblies}; do
+        mv "$out/lib/${finalAttrs.pname}/$dll" "$plugin/"
+      done
+      cp ${metaFile} "$plugin/meta.json"
+
+      rm -rf "$out/lib/${finalAttrs.pname}"
+    '';
+
+  passthru = {
+    # The directory name Jellyfin will see. Kept in passthru so a NixOS module
+    # can link the plugin into place without re-deriving it from the manifest.
+    pluginName = "DLNA_${finalAttrs.version}";
+  };
+
+  meta = {
+    description = "DLNA server plugin for Jellyfin";
+    longDescription = ''
+      Jellyfin served DLNA from its core until 10.9, which moved it out into
+      this plugin. It advertises the library over SSDP and streams to DLNA
+      renderers, transcoding when the device cannot play the source directly.
+    '';
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-dlna";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-dlna/releases/tag/v${lib.versions.major finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ clement-songis ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Packages the DLNA plugin, which was part of the Jellyfin server until 10.9 and
now lives in its own repository. Part of #551935.

The output layout is `lib/jellyfin/plugins/DLNA_11.0.0.0/`, holding the four
assemblies listed in upstream's `build.yaml` plus a `meta.json` manifest, so
that a consumer only has to place the directory where Jellyfin looks for it.
`services.jellyfin.plugins` in #551938 does exactly that.

Two things that are not obvious:

- `src/Directory.Build.Props` hardcodes `0.0.0.0`; upstream's CI passes the real
  version on the command line, hence `-p:Version=`. Without it Jellyfin sees
  every rebuild as the same plugin version.
- `targetAbi` in the manifest tracks upstream's `build.yaml`, not the `jellyfin`
  package. Jellyfin skips a plugin whose `targetAbi` is newer than the running
  server, so pinning it to our `jellyfin` version would break the plugin on
  anyone running an older server.

Loading is covered by the NixOS test in #551938, which asserts on
`Loaded plugin: DLNA 11.0.0.0` in the journal rather than on the files being
present — Jellyfin skips a plugin it cannot use without failing to start, so the
log is the only thing that distinguishes loaded from silently ignored.

### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
