### PR TITLE
ventoy: 1.1.12 -> 1.1.17

### DIFF
--- a/pkgs/by-name/ve/ventoy/000-nixos-sanitization.patch
+++ b/pkgs/by-name/ve/ventoy/000-nixos-sanitization.patch
@@ -161,10 +161,10 @@ diff --color -Naur ventoy-1.1.12-old/tool/VentoyWorker.sh ventoy-1.1.12-new/tool
  
      check_umount_disk "$DISK"
      
-diff --color -Naur ventoy-1.1.12-old/Ventoy2Disk.sh ventoy-1.1.12-new/Ventoy2Disk.sh
---- ventoy-1.1.12-old/Ventoy2Disk.sh	2026-04-24 18:49:51.366082120 +0100
-+++ ventoy-1.1.12-new/Ventoy2Disk.sh	2026-04-24 20:19:55.219025537 +0100
-@@ -32,66 +32,4 @@
+diff --color -Naur ventoy-1.1.17-old/Ventoy2Disk.sh ventoy-1.1.17-new/Ventoy2Disk.sh
+--- ventoy-1.1.17-old/Ventoy2Disk.sh	2026-08-13 01:33:02.176591073 +0300
++++ ventoy-1.1.17-new/Ventoy2Disk.sh	2026-08-13 01:33:02.179127365 +0300
+@@ -30,59 +30,4 @@
  echo '**********************************************'
  echo ''
  
@@ -223,13 +223,6 @@ diff --color -Naur ventoy-1.1.12-old/Ventoy2Disk.sh ventoy-1.1.12-new/Ventoy2Dis
 -    /bin/bash ./tool/VentoyWorker.sh $*
 -else
 -    ash ./tool/VentoyWorker.sh $*
--fi
--
--if [ -n "$OLDDIR" ]; then 
--    CURDIR=$(pwd)
--    if [ "$CURDIR" != "$OLDDIR" ]; then
--        cd "$OLDDIR"
--    fi
 -fi
 +./tool/VentoyWorker.sh $*
 diff --color -Naur ventoy-1.1.12-old/VentoyPlugson.sh ventoy-1.1.12-new/VentoyPlugson.sh

--- a/pkgs/by-name/ve/ventoy/package.nix
+++ b/pkgs/by-name/ve/ventoy/package.nix
@@ -59,11 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
     "ventoy"
     + optionalString (defaultGuiType == "gtk3") "-gtk3"
     + optionalString (defaultGuiType == "qt5") "-qt5";
-  version = "1.1.12";
+  version = "1.1.17";
 
   src = fetchurl {
     url = "https://github.com/ventoy/Ventoy/releases/download/v${finalAttrs.version}/ventoy-${finalAttrs.version}-linux.tar.gz";
-    hash = "sha256-BGILVGvMXu61lxdnWVs3E+495xWAqCRJBTxTp8sy/Nk=";
+    hash = "sha256-f7TtCM72prTTndGSYNjIApGnjf35r31GFXHiPLvEOAU=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/ventoy/Ventoy/releases/tag/v1.1.17

Also regenerates the nixos-sanitization patch's `Ventoy2Disk.sh` hunk: upstream dropped the trailing `$OLDDIR` cd-back block in this release, so the 1.1.12-based hunk no longer applied.