### PR TITLE
bashd: init at v0.2.3

### DIFF
--- a/pkgs/by-name/ba/bashd/package.nix
+++ b/pkgs/by-name/ba/bashd/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nix-update-script,
+  shellcheck,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "bashd";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "matkrin";
+    repo = "bashd";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KTfoOEdgPWVe/1HQnBsTOzhZDK1DP5NRiJewTh+DGmg=";
+  };
+
+  vendorHash = "sha256-B4szacVckxUeF0xndHX3T6FnGTF0BkGo9k8uZUWURVM=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  ldflags = [
+    "-X main.VERSION=${finalAttrs.version}"
+  ];
+
+  preFixup = ''
+    wrapProgram "$out/bin/bashd" --prefix PATH : ${lib.makeBinPath [ shellcheck ]}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/matkrin/bashd";
+    description = "Bash language server";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ supermarin ];
+    mainProgram = "bashd";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add bashd, a bash language server written in Go.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
