### PR TITLE
poetryPlugins.poetry-plugin-migrate: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/by-name/po/poetry/plugins/poetry-plugin-migrate.nix
+++ b/pkgs/by-name/po/poetry/plugins/poetry-plugin-migrate.nix
@@ -4,19 +4,18 @@
   fetchFromGitHub,
   poetry-core,
   poetry,
-  pytest-mock,
   pytestCheckHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "poetry-plugin-migrate";
-  version = "0.1.1";
+  version = "0.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zyf722";
     repo = "poetry-plugin-migrate";
-    tag = version;
-    hash = "sha256-78H4/vHp8W7h6v6OWUdx9pX4142YiNGUFZXHoxxXw1M=";
+    tag = finalAttrs.version;
+    hash = "sha256-/FT053iqd4AgX7hINrGQHrED/ZegDvNSm1P/FfjNHzU=";
   };
 
   build-system = [
@@ -30,15 +29,14 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "poetry_plugin_migrate" ];
 
   nativeCheckInputs = [
-    pytest-mock
     pytestCheckHook
   ];
 
   meta = {
     description = "Poetry plugin to migrate pyproject.toml from Poetry v1 to v2 (PEP-621 compliant)";
     homepage = "https://github.com/zyf722/poetry-plugin-migrate";
-    changelog = "https://github.com/zyf722/poetry-plugin-migrate/releases/tag/${src.tag}";
+    changelog = "https://github.com/zyf722/poetry-plugin-migrate/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ zevisert ];
   };
-}
+})


### PR DESCRIPTION
Bump of [poetry-plugin-migrate after today's release](https://github.com/zyf722/poetry-plugin-migrate/releases/tag/0.2.0) to 0.2.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
