### PR TITLE
ergohaven-entropy: mark as an IBus engine, fix the udev rule; 0.3.4 -> 0.3.20

### DIFF
--- a/pkgs/by-name/er/ergohaven-entropy/package.nix
+++ b/pkgs/by-name/er/ergohaven-entropy/package.nix
@@ -35,16 +35,16 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ergohaven-entropy";
-  version = "0.3.4";
+  version = "0.3.20";
 
   src = fetchFromGitHub {
     owner = "ergohaven";
     repo = "entropy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+8MuDAGYZuSB/oBiP9pUgDzaRG0tpU8pbtJ5qGZeK9w=";
+    hash = "sha256-8RvndwWHNnktqGXDzBOml8jBzHTH6SRtiwx/qIpuYq8=";
   };
 
-  cargoHash = "sha256-N6VlBT0isBLo/9b1gVOuN/d0GewB5oeanKboYSQQPR0=";
+  cargoHash = "sha256-8Gbdf2BLF2QYDXwYp1rCUEfjE62/sQLc+6vm5avIppo=";
 
   __structuredAttrs = true;
 

--- a/pkgs/by-name/er/ergohaven-entropy/package.nix
+++ b/pkgs/by-name/er/ergohaven-entropy/package.nix
@@ -123,6 +123,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   meta = {
+    isIbusEngine = true;
     description = "Modern app for programmable keyboards and input devices";
     longDescription = ''
       Entropy is a desktop app with a modern, minimalist, and intuitive

--- a/pkgs/by-name/er/ergohaven-entropy/package.nix
+++ b/pkgs/by-name/er/ergohaven-entropy/package.nix
@@ -89,7 +89,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     mkdir -p $out/lib/udev/rules.d
     cat > $out/lib/udev/rules.d/59-vial.rules << RULES
-    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{serial}=="*vial:f64c2b3c*", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+    # Entropy Vial hidraw access v2
+    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{serial}=="*vial:f64c2b3c*", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:E126:*", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
     RULES
 
     icoFileToHiColorTheme $src/assets/entropy.ico entropy $out


### PR DESCRIPTION
`programs.entropy.enable = true` does not evaluate on current master:

```
error: A definition for option `i18n.inputMethod.ibus.engines."[definition 1-entry 1]"' is not of type `ibus-engine'
```

The module unconditionally puts `pkgs.ergohaven-entropy` into `i18n.inputMethod.ibus.engines`, and the package installs an IBus component into `$out/share/ibus/component`, but it never set `meta.isIbusEngine`, which that option type requires. First commit adds the flag.

Second commit bumps the package to 0.3.20, the current release (0.3.4 is from July). Changelog: https://github.com/ergohaven/entropy/releases

Third commit fixes the udev rule. Since 0.3.4 the app validates the *contents* of `59-vial.rules` — `vial_udev_rule_is_current` (`src/ui/app_settings.rs`) requires the `# Entropy Vial hidraw access v2` marker, the USB serial match, the Ergohaven Bluetooth match `KERNELS=="0005:E126:*"` and `SUBSYSTEM=="hidraw"`. The rule shipped here had only the USB line and no marker, so the app kept showing the "install udev rules" banner on a system where the module had already installed them, and Bluetooth keyboards were never granted access. The new rule matches what the upstream installer writes (`linux/udev/install-vial-rules.sh`).

Upstream now carries a Nix flake with its own NixOS and home-manager modules (ergohaven/entropy#115, merged 2026-08-25), so the rule and the engine registration can be cross-checked against it.

Disclosure: the commits and this summary were written with the assistance of Claude Code (Claude Opus 5); every change and claim here was reviewed and verified by me, as recorded by the `Assisted-by:` trailers.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Details on the two checked items: the upstream test suite (612 tests) runs in `checkPhase`; `./result/bin/entropy` starts, detects a connected Ergohaven K:04 over hidraw and talks Vial protocol 6 to it; the installed `$out/lib/udev/rules.d/59-vial.rules` carries all four markers the app checks for. A NixOS system with `programs.entropy.enable = true` and `i18n.inputMethod = { enable = true; type = "ibus"; }` fails to evaluate before the first commit with the error above and evaluates afterwards with the engine registered into `ibus-with-plugins`. `nixfmt --check` is clean on the changed file.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
