### PR TITLE
zennotes-desktop: 2.27.0 -> 2.28.1

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.27.0";
-  npmDepsHash = "sha256-cSotsEeJp2/5t7me8ETs+1URHfUoM1boY5lsjUEi8WI=";
+  version = "2.28.1";
+  npmDepsHash = "sha256-UJQMlmDM17f0TreR8kUvZBOMzoNGFV+uxUs8WXr2XfU=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ViZHSH9m02NzexYNbeOuZJ623Nz8dvd2jGqAIj+lKRI=";
+    hash = "sha256-2nGy23US7qFxdVWi+19f5HgEJPEZofeIvQOqn3vPVdg=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update zennotes-desktop 2.27.0 -> 2.28.1. I'm the upstream author of ZenNotes.

2.28.x is the ZenNotes Cloud release (optional sync, backups, and publishing built into the desktop app) plus a set of vim fixes for soft-wrapped lines and a keyboard path for opening databases. 2.28.0 is deliberately skipped: it shipped with the Cloud connect flow pointed at a deployment hostname that stopped resolving the same day, and 2.28.1 corrected the origin within hours. Local vaults work fully offline without a Cloud account, so the package's behavior is unchanged for users who never touch Cloud.

Hash provenance: `npmDepsHash` and the `src` hash are the values our repo's own Nix packaging CI computed and build-verified on a Nix runner for this release (the in-repo flake builds the same workspace from the same lockfile, and that build passed on v2.28.1): https://github.com/ZenNotes/zennotes/pull/590

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.28.1 (and https://github.com/ZenNotes/zennotes/releases/tag/v2.28.0 for the full 2.28 feature set)

## Things done

- Built on platform(s)
  - [x] x86_64-linux (equivalent derivation with these hashes build-verified
        in upstream repo CI on x86_64-linux)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).