### PR TITLE
libfishsound: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/by-name/li/libfishsound/package.nix
+++ b/pkgs/by-name/li/libfishsound/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   autoreconfHook,
   libvorbis,
   speex,
@@ -12,36 +11,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libfishsound";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchurl {
     url = "https://downloads.xiph.org/releases/libfishsound/libfishsound-${finalAttrs.version}.tar.gz";
-    sha256 = "1iz7mn6hw2wg8ljaw74f4g2zdj68ib88x4vjxxg3gjgc5z75f2rf";
+    sha256 = "sha256-A+sWAeIwatyIx3av3yEiF8ZUeZDS0PnKVE2tmoqdu48=";
   };
-
-  patches =
-    let
-      fetchDebPatch =
-        { name, hash }:
-        fetchpatch {
-          inherit name hash;
-          url = "https://salsa.debian.org/multimedia-team/libfishsound/-/raw/f25f31a13dd2ce008614427889b08e6f2222898f/debian/patches/${name}";
-        };
-    in
-    map fetchDebPatch [
-      {
-        name = "0001-Patch-configure.ac-to-specify-config-macro-dir.patch";
-        hash = "sha256-3cijMhgxqwFisc5nt8826QUwOqPI7H425QkDcjnD4iM=";
-      }
-      {
-        name = "0002-flac-set-vendor_string.length-0.patch";
-        hash = "sha256-8195rU9IAhFL3MgB4jLwtJv6BWgz22A38+RmIymIQoo=";
-      }
-      {
-        name = "0003-Fix-incompatible-flac-callback-types.patch";
-        hash = "sha256-BxG1hlThzhJ6VeGcsNpDEtVyKSJTLGFKeHFpFoXW54A=";
-      }
-    ];
 
   propagatedBuildInputs = [
     libvorbis


### PR DESCRIPTION
Bump `libfishsound` from 1.0.0 to 1.0.1

Drop the three Debian patches: all are now merged upstream in 1.0.1

Upstream (gitlab.xiph.org/xiph/libfishsound), tag 1.0.1:
- Patch configure.ac to specify config macro dir https://gitlab.xiph.org/xiph/libfishsound/-/merge_requests/2
- flac: set vendor_string.length = 0 https://gitlab.xiph.org/xiph/libfishsound/-/commit/9201079c51
- Fixed incompatible flac callback types https://gitlab.xiph.org/xiph/libfishsound/-/commit/4a9d94aec6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
