### PR TITLE
python3Packages.ml-dtypes: 0.5.4 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/ml-dtypes/default.nix
+++ b/pkgs/development/python-modules/ml-dtypes/default.nix
@@ -2,10 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
 
   # build-system
-  setuptools,
+  cmake,
+  ninja,
+  scikit-build-core,
 
   # dependencies
   numpy,
@@ -15,37 +16,28 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ml-dtypes";
-  version = "0.5.4";
+  version = "0.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jax-ml";
     repo = "ml_dtypes";
-    tag = "v${version}";
-    hash = "sha256-vGCDLs7Te/3fBZmCQVp2Zm5NnP7K/KCkTod0oFVVKN4=";
+    tag = "v${finalAttrs.version}";
     # Since this upstream patch (https://github.com/jax-ml/ml_dtypes/commit/1bfd097e794413b0d465fa34f2eff0f3828ff521),
     # the attempts to use the nixpkgs packaged eigen dependency have failed.
     # Hence, we rely on the bundled eigen library.
     fetchSubmodules = true;
+    hash = "sha256-NvsZrSiXfJMEVdpxBD3JmyAy5inEKSZVeLvI7YiGBy0=";
   };
 
-  patches = [
-    # Fix tests for numpy 2.4.3, which changed the way testing assertions
-    # handle behaviors with NaN equivalence on the custom numeric types.
-    (fetchpatch2 {
-      url = "https://github.com/jax-ml/ml_dtypes/commit/04c4dc8b23720d9d92f3cc849ffc387d5798db84.patch?full_index=1";
-      hash = "sha256-jqqiDYcHq58JxSqtHfXcNWFbMFhvufqafDPHmORe6F0=";
-    })
+  build-system = [
+    cmake
+    ninja
+    scikit-build-core
   ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools~=" "setuptools>="
-  '';
-
-  build-system = [ setuptools ];
+  dontUseCmakeConfigure = true;
 
   dependencies = [ numpy ];
 
@@ -54,10 +46,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  # Otherwise Python import `ml_dtypes` from the sources instead of the installed files in $out.
   preCheck = ''
-    # remove src module, so tests use the installed module instead
-    mv ./ml_dtypes/tests ./tests
-    rm -rf ./ml_dtypes
+    rm ml_dtypes/__init__.py
   '';
 
   pythonImportsCheck = [ "ml_dtypes" ];
@@ -65,11 +56,11 @@ buildPythonPackage rec {
   meta = {
     description = "Stand-alone implementation of several NumPy dtype extensions used in machine learning libraries";
     homepage = "https://github.com/jax-ml/ml_dtypes";
-    changelog = "https://github.com/jax-ml/ml_dtypes/releases/tag/v${version}";
+    changelog = "https://github.com/jax-ml/ml_dtypes/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       GaetanLepage
       samuela
     ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/jax-ml/ml_dtypes/compare/v0.5.4...v0.6.0
Changelog: https://github.com/jax-ml/ml_dtypes/releases/tag/v0.6.0

cc @samuela

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test