### PR TITLE
nixos/miniflux: fix AppArmor profile

### DIFF
--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -208,7 +208,13 @@ in
       abi <abi/4.0>,
       include <tunables/global>
 
-      profile ${cfg.package}/bin/miniflux {
+      # Flag `attach_disconnected` is necessary
+      # because the PostgreSQL socket path appears
+      # as a "disconnected" path: `run/postgresql/.s.PGSQL.XXXX`,
+      # without the trailing slash, which AppArmor can't resolve.
+      # The flag prepends a `/`, which isn't recommended,
+      # but there aren't any alternative currently.
+      profile ${cfg.package}/bin/miniflux flags=(attach_disconnected) {
         include <abstractions/base>
         include <abstractions/nameservice>
         include <abstractions/ssl_certs>
@@ -216,6 +222,8 @@ in
         include "${pkgs.apparmorRulesFromClosure { name = "miniflux"; } cfg.package}"
         ${cfg.package}/bin/miniflux r,
         /run/miniflux/** rw,
+        /run/postgresql/.s.PGSQL.* rw,
+        /run/credentials/** r,
         include if exists <local/bin.miniflux>
       }
     '';

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -29,6 +29,7 @@ in
     default =
       { ... }:
       {
+        security.apparmor.enable = true;
         services.miniflux = {
           enable = true;
           inherit adminCredentialsFile;
@@ -38,6 +39,7 @@ in
     withoutSudo =
       { ... }:
       {
+        security.apparmor.enable = true;
         services.miniflux = {
           enable = true;
           inherit adminCredentialsFile;
@@ -48,6 +50,7 @@ in
     customized =
       { ... }:
       {
+        security.apparmor.enable = true;
         services.miniflux = {
           enable = true;
           config = {
@@ -82,6 +85,7 @@ in
     externalDb =
       { ... }:
       {
+        security.apparmor.enable = true;
         services.miniflux = {
           enable = true;
           createDatabaseLocally = false;
@@ -105,6 +109,7 @@ in
       machine.succeed(
           f"curl 'http://localhost:{port}/v1/me' -u '{user}' -H Content-Type:application/json | grep '\"is_admin\":true'"
       )
+      machine.fail('journalctl -b --no-pager --grep "^audit: .*apparmor=\\"DENIED\\""')
 
     default.start()
     withoutSudo.start()


### PR DESCRIPTION
And re-enables AppArmor in the corresponding test.

The current AppArmor profile made it so that Miniflux couldn't access systemd secrets, nor the Postgres UNIX socket.

cc @tnias who added the AppArmor profile, and @adamcstephens who disabled it in the test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
