### PR TITLE
openboard: fix build with ffmpeg 9

### DIFF
--- a/pkgs/by-name/op/openboard/ffmpeg-9-compat.patch
+++ b/pkgs/by-name/op/openboard/ffmpeg-9-compat.patch
@@ -1,0 +1,22 @@
+diff --git a/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp b/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
+index 24451f27..50e06801 100644
+--- a/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
++++ b/src/podcast/ffmpeg/UBFFmpegVideoEncoder.cpp
+@@ -448,9 +448,17 @@ bool UBFFmpegVideoEncoder::init()
+         }
+ 
+         c->bit_rate = 96000;
++#if LIBAVCODEC_VERSION_MAJOR >= 61
++        const AVSampleFormat *sampleFormats = nullptr;
++        int nbSampleFormats = 0;
++        avcodec_get_supported_config(c, audioCodec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0, (const void **)&sampleFormats, &nbSampleFormats);
++        c->sample_fmt  = (sampleFormats && nbSampleFormats) ? sampleFormats[0] : AV_SAMPLE_FMT_FLTP;
++#else
+         c->sample_fmt  = audioCodec->sample_fmts ? audioCodec->sample_fmts[0] : AV_SAMPLE_FMT_FLTP;// FLTP by default for AAC
++#endif
+         c->sample_rate = mAudioSampleRate;
+ 
++
+ #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(57, 25, 100)
+         c->channel_layout = AV_CH_LAYOUT_STEREO;
+         c->channels  = av_get_channel_layout_nb_channels(c->channel_layout);

--- a/pkgs/by-name/op/openboard/package.nix
+++ b/pkgs/by-name/op/openboard/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./poppler-26-compat.patch # https://github.com/OpenBoard-org/OpenBoard/pull/1474
+    ./ffmpeg-9-compat.patch # https://github.com/OpenBoard-org/OpenBoard/issues/1519
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
