### PR TITLE
scopehal-apps: 0.1.1 -> 0.2.2

### DIFF
--- a/pkgs/by-name/sc/scopehal-apps/package.nix
+++ b/pkgs/by-name/sc/scopehal-apps/package.nix
@@ -4,43 +4,41 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  gtkmm3,
-  cairomm,
+  gtk3,
   yaml-cpp,
   glfw,
+  libpng,
   libtirpc,
   liblxi,
   libsigcxx,
-  glew,
-  zstd,
+  zlib,
   wrapGAppsHook3,
   makeBinaryWrapper,
   writeDarwinBundle,
   shaderc,
   vulkan-headers,
   vulkan-loader,
-  vulkan-tools,
   glslang,
   spirv-tools,
-  ffts,
   moltenvk,
   llvmPackages,
   hidapi,
+  wayland,
+  wayland-scanner,
 }:
 
 let
-  pname = "scopehal-apps";
-  version = "0.1.1";
+  version = "0.2.2";
 in
 stdenv.mkDerivation {
   pname = "scopehal-apps";
-  version = "${version}";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "ngscopeclient";
     repo = "scopehal-apps";
     tag = "v${version}";
-    hash = "sha256-7ZXfxfRa+1fbMj2IDF/boNL/qCy4i9IyMnzIgOZunDw=";
+    hash = "sha256-LhkhSuoj6lHz3zB4U37qDkMxfV1UktIjwJvwbVGKDDM=";
     fetchSubmodules = true;
   };
 
@@ -54,6 +52,7 @@ stdenv.mkDerivation {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     wrapGAppsHook3
+    wayland-scanner
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     makeBinaryWrapper
@@ -61,23 +60,21 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    cairomm
-    glew
     glfw
     glslang
+    hidapi
     liblxi
+    libpng
     libsigcxx
     vulkan-headers
     vulkan-loader
-    vulkan-tools
     yaml-cpp
-    zstd
-    hidapi
+    zlib
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    ffts
-    gtkmm3
+    gtk3
     libtirpc
+    wayland
   ]
   ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -89,16 +86,11 @@ stdenv.mkDerivation {
     "-DNGSCOPECLIENT_PACKAGE_VERSION_LONG=v${version}-0"
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    # error: variable 'empty_string' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]
-    "-Wno-error=uninitialized"
-  ];
-
   patches = [
     ./remove-required-lsb-release.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    ./remove-brew-molten-vk-lookup.patch
+    ./remove-macos-bundle-fixup.patch
   ];
 
   postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/sc/scopehal-apps/remove-macos-bundle-fixup.patch
+++ b/pkgs/by-name/sc/scopehal-apps/remove-macos-bundle-fixup.patch
@@ -1,12 +1,17 @@
+MoltenVK comes from nixpkgs rather than Homebrew, so the `brew --prefix`
+lookup is a hard build failure here. fixup_bundle() copies dependencies into
+the output and rewrites their install names, which fails in the Nix store
+layout, and signing.cmake resolves its bundle root to
+${CMAKE_INSTALL_PREFIX}/../.. -- i.e. /nix -- and would chmod and re-sign every
+dylib it finds there.
+
 diff --git a/src/ngscopeclient/CMakeLists.txt b/src/ngscopeclient/CMakeLists.txt
-index fb6d19fa..25611981 100644
 --- a/src/ngscopeclient/CMakeLists.txt
 +++ b/src/ngscopeclient/CMakeLists.txt
-@@ -249,31 +249,6 @@ if(LINUX)
- 		DESTINATION share/mime/packages)
+@@ -278,28 +278,9 @@ if(LINUX)
  endif()
- 
--if(APPLE)
+
+ if(APPLE)
 -	set(APPS "\${CMAKE_INSTALL_PREFIX}/bin/ngscopeclient")
 -	set(DIRS "\${CMAKE_INSTALL_PREFIX}/lib")
 -	set(FRAMEWORKS "\${CMAKE_INSTALL_PREFIX}/Frameworks")
@@ -20,17 +25,15 @@ index fb6d19fa..25611981 100644
 -	if(NOT MOLTEN_VK_RESULT EQUAL 0)
 -		message(FATAL_ERROR "failed to find Homebrew prefix for molten-vk")
 -	endif()
--	# https://vulkan.lunarg.com/doc/view/1.3.275.0/mac/getting_started.html#application-bundle-structure-on-macos
--	install(FILES "${CMAKE_SOURCE_DIR}/src/ngscopeclient/macos/MoltenVK_icd.json"
--		DESTINATION bin/vulkan/icd.d/)
+ 	# https://vulkan.lunarg.com/doc/view/1.3.275.0/mac/getting_started.html#application-bundle-structure-on-macos
+ 	install(FILES "${CMAKE_SOURCE_DIR}/src/ngscopeclient/macos/MoltenVK_icd.json"
+ 		DESTINATION bin/vulkan/icd.d/)
 -	install(FILES "${MOLTEN_VK_OUTPUT}/lib/libMoltenVK.dylib" DESTINATION lib)
 -	install(CODE "
 -		include(BundleUtilities)
--		fixup_bundle(\"${APPS}\" \"lib/libMoltenVK.dylib\" \"${DIRS}\")
+-		fixup_bundle(\"${APPS}\" \"${DIRS}/libMoltenVK.dylib\" \"${DIRS}\")
 -		include(\"${CMAKE_SOURCE_DIR}/src/ngscopeclient/macos/signing.cmake\")
 -		")
--endif()
--
+ endif()
+
  # ngscopeclient Windows portable zip/MSI installer build
- if(WIXPATH AND WIN32)
- 	# Run the command to get /mingw64/bin full path using where gcc

--- a/pkgs/by-name/sc/scopehal-apps/remove-required-lsb-release.patch
+++ b/pkgs/by-name/sc/scopehal-apps/remove-required-lsb-release.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 69d8c7b..a2f3b8c 100644
+index 45deed0..a2f3b8c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -337,14 +337,14 @@ set(CPACK_STRIP_FILES TRUE)
+@@ -353,15 +353,15 @@ set(CPACK_STRIP_FILES TRUE)
 
  # Figure out what distro version we're on
  if(LINUX)
@@ -20,3 +20,4 @@ index 69d8c7b..a2f3b8c 100644
 +		)
 
  	message(STATUS "Linux distribution target for packaging: name ${DISTRO_NAME}, version ${DISTRO_VER}")
+


### PR DESCRIPTION
https://github.com/ngscopeclient/scopehal-apps/compare/v0.1.1...v0.2.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
