### PR TITLE
foomatic-db: update / foomatic-db*: strictDeps

### DIFF
--- a/pkgs/by-name/fo/foomatic-db-engine/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-engine/package.nix
@@ -31,6 +31,8 @@ perlPackages.buildPerlPackage rec {
 
   outputs = [ "out" ];
 
+  strictDeps = true;
+
   propagatedBuildInputs = [
     perlPackages.Clone
     perlPackages.DBI

--- a/pkgs/by-name/fo/foomatic-db-engine/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-engine/package.nix
@@ -32,6 +32,7 @@ perlPackages.buildPerlPackage rec {
   outputs = [ "out" ];
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   propagatedBuildInputs = [
     perlPackages.Clone

--- a/pkgs/by-name/fo/foomatic-db-engine/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-engine/package.nix
@@ -37,26 +37,25 @@ perlPackages.buildPerlPackage rec {
     perlPackages.XMLLibXML
   ];
 
-  buildInputs = [
-    curl
-  ]
-  # provide some "cups-*" commands to `foomatic-{configure,printjob}`
-  # so that they can manage a local cups server (add queues, add jobs...)
-  ++ lib.optionals withCupsAccess [
-    cups
-    cups-filters
-  ]
-  # the commands `foomatic-{configure,getpjloptions}` need
-  # netcat if they are used to query or alter a network
-  # printer via AppSocket/HP JetDirect protocol
-  ++ lib.optional withSocketAccess netcat-gnu
-  # `foomatic-configure` can be used to access printers that are
-  # shared via the SMB protocol, but it needs the `smbclient` binary
-  ++ lib.optional withSMBAccess samba;
+  buildInputs =
+    # provide some "cups-*" commands to `foomatic-{configure,printjob}`
+    # so that they can manage a local cups server (add queues, add jobs...)
+    lib.optionals withCupsAccess [
+      cups
+      cups-filters
+    ]
+    # the commands `foomatic-{configure,getpjloptions}` need
+    # netcat if they are used to query or alter a network
+    # printer via AppSocket/HP JetDirect protocol
+    ++ lib.optional withSocketAccess netcat-gnu
+    # `foomatic-configure` can be used to access printers that are
+    # shared via the SMB protocol, but it needs the `smbclient` binary
+    ++ lib.optional withSMBAccess samba;
 
   nativeBuildInputs = [
     autoconf
     automake
+    curl
     file
     makeWrapper
   ];

--- a/pkgs/by-name/fo/foomatic-db-nonfree/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-nonfree/package.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     autoconf

--- a/pkgs/by-name/fo/foomatic-db-nonfree/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-nonfree/package.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-cRZH0CXg03FEqUJdxaNnPVXjf8+ct86PjhL59WQbw60=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     autoconf
     automake

--- a/pkgs/by-name/fo/foomatic-db-ppds/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-ppds/package.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation {
     lib.lists.head
   ];
 
+  strictDeps = true;
+
   buildInputs = [
     coreutils
     cups-filters

--- a/pkgs/by-name/fo/foomatic-db-ppds/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-ppds/package.nix
@@ -5,6 +5,7 @@
   buildEnv,
   foomatic-db-engine,
   stdenv,
+  coreutils,
   cups-filters,
   ghostscript,
   netpbm,
@@ -52,6 +53,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
+    coreutils
     cups-filters
     ghostscript
     netpbm
@@ -77,7 +79,7 @@ stdenv.mkDerivation {
   # Comments indicate the respective
   # package the command is contained in.
   ppdFileCommands = [
-    "cat"
+    "cat" # coreutils
     "echo" # coreutils
     "foomatic-rip" # cups-filters or foomatic-filters
     "gs" # ghostscript

--- a/pkgs/by-name/fo/foomatic-db-ppds/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-ppds/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation {
   ];
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   buildInputs = [
     coreutils
@@ -80,7 +81,7 @@ stdenv.mkDerivation {
 
   # Comments indicate the respective
   # package the command is contained in.
-  ppdFileCommands = [
+  env.ppdFileCommands = lib.join " " [
     "cat" # coreutils
     "echo" # coreutils
     "foomatic-rip" # cups-filters or foomatic-filters

--- a/pkgs/by-name/fo/foomatic-db/package.nix
+++ b/pkgs/by-name/fo/foomatic-db/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  coreutils,
   cups,
   cups-filters,
   ghostscript,
@@ -26,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
+    coreutils
     cups
     cups-filters
     ghostscript
@@ -75,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Comments indicate the respective
   # package the command is contained in.
   ppdFileCommands = [
-    "cat"
+    "cat" # coreutils
     "date"
     "printf" # coreutils
     "rastertohp" # cups

--- a/pkgs/by-name/fo/foomatic-db/package.nix
+++ b/pkgs/by-name/fo/foomatic-db/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-mQEOV+NJId5h/hYOL+2JrEHjqM77qRExDNeqZ0IyA08=";
   };
 
+  strictDeps = true;
+
   buildInputs = [
     coreutils
     cups

--- a/pkgs/by-name/fo/foomatic-db/package.nix
+++ b/pkgs/by-name/fo/foomatic-db/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   buildInputs = [
     coreutils
@@ -78,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Comments indicate the respective
   # package the command is contained in.
-  ppdFileCommands = [
+  env.ppdFileCommands = lib.join " " [
     "cat" # coreutils
     "date"
     "printf" # coreutils

--- a/pkgs/by-name/fo/foomatic-db/package.nix
+++ b/pkgs/by-name/fo/foomatic-db/package.nix
@@ -15,15 +15,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "foomatic-db";
-  version = "0-unstable-2026-02-09";
+  version = "0-unstable-2026-08-13";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db";
-    rev = "57e546cb7774c7b03e7090ced65fb1ffd552f33d";
-    hash = "sha256-mQEOV+NJId5h/hYOL+2JrEHjqM77qRExDNeqZ0IyA08=";
+    rev = "a8bdf5fbe1f736afabd188cbcacb95f459492e3f";
+    hash = "sha256-ySDZNL9/qureR12T9kxh1IJtv7Xret47HO1CZiFQ8mM=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/fo/foomatic-db/package.nix
+++ b/pkgs/by-name/fo/foomatic-db/package.nix
@@ -15,15 +15,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "foomatic-db";
-  version = "0-unstable-2026-08-13";
+  version = "0-unstable-2026-09-04";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db";
-    rev = "a8bdf5fbe1f736afabd188cbcacb95f459492e3f";
-    hash = "sha256-ySDZNL9/qureR12T9kxh1IJtv7Xret47HO1CZiFQ8mM=";
+    rev = "76dd1e31354c189b2edd9ae8201285d622c89395";
+    hash = "sha256-rTowiKV4alVAw9qrqSARVL2Fl+soIzhwQYlANiRXI74=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
*   fix cross-compilation issues by rebalancing `buildInputs` and `nativeBuildInputs`, and enable `strictDeps`
*   enable `__strucutredAttrs` (required adaption of `ppdFileCommands` environment variable)
*   update `foomatic-db` (only [one new commit](https://github.com/OpenPrinting/foomatic-db/commit/a8bdf5fbe1f736afabd188cbcacb95f459492e3f), **update** and [another one](https://github.com/OpenPrinting/foomatic-db/commit/b197a2bfbfb1a383cc557ede9d60f9f72a2f68e7))

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].  (*none*)
  - [ ] [Package tests] at `passthru.tests`.  (*none*)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.  (*none*)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.  (*none*)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

More, tested on `x86_64-linux`:

- [x] `foomatic-db{,-nonfree,-ppds{,-withNonfreeDb}}` build
- [x] `pkgsCross.aarch64-multiplatform.foomatic-db{,-nonfree}` build
- [ ] `pkgsCross.aarch64-multiplatform.foomatic-db-ppds{,-withNonfreeDb}` fail to build, because the dependency `psutils` fails to build

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `c47cb6dd5654ab4b72218e08742c02d52d758327`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>foomatic-db</li>
    <li>foomatic-db-engine</li>
    <li>foomatic-db-nonfree</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>ptouch-driver</li>
  </ul>
</details>