### PR TITLE
nixos/prometheus-exporters/snowflake: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -46,6 +46,8 @@
 
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
 
+- [snowflake-prometheus-exporter](https://github.com/grafana/snowflake-prometheus-exporter), a Prometheus exporter for Snowflake metrics. Available as [services.prometheus.exporters.snowflake](#opt-services.prometheus.exporters.snowflake.enable).
+
 - [feishin](https://github.com/jeffvli/feishin), a modern self-hosted music player. Available as [services.feishin](#opt-services.feishin.enable).
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -120,6 +120,7 @@ let
         "smartctl"
         "smokeping"
         "snmp"
+        "snowflake"
         "speedtest"
         "sql"
         "statsd"

--- a/nixos/modules/services/monitoring/prometheus/exporters/snowflake.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snowflake.nix
@@ -1,0 +1,91 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.snowflake;
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    optional
+    escapeShellArg
+    concatStringsSep
+    getExe
+    ;
+
+  # The private key is passed to systemd via LoadCredential, which exposes it in
+  # the per-service credentials directory (`%d`) readable by the service even
+  # under DynamicUser.
+  args = [
+    "--web.listen-address ${cfg.listenAddress}:${toString cfg.port}"
+    "--account ${escapeShellArg cfg.account}"
+    "--username ${escapeShellArg cfg.username}"
+    "--warehouse ${escapeShellArg cfg.warehouse}"
+    "--role ${escapeShellArg cfg.role}"
+  ]
+  ++ optional (cfg.privateKeyFile != null) "--private-key-path=%d/snowflake-private-key"
+  ++ cfg.extraFlags;
+in
+{
+  port = 9975;
+  extraOpts = {
+    account = mkOption {
+      type = types.str;
+      example = "xy12345.us-east-1";
+      description = "Snowflake account to collect metrics for (`--account`).";
+    };
+    username = mkOption {
+      type = types.str;
+      description = "Username used when querying metrics (`--username`).";
+    };
+    warehouse = mkOption {
+      type = types.str;
+      description = "Warehouse used when querying metrics (`--warehouse`).";
+    };
+    role = mkOption {
+      type = types.str;
+      default = "ACCOUNTADMIN";
+      description = "Role used when querying metrics (`--role`).";
+    };
+    privateKeyFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/snowflake-exporter.p8";
+      description = ''
+        Path to the user's RSA private key for key-pair authentication. The file
+        is passed to the service via {manpage}`systemd.exec(5)` credentials, so
+        it is read only by the exporter and never copied into the world-readable
+        Nix store. If the key is encrypted, supply its password via
+        {option}`environmentFile` (`SNOWFLAKE_EXPORTER_PRIVATE_KEY_PASSWORD`).
+
+        Mutually exclusive with password authentication; when set, do not also
+        provide `SNOWFLAKE_EXPORTER_PASSWORD`.
+      '';
+    };
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/snowflake-exporter.env";
+      description = ''
+        Path to an environment file, as defined in {manpage}`systemd.exec(5)`,
+        used to pass secrets without exposing them in the world-readable Nix
+        store or the process's command line. For password authentication set
+        `SNOWFLAKE_EXPORTER_PASSWORD`; for an encrypted key (see
+        {option}`privateKeyFile`) set `SNOWFLAKE_EXPORTER_PRIVATE_KEY_PASSWORD`.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      EnvironmentFile = mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+      LoadCredential = mkIf (cfg.privateKeyFile != null) [
+        "snowflake-private-key:${cfg.privateKeyFile}"
+      ];
+      ExecStart = "${getExe pkgs.prometheus-snowflake-exporter} ${concatStringsSep " " args}";
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1787,6 +1787,34 @@ let
         '';
       };
 
+    snowflake =
+      { pkgs, ... }:
+      {
+        exporterConfig = {
+          enable = true;
+          account = "dummy";
+          username = "dummy";
+          warehouse = "dummy";
+          # key-pair auth: exercises the LoadCredential + `%d` wiring. The key is
+          # never parsed until a scrape, so a dummy file is enough to boot.
+          privateKeyFile = pkgs.writeText "snowflake-key.p8" "dummy";
+          environmentFile = pkgs.writeText "snowflake-exporter.env" ''
+            SNOWFLAKE_EXPORTER_PRIVATE_KEY_PASSWORD=dummy
+          '';
+        };
+        # Only the landing page is checked. Scraping `/metrics` would run the
+        # collector, which synchronously queries Snowflake and blocks until the
+        # driver's login timeout (~45s) with no reachable server. Booting with
+        # key-pair auth already exercises config validation and the
+        # LoadCredential/environmentFile wiring; the landing page confirms the
+        # exporter booted and is serving.
+        exporterTest = ''
+          wait_for_unit("prometheus-snowflake-exporter.service")
+          wait_for_open_port(9975)
+          succeed("curl -sSf http://localhost:9975/ | grep -i 'Snowflake exporter'")
+        '';
+      };
+
     sql =
       { ... }:
       {


### PR DESCRIPTION
Adds a NixOS module `services.prometheus.exporters.snowflake` for [snowflake-prometheus-exporter](https://github.com/grafana/snowflake-prometheus-exporter) (the package itself landed in #550203), wiring it into the standard `services.prometheus.exporters` framework — systemd unit, dedicated user/group, and firewall options.

Options:
- `account`, `username`, `warehouse` (required) — the Snowflake connection parameters, passed as flags.
- `role` — defaults to `ACCOUNTADMIN`.
- `privateKeyFile` (optional) — RSA private key for key-pair auth, wired to the service via {manpage}`systemd.exec(5)` credentials (`LoadCredential` + `--private-key-path=%d/...`), so the key is read only by the exporter and works under `DynamicUser` without landing in the Nix store.
- `environmentFile` (optional) — supplies secrets without exposing them in the store or on the command line: `SNOWFLAKE_EXPORTER_PASSWORD` for password auth, or `SNOWFLAKE_EXPORTER_PRIVATE_KEY_PASSWORD` for an encrypted key.
- Standard framework options (`port`, default `9975`; `listenAddress`; `openFirewall`; `extraFlags`; …).

Includes a hermetic NixOS test in `nixos/tests/prometheus-exporters.nix` that boots the exporter with key-pair auth and asserts its landing page is served. (The `/metrics` scrape is intentionally not exercised: the collector queries Snowflake synchronously and would block on the driver's login timeout with no reachable server. Booting already exercises config validation and the `LoadCredential`/`environmentFile` wiring.)

> Disclosure: this pull request summary was drafted with assistance from Claude Code (Claude Opus 4.8). All changes were reviewed and tested by me, and the commit carries an `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests) — the new `snowflake` case starts the exporter and checks it serves; passing on x86_64-linux.
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review#usage) on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` — the NixOS test starts `prometheus-snowflake-exporter.service` and confirms it serves.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
