### PR TITLE
iay: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/by-name/ia/iay/package.nix
+++ b/pkgs/by-name/ia/iay/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "iay";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "aaqaishtyaq";
     repo = "iay";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-H0h3ChS+B8+Pnet8rNQIkpr4k/t7P2hYrS06dademUU=";
+    hash = "sha256-eb5J+9AFKU/rQEcwHrVNIaQXAsOqfmI8JPKfNMsTGrg=";
   };
 
-  cargoHash = "sha256-66bhmIk/YCweL9GquPpObkkl2Sn45IlU2HqnKn43294=";
+  cargoHash = "sha256-Ma/gv2x5hm+pa5AW+FnRiD7ueIz76dCOFhAvX1P/nlM=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
## Description of changes

Update `iay` from 0.5.0 to 0.5.1.

- Release: https://github.com/aaqaishtyaq/iay/releases/tag/v0.5.1
- Diff: https://github.com/aaqaishtyaq/iay/compare/v0.5.0...v0.5.1

Patch release; notable fix: cwd shortening (`IAY_SHORTEN_CWD`) no longer mangles the home directory into single letters (e.g. `/h/user`) when `IAY_EXPAND_TILDE=1` is set, and home-directory detection no longer panics if `$HOME` is unset.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. (crate's own `cargo test` suite runs during the Nix build's check phase, all passing)
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (not applicable, minor patch release)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Disclosure per the automation/AI policy: this update (version bump, hash refresh, local build/test verification, and this PR description) was prepared with the assistance of Claude Code (an LLM-based coding tool), by me, the package maintainer (@aaqaishtyaq), who reviewed the diff and build/test output before submitting.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
