### PR TITLE
libpfm: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/li/libpfm/package.nix
+++ b/pkgs/by-name/li/libpfm/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Helper library to program the performance monitoring events";
     longDescription = ''

--- a/pkgs/by-name/li/libpfm/package.nix
+++ b/pkgs/by-name/li/libpfm/package.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = lib.optional stdenv.hostPlatform.isMinGW windows.libgnurx;
 
+  strictDeps = true;
+
   meta = {
     description = "Helper library to program the performance monitoring events";
     longDescription = ''

--- a/pkgs/by-name/li/libpfm/package.nix
+++ b/pkgs/by-name/li/libpfm/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://sourceforge/perfmon2/libpfm4/libpfm-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-0YuXdkx1VSjBBR03bjNUXQ62DG6/hWgENoE/pbBMw9E=";
+    hash = "sha256-0YuXdkx1VSjBBR03bjNUXQ62DG6/hWgENoE/pbBMw9E=";
   };
 
   # Don't install libpfm.so on windows as it doesn't exist
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   # See: https://github.com/NixOS/nixpkgs/pull/252982#discussion_r1314346216
   postPatch = ''
     substituteInPlace config.mk examples/Makefile \
-      --replace '($(SYS),WINDOWS)' '($(SYS),Windows)'
+      --replace-fail '($(SYS),WINDOWS)' '($(SYS),Windows)'
   '';
 
   makeFlags = [
@@ -33,8 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
     "SYS=${stdenv.hostPlatform.uname.system}"
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error";
-  env.CONFIG_PFMLIB_SHARED = if enableShared then "y" else "n";
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+    CONFIG_PFMLIB_SHARED = if enableShared then "y" else "n";
+  };
 
   buildInputs = lib.optional stdenv.hostPlatform.isMinGW windows.libgnurx;
 


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
