### PR TITLE
nixos/pihole-ftl: make list setup idempotent

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl-setup-script.nix
+++ b/nixos/modules/services/networking/pihole-ftl-setup-script.nix
@@ -41,7 +41,7 @@ in
   any_failed=0
 
   addList() {
-    local payload="$1" result type error
+    local payload="$1" result type id error
 
     echo "Adding list: $payload"
     type=$($jq -r '.type' <<< "$payload")
@@ -49,17 +49,25 @@ in
 
     error="$($jq '.error' <<< "$result")"
     if [[ "$error" != "null" ]]; then
-        echo "Error: $error"
-        any_failed=1
+      if $jq -e '
+        .error.key == "database_error"
+        and .error.hint == "The item is already present"
+      ' <<< "$result" > /dev/null; then
+        echo "List already present"
         return
+      fi
+
+      echo "Error: $error"
+      any_failed=1
+      return
     fi
 
     id="$($jq '.lists.[].id?' <<< "$result")"
     if [[ "$id" == "null" ]]; then
-        any_failed=1
-        error="$($jq '.processed.errors.[].error' <<< "$result")"
-        echo "Error: $error"
-        return
+      any_failed=1
+      error="$($jq '.processed.errors.[].error' <<< "$result")"
+      echo "Error: $error"
+      return
     fi
 
     echo "Added list ID $id: $result"


### PR DESCRIPTION
The `pihole-ftl-setup` service attempts to add every configured list on each invocation. Pi-hole returns a `database_error` when a list already exists, causing the oneshot service to exit unsuccessfully even though the configured state is already satisfied.

Treat only the explicit `database_error` response with the hint `The item is already present` as success. Other API and database errors continue to make the setup service fail.

Tested on aarch64 and x86_64 NixOS Pi-hole hosts:

- Ran the generated setup script twice with six existing lists.
- Both runs exited with status 0.
- All duplicate lists were reported as already present.
- Verified that a malformed gravity database still results in failure.
- Verified gravity database integrity and DNS operation after recovery.

Assisted-by: OpenAI Codex (GPT-5)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test