### PR TITLE
meson: add disabledTests support

### DIFF
--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -12,6 +12,7 @@
   replaceVars,
   writeShellScriptBin,
   zlib,
+  jq,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -173,7 +174,10 @@ python3.pkgs.buildPythonApplication rec {
       --replace "python3 -c " "${python3.interpreter} -c "
   '';
 
-  setupHook = ./setup-hook.sh;
+  setupHook = replaceVars ./setup-hook.sh {
+    jqExe = lib.getExe jq;
+    hostPlatform = null;
+  };
   env.hostPlatform = stdenv.targetPlatform.system;
 
   meta = {

--- a/pkgs/by-name/me/meson/setup-hook.sh
+++ b/pkgs/by-name/me/meson/setup-hook.sh
@@ -63,6 +63,19 @@ mesonCheckPhase() {
         flagsArray+=("--timeout-multiplier=0")
     fi
 
+    if [[ -n "${disabledTests[*]-}" ]]; then
+        _disabledTestsJson=$(@jqExe@ --compact-output --null-input '$ARGS.positional' --args -- "${disabledTests[@]}")
+        # NOTE: Meson allows assocating tests with an array of "suite" labels, though this is almost never used in practice
+        # For simplicity, we assume that tests are sufficiently identified by the first element of the suite array
+        flagsArray+=(
+            $(meson introspect --tests | \
+              @jqExe@ --argjson disabled "$_disabledTestsJson" \
+              -r 'map(select(.name | IN($disabled[]) | not))
+                | map("\(.suite[0]):\(.name)")
+                | .[]')
+        )
+    fi
+
     # Parallel building is enabled by default.
     local buildCores=1
     if [ "${enableParallelBuilding-1}" ]; then


### PR DESCRIPTION
Adds support for skipping certain tests with `disabledTests`, just like for Python etc.
I noticed that a lot of meson-based packages have their tests disabled simply because there's just a tiny number of failing tests, and it's not trivial to disable those.
I'll add some documentation for the feature, but please let me know if there's any blocker in the meantime.

Note: Meson 1.12 (released 2026-08-10) adds support for an `--exclude` flag, which would simplify the script a bit, but on the other hand it works fine already.  (https://mesonbuild.com/Release-notes-for-1-12-0.html)
Also, it will probably still take some time until Meson 1.12 lands in Nixpkgs.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
