### PR TITLE
lasuite-meet: 1.25.2 -> 1.26.0

### DIFF
--- a/pkgs/by-name/la/lasuite-meet/frontend.nix
+++ b/pkgs/by-name/la/lasuite-meet/frontend.nix
@@ -17,7 +17,7 @@ buildNpmPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-PArNKjdLqKJSEEKe94mguzKiNSwpYk56inenU3GL1mI=";
+    hash = "sha256-ZvdfLM0GlIZPaKbpDK9ymSgARVMsJE+cop8lKq3R7fE=";
   };
   npmBuildScript = "build";
 

--- a/pkgs/by-name/la/lasuite-meet/mail.nix
+++ b/pkgs/by-name/la/lasuite-meet/mail.nix
@@ -22,7 +22,7 @@ buildNpmPackage (finalAttrs: {
     pname = "${finalAttrs.pname}-npm-deps";
     inherit version src;
     inherit (finalAttrs) sourceRoot;
-    hash = "sha256-rqtLjMp0nCfo1wDAeB5WxVtmL/TR3Ky3qaMaBohnH1M=";
+    hash = "sha256-Ojk0giCc7tTFAGOIisirMywfe5j7JCKoTnWGk/hR+U8=";
   };
   npmBuildScript = "build";
 

--- a/pkgs/by-name/la/lasuite-meet/package.nix
+++ b/pkgs/by-name/la/lasuite-meet/package.nix
@@ -6,13 +6,13 @@
   python3,
 }:
 let
-  version = "1.25.2";
+  version = "1.26.0";
 
   src = fetchFromGitHub {
     owner = "suitenumerique";
     repo = "meet";
     tag = "v${version}";
-    hash = "sha256-gtChKd6sr2nHEmi0Z/nbuCCNsOD8iVIAFjqonZFgQ/Y=";
+    hash = "sha256-WiyVSqkyKDXYYPvzcA/fHcxQJrUThNGfNu+z/KcHK3g=";
   };
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/suitenumerique/meet/compare/v1.25.2...v1.26.0

Changelog: https://github.com/suitenumerique/meet/blob/v1.26.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
