### PR TITLE
spotify: update ffmpeg from 4 to 7

### DIFF
--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -39,7 +39,7 @@
   fontconfig,
   dbus,
   expat,
-  ffmpeg_4,
+  ffmpeg_7-headless,
   curlWithGnuTls,
   zlib,
   zenity,
@@ -74,7 +74,7 @@ let
     curlWithGnuTls
     dbus
     expat
-    ffmpeg_4 # Requires libavcodec < 59 as of 1.2.9.743.g85d9593d
+    ffmpeg_7-headless # Requires libavcodec < 62
     fontconfig
     freetype
     gdk-pixbuf
@@ -200,8 +200,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${nspr.out}/lib/libnspr4.so $libdir/libnspr4.so
     ln -s ${nspr.out}/lib/libplc4.so $libdir/libplc4.so
 
-    ln -s ${ffmpeg_4.lib}/lib/libavcodec.so* $libdir
-    ln -s ${ffmpeg_4.lib}/lib/libavformat.so* $libdir
+    ln -s ${ffmpeg_7-headless.lib}/lib/libavcodec.so* $libdir
+    ln -s ${ffmpeg_7-headless.lib}/lib/libavformat.so* $libdir
 
     rpath="$out/share/spotify:$libdir"
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR updates the FFMPEG Dependency needed for Spotify.

The following Command was used to figure out which libraries are loaded:
```bash
LD_DEBUG=libs ./result/bin/spotify 2>&1 | grep -oE 'lib[^/ ]+\.so(\.[0-9]+)*' | sort -u
```

Spotify tries to load Versions 58 to 61 for compatability reasons.

Also note that the library is only loaded when playing local songs in spotify


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
