### PR TITLE
python3Packages.pettingzoo: 1.26.1 -> 1.27.0

### DIFF
--- a/pkgs/development/python-modules/pettingzoo/default.nix
+++ b/pkgs/development/python-modules/pettingzoo/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -10,30 +11,34 @@
   # dependencies
   gymnasium,
   numpy,
+  typing-extensions,
 
   # optional-dependencies
+  # atari:
   pygame-ce,
+  # butterfly:
   pymunk,
+  # classic:
   chess,
   rlcard,
   shimmy,
+  # other:
+  moviepy,
   pillow,
-  pybox2d,
+  # sisl
   scipy,
-  pre-commit,
-  pynput,
-  pytest,
-  pytest-cov-stub,
-  pytest-markdown-docs,
-  pytest-xdist,
+  pybox2d,
+  swig,
 
   # tests
+  pytest-markdown-docs,
+  pytest-xdist,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pettingzoo";
-  version = "1.26.1";
+  version = "1.27.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -41,7 +46,7 @@ buildPythonPackage (finalAttrs: {
     owner = "Farama-Foundation";
     repo = "PettingZoo";
     tag = finalAttrs.version;
-    hash = "sha256-WrfjkDnmir6bZvtMD7MVQKVoGvK+lutlOoNe9SNQ8jU=";
+    hash = "sha256-fiaHuMmoaL6VweDcXZVLaQcvXHG3B0zcOrePlOajQzo=";
   };
 
   build-system = [
@@ -51,6 +56,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     gymnasium
     numpy
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -67,23 +73,21 @@ buildPythonPackage (finalAttrs: {
       pygame-ce
       rlcard
       shimmy
+      # open-spiel (unpackaged)
     ];
     mpe = [ pygame-ce ];
-    other = [ pillow ];
+    other = [
+      moviepy
+      pillow
+    ];
     sisl = [
-      pybox2d
       pygame-ce
       pymunk
       scipy
-    ];
-    testing = [
-      # autorom
-      pre-commit
-      pynput
-      pytest
-      pytest-cov-stub
-      pytest-markdown-docs
-      pytest-xdist
+      pybox2d
+    ]
+    ++ lib.optionals (pythonAtLeast "3.14") [
+      swig
     ];
   };
 
@@ -91,12 +95,15 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     chess
+    moviepy
+    pybox2d
     pygame-ce
     pymunk
     pytest-markdown-docs
     pytest-xdist
     pytestCheckHook
     rlcard
+    scipy
   ];
 
   disabledTestPaths = [
@@ -109,6 +116,10 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # ImportError: cannot import name 'pytest_plugins' from 'pettingzoo.classic'
     "test_chess"
+
+    # pygame.error: No available video device
+    "test_kaz_obs_updates"
+    "test_rgb_array_render_does_not_init_audio"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Crashes on darwin: `Fatal Python error: Aborted`


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/Farama-Foundation/PettingZoo/compare/1.26.1...1.27.0
Changelog: https://github.com/Farama-Foundation/PettingZoo/releases/tag/1.27.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test