### PR TITLE
claude-code: 2.1.228 -> 2.1.229

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-sz5etvOsW+IL+ma5lVwgXAfdZXOaBDPyshIyjOCid/U=";
+          hash = "sha256-BM2kEgQ5Zt5zuBnKNr2gd7KtafV3R8rS1yDnasbK/O0=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-IN1IIVuthrJ65opzxAINTwXgkDKztnNabRTwVqSmTCU=";
+          hash = "sha256-zrdOH3udWCmm5L1cwa3ynkG7VmWtWuo2ptOv0U4crcY=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-89Hle3ekVbjWxTLnW38YKcOk3ieDpXMq08g6XaDzZhs=";
+          hash = "sha256-e77aT940DZByoG23vTJ5Q20t6f7t6OSY/TLECWYhHD8=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.228";
+      version = "2.1.229";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,53 +1,51 @@
 {
-  "version": "2.1.228",
-  "commit": "4a2077e9c39676b5c335919018dda18f476a7f70",
-  "buildDate": "2026-08-11T01:54:41Z",
+  "version": "2.1.229",
+  "commit": "10b3e93beb60b9548432371b3de664a4190e8da7",
+  "buildDate": "2026-08-12T17:57:28Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "43484b1352cef03a08346f36ef0437755b1aad646ab9313ce187857b794b7247",
-      "size": 289298144
+      "checksum": "d732f0ba0a539c58c2ffcaef06ed03b4e523726f0cb6cc27b3a5b7e7ae0a7a21",
+      "size": 294720528
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "7852f1ae0efb64d46d77a57d8852daddc4a6ffb58aeda6267bd3f3428adc09b3",
-      "size": 298977312
+      "checksum": "1cb62183e9f89ea21eb4950b84896fa7101182c7dfcbbe92e7a293f0b20ba541",
+      "size": 303439136
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "2664006219497bf7021ac43156519cd42eda64ceb2a66f434ecab83e7831f942",
-      "size": 305118136
+      "checksum": "ba53130acbda3ddb00b3dd5641f11733867f5d837a258b7e6ccef4927cc1a509",
+      "size": 308795592
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "d535985e6941a3eb00179ccd7f52ceb0c6623a0305a518ebc4e6514f84a94c99",
-      "size": 308521992
+      "checksum": "200338139a3df04a9ad22233837d1fb53fb6dffa21cd82e47559bfaa115acc1b",
+      "size": 311175440
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "1b8034fb30c90ea7471d6403bc610cb5173b7dedab3a92e89f6a91430c481876",
-      "size": 298431848
+      "checksum": "858d14b64c5c78f4da24a684184a61a05db12cf8f703290f8913c238ce789a27",
+      "size": 302202424
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "0285be21af52692e5d1ea2199171b45fc85d9ca62fb4a2d9f2c244c2bbca8de7",
-      "size": 303129168
+      "checksum": "3f575b0e8de6ab0473b9652979e1f6f506dc7d6b9ecadeeba47716a07c1b09e1",
+      "size": 305483520
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "841efce70b048ae03c752f79000cb6be5c2c2c4d0478f3eaaa762494ade9daf5",
-      "size": 296308896
+      "checksum": "5736c66be98a372d5e5e3b3598ead89ab5a9d1aca60d347fe7b561801c58376c",
+      "size": 307186848
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "e1d23400b3eef8f7b2ddde782ce4d3153aa88b5397d0f42813b8abbe0b47cbcd",
-      "size": 290981024
+      "checksum": "e213992024e807fab57ab53bab039c22c1911df262da30d038a4892b8662ce54",
+      "size": 296566432
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.187",
-      "0.3.190",
       "0.3.191",
       "0.3.195",
       "0.3.196",
@@ -75,7 +73,8 @@
       "0.3.220",
       "0.3.221",
       "0.3.222",
-      "0.3.226"
+      "0.3.226",
+      "0.3.227"
     ],
     "harnessSchema": 1
   }


### PR DESCRIPTION
Update claude-code and vscode-extensions.anthropic.claude-code to 2.1.229.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

> [!NOTE]
> Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard `maintainers/scripts/update.nix` script; the change was built locally and validated across arches via `nixpkgs-review`, and reviewed by a human (@markus1189) before being marked ready.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
