### PR TITLE
open-policy-agent: fix darwin build

### DIFF
--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -16,6 +16,9 @@ buildGoModule (finalAttrs: {
   pname = "open-policy-agent";
   version = "1.16.2";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
@@ -68,6 +71,19 @@ buildGoModule (finalAttrs: {
         "TestClientTLSWithCustomCACert"
         "TestECR"
         "TestManagerWithOPATelemetryUpdateLoop"
+
+        # tests observed to have `no space left on device` failures on darwin on hydra
+        # storage_internal_error:
+        #   cannot create memtable error:
+        #     newMemTable error:
+        #       While opening memtable: /private/tmp/nix-build-open-policy-agent-X.Y.Z.drv-0/opa_test0000000000/data/00001.mem error:
+        #         while opening file: /private/tmp/nix-build-open-policy-agent-X.Y.Z.drv-0/opa_test0000000000/data/00001.mem error:
+        #           truncate /private/tmp/nix-build-open-policy-agent-X.Y.Z.drv-0/opa_test0000000000/data/00001.mem: no space left on device
+        "TestBundleScope"
+        "TestDataV1"
+        "TestDataV1Metrics"
+        "TestDataMetricsEval"
+        "TestQueryV1"
       ]
       ++ lib.optionals (!enableWasmEval) [
         "TestRegoTargetWasmAndTargetPluginDisablesIndexingTopdownStages"
@@ -84,11 +100,6 @@ buildGoModule (finalAttrs: {
       getGoDirs() {
         go list ./... | grep -v -e e2e ${lib.optionalString stdenv.hostPlatform.isDarwin "-e wasm"}
       }
-    ''
-    # remove tests that have "too many open files"/"no space left on device" issues on darwin in hydra
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      rm v1/server/server_test.go
-      rm v1/server/server_bench_test.go
     '';
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''


### PR DESCRIPTION
Skip specific tests rather than deleting the files as it causes compile
errors in the tests.

Replaces #525667

Draft until nixpkgs-review on GHA finishes

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
