### PR TITLE
duckdb-odbc: init at 1.5.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -349,6 +349,12 @@
     githubId = 43320117;
     name = "Sebastian Marquardt";
   };
+  _81reap = {
+    email = "prayag.bhakar@gmail.com";
+    github = "81reap";
+    githubId = 20740005;
+    name = "Prayag Bhakar";
+  };
   _9999years = {
     email = "rbt@fastmail.com";
     github = "9999years";

--- a/pkgs/by-name/du/duckdb-odbc/package.nix
+++ b/pkgs/by-name/du/duckdb-odbc/package.nix
@@ -1,0 +1,60 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  runCommand,
+  stdenv,
+  unixodbc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "duckdb-odbc";
+  version = "1.5.5.0";
+
+  src = fetchFromGitHub {
+    owner = "duckdb";
+    repo = "duckdb-odbc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uh4Jle/gbHyd4rUfoyW0u35fx9dcvEEzTg8QnuHdiwY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ unixodbc ];
+
+  strictDeps = true;
+
+  # The upstream build has no install rule; the driver is the single artifact.
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 libduckdb_odbc${stdenv.hostPlatform.extensions.sharedLibrary} \
+      -t $out/lib
+    runHook postInstall
+  '';
+
+  passthru = {
+    fancyName = "DuckDB";
+    driver = "lib/libduckdb_odbc${stdenv.hostPlatform.extensions.sharedLibrary}";
+    updateScript = nix-update-script { };
+    tests.isql-query = runCommand "duckdb-odbc-isql-query" { nativeBuildInputs = [ unixodbc ]; } ''
+      export ODBCSYSINI=$PWD
+      printf '[DuckDB]\nDriver = %s/${finalAttrs.passthru.driver}\n' \
+        ${finalAttrs.finalPackage} > odbcinst.ini
+      echo "select 41+1 as answer;" \
+        | isql -k "Driver=DuckDB;Database=:memory:" -b \
+        | grep -F "| 42"
+      touch $out
+    '';
+  };
+
+  meta = {
+    homepage = "https://duckdb.org/docs/current/clients/odbc/overview";
+    description = "ODBC driver for DuckDB";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers._81reap ];
+  };
+})

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -19,6 +19,7 @@
   fixDarwinDylibNames,
   fetchFromGitHub,
   psqlodbc,
+  duckdb-odbc,
 }:
 
 # Each of these ODBC drivers can be configured in your odbcinst.ini file using
@@ -41,6 +42,8 @@
     withUnixODBC = true;
     withLibiodbc = false;
   };
+
+  duckdb = duckdb-odbc;
 
   mariadb = stdenv.mkDerivation rec {
     pname = "mariadb-connector-odbc";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[DuckDB already exists in nixpkgs.](https://search.nixos.org/packages?channel=unstable&query=duckdb#show=duckdb) This PR adds the official ODBC driver for DuckDB along with the other `unixodbcDrivers`. This should address the issue #355265 

## AI Disclosure

I used Claude Code to draft the changes. I do not let agents operate on my behalf online. This is a human who has created the PR and this description 👋🏽 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
