### PR TITLE
adaptivecpp: 25.02.0 -> 25.10.0, llvmPackages_18 -> llvmPackages_20

### DIFF
--- a/pkgs/by-name/ad/adaptivecpp/package.nix
+++ b/pkgs/by-name/ad/adaptivecpp/package.nix
@@ -1,12 +1,13 @@
 {
   lib,
   fetchFromGitHub,
-  llvmPackages_18,
+  llvmPackages_20,
   python3,
   cmake,
   boost,
   libxml2,
   libffi,
+  numactl,
   makeWrapper,
   config,
   cudaPackages,
@@ -23,17 +24,17 @@
 }:
 let
   inherit (llvmPackages) stdenv;
-  llvmPackages = llvmPackages_18;
+  llvmPackages = llvmPackages_20;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "adaptivecpp";
-  version = "25.02.0";
+  version = "25.10.0";
 
   src = fetchFromGitHub {
     owner = "AdaptiveCpp";
     repo = "AdaptiveCpp";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-vXfw8+xn3/DYxUKp3QGdQ8sEbDwyk+8jDCyuvQOXigc=";
+    sha256 = "sha256-Z3YuBtR6TVCLQHZCA88oA5N10SnLATVv0/cvb8xwZWs=";
   };
 
   # do not use old FindCUDA cmake module
@@ -72,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     libffi
     boost
     python3
+    numactl
     llvmPackages.openmp
     llvmPackages.libclang.dev
     llvmPackages.llvm
@@ -83,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # adaptivecpp makes use of clangs internal headers. Its cmake does not successfully discover them automatically on nixos, so we supply the path manually
   cmakeFlags = [
+    (lib.cmakeFeature "ACPP_LLD_PATH" (lib.getExe' llvmPackages.lld "ld.lld"))
     (lib.cmakeFeature "CLANG_INCLUDE_PATH" "${llvmPackages.libclang.dev}/include")
     (lib.cmakeBool "WITH_CPU_BACKEND" ompSupport)
     (lib.cmakeBool "WITH_CUDA_BACKEND" cudaSupport)

--- a/pkgs/by-name/ad/adaptivecpp/tests.nix
+++ b/pkgs/by-name/ad/adaptivecpp/tests.nix
@@ -12,6 +12,7 @@
   onetbb,
   cmake,
   boost,
+  numactl,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "${adaptivecpp.pname}-tests";
@@ -24,7 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     onetbb
   ];
-  buildInputs = [ boost ];
+  buildInputs = [
+    boost
+    numactl
+  ];
 
   sourceRoot = "${adaptivecpp.src.name}/tests";
 


### PR DESCRIPTION
changelog: https://github.com/AdaptiveCpp/AdaptiveCpp/releases/tag/v25.10.0

switching to llvm 20 as per support matrix at: https://github.com/AdaptiveCpp/AdaptiveCpp/blob/v25.10.0/doc/installing.md#compilation-flows

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
