### PR TITLE
postgresqlPackages.pg_when: init at 0.1.10

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_when.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_when.nix
@@ -1,0 +1,67 @@
+{
+  buildPgrxExtension,
+  cargo-pgrx_0_18_0,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  postgresql,
+  postgresqlTestExtension,
+  tzdata,
+}:
+buildPgrxExtension (finalAttrs: {
+  inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_18_0;
+
+  pname = "pg_when";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "frectonz";
+    repo = "pg-when";
+    tag = finalAttrs.version;
+    hash = "sha256-2+YCxOB3Svl1DY4mNQg4giks8/fagHAXQ0K16PR96hM=";
+  };
+
+  cargoHash = "sha256-pHY71+egTX9AU8nNeDHCymmaFsz+2JYmRGqKq4uT7w4=";
+
+  # pgrx tests try to install the extension into the postgresql nix store
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  passthru.tests.extension = postgresqlTestExtension {
+    inherit (finalAttrs) finalPackage;
+
+    # timezone lookups need an IANA time zone database
+    env.TZDIR = "${tzdata}/share/zoneinfo";
+
+    sql = ''
+      CREATE EXTENSION pg_when;
+    '';
+    asserts = [
+      {
+        query = "when_is('December 31, 2026 at evening in Asia/Tokyo')";
+        expected = "TIMESTAMPTZ '2026-12-31 18:00:00+09'";
+        description = "exact date with a time keyword and a named timezone resolves correctly";
+      }
+      {
+        query = "seconds_at('January 1, 2000 at midnight in UTC+3')";
+        expected = "946674000";
+        description = "UNIX timestamp accounts for the UTC offset";
+      }
+      {
+        query = "millis_at('1970-01-01 at midnight')";
+        expected = "0";
+        description = "UNIX epoch is zero milliseconds";
+      }
+    ];
+  };
+
+  meta = {
+    description = "PostgreSQL extension for creating time values with natural language";
+    homepage = "https://github.com/frectonz/pg-when";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ frectonz ];
+    platforms = postgresql.meta.platforms;
+  };
+})


### PR DESCRIPTION
[pg-when](https://github.com/frectonz/pg-when) is a PostgreSQL extension that deterministically parses a natural language looking text into a `TIMESTAMPTZ`.

Examples

```SQL
SELECT when_is('5 days ago at this hour in Asia/Tokyo');
SELECT when_is('next friday at 8:00 pm in America/New_York');
SELECT when_is('in 2 months at midnight in UTC-8');
SELECT when_is('last monday at 22:30');
SELECT when_is('December 31, 2026 at evening');

-- It generally follows this pattern, but any subset of it also works.
SELECT when_is('<date> at <time> in <timezone>');
```

I am the upstream author of the extension.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
