### PR TITLE
python3Packages.retinaface: rename to retina-face, cleanup

### DIFF
--- a/pkgs/development/python-modules/deepface/default.nix
+++ b/pkgs/development/python-modules/deepface/default.nix
@@ -13,7 +13,7 @@
   pandas,
   pillow,
   requests,
-  retinaface,
+  retina-face,
   setuptools,
   tensorflow,
   tqdm,
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pandas
     pillow
     requests
-    retinaface
+    retina-face
     tensorflow
     tqdm
   ];

--- a/pkgs/development/python-modules/retina-face/default.nix
+++ b/pkgs/development/python-modules/retina-face/default.nix
@@ -20,7 +20,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "retinaface";
+  pname = "retina-face";
   version = "0.0.17";
   pyproject = true;
 

--- a/pkgs/development/python-modules/retina-face/default.nix
+++ b/pkgs/development/python-modules/retina-face/default.nix
@@ -19,24 +19,18 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "retina-face";
   version = "0.0.17";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "serengil";
     repo = "retinaface";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0s1CSGlK2bF1F2V/IuG2ZqD7CkNfHGvp1M5C3zDnuKs=";
   };
-
-  # requires internet connection
-  disabledTestPaths = [
-    "tests/test_actions.py"
-    "tests/test_align_first.py"
-    "tests/test_expand_face_area.py"
-  ];
 
   build-system = [ setuptools ];
 
@@ -52,13 +46,20 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  # requires internet connection
+  disabledTestPaths = [
+    "tests/test_actions.py"
+    "tests/test_align_first.py"
+    "tests/test_expand_face_area.py"
+  ];
+
   pythonImportsCheck = [ "retinaface" ];
 
   meta = {
     description = "Deep Face Detection Library for Python";
     homepage = "https://github.com/serengil/retinaface";
-    changelog = "https://github.com/serengil/retinaface/releases/tag/v${version}";
+    changelog = "https://github.com/serengil/retinaface/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ derdennisop ];
   };
-}
+})

--- a/pkgs/development/rocm-modules/release-attrPaths.json
+++ b/pkgs/development/rocm-modules/release-attrPaths.json
@@ -490,7 +490,7 @@
     "python3Packages.rembg",
     "python3Packages.rerun-sdk",
     "python3Packages.resize-right",
-    "python3Packages.retinaface",
+    "python3Packages.retina-face",
     "python3Packages.rlax",
     "python3Packages.rlcard",
     "python3Packages.roma",

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -628,6 +628,7 @@ mapAliases {
   requests_oauthlib = throw "'requests_oauthlib' has been renamed to/replaced by 'requests-oauthlib'"; # Converted to throw 2025-10-29
   requests_toolbelt = throw "'requests_toolbelt' has been renamed to/replaced by 'requests-toolbelt'"; # Converted to throw 2025-10-29
   restructuredtext_lint = throw "'restructuredtext_lint' has been renamed to/replaced by 'restructuredtext-lint'"; # Converted to throw 2025-10-29
+  retinaface = retina-face; # Added 2026-08-13
   retry_decorator = throw "'retry_decorator' has been renamed to/replaced by 'retry-decorator'"; # Converted to throw 2025-10-29
   retworkx = throw "'retworkx' has been renamed to/replaced by 'rustworkx'"; # Converted to throw 2025-10-29
   rki-covid-parser = throw "rki-covid-parser has been removed because it is unmaintained and broken"; # added 2025-09-20

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17804,7 +17804,7 @@ self: super: with self; {
 
   rethinkdb = callPackage ../development/python-modules/rethinkdb { };
 
-  retinaface = callPackage ../development/python-modules/retinaface { };
+  retina-face = callPackage ../development/python-modules/retina-face { };
 
   retry = callPackage ../development/python-modules/retry { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.retinaface: rename to retina-face**
- **python3Packages.retina-face: cleanup**

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
