### PR TITLE
net-tools: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -5,13 +5,13 @@
   fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "net-tools";
   version = "2.10";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-smJDWlJB6Jv6UcPKvVEzdTlS96e3uT8y4Iy52W9YDWk=";
+    url = "mirror://sourceforge/net-tools/net-tools-${finalAttrs.version}.tar.xz";
+    hash = "sha256-smJDWlJB6Jv6UcPKvVEzdTlS96e3uT8y4Iy52W9YDWk=";
   };
 
   patches = [
@@ -46,10 +46,12 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "http://net-tools.sourceforge.net/";
     description = "Set of tools for controlling the network subsystem in Linux";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
     "man"
   ];
 
+  strictDeps = true;
+
   meta = {
     homepage = "http://net-tools.sourceforge.net/";
     description = "Set of tools for controlling the network subsystem in Linux";


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
