### PR TITLE
kanidm_1_11: 1.11.0 -> 1.11.1

### DIFF
--- a/pkgs/servers/kanidm/1_11.nix
+++ b/pkgs/servers/kanidm/1_11.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  version = "1.11.0";
-  hash = "sha256-3dcJxJx8UFebW6WMdVTH6kfsNBed+55JFwHWVhZulOU=";
-  cargoHash = "sha256-qOs/uSs3iaiTGsqydpNbZ6KSLNE+k+5bM7k3ijRzNT0=";
+  version = "1.11.1";
+  hash = "sha256-IQmXHl+Gx7QLuLUCmIh919o+ziCy2q2NvVabwQwhML0=";
+  cargoHash = "sha256-DSYynKWb9jjFp3u3c6z9dFXts8ydgEho7xoFlL6cPXs=";
 }


### PR DESCRIPTION
Changelog: https://github.com/kanidm/kanidm/releases/tag/v1.11.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
