### PR TITLE
python3Packages.jupyterlite-sphinx: 0.22.1 -> 0.23.0; datalab: add ngi team to leaf deps

### DIFF
--- a/pkgs/development/python-modules/intersphinx-registry/default.nix
+++ b/pkgs/development/python-modules/intersphinx-registry/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pyprojectVersionPatchHook,
 
   # build-system
   flit-core,
@@ -32,6 +33,10 @@ buildPythonPackage (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-yFpk3NZO2iCjuJ43WvssbDYxNJ6G6KfY5pcTCilsGQs=";
   };
+
+  nativeBuildInputs = [
+    pyprojectVersionPatchHook
+  ];
 
   build-system = [
     flit-core

--- a/pkgs/development/python-modules/intersphinx-registry/default.nix
+++ b/pkgs/development/python-modules/intersphinx-registry/default.nix
@@ -78,5 +78,6 @@ buildPythonPackage (finalAttrs: {
     mainProgram = "intersphinx-registry";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/development/python-modules/jupyterlite-core/default.nix
+++ b/pkgs/development/python-modules/jupyterlite-core/default.nix
@@ -51,5 +51,6 @@ buildPythonPackage (finalAttrs: {
     mainProgram = "jupyter-lite";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
@@ -81,5 +81,6 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/jupyterlite/jupyterlite-sphinx/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "jupyterlite-sphinx";
-  version = "0.22.1";
+  version = "0.23.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -31,7 +31,7 @@ buildPythonPackage (finalAttrs: {
     owner = "jupyterlite";
     repo = "jupyterlite-sphinx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eww/VyHbAp78Bz2jg43XHmetEDrXEqXK45cnXHElG80=";
+    hash = "sha256-cMMPf0CE0YMly6nHze2BZQLdNk32bS9tzVFYLAb38Ew=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/sphinx-gallery/default.nix
+++ b/pkgs/development/python-modules/sphinx-gallery/default.nix
@@ -130,5 +130,6 @@ buildPythonPackage (finalAttrs: {
     mainProgram = "sphinx_gallery_py2jupyter";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
 })


### PR DESCRIPTION
Supersedes and closes https://github.com/NixOS/nixpkgs/pull/552098

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
