### PR TITLE
patchutils: enable structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/tools/text/patchutils/generic.nix
+++ b/pkgs/tools/text/patchutils/generic.nix
@@ -10,12 +10,12 @@
   extraBuildInputs ? [ ],
   ...
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "patchutils";
   inherit version patches;
 
   src = fetchurl {
-    url = "https://cyberelk.net/tim/data/patchutils/stable/${pname}-${version}.tar.xz";
+    url = "https://cyberelk.net/tim/data/patchutils/stable/patchutils-${finalAttrs.version}.tar.xz";
     inherit sha256;
   };
 
@@ -37,18 +37,20 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  doCheck = lib.versionAtLeast version "0.3.4";
+  doCheck = lib.versionAtLeast finalAttrs.version "0.3.4";
 
   preCheck = ''
     patchShebangs tests
     chmod +x scripts/*
   ''
-  + lib.optionalString (lib.versionOlder version "0.4.2") ''
+  + lib.optionalString (lib.versionOlder finalAttrs.version "0.4.2") ''
     find tests -type f -name 'run-test' \
       -exec sed -i '{}' -e 's|/bin/echo|echo|g' \;
   '';
 
   strictDeps = true;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Tools to manipulate patch files";
@@ -57,4 +59,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ artturin ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
