### PR TITLE
defmt-print: init at 1.1.0

### DIFF
--- a/pkgs/by-name/de/defmt-print/package.nix
+++ b/pkgs/by-name/de/defmt-print/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "defmt-print";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "knurling-rs";
+    repo = "defmt";
+    tag = "defmt-print-v${finalAttrs.version}";
+    hash = "sha256-owG78NHFy7A+fZnnnY1GplAXvDyc++WO9t8dAGyQP6s=";
+  };
+
+  cargoHash = "sha256-hgPX5HkVfSK4FHCnFFYuG4KdzjUrbta6LQa+8rK8TuA=";
+
+  cargoBuildFlags = [
+    "--bin"
+    "defmt-print"
+  ];
+
+  # Fails with
+  #
+  # error: to run unit tests enable the `unstable-test` feature, e.g. `cargo t --features unstable-test`
+  doCheck = false;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Utility for decoding and printing defmt encoded logs to stdout";
+    mainProgram = "defmt-print";
+    homepage = "https://defmt.ferrous-systems.com/";
+    changelog = "https://github.com/knurling-rs/defmt/blob/main/CHANGELOG.md#defmt-print";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ rycee ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds the `defmt-print` tool, which is useful for printing logs produced by Rust projects using the [defmt](https://defmt.ferrous-systems.com/) crate.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
