### PR TITLE
openmolcas: 26.02 -> 26.06

### DIFF
--- a/pkgs/by-name/li/libwignernj/package.nix
+++ b/pkgs/by-name/li/libwignernj/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  cmake,
+  gfortran,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libwignernj";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "susilehtola";
+    repo = "libwignernj";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NJcLW+nFgQADOgvmYU8iNffiXYVgmTMeaUkDKbsgHAg=";
+  };
+
+  patches = [
+    ./pkg-config.patch
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postFixup = ''
+    substituteInPlace $dev/lib/cmake/wignernj/wignernjTargets.cmake --replace \
+      'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/include"' \
+      'INTERFACE_INCLUDE_DIRECTORIES "${placeholder "dev"}/include"'
+  '';
+
+  meta = {
+    description = "Exact evaluation of Wigner symbols and Clebsch-Gordan coefficients in C99";
+    homepage = "https://github.com/susilehtola/libwignernj";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.markuskowa ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/li/libwignernj/pkg-config.patch
+++ b/pkgs/by-name/li/libwignernj/pkg-config.patch
@@ -1,0 +1,30 @@
+diff --git a/libwignernj.pc.in b/libwignernj.pc.in
+index 7be95cd..ad1fbfa 100644
+--- a/libwignernj.pc.in
++++ b/libwignernj.pc.in
+@@ -2,8 +2,8 @@
+ # Copyright (c) 2026 Susi Lehtola
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@
+ 
+ Name: libwignernj
+ Description: Exact Wigner 3j/6j/9j symbols and related coefficients via prime factorization
+diff --git a/libwignernj_f03.pc.in b/libwignernj_f03.pc.in
+index 0850d25..10d34e9 100644
+--- a/libwignernj_f03.pc.in
++++ b/libwignernj_f03.pc.in
+@@ -2,8 +2,8 @@
+ # Copyright (c) 2026 Susi Lehtola
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@
+ moddir=${includedir}/wignernj/fortran
+ 
+ Name: libwignernj_f03

--- a/pkgs/by-name/op/openmolcas/package.nix
+++ b/pkgs/by-name/op/openmolcas/package.nix
@@ -16,6 +16,7 @@
   makeWrapper,
   gsl,
   boost188,
+  libwignernj,
   autoPatchelfHook,
   enableQcmaquis ? true,
   # Note that the CASPT2 module is broken with MPI
@@ -65,13 +66,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openmolcas";
-  version = "26.02";
+  version = "26.06";
 
   src = fetchFromGitLab {
     owner = "Molcas";
     repo = "OpenMolcas";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-FzO1fvMw+/r6SKiaODlhkmKlbzQ9TXLYXk+xpz/fs2I=";
+    hash = "sha256-y4eUfp8PIeWSuF4j9wT6C8z8rYFySUrNMa4ezI3/kXg=";
   };
 
   patches = [
@@ -110,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     blas-ilp64
     lapack-ilp64
+    libwignernj
   ]
   ++ lib.optionals enableMpi [
     mpi


### PR DESCRIPTION
Update to latest version. Add libwignerj which is now required.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
