### PR TITLE
lib/systems: derive more platform metadata instead of restating it

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -151,7 +151,14 @@ let
           );
 
         # Derived meta-data
-        useLLVM = final.isFreeBSD || final.isOpenBSD;
+        useLLVM =
+          final.isFreeBSD
+          || final.isOpenBSD
+          || final.isUefi
+          || final.isMsvc
+          ||
+            # because GCC does not support this platform yet
+            (with final; isWindows && isAarch64);
 
         # Use the split GCC package set (`gccNGPackages`) instead of the
         # monolithic `gcc`. No platform selects it yet; it is opt-in, set
@@ -186,9 +193,7 @@ let
             "uclibc"
           else if final.isAndroid then
             "bionic"
-          else if
-            final.isLinux # default
-          then
+          else if final.isLinux then
             "glibc"
           else if final.isFreeBSD then
             "fblibc"
@@ -199,6 +204,8 @@ let
           else if final.isAvr then
             "avrlibc"
           else if final.isGhcjs then
+            null
+          else if final.isUefi then
             null
           else if final.isNone then
             "newlib"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -93,7 +93,6 @@ rec {
     config = "aarch64-unknown-linux-android";
     androidSdkVersion = "35";
     androidNdkVersion = "27";
-    libc = "bionic";
     useAndroidPrebuilt = false;
     useLLVM = true;
   };
@@ -169,22 +168,18 @@ rec {
 
   riscv64-embedded = {
     config = "riscv64-none-elf";
-    libc = "newlib";
   };
 
   riscv32-embedded = {
     config = "riscv32-none-elf";
-    libc = "newlib";
   };
 
   mips64-embedded = {
     config = "mips64-none-elf";
-    libc = "newlib";
   };
 
   mips-embedded = {
     config = "mips-none-elf";
-    libc = "newlib";
   };
 
   # https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc#10-operating-system-package-build-requirements
@@ -201,17 +196,17 @@ rec {
 
   mmix = {
     config = "mmix-unknown-mmixware";
+    # Not `isNone`: the OS here is `mmixware`, so the bare-metal default does
+    # not apply.
     libc = "newlib";
   };
 
   rx-embedded = {
     config = "rx-none-elf";
-    libc = "newlib";
   };
 
   msp430 = {
     config = "msp430-elf";
-    libc = "newlib";
   };
 
   avr = {
@@ -220,12 +215,10 @@ rec {
 
   vc4 = {
     config = "vc4-elf";
-    libc = "newlib";
   };
 
   or1k = {
     config = "or1k-elf";
-    libc = "newlib";
   };
 
   m68k = {
@@ -250,7 +243,6 @@ rec {
 
   arm-embedded = {
     config = "arm-none-eabi";
-    libc = "newlib";
   };
   arm-embedded-nano = {
     config = "arm-none-eabi";
@@ -258,7 +250,6 @@ rec {
   };
   armhf-embedded = {
     config = "arm-none-eabihf";
-    libc = "newlib";
     # GCC8+ does not build without this
     # (https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg552339.html):
     gcc = {
@@ -269,38 +260,31 @@ rec {
 
   aarch64-embedded = {
     config = "aarch64-none-elf";
-    libc = "newlib";
     rust.rustcTarget = "aarch64-unknown-none";
   };
 
   aarch64be-embedded = {
     config = "aarch64_be-none-elf";
-    libc = "newlib";
   };
 
   ppc-embedded = {
     config = "powerpc-none-eabi";
-    libc = "newlib";
   };
 
   ppcle-embedded = {
     config = "powerpcle-none-eabi";
-    libc = "newlib";
   };
 
   i686-embedded = {
     config = "i686-elf";
-    libc = "newlib";
   };
 
   x86_64-embedded = {
     config = "x86_64-elf";
-    libc = "newlib";
   };
 
   microblaze-embedded = {
     config = "microblazeel-none-elf";
-    libc = "newlib";
   };
 
   #
@@ -338,16 +322,10 @@ rec {
 
   x86_64-unknown-uefi = {
     config = "x86_64-unknown-uefi";
-    libc = null;
-    useLLVM = true;
-    linker = "lld";
   };
 
   aarch64-unknown-uefi = {
     config = "aarch64-unknown-uefi";
-    libc = null;
-    useLLVM = true;
-    linker = "lld";
   };
 
   #
@@ -382,12 +360,11 @@ rec {
   };
 
   # mingw-w64 with ucrt for Aarch64, default compiler (which is LLVM
-  # because GCC does not support this platform yet).
+  # see ./default.nix).
   mingw-ucrt-aarch64 = {
     config = "aarch64-w64-mingw32";
     libc = "ucrt";
     rust.rustcTarget = "aarch64-pc-windows-gnullvm";
-    useLLVM = true;
   };
 
   # mingw-64 back compat
@@ -400,12 +377,10 @@ rec {
   # Target the MSVC ABI
   x86_64-windows = {
     config = "x86_64-pc-windows-msvc";
-    useLLVM = true;
   };
 
   aarch64-windows = {
     config = "aarch64-pc-windows-msvc";
-    useLLVM = true;
   };
 
   x86_64-cygwin = {
@@ -416,12 +391,10 @@ rec {
 
   aarch64-freebsd = {
     config = "aarch64-unknown-freebsd";
-    useLLVM = true;
   };
 
   x86_64-freebsd = {
     config = "x86_64-unknown-freebsd";
-    useLLVM = true;
   };
 
   x86_64-netbsd = {


### PR DESCRIPTION
`examples.nix` had settings that only repeated what the `config` already implied. They read as if the platform were special, when it ought to be the default. Now the default logic in `default.nix` ought to handle the setting in question in a rule-based way so it is.

 Change:

- `useLLVM` now covers
  - UEFI
  - MSVC CRT and C++ ABI
  - Windows on AArch64 as well as FreeBSD and OpenBSD

- `libc` gains a UEFI case

hat retires seven `useLLVM` settings, eighteen `libc = "newlib"`, one `libc = "bionic"`, and the `libc`/`linker` pair on the UEFI examples.

The remaining `libc`s in examples now means"this differs from what the triple implies", which is true of the seven left: `newlib-nano`, the mingw `msvcrt`/`ucrt` pairs those entries exist to distinguish, and `mmix`, whose OS is `mmixware` rather than `none` so the bare-metal default does not reach it. That one gains a comment.

No functional change. Elaborating all 87 platforms in `lib.systems.examples` before and after gives byte-identical `config`, `system`, `useLLVM`, `useGccNG`, `libc`, `linker` and `rust.rustcTarget`. `mmix` surfaced that way, having regressed to `native/impure`.

Assisted-by: Claude Code (Claude Opus 5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
