### PR TITLE
 probe-rs-tools: Update only udev rules; 054a0b1 -> 9cc4b7d

### DIFF
--- a/pkgs/by-name/pr/probe-rs-tools/package.nix
+++ b/pkgs/by-name/pr/probe-rs-tools/package.nix
@@ -10,17 +10,16 @@
   openssl,
   stdenv,
 }:
-
-let
-  # udev rules are in another unversioned repo
-  udevRules = fetchurl {
-    url = "https://raw.githubusercontent.com/probe-rs/webpage/054a0b16831593091a8a5624d0e2305573e860ee/public/files/69-probe-rs.rules";
-    hash = "sha256-yjxld5ebm2jpfyzkw+vngBfHu5Nfh2ioLUKQQDY4KYo=";
-  };
-in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "probe-rs-tools";
   version = "0.32.0";
+
+  # udev rules are in another unversioned repo
+  udevRules = fetchurl {
+    # Last updated 2026-08-10
+    url = "https://raw.githubusercontent.com/probe-rs/webpage/9cc4b7d0727cc1ad0b87d5999aa9cdbfd8021632/public/files/69-probe-rs.rules";
+    hash = "sha256-JvH56IOapIIaT1gD9XCd/mdgrha3VVNSjneVDdebnoI=";
+  };
 
   src = fetchFromGitHub {
     owner = "probe-rs";
@@ -47,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   postInstall = ''
-    install -D -m 444 ${udevRules} $out/etc/udev/rules.d/69-probe-rs.rules
+    install -D -m 444 $udevRules $out/etc/udev/rules.d/69-probe-rs.rules
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd probe-rs \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The `probe-rs-tools` depends on two external repos:  The main one for the tool, and a separate one which contains the udev rules.  This change updates (only) the udev rules from commit 054a0b1 to 9cc4b7d.  [You can see the diff of the file here](https://github.com/probe-rs/webpage/compare/054a0b1...9cc4b7d#diff-79684c7189af38a7ef05816c75c36089cdbcfcfdb2c10103ffaf94f3a94d69e7).  Note that only the linked file (`public/files/69-probe-rs.rules`) is pulled into this package.

Additionally, this change moves the fetcher of this file from a `let` into the attributes of the package, making it easier for users to override the udev rules without needing to rewrite the package.

Tagging package maintainers @newAM and @xgroleau 

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
