### PR TITLE
pipewire-control-center: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2325,6 +2325,12 @@
     githubId = 8049011;
     name = "Arik Grahl";
   };
+  arison = {
+    email = "arison@duck.com";
+    github = "ArisoN-ext";
+    githubId = 181835726;
+    name = "ArisoN";
+  };
   ariutta = {
     email = "anders.riutta@gmail.com";
     github = "ariutta";

--- a/pkgs/by-name/pi/pipewire-control-center/package.nix
+++ b/pkgs/by-name/pi/pipewire-control-center/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+  wrapGAppsHook4,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "pipewire-control-center";
+  version = "0.5.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "knightinfected";
+    repo = "PipeWireController";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-18Tbwv4uv75U+l7TQY+6spppB5OkSfHmDn2pSy5EUGM=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [
+    numpy
+    pycairo
+    pygobject3
+    soundfile
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "io.github.knightinfected.PipeWireControlCenter";
+      desktopName = "PipeWire Controller";
+      comment = "Configure PipeWire, filter chains and HRIR virtual surround without editing files";
+      exec = "pipewire-control-center";
+      icon = "audio-card";
+      categories = [
+        "AudioVideo"
+        "Audio"
+        "Settings"
+      ];
+      keywords = [
+        "pipewire"
+        "audio"
+        "surround"
+        "hrir"
+        "equalizer"
+        "filter"
+        "pwcc"
+      ];
+      startupWMClass = "io.github.knightinfected.PipeWireControlCenter";
+    })
+  ];
+
+  pythonImportsCheck = [
+    "pwctl"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GTK4/libadwaita audio control center for PipeWire";
+    longDescription = ''
+      A GUI control center for PipeWire providing audio management, signal paths,
+      virtual devices, a live patchbay, parametric equalizer, performance monitoring,
+      filter chains, microphone cleanup (echo/noise reduction), HRIR virtual surround,
+      routing snapshots, per-app policies, and LADSPA/LV2 effect inserts.
+    '';
+    homepage = "https://github.com/knightinfected/PipeWireController";
+    changelog = "https://github.com/knightinfected/PipeWireController/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ arison ];
+    mainProgram = "pipewire-control-center";
+  };
+})


### PR DESCRIPTION
Adds `pipewire-control-center`, a GTK4/libadwaita control center for PipeWire. It provides audio management, signal paths, virtual devices, patchbay, and more without editing config files.

Homepage: https://github.com/knightinfected/PipeWireController

This PR also adds myself (`arison`) to the maintainers list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
