### PR TITLE
python3Packages.jupysql: cleanup, fix

### DIFF
--- a/pkgs/development/python-modules/jupysql/default.nix
+++ b/pkgs/development/python-modules/jupysql/default.nix
@@ -36,16 +36,16 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jupysql";
   version = "0.11.1";
-
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ploomber";
     repo = "jupysql";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-7wfKvKqDf8LlUiLoevNRxmq8x5wLheOgIeWz72oFcuw=";
   };
 
@@ -84,7 +84,7 @@ buildPythonPackage rec {
     psutil
     writableTmpDirAsHomeHook
   ]
-  ++ optional-dependencies.dev;
+  ++ finalAttrs.passthru.optional-dependencies.dev;
 
   disabledTests = [
     # AttributeError: 'DataFrame' object has no attribute 'frame_equal'
@@ -135,8 +135,8 @@ buildPythonPackage rec {
   meta = {
     description = "Better SQL in Jupyter";
     homepage = "https://github.com/ploomber/jupysql";
-    changelog = "https://github.com/ploomber/jupysql/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/ploomber/jupysql/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ euxane ];
   };
-}
+})

--- a/pkgs/development/python-modules/jupysql/default.nix
+++ b/pkgs/development/python-modules/jupysql/default.nix
@@ -87,6 +87,9 @@ buildPythonPackage (finalAttrs: {
   ++ finalAttrs.passthru.optional-dependencies.dev;
 
   disabledTests = [
+    # ValueError: max() iterable argument is empty
+    "test_columns_with_missing_values[empty-dictionaries]"
+
     # AttributeError: 'DataFrame' object has no attribute 'frame_equal'
     "test_resultset_polars_dataframe"
 


### PR DESCRIPTION
## Things done

- **python3Packages.jupysql: cleanup**
- **python3Packages.jupysql: skip failing test**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
