### PR TITLE
[26.05] sqlite, sqlite-analyzer: 3.51.2 -> 3.51.3

### DIFF
--- a/pkgs/development/libraries/sqlite/Changes-some-legacy-testing-targets-in-the-makefiles.patch
+++ b/pkgs/development/libraries/sqlite/Changes-some-legacy-testing-targets-in-the-makefiles.patch
@@ -1,0 +1,123 @@
+From 24a2f8f767a7bbef924b5b58c6fe8afe2bf250c2 Mon Sep 17 00:00:00 2001
+From: drh <>
+Date: Fri, 13 Mar 2026 14:31:13 +0000
+Subject: [PATCH 2/6] Changes some legacy testing targets in the makefiles into
+ aliases for "devtest" and "releasetest"
+
+FossilOrigin-Name: 238e70fec074005a53794bfe9550db95a8e5ef7b520d58b6b383a339ac50f900
+---
+ Makefile.msc  | 40 ++++++++--------------------------------
+ main.mk       | 34 ++++++++--------------------------
+ manifest      | 15 +++++++--------
+ manifest.uuid |  2 +-
+ 4 files changed, 24 insertions(+), 67 deletions(-)
+
+diff --git a/Makefile.msc b/Makefile.msc
+index 52807ff7f2..4ad026d299 100644
+--- a/Makefile.msc
++++ b/Makefile.msc
+@@ -2594,43 +2594,19 @@ coretestprogs:	testfixture.exe sqlite3.exe
+ 
+ testprogs:	$(TESTPROGS) srcck1.exe fuzzcheck.exe sessionfuzz.exe
+ 
+-fulltest:	alltest fuzztest
+-
+-alltest:	$(TESTPROGS)
+-	@set PATH=$(LIBTCLPATH);$(PATH)
+-	.\testfixture.exe $(TOP)\test\all.test $(TESTOPTS)
+-
+-soaktest:	$(TESTPROGS)
+-	@set PATH=$(LIBTCLPATH);$(PATH)
+-	.\testfixture.exe $(TOP)\test\all.test -soak=1 $(TESTOPTS)
+-
+-fulltestonly:	$(TESTPROGS) fuzztest
+-	@set PATH=$(LIBTCLPATH);$(PATH)
+-	.\testfixture.exe $(TOP)\test\full.test
+-
+-queryplantest:	testfixture.exe shell
+-	@set PATH=$(LIBTCLPATH);$(PATH)
+-	.\testfixture.exe $(TOP)\test\permutations.test queryplanner $(TESTOPTS)
+-
+ fuzztest:	fuzzcheck.exe
+ 	.\fuzzcheck.exe $(FUZZDATA)
+ 
+-# Legacy testing target for third-party integrators.  The SQLite
+-# developers seldom use this target themselves.  Instead
+-# they use "nmake /f Makefile.msc devtest" which runs tests on
+-# a standard set of options
+-#
+-test:	$(TESTPROGS) sourcetest fuzztest tcltest
+-
+-# Minimal testing that runs in less than 3 minutes (on a fast machine)
+ #
+-quicktest:	testfixture.exe sourcetest
+-	@set PATH=$(LIBTCLPATH);$(PATH)
+-	.\testfixture.exe $(TOP)\test\extraquick.test $(TESTOPTS)
+-
+-# This is the common case.  Run many tests that do not take too long,
+-# including fuzzcheck, sqlite3_analyzer, and sqldiff tests.
++# Legacy testing targets, no longer used by the developers and
++# now aliased to one of the commonly used testing targets.
+ #
++quicktest:	devtest
++test:	devtest
++fulltest:	releasetest
++alltest:	releasetest
++soaktest:	releasetest
++fulltestonly:	releasetest
+ 
+ # The veryquick.test TCL tests.
+ #
+diff --git a/main.mk b/main.mk
+index d84c7b2580..336838a364 100644
+--- a/main.mk
++++ b/main.mk
+@@ -1814,20 +1814,6 @@ coretestprogs:	testfixture$(B.exe) sqlite3$(B.exe)
+ 
+ testprogs:	$(TESTPROGS) srcck1$(B.exe) fuzzcheck$(T.exe) sessionfuzz$(T.exe)
+ 
+-# A very detailed test running most or all test cases
+-fulltest:	alltest fuzztest
+-
+-# Run most or all tcl test cases
+-alltest:	$(TESTPROGS)
+-	./testfixture$(T.exe) $(TOP)/test/all.test $(TESTOPTS)
+-
+-# Really really long testing
+-soaktest:	$(TESTPROGS)
+-	./testfixture$(T.exe) $(TOP)/test/all.test -soak=1 $(TESTOPTS)
+-
+-# Do extra testing but not everything.
+-fulltestonly:	$(TESTPROGS) fuzztest
+-	./testfixture$(T.exe) $(TOP)/test/full.test
+ 
+ #
+ # Fuzz testing
+@@ -1894,19 +1880,15 @@ releasetest: srctree-check has_tclsh85 verify-source
+ 	$(TCLSH_CMD) $(TOP)/test/testrunner.tcl release $(TSTRNNR_OPTS)
+ 
+ #
+-# Minimal testing that runs in less than 3 minutes
+-#
+-quicktest:	./testfixture$(T.exe)
+-	./testfixture$(T.exe) $(TOP)/test/extraquick.test $(TESTOPTS)
+-
+-#
+-# Try to run tests on whatever options are specified by the
+-# ./configure.  The developers seldom use this target.  Instead
+-# they use "make devtest" which runs tests on a standard set of
+-# options regardless of how SQLite is configured.  This "test"
+-# target is provided for legacy only.
++# Legacy testing targets, no longer used by the developers and
++# now aliased to one of the commonly used testing targets.
+ #
+-test:	srctree-check fuzztest sourcetest $(TESTPROGS) tcltest
++quicktest:	devtest
++test:	devtest
++fulltest:	releasetest
++alltest:	releasetest
++soaktest:	releasetest
++fulltestonly:	releasetest
+ 
+ #
+ # Run a test using valgrind.  This can take a really long time

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -28,18 +28,22 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sqlite${lib.optionalString interactive "-interactive"}";
-  version = "3.51.2";
+  version = "3.51.3";
 
   # nixpkgs-update: no auto update
   # NB! Make sure to update ./tools.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2026/sqlite-src-${archiveVersion version}.zip";
-    hash = "sha256-hREPdi1QeUFNmd1deRe8P/fgWHbmzL0T2ElqOBfyCCk=";
+    hash = "sha256-+KZ6H1tcrnxtQvCZTKe/GkpYWIaMgq3J/BNAvtXrjNI=";
   };
   docsrc = fetchurl {
     url = "https://sqlite.org/2026/sqlite-doc-${archiveVersion version}.zip";
-    hash = "sha256-xuMNB8XpwSaQHFTY18kKnBo3B4JFUX8GCzxpxN5Dv10=";
+    hash = "sha256-7AU+ZqM7BHm0tMiBM67vTQIhTWPlotWe0GLK9QYeoiw=";
   };
+
+  patches = [
+    ./Changes-some-legacy-testing-targets-in-the-makefiles.patch
+  ];
 
   outputs = [
     "bin"

--- a/pkgs/development/libraries/sqlite/tools.nix
+++ b/pkgs/development/libraries/sqlite/tools.nix
@@ -19,14 +19,14 @@ let
     }:
     stdenv.mkDerivation rec {
       inherit pname;
-      version = "3.51.2";
+      version = "3.51.3";
 
       # nixpkgs-update: no auto update
       src =
         assert version == sqlite.version;
         fetchurl {
           url = "https://sqlite.org/2026/sqlite-src-${archiveVersion version}.zip";
-          hash = "sha256-hREPdi1QeUFNmd1deRe8P/fgWHbmzL0T2ElqOBfyCCk=";
+          hash = "sha256-+KZ6H1tcrnxtQvCZTKe/GkpYWIaMgq3J/BNAvtXrjNI=";
         };
 
       nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
Changes: https://sqlite.org/releaselog/3_51_3.html

3.51.3 is a bugfix release. Most importantly, it fixes a WAL-reset database corruption bug.

Add a patch from branch-3.51 to fix test failures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
