### PR TITLE
llvmPackages_{18,19,20,21,22}.libllvm: backport Darwin triple parsing

### DIFF
--- a/pkgs/development/compilers/llvm/18/llvm/backport-darwin-triple-parsing.patch
+++ b/pkgs/development/compilers/llvm/18/llvm/backport-darwin-triple-parsing.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Tue, 11 Aug 2026 20:12:42 -0400
+Subject: [PATCH] backport-darwin-triple-parsing
+
+---
+ lib/TargetParser/Triple.cpp | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/lib/TargetParser/Triple.cpp b/lib/TargetParser/Triple.cpp
+index 0bbe8a3cedfd..4143c3eac05d 100644
+--- a/lib/TargetParser/Triple.cpp
++++ b/lib/TargetParser/Triple.cpp
+@@ -1253,9 +1253,15 @@ bool Triple::getMacOSXVersion(VersionTuple &Version) const {
+     }
+     if (Version.getMajor() <= 19) {
+       Version = VersionTuple(10, Version.getMajor() - 4);
+-    } else {
+-      // darwin20+ corresponds to macOS 11+.
++    } else if (Version.getMajor() < 25) {
++      // darwin20-24 corresponds to macOS 11-15.
+       Version = VersionTuple(11 + Version.getMajor() - 20);
++    } else if ((Version.getMajor() == 25) || (Version.getMajor() == 26)) {
++      // darwin25-26 corresponds to macOS 26-27.
++      Version = VersionTuple(Version.getMajor() + 1);
++    } else {
++      // Starting with darwin27, it naturally corresponds to the same macOS
++      // version.
+     }
+     break;
+   case MacOSX:
+-- 
+2.54.0
+

--- a/pkgs/development/compilers/llvm/21/llvm/backport-darwin-triple-parsing.patch
+++ b/pkgs/development/compilers/llvm/21/llvm/backport-darwin-triple-parsing.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Tue, 11 Aug 2026 20:19:29 -0400
+Subject: [PATCH] backport-darwin-triple-parsing
+
+---
+ lib/TargetParser/Triple.cpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/lib/TargetParser/Triple.cpp b/lib/TargetParser/Triple.cpp
+index 0584c941d2e6..30cf78dbaabc 100644
+--- a/lib/TargetParser/Triple.cpp
++++ b/lib/TargetParser/Triple.cpp
+@@ -1449,9 +1449,12 @@ bool Triple::getMacOSXVersion(VersionTuple &Version) const {
+     } else if (Version.getMajor() < 25) {
+       // darwin20-24 corresponds to macOS 11-15.
+       Version = VersionTuple(11 + Version.getMajor() - 20);
+-    } else {
+-      // darwin25 corresponds with macOS26+.
++    } else if ((Version.getMajor() == 25) || (Version.getMajor() == 26)) {
++      // darwin25-26 corresponds to macOS 26-27.
+       Version = VersionTuple(Version.getMajor() + 1);
++    } else {
++      // Starting with darwin27, it naturally corresponds to the same macOS
++      // version.
+     }
+     break;
+   case MacOSX:
+-- 
+2.54.0
+

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -250,6 +250,13 @@ stdenv.mkDerivation (
           stripLen = 1;
           hash = "sha256-HHVMVL7ZWiZkbfnD37zYxFWnfvI3LNS0Z2oFHhOaZsU=";
         })
+      ]
+      ++ lib.optionals (lib.versionOlder release_version "23") [
+        # As of macOS 27 (and iOS 27, etc), the Darwin version number is the same as the OS version number.
+        # This change breaks target parsing because `darwin27` is incorrectly interpreted as macOS 28.
+        # This patch is a backport of the target parsing changes in LLVM 23, which fixes the problem.
+        # Hopefully, Apple does not change the version number scheme again any time soon.
+        (getVersionFile "llvm/backport-darwin-triple-parsing.patch")
       ];
 
     nativeBuildInputs = [

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -333,16 +333,6 @@ stdenv.mkDerivation (
               --replace-fail "PhysicalFileSystemWorkingDirFailure" "DISABLED_PhysicalFileSystemWorkingDirFailure"
           ''
         +
-          # Fails on macOS ≥ 26 due to the changed OS version scheme.
-          #
-          # This was fixed upstream in LLVM 21 with
-          # 88f041f3e05e26617856cc096d2e2864dfaa1c7b, but it’s too
-          # painful to backport all the way.
-          lib.optionalString (lib.versionOlder release_version "21") ''
-            substituteInPlace unittests/TargetParser/Host.cpp \
-              --replace-fail "getMacOSHostVersion" "DISABLED_getMacOSHostVersion"
-          ''
-        +
           # This test fails with a `dysmutil` crash; have not yet dug into what's
           # going on here (TODO(@rrbutani)).
           lib.optionalString (stdenv.hostPlatform.isx86 && lib.versionOlder release_version "19") ''

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -20,6 +20,17 @@
       path = ../18;
     }
   ];
+  "llvm/backport-darwin-triple-parsing.patch" = [
+    {
+      after = "18";
+      before = "21";
+      path = ../18;
+    }
+    {
+      after = "21";
+      path = ../21;
+    }
+  ];
   "llvm/gnu-install-dirs.patch" = [
     {
       after = "23";


### PR DESCRIPTION
This fixes breakage on triples for macOS 27, which aligned the Darwin version with the OS version (darwin26 is macOS 27, but so is darwin27, which will be incorrectly interpreted as macOS 28 without this patch). This is probably harmless in most cases, but it causes a test failure in LLVM’s test suite when running under macOS 27.

I tested that the Darwin bootstrap built, my Swift branch builds (with its own patch that will be included in the Swift PR), and that all `llvmPackages_X.llvm` (for `X` in 18...22) build.

Note: `llvmPackages_23.llvm` fails to build, but that failure is due to the lack of `codesign` for the tests rather than the target parsing tests failing, which do pass as expected on macOS 27.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
