### PR TITLE
python3Packages.brevo-python: 1.2.0 -> 5.0.2

### DIFF
--- a/pkgs/development/python-modules/brevo-python/conftest-dont-docker-compose.patch
+++ b/pkgs/development/python-modules/brevo-python/conftest-dont-docker-compose.patch
@@ -1,0 +1,19 @@
+diff --git i/tests/conftest.py w/tests/conftest.py
+index bfee144..f2e9ed5 100644
+--- i/tests/conftest.py
++++ w/tests/conftest.py
+@@ -94,8 +94,6 @@ def pytest_configure(config: pytest.Config) -> None:
+         # Workers never manage the container lifecycle.
+         return
+ 
+-    _start_wiremock()
+-
+ 
+ def pytest_unconfigure(config: pytest.Config) -> None:
+     """
+@@ -108,5 +106,3 @@ def pytest_unconfigure(config: pytest.Config) -> None:
+     if _is_xdist_worker(config):
+         # Workers never manage the container lifecycle.
+         return
+-
+-    _stop_wiremock()

--- a/pkgs/development/python-modules/brevo-python/default.nix
+++ b/pkgs/development/python-modules/brevo-python/default.nix
@@ -2,45 +2,52 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
-  certifi,
-  python-dateutil,
-  six,
-  urllib3,
+  httpx,
+  poetry-core,
+  pydantic,
+  pydantic-core,
+  pytest-asyncio,
   pytestCheckHook,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "brevo-python";
-  version = "1.2.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "getbrevo";
     repo = "brevo-python";
     tag = "v${version}";
-    hash = "sha256-VYj1r69pgKgNCXzxRqvwlj5w+y3IIu21bsZJAe/7zf8=";
+    hash = "sha256-VoH/ytTuqNrjNMMkuSciai4eD/UHOYCE2ddUx+cbf/c=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ poetry-core ];
 
   dependencies = [
-    certifi
-    python-dateutil
-    six
-    urllib3
+    httpx
+    pydantic
+    pydantic-core
+    typing-extensions
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-asyncio
+  ];
+
+  patches = [
+    # `conftest.py` tries to run `docker` to run `wiremock`
+    ./conftest-dont-docker-compose.patch
   ];
 
   disabledTestPaths = [
-    # broken import; https://github.com/getbrevo/brevo-python/issues/2
-    "test/test_configuration.py"
+    # tests requiring `wiremock`
+    "tests/wire/"
   ];
 
-  pythonImportsCheck = [ "brevo_python" ];
+  pythonImportsCheck = [ "brevo" ];
 
   meta = {
     description = "Fully-featured Python API client to interact with Brevo";

--- a/pkgs/development/python-modules/brevo-python/default.nix
+++ b/pkgs/development/python-modules/brevo-python/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "brevo-python";
-  version = "5.0.1";
+  version = "5.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "getbrevo";
     repo = "brevo-python";
     tag = "v${version}";
-    hash = "sha256-mn2EVhTmoXhPfxZRWSNSK23ANwIFfvz5FuW5ErTlqrQ=";
+    hash = "sha256-L6zRPoiqSNDli0dfBG/wRscRhTBZYXO8nVxyHzq9v70=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/brevo-python/default.nix
+++ b/pkgs/development/python-modules/brevo-python/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "brevo-python";
-  version = "4.0.1";
+  version = "5.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "getbrevo";
     repo = "brevo-python";
     tag = "v${version}";
-    hash = "sha256-VoH/ytTuqNrjNMMkuSciai4eD/UHOYCE2ddUx+cbf/c=";
+    hash = "sha256-mn2EVhTmoXhPfxZRWSNSK23ANwIFfvz5FuW5ErTlqrQ=";
   };
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
Update package to a more recent version, containing new features.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
