### PR TITLE
nixos/openthread-border-router: allow web interface to access agent socket

### DIFF
--- a/nixos/modules/services/home-automation/openthread-border-router.nix
+++ b/nixos/modules/services/home-automation/openthread-border-router.nix
@@ -181,6 +181,9 @@ in
     # ot-ctl can be used to query the router instance
     environment.systemPackages = [ cfg.package ];
 
+    # Shared by the agent and web interface for the OpenThread control socket.
+    users.groups.otbr = { };
+
     # Make sure we have ipv6 support, and that forwarding is enabled
     networking.enableIPv6 = true;
     networking.firewall.allowedTCPPorts =
@@ -217,6 +220,7 @@ in
           THREAD_IF = cfg.interfaceName;
         };
         serviceConfig = {
+          Group = "otbr";
           ExecStartPre = "${utils.escapeSystemdExecArg (lib.getExe' cfg.package "otbr-firewall")} start";
           ExecStart = lib.concatStringsSep " " (
             lib.concatLists [
@@ -269,7 +273,7 @@ in
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           SystemCallArchitectures = "native";
-          UMask = "0077";
+          UMask = "0007";
 
           CapabilityBoundingSet = [
             "CAP_NET_ADMIN"
@@ -288,6 +292,7 @@ in
         after = [ "otbr-agent.service" ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
+          Group = "otbr";
           ExecStart = lib.concatStringsSep " " (
             lib.concatLists [
               [


### PR DESCRIPTION
Fixes #548896

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
