### PR TITLE
pictogrep: init at 0.4.2 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28730,6 +28730,11 @@
     githubId = 1618946;
     name = "Tiago Castro";
   };
+  tiagohierath = {
+    github = "tiagohierath";
+    githubId = 84463665;
+    name = "Tiago Hierath";
+  };
   tie = {
     name = "Ivan Trubach";
     email = "mr.trubach@icloud.com";

--- a/pkgs/by-name/pi/pictogrep/package.nix
+++ b/pkgs/by-name/pi/pictogrep/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildGoModule,
+  copyDesktopItems,
+  fetchFromGitHub,
+  makeDesktopItem,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pictogrep";
+  version = "0.4.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tiagohierath";
+    repo = "pictogrep";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sheiEParjSb+P6LY1/p32umNztB2mMaZ1ESzdzKmZmg=";
+  };
+
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  postInstall = ''
+    install -Dm644 assets/pictogrep.png \
+      $out/share/icons/hicolor/512x512/apps/pictogrep.png
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "pictogrep";
+      desktopName = "Pictogrep";
+      comment = finalAttrs.meta.description;
+      exec = "pictogrep";
+      icon = "pictogrep";
+      categories = [
+        "Graphics"
+        "Photography"
+      ];
+      keywords = [
+        "images"
+        "search"
+        "storyboard"
+      ];
+    })
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Find local pictures using natural-language descriptions";
+    homepage = "https://github.com/tiagohierath/pictogrep";
+    changelog = "https://github.com/tiagohierath/pictogrep/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tiagohierath ];
+    mainProgram = "pictogrep";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/pi/pictogrep/package.nix
+++ b/pkgs/by-name/pi/pictogrep/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   copyDesktopItems,
   fetchFromGitHub,
+  fetchpatch2,
   makeDesktopItem,
   testers,
 }:
@@ -21,6 +22,14 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = null;
+
+  patches = [
+    (fetchpatch2 {
+      name = "protect-local-server-from-cross-origin-requests.patch";
+      url = "https://github.com/tiagohierath/pictogrep/commit/24170e8921b6422b0b287edfea19df0c5bec105f.patch?full_index=1";
+      hash = "sha256-3oA5MNPLuOaFJ43a+jzQ6qE0oT1cy1PoyJJi41iEhfo=";
+    })
+  ];
 
   ldflags = [
     "-s"
@@ -62,7 +71,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Find local pictures using natural-language descriptions";
-    homepage = "https://github.com/tiagohierath/pictogrep";
+    homepage = "https://navylily.tv/pictogrep";
     changelog = "https://github.com/tiagohierath/pictogrep/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tiagohierath ];


### PR DESCRIPTION

  Adds Pictogrep 0.4.2 as a new package.

  [Pictogrep](https://navylily.tv/pictogrep) is a local desktop application for finding, organizing, and storyboarding
  pictures using filenames and natural-language descriptions.

  The package:

  - Builds from the tagged v0.4.2 source with a fixed hash.
  - Backports the upstream local-request security hardening from [pictogrep@24170e8](https://github.com/tiagohierath/
  pictogrep/commit/24170e8921b6422b0b287edfea19df0c5bec105f).
  - Installs the executable, desktop entry, application icon, and license metadata.
  - Includes a `passthru.tests.version` package test.
  - Detects Nix installations and directs application updates through the package manager.

  Semantic model assets are downloaded and cached on first use; image analysis and searching happen locally.

  Release: https://github.com/tiagohierath/pictogrep/releases/tag/v0.4.2

  Additional verification:

  - `nixpkgs-vet`: passed
  - ARM64 Linux cross-build: passed
  - ARM64 executable smoke-tested under QEMU
  - Reproducibility rebuild: passed
  - Desktop entry validation: passed
  - Nix sandboxing enabled

  Automation disclosure: This package expression and pull request text were prepared with assistance from OpenAI Codex
  (GPT-5.6) and manually reviewed and understood by the contributor.

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [x] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test