### PR TITLE
Upgrade from NixOS 25.05 to NixOS 25.11+ breaks certificate from ACME module, preventing httpd from starting

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -153,6 +153,19 @@ let
     ''
     + (lib.concatStringsSep "\n" (
       lib.mapAttrsToList (cert: data: ''
+        # Compat with NixOS < 25.11, which tracked "a real certificate exists"
+        # with ConditionPathExists on the self-signing unit rather than with an
+        # acme-success marker. Without this, upgrading replaces a perfectly good
+        # CA-issued certificate with a self-signed one until the next successful
+        # order. A certificate that does not verify against our own self-signing
+        # CA came from a real CA, so record that success up front.
+        if [ -e ${lib.escapeShellArg cert}/fullchain.pem ] \
+          && [ ! -e ${lib.escapeShellArg cert}/acme-success ] \
+          && ! ${lib.getExe' pkgs.openssl "openssl"} verify -CAfile .minica/cert.pem \
+               ${lib.escapeShellArg cert}/fullchain.pem >/dev/null 2>&1; then
+          touch ${lib.escapeShellArg cert}/acme-success
+        fi
+
         for fixpath in ${lib.escapeShellArg cert} .lego/${lib.escapeShellArg cert}; do
           if [ -d "$fixpath" ]; then
             chmod -R u=rwX,g=rX,o= "$fixpath"

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -420,14 +420,20 @@ let
             }
           }
 
-          # Create files to match directory layout for real certificates
-          (
-            cd '${keyName}'
-            cp -vp cert.pem ../out/cert.pem
-            cp -vp key.pem ../out/key.pem
-          )
-          cat out/cert.pem ca/cert.pem > out/fullchain.pem
-          cp ca/cert.pem out/chain.pem
+          # Create files to match directory layout for real certificates.
+          #
+          # orderRenewService installs cert.pem as a symlink to fullchain.pem,
+          # so these outputs may already alias one another. Both cp(1) and >
+          # follow a symlinked destination and write through it, which would
+          # make `cat out/cert.pem ... > out/fullchain.pem` truncate its own
+          # input and leave fullchain.pem holding nothing but the CA
+          # certificate. Unlink first, then write each output exactly once.
+          rm -f out/cert.pem out/key.pem out/chain.pem out/fullchain.pem out/full.pem
+
+          cp -vp '${keyName}/cert.pem' out/cert.pem
+          cp -vp '${keyName}/key.pem' out/key.pem
+          cp -vp ca/cert.pem out/chain.pem
+          cat out/cert.pem out/chain.pem > out/fullchain.pem
           cat out/key.pem out/fullchain.pem > out/full.pem
 
           # Fix up the output files to adhere to the group and

--- a/nixos/tests/acme/python-utils.py
+++ b/nixos/tests/acme/python-utils.py
@@ -131,6 +131,16 @@ def check_fullchain(node, cert_name):
 
     assert False
 
+# Ensures the installed certificate and private key are the same keypair.
+# Webservers may reject a mismatched pair at startup.
+def check_keypair(node, cert_name):
+    certdir = f"/var/lib/acme/{cert_name}"
+    from_cert = node.succeed(f"openssl x509 -noout -pubkey -in {certdir}/fullchain.pem")
+    from_key = node.succeed(f"openssl pkey -pubout -in {certdir}/key.pem")
+    assert (
+        from_cert == from_key
+    ), f"{certdir}/fullchain.pem does not match {certdir}/key.pem"
+
 # Checks the permissions in the cert directories are as expected
 def check_permissions(node, cert_name, group):
     stat = "stat -L -c '%a %U %G' "

--- a/nixos/tests/acme/webserver.nix
+++ b/nixos/tests/acme/webserver.nix
@@ -239,5 +239,20 @@
               webserver.wait_for_unit("renew-triggered.target")
               output = webserver.succeed("journalctl --cursor-file=/tmp/cursor")
               t.assertNotIn("Stopping Nginx Web Server...", output)
-        '';
+        ''
+    + ''
+
+      # Kept last: shutting the CA down leaves acme-order-renew failed, which
+      # would make the is-system-running checks in switch_to report degraded.
+      with subtest("Upgrading from a layout that predates the acme-success marker"):
+          # Once a real certificate is installed, cert.pem has been symlinked to fullchain.pem.
+          # Regenerating the self-signed certificate over that layout must result in working certificate.
+          acme.shutdown()  # Prevent the ordering service from overwriting the output .
+          webserver.succeed(f"test -L /var/lib/acme/{fqdn}/cert.pem")
+          webserver.succeed(f"rm /var/lib/acme/{fqdn}/acme-success")
+          webserver.succeed(f"systemctl restart acme-{fqdn}.service")
+          check_fullchain(webserver, fqdn)
+          check_keypair(webserver, fqdn)
+          check_issuer(webserver, fqdn, "minica")
+    '';
 }

--- a/nixos/tests/acme/webserver.nix
+++ b/nixos/tests/acme/webserver.nix
@@ -173,6 +173,21 @@
         check_issuer(webserver, fqdn, "pebble")
         check_connection(webserver, fqdn)
 
+      with subtest("Retain certificate from a layout that predates the acme-success marker"):
+          # Such a system must not have its CA-issued certificate discarded and
+          # replaced by a self-signed one on the first rebuild.
+          webserver.succeed(f"rm /var/lib/acme/{fqdn}/acme-success")
+          webserver.succeed("systemctl restart acme-setup.service")
+          webserver.succeed(f"test -e /var/lib/acme/{fqdn}/acme-success")
+          mtime_before = webserver.succeed(f"stat -c %Y /var/lib/acme/{fqdn}/fullchain.pem")
+          webserver.succeed(f"systemctl restart acme-{fqdn}.service")
+          mtime_after = webserver.succeed(f"stat -c %Y /var/lib/acme/{fqdn}/fullchain.pem")
+          t.assertEqual(
+              mtime_before, mtime_after, "a CA-issued certificate was rewritten"
+          )
+          check_issuer(webserver, fqdn, "pebble")
+          check_keypair(webserver, fqdn)
+
       with subtest("security.acme changes reflect on web server part 1"):
           check_connection(webserver, f"certchange.{domain}", fail=True)
           switch_to(webserver, "certchange")
@@ -244,10 +259,10 @@
 
       # Kept last: shutting the CA down leaves acme-order-renew failed, which
       # would make the is-system-running checks in switch_to report degraded.
-      with subtest("Upgrading from a layout that predates the acme-success marker"):
+      with subtest("Self-signing on top of an already installed certificate without acme-success marker"):
           # Once a real certificate is installed, cert.pem has been symlinked to fullchain.pem.
-          # Regenerating the self-signed certificate over that layout must result in working certificate.
-          acme.shutdown()  # Prevent the ordering service from overwriting the output .
+          # Regenerating the self-signed certificate over that layout must result in a working certificate.
+          acme.shutdown()  # Prevent the ordering service from overwriting the output.
           webserver.succeed(f"test -L /var/lib/acme/{fqdn}/cert.pem")
           webserver.succeed(f"rm /var/lib/acme/{fqdn}/acme-success")
           webserver.succeed(f"systemctl restart acme-{fqdn}.service")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I am not sure if you still want to fix it, but the migration from NixOS 25.05 seems to be broken:

- NixOS 25.05 has **no `acme-success` marker**, causing the creation of a self-signed certificate via `minica` after the upgrade.
- The file **`cert.pem` is a symlink to `fullchain.pem`** on NixOS 25.05 (and also in the current version)  
  https://github.com/NixOS/nixpkgs/blob/ac62194c3917d5f474c1a844b6fd6da2db95077d/nixos/modules/security/acme/default.nix#L580
- Due to that symlink, **the following line truncates the content of `cert.pem` before reading it**, effectively deleting the certificate which has just been created.  
  https://github.com/NixOS/nixpkgs/blob/a8e65fb37d7758b0e03416638d58720a6b1a7f2a/nixos/modules/security/acme/default.nix#L429

As a result, the Apache HTTP Server (_httpd_) is unable to start. Since ACME needs the webserver to create new certificates, the system is stuck. All services using the certificate are broken until manual intervention. This seems to happen whenever upgrading NixOS 25.05 to any newer version while using the ACME module with the web challenge.

```
[ssl:emerg] [...] AH02565: Certificate and private key ***:443:0 from /var/lib/acme/default/fullchain.pem and /var/lib/acme/default/key.pem do not match
```

**Workaround:** I resolved the issue on my system by deleting the symlink and rebooting the system.

```bash
sudo rm /var/lib/acme/default/cert.pem
sudo reboot
```

## Things done

_Unfortunately, I did not have a strong enough system (with the Nix package manager) at hand to build and test everything._

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
