### PR TITLE
readline, readline70: enable structuredAttrs, modernize

### DIFF
--- a/pkgs/development/libraries/readline/7.0.nix
+++ b/pkgs/development/libraries/readline/7.0.nix
@@ -5,12 +5,12 @@
   ncurses,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "readline";
-  version = "7.0p${toString (builtins.length upstreamPatches)}";
+  version = "7.0p${toString (builtins.length finalAttrs.upstreamPatches)}";
 
   src = fetchurl {
-    url = "mirror://gnu/readline/readline-${meta.branch}.tar.gz";
+    url = "mirror://gnu/readline/readline-${finalAttrs.meta.branch}.tar.gz";
     sha256 = "0d13sg9ksf982rrrmv5mb6a2p4ys9rvg9r71d6il0vr8hmql63bm";
   };
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       patch =
         nr: sha256:
         fetchurl {
-          url = "mirror://gnu/readline/readline-${meta.branch}-patches/readline70-${nr}";
+          url = "mirror://gnu/readline/readline-${finalAttrs.meta.branch}-patches/readline70-${nr}";
           inherit sha256;
         };
     in
@@ -43,9 +43,11 @@ stdenv.mkDerivation rec {
     ./link-against-ncurses.patch
     ./no-arch_only-6.3.patch
   ]
-  ++ upstreamPatches;
+  ++ finalAttrs.upstreamPatches;
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-std=gnu17";
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_COMPILE = "-std=gnu17";
+  };
 
   __structuredAttrs = true;
 
@@ -76,4 +78,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     branch = "7.0";
   };
-}
+})

--- a/pkgs/development/libraries/readline/7.0.nix
+++ b/pkgs/development/libraries/readline/7.0.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-std=gnu17";
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for interactive line editing";
 

--- a/pkgs/development/libraries/readline/8.3.nix
+++ b/pkgs/development/libraries/readline/8.3.nix
@@ -97,6 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/lib/libreadline.so* $out/lib/libreadline.so
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Library for interactive line editing";
 


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

No changes in the CA hashes of the outputs of either package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
