### PR TITLE
ccacheStdenv: preserve stdenv adapter composition

### DIFF
--- a/pkgs/by-name/cc/ccache/package.nix
+++ b/pkgs/by-name/cc/ccache/package.nix
@@ -120,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
           isClang = unwrappedCC.isClang or false;
           isGNU = unwrappedCC.isGNU or false;
           isCcache = true;
+          inherit unwrappedCC;
         }
         // builtins.intersectAttrs {
           hardeningUnsupportedFlagsByTargetPlatform = null;

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -316,6 +316,7 @@ rec {
       throw "Mold can't be used to emit Mach-O (Darwin) binaries"
     else
       let
+        unwrappedCC = stdenv.cc.cc.unwrappedCC or stdenv.cc.cc;
         bintools = stdenv.cc.bintools.override {
           extraBuildCommands = ''
             pushd $out/bin
@@ -340,7 +341,7 @@ rec {
         }
         //
           lib.optionalAttrs
-            (stdenv.cc.isClang || (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12"))
+            (stdenv.cc.isClang || (stdenv.cc.isGNU && lib.versionAtLeast unwrappedCC.version "12"))
             {
               mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
                 env = (args.env or { }) // {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4932,27 +4932,49 @@ with pkgs;
   # You can use a different directory, but whichever directory you choose
   # should be owned by user root, group nixbld with permissions 0770.
   ccacheWrapper =
-    makeOverridable
-      (
-        { extraConfig, cc }:
-        cc.override {
-          cc = ccache.links {
-            inherit extraConfig;
-            unwrappedCC = cc.cc;
+    let
+      makeCcacheWrapper =
+        args@{ extraConfig, cc }:
+        let
+          wrapper = cc.override {
+            cc = ccache.links {
+              inherit extraConfig;
+              unwrappedCC = cc.cc;
+            };
           };
-        }
-      )
-      {
-        extraConfig = "";
-        inherit (stdenv) cc;
-      };
+        in
+        wrapper
+        // {
+          override =
+            newArgs:
+            let
+              evaluatedArgs = if builtins.isFunction newArgs then newArgs (wrapper // args) else newArgs;
+            in
+            if evaluatedArgs ? extraConfig then
+              let
+                ccacheArgs = builtins.intersectAttrs { extraConfig = null; } evaluatedArgs;
+                wrapperArgs = removeAttrs evaluatedArgs [ "extraConfig" ];
+                ccacheWrapper = makeCcacheWrapper (args // ccacheArgs);
+              in
+              if wrapperArgs == { } then ccacheWrapper else ccacheWrapper.override wrapperArgs
+            else
+              wrapper.override evaluatedArgs;
+          overrideCcache =
+            newArgs:
+            makeCcacheWrapper (args // (if builtins.isFunction newArgs then newArgs args else newArgs));
+        };
+    in
+    makeCcacheWrapper {
+      extraConfig = "";
+      inherit (stdenv) cc;
+    };
 
-  ccacheStdenv = lowPrio (
-    makeOverridable
-      (
+  ccacheStdenv =
+    let
+      makeCcacheStdenv =
         { stdenv, ... }@extraArgs:
         overrideCC stdenv (
-          buildPackages.ccacheWrapper.override (
+          buildPackages.ccacheWrapper.overrideCcache (
             {
               inherit (stdenv) cc;
             }
@@ -4960,12 +4982,43 @@ with pkgs;
               extraConfig = extraArgs.extraConfig;
             }
           )
-        )
-      )
-      {
-        inherit stdenv;
-      }
-  );
+        );
+
+      makeOverridableCcacheStdenv =
+        args:
+        let
+          ccacheStdenv' = lowPrio (makeCcacheStdenv args);
+        in
+        ccacheStdenv'
+        // {
+          override =
+            newArgs:
+            let
+              evaluatedArgs = if builtins.isFunction newArgs then newArgs (ccacheStdenv' // args) else newArgs;
+            in
+            if evaluatedArgs ? extraConfig || evaluatedArgs ? stdenv then
+              let
+                ccacheArgs = builtins.intersectAttrs {
+                  extraConfig = null;
+                  stdenv = null;
+                } evaluatedArgs;
+                stdenvArgs = removeAttrs evaluatedArgs [
+                  "extraConfig"
+                  "stdenv"
+                ];
+                ccacheStdenv = makeOverridableCcacheStdenv (args // ccacheArgs);
+              in
+              if stdenvArgs == { } then ccacheStdenv else ccacheStdenv.override stdenvArgs
+            else
+              ccacheStdenv'.override evaluatedArgs;
+          overrideCcache =
+            newArgs:
+            makeOverridableCcacheStdenv (
+              args // (if builtins.isFunction newArgs then newArgs args else newArgs)
+            );
+        };
+    in
+    makeOverridableCcacheStdenv { inherit stdenv; };
 
   chromedriver = callPackage ../development/tools/selenium/chromedriver { };
 


### PR DESCRIPTION
Fixes #300579.

`ccacheWrapper` and `ccacheStdenv` used `makeOverridable` to expose ccache-specific configuration, but that replaced underlying compiler wrapper and stdenv overrides. So when we had stdenv adapters like useMoldLinker, those reconfigured ccache instead of modifying the wrapped stdenv. Similarly environements like `stdnevNoCC` and `clangstdenv` kept using the replacement stdenv.

The fix here is to forward the compiler and stdenv overrides to the wrapped objects, and also expose the compiler wrapped by ccache so `useMoldLinker` can check if that GCC supports `-fuse-ld=mold` from the compiler itself instead of from ccache.

- Built `hello`, `zlib`, `libffi`, and `libyaml` with the ordinary linker and with `useMoldLinker`, including composition with globally configured `ccacheStdenv`.
- Confirmed the mold-linked outputs show `mold 2.41.0` in their `.comment` sections and ran the resulting `hello` executable as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

