### PR TITLE
culmus-fancy: init at 0.0.20240129.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31671,6 +31671,15 @@
     githubId = 85800291;
     email = "yes@ysnt.live";
   };
+  ytg123 = {
+    name = "YTG123";
+    github = "YTG1234";
+    githubId = 54103478;
+
+    email = "ytg1234@pm.me";
+    matrix = "@ytg1234:matrix.org";
+    keys = [ { fingerprint = "B10F 2589 CB25 5F02 1FCF  A5A7 2C0F 50BE 5583 2C81"; } ];
+  };
   yuannan = {
     email = "brandon@emergence.ltd";
     github = "yuannan";

--- a/pkgs/by-name/cu/culmus-fancy/package.nix
+++ b/pkgs/by-name/cu/culmus-fancy/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+  installFonts,
+  gitUpdater,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "culmus-fancy";
+  version = "0.0.20240129.1";
+
+  # Each font is maintained independently from the main Culmus project
+  # and the main website <https://culmus.sourceforge.io/fancy/>
+  # doesn't provide versioned links. Downloading directly from
+  # upstream would break builds on update.
+  # We rely on the Debian package for consistent versioning.
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "hebrew-team";
+    repo = "culmus-fancy";
+    tag = "debian/${finalAttrs.version}";
+    hash = "sha256-ZefHhr1rwCVdLbmvQI305w2k2kDxJURD0KUG8mmEwoc=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    homepage = "https://culmus.sourceforge.io/index.html";
+    description = "Additional Fonts from the Culmus Project";
+    longDescription = "The Fancy Fonts and Taamey Culmus are maintained independently and not included in the standard Culmus distribution.";
+    platforms = lib.platforms.all;
+    license = lib.licenses.gpl2;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    maintainers = [ lib.maintainers.ytg123 ];
+  };
+
+  passthru.updateScript = gitUpdater { rev-prefix = "debian/"; };
+})


### PR DESCRIPTION
Nixpkgs already packages the [main Culmus collection](https://culmus.sourceforge.io/index.html) of fonts. I was disappointed to find that neither my distro of choice (Fedora) nor Nixpkgs has the so-called [fancy fonts](https://culmus.sourceforge.io/fancy/index.html) packaged, so here they are.

The "Fancy Fonts" are additional fonts that are maintained separately from the main project. Annoyingly, since maintainers submit their fonts whenever they feel like it, upstream doesn't provide versioned links and the downloads are updated in-place.

For this reason I can't just download the fonts directly from upstream, as future builds will break on any update. Luckily these fonts are packaged [in Debian](https://tracker.debian.org/pkg/culmus-fancy), so we can use that (and pull directly from the [source](https://salsa.debian.org/hebrew-team/culmus-fancy) that Debian uses), though I'm not sure that it's an entirely good idea.

The same Debian package also includes the ["Taamey Culmus"](https://culmus.sourceforge.io/taamim/index.html) collection. Since they are maintained similarly, and not any easier to package on their own, I figured that specifically excluding them (or creating a separate package for them) is more trouble than it's worth.

## Further Considerations

I don't like relying on Debian but I don't see other options. There is also [this repo](https://github.com/amiad/culmus-fancy-ttf), used by a package on the AUR, that converts the fonts automatically to TTF.  
Also, given that this is Debian, we might not get new versions particularly quickly. Is there any other way of doing this?

As for the update script, I didn't test it (I got some weird error that has to do with my system configuration) and I don't know if the provided `gitUpdater` will even works with this configuration. I'd appreciate some help with that!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
