### PR TITLE
nixos/rancher: make preloaded images detect derivation changes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -182,6 +182,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `services.k3s` and `services.rke2` now expose the images declared in `images` through a `/nix/store` directory symlinked into `/var/lib/rancher/${name}/agent/images/nixos/`. The directory's store path changes whenever any image derivation changes, which makes `${name}` detect and re-import the new archives, while `/var/lib/rancher/${name}/agent/images/` itself remains a normal directory that can still be used for manually added images. Previously, each image was linked with a fixed file name directly in that directory, so the cluster would not notice image updates and old symlinks could become dangling.
+
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
 
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -182,6 +182,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `services.k3s` and `services.rke2` now expose the images declared in `images` through a `/nix/store` directory symlinked into `/var/lib/rancher/${name}/agent/images/nixos/`. The directory's store path changes whenever any image derivation changes, which makes k3s/rke2 detect and re-import the new archives, while `/var/lib/rancher/${name}/agent/images/` itself remains a normal directory that can still be used for manually added images. Previously, each image was linked with a fixed file name directly in that directory, so the cluster would not notice image updates and old symlinks could become dangling. After upgrading, you may want to remove those dangling symlinks (that was the case already when you wanted to stop deploying an image).
+
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
 
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).

--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -849,13 +849,22 @@ let
                 "L+".argument = "${manifest.source}";
               };
             };
-            # Make a systemd-tmpfiles rule for a container image
-            mkImageRule = image: {
-              name = "${imageDir}/${image.name}";
-              value = {
-                "L+".argument = "${image}";
-              };
-            };
+            # Build a single store directory containing symlinks to all
+            # container images declared in the NixOS configuration. The
+            # directory's store path changes whenever any image changes, so
+            # ${name} re-imports images on every generation switch. It is
+            # exposed under ${imageDir}/nixos so that ${imageDir} itself
+            # remains a normal directory that users can still populate manually.
+            agentImagesDir = pkgs.linkFarm "${name}-agent-images" (
+              map (image: {
+                # The store-path hash is included in the link name so that two
+                # different images with the same tarball base name do not
+                # collide. The context is discarded because tmpfiles link names
+                # must not carry store-path references.
+                name = builtins.unsafeDiscardStringContext (builtins.baseNameOf image);
+                path = image;
+              }) cfg.images
+            );
             # Merge charts with charts contained in enabled auto deploying charts
             helmCharts =
               (lib.concatMapAttrs (n: v: { ${n} = v.package; }) (
@@ -873,7 +882,14 @@ let
             };
           in
           (lib.mapAttrs' (_: v: mkManifestRule v) enabledManifests)
-          // (builtins.listToAttrs (map mkImageRule cfg.images))
+          // (lib.optionalAttrs (cfg.images != [ ]) {
+            ${imageDir} = {
+              "d".argument = "";
+            };
+            "${imageDir}/nixos" = {
+              "L+".argument = "${agentImagesDir}";
+            };
+          })
           // (lib.optionalAttrs (cfg.containerdConfigTemplate != null) {
             ${containerdConfigTemplateFile} = {
               "L+".argument = "${pkgs.writeText "config.toml.tmpl" cfg.containerdConfigTemplate}";

--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -849,13 +849,22 @@ let
                 "L+".argument = "${manifest.source}";
               };
             };
-            # Make a systemd-tmpfiles rule for a container image
-            mkImageRule = image: {
-              name = "${imageDir}/${image.name}";
-              value = {
-                "L+".argument = "${image}";
-              };
-            };
+            # Build a single store directory containing symlinks to all
+            # container images declared in the NixOS configuration. The
+            # directory's store path changes whenever any image changes, so
+            # k3s/rke2 re-imports images on every generation switch. It is
+            # exposed under ${imageDir}/nixos so that ${imageDir} itself
+            # remains a normal directory that users can still populate manually.
+            agentImagesDir = pkgs.linkFarm "${name}-agent-images" (
+              map (image: {
+                # The store-path hash is included in the link name so that two
+                # different images with the same tarball base name do not
+                # collide. The context is discarded because tmpfiles link names
+                # must not carry store-path references.
+                name = builtins.unsafeDiscardStringContext (builtins.baseNameOf image);
+                path = image;
+              }) cfg.images
+            );
             # Merge charts with charts contained in enabled auto deploying charts
             helmCharts =
               (lib.concatMapAttrs (n: v: { ${n} = v.package; }) (
@@ -873,7 +882,11 @@ let
             };
           in
           (lib.mapAttrs' (_: v: mkManifestRule v) enabledManifests)
-          // (builtins.listToAttrs (map mkImageRule cfg.images))
+          // (lib.optionalAttrs (cfg.images != [ ]) {
+            "${imageDir}/nixos" = {
+              "L+".argument = "${agentImagesDir}";
+            };
+          })
           // (lib.optionalAttrs (cfg.containerdConfigTemplate != null) {
             ${containerdConfigTemplateFile} = {
               "L+".argument = "${pkgs.writeText "config.toml.tmpl" cfg.containerdConfigTemplate}";

--- a/nixos/modules/services/cluster/rancher/k3s.nix
+++ b/nixos/modules/services/cluster/rancher/k3s.nix
@@ -74,8 +74,9 @@ in
       '';
       description = ''
         List of derivations that provide container images.
-        All images are linked to {file}`${baseModule.paths.imageDir}` before k3s starts and are consequently imported
-        by the k3s agent. Consider importing the k3s airgap images archive of the k3s package in
+        All images are linked into {file}`${baseModule.paths.imageDir}/nixos/` before k3s starts and are consequently imported
+        by the k3s agent, while {file}`${baseModule.paths.imageDir}` itself remains a normal directory that can also be used
+        for manually added images. Consider importing the k3s airgap images archive of the k3s package in
         use, if you want to pre-provision this node with all k3s container images. This option
         only makes sense on nodes with an enabled agent.
       '';

--- a/nixos/modules/services/cluster/rancher/k3s.nix
+++ b/nixos/modules/services/cluster/rancher/k3s.nix
@@ -74,7 +74,7 @@ in
       '';
       description = ''
         List of derivations that provide container images.
-        All images are linked to {file}`${baseModule.paths.imageDir}` before k3s starts and are consequently imported
+        All images are linked into {file}`${baseModule.paths.imageDir}/nixos/` before k3s starts and are consequently imported
         by the k3s agent. Consider importing the k3s airgap images archive of the k3s package in
         use, if you want to pre-provision this node with all k3s container images. This option
         only makes sense on nodes with an enabled agent.

--- a/nixos/modules/services/cluster/rancher/rke2.nix
+++ b/nixos/modules/services/cluster/rancher/rke2.nix
@@ -72,8 +72,9 @@ in
       '';
       description = ''
         List of derivations that provide container images.
-        All images are linked to {file}`${baseModule.paths.imageDir}` before rke2 starts and are consequently imported
-        by the rke2 agent. Consider importing the rke2 core and CNI image archives of the rke2 package in
+        All images are linked into {file}`${baseModule.paths.imageDir}/nixos/` before rke2 starts and are consequently imported
+        by the rke2 agent, while {file}`${baseModule.paths.imageDir}` itself remains a normal directory that can also be used
+        for manually added images. Consider importing the rke2 core and CNI image archives of the rke2 package in
         use, if you want to pre-provision this node with all rke2 container images. For a full list of available airgap images, check the
         [source](https://github.com/NixOS/nixpkgs/blob/c8a1939887ee6e5f5aae29ce97321c0d83165f7d/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json).
         of the rke2 package in use.

--- a/nixos/modules/services/cluster/rancher/rke2.nix
+++ b/nixos/modules/services/cluster/rancher/rke2.nix
@@ -72,7 +72,7 @@ in
       '';
       description = ''
         List of derivations that provide container images.
-        All images are linked to {file}`${baseModule.paths.imageDir}` before rke2 starts and are consequently imported
+        All images are linked into {file}`${baseModule.paths.imageDir}/nixos/` before rke2 starts and are consequently imported
         by the rke2 agent. Consider importing the rke2 core and CNI image archives of the rke2 package in
         use, if you want to pre-provision this node with all rke2 container images. For a full list of available airgap images, check the
         [source](https://github.com/NixOS/nixpkgs/blob/c8a1939887ee6e5f5aae29ce97321c0d83165f7d/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json).

--- a/nixos/tests/rancher/default.nix
+++ b/nixos/tests/rancher/default.nix
@@ -100,6 +100,7 @@ let
       auto-deploy = mkTests ./auto-deploy.nix;
       configuration = mkTests ./configuration.nix;
       etcd = mkTests ./etcd.nix;
+      image-upgrade = mkTests ./image-upgrade.nix;
       multi-node = mkTests ./multi-node.nix;
       single-node = mkTests ./single-node.nix;
     };

--- a/nixos/tests/rancher/image-upgrade.nix
+++ b/nixos/tests/rancher/image-upgrade.nix
@@ -1,0 +1,118 @@
+# Tests that a container image whose contents change (same name and tag)
+# is detected and re-imported by the cluster.
+# It only declares the image change (via a NixOS specialisation) and checks
+# the end result (the pod output); it never inspects how the image is linked.
+{
+  pkgs,
+  lib,
+  rancherDistro,
+  rancherPackage,
+  serviceName,
+  disabledComponents,
+  coreImages,
+  vmResources,
+  ...
+}:
+let
+  containerdSocket =
+    {
+      k3s = "/run/k3s/containerd/containerd.sock";
+      rke2 = "/run/rke2/containerd/containerd.sock";
+    }
+    .${rancherDistro};
+
+  # Build a Docker image with a fixed name but an auto-generated tag based on
+  # the derivation hash. Two derivations with different contents produce
+  # different tags, so the cluster treats them as distinct images.
+  mkTestImage =
+    commandOutput:
+    pkgs.dockerTools.buildImage {
+      name = "test.local/test";
+      compressor = "zstd";
+      copyToRoot = pkgs.busybox;
+      config = {
+        Entrypoint = [ "sh" ];
+        Cmd = [
+          "-c"
+          "echo '${commandOutput}'"
+        ];
+      };
+    };
+
+  testImageV1 = mkTestImage "image v1 deployed";
+  testImageV2 = mkTestImage "image v2 deployed";
+in
+{
+  name = "${rancherPackage.name}-image-upgrade";
+  interactive.sshBackdoor.enable = true;
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ../../modules/profiles/base.nix ];
+
+      environment.systemPackages = with pkgs; [
+        kubectl
+        cri-tools
+      ];
+      environment.sessionVariables.KUBECONFIG = "/etc/rancher/${rancherDistro}/${rancherDistro}.yaml";
+
+      virtualisation = vmResources;
+
+      services.${rancherDistro} = {
+        enable = true;
+        role = "server";
+        package = rancherPackage;
+        disable =
+          {
+            k3s = lib.remove "traefik" disabledComponents;
+            rke2 = lib.remove "rke2-ingress-nginx" disabledComponents;
+          }
+          .${rancherDistro};
+        images =
+          coreImages ++ lib.optional (rancherDistro == "k3s") rancherPackage.airgap-images ++ [ testImageV1 ];
+      };
+
+      # A declaration that swaps the image for one with the same name but a
+      # different auto-generated tag and different contents. Switching to this
+      # specialisation is the only thing the test does to trigger a re-import.
+      specialisation.image-v2 = {
+        inheritParentConfig = true;
+        configuration =
+          { lib, ... }:
+          {
+            services.${rancherDistro}.images = lib.mkForce (
+              coreImages ++ lib.optional (rancherDistro == "k3s") rancherPackage.airgap-images ++ [ testImageV2 ]
+            );
+          };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      def switch_to_v2():
+          toplevel = "${nodes.machine.system.build.toplevel}"
+          machine.succeed(f"{toplevel}/specialisation/image-v2/bin/switch-to-configuration switch")
+
+      machine.wait_for_unit("${serviceName}")
+
+      with subtest("v1 image is imported and runs"):
+          machine.wait_until_succeeds("crictl -r ${containerdSocket} img | grep 'test\\.local/test'")
+          machine.wait_until_succeeds("kubectl get sa default")
+          machine.succeed("kubectl create job test-job --image=${testImageV1.imageName}:${testImageV1.imageTag}")
+          machine.wait_until_succeeds("kubectl wait --for=condition=complete job/test-job --timeout=180s")
+          v1_output = machine.succeed("kubectl logs -l batch.kubernetes.io/job-name=test-job --tail=-1").rstrip()
+          t.assertEqual(v1_output, "image v1 deployed", f"unexpected v1 output: {v1_output!r}")
+
+      with subtest("Same-name image with different auto-generated tag is re-imported"):
+          machine.succeed("kubectl delete job test-job --ignore-not-found=true")
+          switch_to_v2()
+          machine.succeed("kubectl create job test-job --image=${testImageV2.imageName}:${testImageV2.imageTag}")
+          machine.wait_until_succeeds("kubectl wait --for=condition=complete job/test-job --timeout=240s")
+          v2_output = machine.succeed("kubectl logs -l batch.kubernetes.io/job-name=test-job --tail=-1").rstrip()
+          t.assertEqual(v2_output, "image v2 deployed", f"unexpected v2 output: {v2_output!r}")
+    '';
+
+  meta.maintainers = lib.teams.k3s.members ++ pkgs.rke2.meta.maintainers;
+}


### PR DESCRIPTION
`services.k3s` and `services.rke2` used to create one fixed-name symlink per image under `/var/lib/rancher/${name}/agent/images/`. Because the symlink name did not change when the underlying image derivation changed, k3s had no signal that the archive on disk was different and would not re-import it. Old symlinks could also dangle after `nix-collect-garbage` removed the referenced store path.

This change exposes all declared images through a single `/nix/store` directory built with `pkgs.linkFarm`. The directory's store path changes whenever any image changes, so k3s detects and re-imports the archives on every generation switch. The directory is symlinked into `${imageDir}/nixos` so that `${imageDir}` itself remains a normal directory usable for manually added images.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: OpenCode + Kimi k2.7-code
