### PR TITLE
[release-26.05] libvirt: fix security vulnerabilities

### DIFF
--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -135,6 +135,26 @@ stdenv.mkDerivation rec {
   patches = [
     ./0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
 
+    # CVE-2026-15268
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/f74495c7a157618e3df6fa61079678084c4cc685.patch";
+      hash = "sha256-ZOC7ApQiowMyLC0iB51rwDe4dIDwRmpFHpdAdHnEjHY=";
+    })
+    # CVE-2026-18917
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/5a62cbf2907d4590283597b46da9c0f41e7b4d4f.patch";
+      hash = "sha256-EjNp97J2++Wn7MLFaC99HPsJYUj4Nid8Fuk8fGq3Cis=";
+    })
+    # CVE-2026-63622
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/801160fd414ca2cc402bc01ead09b7ed4c3b8f5b.patch";
+      hash = "sha256-balBw0Rs2fSrnOeeiaqKRDnloXIWA1eITuciaZQ7zsk=";
+    })
+    # CVE-2026-63623
+    (fetchpatch {
+      url = "https://gitlab.com/libvirt/libvirt/-/commit/69335a484768d550854da1133d5490074695e825.patch";
+      hash = "sha256-3UCMOVOq//bKkKfRsn9NVq1j9rN3CZlBOsEeYQufleU=";
+    })
     # CVE-2026-61478
     (fetchpatch {
       url = "https://gitlab.com/libvirt/libvirt/-/commit/68da70aae766c6271b8d3b466374d3cc7d1a8afb.patch";


### PR DESCRIPTION
These vulnerabilities were missed in #551428. Thank you @samueldr-at-cyberus for identifying these:

- CVE-2026-15268 (unpublished, but public via Git history)
- CVE-2026-18917 (unpublished, but public via Git history)
- CVE-2026-63622
- CVE-2026-63623


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
