### PR TITLE
wl-freeze: 2.0.2 -> 2.1.0

### DIFF
--- a/pkgs/by-name/wl/wl-freeze/package.nix
+++ b/pkgs/by-name/wl/wl-freeze/package.nix
@@ -8,11 +8,14 @@
   procps,
   psmisc,
   libnotify,
+  xdotool,
+  kdotool,
+  kdePackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wl-freeze";
-  version = "2.0.2";
+  version = "2.1.0";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -21,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Zerodya";
     repo = "wl-freeze";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-miyDiUN86Zy9RfVm1MefKrYihX4+bFv6Jr4Cl4GzGz8=";
+    hash = "sha256-WY1XB17ARU34dAlU7CqMg3AXVlE0qilXwfGMpYeeiwk=";
   };
 
   dontConfigure = true;
@@ -55,6 +58,9 @@ stdenv.mkDerivation (finalAttrs: {
           procps
           psmisc
           libnotify
+          xdotool
+          kdotool
+          kdePackages.qttools
         ]
       }
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
