### PR TITLE
freecad: add missing graphviz runtime dependency

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -8,6 +8,7 @@
   fetchFromGitHub,
   fetchpatch,
   fmt,
+  graphviz,
   gts,
   hdf5,
   libGLU,
@@ -133,6 +134,7 @@ freecad-utils.makeCustomizable (
     qtWrapperArgs =
       let
         binPath = lib.makeBinPath [
+          graphviz
           libredwg
           which # for locating tools
         ];


### PR DESCRIPTION
Fixes #401880

FreeCAD's dependency graph view (`Tools > Dependency Graph`) does not render;
it shows a "Graphviz couldn't be found on your system" dialog instead.

FreeCAD does not link against Graphviz. It generates the DOT description itself
via Boost (`src/App/Graphviz.cpp`) and then executes the Graphviz binaries as
child processes. In `src/Gui/GraphvizView.cpp`:

- `dot` and `unflatten` are held as bare names (lines 302-303)
- the process inherits the environment, so lookup goes through `PATH` (line 312)
- `QProcess::start()` therefore resolves them via `PATH` (line 318)
- when that fails, the warning dialog is raised (lines 320-335)

This is a runtime dependency only, which is why the package builds fine without
it and the failure appears solely when the user opens the view. Adding
`graphviz` to the `binPath` used by `qtWrapperArgs` puts both binaries in scope.
A single entry covers both, since `dot` and `unflatten` ship in the same
`graphviz` output.

### Verification

Built on x86_64-linux, then queried from FreeCAD's own interpreter, inside the
wrapper environment:

```
$ result/bin/FreeCADCmd -c 'import shutil; print(shutil.which("dot"), shutil.which("unflatten"))'
/nix/store/...-graphviz-15.1.0/bin/dot /nix/store/...-graphviz-15.1.0/bin/unflatten
```

End-to-end, exercising the same path the GUI takes — document → `exportGraphviz`
→ `dot -Tsvg`:

```
DOT: 132 bytes -> dot exit=0 -> SVG: 1565 bytes
```

Before this change, `shutil.which("dot")` returns `None` and the render step
fails.
