### PR TITLE
git-privacy: patch Python 3.14 incompatibility

### DIFF
--- a/pkgs/by-name/gi/git-privacy/package.nix
+++ b/pkgs/by-name/gi/git-privacy/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   python3,
 }:
 
@@ -13,25 +13,34 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "EMPRI-DEVOPS";
     repo = "git-privacy";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-b2RkRL8/mZwqc3xCs+oltzualhQtp/7F9POlLlT3UUU=";
   };
 
-  build-system = with python3.pkgs; [
-    setuptools
-  ];
+  build-system = with python3.pkgs; [ setuptools ];
+
+  postPatch = ''
+    # https://github.com/EMPRI-DEVOPS/git-privacy/issues/52
+    substituteInPlace gitprivacy/gitprivacy.py \
+      --replace "from pkg_resources import resource_stream, resource_string" "from importlib import resources" \
+      --replace "hook_txt = resource_string('gitprivacy.resources.hooks', hook).decode()" "hook_txt = resources.files('gitprivacy.resources.hooks').joinpath(hook).read_text()" \
+      --replace "with resource_stream('gitprivacy.resources.hooks', hook) as src, dst:" "with resources.files('gitprivacy.resources.hooks').joinpath(hook).open('rb') as src, dst:"
+  '';
 
   dependencies = with python3.pkgs; [
     click
     git-filter-repo
     gitpython
+    packaging
     pynacl
     setuptools
   ];
 
   nativeCheckInputs = with python3.pkgs; [
-    git
+    gitMinimal
+    packaging
     pytestCheckHook
+    setuptools
   ];
 
   disabledTests = [
@@ -39,13 +48,12 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "TestGitPrivacy"
   ];
 
-  pythonImportsCheck = [
-    "gitprivacy"
-  ];
+  pythonImportsCheck = [ "gitprivacy" ];
 
   meta = {
     description = "Tool to redact Git author and committer dates";
     homepage = "https://github.com/EMPRI-DEVOPS/git-privacy";
+    changelog = "https://github.com/EMPRI-DEVOPS/git-privacy/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "git-privacy";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
