### PR TITLE
cp2k: 2026.1-unstable-2026-06-16 -> 2026.2

### DIFF
--- a/pkgs/by-name/cp/cp2k/package.nix
+++ b/pkgs/by-name/cp/cp2k/package.nix
@@ -6,6 +6,7 @@
   cmake,
   python3,
   gfortran,
+  boost,
   blas,
   lapack,
   dbcsr,
@@ -131,7 +132,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cp2k";
-  version = "2026.1-unstable-2026-06-16";
+  version = "2026.2";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -139,8 +140,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "cp2k";
     repo = "cp2k";
-    rev = "c28f603b5956aa638ef130b21b091da4e3a17639";
-    hash = "sha256-LIghR2gCYbJDux4bFfeKCi+a+VDVbjcZfcVpYwjPkEg=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ojG00n6KiaDW9vLgw/sIrhS8ceyh1mmlxgacw8KfMnA=";
     fetchSubmodules = true;
   };
 
@@ -167,6 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    boost
     fftw
     gsl
     libint


### PR DESCRIPTION
Changelog: https://github.com/markuskowa/nixpkgs/pull/new/upd-cp2k

CC @sheepforce 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
