### PR TITLE
python3, python3-bootstrap: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -835,6 +835,9 @@ stdenv.mkDerivation (finalAttrs: {
         sphinxHook
         python-docs-theme
       ];
+
+      strictDeps = true;
+      __structuredAttrs = true;
     };
 
     tests = passthru.tests // {

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -366,6 +366,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ buildInputs;
 
+  strictDeps = true;
+
   prePatch = optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace configure --replace-fail '`/usr/bin/arch`' '"i386"'
   '';

--- a/pkgs/development/python-modules/bootstrap/build/default.nix
+++ b/pkgs/development/python-modules/bootstrap/build/default.nix
@@ -37,6 +37,9 @@ let
 
           runHook postInstall
         '';
+
+        strictDeps = true;
+        __structuredAttrs = true;
       }
       // attrs
     );

--- a/pkgs/development/python-modules/bootstrap/flit-core/default.nix
+++ b/pkgs/development/python-modules/bootstrap/flit-core/default.nix
@@ -31,4 +31,7 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
 }

--- a/pkgs/development/python-modules/bootstrap/installer/default.nix
+++ b/pkgs/development/python-modules/bootstrap/installer/default.nix
@@ -31,4 +31,7 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
 }

--- a/pkgs/development/python-modules/bootstrap/packaging/default.nix
+++ b/pkgs/development/python-modules/bootstrap/packaging/default.nix
@@ -28,4 +28,7 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
 }


### PR DESCRIPTION
Split off from https://github.com/NixOS/nixpkgs/pull/551108

Tested via https://github.com/NixOS/nixpkgs/pull/551108#issuecomment-5244248102

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
