### PR TITLE
SDL_audiolib: fmt -> fmt_11, unbreak

### DIFF
--- a/pkgs/by-name/de/devilutionx/package.nix
+++ b/pkgs/by-name/de/devilutionx/package.nix
@@ -13,7 +13,7 @@
   SDL_audiolib,
   simpleini,
   flac,
-  fmt,
+  fmt_11,
   libogg,
   libpng,
   libtiff,
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     bzip2
     flac
-    fmt
+    fmt_11
     libogg
     libpng
     libtiff

--- a/pkgs/by-name/sd/SDL_audiolib/package.nix
+++ b/pkgs/by-name/sd/SDL_audiolib/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   pkg-config,
   stdenv,
+  libogg,
   flac,
   fmt_11,
 }:
@@ -29,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     SDL2
+    libogg # required by flac
     flac
     fmt_11
   ];

--- a/pkgs/by-name/sd/SDL_audiolib/package.nix
+++ b/pkgs/by-name/sd/SDL_audiolib/package.nix
@@ -6,7 +6,7 @@
   pkg-config,
   stdenv,
   flac,
-  fmt,
+  fmt_11,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL2
     flac
-    fmt
+    fmt_11
   ];
 
   strictDeps = true;


### PR DESCRIPTION
- **SDL_audiolib: fmt -> fmt_11, unbreak**
- **SDL_audiolib: add libogg**

fixes https://hydra.nixos.org/build/341553959

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
