### PR TITLE
neovim: more discoverability for plugin type option

### DIFF
--- a/pkgs/applications/editors/neovim/plugin-submodule.nix
+++ b/pkgs/applications/editors/neovim/plugin-submodule.nix
@@ -22,7 +22,7 @@ let
       options = {
         config = mkOption {
           type = types.nullOr types.lines;
-          description = "viml configuration associated with this plugin.";
+          description = "Configuration associated with this plugin. Use the 'type' plugin option to set the language (viml by default).";
           default = null;
           example = "set title";
         };

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -70,6 +70,11 @@ let
     #       config   = "let g:grug_far = { 'startInInsertMode': v:false }";
     #       optional = false;
     #     }
+    #     {
+    #       plugin = vimPlugins.far-vim;
+    #       type   = "lua";
+    #       config = "vim.g['far#source'] = 'rg'";
+    #     }
     #     vimPlugins.vim-fugitive
     #  ]
     plugins:

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -23,6 +23,92 @@ let
   # inherit interpreter from neovim
   lua = neovim-unwrapped.lua;
 
+  /**
+    Build a wrapped Neovim with built-in configuration.
+
+    This is a lower-level alternative to wrapNeovim conceived to handle more
+    usecases when wrapping neovim. The interface is being actively worked on so
+    expect breakage. use `wrapNeovim` instead if you want a stable alternative
+
+    # Inputs
+    `attrs`
+    : Configuration for the wrapped Neovim application. See properties below.
+
+    # Configuration Properties
+    `extraName` (defaults to `""`)
+
+    `autoconfigure` (defaults to `true`)
+    : Certain plugins need a custom configuration (available in passthru.initLua) to work with nix. If true, the wrapper automatically appends those snippets when necessary
+
+    `autowrapRuntimeDeps` (defaults to `true`)
+    : Append to PATH runtime deps of plugins
+
+    `wrapperArgs` (defaults to `[ ]`)
+    : Should contain all args but the binary. Can be either a string or list
+
+    `withPython2` (defaults to `false`)
+
+    `withPython3` (defaults to `false`)
+
+    `extraPython3Packages` (defaults to `(_: [ ])`)
+    : The function you would have passed to python3.withPackages
+
+    `waylandSupport` (defaults to `lib.meta.availableOn stdenv.hostPlatform wayland`)
+
+    `withNodeJs` (defaults to `false`)
+
+    `withPerl` (defaults to `false`)
+
+    `withRuby` (defaults to `false`)
+
+    `vimAlias` (defaults to `false`)
+    : Whether to create symlinks in $out/bin/vi(m) -> $out/bin/nvim
+
+    `viAlias` (defaults to `false`)
+
+    `wrapRc` (defaults to `true`)
+    : It sets the VIMINIT environment variable to "lua dofile('${customRc}')"
+      set to false if you want to control where to save the generated config
+      (e.g., in ~/.config/init.vim or project/.nvimrc)
+
+    `neovimRcContent` (defaults to `null`)
+    : `vimL` code that should be sourced as part of the generated init.lua file
+
+    `luaRcContent` (defaults to `""`)
+    : `lua` code to put into the generated init.lua file
+
+    `packpathDirs` (defaults to `null`)
+    : DEPRECATED: entry to load in packpath
+      use 'plugins' instead
+
+    `plugins` (defaults to `[ ]`)
+    : A list of neovim plugin derivations. See example below.
+
+    `extraLuaPackages` (defaults to `(_: [ ])`)
+    : The function you would have passed to lua.withPackages
+
+    # Examples
+    :::{.example #example-neovim-plugins}
+    ## `plugins` usage example
+    ```nix
+    {
+      plugins = [
+        {
+          plugin   = vimPlugins.grug-far-nvim;
+          config   = "let g:grug_far = { 'startInInsertMode': v:false }";
+          optional = false;
+        }
+        {
+          plugin = vimPlugins.far-vim;
+          type   = "lua";
+          config = "vim.g['far#source'] = 'rg'";
+        }
+        vimPlugins.vim-fugitive
+      ]
+    }
+    ```
+    :::
+  */
   wrapper =
     {
       extraName ? "",
@@ -64,8 +150,18 @@ let
 
       # a list of neovim plugin derivations, for instance
       #  plugins = [
-      # { plugin=far-vim; config = "let g:far#source='rg'"; optional = false; }
-      # ]
+      #    {
+      #      plugin   = vimPlugins.grug-far-nvim;
+      #      config   = "let g:grug_far = { 'startInInsertMode': v:false }";
+      #      optional = false;
+      #    }
+      #    {
+      #      plugin = vimPlugins.far-vim;
+      #      type   = "lua";
+      #      config = "vim.g['far#source'] = 'rg'";
+      #    }
+      #    vimPlugins.vim-fugitive
+      #  ]
       plugins ? [ ],
       # the function you would have passed to lua.withPackages
       extraLuaPackages ? (_: [ ]),


### PR DESCRIPTION
These small tweaks to (code-) documentation would have helped me uncover the `type` plugin option more quickly than I did so I wanted to contribute them however small.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
