### PR TITLE
chainsaw: 2.16.2 -> 2.16.3

### DIFF
--- a/pkgs/by-name/ch/chainsaw/package.nix
+++ b/pkgs/by-name/ch/chainsaw/package.nix
@@ -1,39 +1,43 @@
 {
   lib,
-  rustPlatform,
   fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "chainsaw";
-  version = "2.16.2";
+  version = "2.16.3";
 
   src = fetchFromGitHub {
     owner = "WithSecureLabs";
     repo = "chainsaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EKL2MTo5qirpY4TCWwBptpRWJRd6Yp/dLz/5sIsdsbg=";
+    hash = "sha256-dG3WxAWnMBMlV3HxI9E7EDvZgK+qYZwRiZVNRf7jekY=";
   };
 
-  cargoHash = "sha256-bbgRqp3bNw2U69aVqwvJNWOKgW0YhR8SlqzH9jdrHZU=";
+  cargoHash = "sha256-t9Adw4W7m1jWsLhwEtIgJjAWDxRkpOzssKe98InOExQ=";
 
-  ldflags = [
-    "-w"
-    "-s"
-  ];
+  ldflags = [ "-s" ];
+
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   checkFlags = [
-    # failed
+    # Tests are failing
     "--skip=analyse_srum_database_json"
     "--skip=search_jq_simple_string"
     "--skip=search_q_jsonl_simple_string"
     "--skip=search_q_simple_string"
   ];
 
+  doInstallCheck = true;
+
   meta = {
     description = "Rapidly Search and Hunt through Windows Forensic Artefacts";
     homepage = "https://github.com/WithSecureLabs/chainsaw";
-    changelog = "https://github.com/WithSecureLabs/chainsaw/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/WithSecureLabs/chainsaw/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "chainsaw";


### PR DESCRIPTION
Diff: https://github.com/WithSecureLabs/chainsaw/compare/v2.16.2...v2.16.3

Changelog: https://github.com/WithSecureLabs/chainsaw/releases/tag/v2.16.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
