### PR TITLE
docbook-xml: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -23,12 +23,15 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   unpackPhase = ''
+    runHook preUnpack
     mkdir -p $out/xml/dtd/docbook
     cd $out/xml/dtd/docbook
     unpackFile $src
+    runHook postUnpack
   '';
 
   installPhase = ''
+    runHook preInstall
     find . -type f -exec chmod -x {} \;
     runHook postInstall
   '';

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ unzip ];
   propagatedNativeBuildInputs = [ findXMLCatalogs ];
 
+  strictDeps = true;
+
   unpackPhase = ''
     mkdir -p $out/xml/dtd/docbook
     cd $out/xml/dtd/docbook

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     branch = version;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
