### PR TITLE
_1password-gui: 8.12.30 -> 8.12.32

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.12.30",
+      "version": "8.12.32",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.30.x64.tar.gz",
-          "hash": "sha256-jZuPdQo5KPvbYqN5YXFq3lAEqJccWhi6ROFOSvjiWuU="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.32.x64.tar.gz",
+          "hash": "sha256-dg42SQNMS77+393sDP66weZ33VVIKjOQEZwaK82ifZc="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.30.arm64.tar.gz",
-          "hash": "sha256-s4wmVQ7JXV0cakDhueawkQWTjicxOVzdrHQll6zNwvI="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.32.arm64.tar.gz",
+          "hash": "sha256-pjSX6FWMZh1PN/lNMEbPQ2+hZs47tiNC0ptHJGZL3rQ="
         }
       }
     },
     "darwin": {
-      "version": "8.12.30",
+      "version": "8.12.33",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.30-x86_64.zip",
-          "hash": "sha256-LuRoGXVGG5r6Bpg9PC39zICVc4pEgvAh7yY/nlQgnVI="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.33-x86_64.zip",
+          "hash": "sha256-jIvE1S4oP5/nVnmxQyrzW14kwnAI5zB9eKjms29XikI="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.30-aarch64.zip",
-          "hash": "sha256-7qX2UjUaEfJA2Cn8RwcjEkDX6RR4S487B8zYYUKp+mw="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.33-aarch64.zip",
+          "hash": "sha256-CT+3Sn9AyyxHyTRXhajCwsO9n9eqxou3kD1RJ2RZUpk="
         }
       }
     }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
