### PR TITLE
python3Packages.mat2: pin ffmpeg_8

### DIFF
--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   replaceVars,
   exiftool,
-  ffmpeg,
+  ffmpeg_8,
   setuptools,
   wrapGAppsHook3,
   gdk-pixbuf,
@@ -39,7 +39,7 @@ buildPythonPackage (finalAttrs: {
     # hardcode paths to some binaries
     (replaceVars ./paths.patch {
       exiftool = lib.getExe exiftool;
-      ffmpeg = lib.getExe ffmpeg;
+      ffmpeg = lib.getExe ffmpeg_8;
       kdialog = if dolphinIntegration then lib.getExe kdePackages.kdialog else null;
       # replaced in postPatch
       mat2 = null;

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   pytestCheckHook,
   fetchFromGitHub,


### PR DESCRIPTION
Ref: https://github.com/jvoisin/mat2/issues/53

Fix build issue with ffmpeg 9.

I also removed `stdenv` from the inputs since it is unused.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
