### PR TITLE
haskellPackages.yesod-static: patch to use ram over memory

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -430,6 +430,12 @@ with haskellLib;
   # https://github.com/yesodweb/shakespeare/issues/294
   shakespeare = dontCheck super.shakespeare;
 
+  # Switch yesod-static from memory to ram to match crypton >= 1.1,
+  # waiting on https://github.com/yesodweb/yesod/pull/1916
+  yesod-static = appendPatches [
+    ./patches/yesod-static-crypton-1.1-and-ram.patch
+  ] (super.yesod-static.override { memory = self.ram; });
+
   # https://github.com/haskell-numerics/random-fu/issues/100
   rvar = appendPatch (fetchpatch {
     url = "https://github.com/adamConnerSax/random-fu/commit/51ba79d2cea5279821523a3861d4ec7196e71759.patch";

--- a/pkgs/development/haskell-modules/patches/yesod-static-crypton-1.1-and-ram.patch
+++ b/pkgs/development/haskell-modules/patches/yesod-static-crypton-1.1-and-ram.patch
@@ -1,0 +1,26 @@
+Compare https://github.com/yesodweb/yesod/pull/1916
+
+---
+
+diff --git a/yesod-static/yesod-static.cabal b/yesod-static/yesod-static.cabal
+index f91c905c..50881677 100644
+--- a/yesod-static.cabal
++++ b/yesod-static.cabal
+@@ -45,7 +45,7 @@ library
+                    , hashable              >= 1.1
+                    , hjsmin
+                    , http-types            >= 0.7
+-                   , memory
++                   , ram                   >= 0.21 && < 0.23
+                    , mime-types            >= 0.1
+                    , process
+                    , template-haskell
+@@ -106,7 +106,7 @@ test-suite tests
+                    , filepath
+                    , hjsmin
+                    , http-types
+-                   , memory
++                   , ram
+                    , mime-types
+                    , process
+                    , template-haskell


### PR DESCRIPTION
Otherwise, the package will not work together with crypton >= 1.1.

Unfortunately, a lot of other stuff is also broken due to crypton >= 1.1, so I haven't really been able to test reverse dependencies of this yet.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
