### PR TITLE
moonlight-qt: 6.1.0 -> 6.1.0-unstable-2026-08-06, update to ffmpeg9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8460,6 +8460,12 @@
     githubId = 5085029;
     name = "Emanuele Peruffo";
   };
+  epic9491 = {
+    github = "epic9491";
+    githubId = 213664452;
+    matrix = "@gumbo:senseii.dev";
+    name = "sensei";
+  };
   EpicEric = {
     email = "eric@eric.dev.br";
     github = "EpicEric";

--- a/pkgs/by-name/mo/moonlight-qt/package.nix
+++ b/pkgs/by-name/mo/moonlight-qt/package.nix
@@ -2,13 +2,12 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   qt6,
   pkg-config,
   vulkan-headers,
   SDL2,
   SDL2_ttf,
-  ffmpeg_8,
+  ffmpeg,
   libopus,
   libplacebo,
   openssl,
@@ -24,23 +23,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "moonlight-qt";
-  version = "6.1.0";
+  # Upstream has not tagged a release since v6.1.0 in September 2024, and that
+  # tag predates the FFmpeg 7.1 API migration, so it cannot build against
+  # current FFmpeg.
+  version = "6.1.0-unstable-2026-08-06";
 
   src = fetchFromGitHub {
     owner = "moonlight-stream";
     repo = "moonlight-qt";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-rWVNpfRDLrWsqELPFquA6rW6/AfWV+6DNLUCPqIhle0=";
+    rev = "2e13ed9977bc31c73caf8428f08f58d793313ece";
+    hash = "sha256-kCm/YoFGcXhF/Abi5lRV5F7H1AbKJchdDOlfBVR0tRA=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # Fix build for Xcode < 14
-    (fetchpatch {
-      url = "https://github.com/moonlight-stream/moonlight-qt/commit/76deafbd7bf868562d69061e7d6abf2612a2c7ad.patch";
-      hash = "sha256-+rXdexZQpOP6yS+oTmvYVxasWxOX16uU1udN75zNX3w=";
-    })
-  ];
 
   nativeBuildInputs = [
     qt6.qmake
@@ -52,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL2
     SDL2_ttf
-    ffmpeg_8
+    ffmpeg
     libopus
     libplacebo
     qt6.qtdeclarative
@@ -78,10 +72,11 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/Applications/Moonlight.app/Contents/MacOS/Moonlight $out/bin/moonlight
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
-    changelog = "https://github.com/moonlight-stream/moonlight-qt/releases/tag/v${finalAttrs.version}";
     description = "Play your PC games on almost any device";
     homepage = "https://moonlight-stream.org";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
moonlight-qt 6.1.0 doesn't build against FFmpeg 9. It's currently pinned to ffmpeg_8 to work around that, but this only delays the problem until ffmpeg_8 is removed.

Upstream fixed this a while ago but they haven't tagged a release since 6.1.0 (2 years old) despite still actively developing, so there's no newer version to bump to. This moves to a master snapshot, which builds against current FFmpeg and lets the pin be dropped. The Xcode < 14 patch is upstream now; it's been dropped.

PR #552212 fixes this without overhauling the package. Fmpeg 9 removed AVCodec.pix_fmts and changed the Vulkan queue API. This caused the previous breakage once nixpkgs-unstable bumped Ffmpeg.

@azuwis @zmitchell 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
