### PR TITLE
openshot-qt, libopenshot: pin to ffmpeg 8, fix build, update

### DIFF
--- a/pkgs/by-name/li/libopenshot/package.nix
+++ b/pkgs/by-name/li/libopenshot/package.nix
@@ -3,15 +3,22 @@
   stdenv,
   fetchFromGitHub,
   alsa-lib,
+  catch2_3,
   cmake,
   cppzmq,
+  ctestCheckHook,
   doxygen,
-  ffmpeg,
+  # FIXME: unpin when libopenshot supports ffmpeg 9 (AVCodec.{pix_fmts,sample_fmts,...} removed)
+  ffmpeg_8,
+  glib,
   imagemagick,
   jsoncpp,
   libopenshot-audio,
   llvmPackages,
+  opencv4,
+  pipewire,
   pkg-config,
+  protobuf,
   python3,
   qt6,
   swig,
@@ -21,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libopenshot";
-  version = "0.7.0-unstable-2026-04-21";
+  version = "0.7.0-unstable-2026-07-22";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot";
-    rev = "a58565292cb84438b1c6a039c343b4c65003bd82";
-    hash = "sha256-zUzyi/VydrxDLCY7E/LBr7+btthOjal3c7md6PTXQWA=";
+    rev = "eac81cf91555438c54fbadef7fdd05bf803f26ee";
+    hash = "sha256-XeEXvKi5O/0J6rEc8rZs4+x/ImF4X0GFw/dOWn9HCCQ=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
@@ -39,15 +46,19 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     doxygen
     pkg-config
+    protobuf
     swig
   ];
 
   buildInputs = [
+    catch2_3
     cppzmq
-    ffmpeg
+    ffmpeg_8
     imagemagick
     jsoncpp
     libopenshot-audio
+    (opencv4.override { ffmpeg_8-headless = ffmpeg_8; })
+    protobuf
     python3
     qt6.qtbase
     qt6.qtmultimedia
@@ -56,6 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
+    glib
+    pipewire
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     llvmPackages.openmp
@@ -67,6 +80,14 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   doCheck = true;
+
+  nativeCheckInputs = [ ctestCheckHook ];
+
+  # Spherical metadata is not round-tripped when writing/reading with FFmpeg 8
+  ctestFlags = [
+    "--exclude-regex"
+    "^SphericalMetadata"
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_RUBY" false)

--- a/pkgs/by-name/op/openshot-qt/package.nix
+++ b/pkgs/by-name/op/openshot-qt/package.nix
@@ -10,12 +10,12 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "openshot-qt";
-  version = "3.5.1-unstable-2026-04-22";
+  version = "3.5.1-unstable-2026-07-23";
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
-    rev = "930ff919762570eaf35a879574da8f8da9f196be";
-    hash = "sha256-o0BPEzkEAyoZkPkiR9G8i2nANgDFI4wjD5b9hGOqB0c=";
+    rev = "9cd2b3f3ee9024c3496487a2de30a402515ed659";
+    hash = "sha256-SoEt3tuydz+JUzhvUa7Pejxd1LYNia17YvGmVlnh48I=";
   };
   format = "setuptools";
 


### PR DESCRIPTION
…026-07-23


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
