### PR TITLE
sqlit-tui: add missing pytz dependency, fix UI test exclusion

### DIFF
--- a/pkgs/by-name/sq/sqlit-tui/package.nix
+++ b/pkgs/by-name/sq/sqlit-tui/package.nix
@@ -35,6 +35,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     psycopg2
     pyodbc
     pyperclip
+    pytz
     sqlparse
     sshtunnel
     textual
@@ -52,8 +53,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "sqlit" ];
 
-  disabledTests = [
+  disabledTestPaths = [
     "tests/ui/" # UI tests fail in the sandbox
+  ];
+
+  disabledTests = [
     "test_installer_cancel_terminates_process" # timeout error
     "test_detect_strategy_pip_user_fallback" # AssertionError: assert 'externally-managed' == 'pip-user'
   ];


### PR DESCRIPTION
Fixes two checkPhase failures (observed on aarch64-darwin):

- test_timezone_aware_datetime: duckdb imports pytz lazily when converting timezone-aware datetimes, and pytz was not declared. Added to dependencies rather than nativeCheckInputs because the same lazy import fires at runtime on any tz-aware duckdb result.
- tests/ui/.../test_yank_to_line_end_y_dollar: the "tests/ui/" entry in disabledTests never matches — disabledTests feeds pytest -k, a name expression, and a path is not a test name — so the UI suite ran anyway ("UI tests fail in the sandbox" per the existing comment) and a 0.15 s timer-based test races widget teardown. Moved to disabledTestPaths, which deselects the path as intended.

With both: 1488 passed, 693 skipped, 0 failed (was 2 failed), and the UI suite is excluded at collection (checkPhase 69 s vs 178 s).

Diagnosis, patch, and this summary were prepared with assistance from Claude Code (Claude Fable 5); I reproduced the failure, reviewed the change, and built and tested it locally on aarch64-darwin.


## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].