### PR TITLE
nixos/jellyfin: add plugins option

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5349,6 +5349,11 @@
     githubId = 71959829;
     name = "Cleeyv";
   };
+  clement-songis = {
+    github = "clement-songis";
+    githubId = 45465110;
+    name = "Clément Songis";
+  };
   clementpoiret = {
     email = "poiret.clement@outlook.fr";
     github = "clementpoiret";

--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -7,6 +7,7 @@
 
 let
   inherit (lib)
+    mkMerge
     mkIf
     mkDefault
     getExe
@@ -26,7 +27,9 @@ let
     bool
     enum
     ints
+    listOf
     nullOr
+    package
     path
     str
     submodule
@@ -94,6 +97,30 @@ in
       enable = mkEnableOption "Jellyfin Media Server";
 
       package = mkPackageOption pkgs "jellyfin" { };
+
+      plugins = mkOption {
+        type = listOf package;
+        default = [ ];
+        example = literalExpression "[ pkgs.jellyfin-plugin-dlna ]";
+        description = ''
+          Plugins to make available to Jellyfin.
+
+          Each package provides one or more plugin directories under
+          `lib/jellyfin/plugins/`, which are reproduced under
+          {option}`services.jellyfin.dataDir`/plugins before the service starts.
+
+          Plugins installed from Jellyfin's own catalogue live in the same
+          directory and are left untouched, but a plugin listed here takes over
+          its directory name: install a given plugin one way or the other, not
+          both.
+
+          ::: {.note}
+          Updating or removing such a plugin from the dashboard does not work,
+          since its assemblies are read-only store paths. Bump the package
+          instead.
+          :::
+        '';
+      };
 
       user = mkOption {
         type = str;
@@ -389,46 +416,75 @@ in
         wants = [ "network-online.target" ];
         wantedBy = [ "multi-user.target" ];
 
-        preStart = mkIf cfg.hardwareAcceleration.enable (
-          ''
-            configDir=${escapeShellArg cfg.configDir}
-            encodingXml="$configDir/encoding.xml"
-          ''
-          + (
-            if cfg.forceEncodingConfig then
-              ''
-                if [[ -e $encodingXml ]]; then
-                  # this intentionally removes trailing newlines
-                  currentText="$(<"$encodingXml")"
-                  configuredText="$(<${encodingXmlFile})"
-                  if [[ $currentText == "$configuredText" ]]; then
-                    # don't need to do anything
-                    exit 0
-                  else
-                    encodingXmlBackup="$configDir/encoding.xml.backup-$(date -u +"%FT%H_%M_%SZ")"
-                    mv --update=none-fail -T "$encodingXml" "$encodingXmlBackup"
+        preStart = mkMerge [
+          (mkIf (cfg.plugins != [ ]) ''
+            pluginsDir=${escapeShellArg "${cfg.dataDir}/plugins"}
+            mkdir -p "$pluginsDir"
+
+            # The marker distinguishes our directories from the ones the
+            # dashboard's own installer creates, which must survive.
+            find "$pluginsDir" -mindepth 2 -maxdepth 2 -name .nix-jellyfin-plugin \
+              -printf '%h\0' | xargs -0 -r rm -rf
+
+            for source in ${
+              lib.escapeShellArgs (map (plugin: "${plugin}/lib/jellyfin/plugins") cfg.plugins)
+            }; do
+              for plugin in "$source"/*; do
+                target="$pluginsDir/$(basename "$plugin")"
+                mkdir -p "$target"
+                touch "$target/.nix-jellyfin-plugin"
+
+                find "$plugin" -maxdepth 1 -name '*.dll' \
+                  -exec ln -sf -t "$target" {} +
+
+                # Not a symlink: Jellyfin rewrites meta.json while
+                # instantiating the plugin, and a read-only one aborts startup.
+                install -m 0644 "$plugin/meta.json" "$target/meta.json"
+              done
+            done
+          '')
+
+          (mkIf cfg.hardwareAcceleration.enable (
+            ''
+              configDir=${escapeShellArg cfg.configDir}
+              encodingXml="$configDir/encoding.xml"
+            ''
+            + (
+              if cfg.forceEncodingConfig then
+                ''
+                  if [[ -e $encodingXml ]]; then
+                    # this intentionally removes trailing newlines
+                    currentText="$(<"$encodingXml")"
+                    configuredText="$(<${encodingXmlFile})"
+                    if [[ $currentText == "$configuredText" ]]; then
+                      # don't need to do anything
+                      exit 0
+                    else
+                      encodingXmlBackup="$configDir/encoding.xml.backup-$(date -u +"%FT%H_%M_%SZ")"
+                      mv --update=none-fail -T "$encodingXml" "$encodingXmlBackup"
+                    fi
                   fi
-                fi
-                cp --update=none-fail -T ${encodingXmlFile} "$encodingXml"
-                chmod u+w "$encodingXml"
-              ''
-            else
-              ''
-                if [[ -e $encodingXml ]]; then
-                  # this intentionally removes trailing newlines
-                  currentText="$(<"$encodingXml")"
-                  configuredText="$(<${encodingXmlFile})"
-                  if [[ $currentText != "$configuredText" ]]; then
-                    echo "WARN: $encodingXml already exists and is different from the configured settings. transcoding options NOT applied." >&2
-                    echo "WARN: Set config.services.jellyfin.forceEncodingConfig = true to override." >&2
-                  fi
-                else
                   cp --update=none-fail -T ${encodingXmlFile} "$encodingXml"
                   chmod u+w "$encodingXml"
-                fi
-              ''
-          )
-        );
+                ''
+              else
+                ''
+                  if [[ -e $encodingXml ]]; then
+                    # this intentionally removes trailing newlines
+                    currentText="$(<"$encodingXml")"
+                    configuredText="$(<${encodingXmlFile})"
+                    if [[ $currentText != "$configuredText" ]]; then
+                      echo "WARN: $encodingXml already exists and is different from the configured settings. transcoding options NOT applied." >&2
+                      echo "WARN: Set config.services.jellyfin.forceEncodingConfig = true to override." >&2
+                    fi
+                  else
+                    cp --update=none-fail -T ${encodingXmlFile} "$encodingXml"
+                    chmod u+w "$encodingXml"
+                  fi
+                ''
+            )
+          ))
+        ];
 
         # This is mostly follows: https://github.com/jellyfin/jellyfin/blob/master/fedora/jellyfin.service
         # Upstream also disable some hardenings when running in LXC, we do the same with the isContainer option

--- a/nixos/tests/jellyfin.nix
+++ b/nixos/tests/jellyfin.nix
@@ -48,6 +48,22 @@
       virtualisation.diskSize = 3 * 1024;
     };
 
+    machineWithPlugins = {
+      services.jellyfin = {
+        enable = true;
+        plugins = with pkgs; [
+          jellyfin-plugin-dlna
+          jellyfin-plugin-ldapauth
+          jellyfin-plugin-opensubtitles
+          jellyfin-plugin-reports
+          jellyfin-plugin-trakt
+          jellyfin-plugin-tvdb
+          jellyfin-plugin-webhook
+        ];
+      };
+      virtualisation.diskSize = 3 * 1024;
+    };
+
     machineWithForceConfig = {
       services.jellyfin = {
         enable = true;
@@ -99,6 +115,66 @@
 
           # Check device access
           machineWithTranscoding.succeed("systemctl show jellyfin.service --property=DeviceAllow | grep '/dev/dri/renderD128 rw'")
+
+      with subtest("Declaratively installed plugins are loaded"):
+          wait_for_jellyfin(machineWithPlugins)
+
+          # Jellyfin rewrites meta.json while instantiating a plugin, so a
+          # read-only one aborts startup instead of skipping the plugin.
+          machineWithPlugins.succeed(
+              "test -L /var/lib/jellyfin/plugins/DLNA_11.0.0.0/Jellyfin.Plugin.Dlna.dll"
+          )
+          machineWithPlugins.succeed(
+              "test -f /var/lib/jellyfin/plugins/DLNA_11.0.0.0/meta.json "
+              "-a ! -L /var/lib/jellyfin/plugins/DLNA_11.0.0.0/meta.json"
+          )
+          machineWithPlugins.succeed(
+              "test -w /var/lib/jellyfin/plugins/DLNA_11.0.0.0/meta.json"
+          )
+
+          # A plugin Jellyfin cannot use is skipped without failing startup,
+          # so only the log distinguishes loaded from silently ignored. These
+          # are the names the plugin classes report, which upstream lets
+          # diverge from the manifest: ldapauth ships as
+          # "LDAP Authentication_23.0.0.0" but calls itself "LDAP-Auth".
+          for plugin in [
+              "DLNA 11.0.0.0",
+              "LDAP-Auth 23.0.0.0",
+              "Open Subtitles 24.0.0.0",
+              "Reports 18.0.0.0",
+              "Trakt 30.0.0.0",
+              "TheTVDB 22.0.0.0",
+              "Webhook 21.0.0.0",
+          ]:
+              machineWithPlugins.wait_until_succeeds(
+                  f"journalctl --unit jellyfin --grep 'Loaded plugin: {plugin}'"
+              )
+
+          machineWithPlugins.succeed(
+              "test -L '/var/lib/jellyfin/plugins/Open Subtitles_24.0.0.0"
+              "/Jellyfin.Plugin.OpenSubtitles.dll'"
+          )
+
+          # A plugin dropped from the configuration has to be cleaned up,
+          # while one installed from Jellyfin's catalogue must survive. Both
+          # fixtures are created as the service user, like the real thing.
+          machineWithPlugins.succeed("systemctl stop jellyfin.service")
+          machineWithPlugins.succeed(
+              "runuser -u jellyfin -- mkdir -p /var/lib/jellyfin/plugins/Stale_1.0.0.0 "
+              "&& runuser -u jellyfin -- touch "
+              "/var/lib/jellyfin/plugins/Stale_1.0.0.0/.nix-jellyfin-plugin"
+          )
+          machineWithPlugins.succeed(
+              "runuser -u jellyfin -- mkdir -p /var/lib/jellyfin/plugins/FromCatalogue_1.0.0.0"
+          )
+          machineWithPlugins.succeed("systemctl start jellyfin.service")
+          wait_for_jellyfin(machineWithPlugins)
+
+          machineWithPlugins.succeed("test ! -e /var/lib/jellyfin/plugins/Stale_1.0.0.0")
+          machineWithPlugins.succeed("test -d /var/lib/jellyfin/plugins/FromCatalogue_1.0.0.0")
+          machineWithPlugins.succeed(
+              "test -L /var/lib/jellyfin/plugins/DLNA_11.0.0.0/Jellyfin.Plugin.Dlna.dll"
+          )
 
       # Test forceEncodingConfig backup functionality
       with subtest("Force encoding config creates backup"):

--- a/pkgs/build-support/jellyfin/build-jellyfin-plugin/default.nix
+++ b/pkgs/build-support/jellyfin/build-jellyfin-plugin/default.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  jellyfin,
+  nix-update-script,
+  yq-go,
+}:
+
+# Builds a Jellyfin plugin into $out/lib/jellyfin/plugins/<Name>_<Version>,
+# the layout services.jellyfin.plugins reproduces under the server's data
+# directory. The manifest is generated from upstream's build.yaml so that
+# nix-update can bump a plugin on its own.
+#
+# Takes buildDotnetModule's arguments, as an attribute set or a function of
+# finalAttrs, with `version` given as upstream's own (the vN tag); it is padded
+# to the four components Jellyfin compares on.
+
+fnOrAttrs:
+
+buildDotnetModule (
+  finalAttrs:
+  let
+    args = if lib.isFunction fnOrAttrs then fnOrAttrs finalAttrs else fnOrAttrs;
+
+    # "11" -> "11.0.0.0", "1.2" -> "1.2.0.0".
+    pluginVersion = lib.concatStringsSep "." (
+      lib.take 4 (
+        lib.splitString "." finalAttrs.version
+        ++ [
+          "0"
+          "0"
+          "0"
+        ]
+      )
+    );
+  in
+  (removeAttrs args [
+    "meta"
+    "passthru"
+  ])
+  // {
+    dotnet-sdk = args.dotnet-sdk or dotnetCorePackages.sdk_9_0;
+    dotnet-runtime = args.dotnet-runtime or dotnetCorePackages.aspnetcore_9_0;
+
+    executables = [ ];
+
+    nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ yq-go ];
+
+    # Plugins hardcode 0.0.0.0 in Directory.Build.Props and rely on upstream's
+    # CI passing the real version.
+    dotnetBuildFlags = (args.dotnetBuildFlags or [ ]) ++ [ "-p:Version=${pluginVersion}" ];
+
+    postInstall = ''
+      buildYaml=$NIX_BUILD_TOP/source/build.yaml
+      if [[ ! -e $buildYaml ]]; then
+        echo "buildJellyfinPlugin: no build.yaml at the source root; this does not" >&2
+        echo "look like a Jellyfin plugin." >&2
+        exit 1
+      fi
+
+      if [[ $(yq -r '.version' "$buildYaml") != ${lib.escapeShellArg finalAttrs.version} ]]; then
+        echo "buildJellyfinPlugin: version is ${finalAttrs.version} but build.yaml" >&2
+        echo "declares $(yq -r '.version' "$buildYaml")." >&2
+        exit 1
+      fi
+
+      # A plugin needing a newer server than we package is skipped silently at
+      # startup, so an unattended bump would ship something that does nothing.
+      targetAbi="$(yq -r '.targetAbi' "$buildYaml")"
+      oldest="$(printf '%s\n%s\n' "$targetAbi" ${lib.escapeShellArg jellyfin.version} \
+        | sort --version-sort | head -1)"
+      if [[ $oldest != "$targetAbi" ]]; then
+        echo "buildJellyfinPlugin: this plugin needs Jellyfin $targetAbi or newer," >&2
+        echo "but nixpkgs has ${jellyfin.version}. Bump jellyfin first, or hold this" >&2
+        echo "plugin back: the server would skip it without any visible error." >&2
+        exit 1
+      fi
+
+      pluginDir="$out/lib/jellyfin/plugins/$(yq -r '.name' "$buildYaml")_${pluginVersion}"
+      mkdir -p "$pluginDir"
+
+      # A solution builds more assemblies than the plugin ships; the extras are
+      # libraries the server already provides.
+      readarray -t artifacts < <(yq -r '.artifacts[]' "$buildYaml")
+      for artifact in "''${artifacts[@]}"; do
+        mv "$out/lib/${finalAttrs.pname}/$artifact" "$pluginDir/"
+      done
+
+      # status and autoUpdate are ours: the assemblies are read-only store
+      # paths, so an in-place update can only fail.
+      VERSION=${lib.escapeShellArg pluginVersion} \
+        yq -o=json '{
+          "category": .category,
+          "description": .description,
+          "guid": .guid,
+          "name": .name,
+          "overview": .overview,
+          "owner": .owner,
+          "targetAbi": .targetAbi,
+          "version": strenv(VERSION),
+          "assemblies": .artifacts,
+          "status": "Active",
+          "autoUpdate": false,
+          "timestamp": "1970-01-01T00:00:00Z"
+        }' "$buildYaml" > "$pluginDir/meta.json"
+
+      rm -rf "$out/lib/${finalAttrs.pname}"
+    '';
+
+    passthru = {
+      updateScript = nix-update-script {
+        extraArgs = [ "--version-regex=v([0-9.]+)" ];
+      };
+    }
+    // (args.passthru or { });
+
+    meta = {
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.all;
+    }
+    // (args.meta or { });
+  }
+)

--- a/pkgs/by-name/je/jellyfin-plugin-dlna/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-dlna/nuget-deps.json
@@ -1,0 +1,262 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authorization",
+    "version": "8.0.10",
+    "hash": "sha256-VeUAe/OoV2zNDaiSKSv7tXR5barJzLbxS96DUb9bAz8="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Metadata",
+    "version": "8.0.10",
+    "hash": "sha256-SxnMOWJGgUUQyKaRezJQwMUt4eMfWjnhmfk8pldYGNA="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "2.0.0",
+    "hash": "sha256-Eg1MES40kzkGW9tZmjaKtbWI00Kbv7fLJQmjrigjxqk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "2.0.0",
+    "hash": "sha256-H1rEnq/veRWvmp8qmUsrQkQIcVlKilUNzmmKsxJ0md8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.2",
+    "hash": "sha256-cHpe8X2BgYa5DzulZfq24rg8O2K5Lmq2OiLhoyAVgJc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "2.0.0",
+    "hash": "sha256-EMvaXxGzueI8lT97bYJQr0kAj1IK0pjnAcWN82hTnzw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "8.0.2",
+    "hash": "sha256-AjcldddddtN/9aH9pg7ClEZycWtFHLi9IPe1GGhNQys="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "2.0.0",
+    "hash": "sha256-q44LtMvyNEKSvgERvA+BrasKapP92Sc91QR4u2TJ9/Y="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "8.0.0",
+    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-dlna/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-dlna/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildJellyfinPlugin,
+  fetchFromGitHub,
+}:
+
+buildJellyfinPlugin (finalAttrs: {
+  pname = "jellyfin-plugin-dlna";
+  version = "11";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-dlna";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2elz1x3+MDqPskqAcsH5iflB16+YClXK1b+D2oti0XA=";
+  };
+
+  projectFile = "Jellyfin.Plugin.Dlna.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  meta = {
+    description = "DLNA server plugin for Jellyfin";
+    longDescription = ''
+      Jellyfin served DLNA from its core until 10.9, which moved it out into
+      this plugin. It advertises the library over SSDP and streams to DLNA
+      renderers, transcoding when the device cannot play the source directly.
+    '';
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-dlna";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-dlna/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ clement-songis ];
+  };
+})

--- a/pkgs/by-name/je/jellyfin-plugin-ldapauth/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-ldapauth/nuget-deps.json
@@ -1,0 +1,242 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "5.0.0",
+    "hash": "sha256-jJtcchUS8Spt/GddcDtWa4lN1RAVQ2sxDnu1cgwa6vs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Novell.Directory.Ldap.NETStandard",
+    "version": "3.6.0",
+    "hash": "sha256-gXJimDjCeWzBOdrVBm/OTyHPcA5i+Q+/HqK6ZatiYrA="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "SerilogAnalyzer",
+    "version": "0.15.0",
+    "hash": "sha256-NG0osFNhuVIHDUOd3ZUpygSd0foH3C2QwECURL9nA00="
+  },
+  {
+    "pname": "SmartAnalyzers.MultithreadingAnalyzer",
+    "version": "1.1.31",
+    "hash": "sha256-UOhn4T8f5cql/ix8IHecvP6sHUkw2PmnmEfV0jPRZeI="
+  },
+  {
+    "pname": "StyleCop.Analyzers",
+    "version": "1.2.0-beta.556",
+    "hash": "sha256-97YYQcr5vZxTvi36608eUkA1wb6xllZQ7UcXbjrYIfU="
+  },
+  {
+    "pname": "StyleCop.Analyzers.Unstable",
+    "version": "1.2.0.556",
+    "hash": "sha256-aVop7a9r+X2RsZETgngBm3qQPEIiPBWgHzicGSTEymc="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-ldapauth/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-ldapauth/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildJellyfinPlugin,
+  fetchFromGitHub,
+}:
+
+buildJellyfinPlugin (finalAttrs: {
+  pname = "jellyfin-plugin-ldapauth";
+  version = "23";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-ldapauth";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-riRanyEFzEvDv09VY5r3Bs2rU2o/Ijsp687KRtnzkSU=";
+  };
+
+  projectFile = "LDAP-Auth.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  meta = {
+    description = "LDAP authentication provider for Jellyfin";
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-ldapauth";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-ldapauth/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ clement-songis ];
+  };
+})

--- a/pkgs/by-name/je/jellyfin-plugin-opensubtitles/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-opensubtitles/nuget-deps.json
@@ -1,0 +1,372 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "coverlet.collector",
+    "version": "6.0.4",
+    "hash": "sha256-ieiUl7G5pVKQ4V6rxhEe0ehep0/u1RBD3EAI63AQTI0="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "18.0.1",
+    "hash": "sha256-G6y5iyHZ3R2shlLCW/uTusio/UqcnWT79X+UAbxvDQY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "9.0.4",
+    "hash": "sha256-01yWDq/dHgU1Trx2OqVsXK/yobwVTClJXB07LrPc8lU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-5hwq73FCWAJJ8Yb1VHaaryJJhUUiVsetPTrPLlo8N9o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.4",
+    "hash": "sha256-l+qlHrdrqgvnveSMCO4qQx1QObAe5lMl80a4Kc3idzw="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.4",
+    "hash": "sha256-ck7PqIL/3vodYky+d7YX218n+detOoEjZeMr1EqTFPg="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-6WcGpsAYRhrpHloEom0oVP7Ff4Gh/O1XWJETJJ3LvEQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics",
+    "version": "9.0.4",
+    "hash": "sha256-fmRuxerdHGVDFFJMpBv9DIzofBSxjLLsi1GvaGq1dUc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-VgBfZLr/tqAOCW3i8g8lTgdpLU/g5vHfcOUpyoQESig="
+  },
+  {
+    "pname": "Microsoft.Extensions.Http",
+    "version": "9.0.4",
+    "hash": "sha256-gciOa0FAKivI5f/dzbsbS5HniIx9TJ4BTeBZ9In+fAo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.4",
+    "hash": "sha256-Vj+NGOamKeuMrLNUWlVKFFkz7IKGIv6h1A5X4CK9D5E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-n0ZRhQ7U/5Kv1hVqUXGoa5gfrhzcy77yFhfonjq6VFc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.4",
+    "hash": "sha256-QyjtRCG+L9eyH/UWHf/S+7/ZiSOmuGNoKGO9nlXmjxI="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "9.0.4",
+    "hash": "sha256-fhI6GGzVC5edaS/QEdl+2WL8/P6u/+wyq9nkLW17X64="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.4",
+    "hash": "sha256-v/Ygyo1TMTUbnhdQSV2wzD4FOgAEWd1mpESo3kZ557g="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "18.0.1",
+    "hash": "sha256-0c3/rp9di0w7E5UmfRh6Prrm3Aeyi8NOj5bm2i6jAh0="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "18.0.1",
+    "hash": "sha256-oJbS7SZ46RzyOQ+gCysW7qJRy7V8RlQVa5d8uajb91M="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "18.0.1",
+    "hash": "sha256-OXYf5vg4piDr10ve0bZ2ZSb+nb3yOiHayJV3cu5sMV4="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "SerilogAnalyzer",
+    "version": "0.15.0",
+    "hash": "sha256-NG0osFNhuVIHDUOd3ZUpygSd0foH3C2QwECURL9nA00="
+  },
+  {
+    "pname": "SmartAnalyzers.MultithreadingAnalyzer",
+    "version": "1.1.31",
+    "hash": "sha256-UOhn4T8f5cql/ix8IHecvP6sHUkw2PmnmEfV0jPRZeI="
+  },
+  {
+    "pname": "StyleCop.Analyzers",
+    "version": "1.1.118",
+    "hash": "sha256-CjC1f5z0sP15F6FeXqIDOtZLHqgjmQTzpsIrRkxXREI="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "8.0.0",
+    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "8.0.0",
+    "hash": "sha256-dQGC30JauIDWNWXMrSNOJncVa1umR1sijazYwUDdSIE="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  },
+  {
+    "pname": "xunit",
+    "version": "2.9.3",
+    "hash": "sha256-BPrpSbjlIB7PoH+ocCusqMDrMZgRQZSzeTeJzHK/I9c="
+  },
+  {
+    "pname": "xunit.abstractions",
+    "version": "2.0.3",
+    "hash": "sha256-0D1y/C34iARI96gb3bAOG8tcGPMjx+fMabTPpydGlAM="
+  },
+  {
+    "pname": "xunit.analyzers",
+    "version": "1.18.0",
+    "hash": "sha256-DOgamLnfi9Ua5IDm3JVm9MaOFbSSbmq5l8j2NPO3qd0="
+  },
+  {
+    "pname": "xunit.assert",
+    "version": "2.9.3",
+    "hash": "sha256-vHYOde8bd10pOmr7iTAYNtPlqHzsJl4x3t1DDuYdDCA="
+  },
+  {
+    "pname": "xunit.core",
+    "version": "2.9.3",
+    "hash": "sha256-qkVQ8Jw/LZWmxirkPOwiry7bvZn3IuaRzu/sp2H8anw="
+  },
+  {
+    "pname": "xunit.extensibility.core",
+    "version": "2.9.3",
+    "hash": "sha256-mcpVX+m0R7F0ev9CaBnbai9gtu4GVcqijEuRqe89D0g="
+  },
+  {
+    "pname": "xunit.extensibility.execution",
+    "version": "2.9.3",
+    "hash": "sha256-2rxMs2Dt4cAcmOFMwP5Yd3RpP0BnmiL8cXlKysXY0jw="
+  },
+  {
+    "pname": "xunit.runner.visualstudio",
+    "version": "3.1.5",
+    "hash": "sha256-O5657884QGldszsEWQFCDRTXViFBmZ4GGC+4iU+usSQ="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-opensubtitles/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-opensubtitles/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildJellyfinPlugin,
+  fetchFromGitHub,
+}:
+
+buildJellyfinPlugin (finalAttrs: {
+  pname = "jellyfin-plugin-opensubtitles";
+  version = "24";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-opensubtitles";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QkvZ/JAztkr1KwaQuVatPyN/eaWlXuUF18r8HvofAww=";
+  };
+
+  projectFile = "Jellyfin.Plugin.OpenSubtitles.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  meta = {
+    description = "Subtitle downloads from OpenSubtitles for Jellyfin";
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-opensubtitles";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-opensubtitles/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ clement-songis ];
+  };
+})

--- a/pkgs/by-name/je/jellyfin-plugin-reports/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-reports/nuget-deps.json
@@ -1,0 +1,252 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "ClosedXML",
+    "version": "0.104.2",
+    "hash": "sha256-eCp4vBv2ZlWhg+UA9rtU+0VQk1eQuRmVAM7w4HeVHdg="
+  },
+  {
+    "pname": "ClosedXML.Parser",
+    "version": "1.2.0",
+    "hash": "sha256-V0G2f6CJpKYnN/amC0P6/UJJNcgekwzr6NNpSb81Zmw="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "DocumentFormat.OpenXml",
+    "version": "3.1.1",
+    "hash": "sha256-Ae/OjAGkFU6QlS78eh6qrRJZ9lPRqayOdV/Ao1O178w="
+  },
+  {
+    "pname": "DocumentFormat.OpenXml.Framework",
+    "version": "3.1.1",
+    "hash": "sha256-nmmxTIrtTmROSWkufbfqljGVyl0junW9d1bcAKDr8Mo="
+  },
+  {
+    "pname": "ExcelNumberFormat",
+    "version": "1.1.0",
+    "hash": "sha256-xIrzBWCY2PEjIltpwW2BT1j/KJKOH2qPtvumX+NTZvE="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "RBush",
+    "version": "4.0.0",
+    "hash": "sha256-oq2zbVd/Sf6QPwsZ5vnTrvGK7jqDiyf6oJzwhY/2TCQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "SixLabors.Fonts",
+    "version": "1.0.0",
+    "hash": "sha256-kyAQcZZOdD50Lo7l7z8qnFMerJjlAV66HNBq7BI6TNM="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.IO.Packaging",
+    "version": "8.0.1",
+    "hash": "sha256-xf0BAfqQvITompBsvfpxiLts/6sRQEzdjNA3f/q/vY4="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-reports/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-reports/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildJellyfinPlugin,
+  fetchFromGitHub,
+}:
+
+buildJellyfinPlugin (finalAttrs: {
+  pname = "jellyfin-plugin-reports";
+  version = "18";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-reports";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FK2bbAId228ZEFKcQzVagH7g31XFfwDUAFKJhCsujfQ=";
+  };
+
+  projectFile = "Jellyfin.Plugin.Reports.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  meta = {
+    description = "Library and activity reports for Jellyfin";
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-reports";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-reports/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ clement-songis ];
+  };
+})

--- a/pkgs/by-name/je/jellyfin-plugin-trakt/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-trakt/nuget-deps.json
@@ -1,0 +1,292 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "9.0.4",
+    "hash": "sha256-01yWDq/dHgU1Trx2OqVsXK/yobwVTClJXB07LrPc8lU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-5hwq73FCWAJJ8Yb1VHaaryJJhUUiVsetPTrPLlo8N9o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.4",
+    "hash": "sha256-l+qlHrdrqgvnveSMCO4qQx1QObAe5lMl80a4Kc3idzw="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-6WcGpsAYRhrpHloEom0oVP7Ff4Gh/O1XWJETJJ3LvEQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics",
+    "version": "9.0.4",
+    "hash": "sha256-fmRuxerdHGVDFFJMpBv9DIzofBSxjLLsi1GvaGq1dUc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-VgBfZLr/tqAOCW3i8g8lTgdpLU/g5vHfcOUpyoQESig="
+  },
+  {
+    "pname": "Microsoft.Extensions.Http",
+    "version": "9.0.4",
+    "hash": "sha256-gciOa0FAKivI5f/dzbsbS5HniIx9TJ4BTeBZ9In+fAo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.4",
+    "hash": "sha256-Vj+NGOamKeuMrLNUWlVKFFkz7IKGIv6h1A5X4CK9D5E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-n0ZRhQ7U/5Kv1hVqUXGoa5gfrhzcy77yFhfonjq6VFc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.4",
+    "hash": "sha256-QyjtRCG+L9eyH/UWHf/S+7/ZiSOmuGNoKGO9nlXmjxI="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "9.0.4",
+    "hash": "sha256-fhI6GGzVC5edaS/QEdl+2WL8/P6u/+wyq9nkLW17X64="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.4",
+    "hash": "sha256-v/Ygyo1TMTUbnhdQSV2wzD4FOgAEWd1mpESo3kZ557g="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "SerilogAnalyzer",
+    "version": "0.15.0",
+    "hash": "sha256-NG0osFNhuVIHDUOd3ZUpygSd0foH3C2QwECURL9nA00="
+  },
+  {
+    "pname": "SmartAnalyzers.MultithreadingAnalyzer",
+    "version": "1.1.31",
+    "hash": "sha256-UOhn4T8f5cql/ix8IHecvP6sHUkw2PmnmEfV0jPRZeI="
+  },
+  {
+    "pname": "StyleCop.Analyzers",
+    "version": "1.2.0-beta.556",
+    "hash": "sha256-97YYQcr5vZxTvi36608eUkA1wb6xllZQ7UcXbjrYIfU="
+  },
+  {
+    "pname": "StyleCop.Analyzers.Unstable",
+    "version": "1.2.0.556",
+    "hash": "sha256-aVop7a9r+X2RsZETgngBm3qQPEIiPBWgHzicGSTEymc="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-trakt/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-trakt/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildJellyfinPlugin,
+  fetchFromGitHub,
+}:
+
+buildJellyfinPlugin (finalAttrs: {
+  pname = "jellyfin-plugin-trakt";
+  version = "30";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-trakt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jqHZnkkrJ11SQHllnwCqg8an7HPpEfyC4gVhiY9nPag=";
+  };
+
+  projectFile = "Trakt.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  meta = {
+    description = "Trakt.tv scrobbling and library sync for Jellyfin";
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-trakt";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-trakt/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ clement-songis ];
+  };
+})

--- a/pkgs/by-name/je/jellyfin-plugin-tvdb/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-tvdb/nuget-deps.json
@@ -1,0 +1,297 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "9.0.4",
+    "hash": "sha256-01yWDq/dHgU1Trx2OqVsXK/yobwVTClJXB07LrPc8lU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-5hwq73FCWAJJ8Yb1VHaaryJJhUUiVsetPTrPLlo8N9o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.4",
+    "hash": "sha256-l+qlHrdrqgvnveSMCO4qQx1QObAe5lMl80a4Kc3idzw="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-6WcGpsAYRhrpHloEom0oVP7Ff4Gh/O1XWJETJJ3LvEQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics",
+    "version": "9.0.4",
+    "hash": "sha256-fmRuxerdHGVDFFJMpBv9DIzofBSxjLLsi1GvaGq1dUc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-VgBfZLr/tqAOCW3i8g8lTgdpLU/g5vHfcOUpyoQESig="
+  },
+  {
+    "pname": "Microsoft.Extensions.Http",
+    "version": "9.0.4",
+    "hash": "sha256-gciOa0FAKivI5f/dzbsbS5HniIx9TJ4BTeBZ9In+fAo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.4",
+    "hash": "sha256-Vj+NGOamKeuMrLNUWlVKFFkz7IKGIv6h1A5X4CK9D5E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.4",
+    "hash": "sha256-n0ZRhQ7U/5Kv1hVqUXGoa5gfrhzcy77yFhfonjq6VFc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.4",
+    "hash": "sha256-QyjtRCG+L9eyH/UWHf/S+7/ZiSOmuGNoKGO9nlXmjxI="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "9.0.4",
+    "hash": "sha256-fhI6GGzVC5edaS/QEdl+2WL8/P6u/+wyq9nkLW17X64="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.4",
+    "hash": "sha256-v/Ygyo1TMTUbnhdQSV2wzD4FOgAEWd1mpESo3kZ557g="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "SerilogAnalyzer",
+    "version": "0.15.0",
+    "hash": "sha256-NG0osFNhuVIHDUOd3ZUpygSd0foH3C2QwECURL9nA00="
+  },
+  {
+    "pname": "SmartAnalyzers.MultithreadingAnalyzer",
+    "version": "1.1.31",
+    "hash": "sha256-UOhn4T8f5cql/ix8IHecvP6sHUkw2PmnmEfV0jPRZeI="
+  },
+  {
+    "pname": "StyleCop.Analyzers",
+    "version": "1.1.118",
+    "hash": "sha256-CjC1f5z0sP15F6FeXqIDOtZLHqgjmQTzpsIrRkxXREI="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "6.0.1",
+    "hash": "sha256-LuMllKUXb62Hiifu7uIU2mnJNj/HnDkQ5CCDt5uauzM="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  },
+  {
+    "pname": "Tvdb.Sdk",
+    "version": "4.7.10",
+    "hash": "sha256-gztGHgGp7wujW8RWWjAgmlKvxszWXdnI9lCwtodHuHI="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-tvdb/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-tvdb/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildJellyfinPlugin,
+  fetchFromGitHub,
+}:
+
+buildJellyfinPlugin (finalAttrs: {
+  pname = "jellyfin-plugin-tvdb";
+  version = "22";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-tvdb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3cTzCKKgvnwwdaCJv70qAl5j73hixM4cCKVr1KOLh5A=";
+  };
+
+  projectFile = "Jellyfin.Plugin.Tvdb.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  meta = {
+    description = "TheTVDB metadata provider for Jellyfin";
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-tvdb";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-tvdb/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ clement-songis ];
+  };
+})

--- a/pkgs/by-name/je/jellyfin-plugin-webhook/nuget-deps.json
+++ b/pkgs/by-name/je/jellyfin-plugin-webhook/nuget-deps.json
@@ -1,0 +1,297 @@
+[
+  {
+    "pname": "BitFaster.Caching",
+    "version": "2.5.4",
+    "hash": "sha256-PWuVT1kKjL8ulMtv9hWmg0nMChFh8skr34xUl3mQ0Y8="
+  },
+  {
+    "pname": "BouncyCastle.Cryptography",
+    "version": "2.6.2",
+    "hash": "sha256-Yjk2+x/RcVeccGOQOQcRKCiYzyx1mlFnhS5auCII+Ms="
+  },
+  {
+    "pname": "Diacritics",
+    "version": "4.0.17",
+    "hash": "sha256-O1pOeOV7c+dfD/EjwiOmqYhP5RDZyosVOk0OjVuK5Eg="
+  },
+  {
+    "pname": "Handlebars.Net",
+    "version": "2.1.6",
+    "hash": "sha256-NHYBsscfLmPXH9uU2dKM+NWGmVuWXtXx94D8FuvLgkA="
+  },
+  {
+    "pname": "ICU4N",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-1QyOgO7pNMeoEgBtl6o8IG4o91wD2hFUgRI0jM0ltxY="
+  },
+  {
+    "pname": "ICU4N.Transliterator",
+    "version": "60.1.0-alpha.356",
+    "hash": "sha256-RLNwQNVqNz8Omfb/mC/rzQWVq8c7uCnNdG2qi4xJmds="
+  },
+  {
+    "pname": "J2N",
+    "version": "2.0.0",
+    "hash": "sha256-YvtIWErlm2O49hg3lIRm5Ha8/owkQkfMudzuldC3EhA="
+  },
+  {
+    "pname": "Jellyfin.Common",
+    "version": "10.11.11",
+    "hash": "sha256-XaGWBWFAhr6ZmmqHhD6/ebMFLNNCIDb8Aw0kv5D5w5c="
+  },
+  {
+    "pname": "Jellyfin.Controller",
+    "version": "10.11.11",
+    "hash": "sha256-enOjeE3vQ/QgoDlS+nhFE0rZUheVFdOggt++IzjP1/4="
+  },
+  {
+    "pname": "Jellyfin.Data",
+    "version": "10.11.11",
+    "hash": "sha256-FSs4bQkEsz5kTuCNOibIeShVpg5q+KHD5/Bt2Q3yVw4="
+  },
+  {
+    "pname": "Jellyfin.Database.Implementations",
+    "version": "10.11.11",
+    "hash": "sha256-1FHO0T5G3uzS1KY3T97cp5BLo+F13OUhe5D5jZ/Ezio="
+  },
+  {
+    "pname": "Jellyfin.Extensions",
+    "version": "10.11.11",
+    "hash": "sha256-6o0Xa9wjO0f4b+7RXrK2UDfYE0RmKESRbtmWcapECTQ="
+  },
+  {
+    "pname": "Jellyfin.MediaEncoding.Keyframes",
+    "version": "10.11.11",
+    "hash": "sha256-GSJi2x8yo2pc+5zCShY0OXs2h3nHH16/bsqK3jYXQjg="
+  },
+  {
+    "pname": "Jellyfin.Model",
+    "version": "10.11.11",
+    "hash": "sha256-H4xLgcr9nXU9XItyAkiWusvLccke2f40raicJ4OQK+s="
+  },
+  {
+    "pname": "Jellyfin.Naming",
+    "version": "10.11.11",
+    "hash": "sha256-IvlwrWuTeyTM9P77oel1Y821L5g1FYXBH7mmGlHuT8A="
+  },
+  {
+    "pname": "MailKit",
+    "version": "4.16.0",
+    "hash": "sha256-4yyFxq8pJVTIgAJkyAYcuV2+/ZirENgUSk1OSD/gKIo="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "9.0.11",
+    "hash": "sha256-c5RiSd/QPerOYUueN8G4wcmJG8/TmOiJniYI9gf2j8Q="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-60/92aSe/qZcKqDOTf8uNBXea6/lqrjW2WnFSdvCTdk="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "9.0.11",
+    "hash": "sha256-hAiDz5WksFapSdV3N4Db7zAH7M+sBvEiO4I1BmQu+MY="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "9.0.11",
+    "hash": "sha256-mqsnHzVpFTlVyd/vLqAuM8Js0Q7CBJN2K8iYKmq/VXY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-+1PEeH8he6Yk0r/6UpQ69ej38vYtuVyS4JJdKEkrheQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.0.0",
+    "hash": "sha256-1fnNvp62KrviVwYlqVl1CbdaZVpCDah9eCZeNDGDbWM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.11",
+    "hash": "sha256-/ZHjoBvGkq5a6kNvqBTkz5JfBOu1zLFbuTMBsPXUYwY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "9.0.11",
+    "hash": "sha256-Luot2bOpYOV0uM+ISdOCvtN1/IjZarj6aBWT+OdjT/o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-bBvR5XeJpoim/4JUsDtp+z7GU2vx37NwjAjeXLc+Ycg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.11",
+    "hash": "sha256-worKwJgOouaOBOiwYIttp4jJQig7W9M3ZjPbv0f76Lk="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.11",
+    "hash": "sha256-A77to45DYqDT5vCHAa2RBqTVOKND1KdYTX3PCTd2shA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-7ybl+oJ7NkkOX3Ns7KAgaHy3CP2LvI1VBTJ9WbMIYC0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics",
+    "version": "9.0.11",
+    "hash": "sha256-uMx1pKHV76XTGrIpXQqoiEd4hEnUr77jmMiQ336Rvx0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-kbhGSCfsrhh+aCU2l2bUpC6/r2UL42khFVp8mMJdZtQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Http",
+    "version": "9.0.11",
+    "hash": "sha256-NEO01kc0eH4ZnPyMYO+hwEcllUesxf/xLXEGhj65pLM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.11",
+    "hash": "sha256-AGNOGjQ1xEM3ct5iM21TeaJ/zdLtt+UduTUUs5WQi1E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "9.0.11",
+    "hash": "sha256-hk1zL4wTkoix+681q7MC/B9VLThibu4L01Pj6ZtNy14="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.11",
+    "hash": "sha256-e7yi+sje07SUUxbZ6+ZjvcFMgUtpLZ8vz1KdPinF310="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "9.0.11",
+    "hash": "sha256-fF1WP/ul30X8lCXZ9Es6zDpzGzQZ+0uPH1wQnp9Dj84="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.11",
+    "hash": "sha256-T1t0dsPVxP0TrmXfPXsA+wZKgS7TecZXvRS261G+KY8="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "MimeKit",
+    "version": "4.16.0",
+    "hash": "sha256-yWGXVm+EHvBSsZlVHdWdD+rVwdf/5hHxsUfJMSd2Afo="
+  },
+  {
+    "pname": "MQTTnet",
+    "version": "4.3.7.1207",
+    "hash": "sha256-1XRXD9KztTiJGWjOjNBWeP26OV3/jbCZWFSt7Gt5Y3w="
+  },
+  {
+    "pname": "MQTTnet.Extensions.ManagedClient",
+    "version": "4.3.7.1207",
+    "hash": "sha256-Kbv6D2D/0HFzuMkIOj7WzKwBFqTn0UtXyHYL0VTd3hc="
+  },
+  {
+    "pname": "NEbml",
+    "version": "1.1.0.5",
+    "hash": "sha256-MrQLekP6z5y6rfqnCbLefkYv4Fm8di4HqZ/AiYTzBQ4="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "SerilogAnalyzer",
+    "version": "0.15.0",
+    "hash": "sha256-NG0osFNhuVIHDUOd3ZUpygSd0foH3C2QwECURL9nA00="
+  },
+  {
+    "pname": "SmartAnalyzers.MultithreadingAnalyzer",
+    "version": "1.1.31",
+    "hash": "sha256-UOhn4T8f5cql/ix8IHecvP6sHUkw2PmnmEfV0jPRZeI="
+  },
+  {
+    "pname": "StyleCop.Analyzers",
+    "version": "1.2.0-beta.556",
+    "hash": "sha256-97YYQcr5vZxTvi36608eUkA1wb6xllZQ7UcXbjrYIfU="
+  },
+  {
+    "pname": "StyleCop.Analyzers.Unstable",
+    "version": "1.2.0.556",
+    "hash": "sha256-aVop7a9r+X2RsZETgngBm3qQPEIiPBWgHzicGSTEymc="
+  },
+  {
+    "pname": "System.Formats.Asn1",
+    "version": "8.0.1",
+    "hash": "sha256-may/Wg+esmm1N14kQTG4ESMBi+GQKPp0ZrrBo/o6OXM="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Security.Cryptography.Pkcs",
+    "version": "8.0.1",
+    "hash": "sha256-KMNIkJ3yQ/5O6WIhPjyAIarsvIMhkp26A6aby5KkneU="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.11",
+    "hash": "sha256-eufG191lCpSBB471mXeOU/Osp1WAUZvCq+DoB+q9dyU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "9.0.11",
+    "hash": "sha256-9CynbdnW9sOSoP667Nj34AuWD0kzsTGRzY4PS/EK3hc="
+  }
+]

--- a/pkgs/by-name/je/jellyfin-plugin-webhook/package.nix
+++ b/pkgs/by-name/je/jellyfin-plugin-webhook/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildJellyfinPlugin,
+  fetchFromGitHub,
+}:
+
+buildJellyfinPlugin (finalAttrs: {
+  pname = "jellyfin-plugin-webhook";
+  version = "21";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = "jellyfin-plugin-webhook";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a51Ff9G5LP+obf0ELzV6VEXParwU3Jv9zbCF61cC3UY=";
+  };
+
+  projectFile = "Jellyfin.Plugin.Webhook.sln";
+  nugetDeps = ./nuget-deps.json;
+
+  meta = {
+    description = "Server event notifications over webhooks for Jellyfin";
+    homepage = "https://github.com/jellyfin/jellyfin-plugin-webhook";
+    changelog = "https://github.com/jellyfin/jellyfin-plugin-webhook/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ clement-songis ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -426,6 +426,7 @@ with pkgs;
     ;
 
   buildDotnetPackage = callPackage ../build-support/dotnet/build-dotnet-package { };
+  buildJellyfinPlugin = callPackage ../build-support/jellyfin/build-jellyfin-plugin { };
   fetchNuGet = callPackage ../build-support/dotnet/fetchnuget { };
 
   fetchbzr = callPackage ../build-support/fetchbzr { };


### PR DESCRIPTION
Adds `services.jellyfin.plugins`, closing the gap described in #551935.

**Depends on #551937** — the branch contains its commits, because the NixOS test
needs a packaged plugin to load. Review the top commit only; rebase once the
package lands.

Plugin assemblies are symlinked from the store, but `meta.json` is copied. That
is not a stylistic choice: `PluginManager.CreatePluginInstance` rewrites the
manifest while instantiating a plugin, and `File.WriteAllText` on a store path
throws an `UnauthorizedAccessException` that aborts the whole server startup
rather than skipping the plugin. The first version of this PR symlinked the
directory wholesale and the NixOS test caught it as `[FTL] Main: Error while
starting server`.

The rewrite is also unavoidable, since the guard reads:

```csharp
if (string.Equals(manifest.Version, pluginStr, StringComparison.Ordinal)
    || !manifest.Id.Equals(instance.Id))
```

i.e. it fires precisely when the shipped manifest is correct.

Directories created by the module carry a `.nix-jellyfin-plugin` marker, so a
plugin removed from the configuration is cleaned up on the next start while a
plugin installed from Jellyfin's catalogue is left alone. The test covers both.

### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Notify maintainers

@minijackson @fsnkty
