### PR TITLE
rpcs3: fix build with FFmpeg 9

### DIFF
--- a/pkgs/by-name/rp/rpcs3/ffmpeg-9-pix-fmts.patch
+++ b/pkgs/by-name/rp/rpcs3/ffmpeg-9-pix-fmts.patch
@@ -1,0 +1,13 @@
+diff --git a/rpcs3/rpcs3qt/recording_settings_dialog.cpp b/rpcs3/rpcs3qt/recording_settings_dialog.cpp
+--- a/rpcs3/rpcs3qt/recording_settings_dialog.cpp
++++ b/rpcs3/rpcs3qt/recording_settings_dialog.cpp
+@@ -31,9 +31,6 @@ static std::vector<const AVCodec*> get_video_codecs(const AVOutputFormat* fmt)
+ 	void* opaque = nullptr;
+ 	while (const AVCodec* codec = av_codec_iterate(&opaque))
+ 	{
+-		if (!codec->pix_fmts)
+-			continue;
+-
+ 		if (codec->capabilities & AV_CODEC_CAP_EXPERIMENTAL)
+ 			continue;
+ 

--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -66,6 +66,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
+  patches = [
+    # FFmpeg 9 removed AVCodec.pix_fmts; drop the check (RPCS3/rpcs3@a8dd0535935a).
+    ./ffmpeg-9-pix-fmts.patch
+  ];
+
   preConfigure = ''
     cat > ./rpcs3/git-version.h <<EOF
     #define RPCS3_GIT_VERSION "nixpkgs-${lib.sources.shortRev finalAttrs.src.rev}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
