### PR TITLE
[26.05] python3Packages.pymdown-extensions: 10.21.2 -> 10.21.3

### DIFF
--- a/pkgs/development/python-modules/pymdown-extensions/default.nix
+++ b/pkgs/development/python-modules/pymdown-extensions/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   hatchling,
   pytestCheckHook,
   markdown,
@@ -45,15 +46,34 @@ let
 in
 buildPythonPackage rec {
   pname = "pymdown-extensions";
-  version = "10.21.2";
+  version = "10.21.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "facelessuser";
     repo = "pymdown-extensions";
     tag = version;
-    hash = "sha256-BKnrq8m+xQYZs6V+x+3al7yS8531UvvaC4V+ny+f+Qg=";
+    hash = "sha256-hu9fXjZxlris3AhPS7bz3kcSyQtSeh0B6ZAZBsCO4+g=";
   };
+
+  patches = [
+    # Remove when updating to 11.0.0 or later.
+    (fetchpatch2 {
+      name = "CVE-2026-61632.patch";
+      url = "https://github.com/facelessuser/pymdown-extensions/commit/edce35586d11a1ef78bb187bc60497fe6dbf3b64.patch?full_index=1";
+      hash = "sha256-0J/ruQG73Lku/z+lFnb8XWT5WK+psiJyHq3/3ezUY8k=";
+    })
+    # Remove when updating to 11.0.1 or later.
+    (fetchpatch2 {
+      name = "CVE-2026-67422.patch";
+      url = "https://github.com/facelessuser/pymdown-extensions/commit/c68498598d7b13011bb4571350b6e3612a4ce44b.patch?full_index=1";
+      excludes = [
+        "docs/src/markdown/about/changelog.md"
+        "pymdownx/__meta__.py"
+      ];
+      hash = "sha256-r69jhMjTR/1oeSLifjZzG+wXYceSlkUk0KIPsGkOi1E=";
+    })
+  ];
 
   build-system = [ hatchling ];
 


### PR DESCRIPTION
Backports the `pymdown-extensions` security fixes from #550702 to `release-26.05` while retaining the 10.x series.

Closes #544177
Addresses #550210
Addresses #550212

[10.21.3 changelog](https://github.com/facelessuser/pymdown-extensions/blob/10.21.3/docs/src/markdown/about/changelog.md)

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
