### PR TITLE
ananicy-cpp: fix missing <cstring> include with glibc 2.42

### DIFF
--- a/pkgs/by-name/an/ananicy-cpp/package.nix
+++ b/pkgs/by-name/an/ananicy-cpp/package.nix
@@ -2,6 +2,7 @@
   lib,
   clangStdenv,
   fetchFromGitLab,
+  fetchpatch,
   cmake,
   pkg-config,
   spdlog,
@@ -29,6 +30,11 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./match-wrappers.patch
+    (fetchpatch {
+      name = "fix-cstring-include.patch";
+      url = "https://gitlab.com/ananicy-cpp/ananicy-cpp/-/merge_requests/43.diff";
+      hash = "sha256-drBUVh+N3KedJttzQIIA1s+38ngK9BgZFOdpxqBWV0E=";
+    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
ananicy-cpp 1.2.0 fails to build when using glibc 2.42 because `argument.cpp` calls `std::memset` without including `<cstring>` directly. Prior to glibc 2.42 this worked via a transitive include, but that was removed as part of header dependency tightening.

The error from clang:

```
error: no member named 'memset' in namespace 'std'; did you mean simply 'memset'?
   24 |   std::memset(buffer.get(), 0, sz);
```

This patch adds `#include <cstring>` at the top of `argument.cpp`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

> **Automation disclosure**: This patch was identified and the fix was drafted with assistance from an AI tool (Claude Sonnet 4.6). The output was manually reviewed and verified by building locally before submission. The `Assisted-by:` trailer is present in the commit per policy.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test