### PR TITLE
localsend-cli: init at 1.18.1

### DIFF
--- a/pkgs/by-name/lo/localsend-cli/package.nix
+++ b/pkgs/by-name/lo/localsend-cli/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cacert,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "localsend-cli";
+  version = "1.18.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "localsend";
+    repo = "localsend";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uxMfO39U0cC7Svf8QL4WUJJowuwmTjChrZ4VOWcgb4E=";
+  };
+
+  cargoHash = "sha256-khnrHc/88j+JG3sSKvNUsu6JcrM83zIt+W3tT7dz2Ac=";
+
+  cargoBuildFlags = [
+    "--package"
+    "localsend-cli"
+  ];
+
+  checkInputs = [
+    cacert
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source cross-platform alternative to AirDrop (cli version)";
+    homepage = "https://github.com/localsend/localsend";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ zendo ];
+    mainProgram = "localsend-cli";
+  };
+})


### PR DESCRIPTION
official localsend cli version.

https://github.com/localsend/localsend/releases/tag/v1.18.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
