### PR TITLE
haskell.packages.ghc914: test more packages

### DIFF
--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -1,5 +1,5 @@
 import ./common-hadrian.nix {
-  version = "10.1.20260513";
-  rev = "38b76b2f1d918f10d2f9d3e57bd0459dfe671d4f";
-  sha256 = "sha256-b0AZsWVmGi6EaWEtPWPOQAxvTlxG2aBwegw5l5HBPDo=";
+  version = "10.1.20260810";
+  rev = "556db2f32f59ec2d3b1c225d24d677c60a695e3f";
+  sha256 = "sha256-lB4udTc9hQZEnldmvpllDkCtUVte65/ZMhZd7rf5xOY=";
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -94,6 +94,10 @@ with haskellLib;
           || (
             lib.versionAtLeast self.ghc.version "9.12.4.20260606" # 9.12.5-rc1
             && lib.versionOlder self.ghc.version "9.14"
+          )
+          || (
+            lib.versionAtLeast self.ghc.version "9.14.1.20260728" # 9.14.1-rc1
+            && lib.versionOlder self.ghc.version "9.15"
           );
 
         # !!! Use cself/csuper inside for the actual overrides
@@ -109,7 +113,6 @@ with haskellLib;
                   hash = "sha256-+rcwBQILTc1ezcHb3VDampwMYGEG7S4HF1YKAk7QzUs=";
                   relative = "Cabal";
                 })
-
               ]) cself.Cabal_3_16_1_0;
               Cabal-syntax = cself.Cabal-syntax_3_16_1_0;
             };

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -95,10 +95,7 @@ with haskellLib;
             lib.versionAtLeast self.ghc.version "9.12.4.20260606" # 9.12.5-rc1
             && lib.versionOlder self.ghc.version "9.14"
           )
-          || (
-            lib.versionAtLeast self.ghc.version "9.14.1.20260728" # 9.14.1-rc1
-            && lib.versionOlder self.ghc.version "9.15"
-          );
+          || lib.versionAtLeast self.ghc.version "9.14.1.20260728"; # 9.14.1-rc1
 
         # !!! Use cself/csuper inside for the actual overrides
         cabalInstallOverlay =

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -99,19 +99,20 @@ with haskellLib;
         # !!! Use cself/csuper inside for the actual overrides
         cabalInstallOverlay =
           cself: csuper:
-          lib.optionalAttrs (haveSemaphoreCompat200 || lib.versionOlder csuper.ghc.version "9.14") {
-            # Waiting on Cabal-3.18 with https://github.com/haskell/cabal/pull/11628
-            Cabal = appendPatches (lib.optionals haveSemaphoreCompat200 [
-              (pkgs.fetchpatch {
-                name = "Cabal-semaphore-compat-2.0.0.patch";
-                url = "https://github.com/haskell/cabal/commit/2cac53be5659a2a74f1748fd6ab1e00183a18765.diff?full_index=1";
-                hash = "sha256-+rcwBQILTc1ezcHb3VDampwMYGEG7S4HF1YKAk7QzUs=";
-                relative = "Cabal";
-              })
+          lib.optionalAttrs (haveSemaphoreCompat200 || lib.versionOlder csuper.ghc.version "9.14.1.20260728")
+            {
+              # Waiting on Cabal-3.18 with https://github.com/haskell/cabal/pull/11628
+              Cabal = appendPatches (lib.optionals haveSemaphoreCompat200 [
+                (pkgs.fetchpatch {
+                  name = "Cabal-semaphore-compat-2.0.0.patch";
+                  url = "https://github.com/haskell/cabal/commit/2cac53be5659a2a74f1748fd6ab1e00183a18765.diff?full_index=1";
+                  hash = "sha256-+rcwBQILTc1ezcHb3VDampwMYGEG7S4HF1YKAk7QzUs=";
+                  relative = "Cabal";
+                })
 
-            ]) cself.Cabal_3_16_1_0;
-            Cabal-syntax = cself.Cabal-syntax_3_16_1_0;
-          };
+              ]) cself.Cabal_3_16_1_0;
+              Cabal-syntax = cself.Cabal-syntax_3_16_1_0;
+            };
       in
       {
         cabal-install =

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -81,6 +81,9 @@ with haskellLib;
   #
 
   ghc-exactprint = doDistribute self.ghc-exactprint_1_14_1_0;
+  ghc-lib = doDistribute self.ghc-lib_9_14_1_20251220;
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_14_1_20251220;
+  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_14_2_0;
 
   #
   # Jailbreaks

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -80,7 +80,7 @@ with haskellLib;
   # Version upgrades
   #
 
-  ghc-exactprint = doDistribute self.ghc-exactprint_1_14_0_0;
+  ghc-exactprint = doDistribute self.ghc-exactprint_1_14_1_0;
 
   #
   # Jailbreaks
@@ -131,14 +131,17 @@ with haskellLib;
   haskell-debugger-view = doDistribute (unmarkBroken super.haskell-debugger-view);
   haskell-debugger = doDistribute (doJailbreak super.haskell-debugger); # hie-bios < 0.18, random >=1.3.1
 
-  ghc-exactprint_1_14_0_0 = addBuildDepends [
+  ghc-exactprint_1_14_1_0 = addBuildDepends [
     # cabal2nix drops conditional block: impl (ghc >= 9.14)
+    self.containers
     self.Diff
-    self.extra
+    self.directory
+    self.filepath
     self.ghc-paths
     self.silently
+    self.syb
     self.HUnit
-  ] super.ghc-exactprint_1_14_0_0;
+  ] super.ghc-exactprint_1_14_1_0;
 
   #
   # Test suite issues

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -67,7 +67,7 @@ let
     ghc98 = sets.ghc984;
     ghc910 = sets.ghc9103;
     ghc912 = sets.ghc9125;
-    ghc914 = sets.ghc9142;
+    ghc914 = sets.ghc9141;
 
     microhs_0_15 = sets.microhs_0_15_4_0;
     microhs = sets.microhs_0_15;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -68,6 +68,7 @@ let
     ghc984
     ghc9103
     ghc9125
+    ghc9141
   ];
 
   # packagePlatforms applied to `haskell.packages.*`
@@ -525,11 +526,18 @@ let
         compilerNames.ghc948
       ] released;
       Cabal_3_10_3_0 = lib.subtractLists [
-        # time < 1.13 conflicts with time == 1.14.*
+        # time < 1.13 conflicts with time == 1.14.* || == 1.15.*
         compilerNames.ghc9125
+        compilerNames.ghc9141
       ] released;
-      Cabal_3_12_1_0 = released;
-      Cabal_3_14_2_0 = released;
+      Cabal_3_12_1_0 = lib.subtractLists [
+        # time < 1.15 conflicts with time == 1.15.*
+        compilerNames.ghc9141
+      ] released;
+      Cabal_3_14_2_0 = lib.subtractLists [
+        # time < 1.15 conflicts with time == 1.15.*
+        compilerNames.ghc9141
+      ] released;
       Cabal_3_16_1_0 = released;
       cabal2nix = released;
       cabal2nix-unstable = released;
@@ -547,11 +555,16 @@ let
         compilerNames.ghc910
       ];
       haskell-debugger = [
+        compilerNames.ghc9141
         compilerNames.ghc9142
       ];
       haskell-language-server = released;
       hoogle = released;
-      hlint = released;
+      hlint = lib.subtractLists [
+        # https://github.com/ndmitchell/hlint/issues/1672
+        # https://github.com/ndmitchell/hlint/pull/1673
+        compilerNames.ghc9141
+      ] released;
       hpack = released;
       hsdns = released;
       iserv-proxy = released;
@@ -564,10 +577,14 @@ let
       ghc-lib-parser = released;
       ghc-lib-parser-ex = released;
       ghc-source-gen = released;
-      ghc-tags = released;
+      ghc-tags = lib.subtractLists [
+        # https://github.com/arybczak/ghc-tags/pull/31
+        compilerNames.ghc9141
+      ] released;
       hashable = released;
       primitive = released;
       scrod = [
+        compilerNames.ghc9141
         compilerNames.ghc9142
       ];
       semaphore-compat = [
@@ -575,7 +592,11 @@ let
         # requires unix >= 2.8.1.0 which implies GHC >= 9.6 for us.
         compilerNames.ghc967
       ];
-      weeder = released;
+      weeder = lib.subtractLists [
+        # Currently (2026-08-13) blocked on
+        # https://github.com/kcsongor/generic-lens/issues/174
+        compilerNames.ghc9141
+      ] released;
 
       # MicroHs core packages
       ghc-compat = [

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -69,6 +69,7 @@ let
     ghc9103
     ghc9125
     ghc9141
+    ghc9142
   ];
 
   # packagePlatforms applied to `haskell.packages.*`
@@ -529,14 +530,17 @@ let
         # time < 1.13 conflicts with time == 1.14.* || == 1.15.*
         compilerNames.ghc9125
         compilerNames.ghc9141
+        compilerNames.ghc9142
       ] released;
       Cabal_3_12_1_0 = lib.subtractLists [
         # time < 1.15 conflicts with time == 1.15.*
         compilerNames.ghc9141
+        compilerNames.ghc9142
       ] released;
       Cabal_3_14_2_0 = lib.subtractLists [
         # time < 1.15 conflicts with time == 1.15.*
         compilerNames.ghc9141
+        compilerNames.ghc9142
       ] released;
       Cabal_3_16_1_0 = released;
       cabal2nix = released;
@@ -564,6 +568,7 @@ let
         # https://github.com/ndmitchell/hlint/issues/1672
         # https://github.com/ndmitchell/hlint/pull/1673
         compilerNames.ghc9141
+        compilerNames.ghc9142
       ] released;
       hpack = released;
       hsdns = released;
@@ -580,6 +585,7 @@ let
       ghc-tags = lib.subtractLists [
         # https://github.com/arybczak/ghc-tags/pull/31
         compilerNames.ghc9141
+        compilerNames.ghc9142
       ] released;
       hashable = released;
       primitive = released;
@@ -596,6 +602,7 @@ let
         # Currently (2026-08-13) blocked on
         # https://github.com/kcsongor/generic-lens/issues/174
         compilerNames.ghc9141
+        compilerNames.ghc9142
       ] released;
 
       # MicroHs core packages

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -559,6 +559,7 @@ let
       language-nix = released;
       nix-paths = released;
       titlecase = released;
+      ghc-exactprint = released;
       ghc-lib = released;
       ghc-lib-parser = released;
       ghc-lib-parser-ex = released;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
