### PR TITLE
orca: add at-spi2-core to pythonPath

### DIFF
--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -68,7 +68,12 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     gobject-introspection
   ];
 
-  pythonPath = with python3.pkgs; [
+  pythonPath = [
+    # Provides gi/overrides/Atspi.py, without which Atspi.Accessible falls back
+    # to GObject pointer identity and Orca misidentifies accessibles.
+    at-spi2-core
+  ]
+  ++ (with python3.pkgs; [
     dasbus
     pygobject3
     dbus-python
@@ -79,7 +84,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     speechd-minimal
     gst-python
     setproctitle
-  ];
+  ]);
 
   strictDeps = false;
 


### PR DESCRIPTION
Orca has been running without at-spi2-core's PyGObject overrides, which breaks accessible identity.

at-spi2-core installs `gi/overrides/Atspi.py`, which replaces `Atspi.Accessible.__hash__` and `__eq__` with versions built from the accessible's bus name and object path. Without it both fall back to plain GObject pointer identity, so two Python wrappers for the same on-screen object hash differently and compare unequal.

Orca leans on this constantly. It compares accessibles to work out whether focus actually moved, and `Generator` in `generator.py` memoises cell text, descriptions, nesting levels and tree item levels in dicts keyed on `hash(obj)`. With pointer identity those keys are neither stable nor unique: they miss when they should hit, and since CPython reuses freed addresses, a fresh wrapper can land on a dead one's cache entry. What you actually hear is tables and tree views reading out the wrong row, which figures, because that's where Orca re-fetches and compares the same cells the most.

The file is already in the at-spi2-core output, at `$out/lib/python3.14/site-packages/gi/overrides/Atspi.py`. at-spi2-core is only in `buildInputs`, which gets the typelib onto `GI_TYPELIB_PATH` but never puts that directory on Orca's `sys.path`. Debian ships the same file in gir1.2-atspi-2.0 under `/usr/lib/python3/dist-packages`, Arch under `/usr/lib/python3.14/site-packages`, both on the default path, so neither distro has to do anything. We do, because there's no shared site-packages for it to land in.

Adding at-spi2-core to `pythonPath` puts it in the `site.addsitedir` call that wrapPythonPrograms injects into `bin/.orca-wrapped`.

I checked it by running `orca --version` with a probe on `PYTHONPATH` that prints what the descriptors actually are.

Before:

```
__hash__: <slot wrapper '__hash__' of 'gi._gi.GObject' objects>
__eq__  : <slot wrapper '__eq__' of 'gi._gi.GObject' objects>
```

After:

```
__hash__: <function Accessible.__hash__ at 0x...>
__eq__  : <function Accessible.__eq__ at 0x...>
```

I also use this daily as a screen reader user, and tree view navigation is noticeably less broken with the override in place.

`nixpkgs-review rev HEAD` on x86_64-linux: 3 packages built, none failed. The rebuild set is orca itself plus cosmic-greeter and pantheon.elementary-session-settings, which both reference it.

This needs doing before 51 lands anyway. Upstream added a meson check that fails the build unless `Atspi.Accessible.__hash__.__module__` is `gi.overrides.Atspi` (commit 15145c3ba, "Fail at configure when AT-SPI Python overrides are missing"), so 50.2 is the last release that will build with the overrides missing.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Disclosure per the automation/AI policy: the investigation that found this, the patch, and this summary were done with Claude Code (claude-opus-5). I reviewed the diff, and I tested the built result in my own desktop session before submitting.

cc @NixOS/gnome
