### PR TITLE
mongrel: init at 5.71.42

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30153,6 +30153,12 @@
     githubId = 6148271;
     name = "Dave Nicponski";
   };
+  visorcraft = {
+    email = "packages@visorcraft.com";
+    github = "visorcraft";
+    githubId = 29009015;
+    name = "VisorCraft";
+  };
   vitorpavani = {
     email = "vipavani@hotmail.com";
     github = "vitorpavani";

--- a/pkgs/by-name/mo/mongrel/package.nix
+++ b/pkgs/by-name/mo/mongrel/package.nix
@@ -9,11 +9,11 @@
 
 let
   pname = "mongrel";
-  version = "5.71.41";
+  version = "5.71.42";
 
   src = fetchurl {
     url = "https://downloads.visorcraft.com/mongrel/${version}/Mongrel_${version}_amd64.AppImage";
-    hash = "sha256-brOsELYwzD01yJ2rQnTsmPtvuIY6sGhB8AldCUGrigY=";
+    hash = "sha256-fC+GkeBogxwSm+AkFsqCVp3WRxr4T3gfNzkoOeaxvXE=";
   };
 
   appimageContents = appimageTools.extract {

--- a/pkgs/by-name/mo/mongrel/package.nix
+++ b/pkgs/by-name/mo/mongrel/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  webkitgtk_4_1,
+  libsoup_3,
+  glib-networking,
+}:
+
+let
+  pname = "mongrel";
+  version = "5.71.41";
+
+  src = fetchurl {
+    url = "https://downloads.visorcraft.com/mongrel/${version}/Mongrel_${version}_amd64.AppImage";
+    hash = "sha256-brOsELYwzD01yJ2rQnTsmPtvuIY6sGhB8AldCUGrigY=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [
+    webkitgtk_4_1
+    libsoup_3
+    glib-networking
+  ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/mongrel.desktop -t $out/share/applications
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  meta = {
+    description = "Desktop workbench for databases, terminals, and API clients";
+    longDescription = ''
+      Mongrel is a multi-database desktop workbench covering 30+ database
+      engines, with SSH/Mosh/Telnet/Serial terminals, SFTP/SCP, Docker/Podman,
+      Kubernetes, and an HTTP/GraphQL/WebSocket/gRPC API client.
+    '';
+    homepage = "https://www.visorcraft.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ visorcraft ];
+    mainProgram = "mongrel";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/552362 (that PR was closed after an accidental history rewrite while fixing `keep-sorted` order in `maintainers/maintainer-list.nix`). This branch is a single commit on current `master` with `visorcraft` inserted in keep-sorted order between `virusdave` and `vitorpavani`.

Adds [Mongrel](https://www.visorcraft.com/) 5.71.41, a proprietary (paid license with a 7-day free trial) desktop database workbench covering 30+ database engines, plus SSH/Mosh/Telnet/Serial terminals, SFTP/SCP, Docker/Podman, Kubernetes, and an HTTP/GraphQL/WebSocket/gRPC API client. Built upstream with Tauri v2.

This PR is submitted by the vendor (VisorCraft, GitHub account `visorcraft`), who is also added as the package maintainer. The source is closed, so this packages the official Linux x86-64 AppImage with `appimageTools.wrapType2`, following the structure of recently merged Tauri/WebKitGTK unfree binary packages such as `qidi-slicer-bin` and `keet`. The upstream sha256 was verified against the published value at https://www.visorcraft.com/api/downloads/mongrel before adding it to the expression.

Disclosure per the automation/AI policy: this contribution was prepared with LLM-based AI assistance acting on behalf of VisorCraft; a responsible person at VisorCraft directed and reviewed the submission.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Note on verification: no Nix toolchain was available in the environment where this was prepared, so the expression was **not** built or evaluated locally and `nixfmt` was not run. The expression was written to match the nixfmt-formatted precedents above, and the AppImage was downloaded and inspected (sha256 verified; desktop file, icons, and `mongrel` binary confirmed present). Happy to address any eval or formatting feedback from CI or reviewers.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

