### PR TITLE
nixos/virtualbox-guest: add package option

### DIFF
--- a/nixos/modules/tasks/filesystems/vboxsf.nix
+++ b/nixos/modules/tasks/filesystems/vboxsf.nix
@@ -13,7 +13,7 @@ let
 
   package = pkgs.runCommand "mount.vboxsf" { preferLocalBuild = true; } ''
     mkdir -p $out/bin
-    cp ${pkgs.linuxPackages.virtualboxGuestAdditions}/bin/mount.vboxsf $out/bin
+    cp ${config.virtualisation.virtualbox.guest.package}/bin/mount.vboxsf $out/bin
   '';
 in
 

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -7,7 +7,6 @@
 }:
 let
   cfg = config.virtualisation.virtualbox.guest;
-  kernel = config.boot.kernelPackages;
 
   mkVirtualBoxUserService = serviceArgs: verbose: {
     description = "VirtualBox Guest User Services ${serviceArgs}";
@@ -25,7 +24,7 @@ let
     preStart = "${pkgs.bash}/bin/bash -c \"if [ -z $DISPLAY ]; then exit 1; fi\"";
     serviceConfig = {
       ExecStart =
-        "@${kernel.virtualboxGuestAdditions}/bin/VBoxClient"
+        "@${cfg.package}/bin/VBoxClient"
         + (lib.strings.optionalString verbose " --verbose")
         + " --foreground ${serviceArgs}";
       # Wait after a failure, hoping that the display environment is ready after waiting
@@ -65,6 +64,8 @@ in
       type = lib.types.bool;
       description = "Whether to enable the VirtualBox service and other guest additions.";
     };
+
+    package = lib.mkPackageOption config.boot.kernelPackages "virtualboxGuestAdditions" { };
 
     clipboard = lib.mkOption {
       default = true;
@@ -115,9 +116,9 @@ in
           }
         ];
 
-        environment.systemPackages = [ kernel.virtualboxGuestAdditions ];
+        environment.systemPackages = [ cfg.package ];
 
-        boot.extraModulePackages = lib.mkIf cfg.use3rdPartyModules [ kernel.virtualboxGuestAdditions ];
+        boot.extraModulePackages = lib.mkIf cfg.use3rdPartyModules [ cfg.package ];
 
         systemd.services.virtualbox = {
           description = "VirtualBox Guest Services";
@@ -128,7 +129,7 @@ in
 
           unitConfig.ConditionVirtualization = "oracle";
 
-          serviceConfig.ExecStart = "@${kernel.virtualboxGuestAdditions}/bin/VBoxService VBoxService --foreground";
+          serviceConfig.ExecStart = "@${cfg.package}/bin/VBoxService VBoxService --foreground";
         };
 
         users.groups.vboxuserdev = { };


### PR DESCRIPTION
- Added package option to virtualboxGuestAdditions nixos module

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
