### PR TITLE
nixpkgs-lint: parse meta.maintainers list of attrsets

### DIFF
--- a/maintainers/scripts/nixpkgs-lint.pl
+++ b/maintainers/scripts/nixpkgs-lint.pl
@@ -66,6 +66,23 @@ foreach my $attr (sort keys %{$info->{item}}) {
         @maintainers = map { $_->{value} } @{$x->{string}};
     } elsif (defined $x->{value}) {
         @maintainers = ($x->{value});
+    } elsif (defined $x->{list}) {
+        my $list = $x->{list}[0];
+        if (defined $list->{string}) {
+            @maintainers = map { $_->{value} } @{$list->{string}};
+        } elsif (defined $list->{attrs}) {
+            foreach my $maintainerAttrs (@{$list->{attrs}}) {
+                my $maintainerLabel = "";
+                if (defined $maintainerAttrs->{attr}) {
+                    foreach my $maintainerField (@{$maintainerAttrs->{attr}}) {
+                        if (defined $maintainerField->{string}) {
+                            $maintainerLabel .= $maintainerField->{string}[0]->{value} . " ";
+                        }
+                    }
+                }
+                push @maintainers, $maintainerLabel || "present";
+            }
+        }
     }
 
     if (defined $maintainer && scalar(grep { $_ =~ /$maintainer/i } @maintainers) == 0) {


### PR DESCRIPTION
Depends on nix internal xml parsing.
`nix-env --query --meta --xml` returned a bogus value before https://github.com/NixOS/nix/pull/16299

If you used nixpkgs-lint before nix pr https://github.com/NixOS/nix/pull/16299, maintainers were always considered missing.
```bash
$ ./maintainers/scripts/nixpkgs-lint.pl -p firefox -f . 2> >(grep -v "evaluation warning") | grep maintainer
firefox: Lacks a maintainer
firefox-esr: Lacks a maintainer
firefox-esr-153: Lacks a maintainer
firefox-mobile: Lacks a maintainer
Number of missing maintainers: 4
```

It was due to `nix-env --xml --meta` parsing incorrectly `meta.maintainers`.

With the new code in nix, the perl script got outdated.
It now works and parses maintainers correctly:
```bash
$ PATH="$HOME/nix/fix-nix-env-xml-serialize-meta-attribute/build/src/nix:$PATH" \
./maintainers/scripts/nixpkgs-lint.pl -p firefox -f . 2> >(grep -v "warning") | grep maintainer
Number of missing maintainers: 0
``` 

## Checklist
- [ ] Waiting for upstream PR https://github.com/NixOS/nix/pull/16299 to get merged.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
