### PR TITLE
openbsd: fix package and static builds

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/makefs/compat.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/makefs/compat.patch
@@ -70,8 +70,9 @@ new file mode 100644
 index 00000000000..8cc830662bd
 --- /dev/null
 +++ b/usr.sbin/makefs/compat.h
-@@ -0,0 +1,71 @@
+@@ -0,0 +1,73 @@
 +#pragma once
++#ifndef __OpenBSD__
 +#include <stdint.h>
 +#include <stddef.h>
 +#include <stdio.h>
@@ -142,6 +143,7 @@ index 00000000000..8cc830662bd
 +		return -1;
 +	}
 +}
++#endif
 diff --git a/usr.sbin/makefs/ffs.c b/usr.sbin/makefs/ffs.c
 index b055c62a598..c99cbfef5a7 100644
 --- a/usr.sbin/makefs/ffs.c
@@ -225,7 +227,11 @@ index 00000000000..f382f87226c
 +#include <bsdroot/sys/sys/disklabel.h>
 diff --git a/usr.sbin/makefs/include/sys/endian.h b/usr.sbin/makefs/include/sys/endian.h
 new file mode 100644
-index 00000000000..e69de29bb2d
+index 00000000000..be462c1715e
+--- /dev/null
++++ b/usr.sbin/makefs/include/sys/endian.h
+@@ -0,0 +1 @@
++#include_next <sys/endian.h>
 diff --git a/usr.sbin/makefs/include/sys/uuid.h b/usr.sbin/makefs/include/sys/uuid.h
 new file mode 100644
 index 00000000000..7c2abace377
@@ -259,7 +265,11 @@ index 00000000000..9ec3e81be3d
 +#include <bsdroot/sys/ufs/ufs/dir.h>
 diff --git a/usr.sbin/makefs/include/util.h b/usr.sbin/makefs/include/util.h
 new file mode 100644
-index 00000000000..e69de29bb2d
+index 00000000000..99058c68b50
+--- /dev/null
++++ b/usr.sbin/makefs/include/util.h
+@@ -0,0 +1 @@
++#include_next <util.h>
 diff --git a/usr.sbin/makefs/makefs.c b/usr.sbin/makefs/makefs.c
 index af39605d996..10d86fa10e2 100644
 --- a/usr.sbin/makefs/makefs.c

--- a/pkgs/os-specific/bsd/openbsd/pkgs/rc/boot-phases.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rc/boot-phases.patch
@@ -7,7 +7,6 @@ also removes some of the parts of the boot script which are inappropriate for a
 nix-based system, for example, re-linking code objects and setting PATH.
 
 diff --git a/etc/rc b/etc/rc
-index 9d87fac8caf..581c1e3f4ab 100644
 --- a/etc/rc
 +++ b/etc/rc
 @@ -9,6 +9,10 @@ set +o sh
@@ -21,7 +20,7 @@ index 9d87fac8caf..581c1e3f4ab 100644
  # Strip in- and whole-line comments from a file.
  # Strip leading and trailing whitespace if IFS is set.
  # Usage: stripcom /path/to/file
-@@ -337,7 +341,6 @@ trap : 3	# Shouldn't be needed.
+@@ -359,7 +363,6 @@ trap : 3	# Shouldn't be needed.
  
  export HOME=/
  export INRC=1
@@ -29,7 +28,7 @@ index 9d87fac8caf..581c1e3f4ab 100644
  
  # /etc/myname contains my symbolic name.
  if [[ -f /etc/myname ]]; then
-@@ -413,17 +416,12 @@ fi
+@@ -431,17 +434,12 @@ fi
  # From now on, allow user to interrupt (^C) the boot process.
  trap "echo 'Boot interrupted.'; exit 1" 3
  
@@ -47,7 +46,7 @@ index 9d87fac8caf..581c1e3f4ab 100644
  
  rm -f /fastboot
  
-@@ -483,9 +481,9 @@ mount -s /var >/dev/null 2>&1		# cannot be on NFS
+@@ -503,9 +501,9 @@ mount -s /var >/dev/null 2>&1		# cannot be on NFS
  mount -s /var/log >/dev/null 2>&1	# cannot be on NFS
  mount -s /usr >/dev/null 2>&1		# if NFS, fstab must use IP address
  
@@ -59,31 +58,31 @@ index 9d87fac8caf..581c1e3f4ab 100644
  
  echo 'starting network'
  
-@@ -495,12 +493,10 @@ ifconfig -g carp carpdemote 128
+@@ -515,12 +513,10 @@ ifconfig -g carp carpdemote 128
  
  sh /etc/netstart
  
 -start_daemon unwind >/dev/null 2>&1
 +daemon_phase 30
  
- random_seed
+ store_random
  
 -wait_reorder_libs
 -
  # Load pf rules and bring up pfsync interface.
  if [[ $pf != NO ]]; then
  	if [[ -f /etc/pf.conf ]]; then
-@@ -522,8 +518,7 @@ dmesg >/var/run/dmesg.boot
+@@ -541,8 +537,7 @@ dmesg >/var/run/dmesg.boot
  make_keys
  
  echo -n 'starting early daemons:'
--start_daemon syslogd ldattach pflogd nsd unbound ntpd
+-start_daemon syslogd ldattach bpflogd pflogd nsd unbound ntpd
 -start_daemon iscsid isakmpd iked sasyncd ldapd npppd
 +daemon_phase 40
  echo '.'
  
  # Load IPsec rules.
-@@ -532,11 +527,7 @@ if [[ $ipsec != NO && -f /etc/ipsec.conf ]]; then
+@@ -551,11 +545,7 @@ if [[ $ipsec != NO && -f /etc/ipsec.conf ]]; then
  fi
  
  echo -n 'starting RPC daemons:'
@@ -96,13 +95,13 @@ index 9d87fac8caf..581c1e3f4ab 100644
  echo '.'
  
  # Check and mount remaining file systems and enable additional swap.
-@@ -626,43 +617,24 @@ echo 'preserving editor files.'; /usr/libexec/vi.recover
+@@ -648,43 +637,24 @@ echo 'preserving editor files.'; /usr/libexec/vi.recover
  run_upgrade_script sysmerge
  
  echo -n 'starting network daemons:'
 -start_daemon ldomd sshd snmpd ldpd ripd ospfd ospf6d bgpd ifstated
 -start_daemon relayd dhcpd dhcrelay mrouted dvmrpd radiusd eigrpd route6d
--start_daemon rad hostapd lpd smtpd slowcgi bgplgd httpd ftpd
+-start_daemon dhcp6leased rad hostapd lpd smtpd slowcgi bgplgd httpd ftpd
 -start_daemon ftpproxy ftpproxy6 tftpd tftpproxy identd inetd rarpd bootparamd
 -start_daemon rbootd mopd vmd spamd spamlogd sndiod
 +daemon_phase 60

--- a/pkgs/os-specific/bsd/openbsd/pkgs/stand/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/stand/package.nix
@@ -1,6 +1,7 @@
 {
   mkDerivation,
   stdenv,
+  buildPackages,
   pkgsBuildTarget,
 }:
 
@@ -10,12 +11,41 @@ mkDerivation {
 
   patches = [
     ../sys/initpath.patch
-    ./cmd-buff-size.patch
+    ../cmd-buff-size.patch
   ];
 
   # gcc compat
   postPatch = ''
     find $BSDSRCDIR -name Makefile -print0 | xargs -0 sed -E -i -e 's/-nopie/-no-pie/g'
+
+    # These host utilities require OpenBSD base libraries and are not installed.
+    substituteInPlace $BSDSRCDIR/sys/arch/amd64/stand/Makefile \
+      --replace-fail 'SUBDIR+=rdboot vmboot' ""
+
+    # lld requires an explicit zero image base for boot code linked below its
+    # default image base.
+    substituteInPlace \
+      $BSDSRCDIR/sys/arch/amd64/stand/{mbr,biosboot}/Makefile \
+      --replace-fail '-Ttext 0' '-Ttext 0 --image-base=0'
+    substituteInPlace \
+      $BSDSRCDIR/sys/arch/amd64/stand/{boot,cdboot,pxeboot}/Makefile \
+      --replace-fail '-Ttext $(LINKADDR)' '-Ttext $(LINKADDR) --image-base=0'
+    substituteInPlace $BSDSRCDIR/sys/arch/amd64/stand/cdbr/Makefile \
+      --replace-fail '-Ttext ''${ORG}' '-Ttext ''${ORG} --image-base=0'
+
+    # LLVM objcopy reads the lld-produced ELF image, then GNU objcopy converts
+    # it to the PE format used by EFI.
+    substituteInPlace $BSDSRCDIR/sys/arch/amd64/stand/efiboot/Makefile.common \
+      --replace-fail '    --target=''${OBJFMT} ''${PROG.so} ''${.TARGET}' \
+        '    --input-target=''${INPUTFMT} --output-target=''${OBJFMT} --subsystem=efi-app ''${PROG.so}.elf ''${.TARGET}'
+    sed -i '/^''${PROG}: ''${PROG.so}$/a\	''${LLVM_OBJCOPY} --output-target=''${INPUTFMT} ''${PROG.so} ''${PROG.so}.elf' \
+      $BSDSRCDIR/sys/arch/amd64/stand/efiboot/Makefile.common
+    substituteInPlace $BSDSRCDIR/sys/arch/amd64/stand/efiboot/bootx64/Makefile \
+      --replace-fail 'OBJFMT=		efi-app-x86_64' \
+        $'OBJFMT=\t\tpei-x86-64\nINPUTFMT=\telf64-x86-64'
+    substituteInPlace $BSDSRCDIR/sys/arch/amd64/stand/efiboot/bootia32/Makefile \
+      --replace-fail 'OBJFMT=		efi-app-ia32' \
+        $'OBJFMT=\t\tpei-i386\nINPUTFMT=\telf32-i386'
     substituteInPlace $BSDSRCDIR/sys/arch/*/stand/boot/check-boot.pl --replace-fail /usr/bin/objdump objdump
     substituteInPlace $BSDSRCDIR/sys/arch/*/stand/Makefile --replace-quiet " boot " " " --replace-quiet " fdboot " " "
   '';
@@ -32,6 +62,8 @@ mkDerivation {
     ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}objcopy $TMP/bin/objcopy
     ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}objcopy $TMP/bin/
 
+    export OBJCOPY="${buildPackages.binutils-unwrapped-all-targets}/bin/${stdenv.cc.targetPrefix}objcopy"
+    export LLVM_OBJCOPY="${buildPackages.llvmPackages.llvm}/bin/llvm-objcopy"
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-pointer-sign"
   '';
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sys/initpath.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sys/initpath.patch
@@ -9,23 +9,15 @@ diff --git a/sys/arch/amd64/amd64/machdep.c b/sys/arch/amd64/amd64/machdep.c
 index f58e6c585c1..874f5a74d6d 100644
 --- a/sys/arch/amd64/amd64/machdep.c
 +++ b/sys/arch/amd64/amd64/machdep.c
-@@ -181,6 +181,7 @@ int	physmem;
- u_int64_t	dumpmem_low;
- u_int64_t	dumpmem_high;
+@@ -186,6 +186,7 @@ int	physmem;
  extern int	boothowto;
 +extern char	initpath[MAXPATHLEN];
- int	cpu_class;
  
  paddr_t	dumpmem_paddr;
-@@ -255,6 +256,7 @@ bios_memmap_t	*bios_memmap;
- u_int32_t	bios_cksumlen;
- bios_efiinfo_t	*bios_efiinfo;
- bios_ucode_t	*bios_ucode;
-+char		*passed_init;
+ vaddr_t	dumpmem_vaddr;
+ psize_t	dumpmem_sz;
  
- #if NEFI > 0
- EFI_MEMORY_DESCRIPTOR *mmap;
-@@ -1992,6 +1994,7 @@ getbootinfo(char *bootinfo, int bootinfo_size)
+@@ -1992,6 +1993,7 @@ getbootinfo(char *bootinfo, int bootinfo_size)
  	bios_ddb_t *bios_ddb;
  	bios_bootduid_t *bios_bootduid;
  	bios_bootsr_t *bios_bootsr;
@@ -33,7 +25,7 @@ index f58e6c585c1..874f5a74d6d 100644
  #undef BOOTINFO_DEBUG
  #ifdef BOOTINFO_DEBUG
  	printf("bootargv:");
-@@ -2089,6 +2092,11 @@ getbootinfo(char *bootinfo, int bootinfo_size)
+@@ -2089,6 +2091,11 @@ getbootinfo(char *bootinfo, int bootinfo_size)
  			bios_ucode = (bios_ucode_t *)q->ba_arg;
  			break;
  
@@ -76,16 +68,7 @@ diff --git a/sys/kern/init_main.c b/sys/kern/init_main.c
 index b4816b2e9a0..db412097035 100644
 --- a/sys/kern/init_main.c
 +++ b/sys/kern/init_main.c
-@@ -103,6 +103,8 @@ extern void stoeplitz_init(void);
- #include "vscsi.h"
- #include "softraid.h"
- 
-+#define DEBUG 1
-+
- const char	copyright[] =
- "Copyright (c) 1982, 1986, 1989, 1991, 1993\n"
- "\tThe Regents of the University of California.  All rights reserved.\n"
-@@ -127,6 +129,7 @@ int	db_active = 0;
+@@ -127,6 +127,7 @@ int	db_active = 0;
  int	ncpus =  1;
  int	ncpusfound = 1;			/* number of cpus we find */
  volatile int start_init_exec;		/* semaphore for start_init() */
@@ -93,7 +76,7 @@ index b4816b2e9a0..db412097035 100644
  
  #if !defined(NO_PROPOLICE)
  long	__guard_local __attribute__((section(".openbsd.randomdata")));
-@@ -557,6 +560,7 @@ static char *initpaths[] = {
+@@ -557,6 +558,7 @@ static char *initpaths[] = {
  	"/sbin/init",
  	"/sbin/oinit",
  	"/sbin/init.bak",

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sys/package.nix
@@ -31,7 +31,7 @@
       +
         # Clang flags compatibility
         ''
-          find $BSDSRCDIR -name 'Makefile*' -exec sed -E -i -e 's/-fno-ret-protector/-fno-stack-protector/g' -e 's/-nopie/-no-pie/g' {} +
+          find $BSDSRCDIR -name 'Makefile*' -exec sed -E -i -e 's/-fno-ret-protector/-fno-stack-protector/g' -e 's/-fret-clean//g' -e 's/-nopie/-no-pie/g' {} +
           sed -E -i -e 's_^\tinstall.*$_\tinstall bsd ''${out}/bsd_' -e s/update-link// $BSDSRCDIR/sys/arch/*/conf/Makefile.*
         ''
       +

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -95,6 +95,8 @@ rec {
             (mkDerivationSuper args).overrideAttrs (
               args:
               (
+                # OpenBSD's rcrt0 expects the linker-provided _DYNAMIC symbol
+                # emitted for static PIE executables.
                 if (args ? NIX_CFLAGS_LINK) then
                   lib.warn
                     (
@@ -103,12 +105,18 @@ rec {
                       + lib.optionalString (args ? version) "-${args.version}"
                     )
                     {
-                      NIX_CFLAGS_LINK = toString (args.NIX_CFLAGS_LINK or "") + " -static";
+                      NIX_CFLAGS_LINK =
+                        toString (args.NIX_CFLAGS_LINK or "")
+                        + " -static"
+                        + lib.optionalString stdenv.hostPlatform.isOpenBSD " -pie";
                     }
                 else
                   {
                     env = (args.env or { }) // {
-                      NIX_CFLAGS_LINK = toString (args.env.NIX_CFLAGS_LINK or "") + " -static";
+                      NIX_CFLAGS_LINK =
+                        toString (args.env.NIX_CFLAGS_LINK or "")
+                        + " -static"
+                        + lib.optionalString stdenv.hostPlatform.isOpenBSD " -pie";
                     };
                   }
               )


### PR DESCRIPTION
## Description

Fix OpenBSD cross-compilation support and update the patches used by NixBSD.

- Refresh the kernel init path and boot phase patches (NixBSD).
- Fix OpenBSD kernel and bootloader cross builds with current Clang, lld, and objcopy.
- Fix `makefs` compatibility headers shadowing OpenBSD target headers.
- Build OpenBSD static binaries as static PIE, as required by `rcrt0`.

This addresses OpenBSD cross-build and static-linking issues noted after the [OpenBSD 7.9 source update in NixOS/nixpkgs#534600](https://github.com/NixOS/nixpkgs/pull/534600).

I also opened a PR upstream for the `-pie` flag, so it get's handled by default in the future https://github.com/llvm/llvm-project/pull/216907

## What was built

All 97 supported cross-compiled OpenBSD derivations, both normally and with `pkgsStatic`:

```nix
nix build --impure --no-link --keep-going --expr '
  let
    p = import ./. {
      system = builtins.currentSystem;
      crossSystem = "x86_64-unknown-openbsd";
    };
    packagesFor = ps:
      let
        scope = removeAttrs ps.openbsd [
          "boot-config"
          "boot-ctags"
          "compatHook"
        ];
      in
      builtins.filter
        (d: p.lib.isDerivation d && p.lib.meta.availableOn ps.stdenv.hostPlatform d)
        (builtins.attrValues scope);
  in
  packagesFor p ++ packagesFor p.pkgsStatic
'
```

A representative static binary was also inspected:

```
ELF 64-bit LSB pie executable, x86-64, OpenBSD, static-pie linked
```

_Assisted-by: Codex (GPT-5.6-Sol)_

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
