### PR TITLE
pcsx2: pin ffmpeg_8

### DIFF
--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -6,7 +6,7 @@
   cubeb,
   curl,
   kdePackages,
-  ffmpeg,
+  ffmpeg_8,
   gtk3,
   libxrandr,
   libaio,
@@ -86,7 +86,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     kdePackages.extra-cmake-modules
     curl
-    ffmpeg
+    ffmpeg_8
     gtk3
     libaio
     libbacktrace


### PR DESCRIPTION
Fix build failure caused by the update to `ffmpeg` 9.
```
/build/source/pcsx2/GS/GSCapture.cpp:460:28: error: no member named 'pix_fmts' in 'AVCodec'
  460 |                         for (u32 i = 0; vcodec->pix_fmts[i] != AV_PIX_FMT_NONE; i++)
      |                                         ~~~~~~  ^
/build/source/pcsx2/GS/GSCapture.cpp:462:17: error: no member named 'pix_fmts' in 'AVCodec'
  462 |                                 if (vcodec->pix_fmts[i] == preferred_sw_pix_fmt)
      |                                     ~~~~~~  ^
/build/source/pcsx2/GS/GSCapture.cpp:464:27: error: no member named 'pix_fmts' in 'AVCodec'
  464 |                                         sw_pix_fmt = vcodec->pix_fmts[i];
      |                                                      ~~~~~~  ^
/build/source/pcsx2/GS/GSCapture.cpp:689:42: error: no member named 'sample_fmts' in 'AVCodec'
  689 |                 for (const AVSampleFormat* p = acodec->sample_fmts; *p != AV_SAMPLE_FMT_NONE; p++)
      |                                                ~~~~~~  ^
[ 67%] Building CXX object pcsx2/CMakeFiles/PCSX2.dir/GS/MultiISA.cpp.o
/build/source/pcsx2/GS/GSCapture.cpp:700:48: error: no member named 'sample_fmts' in 'AVCodec'
  700 |                         s_audio_codec_context->sample_fmt = acodec->sample_fmts[0];
      |                                                             ~~~~~~  ^
/build/source/pcsx2/GS/GSCapture.cpp:1536:15: error: no member named 'pix_fmts' in 'AVCodec'
 1536 |         if (v_codec->pix_fmts == nullptr)
      |             ~~~~~~~  ^
/build/source/pcsx2/GS/GSCapture.cpp:1542:27: error: no member named 'pix_fmts' in 'AVCodec'
 1542 |         for (int i = 0; v_codec->pix_fmts[i] != AVPixelFormat::AV_PIX_FMT_NONE; i++)
      |                         ~~~~~~~  ^
/build/source/pcsx2/GS/GSCapture.cpp:1544:29: error: no member named 'pix_fmts' in 'AVCodec'
 1544 |                 ret.emplace_back(v_codec->pix_fmts[i], wrap_av_get_pix_fmt_name(v_codec->pix_fmts[i]));
      |                                  ~~~~~~~  ^
/build/source/pcsx2/GS/GSCapture.cpp:1544:76: error: no member named 'pix_fmts' in 'AVCodec'
 1544 |                 ret.emplace_back(v_codec->pix_fmts[i], wrap_av_get_pix_fmt_name(v_codec->pix_fmts[i]));

```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
