### PR TITLE
valhalla: get working on macOS

### DIFF
--- a/pkgs/by-name/pr/prime-server/package.nix
+++ b/pkgs/by-name/pr/prime-server/package.nix
@@ -33,8 +33,17 @@ stdenv.mkDerivation (finalAttrs: {
     libsodium
   ];
 
-  # https://github.com/kevinkreiser/prime_server/issues/95
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=unused-variable" ];
+  env.NIX_CFLAGS_COMPILE = toString (
+    [
+      # https://github.com/kevinkreiser/prime_server/issues/95
+      "-Wno-error=unused-variable"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # logging.hpp calls sprintf, which the macOS SDK marks deprecated. The
+      # build uses -Werror, so the deprecation stops it.
+      "-Wno-error=deprecated-declarations"
+    ]
+  );
 
   meta = {
     description = "Non-blocking (web)server API for distributed computing and SOA based on zeromq";

--- a/pkgs/development/libraries/valhalla/default.nix
+++ b/pkgs/development/libraries/valhalla/default.nix
@@ -49,6 +49,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_TESTS" false)
     (lib.cmakeBool "ENABLE_SINGLE_FILES_WERROR" false)
     (lib.cmakeBool "PREFER_EXTERNAL_DEPS" true)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # On darwin Valhalla only looks at the Homebrew paths
+    (lib.cmakeFeature "SQLITE3_INCLUDE_DIR" "${lib.getDev sqlite}/include")
+    (lib.cmakeFeature "SQLITE3_LIBRARY" "${lib.getLib sqlite}/lib/libsqlite3.dylib")
   ];
 
   buildInputs = [
@@ -83,6 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.Thra11 ];
     pkgConfigModules = [ "libvalhalla" ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The prime_server fix can get removed if https://github.com/NixOS/nixpkgs/pull/547724 is merged first

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
