### PR TITLE
rPackages.iscream: fix build with more robust filtering

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -2530,9 +2530,15 @@ let
     iscream = old.iscream.overrideAttrs (attrs: {
       # https://huishenlab.github.io/iscream/articles/htslib.html
       # Rhtslib (in LinkingTo) is not needed if we provide a proper htslib
-      propagatedBuildInputs =
-        builtins.filter (el: el != pkgs.rPackages.Rhtslib) attrs.propagatedBuildInputs
-        ++ [ pkgs.htslib ];
+      nativeBuildInputs = builtins.filter (el: el.pname != "Rhtslib") attrs.nativeBuildInputs;
+      propagatedBuildInputs = builtins.filter (el: el.pname != "Rhtslib") attrs.propagatedBuildInputs;
+
+      buildInputs = (attrs.buildInputs or [ ]) ++ [ pkgs.htslib ];
+
+      postPatch = ''
+        substituteInPlace "DESCRIPTION" \
+          --replace-fail ", Rhtslib" ""
+      '';
     });
 
     littler = old.littler.overrideAttrs (attrs: {


### PR DESCRIPTION
Targeting https://github.com/NixOS/nixpkgs/pull/552051

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
