### PR TITLE
nixl: 1.3.2 -> 1.4.0

### DIFF
--- a/pkgs/by-name/ni/nixl/package.nix
+++ b/pkgs/by-name/ni/nixl/package.nix
@@ -36,7 +36,7 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "nixl";
-  version = "1.3.2";
+  version = "1.4.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -45,7 +45,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     owner = "ai-dynamo";
     repo = "nixl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aSZ9kiEAQlVFW3+XJih5Ujk1mxOvaepX19u3Xfz4iSg=";
+    hash = "sha256-fOtPutRgKscP396J0Rh6V9PIQ+LsE7h71vtduviHvWI=";
   };
 
   postPatch =
@@ -63,17 +63,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     + ''
       substituteInPlace src/plugins/ucx/ucx_backend.cpp \
         --replace-fail 'io_->post(' 'asio::post(*io_, '
-    ''
-    # Fix UB: explicit destructor call on lock_guard (GCC 15 -Werror=maybe-uninitialized)
-    # Replace lock_guard + manual destructor with unique_lock + unlock()
-    + ''
-      substituteInPlace src/plugins/libfabric/libfabric_backend.cpp \
-        --replace-fail \
-          'std::lock_guard<std::mutex> lock(connection_state_mutex_);' \
-          'std::unique_lock<std::mutex> lock(connection_state_mutex_);' \
-        --replace-fail \
-          'lock.~lock_guard();' \
-          'lock.unlock();'
     ''
     # Fix GDS plugin: Nix uses lib/ not lib64/
     + ''

--- a/pkgs/development/python-modules/nixl/default.nix
+++ b/pkgs/development/python-modules/nixl/default.nix
@@ -63,13 +63,18 @@ buildPythonPackage.override { inherit (nixl) stdenv; } (finalAttrs: {
     torch
   ];
 
-  # Install the `nixl` shim module (re-exports nixl_cu{12,13}).
-  # Upstream builds this as a separate wheel via `uv build` (nixl-meta), but that doesn't work in
+  # Install the `nixl` shim module (re-exports nixl_cu{12,13}) along with its `nixl_meta_utils`
+  # helper.
+  # Upstream builds these as a separate wheel via `uv build` (nixl-meta), but that doesn't work in
   # the sandbox.
   postInstall = ''
     install -Dm644 \
       src/bindings/python/nixl-meta/nixl/__init__.py \
       "$out/${python.sitePackages}/nixl/__init__.py"
+
+    install -Dm644 \
+      src/bindings/python/nixl-meta/nixl_meta_utils.py \
+      "$out/${python.sitePackages}/nixl_meta_utils.py"
   '';
 
   pythonImportsCheck = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/ai-dynamo/nixl/compare/v1.3.2...v1.4.0
Changelog: https://github.com/ai-dynamo/nixl/releases/tag/v1.4.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test