### PR TITLE
manim: 0.20.1 -> 0.21.0

### DIFF
--- a/pkgs/development/python-modules/manim/default.nix
+++ b/pkgs/development/python-modules/manim/default.nix
@@ -5,7 +5,7 @@
   texliveInfraOnly,
 
   # build-system
-  hatchling,
+  uv-build,
 
   # buildInputs
   cairo,
@@ -42,6 +42,7 @@
   # optional-dependencies
   jupyterlab,
   notebook,
+  typst,
 
   # tests
   ffmpeg,
@@ -187,21 +188,31 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "manim";
+  version = "0.21.0";
   pyproject = true;
-  version = "0.20.1";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ManimCommunity";
     repo = "manim";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rfPqKPbxT8UsxSin4DquDjPMAUEYmKixx2fBlr5mz8U=";
+    hash = "sha256-K6+U+ri/bBf760JmyhpkzQsQqp+ofve5zBByZPVdc1w=";
   };
 
-  build-system = [
-    hatchling
-  ];
-
   patches = [ ./pytest-report-header.patch ];
+
+  postPatch =
+    # nixpkgs still ships uv-build < 0.12.1
+    ''
+      substituteInPlace pyproject.toml \
+        --replace-fail \
+          "uv_build>=0.12.1,<0.13.0" \
+          "uv_build"
+    '';
+
+  build-system = [
+    uv-build
+  ];
 
   buildInputs = [ cairo ];
 
@@ -246,6 +257,9 @@ buildPythonPackage (finalAttrs: {
     ];
     # TODO package dearpygui
     # gui = [ dearpygui ];
+    typst = [
+      typst
+    ];
   };
 
   makeWrapperArgs = [
@@ -264,10 +278,11 @@ buildPythonPackage (finalAttrs: {
     pytest-cov-stub
     pytest-xdist
     pytestCheckHook
+    typst
     versionCheckHook
   ];
 
-  # about 55 of ~600 tests failing mostly due to demand for display
+  # about 45 of ~1050 tests failing mostly due to demand for display
   disabledTests = import ./failing_tests.nix;
 
   pythonImportsCheck = [ "manim" ];

--- a/pkgs/development/python-modules/manim/failing_tests.nix
+++ b/pkgs/development/python-modules/manim/failing_tests.nix
@@ -49,42 +49,6 @@
 
   # reason for failure: tests try to reach network
   "test_logging_to_file"
-  "test_plugin_function_like"
-  "test_plugin_no_all"
-  "test_plugin_with_all"
-
-  # failing with:
-  # E           AssertionError:
-  # E           Not equal to tolerance rtol=1e-07, atol=1.01
-  # E           Frame no -1. You can use --show_diff to visually show the difference.
-  # E           Mismatched elements: 18525 / 1639680 (1.13%)
-  # E           Max absolute difference: 255
-  # E           Max relative difference: 255.
-  "test_Text2Color"
-  "test_PointCloudDot"
-  "test_Torus"
-
-  # test_ImplicitFunction[/test_implicit_graph] failing with:
-  # E           AssertionError:
-  # E           Not equal to tolerance rtol=1e-07, atol=1.01
-  # E           Frame no -1. You can use --show_diff to visually show the difference.
-  # E           Mismatched elements: 1185[/633] / 1639680[/1639680] (0.0723[/0.0386]%)
-  # E           Max absolute difference: 125[/121]
-  # E           Max relative difference: 6.5[/1]
-  #
-  # These started failing after relaxing the “watchdog” and “isosurfaces” dependencies,
-  # likely due to a tolerance difference.  They should, however, start working again when [1] is
-  # included in a Manim release.
-  # [1]: https://github.com/ManimCommunity/manim/pull/3376
-  "test_ImplicitFunction"
-  "test_implicit_graph"
-
-  # failing with:
-  # TypeError: __init__() got an unexpected keyword argument 'msg' - maybe you meant pytest.mark.skipif?
-  "test_force_window_opengl_render_with_movies"
-
-  # mismatching expectation on the new commandline
-  "test_manim_new_command"
 
   # This tests checks if the manim executable is a python script. In our case it is not.
   # It is a wrapper shell script instead.


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/ManimCommunity/manim/compare/v0.20.1...v0.21.0
Changelog: https://github.com/ManimCommunity/manim/releases/tag/v0.21.0

cc @osbm @hexadecimalDinosaur

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test