### PR TITLE
python3Packages.plumbum: fix darwin build by deselecting test_pgrep

### DIFF
--- a/pkgs/development/python-modules/plumbum/default.nix
+++ b/pkgs/development/python-modules/plumbum/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   hatch-vcs,
@@ -62,6 +63,16 @@ buildPythonPackage rec {
   pytestFlags = [
     # broken in nix env
     "--deselect=tests/test_local.py::TestLocalMachine::test_local"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # list_processes() splits `ps -o pid,uid,stat,args` on whitespace; macOS
+    # leaves stat blank for tty-less children, which shifts the split and
+    # drops the executable path from args, so pgrep("[pP]ython") never
+    # matches the test process itself. Fixed upstream but unreleased:
+    # https://github.com/tomerfiliba/plumbum/pull/845 and
+    # https://github.com/tomerfiliba/plumbum/pull/846 (negative uid
+    # follow-up). Once a release carries both, drop this deselect.
+    "--deselect=tests/test_local.py::TestLocalMachine::test_pgrep"
   ];
 
   meta = {


### PR DESCRIPTION
No aarch64-darwin binary is published for `python3Packages.plumbum` because
`tests/test_local.py::TestLocalMachine::test_pgrep` fails on every darwin
build, deterministically.

`list_processes()` splits each `ps -e -o pid,uid,stat,args` row on
whitespace, assuming `STAT` is never empty. macOS leaves `STAT` blank for
any child process without a controlling tty - true of every process a nix
build spawns - which shifts the split and drops the executable path from
`args`, so `pgrep("[pP]ython")` never matches the test process itself.
Confirmed by patching the test to dump its own `ProcInfo` before asserting:
the `args` it captured no longer contained "python" at all.

This is fixed upstream in tomerfiliba/plumbum#845 (merged, unreleased), with
a follow-up fixing a regression that fix introduces on real macOS output (a
negative uid - macOS reports `nobody` as `-2`) in tomerfiliba/plumbum#846.
Neither has shipped in a release, so this deselects by exact pytest node id
rather than waiting - the same idiom already used for `test_local` directly
above it. The comment says to drop the deselect once a release carries both
fixes.

## Verification

Built and tested on aarch64-darwin against this PR's base commit.

**Test suite** - identical results with and without `sandbox = true`:

```
484 passed, 102 skipped, 3 deselected
```

The two other deselects are the pre-existing `test_local` and its remote
counterpart. Note `test_list_processes` is deliberately *not* deselected and
passes, including under sandboxing - the darwin seatbelt profile still
permits process enumeration.

**`nixpkgs-review pr 552121`** on aarch64-darwin: **14 built, 8 failed.**

Built: `copier`, `python31{3,4}Packages.{plumbum,copier,copier-template-tester,pwntools,rpyc}`,
`adenum`, `flexget`, `pwntools`.

Failed: `python31{3,4}Packages.{angr,angrcli,angrop,habitipy}`.

**None of the 8 are regressions.** Every one of these 22 packages depends on
plumbum (`angr` transitively, via `rpyc`), so on the base commit *all 22*
fail - the build stops at plumbum itself. I verified this directly: building
`python314Packages.habitipy` on the base commit fails with
`1 failed, 484 passed ... FAILED tests/test_local.py::TestLocalMachine::test_pgrep`
followed by `Build failed due to failed dependency`.

With this PR those 8 get *further* and then fail for their own unrelated
reasons, newly visible because the plumbum blocker is gone:

- `habitipy`: `ModuleNotFoundError: No module named 'pkg_resources'` (uses the
  API removed in setuptools 83)
- `angr`/`angrcli`/`angrop`: `Exception: angr requires setuptools-rust to build`

Neither can be caused by adding a pytest deselect flag to plumbum. So this
PR takes aarch64-darwin from 0/22 of these packages building to 14/22.

**Functional test:** built `copier` from this branch and ran a real
`copier copy` against a local template - exit 0, files created, template
variables substituted correctly. plumbum is a propagated dependency of
copier, so this exercises it at runtime rather than only in its own test
suite.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

---

Prepared with AI assistance. The root cause was found by instrumenting the
failing test on real hardware, and every claim above was verified by running
the builds rather than reasoned about - including checking the
`nixpkgs-review` failures against the base commit rather than assuming they
were pre-existing.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test