### PR TITLE
xroar: init at 1.13.0.dev-unstable-2026-08-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4869,6 +4869,12 @@
     githubId = 543423;
     name = "Alex Wied";
   };
+  ceridwen15 = {
+    email = "me@cdwn.gay";
+    github = "NonsensicalNickname";
+    githubId = 118519066;
+    name = "Ceridwen Weaving";
+  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";

--- a/pkgs/by-name/xr/xroar/package.nix
+++ b/pkgs/by-name/xr/xroar/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  testers,
+  wrapGAppsHook3,
+  gobject-introspection,
+  texinfo,
+  pkg-config,
+  autoreconfHook,
+  pulseaudio,
+  libpng,
+  gtk3,
+  gdk-pixbuf,
+  gsettings-desktop-schemas,
+  adwaita-icon-theme,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xroar";
+  version = "1.13.0.dev-unstable-2026-08-07";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchgit {
+    url = "https://www.6809.org.uk/git/xroar.git";
+    rev = "190788e71ae63a4ca44f4e6e66f907852aaf26bb";
+    hash = "sha256-GMOh7EQT7u4JeRnIHaSIZqgTTWK4s/3jXtNscGuOm5w=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    gobject-introspection
+
+    texinfo
+    pkg-config
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    pulseaudio
+    libpng
+    gtk3
+    gdk-pixbuf
+    gsettings-desktop-schemas
+    adwaita-icon-theme
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "xroar --version";
+    version = "XRoar ${builtins.elemAt (lib.splitString "-" finalAttrs.version) 0}";
+  };
+
+  meta = {
+    description = "Emulator for the Dragon 32/64; Tandy Colour Computers 1, 2 and 3; the Tandy MC-10; and others";
+    homepage = "https://www.6809.org.uk/xroar/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      ceridwen15
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "xroar";
+  };
+})


### PR DESCRIPTION
Added xroar at version 1.13.0.dev-unstable-2026-08-07. [XRoar](https://www.6809.org.uk/xroar/) is an emulator for the Dragon32/64, Tandy CoCo, and others.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].