### PR TITLE
aube: 1.32.0 -> 2.1.0

### DIFF
--- a/pkgs/by-name/au/aube/package.nix
+++ b/pkgs/by-name/au/aube/package.nix
@@ -4,6 +4,7 @@
   rustPlatform,
   cacert,
   cmake,
+  nodejs,
   gitMinimal,
   writableTmpDirAsHomeHook,
   versionCheckHook,
@@ -12,20 +13,21 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "aube";
-  version = "1.32.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "aube";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0BnaxRk6+KY4AGZ31lis0zxc9uWp3OrxCgp9SgOrqNI=";
+    hash = "sha256-lV/nxRThPkmGdoCLxH38BZz1SyjNPx1fK0AwL2Ur0EA=";
   };
 
-  cargoHash = "sha256-vYbbnEpVWG6kjnycl1kk3D+lXuzTzOKuilA0ImBHYAI=";
+  cargoHash = "sha256-/W1yGCCXoFwjyEQ9T/TtdklFwvZOhNuMBoer2GmmERs=";
 
   nativeBuildInputs = [ cmake ]; # libz-ng-sys
 
   nativeCheckInputs = [
+    nodejs
     gitMinimal
     writableTmpDirAsHomeHook
   ];
@@ -35,10 +37,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   checkFlags = [
+    "--skip=spawn_program_tests::spawn_program_runs_the_program_with_its_args"
+    "--skip=cli_spec_tests::add_rejects_deny_build_with_dangerously_allow_all_builds"
+    "--skip=commands::add_supply_chain::tests::bundled_corpus_detects_common_package_typo"
+    "--skip=commands::exec::tests::bin_command_executes_native_target_behind_generated_shim"
     # failed on x86_64-linux
     "--skip=concurrency::tests::floor_and_ceiling_inclusive"
     "--skip=http::ticket_cache::tests::max_per_host_evicts_oldest"
     "--skip=http::ticket_cache::tests::invalidate_removes_all_for_host"
+    # failed on aarch64-darwin
+    "--skip=facade_install_preserves_non_utf8_storage_paths"
     # require network access
     "--skip=http::ticket_cache::tests::roundtrip_persists_across_open"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
