### PR TITLE
npm-lockfile-fix: add cacert for Darwin sandbox

### DIFF
--- a/pkgs/by-name/np/npm-lockfile-fix/package.nix
+++ b/pkgs/by-name/np/npm-lockfile-fix/package.nix
@@ -1,8 +1,10 @@
 {
   lib,
+  stdenv,
   python3,
   fetchFromGitHub,
   nix-update-script,
+  cacert,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -26,6 +28,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   doCheck = false; # no tests
+
+  # requests resolves the CA bundle via REQUESTS_CA_BUNDLE before falling back
+  # to NIX_SSL_CERT_FILE, which on Darwin points to a host path that is not
+  # available inside a sandboxed build. Set it explicitly so the package works
+  # whenever it is invoked from a sandboxed environment.
+  makeWrapperArgs = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--set"
+    "REQUESTS_CA_BUNDLE"
+    "${cacert}/etc/ssl/certs/ca-bundle.crt"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Using `npm-lockfile-fix` for fix sources is a common pattern in nixpkgs, but it fails on Darwin because the TLS CA certificates are not available in the sandbox:

```nix
  src = fetchFromGitHub {
    owner = "owner";
    repo = "repo";
    tag = "v${finalAttrs.version}";
    hash = "sha256-00000000000000000000000000000000000000000000";
    postFetch = "${lib.getExe npm-lockfile-fix} $out/package-lock.json";
  };
```

This PR sets `REQUESTS_CA_BUNDLE="${cacert}/etc/ssl/certs/ca-bundle.crt"` in the wrapper on Darwin.

The alternative is for every user to export the variable in the `postFetch`:

```nix
    postFetch = ''
      ${lib.optionalString stdenv.hostPlatform.isDarwin "export REQUESTS_CA_BUNDLE=${cacert}/etc/ssl/certs/ca-bundle.crt"}
      ${lib.getExe npm-lockfile-fix} $out/package-lock.json
    '';
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assited by OpenCode (DeepSeek V4 Flash 0731)