### PR TITLE
nixos/nextcloud: add further default settings

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -900,7 +900,7 @@ in
               "syslog"
               "systemd"
             ];
-            default = "syslog";
+            default = "systemd";
             description = ''
               Logging backend to use.
               systemd automatically adds the php-systemd extensions to services.nextcloud.phpExtraExtensions.

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -970,6 +970,17 @@ in
               the `+49` prefix can be omitted for phone numbers.
             '';
           };
+          maintenance_window_start = lib.mkOption {
+            default = 100;
+            type = lib.types.int;
+            example = 1;
+            description = ''
+              UTC Hour for maintenance windows which advertise themselves as not time sensitive.
+              A value of 1, e.g., will only run these background jobs between 01:00am UTC and
+              05:00am UTC.
+              Default is 100 which disables this feature.
+            '';
+          };
           "profile.enabled" = lib.mkEnableOption "global profiles" // {
             description = ''
               Makes user-profiles globally available under `nextcloud.tld/u/user.name`.

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -916,6 +916,15 @@ in
               skeleton files.
             '';
           };
+          serverid = lib.mkOption {
+            default = 1;
+            type = lib.types.ints.between 0 511;
+            description = ''
+              Server ID, must be an integer between 0 and 511 (inclusive).
+              Should be configured if your Nextcloud instance is using different PHP
+              servers.
+            '';
+          };
           trusted_domains = lib.mkOption {
             type = lib.types.listOf lib.types.str;
             default = [ ];


### PR DESCRIPTION
Add some default settings which otherwise get advertised as missing in the Nextcloud admin panel

- log_type: change default to `systemd` since this is the default in nixos
- serverid: only required to configure different values if several php servers are used. default set to `1`
- maintenance_window_start: Set setting to value `100` (disable maintenance window) which is the default according to upstream https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/config_sample_php_parameters.html#maintenance-window-start


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
