### PR TITLE
omp: init at 18.1.17

### DIFF
--- a/pkgs/by-name/oh/oh-my-pi/package.nix
+++ b/pkgs/by-name/oh/oh-my-pi/package.nix
@@ -53,14 +53,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-LzBuO6T13J7oG4mvsOG2faBIkbN7b636iaLrUuLDDvA=";
   };
 
-  # Upstream requires Bun >= 1.3.14, but Nixpkgs currently provides Bun 1.3.13.
-  # Bypass the strict semver check to allow running under pkgs.bun until Nixpkgs updates Bun.
   postPatch = ''
     substituteInPlace packages/coding-agent/src/cli.ts \
       --replace-fail 'if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0)' 'if (false)'
   '';
 
-  # required until https://github.com/NixOS/nixpkgs/issues/255890 & https://github.com/NixOS/nixpkgs/issues/#335534 are fixed
+  # required until https://github.com/NixOS/nixpkgs/issues/255890 & https://github.com/NixOS/nixpkgs/issues/335534 are fixed
   passthru.node_modules = stdenv.mkDerivation {
     pname = "oh-my-pi-node_modules";
     inherit (finalAttrs) version src;
@@ -100,6 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postInstall
     '';
 
+    # Prevents breaking symlinks in node_modules
     dontFixup = true;
 
     outputHash = "sha256-MQzVxwhWIxvEd4X/KcB/oYILrSvnYB4wjjetgJxspSA=";
@@ -133,7 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     RUSTC_BOOTSTRAP = "1";
   }
-  // lib.optionalAttrs stdenv.hostPlatform.isx86_64 { RUSTFLAGS = "-C target-cpu=x86-64-v2"; }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin { BUN_NO_CODESIGN_MACHO_BINARY = "1"; };
 
   configurePhase = ''

--- a/pkgs/by-name/oh/oh-my-pi/package.nix
+++ b/pkgs/by-name/oh/oh-my-pi/package.nix
@@ -227,7 +227,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/can1357/oh-my-pi/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "omp";
-    maintainers = with lib.maintainers; [ malix ];
+    maintainers = with lib.maintainers; [
+      malix
+      naxdy
+    ];
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/pkgs/by-name/oh/oh-my-pi/package.nix
+++ b/pkgs/by-name/oh/oh-my-pi/package.nix
@@ -1,0 +1,233 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bun,
+  cargo,
+  rustc,
+  cmake,
+  ninja,
+  pkg-config,
+  rustPlatform,
+  autoPatchelfHook,
+  chromium,
+  installShellFiles,
+  makeWrapper,
+  libopus,
+  alsa-lib,
+  libpulseaudio,
+  pipewire,
+  darwin,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  withPuppeteer ? false,
+  withWaylandScreencast ? false,
+}:
+let
+  addonName =
+    let
+      inherit (stdenv.hostPlatform) node isx86_64;
+      arch = if isx86_64 then "x64-baseline" else node.arch;
+    in
+    "pi_natives.${node.platform}-${arch}.node";
+
+  nativeLibrary = "libpi_natives${stdenv.hostPlatform.extensions.sharedLibrary}";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oh-my-pi";
+  version = "17.3.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "can1357";
+    repo = "oh-my-pi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GvzeVpyAfQ7Vh5Bd5eOCv5FOzmfHACfZZS7Xh+dF/lQ=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-LzBuO6T13J7oG4mvsOG2faBIkbN7b636iaLrUuLDDvA=";
+  };
+
+  # required until https://github.com/NixOS/nixpkgs/issues/255890 & https://github.com/NixOS/nixpkgs/issues/#335534 are fixed
+  passthru.node_modules = stdenv.mkDerivation {
+    pname = "oh-my-pi-node_modules";
+    inherit (finalAttrs) version src;
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      find . -type d -name node_modules -exec cp -R --parents {} $out \;
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+
+    outputHash = "sha256-MQzVxwhWIxvEd4X/KcB/oYILrSvnYB4wjjetgJxspSA=";
+    outputHashMode = "recursive";
+  };
+
+  nativeBuildInputs = [
+    bun
+    cargo
+    cmake
+    installShellFiles
+    makeWrapper
+    ninja
+    pkg-config
+    rustc
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+
+  buildInputs = [
+    libopus
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ]
+  ++ lib.optionals withWaylandScreencast [ pipewire ];
+
+  dontStrip = true;
+
+  env = {
+    RUSTC_BOOTSTRAP = "1";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isx86_64 { RUSTFLAGS = "-C target-cpu=x86-64-v2"; }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin { BUN_NO_CODESIGN_MACHO_BINARY = "1"; };
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${finalAttrs.passthru.node_modules}/* .
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    echo "Building pi-natives"
+    cargo build --release -p pi-natives ${lib.optionalString withWaylandScreencast "--features wayland-pipewire"}
+    install -Dm755 "target/release/${nativeLibrary}" \
+      "packages/natives/native/${addonName}"
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      autoPatchelf -- "packages/natives/native/${addonName}"
+      patchelf --add-rpath "${
+        lib.makeLibraryPath [
+          libpulseaudio
+          alsa-lib
+        ]
+      }" \
+        "packages/natives/native/${addonName}"
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      signIfRequired "packages/natives/native/${addonName}"
+    ''}
+
+    echo "Building JS bundle"
+    bun --cwd="$PWD/packages/coding-agent" run prepack
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/oh-my-pi
+    cp -R packages python node_modules $out/lib/oh-my-pi/
+
+    makeWrapper "${lib.getExe bun}" "$out/bin/omp" \
+      --add-flags "$out/lib/oh-my-pi/packages/coding-agent/dist/cli.js" \
+      ${lib.optionalString withPuppeteer ''
+        --set PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true \
+        --set PUPPETEER_EXECUTABLE_PATH "${lib.getExe chromium}"
+      ''}
+
+    mkdir -p "$out/nix-support"
+    ${
+      if stdenv.hostPlatform.isLinux then
+        ''
+          patchelf --print-rpath "packages/natives/native/${addonName}" \
+            > "$out/nix-support/embedded-addon-runpath"
+        ''
+      else
+        ''
+          echo "${lib.getLib libopus}/lib" > "$out/nix-support/embedded-addon-runpath"
+        ''
+    }
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd omp \
+      ${lib.concatMapStringsSep " " (sh: "--${sh} <($out/bin/omp completions ${sh})") [
+        "bash"
+        "zsh"
+        "fish"
+      ]}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "passthru.node_modules"
+    ];
+  };
+
+  meta = {
+    description = "Terminal-based coding agent with multi-model support";
+    homepage = "https://omp.sh";
+    changelog = "https://github.com/can1357/oh-my-pi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "omp";
+    maintainers = with lib.maintainers; [ malix ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+})

--- a/pkgs/by-name/oh/oh-my-pi/package.nix
+++ b/pkgs/by-name/oh/oh-my-pi/package.nix
@@ -53,6 +53,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-LzBuO6T13J7oG4mvsOG2faBIkbN7b636iaLrUuLDDvA=";
   };
 
+  # Upstream requires Bun >= 1.3.14, but Nixpkgs currently provides Bun 1.3.13.
+  # Bypass the strict semver check to allow running under pkgs.bun until Nixpkgs updates Bun.
+  postPatch = ''
+    substituteInPlace packages/coding-agent/src/cli.ts \
+      --replace-fail 'if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0)' 'if (false)'
+  '';
+
   # required until https://github.com/NixOS/nixpkgs/issues/255890 & https://github.com/NixOS/nixpkgs/issues/#335534 are fixed
   passthru.node_modules = stdenv.mkDerivation {
     pname = "oh-my-pi-node_modules";

--- a/pkgs/by-name/om/omp/package.nix
+++ b/pkgs/by-name/om/omp/package.nix
@@ -1,0 +1,241 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bun,
+  cargo,
+  rustc,
+  cmake,
+  ninja,
+  pkg-config,
+  rustPlatform,
+  autoPatchelfHook,
+  installShellFiles,
+  makeWrapper,
+  libopus,
+  alsa-lib,
+  libpulseaudio,
+  pipewire,
+  darwin,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  pipewireSupport ? stdenv.hostPlatform.isLinux,
+}:
+let
+  addonName =
+    let
+      inherit (stdenv.hostPlatform) node isx86_64;
+      arch = if isx86_64 then "x64-baseline" else node.arch;
+    in
+    "pi_natives.${node.platform}-${arch}.node";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omp";
+  version = "18.1.17";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "can1357";
+    repo = "oh-my-pi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2Pm47xHRvEQoOvWYFNtJhgJkueAThfrLYhBysjQCQoQ=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-89/hqvbgMeJLKZdzP+ZnJRjSXs1NoDu8hAQIdlNlDQM=";
+  };
+
+  postPatch = ''
+    substituteInPlace packages/coding-agent/src/cli.ts \
+      --replace-fail 'if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0)' 'if (false)'
+  '';
+
+  # required until https://github.com/NixOS/nixpkgs/issues/255890 & https://github.com/NixOS/nixpkgs/issues/335534 are fixed
+  node_modules = stdenv.mkDerivation {
+    pname = "${finalAttrs.pname}-node_modules";
+    inherit (finalAttrs) version src;
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      find . -type d -name node_modules -exec cp -R --parents {} $out \;
+
+      runHook postInstall
+    '';
+
+    # Prevents breaking symlinks in node_modules
+    dontFixup = true;
+
+    outputHash = "sha256-wqfKptBYo7GENPQLz3BfZ/m9i5lhng6yYjWbz7L6NNw=";
+    outputHashMode = "recursive";
+  };
+
+  nativeBuildInputs = [
+    bun
+    cargo
+    cmake
+    installShellFiles
+    makeWrapper
+    ninja
+    pkg-config
+    rustc
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+
+  buildInputs = [
+    libopus
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ]
+  ++ lib.optionals pipewireSupport [ pipewire ];
+
+  dontStrip = true;
+
+  env = {
+    RUSTC_BOOTSTRAP = "1";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin { BUN_NO_CODESIGN_MACHO_BINARY = "1"; };
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${finalAttrs.node_modules}/* .
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    echo "Building pi-natives"
+    cargo build --release -p pi-natives ${lib.optionalString pipewireSupport "--features wayland-pipewire"}
+    install -Dm755 "target/release/libpi_natives${stdenv.hostPlatform.extensions.sharedLibrary}" \
+      "packages/natives/native/${addonName}"
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      autoPatchelf -- "packages/natives/native/${addonName}"
+      patchelf --add-rpath "${
+        lib.makeLibraryPath [
+          libpulseaudio
+          alsa-lib
+        ]
+      }" \
+        "packages/natives/native/${addonName}"
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      signIfRequired "packages/natives/native/${addonName}"
+    ''}
+
+    echo "Building JS bundle"
+    bun --cwd="$PWD/packages/coding-agent" run prepack
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/omp
+    cp -R packages python node_modules $out/lib/omp/
+    chmod -R u+w $out/lib/omp
+
+    # Prune foreign binaries to eliminate dead code and prevent autoPatchelf issues
+    find $out/lib/omp/node_modules -type d \( ${
+      lib.concatStringsSep " -o " (
+        lib.map (n: "-name '*${n}*'") (
+          [
+            "musl"
+            "sunos"
+            "win32"
+            "aix"
+            "openbsd"
+            "freebsd"
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isDarwin [
+            "linux"
+            "x64"
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            "darwin"
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+            "arm64"
+          ]
+        )
+      )
+    } \) -exec rm -rf {} +
+    find $out/lib/omp/node_modules -type f -name '*.exe' -delete
+
+    makeWrapper "${lib.getExe bun}" "$out/bin/omp" --add-flags "$out/lib/omp/packages/coding-agent/dist/cli.js"
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd omp \
+      ${lib.concatMapStringsSep " " (sh: "--${sh} <($out/bin/omp completions ${sh})") [
+        "bash"
+        "zsh"
+        "fish"
+      ]}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "node_modules"
+    ];
+  };
+
+  meta = {
+    description = "Terminal-based coding agent with multi-model support";
+    homepage = "https://omp.sh";
+    changelog = "https://github.com/can1357/oh-my-pi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "omp";
+    maintainers = with lib.maintainers; [
+      malix
+      naxdy
+      adamcstephens
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- https://omp.sh/
- https://github.com/can1357/oh-my-pi

An alternative packaging would be to vendor the `bun.nix` file to deduplicate dependencies, but I do not want to add +9000 lines just for this

But this would be solved by default when #255890 & #335534 will be fixed

CLOSES: #541035 #540856

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. used various agentic coding harness, but mainly Oh-My-Pi using GPT 5.6 Luna Max

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test