### PR TITLE
openloco: support darwin

### DIFF
--- a/pkgs/by-name/op/openloco/package.nix
+++ b/pkgs/by-name/op/openloco/package.nix
@@ -9,6 +9,7 @@
   libzip,
   openal,
   pkg-config,
+  makeBinaryWrapper,
   yaml-cpp,
   fmt_11,
   libx11,
@@ -54,6 +55,13 @@ stdenv.mkDerivation rec {
 
     # prefetch openloco-objects
     sed -i 's#URL \+${openloco-objects.url}#URL ${openloco-objects}#' CMakeLists.txt
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # experimental libraries result in compilation issues using Clang for Darwin.
+    # hence, disable the experimental libraries option.
+    substituteInPlace src/OpenLoco/CMakeLists.txt \
+        --replace-fail '-fexperimental-library' \
+                       '-D_LIBCPP_ENABLE_EXPERIMENTAL -D_LIBCPP_PSTL_BACKEND_SERIAL'
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=null-dereference";
@@ -65,6 +73,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    makeBinaryWrapper
   ];
 
   buildInputs = [
@@ -74,14 +83,22 @@ stdenv.mkDerivation rec {
     openal
     yaml-cpp
     fmt_11
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     libx11
   ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications $out/bin
+    cp -R OpenLoco.app $out/Applications/
+    makeBinaryWrapper $out/Applications/OpenLoco.app/Contents/MacOS/OpenLoco $out/bin/OpenLoco
+  '';
 
   meta = {
     description = "Open source re-implementation of Chris Sawyer's Locomotion";
     homepage = "https://github.com/OpenLoco/OpenLoco";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ icewind1991 ];
     mainProgram = "OpenLoco";
   };


### PR DESCRIPTION
Adds Darwin support to the OpenLoco package.

Tested on macOS 14.8.7.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
