### PR TITLE
unifont: fix cross compilation

### DIFF
--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -1,6 +1,8 @@
 {
   lib,
   stdenv,
+  bashNonInteractive,
+  buildPackages,
   fetchurl,
   perl,
   bdftopcf,
@@ -25,6 +27,14 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     rm -r font/precompiled
     patchShebangs ./src
+    ${lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      substituteInPlace Makefile --replace-fail \
+        'bin/unigenwidth ' \
+        '$(BINDIR)/unigenwidth '
+      substituteInPlace font/Makefile --replace-fail \
+        '"BINDIR:../../../$(BINDIR)/"' \
+        '"BINDIR:$(BINDIR)/"'
+    ''}
   '';
 
   nativeBuildInputs = [
@@ -35,16 +45,26 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    bashNonInteractive
     perlenv
   ];
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "BINDIR=${buildPackages.unifont.bin}/bin"
+  ];
 
   buildFlags = [ "BUILDFONT=1" ];
 
   postInstall = ''
     moveToOutput bin "$bin"
     moveToOutput share/unifont "$doc"
+  '';
+
+  postFixup = ''
+    patchShebangs --host --update "$bin"
   '';
 
   outputs = [


### PR DESCRIPTION
fixes `nix-build -A pkgsCross.aarch64-multiplatform.unifont`.

unifont uses binaries produced early in the build to perform the later build steps. that would mean invoking binaries built for the wrong architecture when cross-compiling, but they provide a `BINDIR=...` Makefile option for us to provide the build-time binaries in this case.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
