### PR TITLE
vellum: init at 0.6.0, nixos/vellum: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -84,6 +84,8 @@
 
 - [Krill](https://nlnetlabs.nl/projects/krill/about), RPKI CA and Publication Server written in Rust. Available as [services.krill](#opt-services.krill.enable).
 
+- [vellum](https://github.com/greyxp1/vellum) is a live screen annotation overlay for Wayland. Available as [programs.vellum](#opt-programs.vellum.enable).
+
 - [stash-clipboard](https://github.com/NotAShelf/stash), a Wayland clipboard "manager" with fast persistent history and multi-media support. Available as [services.stash-clipboard](#opt-services.stash-clipboard.enable).
 
 - [OO7](https://github.com/linux-credentials/oo7) is a desktop-agnostic Secret Service provider. Available as [services.oo7](#opt-services.oo7.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -352,6 +352,7 @@
   ./programs/udevil.nix
   ./programs/upki.nix
   ./programs/usbtop.nix
+  ./programs/vellum.nix
   ./programs/vim.nix
   ./programs/virt-manager.nix
   ./programs/vivid.nix

--- a/nixos/modules/programs/vellum.nix
+++ b/nixos/modules/programs/vellum.nix
@@ -1,0 +1,81 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.vellum;
+
+  inherit (lib)
+    getExe
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+  inherit (lib.types) separatedString;
+
+  toml = pkgs.formats.toml { };
+in
+{
+  options.programs.vellum = {
+    enable = mkEnableOption "vellum, a live screen annotation overlay for Wayland";
+
+    package = mkPackageOption pkgs "vellum" { };
+
+    settings = mkOption {
+      inherit (toml) type;
+      default = { };
+      description = ''
+        Configuration options for vellum.
+        See available options at <https://github.com/greyxp1/vellum/blob/master/docs/configuration.md>.
+      '';
+      example = literalExpression ''
+        {
+          default_tool = "arrow";
+          remember_last_tool = false;
+          feedback_duration_ms = 250;
+        }
+      '';
+    };
+
+    extraOptions = mkOption {
+      type = separatedString " ";
+      default = "";
+      description = ''
+        Extra command-line options to pass to
+        the {command}`vellum` daemon.
+      '';
+      example = "--force-backend vulkan";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = [ cfg.package ];
+
+      etc."xdg/vellum/config.toml" = mkIf (cfg.settings != { }) {
+        source = toml.generate "vellum-config.toml" cfg.settings;
+      };
+    };
+
+    systemd.user.services.vellum = {
+      description = "Vellum screen annotation overlay";
+      after = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      restartTriggers = [ config.environment.etc."xdg/vellum/config.toml".source ];
+      serviceConfig = {
+        ExecStart = "${getExe cfg.package} ${cfg.extraOptions}";
+        Restart = "on-failure";
+      };
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ poz ];
+  };
+}

--- a/pkgs/by-name/ve/vellum/package.nix
+++ b/pkgs/by-name/ve/vellum/package.nix
@@ -1,0 +1,73 @@
+{
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  libGL,
+  libxkbcommon,
+  makeBinaryWrapper,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+  vulkan-loader,
+  wayland,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "vellum";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "greyxp1";
+    repo = "vellum";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uWGaCeENwaqg2+wbtfgpDAjxIsJbgUcMnvSPauwjcBI=";
+  };
+
+  cargoHash = "sha256-quZW6jkGzvRHNgkJQS4entJyXeYftBOV89hKaFfQCDw=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxkbcommon
+    wayland
+  ];
+
+  postInstall = ''
+    manDir=$(find target -type d -path '*/build/vellum-*/out/man' -print -quit)
+    installManPage "$manDir"/*.1
+
+    wrapProgram $out/bin/vellum \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libGL
+          vulkan-loader
+          wayland
+        ]
+      }
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Live screen annotation overlay for Wayland";
+    homepage = "https://github.com/greyxp1/vellum";
+    changelog = "https://github.com/greyxp1/vellum/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/greyxp1/vellum/releases";
+    license =
+      with lib.licenses;
+      AND [
+        isc
+        mit
+      ];
+    maintainers = with lib.maintainers; [ poz ];
+    platforms = lib.platforms.linux;
+    mainProgram = "vellum";
+  };
+})


### PR DESCRIPTION
https://github.com/greyxp1/vellum

the module adds a user systemd service and writes config to `/etc/xdg/vellum/config.toml`

@greyxp1

for anyone wanting to test this, add the following input:

```nix
inputs.nixpkgs-vellum.url = "github:imnotpoz/nixpkgs/vellum";
```

then somewhere in your config do:

```nix
imports = [ "${inputs.nixpkgs-vellum}/nixos/modules/programs/vellum.nix" ];

programs.vellum = {
  enable = true;
  package = inputs.nixpkgs-vellum.legacyPackages.${pkgs.stdenv.system}.vellum;
  settings = {
    # your config
    # ...
  };
};
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
