### PR TITLE
unzip: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   bzip2,
+  bashNonInteractive,
   enableNLS ? false,
   libnatspec,
 }:
@@ -71,7 +72,13 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ bzip2 ];
-  buildInputs = [ bzip2 ] ++ lib.optional enableNLS libnatspec;
+  buildInputs = [
+    bashNonInteractive # for zipgrep shebang
+    bzip2
+  ]
+  ++ lib.optional enableNLS libnatspec;
+
+  strictDeps = true;
 
   makefile = "unix/Makefile";
 

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -8,12 +8,12 @@
   libnatspec,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "unzip";
   version = "6.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/infozip/unzip${lib.replaceStrings [ "." ] [ "" ] version}.tar.gz";
+    url = "mirror://sourceforge/infozip/unzip${lib.replaceString "." "" finalAttrs.version}.tar.gz";
     sha256 = "0dxx11knh3nk95p2gg2ak777dd11pr7jx5das2g49l262scrcv83";
   };
 
@@ -112,6 +112,8 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "http://www.info-zip.org";
     description = "Extraction utility for archives compressed in .zip format";
@@ -120,4 +122,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ RossComputerGuy ];
     mainProgram = "unzip";
   };
-}
+})

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://sourceforge/infozip/unzip${lib.replaceString "." "" finalAttrs.version}.tar.gz";
-    sha256 = "0dxx11knh3nk95p2gg2ak777dd11pr7jx5das2g49l262scrcv83";
+    hash = "sha256-A22WmRZG0ESe0KqVLk++IbR2zplKvCduSdMOaGcIvTc=";
   };
 
   hardeningDisable = [


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
