### PR TITLE
veusz: fix build and runtime

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -519,6 +519,18 @@
     githubId = 908758;
     name = "Abigail Bunyan";
   };
+  abkein = {
+    email = "rickbatra0z@gmail.com";
+    githubId = 55838194;
+    github = "abkein";
+    matrix = "@ab-kein:matrix.org";
+    name = "Ab Kein";
+    keys = [
+      {
+        fingerprint = "1702 7FA2 CDE2 89D5 D161  3C39 94A8 4F22 E630 CA42";
+      }
+    ];
+  };
   aboseley = {
     email = "adam.boseley@gmail.com";
     github = "aboseley";

--- a/pkgs/by-name/ve/veusz/package.nix
+++ b/pkgs/by-name/ve/veusz/package.nix
@@ -1,30 +1,40 @@
 {
   lib,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
   python3Packages,
-  fetchPypi,
   qt6,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "veusz";
   version = "4.2.1";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-+txG1MQWbZaVq322p4ZctzanPw+geEf9ilu5kGQI3Qk=";
+  src = fetchFromGitHub {
+    owner = finalAttrs.pname;
+    repo = finalAttrs.pname;
+    rev = "veusz-${finalAttrs.version}";
+    hash = "sha256-gQasdQuXLDDVEELY2ux2URu8888V8CIUwyXBcNnPmPE=";
   };
 
-  nativeBuildInputs = [
-    python3Packages.sip
-    python3Packages.tomli
+  build-system = with python3Packages; [ setuptools ];
+
+  nativeBuildInputs = with python3Packages; [
+    copyDesktopItems
+    sip
+    tomli
     qt6.qmake
     qt6.wrapQtAppsHook
   ];
 
   dontUseQmakeConfigure = true;
 
-  buildInputs = [ qt6.qtbase ];
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtsvg
+  ];
 
   # veusz is a script and not an ELF-executable, so wrapQtAppsHook will not wrap
   # it automatically -> we have to do it explicitly
@@ -33,33 +43,44 @@ python3Packages.buildPythonApplication (finalAttrs: {
     wrapQtApp "$out/bin/veusz"
   '';
 
-  # vectorfield.vsz renders a PPM bitmap whose pixel values differ across Qt versions/platforms
-  patches = [ ./skip-vectorfield-test.patch ];
+  patches = [
+    # vectorfield.vsz renders a PPM bitmap whose pixel values differ across Qt versions/platforms
+    ./skip-vectorfield-test.patch
+    # Remove these after https://github.com/veusz/veusz/pull/830 is merged
+    ./sip-pyproject.patch
+    ./use-pyvo-samp.patch
+  ];
 
   # pyqt_setuptools.py uses the platlib path from sysconfig, but NixOS doesn't
-  # really have a corresponding path, so patching the location of PyQt5 inplace
+  # really have a corresponding path, so patching the location of PyQt6 inplace
   postPatch = ''
     substituteInPlace pyqt_setuptools.py \
-      --replace-fail "get_path('platlib')" "'${python3Packages.pyqt5}/${python3Packages.python.sitePackages}'"
+      --replace-fail "get_path('platlib')" "'${python3Packages.pyqt6}/${python3Packages.python.sitePackages}'"
     patchShebangs tests/runselftest.py
   '';
 
-  # you can find these options at
-  # https://github.com/veusz/veusz/blob/53b99dffa999f2bc41fdc5335d7797ae857c761f/pyqtdistutils.py#L71
-  setupPyBuildFlags = [
-    # veusz tries to find a libinfix and fails without one
-    # but we simply don't need a libinfix, so set it to empty here
-    "--qt-libinfix="
-  ];
+  postInstall = ''
+    install -Dm444 icons/veusz.svg \
+      "$out/share/icons/hicolor/scalable/apps/veusz.svg"
+    install -Dm444 support/veusz.xml \
+      "$out/share/mime/packages/veusz.xml"
+    install -Dm444 support/veusz.appdata.xml \
+      "$out/share/metainfo/io.github.veusz.Veusz.metainfo.xml"
+    substituteInPlace "$out/share/metainfo/io.github.veusz.Veusz.metainfo.xml" \
+      --replace-fail '<launchable type="desktop-id">Veusz.desktop</launchable>' \
+      '<launchable type="desktop-id">veusz.desktop</launchable>'
+  '';
 
   dependencies = with python3Packages; [
     numpy
     pyqt6
-    # optional requirements:
+    # optional dependencies
     dbus-python
     h5py
-    # astropy -- fails to build on master
-    # optional TODO: add iminuit, pyemf and sampy
+    astropy
+    pyvo
+    iminuit
+    pyemf3
   ];
 
   installCheckPhase = ''
@@ -71,10 +92,41 @@ python3Packages.buildPythonApplication (finalAttrs: {
     runHook postInstallCheck
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      desktopName = "Veusz";
+      genericName = "Scientific plotting";
+      comment = "Scientific plotting and graphing package";
+      exec = "veusz %F";
+      terminal = false;
+      icon = "veusz";
+      categories = [
+        "DataVisualization"
+        "Science"
+      ];
+      mimeTypes = [ "application/x-veusz" ];
+      keywords = [
+        "graphing"
+        "plotting"
+        "graph"
+        "plot"
+        "visualization"
+        "visualisation"
+        "science"
+        "math"
+        "maths"
+        "mathematics"
+        "data"
+      ];
+    })
+  ];
+
   meta = {
     description = "Scientific plotting and graphing program with a GUI";
     mainProgram = "veusz";
     homepage = "https://veusz.github.io/";
+    changelog = with finalAttrs.src; "https://github.com/${owner}/${repo}/releases/tag/${rev}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ laikq ];

--- a/pkgs/by-name/ve/veusz/sip-pyproject.patch
+++ b/pkgs/by-name/ve/veusz/sip-pyproject.patch
@@ -1,0 +1,11 @@
+--- a/pyqt_setuptools.py
++++ b/pyqt_setuptools.py
+@@ -267,7 +267,7 @@ class sip_build_ext(build_ext):
+ requires=["sip >= 6.8, <7"]
+ build-backend="sipbuild.api"
+
+-[tool.sip.metadata]
++[project]
+ name="{modulename}"
+
+ [tool.sip.project]

--- a/pkgs/by-name/ve/veusz/use-pyvo-samp.patch
+++ b/pkgs/by-name/ve/veusz/use-pyvo-samp.patch
@@ -1,0 +1,19 @@
+--- a/veusz/utils/vzsamp.py
++++ b/veusz/utils/vzsamp.py
+@@ -28,10 +28,13 @@ sampcl = None
+
+ try:
+     try:
+-        # astropy 2.0+
+-        from astropy import samp
++        from pyvo import samp
+     except ImportError:
+-        from astropy.io import samp
++        try:
++            # astropy 2.0+
++            from astropy import samp
++        except ImportError:
++            from astropy.io import samp
+
+ except ImportError:
+     def setup():

--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -18,7 +18,7 @@
   pytestCheckHook,
   pyvo,
   astropy-helpers,
-  setuptools,
+  setuptools_80,
   writableTmpDirAsHomeHook,
 }:
 
@@ -35,8 +35,8 @@ buildPythonPackage rec {
   };
 
   build-system = [
-    astropy-helpers
-    setuptools
+    (astropy-helpers.override { setuptools = setuptools_80; })
+    setuptools_80
   ];
 
   dependencies = [
@@ -50,7 +50,7 @@ buildPythonPackage rec {
 
   # Disable automatic update of the astropy-helper module
   postPatch = ''
-    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+    substituteInPlace setup.cfg --replace-fail "auto_use = True" "auto_use = False"
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -71,6 +71,10 @@ buildPythonPackage rec {
   preCheck = ''
     cd build/lib
   '';
+
+  # pytest 9 warns about iterator parameters, which this release promotes to
+  # errors via its global filterwarnings setting. This is fixed upstream.
+  pytestFlags = [ "-Wignore::pytest.PytestRemovedIn10Warning" ];
 
   pythonImportsCheck = [ "astroquery" ];
 

--- a/pkgs/development/python-modules/pyemf3/default.nix
+++ b/pkgs/development/python-modules/pyemf3/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  # build-system
+  setuptools,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "pyemf3";
+  version = "3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jeremysanders";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-rIofdyT9XsWPViBbcNyLXxLBFMUeKxLE95axo8Ydvn8=";
+  };
+
+  build-system = [ setuptools ];
+
+  patches = [
+    ./python3-integer-division.patch
+  ];
+
+  postPatch = ''
+    for test in tests/*.py; do
+      if grep -q '^import pyemf$' "$test"; then
+        substituteInPlace "$test" \
+          --replace-fail "import pyemf" "import pyemf3 as pyemf"
+      fi
+    done
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    for expected in tests/orig/*.emf; do
+      testName="$(basename "$expected" .emf)"
+
+      python "tests/$testName.py"
+      cmp "$testName.emf" "$expected"
+
+      python - "$expected" "$testName.roundtrip.emf" <<'PY'
+    import sys
+    import pyemf3
+
+    metafile = pyemf3.EMF()
+    metafile.load(sys.argv[1])
+    metafile.save(sys.argv[2])
+    PY
+      cmp "$testName.roundtrip.emf" "$expected"
+    done
+
+    runHook postInstallCheck
+  '';
+
+  pythonImportsCheck = [ "pyemf3" ];
+
+  meta = with lib; {
+    description = "Pure Python Enhanced Metafile Library";
+    homepage = "https://github.com/jeremysanders/pyemf3/";
+    license = licenses.lgpl21Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ abkein ];
+  };
+})

--- a/pkgs/development/python-modules/pyemf3/python3-integer-division.patch
+++ b/pkgs/development/python-modules/pyemf3/python3-integer-division.patch
@@ -1,0 +1,13 @@
+--- a/pyemf3/dc.py
++++ b/pyemf3/dc.py
+@@ -128,8 +128,8 @@ class _DC:
+ 
+         self.setPhysicalSize(header.rclFrame)
+         if header.szlMicrometers[0]>0:
+-            self.ref_width=header.szlMicrometers[0]/10
+-            self.ref_height=header.szlMicrometers[1]/10
++            self.ref_width=header.szlMicrometers[0]//10
++            self.ref_height=header.szlMicrometers[1]//10
+         else:
+             self.ref_width=header.szlMillimeters[0]*100
+             self.ref_height=header.szlMillimeters[1]*100

--- a/pkgs/development/python-modules/pyvo/default.nix
+++ b/pkgs/development/python-modules/pyvo/default.nix
@@ -1,25 +1,40 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  astropy,
-  pillow,
-  pytestCheckHook,
-  pytest-astropy,
-  requests,
-  requests-mock,
+  fetchFromGitHub,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  astropy,
+  requests,
+
+  # optional dependencies
+  pillow,
+  defusedxml,
+
+  # testing
+  pytestCheckHook,
+  pytest-astropy,
+  pytest-timeout,
+  pytest-doctestplus,
+  requests-mock,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pyvo";
-  version = "1.8.1";
+  version = "1.9.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-08xgqj00FtIsieRloE36n1IQhf3VIozOLP/S/uOp5wk=";
+  src = fetchFromGitHub {
+    owner = "astropy";
+    repo = finalAttrs.pname;
+    # A few commits above 1.9.1 to include https://github.com/astropy/pyvo/pull/757,
+    # which fixes tests
+    rev = "6c5311c06cd04cf0c56f648ccdae50338cc351a2";
+    hash = "sha256-kqYA/qgqTZe4GwOwtzIKy/X3mrVukn7mq3CiqJIWI+A=";
   };
 
   build-system = [
@@ -32,12 +47,27 @@ buildPythonPackage (finalAttrs: {
     requests
   ];
 
+  optional-dependencies = {
+    all = [
+      pillow
+      defusedxml
+    ];
+    test = [
+      pytest-astropy
+      pytest-timeout
+      pytest-doctestplus
+      requests-mock
+    ];
+  };
+
   nativeCheckInputs = [
-    pillow
     pytestCheckHook
-    pytest-astropy
-    requests-mock
-  ];
+  ]
+  ++ (with finalAttrs.passthru.optional-dependencies; all ++ test);
+
+  preCheck = ''
+    export HOME="$TMPDIR"
+  '';
 
   disabledTestPaths = [
     # touches network
@@ -46,11 +76,11 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "pyvo" ];
 
-  meta = {
+  meta = with lib; {
     description = "Astropy affiliated package for accessing Virtual Observatory data and services";
     homepage = "https://github.com/astropy/pyvo";
     changelog = "https://github.com/astropy/pyvo/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ smaret ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ smaret ];
   };
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14599,6 +14599,8 @@ self: super: with self; {
 
   pyemd = callPackage ../development/python-modules/pyemd { };
 
+  pyemf3 = callPackage ../development/python-modules/pyemf3 { };
+
   pyemoncms = callPackage ../development/python-modules/pyemoncms { };
 
   pyemvue = callPackage ../development/python-modules/pyemvue { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Veusz:
- Added a .desktop item to ensure proper QT integration and general convenience.
- Fixed `pyqt5` -> `pyqt6` typo.
- Added `qt6.qtsvg`, because otherwise dark icons on dark background are displayed if system theme is dark.
- Added missing dependencies for UX.

`python3Packages.pyemf3`: added new package as a veusz dependency for `.emf` (enhanced metafile) support.

`python3Packages.pyvo`: `pyvo.samp`needed by veusz for SAMP support, `astropy.samp` is deprecated. Updated 1.8.1 -> 1.9.1, otherwise `pyvo.samp` itself depends on `atropy.samp`.

`python3Packages.astroquery`: not related at all, but since it's a two-minute fix...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
