### PR TITLE
bulletty: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/by-name/bu/bulletty/package.nix
+++ b/pkgs/by-name/bu/bulletty/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   rustPlatform,
+  cacert,
   fetchFromGitHub,
   pkg-config,
   openssl,
@@ -10,13 +11,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bulletty";
-  version = "0.2.2";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "CrociDB";
     repo = "bulletty";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Keo7Xl8dU5ZnUxXilf93qVv0tjx5O2JfWU1obzrprxo=";
+    hash = "sha256-ZuNug06zL89D7EWh6UFLiT/Xs/bQOEKY/UiDdkU091M=";
   };
 
   patches = [
@@ -24,13 +25,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./remove-rustfmt-exec.patch
   ];
 
-  cargoHash = "sha256-bwQcmA0/wQmwEobhDkDCi5s3MgxxCi0I4m2yuQ2/XZo=";
+  cargoHash = "sha256-fOuUBp5ij0ZqcRhhEIl3pAinsheIHF9VW9Uw3RB4pCI=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ];
 
+  checkInputs = [ cacert ];
+
   env.OPENSSL_NO_VENDOR = true;
+
+  # Upstream test binds a localhost TCP listener
+  __darwinAllowLocalNetworking = true;
+  sandboxProfile = ''
+    (allow mach-lookup
+     (global-name "com.apple.FSEvents")
+     (global-name "com.apple.SystemConfiguration.configd"))
+  '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
* update to [v0.3.0](https://github.com/crocidb/bulletty/releases/tag/v0.3.0) ([diff](https://github.com/crocidb/bulletty/compare/v0.2.2...v0.3.0))
* add and use `cacert` as a build input, since upstream added a test that uses HTTPS
* a few darwin-specific sandbox tweaks to support a test that uses the loopback interface

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
