### PR TITLE
mlos-host-utils: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19181,6 +19181,12 @@
     githubId = 75925945;
     name = "Andrew Semeykin";
   };
+  mopigames = {
+    email = "mopigames2.0@gmail.com";
+    github = "MopigamesYT";
+    githubId = 95306417;
+    name = "Margot Prego";
+  };
   moraxyc = {
     name = "Moraxyc Xu";
     email = "i@qaq.li";

--- a/pkgs/by-name/ml/mlos-host-utils/package.nix
+++ b/pkgs/by-name/ml/mlos-host-utils/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mlos-host-utils";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "MopigamesYT";
+    repo = "moonlight-os";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TZDaNAV+v7reKiBllkbESQ1/n1ItGKFDNGMUcuNcXcM=";
+  };
+
+  __structuredAttrs = true;
+
+  # The agent is one directory of a repository that is otherwise an ISO
+  # build, so the Go module is not at the root.
+  modRoot = "host-utils";
+
+  # Standard library only -- there is no go.sum and nothing to vendor.
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "USB passthrough agent for the PC you stream from with Moonlight OS";
+    longDescription = ''
+      The host PC half of USB passthrough for Moonlight OS. Moonlight OS says
+      which USB devices are plugged into the thin client; this agent attaches
+      them to the machine the game is actually running on, over USB/IP.
+
+      Note that `mlos-host-utils install` is meant for imperative distributions:
+      it installs a usbip package with the system package manager and writes a
+      unit into /etc/systemd/system, neither of which survives a rebuild. On
+      NixOS, run the agent from a systemd service of your own, or use the
+      services.mlos-host-utils module the upstream flake provides.
+    '';
+    homepage = "https://github.com/MopigamesYT/moonlight-os";
+    changelog = "https://github.com/MopigamesYT/moonlight-os/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mpl20;
+    mainProgram = "mlos-host-utils";
+    maintainers = with lib.maintainers; [ mopigames ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
New package: `mlos-host-utils`, the host PC half of USB passthrough for
[Moonlight OS](https://github.com/MopigamesYT/moonlight-os).

Moonlight OS is a thin-client OS for game streaming. It tells the machine you
actually stream from which USB devices are plugged into the client — a racing
wheel, a HOTAS, a licence dongle — and this agent attaches them over USB/IP so
they appear on the host. One static Go binary, standard library only, so
`vendorHash = null`.

I am the upstream author.

Note on NixOS: the binary has an imperative `install` subcommand meant for
other distributions, which installs a usbip package and writes a unit into
`/etc/systemd/system`. It detects NixOS and refuses rather than doing half of
that; the `meta.longDescription` says so, and a NixOS module lives in the
upstream flake for now.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  <br>`nixpkgs-review rev HEAD`: 1 package added, 1 package built, no other packages impacted.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The package expression and the maintainer entry were written with Claude Code
(claude-opus-5), disclosed with an `Assisted-by:` trailer on the commit and
here for this summary. I reviewed both, built the package, and ran the binary.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
