### PR TITLE
aseprite: 1.3.18.1 -> 1.3.18.2

### DIFF
--- a/pkgs/by-name/as/aseprite/package.nix
+++ b/pkgs/by-name/as/aseprite/package.nix
@@ -34,21 +34,21 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "aseprite";
-  version = "1.3.18.1";
+  version = "1.3.18.2";
 
   src = fetchFromGitHub {
     owner = "aseprite";
     repo = "aseprite";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-uItjmYg21Ph2QIYFKm0N6kVwJtedH0aVKm8hSbQcJIM=";
+    hash = "sha256-Blv/OXnQSofbwzjng24HwLjEViXx13EqkAZvBSjnB3Y=";
   };
 
   asepriteStrings = fetchFromGitHub {
     owner = "aseprite";
     repo = "strings";
-    rev = "417074f649f359f98511fc87a707c276d87f5739";
-    hash = "sha256-5bB7yK4eJHhkUwGYtIFYdFXpRrBt69VBbTh7EmPFI08=";
+    rev = "b43be33343efa40c1c4bda00f985b8cd83bddf2a";
+    hash = "sha256-JxNEtWnP3RtntXM3CmJLXyByW6dri98COp2O0A6ZwBA=";
   };
 
   # Translation files are copied without overwriting existing ones to preserve
@@ -103,6 +103,10 @@ clangStdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/ver/CMakeLists.txt \
       --replace-fail '"1.x-dev"' '"${finalAttrs.version}"'
+
+    # fmt 12.2 no longer exposes fmt::format through fmt/core.h.
+    substituteInPlace src/app/i18n/strings.h \
+      --replace-fail '"fmt/core.h"' '"fmt/format.h"'
 
     # Fix build on Darwin with `-Werror=format-security`
     # (NSLog requires a string-literal format)


### PR DESCRIPTION
https://github.com/aseprite/aseprite/releases/tag/v1.3.18.2

Close https://github.com/NixOS/nixpkgs/issues/552132
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
