### PR TITLE
libinklevel: 0.9.4 -> 0.9.7

### DIFF
--- a/pkgs/by-name/li/libinklevel/package.nix
+++ b/pkgs/by-name/li/libinklevel/package.nix
@@ -4,20 +4,22 @@
   fetchurl,
   pkg-config,
   libusb1,
+  libxml2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libinklevel";
-  version = "0.9.4";
+  version = "0.9.7";
 
   src = fetchurl {
     url = "mirror://sourceforge/libinklevel/libinklevel-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-J0cEaC5v4naO4GGUzdfV55kB7KzA+q+v64i5y5Xbp9Q=";
+    sha256 = "sha256-gZ07tMJXhyLBBXyfPamZoaPrRmKPD+ka61K/zNOIRnU=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     libusb1
+    libxml2
   ];
 
   outputs = [


### PR DESCRIPTION
Bump `libinklevel` from 0.9.4 to 0.9.7

Added `libxml2` to `buildInputs`; this was required since `0.9.5`

This can be verified over here: https://libinklevel.sourceforge.net/index.html
> <html>
> <body>
> <!--StartFragment-->
> 28/12/2022 | Release of version 0.9.5. This release adds support for Canon TS 200 series printers. Libxml2 has been > added as a dependency.
> <!--EndFragment-->
> </body>
> </html>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
