### PR TITLE
airshipper: fix executable patchers and update dependencies

### DIFF
--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -16,10 +16,7 @@
   alsa-lib,
   stdenv,
   libxcb,
-  bzip2,
   cmake,
-  fontconfig,
-  freetype,
   pkg-config,
   makeWrapper,
   writeShellScript,
@@ -42,6 +39,8 @@ let
         libxi
         vulkan-loader
         libGL
+        wayland
+        wayland-protocols
       ];
     in
     writeShellScript "voxygen-patch" ''
@@ -63,7 +62,7 @@ let
       veloren-server-cli
   '';
 in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "airshipper";
   inherit version;
 
@@ -77,7 +76,6 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-ry0hFvMDnotDQu6mqgyt+6hKOvGRJLmZKs3SxEVtDRg=";
 
   buildInputs = [
-    fontconfig
     openssl
     wayland
     wayland-protocols
@@ -86,9 +84,10 @@ rustPlatform.buildRustPackage {
     libxrandr
     libxi
     libxcursor
+    vulkan-loader
+    libGL
   ];
   nativeBuildInputs = [
-    cmake
     pkg-config
     makeWrapper
   ];
@@ -100,31 +99,21 @@ rustPlatform.buildRustPackage {
     install -Dm444    "client/assets/net.veloren.airshipper.png"  "$out/share/icons/net.veloren.airshipper.png"
   '';
 
-  postFixup =
-    let
-      libPath = lib.makeLibraryPath [
-        libGL
-        vulkan-loader
-        wayland
-        wayland-protocols
-        bzip2
-        fontconfig
-        freetype
-        libxkbcommon
-        libx11
-        libxrandr
-        libxi
-        libxcursor
-      ];
-    in
-    ''
-      # We set LD_LIBRARY_PATH instead of using patchelf in order to propagate the libs
-      # to both Airshipper itself as well as the binaries downloaded by Airshipper.
-      wrapProgram "$out/bin/airshipper" \
-        --set VELOREN_VOXYGEN_PATCHER "${patchVoxygen}" \
-        --set VELOREN_SERVER_CLI_PATCHER "${patchServer}" \
-        --prefix LD_LIBRARY_PATH : "${libPath}"
-    '';
+  postFixup = ''
+    ${patchelf}/bin/patchelf \
+      --set-rpath ${
+        lib.makeLibraryPath (
+          buildInputs
+          ++ [
+            (lib.getLib stdenv.cc.cc)
+            stdenv.cc.libc
+          ]
+        )
+      } "$out/bin/airshipper"
+    wrapProgram "$out/bin/airshipper" \
+      --set VELOREN_VOXYGEN_PATCHER "${patchVoxygen}" \
+      --set VELOREN_SERVER_CLI_PATCHER "${patchServer}"
+  '';
 
   doCheck = false;
   cargoBuildFlags = [

--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -25,23 +25,7 @@
 let
   # Patch for airshipper to install veloren client
   patchVoxygen =
-    let
-      runtimeLibs = [
-        udev
-        alsa-lib
-        (lib.getLib stdenv.cc.cc)
-        libxkbcommon
-        libxcb
-        libx11
-        libxcursor
-        libxrandr
-        libxi
-        vulkan-loader
-        libGL
-        wayland
-        wayland-protocols
-      ];
-    in
+    runtimeLibs:
     writeShellScript "voxygen-patch" ''
       echo "making veloren-voxygen executable"
       chmod +x veloren-voxygen
@@ -98,6 +82,25 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm444    "client/assets/net.veloren.airshipper.png"  "$out/share/icons/net.veloren.airshipper.png"
   '';
 
+  passthru = {
+    inherit patchVoxygen patchServer;
+    runtimeLibs = [
+      udev
+      alsa-lib
+      (lib.getLib stdenv.cc.cc)
+      libxkbcommon
+      libxcb
+      libx11
+      libxcursor
+      libxrandr
+      libxi
+      vulkan-loader
+      libGL
+      wayland
+      wayland-protocols
+    ];
+  };
+
   postFixup = ''
     ${patchelf}/bin/patchelf \
       --set-rpath ${
@@ -110,8 +113,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
         )
       } "$out/bin/airshipper"
     wrapProgram "$out/bin/airshipper" \
-      --set VELOREN_VOXYGEN_PATCHER "${patchVoxygen}" \
-      --set VELOREN_SERVER_CLI_PATCHER "${patchServer}"
+      --set VELOREN_VOXYGEN_PATCHER "${finalAttrs.passthru.patchVoxygen finalAttrs.passthru.runtimeLibs}" \
+      --set VELOREN_SERVER_CLI_PATCHER "${finalAttrs.passthru.patchServer}"
   '';
 
   doCheck = false;

--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -23,7 +23,6 @@
   patchelf,
 }:
 let
-  version = "0.17.0";
   # Patch for airshipper to install veloren client
   patchVoxygen =
     let
@@ -62,14 +61,14 @@ let
       veloren-server-cli
   '';
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "airshipper";
-  inherit version;
+  version = "0.17.0";
 
   src = fetchFromGitLab {
     owner = "Veloren";
     repo = "airshipper";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-M89RswC08MZnNfk2T1+rtDajTpDGTnJoZ2U8bU5U2+0=";
   };
 
@@ -103,7 +102,7 @@ rustPlatform.buildRustPackage rec {
     ${patchelf}/bin/patchelf \
       --set-rpath ${
         lib.makeLibraryPath (
-          buildInputs
+          finalAttrs.buildInputs
           ++ [
             (lib.getLib stdenv.cc.cc)
             stdenv.cc.libc
@@ -132,4 +131,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ yusdacra ];
   };
-}
+})

--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -16,7 +16,6 @@
   alsa-lib,
   stdenv,
   libxcb,
-  cmake,
   pkg-config,
   makeWrapper,
   writeShellScript,

--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -27,8 +27,8 @@
 }:
 let
   version = "0.17.0";
-  # Patch for airshipper to install veloren
-  patch =
+  # Patch for airshipper to install veloren client
+  patchVoxygen =
     let
       runtimeLibs = [
         udev
@@ -44,18 +44,24 @@ let
         libGL
       ];
     in
-    writeShellScript "patch" ''
-      echo "making binaries executable"
-      chmod +x {veloren-voxygen,veloren-server-cli}
-      echo "patching dynamic linkers"
-      ${patchelf}/bin/patchelf \
-        --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
-        veloren-server-cli
+    writeShellScript "voxygen-patch" ''
+      echo "making veloren-voxygen executable"
+      chmod +x veloren-voxygen
+      echo "patching veloren-voxygen dynamic linker"
       ${patchelf}/bin/patchelf \
         --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
         --set-rpath "${lib.makeLibraryPath runtimeLibs}" \
         veloren-voxygen
     '';
+  # Patch for airshipper to install veloren server
+  patchServer = writeShellScript "server-cli-patch" ''
+    echo "making veloren-server-cli executable"
+    chmod +x veloren-server-cli
+    echo "patching veloren-server-cli dynamic linker"
+    ${patchelf}/bin/patchelf \
+      --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
+      veloren-server-cli
+  '';
 in
 rustPlatform.buildRustPackage {
   pname = "airshipper";
@@ -115,7 +121,8 @@ rustPlatform.buildRustPackage {
       # We set LD_LIBRARY_PATH instead of using patchelf in order to propagate the libs
       # to both Airshipper itself as well as the binaries downloaded by Airshipper.
       wrapProgram "$out/bin/airshipper" \
-        --set VELOREN_PATCHER "${patch}" \
+        --set VELOREN_VOXYGEN_PATCHER "${patchVoxygen}" \
+        --set VELOREN_SERVER_CLI_PATCHER "${patchServer}" \
         --prefix LD_LIBRARY_PATH : "${libPath}"
     '';
 


### PR DESCRIPTION
With the last release the patcher was split into two, one for each executable. It didn't occur to me that nixpkgs packages airshipper existed as well (we maintain our own flake in our repository).

While I was at it I noticed some unnecessary and some missing dependencies, and that LD_LIBRARY_PATH was being redundantly set. Let me know if you think there's a better way to factor the airshipper patchelf (as opposed to my making the set `rec`) or if the gcc and libc are redundant for that.

Cc @pbsds 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [~] [NixOS tests] in [nixos/tests].
  - [~] [Package tests] at `passthru.tests`.
  - [~] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [~] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [~] Module addition: when adding a new NixOS module.
  - [~] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
