### PR TITLE
zfs_2_4: more backports

### DIFF
--- a/pkgs/os-specific/linux/zfs/2_4.nix
+++ b/pkgs/os-specific/linux/zfs/2_4.nix
@@ -25,6 +25,12 @@ callPackage ./generic.nix args {
       url = "https://github.com/openzfs/zfs/commit/6fb72fda0f60d9efb591e320f83f78b19ec451cc.patch?full_index=1";
       hash = "sha256-UuSVmO61Ux5S3F+JAtRnHyeVS4EFobDTKBuD5s8PI+k=";
     })
+    # backport kernel memory corruption fix
+    # https://github.com/openzfs/zfs/issues/18787
+    (fetchpatch {
+      url = "https://github.com/openzfs/zfs/commit/223b8bc446851e5e796e5446ac24d03bbf468f43.patch?full_index=1";
+      hash = "sha256-I29A+NLYLzy7cMC8FQpBdSYbjFu/kscgTW8mAauPVf4=";
+    })
   ];
 
   tests = {

--- a/pkgs/os-specific/linux/zfs/2_4.nix
+++ b/pkgs/os-specific/linux/zfs/2_4.nix
@@ -18,6 +18,7 @@ callPackage ./generic.nix args {
   # this package should point to the latest release.
   version = "2.4.3";
 
+  # if adding a patch here, check if it also needs to be applied to zfs_unstable
   extraPatches = [
     # https://github.com/openzfs/zfs/issues/18366
     # dedup data corruption fix unreleased as of OpenZFS 2.4.3

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -1,6 +1,7 @@
 {
   callPackage,
   nixosTests,
+  fetchpatch,
   ...
 }@args:
 
@@ -18,6 +19,22 @@ callPackage ./generic.nix args {
   # maintainers.
   version = "2.4.3";
   # rev = "";
+
+  # if adding a patch here, check if it also needs to be applied to the stable branches
+  extraPatches = [
+    # https://github.com/openzfs/zfs/issues/18366
+    # dedup data corruption fix unreleased as of OpenZFS 2.4.3
+    (fetchpatch {
+      url = "https://github.com/openzfs/zfs/commit/6fb72fda0f60d9efb591e320f83f78b19ec451cc.patch?full_index=1";
+      hash = "sha256-UuSVmO61Ux5S3F+JAtRnHyeVS4EFobDTKBuD5s8PI+k=";
+    })
+    # backport kernel memory corruption fix
+    # https://github.com/openzfs/zfs/issues/18787
+    (fetchpatch {
+      url = "https://github.com/openzfs/zfs/commit/223b8bc446851e5e796e5446ac24d03bbf468f43.patch?full_index=1";
+      hash = "sha256-I29A+NLYLzy7cMC8FQpBdSYbjFu/kscgTW8mAauPVf4=";
+    })
+  ];
 
   tests = {
     inherit (nixosTests.zfs) unstable;


### PR DESCRIPTION
Not sure how I feel about the 7.1 thing, but it _feels_ fine? The other one is 100% necessary though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
