### PR TITLE
[26.05] python3Packages.unearth: fix CVE-2026-73030

### DIFF
--- a/pkgs/development/python-modules/unearth/default.nix
+++ b/pkgs/development/python-modules/unearth/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   packaging,
   pdm-backend,
   httpx,
@@ -22,6 +23,16 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-HlPX9S9G3V+HXnf/HFWxJHfiFaCS5LZsl2SnffSptSA=";
   };
+
+  patches = [
+    # https://github.com/frostming/unearth/pull/176
+    (fetchpatch {
+      name = "fix-packaging-26.0-changes.patch";
+      url = "https://github.com/frostming/unearth/commit/69ece0800edeefb1daf035bb0ee348e17a4393fd.patch";
+      hash = "sha256-t/Ubv9qC1Fvh4JsnfVgOZO/O7ZpCGHugBUt9qAjnH8c=";
+      excludes = [ "pdm.lock" ];
+    })
+  ];
 
   build-system = [ pdm-backend ];
 

--- a/pkgs/development/python-modules/unearth/default.nix
+++ b/pkgs/development/python-modules/unearth/default.nix
@@ -32,6 +32,12 @@ buildPythonPackage rec {
       hash = "sha256-t/Ubv9qC1Fvh4JsnfVgOZO/O7ZpCGHugBUt9qAjnH8c=";
       excludes = [ "pdm.lock" ];
     })
+    # Remove when updating to the first release containing this fix.
+    (fetchpatch {
+      name = "CVE-2026-73030.patch";
+      url = "https://github.com/frostming/unearth/commit/6c78164e7bfa28b8b3d6f247b87e560692e3c8ba.patch";
+      hash = "sha256-OEf4YnpNhZcIWaFMSXQP0SA7kRV9FqKIpnkLbUrQj+4=";
+    })
   ];
 
   build-system = [ pdm-backend ];


### PR DESCRIPTION
Backport of #551542 to fix CVE-2026-73030 in `release-26.05`.

This also backports the prerequisite `unearth` compatibility fix from #531813, which is required after the Packaging 26.1 update on the release branch.

Addresses #551406

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
