### PR TITLE
flex, flex_2_5_35: enable strictDeps, enable structuredAttrs, modernize

### DIFF
--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ m4 ];
 
+  strictDeps = true;
+
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     ac_cv_func_malloc_0_nonnull=yes
     ac_cv_func_realloc_0_nonnull=yes

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -10,13 +10,13 @@
   m4,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "flex";
   version = "2.5.35";
 
   src = fetchurl {
     url = "https://github.com/westes/flex/archive/flex-${
-      lib.replaceStrings [ "." ] [ "-" ] version
+      lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     }.tar.gz";
     sha256 = "0wh06nix8bd4w1aq4k2fbbkdq5i30a9lxz3xczf3ff28yy0kfwzm";
   };
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails 2 out of 46 tests
 
+  __structuredAttrs = true;
+
   meta = {
     branch = "2.5.35";
     homepage = "https://flex.sourceforge.net/";
@@ -56,4 +58,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://github.com/westes/flex/archive/flex-${
       lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     }.tar.gz";
-    sha256 = "0wh06nix8bd4w1aq4k2fbbkdq5i30a9lxz3xczf3ff28yy0kfwzm";
+    hash = "sha256-9XM3gfdIODfcZ338TpMCIxbc5lpOTIJV4KQt1KM1AHI=";
   };
 
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -54,6 +54,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison ];
   propagatedBuildInputs = [ m4 ];
 
+  strictDeps = true;
+
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     export ac_cv_func_malloc_0_nonnull=yes
     export ac_cv_func_realloc_0_nonnull=yes

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/westes/flex/releases/download/v${finalAttrs.version}/flex-${finalAttrs.version}.tar.gz";
-    sha256 = "15g9bv236nzi665p9ggqjlfn4dwck5835vf0bbw2cz7h5c1swyp8";
+    hash = "sha256-6HquAyvwfCb4WsDtMlCZjDdiHZX4vXSLMfFbM8Re6ZU=";
   };
 
   patches = [
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
       # https://github.com/westes/flex/commit/24fd0551333e
       name = "glibc-2.26.patch";
       url = "https://raw.githubusercontent.com/lede-project/source/0fb14a2b1ab2f82ce63f4437b062229d73d90516/tools/flex/patches/200-build-AC_USE_SYSTEM_EXTENSIONS-in-configure.ac.patch";
-      sha256 = "0mpp41zdg17gx30kcpj83jl8hssks3adbks0qzbhcz882b9c083r";
+      hash = "sha256-eSDA0hIIfQbXx0DP1dTQU2uIqBxIXjbB6O+E134g91Y=";
     })
     (fetchurl {
       name = "gcc-15.patch";

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -13,12 +13,12 @@
 # dependency during bootstrap. Useful when gcc is built from snapshot
 # or from a git tree (flex lexers are not pre-generated there).
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "flex";
   version = "2.6.4";
 
   src = fetchurl {
-    url = "https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz";
+    url = "https://github.com/westes/flex/releases/download/v${finalAttrs.version}/flex-${finalAttrs.version}.tar.gz";
     sha256 = "15g9bv236nzi665p9ggqjlfn4dwck5835vf0bbw2cz7h5c1swyp8";
   };
 
@@ -71,10 +71,12 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/flex $out/bin/lex
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/westes/flex";
     description = "Fast lexical analyser generator";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -41,9 +41,9 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tests
   ''
   + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
-    substituteInPlace Makefile.in --replace "tests" " "
+    substituteInPlace Makefile.in --replace-fail "tests" " "
 
-    substituteInPlace doc/Makefile.am --replace 'flex.1: $(top_srcdir)/configure.ac' 'flex.1: '
+    substituteInPlace doc/Makefile.am --replace-fail 'flex.1: $(top_srcdir)/configure.ac' 'flex.1: '
   '';
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
