### PR TITLE
punes: pin ffmpeg_8

### DIFF
--- a/pkgs/by-name/pu/punes/package.nix
+++ b/pkgs/by-name/pu/punes/package.nix
@@ -6,7 +6,7 @@
   gitUpdater,
   cmake,
   pkg-config,
-  ffmpeg,
+  ffmpeg_8,
   libGLU,
   alsa-lib,
   libx11,
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]);
 
   buildInputs = [
-    ffmpeg
+    ffmpeg_8
     libGLU
   ]
   ++ (with qtPackages; [


### PR DESCRIPTION
Fix build failure caused by the update to ffmpeg 9.

Note that while testing I did not have any audio, but this also happens with `punes` from `nixos-26.05` (which still uses ffmpeg 8). This is most likely a configuration issue on my end and is not a regression caused by the pin.
```
       >  1495 |         p = codec->supported_samplerates;
       >       |                  ^~
       > /build/source/src/core/recording.c:1501:18: error: 'AVCodec' has no member named 'supported_samplerates'
       >  1501 |         p = codec->supported_samplerates;
       >       |                  ^~
       > /build/source/src/core/recording.c: In function 'ffmpeg_audio_select_channel_layout':
       > /build/source/src/core/recording.c:1615:19: error: 'AVCodec' has no member named 'ch_layouts'
       >  1615 |         if (!codec->ch_layouts) {
       >       |                   ^~
       > /build/source/src/core/recording.c:1635:18: error: 'AVCodec' has no member named 'ch_layouts'
       >  1635 |         p = codec->ch_layouts;
       >       |                  ^~
       > /build/source/src/core/recording.c:1646:18: error: 'AVCodec' has no member named 'ch_layouts'
       >  1646 |         p = codec->ch_layouts;
       >       |                  ^~
       > make[2]: *** [src/CMakeFiles/punes.dir/build.make:7046: src/CMakeFiles/punes.dir/core/recording.c.o] Error 1

```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
