### PR TITLE
[26.05] dracut: fix CVE-2026-15816

### DIFF
--- a/pkgs/by-name/dr/dracut/package.nix
+++ b/pkgs/by-name/dr/dracut/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   gitUpdater,
   makeBinaryWrapper,
   pkg-config,
@@ -37,6 +38,32 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-zSyC2SnSQkmS/mDpBXG2DtVVanRRI9COKQJqYZZCPJM=";
   };
+
+  patches = [
+    # dracut-lib.sh moved from 99base to 80base after 059.
+    # Required by the CVE-2026-15816 fix below; remove when updating to 112 or newer.
+    (fetchpatch2 {
+      name = "add-escape-function.patch";
+      url = "https://github.com/dracut-ng/dracut/commit/207c339728eff81127469c2f6fe106447c781009.patch?full_index=1";
+      relative = "modules.d/80base";
+      extraPrefix = "modules.d/99base/";
+      hash = "sha256-r8dsJvmb09QH6ZRTceBg3Bo+WbCKA8U7Pj0rAjXDcm4=";
+    })
+    # Remove when updating to the first release after 112 containing this fix.
+    (fetchpatch2 {
+      name = "CVE-2026-15816.patch";
+      url = "https://github.com/dracut-ng/dracut/commit/c4d555716d569038ca38365741e94ee07908f261.patch?full_index=1";
+      relative = "modules.d/80base";
+      extraPrefix = "modules.d/99base/";
+      hash = "sha256-ja15T++ojzjExRgPjyyuUx/vkLhR9AWBBWgz9hTzHCU=";
+    })
+  ];
+
+  # Don't create .orig files when the backported patches apply with offsets.
+  patchFlags = [
+    "--no-backup-if-mismatch"
+    "-p1"
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
Applies the upstream fix for CVE-2026-15816 to dracut 059 in release-26.05.

Upstream fix: https://redirect.github.com/dracut-ng/dracut/commit/c4d555716d569038ca38365741e94ee07908f261

Master PR: #551364

Closes #551122

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
