### PR TITLE
deepseek-harness: init at 0.1.0-rc.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1249,6 +1249,12 @@
     githubId = 3955369;
     name = "Lemon Lam";
   };
+  alephcasara = {
+    email = "aurus2@gmail.com";
+    github = "AlephCasara";
+    githubId = 70831534;
+    name = "Aleph Casara";
+  };
   alerque = {
     email = "caleb@alerque.com";
     github = "alerque";

--- a/pkgs/by-name/de/deepseek-harness/package.nix
+++ b/pkgs/by-name/de/deepseek-harness/package.nix
@@ -513,12 +513,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     landlock="$(
       LANDLOCK_ENTRY="$app/node_modules/@deepseek-ai/node-addon-landlock-run/lib/index.js" \
-        ${lib.getExe runtimeNode} --input-type=module <<'NODE'
-      import { pathToFileURL } from "node:url";
-
-      const entry = await import(pathToFileURL(process.env.LANDLOCK_ENTRY));
-      process.stdout.write(entry.launcherPath());
-      NODE
+        ${lib.getExe runtimeNode} --input-type=module --eval \
+          'import { pathToFileURL } from "node:url"; const entry = await import(pathToFileURL(process.env.LANDLOCK_ENTRY)); process.stdout.write(entry.launcherPath());'
     )"
 
     test -x "$landlock"

--- a/pkgs/by-name/de/deepseek-harness/package.nix
+++ b/pkgs/by-name/de/deepseek-harness/package.nix
@@ -1,4 +1,5 @@
 {
+  bashInteractive,
   fetchFromGitHub,
   fetchPnpmDeps,
   lib,
@@ -65,6 +66,12 @@ stdenv.mkDerivation (finalAttrs: {
           "'${lib.getExe pkgsStatic.stdenv.cc}'"
     ''}
 
+    # NixOS does not provide /bin/bash; use the packaged interactive shell locally.
+    substituteInPlace packages/terminal/terminal-bash/src/config.ts \
+      --replace-fail \
+        "shellPath: z.string().default('/bin/bash')" \
+        "shellPath: z.string().default('${lib.getExe bashInteractive}')"
+
     # Keep CSS IDs relative to avoid build-root references and sort exports for deterministic bundles.
     substituteInPlace packages/client/tsdown.client.ts \
       --replace-fail \
@@ -122,6 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
       mkdirSync,
       readFileSync,
       rmSync,
+      writeFileSync,
     } from "node:fs";
     import { dirname, join } from "node:path";
     import { spawnSync } from "node:child_process";
@@ -176,6 +184,32 @@ stdenv.mkDerivation (finalAttrs: {
       if (result.error !== undefined || result.status !== 0) {
         throw new Error(command + " failed: " + args.join(" "));
       }
+    };
+
+    const dependencyFields = [
+      "dependencies",
+      "devDependencies",
+      "optionalDependencies",
+      "peerDependencies",
+      "peerDependenciesMeta",
+    ];
+
+    const canonicalizeManifest = manifestPath => {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+      for (const field of dependencyFields) {
+        if (manifest[field] === undefined) {
+          continue;
+        }
+
+        manifest[field] = Object.fromEntries(
+          Object.entries(manifest[field]).sort(([a], [b]) =>
+            a < b ? -1 : a > b ? 1 : 0,
+          ),
+        );
+      }
+
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
     };
 
     const materialize = name => {
@@ -246,6 +280,7 @@ stdenv.mkDerivation (finalAttrs: {
         ],
       );
 
+      canonicalizeManifest(join(destination, "package.json"));
       rmSync(archive);
     };
 
@@ -335,6 +370,35 @@ stdenv.mkDerivation (finalAttrs: {
       pnpm --dir apps/cli pack --out "$cliTar"
     tar -xzf "$cliTar" --strip-components=1 -C "$app"
 
+    APP="$app" ${lib.getExe runtimeNode} --input-type=module <<'NODE'
+    import { readFileSync, writeFileSync } from "node:fs";
+    import { join } from "node:path";
+
+    const dependencyFields = [
+      "dependencies",
+      "devDependencies",
+      "optionalDependencies",
+      "peerDependencies",
+      "peerDependenciesMeta",
+    ];
+    const manifestPath = join(process.env.APP, "package.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+    for (const field of dependencyFields) {
+      if (manifest[field] === undefined) {
+        continue;
+      }
+
+      manifest[field] = Object.fromEntries(
+        Object.entries(manifest[field]).sort(([a], [b]) =>
+          a < b ? -1 : a > b ? 1 : 0,
+        ),
+      );
+    }
+
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    NODE
+
     rm -f \
       "$cliTar" \
       "$app/node_modules/.modules.yaml" \
@@ -364,6 +428,7 @@ stdenv.mkDerivation (finalAttrs: {
       --add-flags "$app/lib/bin.js" \
       --prefix PATH : ${
         lib.makeBinPath [
+          bashInteractive
           runtimeNode
           pnpm
         ]
@@ -386,6 +451,14 @@ stdenv.mkDerivation (finalAttrs: {
     app="$out/lib/node_modules/@deepseek-ai/dsh"
 
     "$out/bin/dsh" --help > /dev/null
+
+    terminalBash="$app/node_modules/@deepseek-ai/dsh-terminal-bash/lib/index.js"
+    grep -F ${lib.escapeShellArg (lib.getExe bashInteractive)} "$terminalBash" > /dev/null
+
+    if grep -F 'default("/bin/bash")' "$terminalBash" > /dev/null; then
+      echo "terminal-bash still defaults to /bin/bash" >&2
+      exit 1
+    fi
 
     runtimeHome="$(mktemp -d)"
 

--- a/pkgs/by-name/de/deepseek-harness/package.nix
+++ b/pkgs/by-name/de/deepseek-harness/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "deepseek-harness";
 
   # rc.5 is pinned because rc.6 was published without matching public source and lockfile.
-  version = "0.1.0-rc.5";
+  version = "0-unstable-2026-08-13";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -377,6 +377,10 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   versionCheckProgramArg = "--version";
+
+  preVersionCheck = ''
+    export version=0.1.0-rc.5
+  '';
 
   postInstallCheck = ''
     app="$out/lib/node_modules/@deepseek-ai/dsh"

--- a/pkgs/by-name/de/deepseek-harness/package.nix
+++ b/pkgs/by-name/de/deepseek-harness/package.nix
@@ -6,7 +6,7 @@
   node-gyp,
   nodejs_24,
   nodejs-slim_24,
-  pkgsMusl,
+  pkgsStatic,
   pnpmConfigHook,
   pnpm_11,
   python3,
@@ -28,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "deepseek-harness";
   version = "0.1.0-rc.5";
 
+  __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchFromGitHub {
@@ -60,10 +61,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    substituteInPlace native/landlock-run/scripts/build.ts \
-      --replace-fail \
-        "'musl-gcc'" \
-        "'${lib.getExe pkgsMusl.stdenv.cc}'"
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace native/landlock-run/scripts/build.ts \
+        --replace-fail \
+          "'musl-gcc'" \
+          "'${lib.getExe pkgsStatic.stdenv.cc}'"
+    ''}
 
     # Keep virtual CSS module IDs relative so Rolldown does not embed the build root.
     substituteInPlace packages/client/tsdown.client.ts \

--- a/pkgs/by-name/de/deepseek-harness/package.nix
+++ b/pkgs/by-name/de/deepseek-harness/package.nix
@@ -1,0 +1,386 @@
+{
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  lib,
+  makeBinaryWrapper,
+  node-gyp,
+  nodejs_24,
+  nodejs-slim_24,
+  pkgsMusl,
+  pnpmConfigHook,
+  pnpm_11,
+  python3,
+  stdenv,
+  versionCheckHook,
+}:
+
+let
+  runtimeNode = nodejs-slim_24;
+  pnpm = pnpm_11.override { nodejs-slim = runtimeNode; };
+
+  landlockPackage =
+    if stdenv.hostPlatform.isAarch64 then
+      "node-addon-landlock-run-linux-arm64"
+    else
+      "node-addon-landlock-run-linux-x64";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "deepseek-harness";
+  version = "0.1.0-rc.5";
+
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "deepseek-ai";
+    repo = "deepseek-harness";
+    rev = "47f943859bef60e4160492346772ded9b24f765a";
+    hash = "sha256-ZPGCNoPXVjP76Tm/tFPDX2X95cd83M4iHLmVP5dR+Ps=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-aySHq0ywTMM5q7YuGHZrV3yQE3bwppgGfWH3wRnHCXk=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    node-gyp
+    nodejs_24
+    pnpm
+    pnpmConfigHook
+    python3
+  ];
+
+  disallowedReferences = [
+    node-gyp
+    nodejs_24
+    python3
+  ];
+
+  postPatch = ''
+    substituteInPlace native/landlock-run/scripts/build.ts \
+      --replace-fail \
+        "'musl-gcc'" \
+        "'${lib.getExe pkgsMusl.stdenv.cc}'"
+
+    # Keep virtual CSS module IDs relative so Rolldown does not embed the build root.
+    substituteInPlace packages/client/tsdown.client.ts \
+      --replace-fail \
+        'return CSS_VIRTUAL_PREFIX + abs + CSS_VIRTUAL_SUFFIX' \
+        'return CSS_VIRTUAL_PREFIX + relative(process.cwd(), abs) + CSS_VIRTUAL_SUFFIX' \
+      --replace-fail \
+        'const fileId = virtualId.slice(CSS_VIRTUAL_PREFIX.length, -CSS_VIRTUAL_SUFFIX.length)' \
+        'const fileId = resolvePath(virtualId.slice(CSS_VIRTUAL_PREFIX.length, -CSS_VIRTUAL_SUFFIX.length))' \
+      --replace-fail \
+        'Object.entries(cssExports ?? {})' \
+        'Object.entries(cssExports ?? {}).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    GITHUB_ACTIONS=true pnpm rebuild
+    pnpm run build
+    pnpm --dir native/landlock-run run build:native
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    deployDir="$NIX_BUILD_TOP/dsh-deploy"
+    app="$out/lib/node_modules/@deepseek-ai/dsh"
+
+    npm_config_ignore_scripts=true \
+      pnpm \
+        --offline \
+        --ignore-scripts \
+        --filter @deepseek-ai/dsh \
+        --prod \
+        --config.inject-workspace-packages=true \
+        --config.link-workspace-packages=true \
+        --config.node-linker=hoisted \
+        deploy "$deployDir"
+
+    # dsh-app-boot imports this peer, but apps/cli does not declare it.
+    cp -a \
+      vendor/group \
+      "$deployDir/node_modules/@deepseek-ai/cordis-plugin-group"
+
+    rm -rf \
+      "$deployDir/node_modules/@deepseek-ai/cordis-plugin-group/node_modules"
+
+    # Several workspace packages import runtime dependencies declared as devDependencies.
+    for package in \
+      packages/code-runtime/code-runtime \
+      packages/compaction/compaction \
+      packages/core/scope \
+      packages/fs/fs \
+      packages/identity/anonymous-user-id \
+      packages/sandbox/sandbox \
+      packages/session/session-telemetry \
+      packages/session/session-title-llm \
+      packages/shell/bash-local \
+      packages/shell/shell \
+      packages/spill/spill \
+      packages/subagent/subagent-in-process-driver \
+      packages/subprocess/subprocess \
+      packages/util/atomic-write \
+      packages/util/output-retention \
+      packages/util/timeout \
+      packages/workflow/workflow
+    do
+      name="$(node -p "require('./$package/package.json').name.split('/')[1]")"
+      mkdir -p "$deployDir/node_modules/@deepseek-ai/$name"
+      cp -a \
+        "$package/package.json" \
+        "$package/lib" \
+        "$deployDir/node_modules/@deepseek-ai/$name/"
+    done
+
+    if [[ -d "$deployDir/node_modules/koffi" ]]; then
+      (
+        cd "$deployDir/node_modules/koffi"
+        node ./cnoke.cjs \
+          -P . \
+          -D src/koffi \
+          --prebuild \
+          --release
+      )
+    fi
+
+    if [[ -d "$deployDir/node_modules/node-pty" ]]; then
+      (
+        cd "$deployDir/node_modules/node-pty"
+        node scripts/prebuild.js || node-gyp rebuild
+        node scripts/post-install.js
+      )
+    fi
+
+    if [[ -d "$deployDir/node_modules/@deepseek-ai/dsh-subprocess-local" ]]; then
+      (
+        cd "$deployDir/node_modules/@deepseek-ai/dsh-subprocess-local"
+        node scripts/ensure-spawn-helper.mjs
+      )
+    fi
+
+    mkdir -p "$app" "$out/bin"
+    cp -a "$deployDir/." "$app/"
+
+    # pnpm deploy rewrites workspace dependencies to build-directory file URLs.
+    cp apps/cli/package.json "$app/package.json"
+
+    rm -f \
+      "$app/pnpm-lock.yaml" \
+      "$app/node_modules/.modules.yaml" \
+      "$app/node_modules/.pnpm/lock.yaml" \
+      "$app/node_modules/.pnpm-workspace-state-v1.json"
+
+    if [[ -d "$app/node_modules/node-pty/prebuilds" ]]; then
+      rm -rf \
+        "$app/node_modules/node-pty/prebuilds"/darwin-* \
+        "$app/node_modules/node-pty/prebuilds"/win32-*
+    fi
+
+    if [[ -d "$app/node_modules/node-pty/build" ]]; then
+      find "$app/node_modules/node-pty/build" -type f \
+        ! -path '*/Release/pty.node' -delete
+      find "$app/node_modules/node-pty/build" -depth -type d -empty -delete
+    fi
+
+    rm -rf "$app/node_modules/node-pty/node-addon-api"
+
+    ${lib.optionalString stdenv.hostPlatform.isx86_64 ''
+      rm -rf \
+        "$app/node_modules/@deepseek-ai/node-addon-landlock-run-linux-arm64"
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      rm -rf \
+        "$app/node_modules/@deepseek-ai/node-addon-landlock-run-linux-x64"
+    ''}
+
+    # Nix-built Node currently needs this for the HMR loader used by dsh web.
+    makeBinaryWrapper ${lib.getExe runtimeNode} "$out/bin/dsh" \
+      --add-flags "--expose-internals" \
+      --add-flags "$app/lib/bin.js" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          runtimeNode
+          pnpm
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = "--version";
+
+  postInstallCheck = ''
+    app="$out/lib/node_modules/@deepseek-ai/dsh"
+
+    "$out/bin/dsh" --help > /dev/null
+
+    runtimeHome="$(mktemp -d)"
+
+    env -i \
+      HOME="$runtimeHome" \
+      DSH_HOME="$runtimeHome/dsh" \
+      PATH="$out/bin" \
+      "$out/bin/dsh" \
+        --profile headless \
+        --dump-default-config > /dev/null
+
+    env -i \
+      HOME="$runtimeHome" \
+      DSH_HOME="$runtimeHome/dsh" \
+      PATH="$out/bin" \
+      "$out/bin/dsh" \
+        plugin \
+        --profile install-check \
+        --version \
+      | grep -Fx ${lib.escapeShellArg pnpm.version}
+
+    webHome="$(mktemp -d)"
+    webLog="$(mktemp)"
+
+    env -i \
+      HOME="$webHome" \
+      DSH_HOME="$webHome/dsh" \
+      PATH="$out/bin" \
+      "$out/bin/dsh" \
+        web \
+        --host 127.0.0.1 \
+        --port 0 > "$webLog" 2>&1 &
+
+    webPid=$!
+
+    cleanupWeb() {
+      kill "$webPid" 2> /dev/null || true
+      wait "$webPid" 2> /dev/null || true
+    }
+
+    trap cleanupWeb EXIT
+
+    for _ in {1..100}; do
+      if ! kill -0 "$webPid" 2> /dev/null; then
+        cat "$webLog" >&2
+        exit 1
+      fi
+
+      webUrl="$(sed -n 's/^dsh web: //p' "$webLog")"
+
+      if [[ -n "$webUrl" ]]; then
+        break
+      fi
+
+      sleep 0.1
+    done
+
+    test -n "''${webUrl:-}"
+
+    WEB_URL="$webUrl" ${lib.getExe runtimeNode} <<'NODE'
+    const response = await fetch(process.env.WEB_URL);
+
+    if (!response.ok) {
+      process.exit(1);
+    }
+
+    const html = await response.text();
+
+    if (!html.includes("<html")) {
+      process.exit(1);
+    }
+    NODE
+
+    cleanupWeb
+    trap - EXIT
+
+    APP="$app" ${lib.getExe runtimeNode} <<'NODE'
+    const path = require("node:path");
+
+    const pty = require(
+      path.join(process.env.APP, "node_modules/node-pty"),
+    );
+
+    require(path.join(process.env.APP, "node_modules/koffi"));
+    require(path.join(process.env.APP, "node_modules/sharp"));
+    require(
+      path.join(
+        process.env.APP,
+        "node_modules/node-addon-require-builtin",
+      ),
+    );
+
+    const child = pty.spawn(
+      "${stdenv.shell}",
+      ["-c", "printf dsh-nix-pty-ok"],
+      {
+        cols: 80,
+        rows: 24,
+      },
+    );
+
+    let output = "";
+
+    const timeout = setTimeout(() => {
+      child.kill();
+      process.exit(1);
+    }, 5000);
+
+    child.onData((data) => {
+      output += data;
+    });
+
+    child.onExit(({ exitCode }) => {
+      clearTimeout(timeout);
+
+      if (
+        exitCode !== 0 ||
+        !output.includes("dsh-nix-pty-ok")
+      ) {
+        process.exit(1);
+      }
+    });
+    NODE
+
+    landlock="$app/node_modules/@deepseek-ai/${landlockPackage}/bin/landlock-run"
+
+    test -x "$landlock"
+
+    "$landlock" --probe \
+      | grep -Eq '^landlock: (fully|partially) enforced$'
+
+    if find "$out" -xtype l -print -quit | grep -q .; then
+      find "$out" -xtype l -print >&2
+      exit 1
+    fi
+
+    if grep -RlaE '/build/(source|tmp\.|\.home)' "$out"; then
+      exit 1
+    fi
+  '';
+
+  meta = {
+    description = "Open-source agent harness developed by DeepSeek AI";
+    homepage = "https://github.com/deepseek-ai/deepseek-harness";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ alephcasara ];
+    mainProgram = "dsh";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+  };
+})

--- a/pkgs/by-name/de/deepseek-harness/package.nix
+++ b/pkgs/by-name/de/deepseek-harness/package.nix
@@ -17,15 +17,11 @@
 let
   runtimeNode = nodejs-slim_24;
   pnpm = pnpm_11.override { nodejs-slim = runtimeNode; };
-
-  landlockPackage =
-    if stdenv.hostPlatform.isAarch64 then
-      "node-addon-landlock-run-linux-arm64"
-    else
-      "node-addon-landlock-run-linux-x64";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "deepseek-harness";
+
+  # rc.5 is pinned because rc.6 was published without matching public source and lockfile.
   version = "0.1.0-rc.5";
 
   __structuredAttrs = true;
@@ -54,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  disallowedReferences = [
+  outputChecks.out.disallowedRequisites = [
     node-gyp
     nodejs_24
     python3
@@ -62,13 +58,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      # Upstream hard-codes musl-gcc; use Nixpkgs' static-musl compiler in the sandbox.
       substituteInPlace native/landlock-run/scripts/build.ts \
         --replace-fail \
           "'musl-gcc'" \
           "'${lib.getExe pkgsStatic.stdenv.cc}'"
     ''}
 
-    # Keep virtual CSS module IDs relative so Rolldown does not embed the build root.
+    # Keep CSS IDs relative to avoid build-root references and sort exports for deterministic bundles.
     substituteInPlace packages/client/tsdown.client.ts \
       --replace-fail \
         'return CSS_VIRTUAL_PREFIX + abs + CSS_VIRTUAL_SUFFIX' \
@@ -84,6 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
+    # pnpmConfigHook installs with lifecycle scripts disabled; rebuild the upstream allowlist.
+    # CI mode prevents the root postinstall from mutating Git hooks.
     GITHUB_ACTIONS=true pnpm rebuild
     pnpm run build
     pnpm --dir native/landlock-run run build:native
@@ -95,55 +94,211 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     deployDir="$NIX_BUILD_TOP/dsh-deploy"
+    packDir="$NIX_BUILD_TOP/dsh-packs"
     app="$out/lib/node_modules/@deepseek-ai/dsh"
 
-    npm_config_ignore_scripts=true \
-      pnpm \
-        --offline \
-        --ignore-scripts \
-        --filter @deepseek-ai/dsh \
-        --prod \
-        --config.inject-workspace-packages=true \
-        --config.link-workspace-packages=true \
-        --config.node-linker=hoisted \
-        deploy "$deployDir"
+    mkdir -p "$packDir"
 
-    # dsh-app-boot imports this peer, but apps/cli does not declare it.
-    cp -a \
-      vendor/group \
-      "$deployDir/node_modules/@deepseek-ai/cordis-plugin-group"
+    # Use pnpm's lockfile-aware deploy path. Injection is required by pnpm 11;
+    # the hoisted layout mirrors the npm installation shape upstream publishes for.
+    pnpm \
+      --offline \
+      --ignore-scripts \
+      --filter @deepseek-ai/dsh \
+      --prod \
+      --config.inject-workspace-packages=true \
+      --config.node-linker=hoisted \
+      deploy "$deployDir"
 
-    rm -rf \
-      "$deployDir/node_modules/@deepseek-ai/cordis-plugin-group/node_modules"
+    # pnpm deploy can omit workspace packages that are required only through
+    # peerDependencies. Derive the required peer closure from upstream manifests
+    # and materialize only missing packages through pnpm pack, matching upstream's
+    # published payload transformation instead of maintaining a downstream list.
+    DEPLOY_DIR="$deployDir" PACK_DIR="$packDir" \
+      node --input-type=module <<'NODE'
+    import {
+      existsSync,
+      globSync,
+      mkdirSync,
+      readFileSync,
+      rmSync,
+    } from "node:fs";
+    import { dirname, join } from "node:path";
+    import { spawnSync } from "node:child_process";
 
-    # Several workspace packages import runtime dependencies declared as devDependencies.
-    for package in \
-      packages/code-runtime/code-runtime \
-      packages/compaction/compaction \
-      packages/core/scope \
-      packages/fs/fs \
-      packages/identity/anonymous-user-id \
-      packages/sandbox/sandbox \
-      packages/session/session-telemetry \
-      packages/session/session-title-llm \
-      packages/shell/bash-local \
-      packages/shell/shell \
-      packages/spill/spill \
-      packages/subagent/subagent-in-process-driver \
-      packages/subprocess/subprocess \
-      packages/util/atomic-write \
-      packages/util/output-retention \
-      packages/util/timeout \
-      packages/workflow/workflow
-    do
-      name="$(node -p "require('./$package/package.json').name.split('/')[1]")"
-      mkdir -p "$deployDir/node_modules/@deepseek-ai/$name"
-      cp -a \
-        "$package/package.json" \
-        "$package/lib" \
-        "$deployDir/node_modules/@deepseek-ai/$name/"
-    done
+    const deployDir = process.env.DEPLOY_DIR;
+    const packDir = process.env.PACK_DIR;
 
+    if (deployDir === undefined || packDir === undefined) {
+      throw new Error("missing deployment paths");
+    }
+
+    const workspace = new Map();
+
+    for (const manifestPath of [
+      ...globSync("vendor/*/package.json"),
+      ...globSync("packages/*/*/package.json"),
+      ...globSync("native/landlock-run/packages/*/package.json"),
+      ...globSync("apps/*/package.json"),
+    ].sort()) {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+      if (typeof manifest.name !== "string") {
+        throw new Error("workspace manifest has no package name: " + manifestPath);
+      }
+
+      if (workspace.has(manifest.name)) {
+        throw new Error("duplicate workspace package name: " + manifest.name);
+      }
+
+      workspace.set(manifest.name, {
+        dir: dirname(manifestPath),
+        manifest,
+      });
+    }
+
+    const rootName = "@deepseek-ai/dsh";
+    const packagePath = name =>
+      join(deployDir, "node_modules", ...name.split("/"));
+
+    if (!workspace.has(rootName)) {
+      throw new Error("CLI workspace manifest not found");
+    }
+
+    const run = (command, args, options = {}) => {
+      const result = spawnSync(command, args, {
+        cwd: process.cwd(),
+        env: process.env,
+        stdio: "inherit",
+        ...options,
+      });
+
+      if (result.error !== undefined || result.status !== 0) {
+        throw new Error(command + " failed: " + args.join(" "));
+      }
+    };
+
+    const materialize = name => {
+      const entry = workspace.get(name);
+
+      if (entry === undefined) {
+        throw new Error("workspace package not found: " + name);
+      }
+
+      const optionalDependencies = Object.keys(
+        entry.manifest.optionalDependencies ?? {},
+      );
+
+      if (optionalDependencies.length > 0) {
+        throw new Error(
+          name
+            + " is missing from pnpm deploy but has optional dependencies: "
+            + optionalDependencies.join(", "),
+        );
+      }
+
+      const requiredExternal = [
+        ...Object.keys(entry.manifest.dependencies ?? {}),
+        ...Object.keys(entry.manifest.peerDependencies ?? {}).filter(
+          peer => entry.manifest.peerDependenciesMeta?.[peer]?.optional !== true,
+        ),
+      ]
+        .filter(dependency => !workspace.has(dependency))
+        .filter(dependency => !existsSync(packagePath(dependency)));
+
+      if (requiredExternal.length > 0) {
+        throw new Error(
+          name
+            + " requires external runtime packages absent from pnpm deploy: "
+            + [...new Set(requiredExternal)].sort().join(", "),
+        );
+      }
+
+      const archive = join(
+        packDir,
+        name.replace(/^@/, "").replaceAll("/", "-") + ".tgz",
+      );
+      rmSync(archive, { force: true });
+
+      run(
+        "pnpm",
+        ["--dir", entry.dir, "pack", "--out", archive],
+        {
+          env: {
+            ...process.env,
+            pnpm_config_ignore_scripts: "true",
+          },
+        },
+      );
+
+      const destination = packagePath(name);
+      rmSync(destination, { force: true, recursive: true });
+      mkdirSync(destination, { recursive: true });
+
+      run(
+        "tar",
+        [
+          "-xzf",
+          archive,
+          "--strip-components=1",
+          "-C",
+          destination,
+        ],
+      );
+
+      rmSync(archive);
+    };
+
+    const materialized = [];
+
+    while (true) {
+      const missing = new Set();
+
+      for (const [name, entry] of workspace) {
+        if (name !== rootName && !existsSync(packagePath(name))) {
+          continue;
+        }
+
+        const runtimeEdges = new Set(
+          Object.keys(entry.manifest.dependencies ?? {}),
+        );
+
+        for (const peer of Object.keys(entry.manifest.peerDependencies ?? {})) {
+          if (entry.manifest.peerDependenciesMeta?.[peer]?.optional !== true) {
+            runtimeEdges.add(peer);
+          }
+        }
+
+        for (const dependency of runtimeEdges) {
+          if (
+            workspace.has(dependency)
+            && !existsSync(packagePath(dependency))
+          ) {
+            missing.add(dependency);
+          }
+        }
+      }
+
+      if (missing.size === 0) {
+        break;
+      }
+
+      for (const name of [...missing].sort()) {
+        materialize(name);
+        materialized.push(name);
+      }
+    }
+
+    if (materialized.length > 0) {
+      console.log(
+        "materialized workspace runtime peers: "
+          + materialized.join(", "),
+      );
+    }
+    NODE
+
+    # deploy runs with lifecycle scripts disabled; recreate only native/runtime
+    # artifacts needed by the final closure.
     if [[ -d "$deployDir/node_modules/koffi" ]]; then
       (
         cd "$deployDir/node_modules/koffi"
@@ -171,13 +326,17 @@ stdenv.mkDerivation (finalAttrs: {
     fi
 
     mkdir -p "$app" "$out/bin"
-    cp -a "$deployDir/." "$app/"
+    cp -a "$deployDir/node_modules" "$app/"
 
-    # pnpm deploy rewrites workspace dependencies to build-directory file URLs.
-    cp apps/cli/package.json "$app/package.json"
+    # pnpm deploy can preserve workspace: ranges in package.json. Install the CLI
+    # from its upstream pack payload so the manifest matches what DeepSeek publishes.
+    cliTar="$packDir/dsh-cli.tgz"
+    pnpm_config_ignore_scripts=true \
+      pnpm --dir apps/cli pack --out "$cliTar"
+    tar -xzf "$cliTar" --strip-components=1 -C "$app"
 
     rm -f \
-      "$app/pnpm-lock.yaml" \
+      "$cliTar" \
       "$app/node_modules/.modules.yaml" \
       "$app/node_modules/.pnpm/lock.yaml" \
       "$app/node_modules/.pnpm-workspace-state-v1.json"
@@ -196,15 +355,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     rm -rf "$app/node_modules/node-pty/node-addon-api"
 
-    ${lib.optionalString stdenv.hostPlatform.isx86_64 ''
-      rm -rf \
-        "$app/node_modules/@deepseek-ai/node-addon-landlock-run-linux-arm64"
-    ''}
-
-    ${lib.optionalString stdenv.hostPlatform.isAarch64 ''
-      rm -rf \
-        "$app/node_modules/@deepseek-ai/node-addon-landlock-run-linux-x64"
-    ''}
+    # Only x86_64-linux is declared below; drop the unused arm64 optional package.
+    rm -rf "$app/node_modules/@deepseek-ai/node-addon-landlock-run-linux-arm64"
 
     # Nix-built Node currently needs this for the HMR loader used by dsh web.
     makeBinaryWrapper ${lib.getExe runtimeNode} "$out/bin/dsh" \
@@ -354,12 +506,60 @@ stdenv.mkDerivation (finalAttrs: {
     });
     NODE
 
-    landlock="$app/node_modules/@deepseek-ai/${landlockPackage}/bin/landlock-run"
+    if grep -q 'workspace:' "$app/package.json"; then
+      echo "packed CLI manifest still contains workspace: dependencies" >&2
+      exit 1
+    fi
+
+    landlock="$(
+      LANDLOCK_ENTRY="$app/node_modules/@deepseek-ai/node-addon-landlock-run/lib/index.js" \
+        ${lib.getExe runtimeNode} --input-type=module <<'NODE'
+      import { pathToFileURL } from "node:url";
+
+      const entry = await import(pathToFileURL(process.env.LANDLOCK_ENTRY));
+      process.stdout.write(entry.launcherPath());
+      NODE
+    )"
 
     test -x "$landlock"
 
-    "$landlock" --probe \
-      | grep -Eq '^landlock: (fully|partially) enforced$'
+    landlockProbe="$(mktemp)"
+
+    if "$landlock" --probe > "$landlockProbe" 2>&1; then
+      grep -Eq '^landlock: (fully|partially) enforced' "$landlockProbe"
+
+      allowedDir="$(mktemp -d)"
+      deniedDir="$(mktemp -d)"
+      printf 'allowed\n' > "$allowedDir/readable"
+      printf 'denied\n' > "$deniedDir/blocked"
+
+      "$landlock" \
+        --ro /nix/store \
+        --rw /dev/null \
+        --rw "$allowedDir" \
+        -- \
+        "${stdenv.shell}" \
+        -c '
+          printf "written\n" > "$1/writable"
+          test "$(cat "$1/readable")" = allowed
+          test "$(cat "$1/writable")" = written
+
+          if cat "$2/blocked" > /dev/null 2>&1; then
+            exit 1
+          fi
+
+          if : > "$2/created" 2> /dev/null; then
+            exit 1
+          fi
+        ' \
+        _ \
+        "$allowedDir" \
+        "$deniedDir"
+    else
+      probeStatus=$?
+      test "$probeStatus" -eq 125
+      grep -q '^landlock-run: ' "$landlockProbe"
+    fi
 
     if find "$out" -xtype l -print -quit | grep -q .; then
       find "$out" -xtype l -print >&2
@@ -377,10 +577,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ alephcasara ];
     mainProgram = "dsh";
-    platforms = [
-      "aarch64-linux"
-      "x86_64-linux"
-    ];
+    platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       binaryNativeCode


### PR DESCRIPTION
Adds DeepSeek Harness (`dsh`), the open-source agent harness developed by
DeepSeek AI, at developer-preview version 0.1.0-rc.5.

This builds the corresponding public upstream source revision and uses the
upstream `pnpm-lock.yaml` through `fetchPnpmDeps` and `pnpmConfigHook`.

I intentionally package rc.5 rather than the newer rc.6 npm artifact because
rc.6 does not currently have a corresponding public source revision/lockfile.
This keeps dependency resolution upstream-owned instead of maintaining a
downstream-generated npm lockfile in nixpkgs.

The package:
- builds the upstream PNPM workspace with Node.js 24;
- deploys the production CLI dependency closure only;
- runs with `nodejs-slim_24`;
- provides PNPM at runtime for `dsh plugin`;
- verifies CLI and headless operation;
- starts `dsh web` on loopback and verifies a real HTTP response;
- exercises `node-pty` with a real PTY;
- loads Koffi, Sharp, and node-addon-require-builtin;
- probes Landlock enforcement;
- checks for broken symlinks and build-directory references.

Supported platforms:
- x86_64-linux
- aarch64-linux

Local functional testing and nixpkgs-review were performed on x86_64-linux.

Packaging analysis and the Nix expression were assisted by OpenAI Codex
(GPT-5.6 Sol); I manually reviewed and tested the resulting changes.
