### PR TITLE
Switch Cygwin over to GCC NG

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -161,14 +161,12 @@ let
             (with final; isWindows && isAarch64);
 
         # Use the split GCC package set (`gccNGPackages`) instead of the
-        # monolithic `gcc`. No platform selects it yet; it is opt-in, set
-        # explicitly on a platform spec, so that the split set can be exercised
-        # before anything depends on it.
+        # monolithic `gcc`.
         #
-        # I (@Ericson2314) plan on making obscure low-tier platforms (e.g.
-        # NetBSD) use it soon, so we can dogfood GCC NG and thereby iron out its
-        # bugs.
-        useGccNG = false;
+        # I (@Ericson2314) plan on making more obscure low-tier
+        # platforms (e.g. NetBSD) use it soon, so we can dogfood GCC NG
+        # and thereby iron out its bugs.
+        useGccNG = final.isCygwin;
 
         libc =
           if final.isDarwin then

--- a/pkgs/by-name/li/libbacktrace/package.nix
+++ b/pkgs/by-name/li/libbacktrace/package.nix
@@ -77,6 +77,17 @@ stdenv.mkDerivation {
     (lib.enableFeature enableShared "shared")
   ];
 
+  # A (PE/COFF) DLL has to resolve every symbol at link time, and
+  # libtool declines to build one at all unless told unresolved symbols
+  # are not allowed. We don't have any unresolved symbols so we can pass
+  # this flag.
+  #
+  # We only want this affecting the build. It could mess up configure
+  # scripts if we defined it for the entire derivation.
+  #
+  # TODO use `lib.optionalString` at the cost of some rebuilds.
+  makeFlags = if enableShared && stdenv.hostPlatform.isPE then "LDFLAGS=-no-undefined" else null;
+
   doCheck = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isMusl;
 
   passthru = {

--- a/pkgs/by-name/mu/musl/package.nix
+++ b/pkgs/by-name/mu/musl/package.nix
@@ -177,9 +177,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     linuxHeaders = linuxHeaders;
 
-    # musl's threads are POSIX threads. `libgcc` and `libstdc++` have to be
-    # configured for the same threading model as each other, so rather than
-    # have each guess, they take it from the libc they are built against.
+    # musl's threads are POSIX threads.
+    #
+    # See the comment on `threadModel` in
+    # pkgs/development/compilers/gcc/ng/common/libgcc/default.nix for further
+    # details.
     threadModel = "posix";
   };
 

--- a/pkgs/development/compilers/gcc/ng/15/libgfortran/force-regular-dirs.patch
+++ b/pkgs/development/compilers/gcc/ng/15/libgfortran/force-regular-dirs.patch
@@ -8,10 +8,9 @@ Subject: [PATCH] libgfortran: Force regular include/lib dir
  1 file changed, 5 insertions(+), 8 deletions(-)
 
 diff --git a/libgfortran/Makefile.am b/libgfortran/Makefile.am
-index 21b35c76a06..3d38cde5b42 100644
 --- a/libgfortran/Makefile.am
 +++ b/libgfortran/Makefile.am
-@@ -42,14 +42,13 @@ extra_darwin_ldflags_libgfortran += -Wc,-nodefaultrpaths
+@@ -42,8 +42,7 @@
  extra_darwin_ldflags_libgfortran += -Wl,-rpath,@loader_path
  endif
  
@@ -21,6 +20,9 @@ index 21b35c76a06..3d38cde5b42 100644
  
  LTLDFLAGS = $(shell $(SHELL) $(top_srcdir)/../libtool-ldflags $(LDFLAGS)) \
  	    $(lt_host_flags)
+@@ -58,8 +57,8 @@
+ 	      -I../libbacktrace
+ endif
  
 -toolexeclib_LTLIBRARIES = libgfortran.la
 -toolexeclib_DATA = libgfortran.spec
@@ -28,8 +30,8 @@ index 21b35c76a06..3d38cde5b42 100644
 +toolexeclib_DATA = libgfortran.spec # needs "exec" in name
  libgfortran_la_LINK = $(LINK) $(libgfortran_la_LDFLAGS)
  libgfortran_la_LDFLAGS = -version-info `grep -v '^\#' $(srcdir)/libtool-version` \
- 	$(LTLDFLAGS) $(LIBQUADLIB) ../libbacktrace/libbacktrace.la \
-@@ -58,16 +57,14 @@ libgfortran_la_LDFLAGS = -version-info `grep -v '^\#' $(srcdir)/libtool-version`
+ 	$(LTLDFLAGS) $(LIBQUADLIB) $(LIBBACKTRACE_LIB) \
+@@ -68,16 +67,14 @@
  	$(version_arg) -Wc,-shared-libgcc
  libgfortran_la_DEPENDENCIES = $(version_dep) libgfortran.spec $(LIBQUADLIB_DEP)
  
@@ -50,4 +52,3 @@ index 21b35c76a06..3d38cde5b42 100644
  ## io.h conflicts with a system header on some platforms, so
 -- 
 2.47.2
-

--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -206,7 +206,7 @@ makeScopeWithSplicing' {
       # Stage 2: libgcc available, libc not yet — what compiling a libc needs.
       # `binutilsNoLibc` is what keeps the libc out, so nothing here refers to
       # a libc derivation and the cycle stays broken.
-      gccWithLibgcc = wrapCCWith {
+      gccWithLibgccNoCxx = wrapCCWith {
         cc = gccPackages.gcc-unwrapped;
         libcxx = null;
         bintools = binutilsNoLibc;
@@ -217,6 +217,33 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc-no-libc}/lib"
         ];
       };
+
+      # Freestanding libstdc++ not depending on any libc
+      libstdcxx-no-libc = callPackage ./libstdcxx {
+        stdenv = overrideCC stdenv buildGccPackages.gccWithLibgccNoCxx;
+        # The set's plain `libgcc` is the finished one, which is built after
+        # the libc; only the bootstrap libgcc exists this early.
+        libgcc = gccPackages.libgcc-no-libc;
+      };
+
+      gccWithLibgcc =
+        # Cygwin's libc is in partly C++ and needs C++ headers to build.
+        if stdenv.targetPlatform.isCygwin then
+          wrapCCWith {
+            cc = gccPackages.gcc-unwrapped;
+            libcxx = targetGccPackages.libstdcxx-no-libc;
+            bintools = binutilsNoLibc;
+            extraPackages = [
+              targetGccPackages.libgcc-no-libc
+            ];
+            nixSupport.cc-cflags = [
+              "-B${targetGccPackages.libgcc-no-libc}/lib"
+              # See above for why `libcxx = ...` is not enough.
+              "-B${targetGccPackages.libstdcxx-no-libc}/lib"
+            ];
+          }
+        else
+          gccPackages.gccWithLibgccNoCxx;
 
       # Stage 3: real libc, bootstrap libgcc still. The finished libgcc is what
       # this is about to build.

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -91,6 +91,13 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-54/HzM+aeWq8CTkQu8Pualqc/LgRLS0+8EY8uPUsD+s=";
     })
 
+    # Make --disable-fixinclude compatible with Cygwin
+    (fetchpatch {
+      name = "mingw-drop-obsolete-STMP_FIXINC-override.patch";
+      url = "https://github.com/gcc-mirror/gcc/commit/7fb73dd7bb8aabab1416f0b28e6df45131a8e8ab.diff";
+      hash = "sha256-FmFJISfXt+/TCRcd4rYfwacBiTqu+/OKw0VvLh46Hz0=";
+    })
+
     # Not upstream yet; a follow-up to the series above (drop the `/raw` to
     # read them). They extend that series' `<target>-as` preference to `PATH`,
     # where we put the cross toolchain, so a cross compiler finds its tools
@@ -329,15 +336,24 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-system-zlib"
     "--with-system-libbacktrace"
     "--without-included-gettext"
+
+    # No host platform headers are exposed to gcc, whatever the relationship
+    # between build, host and target. cc-wrapper supplies the target libc
+    # (`-idirafter <libc.dev>/include` and the corresponding `-B`/`-L` flags),
+    # as in the LLVM package set, where `clang` likewise carries no libc
+    # reference (`--without-headers` above). Naming one here --
+    # `--with-sysroot`, `--with-native-system-header-dir` -- would make every
+    # libc change rebuild the compiler, precisely the coupling this split
+    # package set exists to remove.
+    #
+    # So `fixincludes` has nothing to do either: it exists to copy the headers
+    # gcc found and rewrite the ones it knows to be broken. Left on, it falls
+    # back to `/usr/include` and stops the build outright when that is missing.
+    # `limits.h` and `syslimits.h` come from a separate prerequisite and are
+    # unaffected.
+    "--disable-fixincludes"
+
     "--enable-linker-build-id"
-    # Deliberately *no* `--with-sysroot` / `--with-native-system-header-dir`
-    # pointing at the target libc. Baking a libc store path into the compiler
-    # makes every libc change rebuild the compiler, which is precisely the
-    # coupling this split package set exists to remove. cc-wrapper already
-    # supplies the target libc (`-idirafter <libc.dev>/include` and the
-    # corresponding `-B`/`-L` flags), so the compiler proper does not need to
-    # know about it -- exactly as in the LLVM package set, where `clang`
-    # likewise carries no libc reference (`--without-headers` above).
   ]
   ++ lib.optionals enablePlugin [
     "--enable-plugin"

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -38,8 +38,11 @@
   autoreconfHook269,
   bintools,
   # Build the shared runtime libraries, and so have the driver's specs emit
-  # `-lgcc_s`. Derived the way the monolithic build derives it.
-  enableTargetShared ? stdenv.targetPlatform.hasSharedLibraries,
+  # `-lgcc_s`. Derived the way the monolithic build derives it, including its
+  # exclusion of Cygwin: there the specs would also emit `-lgcc_eh`, and no
+  # stage of this package set produces one, so every C++ link performed while
+  # building the libc fails on a library that does not exist.
+  enableTargetShared ? stdenv.targetPlatform.hasSharedLibraries && !stdenv.targetPlatform.isCygwin,
 }:
 let
   inherit (stdenv) targetPlatform hostPlatform;

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -37,11 +37,10 @@
   libbacktrace,
   autoreconfHook269,
   bintools,
-  # Build the shared runtime libraries, and so have the driver's specs emit
-  # `-lgcc_s`. Derived the way the monolithic build derives it, including its
-  # exclusion of Cygwin: there the specs would also emit `-lgcc_eh`, and no
-  # stage of this package set produces one, so every C++ link performed while
-  # building the libc fails on a library that does not exist.
+  enableShared ? stdenv.hostPlatform.hasSharedLibraries,
+  # Whether the driver's specs emit `-lgcc_s`. Derived as the monolithic build
+  # derives it, Cygwin excluded: there they would also emit `-lgcc_eh`, which no
+  # stage of this package set produces.
   enableTargetShared ? stdenv.targetPlatform.hasSharedLibraries && !stdenv.targetPlatform.isCygwin,
 }:
 let
@@ -296,10 +295,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-install-libiberty"
     "--disable-multilib"
     "--disable-nls"
-    # Derived rather than forced off: the driver's specs only emit `-lgcc_s`
-    # for a target that has shared libraries, so hardcoding this leaves every
-    # throwing C++ program unlinkable even though `libgcc_s.so` is built and
-    # findable. Same predicate the monolithic build uses.
+    (lib.enableFeature enableShared "host-shared")
     (lib.enableFeature enableTargetShared "shared")
     "--enable-default-pie"
     "--enable-languages=${

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -370,6 +370,13 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-vtable-verify"
 
     "--with-system-zlib"
+
+    # State this rather than leave it to be inferred (see below): configure
+    # works it out from `host != target` alone, so a native build of the
+    # pre-libc stage would come out `false` and compile every file against a
+    # libc that is not there yet. A value given here wins, since configure only
+    # defaults it, with `: ${inhibit_libc=false}`.
+    "inhibit_libc=${if libc == null then "true" else "false"}"
   ]
   # `gcc/configure` sets `inhibit_libc=true` when host != target and
   # `$target_header_dir/stdio.h` does not exist. `inhibit_libc` makes

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -21,18 +21,29 @@
   # The following are arguments rather than a `let` bindings only so
   # that it is in scope for the default definition above.
 
-  # Whether a shared libgcc can be built at all here, derived the way the
-  # monolithic build derives it rather than forced off.
+  # Whether to build a shared libgcc.
   #
-  # Shared needs something to link against. Normally that is the libc, on any
-  # format -- PE/COFF included -- which is why every stage after the bootstrap
-  # builds it. ELF additionally allows it *before* the libc exists, because a
-  # shared object may keep undefined symbols; `libgcc_s.so` comes out with an
-  # empty `DT_NEEDED`, which is why the monolithic build ships one even from
-  # its nolibc stage. A PE/COFF DLL must resolve everything at link time, so
-  # there the bootstrap yields only `libgcc.a` -- all it is used for anyway.
+  # In addition to being the default, this is also the *maximal* condition --
+  # by default we enable shared wherever possible, and enabling shared in more
+  # cases should not work. That is why this is also used in the assert below.
   __defaultEnableShared ?
-    stdenv.hostPlatform.hasSharedLibraries && (__haveLinkableLibc || stdenv.hostPlatform.isElf),
+    # Of course if the platform as a whole doesn't support shared libraries, we
+    # cannot either.
+    stdenv.hostPlatform.hasSharedLibraries
+    # libstdc++ and libgomp choke if we try to build a shared libgcc, because
+    # the shared libgcc has fewer symbols, with the unwinder and the emulated-
+    # TLS support in `libgcc_eh.a` instead, which those libraries don't link.
+    #
+    # We could perhaps patch those libraries to link `libgcc_eh.a` too as
+    # needed, but it didn't feel worth the fight at this time.
+    && !stdenv.hostPlatform.isCygwin
+    # Shared needs something to link against. Normally that is the libc, on any
+    # format -- PE/COFF included -- which is why every stage after the bootstrap
+    # builds it. ELF additionally allows it *before* the libc exists, because a
+    # shared object may keep undefined symbols; `libgcc_s.so` comes out with an
+    # empty `DT_NEEDED`. A PE/COFF DLL must resolve everything at link time, so
+    # there the bootstrap yields only `libgcc.a` -- all it is used for anyway.
+    && (__haveLinkableLibc || stdenv.hostPlatform.isElf),
 
   # Whether the compiler has a libc that can actually be linked against, as
   # opposed to nothing at all or a headers-only stand-in.

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -54,13 +54,23 @@ let
   # there rather than guess — and pass it on in `passthru` so that `libstdcxx`,
   # which has to agree, reads the same answer instead of probing for its own.
   #
-  # This is what makes the bootstrap build single-threaded without being told
-  # to be: a headers-only package declares no `threadModel`, and a real libc
-  # does. That build exists only to get the libc built and is thrown away
-  # afterwards, so there is nothing to be gained from threading it, and plenty
-  # to go wrong: `gthr-posix.h` includes `<pthread.h>` unconditionally, which
-  # at that point is either absent or a stand-in for a libc that does not exist
-  # yet.
+  # A headers-only package declares no `threadModel`, and a real libc does.
+  # That build exists only to get the libc built and is thrown away afterwards,
+  # so there is nothing to be gained from threading it, and plenty to go wrong:
+  # `gthr-posix.h` includes `<pthread.h>` unconditionally, which at that point
+  # is either absent or a stand-in for a libc that does not exist yet.
+  #
+  # If, in the future, we ever wish to use the headers-only build to avoid
+  # building those other libraries twice (other distros sometimes do this), we
+  # would declare the threading model unconditonally, and then there would be
+  # more cyclic symbol-level dependencies between them and us.
+  #
+  # libgcc (and libstdc++) read this attribute rather than probing the
+  # compiler, which in a split package set is configured separately from the
+  # runtimes and so can disagree. Only if we switched `cc-wrapper` to give GCC
+  # "spec files" (more powerful than CLI flags) would be be able to get the
+  # compiler `-v` flag correct with respect to the libraries it happend to be
+  # wrapped with.
   threadModel = if libc == null then "single" else libc.threadModel or "single";
 in
 

--- a/pkgs/development/compilers/gcc/ng/common/libgfortran/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgfortran/default.nix
@@ -37,8 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    (getVersionFile "libgfortran/force-regular-dirs.patch")
-
     # From the posting to gcc-patches, which covers every component that links
     # libbacktrace. Take only this component's non-generated files: the
     # generated ones are rebuilt by `autoreconfHook269` below, against a GCC
@@ -53,6 +51,11 @@ stdenv.mkDerivation (finalAttrs: {
       ];
       hash = "sha256-QB+Wto9V1XXYhUhUSeP7Mxoj/iZQdMOT+7aSWyHjXX0=";
     })
+
+    # Applied after `system-libbacktrace.patch` above: both rewrite the same
+    # region of `libgfortran/Makefile.am`, and this one is ours to rebase --
+    # the other is the version posted upstream, kept as posted.
+    (getVersionFile "libgfortran/force-regular-dirs.patch")
   ];
 
   autoreconfFlags = "--install --force --verbose . libgfortran";

--- a/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
@@ -13,8 +13,36 @@
   libgcc,
   libbacktrace,
 }:
+let
+  # A full libstdc++ needs a libc to link against. Without one, build the
+  # freestanding subset instead: the libsupc++ headers, which are what a libc
+  # that is itself partly C++ needs in order to compile. No library comes out
+  # of that stage and none is wanted -- it exists only so the C++ parts of a
+  # libc have `<new>` and friends to include.
+  hosted = stdenv.cc.libc != null && !(stdenv.cc.libc.headersOnly or false);
+
+  cxxForLibstdcxxFlags = [
+    "-shared-libgcc"
+    "-nostdinc++"
+  ]
+  # libstdc++ ships headers named after C headers (`stdlib.h`, `math.h`, ...)
+  # which shadow the C library's in C++. They forward by re-exporting from
+  # `<cstdlib>` and friends, and most of what they re-export -- `malloc` and
+  # `free` among it -- sits behind `#if _GLIBCXX_HOSTED`. So in a freestanding
+  # build any header that reaches for plain `<stdlib.h>` gets one with no
+  # `malloc` in it. gcc's own `mm_malloc.h` does exactly that, and on this
+  # target it is unavoidable: `unwind.h` pulls in `<windows.h>` for SEH, which
+  # reaches the x86 intrinsics headers.
+  #
+  # This macro is libstdc++'s own way of saying "forward to the real C header",
+  # which is what its sources want while it is being built.
+  # The C driver flags libstdc++ is built with. `-shared-libgcc` puts back the
+  # linkage `g++` would have chosen and `-nostdinc++` keeps any installed C++
+  # headers out; see the `RAW_CXX_FOR_TARGET` note at `preConfigure`.
+  ++ lib.optionals (!hosted) [ "-D_GLIBCXX_INCLUDE_NEXT_C_HEADERS" ];
+in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "libstdcxx";
+  pname = "libstdcxx" + lib.optionalString (!hosted) "-no-libc";
   inherit version;
 
   src = runCommand "libstdcxx-src-${version}" { src = monorepoSrc; } (
@@ -109,7 +137,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ libbacktrace ];
+  # We don't need `std::backtrace` in the bootstrap pre-libc libstdc++
+  buildInputs = lib.optional hosted libbacktrace;
 
   nativeBuildInputs = [
     autoreconfHook269
@@ -143,7 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
   # keeps any already-installed C++ headers out of a build whose whole
   # purpose is to produce them.
   + ''
-    cxxForLibstdcxx="$CC -shared-libgcc -nostdinc++"
+    cxxForLibstdcxx="$CC ${lib.escapeShellArgs cxxForLibstdcxxFlags}"
 
   ''
   # Put libgcc's `gthr-default.h` where libstdc++ expects to find it.
@@ -173,6 +202,23 @@ stdenv.mkDerivation (finalAttrs: {
 
     export CXX="$cxxForLibstdcxx"
     echo "libstdcxx: building with CXX=$CXX"
+  ''
+  # `--enable-static` is not enough on its own here, which is why this is
+  # done to the output rather than the input. configure agrees with us --
+  # `config.log` records `enable_static=yes` -- but libtool's Windows
+  # handling reassigns that variable while working out what a DLL-based
+  # target can build, and `build_old_libs` is substituted from the value it
+  # lands on. With shared libraries off as well, the generated script ends
+  # up refusing both kinds and `make` stops at "not configured to build any
+  # kind of library". Put the one answer back that this build needs.
+  + lib.optionalString (!hosted) ''
+    enableStaticInLibtool() {
+      local lt
+      for lt in $(find "$buildRoot" -type f -name libtool); do
+        sed -i 's/^build_old_libs=no$/build_old_libs=yes/' "$lt"
+      done
+    }
+    postConfigureHooks+=(enableStaticInLibtool)
   '';
 
   configurePlatforms = [
@@ -189,6 +235,8 @@ stdenv.mkDerivation (finalAttrs: {
     "cross_compiling=true"
     "--disable-multilib"
 
+    (lib.enableFeature hosted "libstdcxx-backtrace")
+    # This is safely ignored when we disable the above
     "--with-system-libbacktrace"
 
     # `gnu` is the glibc locale model: `config/locale/gnu/ctype_members.cc`
@@ -202,6 +250,50 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-vtable-verify"
     "--enable-libstdcxx-visibility"
     "--with-default-libstdcxx-abi=new"
+  ]
+  ++ lib.optionals (!hosted) [
+    "--disable-hosted-libstdcxx"
+
+    # We can only statically link when we don't yet have a libc. Might
+    # have been able to autodetect but better to be explicit.
+    "--enable-static"
+    "--disable-shared"
+
+    # Answer the C library's capabilities from a table instead of
+    # probing for them: every probe is a link test, and there is nothing
+    # here to link against. It selects an `os_include_dir` and hardcodes
+    # a batch of `HAVE_*`.
+    #
+    # `build` != `host` already sets `GLIBCXX_IS_NATIVE=false` which is
+    # supposed to be sufficient for this, at least if I am reading
+    # https://github.com/gcc-mirror/gcc/blob/4db0e8df15bef836558857c291c323add11d035c/libstdc%2B%2B-v3/configure.ac#L310-L342
+    # correctly.
+    #
+    # However, it isn't in fact sufficient, and we will get
+    # post-GCC_NO_EXECUTABLES would-link configure errors. This newlib
+    # flag actually does do the job. While nothing here uses newlib, the
+    # table is close enough -- none of it reaches the libsupc++ headers,
+    # which are all this stage installs.
+    "--with-newlib"
+
+    # Disabling backgtrace (as we do above) does not stop its `fcntl`
+    # and `getexecname` probes, which run before anything consults the
+    # flag, and which link, causing more post-GCC_NO_EXECUTABLES
+    # would-link configure errors.
+    #
+    # `--with-target-subdir` stops those probes, for a reason its name
+    # does not suggest. Upstream tests it only for emptiness -- never as
+    # a path -- and uses it to mean "I am an in-tree GCC target
+    # library", which it takes as "I cannot link", answering from a
+    # `case "${host}"` table instead of probing. It says so at the
+    # `dl_iterate_phdr` check just above: "When built as a GCC target
+    # library, we can't do a link test." So `.` here is not a directory
+    # we use; it is that claim.
+    #
+    # The table's answers happen to be the true ones for this host:
+    # `fcntl` yes (only mingw is excluded) and `getexecname` no (only
+    # solaris2).
+    "--with-target-subdir=."
   ];
 
   hardeningDisable = [
@@ -209,11 +301,14 @@ stdenv.mkDerivation (finalAttrs: {
     "fortify"
   ];
 
+  # Not just tidiness: the manifest names paths under the header directory, so
+  # leaving it in `lib` makes `out` refer to `dev` and the outputs cycle.
   postInstall = ''
     moveToOutput lib/libstdc++.modules.json "$dev"
   '';
 
-  doCheck = true;
+  # Nothing to run the testsuite against before there is a libc.
+  doCheck = hosted;
 
   passthru = {
     isGNU = true;
@@ -222,5 +317,12 @@ stdenv.mkDerivation (finalAttrs: {
   meta = gcc_meta // {
     homepage = "https://gcc.gnu.org/onlinedocs/libstdc++";
     description = "GNU C++ Library";
+    # The freestanding, pre-libc build exists for exactly one reason:
+    # Cygwin's libc is partly C++ and so needs C++ headers before it
+    # exists itself. Elsewhere it is unneeded, and we don't care whether
+    # it builds or not at this time. (And it appears to not build at
+    # this time). Marking broken rather because in principle it ought to
+    # work.
+    broken = !hosted && !stdenv.hostPlatform.isCygwin;
   };
 })

--- a/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
@@ -13,8 +13,36 @@
   libgcc,
   libbacktrace,
 }:
+let
+  # A full libstdc++ needs a libc to link against. Without one, build the
+  # freestanding subset instead: the libsupc++ headers, which are what a libc
+  # that is itself partly C++ needs in order to compile. No library comes out
+  # of that stage and none is wanted -- it exists only so the C++ parts of a
+  # libc have `<new>` and friends to include.
+  hosted = stdenv.cc.libc != null && !(stdenv.cc.libc.headersOnly or false);
+
+  cxxForLibstdcxxFlags = [
+    "-shared-libgcc"
+    "-nostdinc++"
+  ]
+  # libstdc++ ships headers named after C headers (`stdlib.h`, `math.h`, ...)
+  # which shadow the C library's in C++. They forward by re-exporting from
+  # `<cstdlib>` and friends, and most of what they re-export -- `malloc` and
+  # `free` among it -- sits behind `#if _GLIBCXX_HOSTED`. So in a freestanding
+  # build any header that reaches for plain `<stdlib.h>` gets one with no
+  # `malloc` in it. gcc's own `mm_malloc.h` does exactly that, and on this
+  # target it is unavoidable: `unwind.h` pulls in `<windows.h>` for SEH, which
+  # reaches the x86 intrinsics headers.
+  #
+  # This macro is libstdc++'s own way of saying "forward to the real C header",
+  # which is what its sources want while it is being built.
+  # The C driver flags libstdc++ is built with. `-shared-libgcc` puts back the
+  # linkage `g++` would have chosen and `-nostdinc++` keeps any installed C++
+  # headers out; see the `RAW_CXX_FOR_TARGET` note at `preConfigure`.
+  ++ lib.optionals (!hosted) [ "-D_GLIBCXX_INCLUDE_NEXT_C_HEADERS" ];
+in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "libstdcxx";
+  pname = "libstdcxx" + lib.optionalString (!hosted) "-no-libc";
   inherit version;
 
   src = runCommand "libstdcxx-src-${version}" { src = monorepoSrc; } (
@@ -109,7 +137,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ libbacktrace ];
+  # We don't need `std::backtrace` in the bootstrap pre-libc libstdc++
+  buildInputs = lib.optional hosted libbacktrace;
 
   nativeBuildInputs = [
     autoreconfHook269
@@ -143,7 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
   # keeps any already-installed C++ headers out of a build whose whole
   # purpose is to produce them.
   + ''
-    cxxForLibstdcxx="$CC -shared-libgcc -nostdinc++"
+    cxxForLibstdcxx="$CC ${lib.escapeShellArgs cxxForLibstdcxxFlags}"
 
   ''
   # Put libgcc's `gthr-default.h` where libstdc++ expects to find it.
@@ -173,6 +202,23 @@ stdenv.mkDerivation (finalAttrs: {
 
     export CXX="$cxxForLibstdcxx"
     echo "libstdcxx: building with CXX=$CXX"
+  ''
+  # `--enable-static` is not enough on its own here, which is why this is
+  # done to the output rather than the input. configure agrees with us --
+  # `config.log` records `enable_static=yes` -- but libtool's Windows
+  # handling reassigns that variable while working out what a DLL-based
+  # target can build, and `build_old_libs` is substituted from the value it
+  # lands on. With shared libraries off as well, the generated script ends
+  # up refusing both kinds and `make` stops at "not configured to build any
+  # kind of library". Put the one answer back that this build needs.
+  + lib.optionalString (!hosted) ''
+    enableStaticInLibtool() {
+      local lt
+      for lt in $(find "$buildRoot" -type f -name libtool); do
+        sed -i 's/^build_old_libs=no$/build_old_libs=yes/' "$lt"
+      done
+    }
+    postConfigureHooks+=(enableStaticInLibtool)
   '';
 
   configurePlatforms = [
@@ -189,6 +235,8 @@ stdenv.mkDerivation (finalAttrs: {
     "cross_compiling=true"
     "--disable-multilib"
 
+    (lib.enableFeature hosted "libstdcxx-backtrace")
+    # This is safely ignored when we disable the above
     "--with-system-libbacktrace"
 
     # `gnu` is the glibc locale model: `config/locale/gnu/ctype_members.cc`
@@ -202,6 +250,50 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-vtable-verify"
     "--enable-libstdcxx-visibility"
     "--with-default-libstdcxx-abi=new"
+  ]
+  ++ lib.optionals (!hosted) [
+    "--disable-hosted-libstdcxx"
+
+    # We can only statically link when we don't yet have a libc. Might
+    # have been able to autodetect but better to be explicit.
+    "--enable-static"
+    "--disable-shared"
+
+    # Answer the C library's capabilities from a table instead of
+    # probing for them: every probe is a link test, and there is nothing
+    # here to link against. It selects an `os_include_dir` and hardcodes
+    # a batch of `HAVE_*`.
+    #
+    # `build` != `host` already sets `GLIBCXX_IS_NATIVE=false` which is
+    # supposed to be sufficient for this, at least if I am reading
+    # https://github.com/gcc-mirror/gcc/blob/4db0e8df15bef836558857c291c323add11d035c/libstdc%2B%2B-v3/configure.ac#L310-L342
+    # correctly.
+    #
+    # However, it isn't in fact sufficient, and we will get
+    # post-GCC_NO_EXECUTABLES would-link configure errors. This newlib
+    # flag actually does do the job. While nothing here uses newlib, the
+    # table is close enough -- none of it reaches the libsupc++ headers,
+    # which are all this stage installs.
+    "--with-newlib"
+
+    # Disabling backgtrace (as we do above) does not stop its `fcntl`
+    # and `getexecname` probes, which run before anything consults the
+    # flag, and which link, causing more post-GCC_NO_EXECUTABLES
+    # would-link configure errors.
+    #
+    # `--with-target-subdir` stops those probes, for a reason its name
+    # does not suggest. Upstream tests it only for emptiness -- never as
+    # a path -- and uses it to mean "I am an in-tree GCC target
+    # library", which it takes as "I cannot link", answering from a
+    # `case "${host}"` table instead of probing. It says so at the
+    # `dl_iterate_phdr` check just above: "When built as a GCC target
+    # library, we can't do a link test." So `.` here is not a directory
+    # we use; it is that claim.
+    #
+    # The table's answers happen to be the true ones for this host:
+    # `fcntl` yes (only mingw is excluded) and `getexecname` no (only
+    # solaris2).
+    "--with-target-subdir=."
   ];
 
   hardeningDisable = [
@@ -209,11 +301,14 @@ stdenv.mkDerivation (finalAttrs: {
     "fortify"
   ];
 
+  # Not just tidiness: the manifest names paths under the header directory, so
+  # leaving it in `lib` makes `out` refer to `dev` and the outputs cycle.
   postInstall = ''
     moveToOutput lib/libstdc++.modules.json "$dev"
   '';
 
-  doCheck = true;
+  # Nothing to run the testsuite against before there is a libc.
+  doCheck = hosted;
 
   passthru = {
     isGNU = true;

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -279,9 +279,11 @@ stdenv.mkDerivation (
       inherit version;
       minorRelease = version;
 
-      # glibc's threads are POSIX threads. `libgcc` and `libstdc++` have to be
-      # configured for the same threading model as each other, so rather than
-      # have each guess, they take it from the libc they are built against.
+      # glibc's threads are POSIX threads.
+      #
+      # See the comment on `threadModel` in
+      # pkgs/development/compilers/gcc/ng/common/libgcc/default.nix for further
+      # details.
       threadModel = "posix";
     };
   }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libc.nix
@@ -48,9 +48,10 @@ symlinkJoin {
   '';
 
   # NetBSD's threads are POSIX threads — `libpthread` is joined in above.
-  # `libgcc` and `libstdc++` have to be configured for the same threading model
-  # as each other, so rather than have each guess, they take it from the libc
-  # they are built against.
+  #
+  # See the comment on `threadModel` in
+  # pkgs/development/compilers/gcc/ng/common/libgcc/default.nix for further
+  # details.
   passthru.threadModel = "posix";
 
   meta.platforms = lib.platforms.netbsd;

--- a/pkgs/os-specific/cygwin/newlib-cygwin/default.nix
+++ b/pkgs/os-specific/cygwin/newlib-cygwin/default.nix
@@ -52,7 +52,22 @@
       !headersOnly && stdenvNoLibc.hostPlatform != stdenvNoLibc.buildPlatform
     ) ./fix-cross.patch;
 
-    passthru.w32api = if headersOnly then w32api-headers else w32api;
+    passthru = {
+      w32api = if headersOnly then w32api-headers else w32api;
+
+      # The headers-only build is the stand-in used to bootstrap a toolchain
+      # before this package itself exists. Runtimes built against it can
+      # compile, but there is nothing here to link against.
+      inherit headersOnly;
+    }
+    # Cygwin's threads are POSIX threads.
+    #
+    # See the comment on `threadModel` in
+    # pkgs/development/compilers/gcc/ng/common/libgcc/default.nix for further
+    # details.
+    // lib.optionalAttrs (!headersOnly) {
+      threadModel = "posix";
+    };
 
     meta = {
       homepage = "https://cygwin.com/";


### PR DESCRIPTION
Trying to convert some more obscure things first as brave guinepigs.

@corngood does have a native stdenv for Cygwin, but as it didn't make it upstream yet I am just looking at the cross build case.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
