### PR TITLE
pi-coding-agent: Prune development dependencies

### DIFF
--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -69,6 +69,12 @@ buildNpmPackage (finalAttrs: {
     runHook postBuild
   '';
 
+  dontNpmPrune = true;
+
+  preInstall = ''
+    npm prune --omit=dev --no-save
+  '';
+
   # npm workspace symlinks in the output point into packages/ which
   # doesn't exist there. Replace runtime deps with built content and
   # delete the rest.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Reduces the package size.
```
❯ nix store diff-closures result-orig/ result/
pi-coding-agent: -111.0 MiB

❯ diff --exclude='.package-lock.json' -r result-orig/ result/
diff '--color=auto' '--exclude=.package-lock.json' -r result-orig/bin/pi result/bin/pi
16c16
< exec -a "$0" "/nix/store/1j423i8bf5j315r77l3xl7b924n1qlpw-pi-coding-agent-0.84.0/bin/.pi-wrapped"  "$@" 
---
> exec -a "$0" "/nix/store/7993pdy2spiq443j1dlmz1frnpiz7baj-pi-coding-agent-0.84.0/bin/.pi-wrapped"  "$@" 
diff '--color=auto' '--exclude=.package-lock.json' -r result-orig/bin/.pi-wrapped result/bin/.pi-wrapped
2c2
< exec "/nix/store/hwjfj8m2kcsl7kz2xa5yf84jbfh9jssf-nodejs-24.18.1/bin/node"  /nix/store/1j423i8bf5j315r77l3xl7b924n1qlpw-pi-coding-agent-0.84.0/lib/node_modules/pi-monorepo/dist/cli.js "$@" 
---
> exec "/nix/store/hwjfj8m2kcsl7kz2xa5yf84jbfh9jssf-nodejs-24.18.1/bin/node"  /nix/store/7993pdy2spiq443j1dlmz1frnpiz7baj-pi-coding-agent-0.84.0/lib/node_modules/pi-monorepo/dist/cli.js "$@" 
Only in result-orig/lib/node_modules/pi-monorepo/node_modules/.bin: biome
Only in result-orig/lib/node_modules/pi-monorepo/node_modules/.bin: husky
Only in result-orig/lib/node_modules/pi-monorepo/node_modules/.bin: tsgo
Only in result-orig/lib/node_modules/pi-monorepo/node_modules/.bin: vitest-evals
Only in result-orig/lib/node_modules/pi-monorepo/node_modules: @biomejs
Only in result-orig/lib/node_modules/pi-monorepo/node_modules: husky
Only in result-orig/lib/node_modules/pi-monorepo/node_modules: @typescript
Only in result-orig/lib/node_modules/pi-monorepo/node_modules: @vitest-evals
Only in result-orig/lib/node_modules/pi-monorepo/node_modules: vitest-evals
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
