### PR TITLE
gpac: 26.02.0 -> 26.07.0

### DIFF
--- a/pkgs/by-name/gp/gpac/package.nix
+++ b/pkgs/by-name/gp/gpac/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   gitUpdater,
   unstableGitUpdater,
   cctools,
@@ -40,12 +39,12 @@
 
 let
   stable = rec {
-    version = "26.02.0";
+    version = "26.07.0";
     src = fetchFromGitHub {
       owner = "gpac";
       repo = "gpac";
       rev = "v${version}";
-      hash = "sha256-UtL+KG3dsp6dD7cfTK7e17ngt/RHKJL0s5IopTM3VOk=";
+      hash = "sha256-L4GKXCFsKVxWXZJJeiAegXJySoS9+/V+/cuzEJEse+I=";
     };
     updateScript = gitUpdater {
       rev-prefix = "v";
@@ -53,12 +52,12 @@ let
     };
   };
   unstable = {
-    version = "26.02.0-unstable-2026-04-29";
+    version = "26.07.0-unstable-2026-08-04";
     src = fetchFromGitHub {
       owner = "gpac";
       repo = "gpac";
-      rev = "525bf1af642c30af04e4df5345e6d798c0a4d8a1";
-      hash = "sha256-G/4gefsS2hUKo8VEt80YZOaGJSjrzXFrdHO/u33BiDw=";
+      rev = "014bb6de5136e9466f6339486901db4d46570784";
+      hash = "sha256-Uj3+CH2xkw504A2LUmruQ5vdQXhGqKY7Lx1Yp5263J0=";
     };
     updateScript = unstableGitUpdater {
       tagFormat = "v*";
@@ -109,14 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
     pulseaudio
     SDL2
     curl
-  ];
-
-  patches = lib.optionals (releaseChannel == "stable") [
-    (fetchpatch2 {
-      # CVE-2026-7135 fix
-      url = "https://github.com/gpac/gpac/commit/cf6ac48c972eaaee2af270adc3f36615325deb3e.patch?full_index=1";
-      hash = "sha256-JaJiQAQvzdB74ag2/aZTiQa2NqlgqgMYS1tsk/R+wiI=";
-    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/524787
Fixes https://github.com/NixOS/nixpkgs/issues/539170
Fixes https://github.com/NixOS/nixpkgs/issues/539169

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
