### PR TITLE
python3Packages.git-dummy: fix on darwin

### DIFF
--- a/pkgs/by-name/gi/git-sim/package.nix
+++ b/pkgs/by-name/gi/git-sim/package.nix
@@ -1,44 +1,31 @@
 {
   lib,
   stdenv,
+  python3Packages,
   fetchFromGitHub,
   installShellFiles,
-  python3,
-
-  # Override Python packages using
-  # self: super: { pkg = super.pkg.overridePythonAttrs (oldAttrs: { ... }); }
-  # Applied after defaultOverrides
-  packageOverrides ? self: super: { },
+  addBinToPathHook,
 }:
-let
-  python = python3.override {
-    self = python;
-    packageOverrides = lib.composeManyExtensions [ packageOverrides ];
-  };
-
-  version = "0.3.5";
-in
-
-with python.pkgs;
-buildPythonApplication {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "git-sim";
-  inherit version;
+  version = "0.3.5";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "initialcommit-com";
     repo = "git-sim";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-4jHkAlF2SAzHjBi8pmAJ0TKkcLxw+6EdGsXnHZUMILw=";
   };
 
   patches = [ ./tests.patch ];
 
-  build-system = [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
   pythonRemoveDeps = [ "opencv-python-headless" ];
 
-  dependencies = [
+  dependencies = with python3Packages; [
     gitpython
     manim
     opencv4
@@ -49,7 +36,12 @@ buildPythonApplication {
   ];
 
   # https://github.com/NixOS/nixpkgs/commit/8033561015355dd3c3cf419d81ead31e534d2138
-  makeWrapperArgs = [ "--prefix PYTHONWARNINGS , ignore:::pydub.utils:" ];
+  makeWrapperArgs = [
+    "--prefix"
+    "PYTHONWARNINGS"
+    ","
+    "ignore:::pydub.utils:"
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -61,23 +53,25 @@ buildPythonApplication {
         --fish <($out/bin/git-sim --show-completion fish) \
         --zsh <($out/bin/git-sim --show-completion zsh)
     ''
-    + "ln -s ${git-dummy}/bin/git-dummy $out/bin/";
-
-  preCheck = ''
-    PATH=$PATH:$out/bin
-  '';
+    + ''
+      ln -s ${lib.getExe python3Packages.git-dummy} $out/bin/
+    '';
 
   nativeCheckInputs = [
+    addBinToPathHook
+  ]
+  ++ (with python3Packages; [
     pytestCheckHook
     git-dummy
-  ];
+  ]);
 
   doCheck = false;
 
   meta = {
     description = "Visually simulate Git operations in your own repos with a single terminal command";
     homepage = "https://initialcommit.com/tools/git-sim";
+    changelog = "https://github.com/initialcommit-com/git-sim/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ mathiassven ];
   };
-}
+})

--- a/pkgs/by-name/gi/git-sim/package.nix
+++ b/pkgs/by-name/gi/git-sim/package.nix
@@ -47,12 +47,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   postInstall =
     # https://github.com/NixOS/nixpkgs/issues/308283
-    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      installShellCompletion --cmd git-sim \
-        --bash <($out/bin/git-sim --show-completion bash) \
-        --fish <($out/bin/git-sim --show-completion fish) \
-        --zsh <($out/bin/git-sim --show-completion zsh)
-    ''
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      # Otherwise, typer ignores the requested shell and instead detects it by walking the
+      # process tree, which yields bash on linux and fails outright on darwin:
+      # https://github.com/fastapi/typer/blob/0.25.1/typer/completion.py#L42-L59
+      ''
+        export _TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1
+        installShellCompletion --cmd git-sim \
+          --bash <($out/bin/git-sim --show-completion bash) \
+          --fish <($out/bin/git-sim --show-completion fish) \
+          --zsh <($out/bin/git-sim --show-completion zsh)
+      ''
     + ''
       ln -s ${lib.getExe python3Packages.git-dummy} $out/bin/
     '';

--- a/pkgs/development/python-modules/git-dummy/default.nix
+++ b/pkgs/development/python-modules/git-dummy/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage (finalAttrs: {
   pname = "git-dummy";
   version = "0.1.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "initialcommit-com";
@@ -46,6 +47,9 @@ buildPythonPackage (finalAttrs: {
         --fish <($out/bin/git-dummy --show-completion fish) \
         --zsh <($out/bin/git-dummy --show-completion zsh)
     '';
+
+  # No python tests nor --version flag
+  doCheck = false;
 
   meta = {
     description = "Generate dummy Git repositories populated with the desired number of commits, branches, and structure";

--- a/pkgs/development/python-modules/git-dummy/default.nix
+++ b/pkgs/development/python-modules/git-dummy/default.nix
@@ -41,12 +41,17 @@ buildPythonPackage (finalAttrs: {
 
   postInstall =
     # https://github.com/NixOS/nixpkgs/issues/308283
-    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      installShellCompletion --cmd git-dummy \
-        --bash <($out/bin/git-dummy --show-completion bash) \
-        --fish <($out/bin/git-dummy --show-completion fish) \
-        --zsh <($out/bin/git-dummy --show-completion zsh)
-    '';
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      # Otherwise, typer ignores the requested shell and instead detects it by walking the
+      # process tree, which yields bash on linux and fails outright on darwin:
+      # https://github.com/fastapi/typer/blob/0.25.1/typer/completion.py#L42-L59
+      ''
+        export _TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1
+        installShellCompletion --cmd git-dummy \
+          --bash <($out/bin/git-dummy --show-completion bash) \
+          --fish <($out/bin/git-dummy --show-completion fish) \
+          --zsh <($out/bin/git-dummy --show-completion zsh)
+      '';
 
   # No python tests nor --version flag
   doCheck = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.git-dummy: cleanup**
- **python3Packages.git-dummy: fix build on darwin**
- **git-sim: cleanup**
- **git-sim: fix on darwin**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

