### PR TITLE
timidity: cleanup, fix on darwin

### DIFF
--- a/pkgs/by-name/ti/timidity/package.nix
+++ b/pkgs/by-name/ti/timidity/package.nix
@@ -14,13 +14,16 @@
   libvorbis,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "timidity";
   version = "2.15.0";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchurl {
-    url = "mirror://sourceforge/timidity/TiMidity++-${version}.tar.bz2";
-    sha256 = "1xf8n6dqzvi6nr2asags12ijbj1lwk1hgl3s27vm2szib8ww07qn";
+    url = "mirror://sourceforge/timidity/TiMidity++-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-Fh/AOVrxa1H3EXrQB8PkNMglowj6Ka1Etibuj5uxyPU=";
   };
 
   patches = [
@@ -63,7 +66,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-ncurses"
-    ("--enable-audio=" + builtins.concatStringsSep "," enabledOutputModes)
+    ("--enable-audio=" + builtins.concatStringsSep "," finalAttrs.enabledOutputModes)
     "lib_cv_va_copy=yes"
     "lib_cv___va_copy=yes"
   ]
@@ -108,9 +111,14 @@ stdenv.mkDerivation rec {
     cp ${./timidity.cfg} $out/share/timidity/timidity.cfg
     substituteAllInPlace $out/share/timidity/timidity.cfg
     tar --strip-components=1 -xf $instruments -C $out/share/timidity/
-    # All but one of the symlinks in the instruments tarball have their permissions set to 0000.
-    # This causes problems on systems like Darwin that actually use symlink permissions.
-    chmod -Rh u+rwX $out/share/timidity/
+  ''
+  # All but one of the symlinks in the instruments tarball have their permissions set to 0000.
+  # This causes problems on systems like Darwin that actually use symlink permissions.
+  # Nix chowns the output to root but never canonicalises symlink modes, so this has to grant
+  # read to everyone: with u+rwX only root could readlink(), which breaks NAR serialisation
+  # (`nix copy`, `nix-copy-closure`) for unprivileged users.
+  + ''
+    chmod -Rh a+rX $out/share/timidity/
   '';
 
   passthru.tests = nixosTests.timidity;
@@ -123,4 +131,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "timidity";
   };
-}
+})

--- a/pkgs/by-name/ti/timidity/package.nix
+++ b/pkgs/by-name/ti/timidity/package.nix
@@ -8,6 +8,7 @@
   ncurses,
   alsa-lib,
   buildPackages,
+  versionCheckHook,
 
   ## Additional optional output modes
   enableVorbis ? false,
@@ -120,6 +121,11 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     chmod -Rh a+rX $out/share/timidity/
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   passthru.tests = nixosTests.timidity;
 


### PR DESCRIPTION
## Things done

- **timidity: cleanup, fix on darwin**
- **timidity: add versionCheckHook**

```
copying path '/nix/store/7dy79j3j2krwi0l4ff2nig3imqsjn3sa-timidity-2.15.0' from 'ssh://darwin'...
error: filesystem error: in read_symlink: Permission denied ["/nix/store/7dy79j3j2krwi0l4ff2nig3imqsjn3sa-timidity-2.15.0/share/timidity/clavinet.pat"]
error: reached end of FramedSource
```

I used Claude to help me investigate this one.

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
