### PR TITLE
tetragon: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/by-name/te/tetragon/package.nix
+++ b/pkgs/by-name/te/tetragon/package.nix
@@ -5,27 +5,33 @@
   pkg-config,
   go,
   llvm,
-  clang,
+  clang_20,
   bash,
   writableTmpDirAsHomeHook,
   gitMinimal,
+  installShellFiles,
+  nix-update-script,
 }:
-
+let
+  # https://github.com/cilium/tetragon/issues/5389
+  clang = clang_20;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "tetragon";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "cilium";
     repo = "tetragon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-A6a7yjxenB/7sfdfoIaJAxdkw0ouNinZtahNMRAytwA=";
+    hash = "sha256-MOBT2hdzssrWW34v0K4CE4qlAmB+Y7F/R5kAxjl6yT8=";
   };
 
   nativeBuildInputs = [
     pkg-config
     writableTmpDirAsHomeHook
     gitMinimal
+    installShellFiles
   ];
 
   buildInputs = [
@@ -68,16 +74,32 @@ stdenv.mkDerivation (finalAttrs: {
     cp -n -r ./bpf/objs $out/lib/tetragon/bpf
     install -m755 -D ./tetra $out/bin/tetra
     install -m755 -D ./tetragon $out/bin/tetragon
-
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd tetra \
+      --bash <($out/bin/tetra completion bash) \
+      --fish <($out/bin/tetra completion fish) \
+      --zsh <($out/bin/tetra completion zsh)
+    installShellCompletion --cmd tetragon \
+      --bash <($out/bin/tetragon completion bash) \
+      --fish <($out/bin/tetragon completion fish) \
+      --zsh <($out/bin/tetragon completion zsh)
+  ''
+  + ''
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
 
   meta = {
     description = "Real-time, eBPF-based Security Observability and Runtime Enforcement tool";
     homepage = "https://github.com/cilium/tetragon";
     license = lib.licenses.asl20;
     mainProgram = "tetragon";
-    maintainers = with lib.maintainers; [ gangaram ];
+    maintainers = with lib.maintainers; [
+      gangaram
+      RoGreat
+    ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Required a downgrade from clang-21 to clang-20 to get the runtime to work (https://github.com/cilium/tetragon/issues/5389). While I was at it, also included some shell completions and updates on new releases (for those using the `nix-update` tool). Getting this out of the way while I wait on a reviewer for the module https://github.com/NixOS/nixpkgs/pull/550029.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
