### PR TITLE
nixos/test-driver: Use types.lines for testScript

### DIFF
--- a/nixos/lib/testing/testScript.nix
+++ b/nixos/lib/testing/testScript.nix
@@ -8,12 +8,12 @@ testModuleArgs@{
 }:
 let
   inherit (lib) mkOption types;
-  inherit (types) either str functionTo;
+  inherit (types) either lines functionTo;
 in
 {
   options = {
     testScript = mkOption {
-      type = either str (functionTo str);
+      type = either lines (functionTo lines);
       apply =
         v:
         if lib.isFunction v then
@@ -27,7 +27,7 @@ in
       '';
     };
     testScriptString = mkOption {
-      type = str;
+      type = lines;
       readOnly = true;
       internal = true;
     };


### PR DESCRIPTION
I usually write extensive test modules and more often than not, I want to use something like this:

```nix
testScript = lib.mkBefore ''
  ... some common initialisation ...
'';
```

Unfortunately, the type of `testScript` is `types.str`, so right now I'm working around this using ugly things like this:

```nix
options.testScript = lib.mkOption {
  type = let
    newType = types.either types.lines (types.functionTo types.lines);
  in newType // {
    typeMerge = lib.const newType;
  };
};
```

While this results in roughly the same (using `types.lines` instead of `types.str`), I should not have to do this downstream, so hereby let's make it `types.lines`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test