### PR TITLE
max: init at 26.26.0

### DIFF
--- a/pkgs/by-name/ma/max/package.nix
+++ b/pkgs/by-name/ma/max/package.nix
@@ -1,0 +1,191 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  dpkg,
+  buildFHSEnvBubblewrap,
+  glib,
+  zlib,
+  expat,
+  fontconfig,
+  freetype,
+  nspr,
+  nss,
+  libx11,
+  libxext,
+  libxdamage,
+  libxfixes,
+  libxrandr,
+  libxcomposite,
+  libxcursor,
+  libxi,
+  libxtst,
+  libxscrnsaver,
+  libxkbfile,
+  libxcb,
+  libxcb-util,
+  libxcb-cursor,
+  libxcb-image,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxcb-wm,
+  libxkbcommon,
+  mesa,
+  libGL,
+  libdrm,
+  libgbm,
+  alsa-lib,
+  pulseaudio,
+  pipewire,
+  libgcrypt,
+  libgpg-error,
+  gdk-pixbuf,
+  libnotify,
+  dbus,
+  hicolor-icon-theme,
+  shared-mime-info,
+  gtk3,
+}:
+
+let
+  version = "26.26.0";
+
+  src = fetchurl {
+    url = "https://download.max.ru/linux/deb/pool/main/m/max/MAX-26.26.0.76189.deb";
+    hash = "sha256-4xRS8Z6VJKVBAMmtgOL/LAjKsdLPtV0qrI8immA9UAM=";
+  };
+
+  runtimePkgs = [
+    glib
+    zlib
+    expat
+    fontconfig
+    freetype
+
+    nspr
+    nss
+
+    libx11
+    libxext
+    libxdamage
+    libxfixes
+    libxrandr
+    libxcomposite
+    libxcursor
+    libxi
+    libxtst
+    libxscrnsaver
+    libxkbfile
+
+    libxcb
+    libxcb-util
+    libxcb-cursor
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    libxcb-wm
+
+    libxkbcommon
+
+    mesa
+    libGL
+    libdrm
+    libgbm
+
+    alsa-lib
+    pulseaudio
+    pipewire
+
+    libgcrypt
+    libgpg-error
+
+    gdk-pixbuf
+    libnotify
+    dbus
+
+    hicolor-icon-theme
+    shared-mime-info
+    gtk3
+  ];
+
+  maxApp = stdenvNoCC.mkDerivation {
+    pname = "max-app";
+    inherit version src;
+
+    nativeBuildInputs = [ dpkg ];
+
+    unpackPhase = ''
+      mkdir unpacked
+      dpkg -x "$src" unpacked
+    '';
+
+    installPhase = ''
+      mkdir -p "$out/share"
+      cp -r unpacked/usr/share/max "$out/share/max"
+    '';
+
+    dontStrip = true;
+  };
+
+  maxFhs = buildFHSEnvBubblewrap {
+    name = "max";
+
+    targetPkgs = _: runtimePkgs;
+    multiPkgs = _: runtimePkgs;
+
+    unshareUser = false;
+    chdirToPwd = false;
+
+    extraPreBwrapCmds = ''
+      mkdir -p "$HOME"
+      mkdir -p "$XDG_RUNTIME_DIR"
+    '';
+
+    profile = ''
+      export LD_LIBRARY_PATH="${lib.makeLibraryPath runtimePkgs}:${maxApp}/share/max/lib64:${maxApp}/share/max/bin/max-service/lib64:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH"
+      export QT_QPA_PLATFORM=xcb
+      export QT_X11_NO_MITSHM=1
+      export XDG_RUNTIME_DIR="''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    '';
+
+    runScript = "${maxApp}/share/max/bin/max";
+  };
+
+in
+stdenvNoCC.mkDerivation {
+  pname = "max";
+  inherit version;
+
+  dontUnpack = true;
+
+  installPhase = ''
+        runHook preInstall
+
+        mkdir -p "$out/bin"
+        mkdir -p "$out/share/applications"
+
+        ln -s ${maxFhs}/bin/max "$out/bin/max"
+
+        cat > "$out/share/applications/max.desktop" <<EOF_DESKTOP
+    [Desktop Entry]
+    Name=MAX
+    Comment=Messaging application
+    Exec=$out/bin/max
+    Terminal=false
+    Type=Application
+    Categories=Network;InstantMessaging;
+    EOF_DESKTOP
+
+        runHook postInstall
+  '';
+
+  meta = {
+    description = "Messaging application";
+    homepage = "https://max.ru/";
+    downloadPage = "https://download.max.ru/";
+    license = lib.licenses.unfree;
+    mainProgram = "max";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ma/max/package.nix
+++ b/pkgs/by-name/ma/max/package.nix
@@ -154,6 +154,8 @@ let
 in
 stdenvNoCC.mkDerivation {
   pname = "max";
+  strictDeps = true;
+  __structuredAttrs = true;
   inherit version;
 
   dontUnpack = true;


### PR DESCRIPTION
## Description

Add MAX Messenger for x86_64-linux.

MAX is packaged from the official Linux `.deb` release and runs inside
an FHS environment with the required runtime libraries.

## Testing

- `NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link -A max`
- `NIXPKGS_ALLOW_UNFREE=1 nix build --impure --no-link .#max`
- `nix flake check --impure --no-build`
- `git diff --cached --check`

The application was also tested locally and launches successfully.