### PR TITLE
libgcrypt: fix build with `pkgsLLVM`

### DIFF
--- a/pkgs/by-name/li/libgcrypt/package.nix
+++ b/pkgs/by-name/li/libgcrypt/package.nix
@@ -104,12 +104,17 @@ stdenv.mkDerivation rec {
     sed -i 's,\(-lcap\),-L${libcap.lib}/lib \1,' $lib/lib/libgcrypt.la
   '';
 
-  # TODO: figure out why this is even necessary and why the missing dylib only crashes
-  # random instead of every test
-  preCheck = lib.optionalString (stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic) ''
-    mkdir -p $lib/lib
-    cp src/.libs/libgcrypt.20.dylib $lib/lib
-  '';
+  preCheck =
+    # glibc loads libgcc_s dynamically when a thread exits
+    lib.optionalString (stdenv.hostPlatform.isLinux && stdenv.cc.isClang) ''
+      export LD_LIBRARY_PATH="${buildPackages.stdenv.cc.cc.libgcc}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    ''
+    # TODO: figure out why this is even necessary and why the missing dylib only crashes
+    # random instead of every test
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic) ''
+      mkdir -p $lib/lib
+      cp src/.libs/libgcrypt.20.dylib $lib/lib
+    '';
 
   doCheck = true;
   enableParallelChecking = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix build with Clang.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
