### PR TITLE
python3Packages: fix primer3 metadata and genome-collector build

### DIFF
--- a/pkgs/development/python-modules/dnachisel/default.nix
+++ b/pkgs/development/python-modules/dnachisel/default.nix
@@ -8,7 +8,7 @@
   genome-collector,
   matplotlib,
   numpy,
-  primer3,
+  primer3-py,
   proglog,
   pytestCheckHook,
   python-codon-tables,
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    primer3
+    primer3-py
     genome-collector
     matplotlib
     pytestCheckHook

--- a/pkgs/development/python-modules/genome-collector/default.nix
+++ b/pkgs/development/python-modules/genome-collector/default.nix
@@ -5,19 +5,29 @@
   biopython,
   fetchPypi,
   proglog,
+  setuptools,
 }:
 
 buildPythonPackage rec {
-  pname = "genome_collector";
+  pname = "genome-collector";
   version = "0.1.6";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "genome_collector";
+    inherit version;
     sha256 = "0023ihrz0waxbhq28xh1ymvk51ih882y9psg4glm6s9d1zmqvdph";
   };
 
-  propagatedBuildInputs = [
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "import ez_setup" "" \
+      --replace-fail "ez_setup.use_setuptools()" ""
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     appdirs
     biopython
     proglog

--- a/pkgs/development/python-modules/primer3-py/default.nix
+++ b/pkgs/development/python-modules/primer3-py/default.nix
@@ -12,7 +12,7 @@
 }:
 
 buildPythonPackage (finalAttrs: {
-  pname = "primer3";
+  pname = "primer3-py";
   version = "2.3.0";
   pyproject = true;
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -471,6 +471,7 @@ mapAliases {
   postgrest-py = postgrest; # added 2025-08-29
   powerlineMemSegment = throw "'powerlineMemSegment' has been renamed to/replaced by 'powerline-mem-segment'"; # Converted to throw 2025-10-29
   prayer-times-calculator = throw "'prayer-times-calculator' has been renamed to/replaced by 'prayer-times-calculator-offline'"; # Converted to throw 2025-10-29
+  primer3 = primer3-py; # Added 2026-08-13
   prometheus_client = throw "'prometheus_client' has been renamed to/replaced by 'prometheus-client'"; # Converted to throw 2025-10-29
   prompt_toolkit = throw "'prompt_toolkit' has been renamed to/replaced by 'prompt-toolkit'"; # Converted to throw 2025-10-29
   protonup = throw "'protonup' has been renamed to/replaced by 'protonup-ng'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13698,7 +13698,7 @@ self: super: with self; {
 
   primepy = callPackage ../development/python-modules/primepy { };
 
-  primer3 = callPackage ../development/python-modules/primer3 { };
+  primer3-py = callPackage ../development/python-modules/primer3-py { };
 
   primp = callPackage ../development/python-modules/primp { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Use the upstream distribution name `primer3-py` as the Primer3 `pname` so `pythonMetadataCheckHook` can find the installed metadata; the nixpkgs attribute and Python import remain `primer3`.
While validating the `dnachisel` reverse dependency, its `genome-collector` test dependency failed because its bundled `ez_setup` attempted to download an obsolete setuptools release inside the sandbox. Remove that bootstrap and migrate the package to the pyproject build flow with setuptools declared explicitly.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
