### PR TITLE
taskflow: apply debian patch to work around gcc 16 regression

### DIFF
--- a/pkgs/by-name/ta/taskflow/package.nix
+++ b/pkgs/by-name/ta/taskflow/package.nix
@@ -23,6 +23,21 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./unvendor-doctest.patch {
       inherit doctest;
     })
+
+    # GCC 16 has a regression in std::inclusive_scan where it modifies the
+    # input data instead of leaving it unchanged, causing some incorrect
+    # behavior and broken tests within taskflow. To work around this, Debian
+    # reimplemented equivalent correct behavior in one case and copied the
+    # input in another as appropriate. We adopt their approach to work around
+    # this regression.
+    # gcc bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=126604
+    # debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1133642
+    # taskflow issue: https://github.com/taskflow/taskflow/issues/809
+    (fetchpatch {
+      name = "gcc16-inclusive-scan-regression.patch";
+      url = "https://salsa.debian.org/debian/taskflow/-/raw/039540a03c90cc825ce588f7ffae70db5472428f/debian/patches/fix-gcc16-inclusive-scan-move.patch";
+      hash = "sha256-A8dUYKtjvvHAOrFGzDjat2hUHO1zoMbfdNnFJLZZbL0=";
+    })
   ];
 
   postPatch = ''
@@ -37,8 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    # FIXME remove once Taskflow is updated to 4.0.0
-    (lib.cmakeFeature "CMAKE_CXX_STANDARD" "20")
     # building the tests implies running them in the buildPhase
     (lib.cmakeBool "TF_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];


### PR DESCRIPTION
GCC 16 has a regression in std::inclusive_scan where it modifies the input data instead of leaving it unchanged, causing some incorrect behavior and broken tests within taskflow. To work around this, Debian reimplemented equivalent correct behavior in one case and copied the input in another as appropriate. We adopt their approach to work around this regression.

failing build logs: https://hydra.nixos.org/build/339231018/log
gcc bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=126604
debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1133642
taskflow issue: https://github.com/taskflow/taskflow/issues/809

working towards #537781 (making gcc 16 the default)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
