### PR TITLE
treewide: finalAttrs.doCheck -> finalAttrs.finalPackage.doCheck

### DIFF
--- a/pkgs/by-name/ca/cadabra2/package.nix
+++ b/pkgs/by-name/ca/cadabra2/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
     (lib.cmakeBool "PACKAGING_MODE" true)
 
-    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/co/collada-dom/package.nix
+++ b/pkgs/by-name/co/collada-dom/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "OPT_COMPILE_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "OPT_COMPILE_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;

--- a/pkgs/by-name/in/intel-llvm/unified-runtime.nix
+++ b/pkgs/by-name/in/intel-llvm/unified-runtime.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     filecheck
   ];
 
-  postPatch = lib.optionalString finalAttrs.doCheck ''
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
     # These tests don't run without setting UR_DPCXX,
     # however they aren't properly excluded, causing lit to fail.
     rm test/adapters/hip/lit.cfg.py
@@ -139,9 +139,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     (lib.cmakeBool "UR_ENABLE_LATENCY_HISTOGRAM" true)
 
-    (lib.cmakeBool "UR_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "UR_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     # The test hello_world.test depends on the hello_world example, so build examples when testing
-    (lib.cmakeBool "UR_BUILD_EXAMPLES" finalAttrs.doCheck)
+    (lib.cmakeBool "UR_BUILD_EXAMPLES" finalAttrs.finalPackage.doCheck)
 
     (lib.cmakeBool "UR_BUILD_ADAPTER_L0" levelZeroSupport)
     (lib.cmakeBool "UR_BUILD_ADAPTER_L0_V2" levelZeroSupport)

--- a/pkgs/by-name/jr/jrl-cmakemodules/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "JRL_CMAKEMODULES_GENERATE_API_DOC" true)
-    (lib.cmakeBool "JRL_CMAKEMODULES_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "JRL_CMAKEMODULES_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -78,7 +78,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     # rejects -ftls-model; fall back to non-thread-local errno.
     (lib.mesonBool "thread-local-storage" false)
   ]
-  ++ lib.optionals finalAttrs.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     (lib.mesonBool "tests" true)
     (lib.mesonBool "native-tests" canExecute)
     (lib.mesonBool "native-math-tests" canExecute)

--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_DOCUMENTATION" false)
     (lib.cmakeBool "BUILD_EXAMPLES" false)
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "BUILD_OMEMO" withOmemo)
     (lib.cmakeBool "WITH_ENCRYPTION" withEncryption)
     (lib.cmakeBool "WITH_GSTREAMER" withGstreamer)

--- a/pkgs/by-name/un/unified-memory-framework/package.nix
+++ b/pkgs/by-name/un/unified-memory-framework/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
   ]
-  ++ lib.optionals finalAttrs.doCheck [
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
     numactl
     gtest
     gbenchmark
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     (lib.cmakeBool "UMF_BUILD_LIBUMF_POOL_JEMALLOC" useJemalloc)
 
-    (lib.cmakeBool "UMF_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "UMF_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     # We won't be able to run these inside the sandbox, so no use in building them
     (lib.cmakeBool "UMF_BUILD_GPU_TESTS" false)
     (lib.cmakeBool "UMF_BUILD_BENCHMARKS" false)

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -188,7 +188,7 @@ buildPythonPackage (finalAttrs: {
 
   # Disable on aarch64-linux due to broken onnxruntime
   # https://github.com/microsoft/onnxruntime/issues/10038
-  pythonImportsCheck = lib.optionals finalAttrs.doCheck [ "chromadb" ];
+  pythonImportsCheck = lib.optionals finalAttrs.finalPackage.doCheck [ "chromadb" ];
 
   # Test collection breaks on aarch64-linux
   doCheck = with stdenv.buildPlatform; !(isAarch && isLinux);

--- a/pkgs/development/python-modules/prefect/default.nix
+++ b/pkgs/development/python-modules/prefect/default.nix
@@ -108,7 +108,7 @@ buildPythonPackage (finalAttrs: {
         'default-version = "3.6.24+nogit"' \
         'default-version = "${finalAttrs.version}"'
   ''
-  + lib.optionalString finalAttrs.doCheck ''
+  + lib.optionalString finalAttrs.finalPackage.doCheck ''
     substituteInPlace src/prefect/__init__.py \
       --replace-fail \
         '__development_base_path__: pathlib.Path = __module_path__.parents[1]' \

--- a/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
+++ b/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
@@ -54,7 +54,9 @@ buildPythonPackage (finalAttrs: {
 
   # When doCheck is disabled, nnativeCheckInputs are not available and the package fails to import:
   #   ModuleNotFoundError: No module named 'snakemake'
-  pythonImportsCheck = lib.optionals finalAttrs.doCheck [ "snakemake_storage_plugin_xrootd" ];
+  pythonImportsCheck = lib.optionals finalAttrs.finalPackage.doCheck [
+    "snakemake_storage_plugin_xrootd"
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
context https://github.com/NixOS/nixpkgs/issues/272978

Thanks @coolcuber for pointing to this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
