### PR TITLE
flsmg: 4.0.23 -> 4.0.24

### DIFF
--- a/pkgs/by-name/fl/flmsg/add-missing-pthread-include.patch
+++ b/pkgs/by-name/fl/flmsg/add-missing-pthread-include.patch
@@ -1,0 +1,13 @@
+font_browser.cxx uses pthread_create and pthread_t, but never includes <pthread.h>
+The header is likely pulled from a different header that includes it; however, on stricter/newer compilers it will fail (It needs the header to be explicity included in the file it is called in)
+
+--- a/src/widgets/font_browser.cxx
++++ b/src/widgets/font_browser.cxx
+@@ -33,6 +33,7 @@
+ #include <string>
+ #include <cstdio>
+ #include <stdint.h>
++#include <pthread.h>
+
+ #include <FL/Fl.H>
+ #include <FL/Fl_Color_Chooser.H>

--- a/pkgs/by-name/fl/flmsg/package.nix
+++ b/pkgs/by-name/fl/flmsg/package.nix
@@ -5,16 +5,21 @@
   fltk_1_3,
   libjpeg,
   pkg-config,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "4.0.23";
+  version = "4.0.24";
   pname = "flmsg";
-
   src = fetchurl {
     url = "mirror://sourceforge/fldigi/flmsg-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-3eR0wrzkNjlqm5xW5dtgihs33cVUmZeS0/rf+xnPeRY=";
+    sha256 = "sha256-kzQHmND5zK/Hy40Z0RRstnJ5x5cjxDax0l2idjmeBpQ=";
   };
+
+  #This has been reported to upstream via email : w1hkj@w1hkj.com
+  patches = [
+    ./add-missing-pthread-include.patch
+  ];
 
   buildInputs = [
     fltk_1_3
@@ -24,6 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Digital modem message program";


### PR DESCRIPTION
Bump `flsmg` from 4.0.23 to 4.0.24

Added `versionCheckHook`
Included a patch to include the missing header file `pthread.h`, else `nix-build -A flmsg` will fail with the following error:
  > widgets/font_browser.cxx: In function 'void find_fonts()':
       > widgets/font_browser.cxx:391:13: error: 'pthread_create' was not de
       >   391 |         if (pthread_create(&find_font_thread, NULL, find_fi
       >       |             ^~~~~~~~~~~~~~
       >       |             pthread_t
       > make[2]: *** [Makefile:3513: widgets/flmsg-font_browser.o] Error 1
>

 I have also sent an email to upstream regarding this issue. (Upstream author and email: David Freese, w1hkj@w1hkj.com)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
