### PR TITLE
bambuddy: 1.2.5.1 -> 1.2.5.5

### DIFF
--- a/pkgs/by-name/ba/bambuddy/package.nix
+++ b/pkgs/by-name/ba/bambuddy/package.nix
@@ -1,28 +1,36 @@
 {
-  fetchFromGitHub,
-  buildNpmPackage,
-  python3,
   stdenv,
+  fetchFromGitHub,
   makeWrapper,
+  buildNpmPackage,
   lib,
   ffmpeg,
+  python3Packages,
+  python3,
+  nix-update-script,
 }:
-let
-  version = "1.2.5.1";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bambuddy";
+  version = "1.2.5.5";
 
   src = fetchFromGitHub {
     owner = "maziggy";
     repo = "bambuddy";
-    tag = "v${version}";
-    hash = "sha256-cYDl1QbIMECqE0zkKL92Vnoh1M6PIpVdsb3tGJHYPJ8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hdg4pmyu54Q4oLwoqedLCi5uDkxeZ/okdS39aLmBfUI=";
   };
 
-  frontend = buildNpmPackage {
-    pname = "bambuddy-frontend";
-    inherit version src;
+  strictDeps = true;
+  __structuredAttrs = true;
 
-    sourceRoot = "${src.name}/frontend";
-    npmDepsHash = "sha256-v8ejfkuMxnybhdc9CD4Y/UmGCxUDGtVr9KAEQ5a6ca4=";
+  nativeBuildInputs = [ makeWrapper ];
+
+  frontend = buildNpmPackage {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+
+    sourceRoot = "${finalAttrs.src.name}/frontend";
+    npmDepsHash = "sha256-vm6hm4bnw0gZIquXapHF7aWx7KV6ZklSwyrcY+MeqPI=";
 
     preBuild = "chmod -R u+w ../static";
 
@@ -36,9 +44,31 @@ let
     '';
   };
 
-  # https://github.com/maziggy/bambuddy/blob/main/requirements.txt
-  python = python3.withPackages (
-    ps: with ps; [
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/bambuddy
+    cp -r . $out/lib/bambuddy/
+
+    rm -rf $out/lib/bambuddy/static
+    ln -s ${finalAttrs.frontend} $out/lib/bambuddy/static
+
+    mkdir -p $out/bin
+
+    makeWrapper ${lib.getExe' finalAttrs.passthru.python "uvicorn"} $out/bin/bambuddy \
+      --chdir "$out/lib/bambuddy" \
+      --prefix PYTHONPATH : "$out/lib/bambuddy" \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]} \
+      --add-flags "backend.app.main:app"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit (finalAttrs) frontend;
+
+    # https://github.com/maziggy/bambuddy/blob/main/requirements.txt
+    pythonPackages = with python3Packages; [
       aiofiles
       aioftp
       aiosqlite
@@ -78,45 +108,26 @@ let
       trimesh
       uvicorn
       websockets
-    ]
-  );
-in
-stdenv.mkDerivation {
-  pname = "bambuddy";
-  inherit version src;
+    ];
 
-  strictDeps = true;
-  __structuredAttrs = true;
+    python = python3.withPackages (_: finalAttrs.passthru.pythonPackages);
 
-  nativeBuildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib/bambuddy
-    cp -r . $out/lib/bambuddy/
-
-    rm -rf $out/lib/bambuddy/static
-    ln -s ${frontend} $out/lib/bambuddy/static
-
-    mkdir -p $out/bin
-
-    makeWrapper ${lib.getExe' python "uvicorn"} $out/bin/bambuddy \
-      --chdir "$out/lib/bambuddy" \
-      --prefix PYTHONPATH : "$out/lib/bambuddy" \
-      --prefix PATH : ${ffmpeg}/bin \
-      --add-flags "backend.app.main:app"
-
-    runHook postInstall
-  '';
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--use-github-releases"
+        "--subpackage"
+        "frontend"
+      ];
+    };
+  };
 
   meta = {
     description = "Self-hosted command center for Bambu Lab";
     homepage = "https://bambuddy.cool/";
-    changelog = "https://github.com/maziggy/bambuddy/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/maziggy/bambuddy/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ onatustun ];
     mainProgram = "bambuddy";
-    platforms = with lib.platforms; linux ++ darwin;
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/maziggy/bambuddy/releases/tag/v1.2.5.5
https://github.com/maziggy/bambuddy/compare/v1.2.5.1...v1.2.5.5
Refactor package to use finalAttrs pattern, added passthru for python and nix-update-script.

Dropped darwin support. aarch64-darwin build fails due to a cycle in alembic.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
