### PR TITLE
pyldapsearch: init at 0.2.0

### DIFF
--- a/pkgs/by-name/py/pyldapsearch/package.nix
+++ b/pkgs/by-name/py/pyldapsearch/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication pyldapsearch

--- a/pkgs/development/python-modules/pyldapsearch/default.nix
+++ b/pkgs/development/python-modules/pyldapsearch/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  cffi,
+  click,
+  fetchFromGitHub,
+  hatchling,
+  impacket,
+  msldap,
+  nix-update-script,
+  pyasn1,
+  pycryptodome,
+  rich,
+  setuptools,
+  typer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyldapsearch";
+  version = "0.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Tw1sm";
+    repo = "pyldapsearch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-prypaCGS2BpZGqC/3GrJoRhEhU27dsibVOy2rW+/ePs=";
+  };
+
+  pythonRelaxDeps = [ "click" ];
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    cffi
+    click
+    impacket
+    msldap
+    pyasn1
+    pycryptodome
+    rich
+    setuptools
+    typer
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyldapsearch" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for issuing manual LDAP queries which offers bofhound compatible output";
+    homepage = "https://github.com/Tw1sm/pyldapsearch";
+    changelog = "https://github.com/Tw1sm/pyldapsearch/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "pyldapsearch";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14999,6 +14999,8 @@ self: super: with self; {
 
   pyld = callPackage ../development/python-modules/pyld { };
 
+  pyldapsearch = callPackage ../development/python-modules/pyldapsearch { };
+
   pyldavis = callPackage ../development/python-modules/pyldavis { };
 
   pylddwrap = callPackage ../development/python-modules/pylddwrap { };


### PR DESCRIPTION
Tool for issuing manual LDAP queries which offers bofhound compatible output

https://github.com/Tw1sm/pyldapsearch

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
