### PR TITLE
lib.licenses: add valveSDK

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1617,6 +1617,13 @@ lib.mapAttrs mkLicense (
       fullName = "Universal Permissive License";
     };
 
+    valveSDK = {
+      fullName = "Valve Corporation Steamworks SDK Access Agreement";
+      url = "https://partner.steamgames.com/documentation/sdk_access_agreement";
+      free = false;
+      redistributable = true;
+    };
+
     vim = {
       spdxId = "Vim";
       fullName = "Vim License";

--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -184,12 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [
       gpl3Only
       # For libsteam_api.so
-      (
-        unfreeRedistributable
-        // {
-          url = "https://partner.steamgames.com/documentation/sdk_access_agreement";
-        }
-      )
+      valveSDK
     ];
     maintainers = with lib.maintainers; [ weirdrock ];
     mainProgram = "rimsort";

--- a/pkgs/by-name/sa/samira/package.nix
+++ b/pkgs/by-name/sa/samira/package.nix
@@ -68,17 +68,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/jsnli/Samira/releases/tag/v${finalAttrs.version}";
     license = [
       lib.licenses.gpl3
-      (
-        # while the license itself is unfree, it allows redistributing files
-        # inside "redistributable_bin/" directory, that `libsteam_api.so`
-        # conveniently is inside that folder
-        lib.licenses.unfreeRedistributableFirmware
-        // {
-          fullName = "Valve Corporation Steamworks SDK Access Agreement";
-          shortName = "valveSDKLicense";
-          url = "https://partner.steamgames.com/documentation/sdk_access_agreement";
-        }
-      )
+      lib.licenses.valveSDK
     ];
     # the libsteam_api.so supports only x86_64-linux
     platforms = [ "x86_64-linux" ];

--- a/pkgs/development/python-modules/steamworkspy/default.nix
+++ b/pkgs/development/python-modules/steamworkspy/default.nix
@@ -65,12 +65,7 @@ buildPythonPackage {
     license = with lib.licenses; [
       mit
       # For steamworks headers and libsteamapi.so
-      (
-        unfreeRedistributable
-        // {
-          url = "https://partner.steamgames.com/documentation/sdk_access_agreement";
-        }
-      )
+      valveSDK
     ];
     # steamworksSrc is x86_64-linux only
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
This has multiple usages in tree, lets just define it in `lib.licenses` instead of doing these custom overrides of other licenses.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
