### PR TITLE
 zenoh-c: fix CMake export,  zenoh-cpp: fix CMake export

### DIFF
--- a/pkgs/by-name/ze/zenoh-c/package.nix
+++ b/pkgs/by-name/ze/zenoh-c/package.nix
@@ -8,7 +8,7 @@
   rustc,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zenoh-c";
   version = "1.9.0"; # nixpkgs-update: no auto update
 
@@ -22,13 +22,22 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src pname version;
+    inherit (finalAttrs) src pname version;
     hash = "sha256-7xWu9wgZqDzd60buMnF9B6Y5LRkG5C2JWiG7VwgSCvU=";
   };
 
   outputs = [
     "out"
     "dev"
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    # Those features are used by
+    # https://github.com/ros2/rmw_zenoh/blob/rolling/zenoh_cpp_vendor/CMakeLists.txt
+    (lib.cmakeBool "ZENOHC_BUILD_WITH_SHARED_MEMORY" true)
+    (lib.cmakeBool "ZENOHC_BUILD_WITH_UNSTABLE_API" true)
+    (lib.cmakeFeature "ZENOHC_CARGO_FLAGS" "--features=zenoh/transport_serial")
   ];
 
   nativeBuildInputs = [
@@ -38,10 +47,16 @@ stdenv.mkDerivation rec {
     rustc
   ];
 
+  # ref. https://github.com/eclipse-zenoh/zenoh-c/pull/1314
   postInstall = ''
     substituteInPlace $out/lib/pkgconfig/zenohc.pc \
       --replace-fail "\''${prefix}/" ""
+    substituteInPlace $out/lib/cmake/zenohc/zenohcConfig.cmake \
+      --replace-fail "''${PACKAGE_PREFIX_DIR}" "$out"
   '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "C API for zenoh";
@@ -52,4 +67,4 @@ stdenv.mkDerivation rec {
     ];
     maintainers = with lib.maintainers; [ markuskowa ];
   };
-}
+})

--- a/pkgs/by-name/ze/zenoh-cpp/package.nix
+++ b/pkgs/by-name/ze/zenoh-cpp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   zenoh-c,
 }:
@@ -17,9 +18,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MwQKTxrQqfoASCRk+vBeS9EHvmh6sqrpqygQVrdGkWw=";
   };
 
+  patches = [
+    # ref. https://github.com/eclipse-zenoh/zenoh-cpp/pull/790 merged upstream
+    (fetchpatch2 {
+      name = "fix-cmake-exports-and-pc.patch";
+      url = "https://github.com/eclipse-zenoh/zenoh-cpp/commit/a55543277ce93fa3d0871b5b30fb18c04a283db2.patch?full_index=true";
+      hash = "sha256-oaCeLTrQ7veWzpTEKGo4pDmNLKmnBIjBkuX71vRtjoo=";
+    })
+  ];
+
   cmakeFlags = [
-    "-DZENOHCXX_ZENOHC=ON"
-    "-DZENOHCXX_ZENOHPICO=OFF"
+    (lib.cmakeBool "ZENOHCXX_ZENOHC" true)
+    (lib.cmakeBool "ZENOHCXX_ZENOHPICO" false)
   ];
 
   nativeBuildInputs = [
@@ -30,10 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     zenoh-c
   ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/zenohcxx.pc \
-      --replace-fail "\''${prefix}/" ""
-  '';
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "C++ API for zenoh";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
