### PR TITLE
electrum: 4.8.0 -> 4.8.1

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -9,6 +9,8 @@
   enablePythonEcdsa ? false,
   callPackage,
   qtwayland,
+
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -22,17 +24,15 @@ let
 in
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "electrum";
-  version = "4.8.0";
+  version = "4.8.1";
   pyproject = true;
 
   src = fetchurl {
     url = "https://download.electrum.org/${finalAttrs.version}/Electrum-${finalAttrs.version}.tar.gz";
-    hash = "sha256-z14bzs81eJNTMSWSBLTyCmsljDNztG54SVkoTcSqvsM=";
+    hash = "sha256-71t/YdLItZg6D5yFFVbjpveKncIv5hG7pJxu67a9/b4=";
   };
 
-  build-system = with python3.pkgs; [
-    setuptools
-  ];
+  build-system = [ python3.pkgs.setuptools ];
 
   nativeBuildInputs = [
     python3.pkgs.pythonRelaxDepsHook
@@ -90,11 +90,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "protobuf"
   ];
 
-  checkInputs =
-    with python3.pkgs;
-    lib.optionals enableQt [
-      pyqt6
-    ];
+  checkInputs = lib.optionals enableQt [
+    python3.pkgs.pyqt6
+  ];
   disabledTestPaths = lib.optionals (!enableQt) [
     "tests/test_qml_types.py"
   ];
@@ -132,14 +130,15 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pytestCheckHook
     pyaes
     pycryptodomex
+
+    # avoid homeless-shelter error in tests
+    writableTmpDirAsHomeHook
   ];
 
   enabledTestPaths = [ "tests" ];
 
-  # avoid homeless-shelter error in tests
   preCheck = ''
     export PYTHONPATH=${python3.pkgs.protobuf}/${python3.sitePackages}:$PYTHONPATH
-    export HOME="$(mktemp -d)"
   '';
 
   postCheck = ''


### PR DESCRIPTION
https://github.com/spesmilo/electrum/blob/4.8.1/RELEASE-NOTES
Diff: https://github.com/spesmilo/electrum/compare/4.8.0...4.8.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
