### PR TITLE
nixos/gopodder: init gopodder

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -76,6 +76,8 @@
 
 - [gocron](https://github.com/flohoss/gocron), a task scheduler with web interface. Available as [services.gocron](#opt-services.gocron.enable).
 
+- [gopodder](https://github.com/cbrgm/gopodder), a self-hostable podcast synchronization server compatible with the gPodder API. Available as [services.gopodder](#opt-services.gopodder.enable).
+
 - [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
 
 - [ioquake3](https://ioquake3.org), a open-source port of the 3D action shooter Quake 3 Arena. Available as [programs.ioquake3](#opt-programs.ioquake3.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -904,6 +904,7 @@
   ./services/misc/gitolite.nix
   ./services/misc/gitweb.nix
   ./services/misc/gollum.nix
+  ./services/misc/gopodder.nix
   ./services/misc/gotenberg.nix
   ./services/misc/gpsd.nix
   ./services/misc/graphical-desktop.nix

--- a/nixos/modules/services/misc/gopodder.nix
+++ b/nixos/modules/services/misc/gopodder.nix
@@ -1,0 +1,206 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.services.gopodder;
+
+  usePostgres = cfg.database.type == "postgres";
+in
+{
+  options.services.gopodder = {
+    enable = mkEnableOption "Gopodder, podcast synchronization server";
+
+    package = mkPackageOption pkgs "gopodder" { };
+
+    host = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      example = "127.0.0.1";
+      description = "Host address Gopodder binds to.";
+    };
+
+    debugHost = mkOption {
+      type = types.str;
+      default = "";
+      example = "";
+      description = "Listen address for debug/metrics (disabled if empty).";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      example = 4242;
+      description = "TCP port Gopodder host will listen on.";
+    };
+
+    logLevel = mkOption {
+      type = types.enum [
+        "debug"
+        "info"
+        "warn"
+        "error"
+      ];
+      default = "info";
+      example = "debug";
+      description = "Log level (debug, info, warn, error)";
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Path to file containing runtime secrets, such as `GOPODDER_DB_PASSWORD`";
+      example = "/run/secrets/gopodder.env";
+    };
+
+    database = {
+      type = mkOption {
+        type = types.enum [
+          "sqlite"
+          "postgres"
+        ];
+        default = "sqlite";
+        description = "Database type to use";
+      };
+
+      host = mkOption {
+        type = types.str;
+        default = "";
+        description = "PostgreSQL host";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 5432;
+        description = "PostgreSQL port";
+      };
+
+      name = mkOption {
+        type = types.str;
+        default = "gopodder";
+        description = "PostgreSQL database name";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "gopodder";
+        description = "PostgreSQL user";
+      };
+
+      createLocally = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to create a local PostgreSQL database automatically";
+      };
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "gopodder";
+      description = "User account under which Gopodder runs";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "gopodder";
+      description = "Group under which Gopodder runs";
+    };
+
+    openFirewall = mkOption {
+      description = "Open ports in the firewall for the Gopodder web interface.";
+      default = false;
+      type = types.bool;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.database.createLocally -> usePostgres;
+        message = "services.gopodder.database.createLocally is enabled but not database.type is not postgres";
+      }
+      {
+        assertion = cfg.database.createLocally -> cfg.database.host == "";
+        message = "services.gopodder.database.host must be empty when services.gopodder.database.createLocally is enabled";
+      }
+      {
+        assertion =
+          cfg.database.createLocally
+          -> cfg.database.user == cfg.user && cfg.database.user == cfg.database.name;
+        message = "specifying services.gopodder.database.user should be the same as services.gopodder.user as well as services.gopodder.database.name when running a local db setup";
+      }
+      {
+        assertion = (usePostgres && !cfg.database.createLocally) -> cfg.environmentFile != null;
+        message = "specifying services.gopodder.environmentFile is not supported when used along with a local db setup";
+      }
+    ];
+
+    services.postgresql = mkIf (cfg.database.createLocally) {
+      enable = true;
+      ensureUsers = [
+        {
+          name = "${cfg.database.user}";
+          ensureDBOwnership = true;
+        }
+      ];
+      ensureDatabases = [ cfg.database.name ];
+    };
+
+    systemd.services.gopodder = {
+      description = "Gopodder podcast synchronization server";
+      wantedBy = [ "multi-user.target" ];
+      requires = optionals cfg.database.createLocally [
+        "postgresql.target"
+      ];
+      after = [
+        "network.target"
+      ]
+      ++ optionals cfg.database.createLocally [
+        "postgresql.target"
+      ];
+      environment = {
+        GOPODDER_LISTEN_ADDRESS = cfg.host + ":" + toString cfg.port;
+        GOPODDER_DEBUG_ADDRESS = cfg.debugHost;
+        GOPODDER_DB_BACKEND = cfg.database.type;
+        GOPODDER_LOG_LEVEL = cfg.logLevel;
+        GOPODDER_DB_PATH = mkIf (!usePostgres) "gopodder.db";
+      }
+      // optionalAttrs (cfg.database.createLocally) {
+        GOPODDER_DB_POSTGRES =
+          if cfg.database.host == "" then
+            "host=/run/postgresql dbname=${cfg.database.name} user=${cfg.database.user}"
+          else
+            "host=${cfg.database.host} port=${toString cfg.database.port} dbname=${cfg.database.name} user=${cfg.database.user}";
+      };
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = optional (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStart = "${cfg.package}/bin/gopodder serve";
+        WorkingDirectory = "/var/lib/gopodder";
+        StateDirectory = "gopodder";
+        StateDirectoryMode = "0700";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHome = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+    };
+
+    users.groups.${cfg.group} = { };
+  };
+
+  meta.maintainers = with maintainers; [ nielmin ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -720,6 +720,7 @@ in
   gollum = runTest ./gollum.nix;
   gonic = runTest ./gonic.nix;
   google-oslogin = runTest ./google-oslogin;
+  gopodder = runTest ./gopodder.nix;
   gopro-tool = runTest ./gopro-tool.nix;
   goss = runTest ./goss.nix;
   gotenberg = runTest ./gotenberg.nix;

--- a/nixos/tests/gopodder.nix
+++ b/nixos/tests/gopodder.nix
@@ -1,0 +1,39 @@
+{ lib, ... }: {
+  name = "gopodder";
+
+  nodes = {
+    vm1 = { pkgs, ... }: {
+      services.gopodder = {
+        enable = true;
+        port = 1234;
+        logLevel = "debug";
+      };
+    };
+    vm2 = { pkgs, ... }: {
+      services.gopodder = {
+        enable = true;
+        port = 8080;
+        database = {
+          type = "postgres";
+          createLocally = true;
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("SQLite backend on custom port"):
+        vm1.wait_for_unit("gopodder.service")
+        vm1.wait_for_open_port(1234)
+        vm1.succeed("curl --fail http://localhost:1234/")
+        vm1.succeed("test -d /var/lib/gopodder")
+
+    with subtest("PostgreSQL local database backend"):
+        vm2.wait_for_unit("postgresql.service")
+        vm2.wait_for_unit("gopodder.service")
+        vm2.wait_for_open_port(8080)
+        vm2.succeed("curl --fail http://localhost:8080/")
+  '';
+}


### PR DESCRIPTION
Add a NixOS module for [gopodder](https://github.com/cbrgm/gopodder), a self-hosted podcast sync server that I maintain.

I'm unsure if 'misc' is the right place for this type of service, so let me know that needs to be changed.

Besides the actual test, I also ran this on my personal config to make sure both `sqlite` and `postgres` work as intended.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
