### PR TITLE
getopt: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/ge/getopt/package.nix
+++ b/pkgs/by-name/ge/getopt/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
     "CC:=$(CC)"
   ];
 
+  __structuredAttrs = true;
+
   meta = {
     platforms = lib.platforms.unix;
     homepage = "http://frodo.looijaard.name/project/getopt";

--- a/pkgs/by-name/ge/getopt/package.nix
+++ b/pkgs/by-name/ge/getopt/package.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
   # attempt to use C library functions without declaring them, which is raised as an error.
   env.NIX_CFLAGS_COMPILE = "-D__GNU_LIBRARY__";
 
+  strictDeps = true;
+
   makeFlags = [
     "WITHOUT_GETTEXT=1"
     "LIBCGETOPT=0"


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
