### PR TITLE
scion: 0.12.0 -> 0.15.1

### DIFF
--- a/pkgs/by-name/sc/scion/package.nix
+++ b/pkgs/by-name/sc/scion/package.nix
@@ -4,25 +4,32 @@
   fetchFromGitHub,
   nix-update-script,
   nixosTests,
+  ciMode ? true, # Override to false to run time-sensitive tests locally
 }:
 buildGoModule (finalAttrs: {
   pname = "scion";
 
-  version = "0.12.0";
+  version = "0.15.1";
 
   src = fetchFromGitHub {
     owner = "scionproto";
     repo = "scion";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-J51GIQQhS623wFUU5dI/TwT2rkDH69518lpdCLZ/iM0=";
+    hash = "sha256-UQgCjX9xYClsBviNwCmxHXAJ7MNce7olpzaCM2ybuc0=";
   };
 
-  vendorHash = "sha256-Ew/hQM8uhaM89sCcPKUBbiGukDq3h5x+KID3w/8BDHg=";
+  __structuredAttrs = true;
+
+  # Tests bind to localhost
+  __darwinAllowLocalNetworking = true;
+
+  vendorHash = "sha256-A9K2/bWYUdMA8ypSisxk4NMOavHz51FaHEaxahz+0ek=";
 
   excludedPackages = [
     "acceptance"
     "demo"
     "tools"
+    "private/underlay/ebpf"
     "pkg/private/xtest/graphupdater"
   ];
 
@@ -37,6 +44,11 @@ buildGoModule (finalAttrs: {
   '';
 
   doCheck = true;
+
+  # Upstream disables time-sensitive tests and adjusts timeouts in CI
+  preCheck = lib.optionalString ciMode ''
+    export CI=42
+  '';
 
   tags = [ "sqlite_mattn" ];
 


### PR DESCRIPTION
Diff: https://github.com/scionproto/scion/compare/v0.12.0...v0.15.1

- Exclude `private/underlay/ebpf` from build, which requires development build mode.
- Set `__structuredAttrs`
- Set `__darwinAllowLocalNetworking`, for tests
- Upstream adjusts the test suite with longer timeouts[^1] and excluding a
time-sensitive test (`TestAcceptLoopParallelism`[^2]) when running in CI, which
it detects by checking the environment for the presence of the `CI`
environment variable.  Parameterize this via `ciMode` attr, which the
caller can override if they wish to build and run the tests locally.

[^1]: https://github.com/scionproto/scion/blob/bb10ec5e2e60c2691ae4e93f821f66e93272688a/pkg/grpc/dialer_test.go#L128-L130
[^2]: https://github.com/scionproto/scion/blob/bb10ec5e2e60c2691ae4e93f821f66e93272688a/pkg/snet/squic/net_test.go#L43-L46


See https://github.com/NixOS/nixpkgs/pull/460012#issuecomment-3508040671
Tests seem to be working ok now.

Ref: https://github.com/ngi-nix/projects/issues/73

This work is done as part of Summer of Nix 2026.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
