### PR TITLE
nixos/prometheus-exporters/yace: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -110,6 +110,8 @@
 
 - [Rundeck](https://www.rundeck.com), Self-Service Operations [services.rundeck](#opt-services.rundeck.enable).
 
+- [yet-another-cloudwatch-exporter](https://github.com/prometheus-community/yet-another-cloudwatch-exporter), a Prometheus exporter for AWS CloudWatch metrics. Available as [services.prometheus.exporters.yace](#opt-services.prometheus.exporters.yace.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -135,6 +135,7 @@ let
         "varnish"
         "wireguard"
         "xray"
+        "yace"
         "zfs-siebenmann"
         "zfs"
       ]

--- a/nixos/modules/services/monitoring/prometheus/exporters/yace.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/yace.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.yace;
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    escapeShellArg
+    concatStringsSep
+    getExe
+    ;
+in
+{
+  port = 5000;
+  extraOpts = {
+    configFile = mkOption {
+      type = types.path;
+      description = ''
+        Path to the YACE configuration file, defining which CloudWatch
+        metrics to scrape. See
+        <https://github.com/prometheus-community/yet-another-cloudwatch-exporter#configuration>
+        for the format. AWS credentials are supplied separately via the
+        environment (see {option}`environmentFile`, an IMDS instance role,
+        or the usual `AWS_*` variables).
+      '';
+    };
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/yace.env";
+      description = ''
+        Path to an environment file, as defined in {manpage}`systemd.exec(5)`,
+        used to pass AWS credentials (e.g. `AWS_ACCESS_KEY_ID`,
+        `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) to the exporter without exposing
+        them in the world-readable Nix store. Not needed on EC2 with an IMDS
+        instance role.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+      ExecStart = concatStringsSep " " (
+        [
+          (getExe pkgs.yet-another-cloudwatch-exporter)
+          "--config.file ${escapeShellArg cfg.configFile}"
+          "--listen-address ${cfg.listenAddress}:${toString cfg.port}"
+        ]
+        ++ cfg.extraFlags
+      );
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -2141,6 +2141,30 @@ let
         '';
       };
 
+    yace =
+      { pkgs, ... }:
+      {
+        exporterConfig = {
+          enable = true;
+          configFile = pkgs.writeText "yace-config.yml" ''
+            apiVersion: v1alpha1
+            sts-region: us-east-1
+            discovery:
+              jobs:
+                - type: AWS/EC2
+                  regions: [us-east-1]
+                  metrics:
+                    - name: CPUUtilization
+                      statistics: [Average]
+          '';
+        };
+        exporterTest = ''
+          wait_for_unit("prometheus-yace-exporter.service")
+          wait_for_open_port(5000)
+          succeed("curl -sSf http://localhost:5000/metrics")
+        '';
+      };
+
     zfs =
       { ... }:
       {


### PR DESCRIPTION
Adds a NixOS module `services.prometheus.exporters.yace` for [yet-another-cloudwatch-exporter](https://github.com/prometheus-community/yet-another-cloudwatch-exporter) (the package itself landed in #547172), wiring it into the standard `services.prometheus.exporters` framework — systemd unit, dedicated user/group, and firewall options.

Options:
- `configFile` (required) — path to the YACE config defining which CloudWatch metrics to scrape.
- `environmentFile` (optional) — supplies AWS credentials via a systemd `EnvironmentFile`, keeping them out of the world-readable Nix store. Not needed on EC2 with an IMDS instance role.
- Standard framework options (`port`, default `5000`; `listenAddress`; `openFirewall`; `extraFlags`; …).

Includes a hermetic NixOS test in `nixos/tests/prometheus-exporters.nix` that boots the exporter with a dummy config and asserts `/metrics` serves on port 5000.

> Disclosure: this pull request summary was drafted with assistance from Claude Code (Claude Opus 4.8). All changes were reviewed and tested by me, and the commit carries an `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests) — the new `yace` case boots the exporter with a dummy config and asserts `/metrics` on port 5000; passing on x86_64-linux.
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review#usage) on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` — the NixOS test starts `prometheus-yace-exporter.service` and confirms it serves metrics.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
