### PR TITLE
python3Packages.modbus-connection: 3.9.0 -> 4.6.1

### DIFF
--- a/pkgs/development/python-modules/modbus-connection/default.nix
+++ b/pkgs/development/python-modules/modbus-connection/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "modbus-connection";
-  version = "3.9.0";
+  version = "4.6.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -20,7 +20,7 @@ buildPythonPackage (finalAttrs: {
     owner = "home-assistant-libs";
     repo = "modbus-connection";
     tag = finalAttrs.version;
-    hash = "sha256-WmPjIAxC9e6tYxPJSQpvdhUNj2tbYim5e1RP5MIiL9M=";
+    hash = "sha256-oQgBOyNu0FQeZ1IzUfR6YqlKY0xt1rqVFGIxCZuAOmw=";
   };
 
   nativeBuildInputs = [
@@ -39,7 +39,8 @@ buildPythonPackage (finalAttrs: {
     tmodbus = [
       tmodbus
     ]
-    ++ tmodbus.optional-dependencies.async-serial;
+    ++ tmodbus.optional-dependencies.async-serial
+    ++ tmodbus.optional-dependencies.security;
   };
 
   nativeCheckInputs = [
@@ -50,6 +51,7 @@ buildPythonPackage (finalAttrs: {
 
   disabledTests = [
     # tries to git clone https://github.com/sunspec/models
+    "test_generated_layout_matches_a_real_device"
     "test_official_model_catalogue_generates_and_imports"
   ];
 


### PR DESCRIPTION
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.0.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.1.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.2.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.3.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.4.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.5.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.5.1
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.6.0
https://github.com/home-assistant-libs/modbus-connection/releases/tag/4.6.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
