### PR TITLE
cook-cli: re-add server

### DIFF
--- a/pkgs/by-name/co/cook-cli/package.nix
+++ b/pkgs/by-name/co/cook-cli/package.nix
@@ -8,6 +8,10 @@
   openssl,
   nodejs,
   nix-update-script,
+  withSync ? true,
+  withServer ? true,
+  withImport ? true,
+  withLSP ? true,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cook-cli";
@@ -24,6 +28,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Build without the self-updating feature
   buildNoDefaultFeatures = true;
+  buildFeatures =
+    lib.optional withSync "sync"
+    ++ lib.optional withServer "server"
+    ++ lib.optional withImport "import"
+    ++ lib.optional withLSP "lsp";
+
+  checkFlags = [
+    # set to false because it fails a test
+    # see this issue https://github.com/cooklang/cookcli/issues/440
+    "--skip=test_help_output"
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/co/cook-cli/package.nix
+++ b/pkgs/by-name/co/cook-cli/package.nix
@@ -24,6 +24,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Build without the self-updating feature
   buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "sync"
+    "server"
+    "import"
+    "lsp"
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Hello,

I'm sorry i didn't test the `server` feature while doing #551483

It is now behind a `Cargo` `feature` since https://github.com/cooklang/cookcli/issues/369

I didn't check this line

https://github.com/NixOS/nixpkgs/blob/0e251e24a4f24e036a084b6b4b2d2491af4167f4/pkgs/by-name/co/cook-cli/package.nix#L26

This PR re-add all default features but `self-update`

I also added `cook-cli-minimal` to have the package with no default feature at all

I don't know if it is better to have `cook-cli-minimal` or `cook-cli-full` ;
Which one should be the default `cook-cli` ?

Stuff i have checked :

```sh
# tested the minimal with build
nix-build -A cook-cli-minimal # took ~6m
/nix/store/q0yqj269vw2frlfwqkhs69qkxzxgy6q8-cook-cli-0.33.0/bin/cook build web \
    --base-path="$RECIPES_PATH" \
    --base-url="$OUTPUT_BASE_URL" \
    --lang="$LANG" \
    --sitemap="$OUTPUT_BASE_URL" \
    --repo-url="https://gitlab.com/pinage404/moku" \
    --compress \
    "$OUTPUT_BASE_PATH"

# test the full with server and build
nix-build -A cook-cli # took ~15m 😴
/nix/store/m1zlsliwlxl61275z68iffvk3nfsybin-cook-cli-0.33.0/bin/cook server ./Recettes/
/nix/store/m1zlsliwlxl61275z68iffvk3nfsybin-cook-cli-0.33.0/bin/cook build web \
    --base-path="$RECIPES_PATH" \
    --base-url="$OUTPUT_BASE_URL" \
    --lang="$LANG" \
    --sitemap="$OUTPUT_BASE_URL" \
    --repo-url="https://gitlab.com/pinage404/moku" \
    --compress \
    "$OUTPUT_BASE_PATH"
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
