### PR TITLE
python3Packages.flashinfer-python: rename from flashinfer

### DIFF
--- a/pkgs/development/python-modules/flashinfer-python/default.nix
+++ b/pkgs/development/python-modules/flashinfer-python/default.nix
@@ -31,7 +31,7 @@
 }:
 
 buildPythonPackage (finalAttrs: {
-  pname = "flashinfer";
+  pname = "flashinfer-python";
   version = "0.6.4";
   pyproject = true;
 

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -101,7 +101,7 @@
   py-libnuma,
   # cuda-only
   cupy,
-  flashinfer,
+  flashinfer-python,
   nvidia-ml-py,
   # rocm-only
   bash,
@@ -595,7 +595,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   ]
   ++ lib.optionals cudaSupport [
     cupy
-    flashinfer
+    flashinfer-python
     nvidia-ml-py
     tokenspeed-mla
   ]

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -255,6 +255,7 @@ mapAliases {
   filesplit = throw "filesplit has been removed, since it is unmaintained"; # added 2025-08-20
   fints_4 = throw "fints_4 has been removed, migrate to fints"; # added 2026-06-04
   flake8-future-import = throw "'flake8-future-import' has been removed as it was unmaintained upstream"; # Added 2026-03-22
+  flashinfer = warnAlias "'flashinfer' has been renamed to 'flashinfer-python'" flashinfer-python; # Added 2026-08-13
   flask-security-too = throw "'flask-security-too' has been renamed to/replaced by 'flask-security'"; # Converted to throw 2025-10-29
   flask-silk = throw "flask-silk was removed, as it is unmaintained since 2018."; # added 2025-05-25
   flask-themes2 = throw "'flask-themes2' was removed as the only consumer pyload-ng was removed"; # added 2026-03-21

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6135,7 +6135,7 @@ self: super: with self; {
 
   flash-mla = callPackage ../development/python-modules/flash-mla { };
 
-  flashinfer = callPackage ../development/python-modules/flashinfer { };
+  flashinfer-python = callPackage ../development/python-modules/flashinfer-python { };
 
   flashtext = callPackage ../development/python-modules/flashtext { };
 

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -132,7 +132,7 @@ let
         cupy = linux;
         faiss = linux;
         faster-whisper = linux;
-        flashinfer = linux;
+        flashinfer-python = linux;
         flax = linux;
         gpt-2-simple = linux;
         grad-cam = linux;


### PR DESCRIPTION
`flashinfer` installs its Python distribution metadata under the name `flashinfer-python`, while the derivation used `pname = "flashinfer"`. As a result, `pythonMetadataCheckPhase` queried `importlib.metadata.version("flashinfer")` and failed with `PackageNotFoundError`.

Rename the package attribute and directory to `flashinfer-python` to match the upstream distribution name. Keep `flashinfer` as a warning alias for compatibility, and update the `vllm` and CUDA release-set references.

The Python module remains importable as `flashinfer`.

## Verification

Ran:

```console
nixpkgs-review --extra-nixpkgs-config "{ allowUnfree = true; cudaSupport = true; }" --package python313Packages.flashinfer-python --package python314Packages.flashinfer-python
```

Both packages built successfully on `x86_64-linux` and passed `pythonMetadataCheckPhase`.

Also verified that the deprecated `flashinfer` alias resolves to the same derivation, the CUDA-enabled `vllm` derivation uses `flashinfer-python`, and the `release-cuda.nix` attribute evaluates successfully.

## Automation disclosure

Codex (GPT-5) assisted with diagnosis, patch preparation, validation, and this PR description.
