### PR TITLE
ddrescueview: gtk2 -> gtk3

### DIFF
--- a/pkgs/by-name/dd/ddrescueview/package.nix
+++ b/pkgs/by-name/dd/ddrescueview/package.nix
@@ -8,9 +8,11 @@
   cairo,
   gdk-pixbuf,
   glib,
-  gtk2,
+  gtk3,
+  harfbuzz,
   libx11,
   pango,
+  writableTmpDirAsHomeHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -26,6 +28,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     fpc
     lazarus
+    writableTmpDirAsHomeHook
   ];
 
   buildInputs = [
@@ -33,7 +36,8 @@ stdenv.mkDerivation rec {
     cairo
     gdk-pixbuf
     glib
-    gtk2
+    gtk3
+    harfbuzz
     libx11
     pango
   ];
@@ -45,7 +49,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildPhase = ''
-    lazbuild --lazarusdir=${lazarus}/share/lazarus ddrescueview.lpi
+    lazbuild --lazarusdir=${lazarus}/share/lazarus --ws=gtk3 ddrescueview.lpi
   '';
 
   installPhase = ''


### PR DESCRIPTION
gtk 2 is long deprecated and going away (#410814), and now that our lazarus uses gtk 3, we can switch ddrescueview as well.

we don't use ddrescue and so can't evaluate exactly how the program works, but it seems to launch and be interactive just fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
