### PR TITLE
yacreader: 10.0.0 -> 10.2.0

### DIFF
--- a/pkgs/by-name/ya/yacreader/package.nix
+++ b/pkgs/by-name/ya/yacreader/package.nix
@@ -22,13 +22,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yacreader";
-  version = "10.0.0";
+  version = "10.2.0";
 
   src = fetchFromGitHub {
     owner = "YACReader";
     repo = "yacreader";
     tag = finalAttrs.version;
-    hash = "sha256-nJ4S4ej/I+ifDNa3CPpusFpDsEwZwYDt0JLaebptjuU=";
+    hash = "sha256-bqOukeAXTOMI/T5zoBsA9ZtEGq+6EV/zRH7c+nWX4Lc=";
   };
 
   patches = [
@@ -42,9 +42,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Pipewire is dlopen'd, so we must tell it where to look
-  preConfigure = ''
-    qtWrapperArgs+=("--prefix" "LD_LIBRARY_PATH" ":" "${lib.makeLibraryPath [ pipewire ]}")
-  '';
+  # So is qtwebapp on macOS
+  preConfigure =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      qtWrapperArgs+=("--prefix" "LD_LIBRARY_PATH" ":" "${lib.makeLibraryPath [ pipewire ]}")
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      qtWrapperArgs+=("--prefix" "DYLD_LIBRARY_PATH" ":" "${lib.makeLibraryPath [ qtwebapp ]}")
+    '';
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -52,7 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     # force unarr backend on all platforms
     (lib.cmakeBool "BUILD_SERVER_STANDALONE" onlyServer)
-    (lib.cmakeFeature "PDF_BACKEND" "poppler")
     (lib.cmakeFeature "DECOMPRESSION_BACKEND" "unarr")
   ];
 
@@ -89,20 +93,17 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p "$out"/Applications
+    mkdir -p "$out/Applications/YACReader.app/Contents/MacOS/languages"
+    mkdir -p "$out/Applications/YACReaderLibrary.app/Contents/MacOS/languages"
+    mkdir -p "$out/Applications/YACReaderLibraryServer.app/Contents/MacOS/languages"
 
-    cp -r YACReader/YACReader.app "$out"/Applications/
-    cp -r YACReaderLibrary/YACReaderLibrary.app "$out"/Applications/
-    cp -r YACReaderLibraryServer/YACReaderLibraryServer.app "$out"/Applications/
+    cp -r bin/YACReader.app "$out"/Applications/
+    cp -r bin/YACReaderLibrary.app "$out"/Applications/
+    cp -r bin/YACReaderLibraryServer.app "$out"/Applications/
 
-    cp -r release/server "$out"/Applications/YACReaderLibrary.app/Contents/MacOS/
-    cp -r release/server "$out"/Applications/YACReaderLibraryServer.app/Contents/MacOS/
-    cp -r release/languages "$out"/Applications/YACReader.app/Contents/MacOS/
-    cp -r release/languages "$out"/Applications/YACReaderLibrary.app/Contents/MacOS/
-    cp -r release/languages "$out"/Applications/YACReaderLibraryServer.app/Contents/MacOS/
-
-    makeWrapper "$out"/Applications/YACReader.app/Contents/MacOS/YACReader "$out/bin/YACReader"
-    makeWrapper "$out"/Applications/YACReaderLibrary.app/Contents/MacOS/YACReaderLibrary "$out/bin/YACReaderLibrary"
-    makeWrapper "$out"/Applications/YACReaderLibraryServer.app/Contents/MacOS/YACReaderLibraryServer "$out/bin/YACReaderLibraryServer"
+    find . -name "*.qm" ! -name "*_source.qm" -exec cp {} "$out/Applications/YACReader.app/Contents/MacOS/languages/" \;
+    find . -name "*.qm" ! -name "*_source.qm" -exec cp {} "$out/Applications/YACReaderLibrary.app/Contents/MacOS/languages/" \;
+    find . -name "*.qm" ! -name "*_source.qm" -exec cp {} "$out/Applications/YACReaderLibraryServer.app/Contents/MacOS/languages/" \;
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ya/yacreader/qtwebapp-devendor.patch
+++ b/pkgs/by-name/ya/yacreader/qtwebapp-devendor.patch
@@ -12,7 +12,7 @@ index 839072efe4..8b8a2a5dd4 100644
      common_all
      comic_backend
      db_helper
-+    PRIVATE
++    PUBLIC
 +    PkgConfig::QtWebApp
  )
 diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumps yacreader from version 10.0.0 to 10.2.0:
Notes: https://github.com/YACReader/yacreader/releases/tag/10.2.0
Diff: https://github.com/YACReader/yacreader/compare/10.0.0...10.2.0

Additionally fixes Darwin build failure.

Resolves #533366
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
