### PR TITLE
wanderer, wanderer-db: init at 0.20.0, add NixOS module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17129,6 +17129,12 @@
     githubId = 36235154;
     name = "Sean Haugh";
   };
+  maartenbehn = {
+    email = "nixpkgs@stroby.org";
+    name = "Maarten Behn";
+    github = "MaartenBehn";
+    githubId = 46872913;
+  };
   mabster314 = {
     name = "Max Haland";
     email = "max@haland.org";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -214,6 +214,21 @@
   "module-services-tdarr-server-only": [
     "index.html#module-services-tdarr-server-only"
   ],
+  "module-services-wanderer": [
+    "index.html#module-services-wanderer"
+  ],
+  "module-services-wanderer-basic-usage": [
+    "index.html#module-services-wanderer-basic-usage"
+  ],
+  "module-services-wanderer-external-meiliserach": [
+    "index.html#module-services-wanderer-external-meiliserach"
+  ],
+  "module-services-wanderer-reverse-proxy-configuration": [
+    "index.html#module-services-wanderer-reverse-proxy-configuration"
+  ],
+  "module-services-wanderer-sops": [
+    "index.html#module-services-wanderer-sops"
+  ],
   "module-services-zapret2": [
     "index.html#module-services-zapret2"
   ],

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1846,6 +1846,7 @@
   ./services/web-apps/umami.nix
   ./services/web-apps/vikunja.nix
   ./services/web-apps/wakapi.nix
+  ./services/web-apps/wanderer.nix
   ./services/web-apps/wealthfolio.nix
   ./services/web-apps/weblate.nix
   ./services/web-apps/websurfx.nix

--- a/nixos/modules/services/web-apps/wanderer.md
+++ b/nixos/modules/services/web-apps/wanderer.md
@@ -1,0 +1,131 @@
+# Wanderer {#module-services-wanderer}
+
+[Wanderer](https://github.com/open-wanderer/wanderer) is an open-source, self-hosted web application for tracking, organizing, and visualizing outdoor trails and GPS tracks. It uses PocketBase as its backend database and optionally integrates with Meilisearch for fast search functionality.
+
+## Configuration {#module-services-wanderer-basic-usage}
+
+To enable Wanderer with default settings and a local Meilisearch instance, add the following to your configuration:
+
+```nix
+{ config, pkgs, ... }: {
+  services.wanderer = {
+    enable = true;
+    port = 8080;
+    origin = "https://wanderer.example.com";
+    dataDir = "/var/lib/wanderer";
+    environmentFile = "/run/secrets/wanderer.env";
+
+    pocketbase = {
+      port = 8081;
+      publicUrl = "http://wanderer-db.example.com";
+    };
+
+    meilisearch = {
+      enable = true;
+      port = 7700;
+      masterKeyFile = "/run/secrets/meili_master_key";
+    };
+  };
+}
+```
+
+This starts the PocketBase backend service (`wanderer-db.service`) on port 8081 and the Node.js frontend (`wanderer.service`) on port 8080.
+Wanderer requires the environment variables `MEILI_MASTER_KEY` and `POCKETBASE_ENCRYPTION_KEY` to securely access its search engine and encrypt database contents.
+
+## Managing Secrets with sops-nix {#module-services-wanderer-sops}
+
+When using sops-nix, construct a combined environment template for {option}`services.wanderer.environmentFile`:
+
+```nix
+{ config, pkgs, ... }: {
+  sops.secrets = {
+    "meili_master_key" = { mode = "0444"; };
+    "wanderer_pb_encryption_key" = { mode = "0444"; };
+  };
+
+  sops.templates."wanderer.env" = {
+    owner = "wanderer";
+    group = "wanderer";
+    content = ''
+      MEILI_MASTER_KEY=${config.sops.placeholder."meili_master_key"}
+      POCKETBASE_ENCRYPTION_KEY=${config.sops.placeholder."wanderer_pb_encryption_key"}
+    '';
+  };
+
+  services.wanderer = {
+    enable = true;
+    environmentFile = config.sops.templates."wanderer.env".path;
+
+    meilisearch = {
+      enable = true;
+      masterKeyFile = config.sops.secrets."meili_master_key".path;
+    };
+
+    # Rest of config
+  };
+}
+```
+
+## Using an External Meilisearch Instance {#module-services-wanderer-external-meiliserach}
+
+If you already have a shared Meilisearch instance running, set {option}`services.wanderer.meilisearch.enable` to false and point to your endpoint using {option}`services.wanderer.meilisearch.url`:
+
+```nix
+{ config, pkgs, ... }:
+{
+  services.wanderer = {
+    meilisearch = {
+      enable = false;
+      url = "http://127.0.0.1:7700";
+    };
+
+    # Rest of config
+  };
+}
+```
+
+## Reverse Proxy Configuration {#module-services-wanderer-reverse-proxy-configuration}
+Wanderer requires two public-facing endpoints:
+the web engine ({option}`services.wanderer.port`) and the PocketBase backend ({option}`services.wanderer.pocketbase.port`).
+
+The following example configures NGINX for both endpoints:
+
+```nix
+{ config, pkgs, ... }: {
+  services.wanderer = {
+    enable = true;
+    port = 8003;
+    origin = "https://wanderer.example.com";
+
+    pocketbase = {
+      port = 8004;
+      publicUrl = "https://wanderer-db.example.com";
+    };
+
+    # Rest of config
+  };
+
+  services.nginx = {
+    enable = true;
+    virtualHosts = {
+      "wanderer.example.com" = {
+        forceSSL = true;
+        enableACME = true;
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:8003";
+          proxyWebsockets = true;
+        };
+      };
+      "wanderer-db.example.com" = {
+        forceSSL = true;
+        enableACME = true;
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:8004";
+          proxyWebsockets = true;
+        };
+      };
+    };
+  };
+}
+```
+

--- a/nixos/modules/services/web-apps/wanderer.nix
+++ b/nixos/modules/services/web-apps/wanderer.nix
@@ -1,0 +1,195 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.wanderer;
+
+  wandererPkg = cfg.package;
+  wandererDbPkg = cfg.dbPackage;
+in
+{
+
+  options.services.wanderer = {
+    enable = lib.mkEnableOption "Wanderer Trail Database Service";
+
+    package = lib.mkPackageOption pkgs "wanderer" { };
+
+    dbPackage = lib.mkPackageOption pkgs "wanderer-db" { };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Port Wanderer HTTP server listens on.";
+    };
+
+    origin = lib.mkOption {
+      type = lib.types.str;
+      default = "http://localhost:8080";
+      description = "Canonical origin URL for CORS and frontend redirects.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/wanderer";
+      description = "State directory where PocketBase data and uploads are stored.";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/wanderer.env";
+      description = ''
+        Environment file containing sensitive variables like `MEILI_MASTER_KEY`
+        and `POCKETBASE_ENCRYPTION_KEY`.
+      '';
+    };
+
+    pocketbase = {
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8091;
+        description = "Port PocketBase listens on.";
+      };
+
+      publicUrl = lib.mkOption {
+        type = lib.types.str;
+        default = "http://127.0.0.1:8091";
+        description = "URL used by client browsers to communicate with PocketBase.";
+      };
+    };
+
+    meilisearch = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Automatically enable and configure a local Meilisearch instance.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 7700;
+        description = "Port local Meilisearch listens on.";
+      };
+
+      url = lib.mkOption {
+        type = lib.types.str;
+        default = "http://127.0.0.1:7700";
+        description = "URL under which Meilisearch can be reached.";
+      };
+
+      masterKeyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/meili_master_key";
+        description = "Path to the file containing the Meilisearch master key.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.meilisearch.enable -> (cfg.meilisearch.masterKeyFile != null);
+        message = "services.wanderer.meilisearch.masterKeyFile must be set when local Meilisearch is enabled.";
+      }
+    ];
+
+    services.meilisearch = lib.mkIf cfg.meilisearch.enable {
+      enable = true;
+      listenAddress = "127.0.0.1";
+      listenPort = cfg.meilisearch.port;
+      masterKeyFile = cfg.meilisearch.masterKeyFile;
+    };
+
+    users.users.wanderer = {
+      isSystemUser = true;
+      group = "wanderer";
+      home = cfg.dataDir;
+    };
+    users.groups.wanderer = { };
+
+    systemd.services.wanderer-db = {
+      description = "Wanderer PocketBase Backend";
+      after = [ "network.target" ] ++ lib.optional cfg.meilisearch.enable "meilisearch.service";
+      wants = [ "network.target" ] ++ lib.optional cfg.meilisearch.enable "meilisearch.service";
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        MEILI_URL = cfg.meilisearch.url;
+        ORIGIN = cfg.origin;
+      };
+
+      serviceConfig = {
+        User = "wanderer";
+        Group = "wanderer";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStart = "${wandererDbPkg}/bin/wanderer-db serve --http=127.0.0.1:${toString cfg.pocketbase.port} --dir=${cfg.dataDir}/pb_data";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        StateDirectory = "wanderer";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+      };
+    };
+
+    systemd.services.wanderer = {
+      description = "Wanderer Trail Database Web Engine";
+      after = [
+        "network.target"
+        "wanderer-db.service"
+      ];
+      requires = [ "wanderer-db.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        PORT = toString cfg.port;
+        HOST = "127.0.0.1";
+        ORIGIN = cfg.origin;
+        BODY_SIZE_LIMIT = "Infinity";
+        PUBLIC_POCKETBASE_URL = cfg.pocketbase.publicUrl;
+        UPLOAD_FOLDER = "${cfg.dataDir}/uploads";
+        MEILI_URL = cfg.meilisearch.url;
+        OVERPASS_API_URL = "https://overpass-api.de";
+        VALHALLA_URL = "https://valhalla1.openstreetmap.de";
+        NOMINATIM_URL = "https://nominatim.openstreetmap.org";
+        PUBLIC_MAP_MAX_POLYLINES = "100";
+        NODE_ENV = "production";
+      };
+
+      serviceConfig = {
+        User = "wanderer";
+        Group = "wanderer";
+        ExecStart = "${wandererPkg}/bin/wanderer";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        StateDirectory = "wanderer";
+        StateDirectoryMode = "0750";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        NoNewPrivileges = true;
+        CapabilityBoundingSet = "";
+        RestrictRealtime = true;
+        ProtectClock = true;
+      };
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ maartenbehn ];
+    doc = ./wanderer.md;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1879,6 +1879,7 @@ in
   vsftpd = runTest ./vsftpd.nix;
   waagent = runTest ./waagent.nix;
   wakapi = runTest ./wakapi.nix;
+  wanderer = runTest ./wanderer.nix;
   warpgate = runTest ./warpgate.nix;
   warzone2100 = runTest ./warzone2100.nix;
   wasabibackend = runTest ./wasabibackend.nix;

--- a/nixos/tests/wanderer.nix
+++ b/nixos/tests/wanderer.nix
@@ -1,0 +1,51 @@
+{ lib, ... }: {
+  name = "wanderer";
+  meta.maintainers = [ lib.maintainers.maartenbehn ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.etc = {
+        "secrets/meili_key".text = "a-very-secret-meili-master-key-123456789";
+        "secrets/wanderer.env".text = ''
+          MEILI_MASTER_KEY=a-very-secret-meili-master-key-123456789
+          POCKETBASE_ENCRYPTION_KEY=12345678901234567890123456789012
+        '';
+      };
+
+      services.wanderer = {
+        enable = true;
+        port = 8080;
+        origin = "http://localhost:8080";
+
+        pocketbase = {
+          port = 8091;
+          publicUrl = "http://localhost:8091";
+        };
+
+        meilisearch = {
+          enable = true;
+          port = 7700;
+          masterKeyFile = "/etc/secrets/meili_key";
+        };
+
+        environmentFile = "/etc/secrets/wanderer.env";
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("meilisearch.service")
+    machine.wait_for_unit("wanderer-db.service")
+    machine.wait_for_unit("wanderer.service")
+
+    machine.wait_for_open_port(7700)
+    machine.wait_for_open_port(8091)
+    machine.wait_for_open_port(8080)
+
+    machine.succeed("curl -fsS http://127.0.0.1:8091/api/health")
+
+    machine.succeed("curl -fsS http://127.0.0.1:8080/")
+  '';
+}

--- a/pkgs/by-name/wa/wanderer-db/package.nix
+++ b/pkgs/by-name/wa/wanderer-db/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "wanderer-db";
+  version = "0.20.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "open-wanderer";
+    repo = "wanderer";
+    rev = "v${version}";
+    hash = "sha256-Z4oKOf8bLyoYqjsg/bWWc8GYai2ZUYISFBiu4AHGexY=";
+  };
+
+  sourceRoot = "${src.name}/db";
+
+  proxyVendor = true;
+  vendorHash = "sha256-WaG+bc9QxgffJGHOaSz0S7/bXDMu57Drvqa7Qk0WMSY=";
+
+  postInstall = ''
+    if [ -f $out/bin/pocketbase ]; then
+      mv $out/bin/pocketbase $out/bin/wanderer-db
+    fi
+  '';
+
+  meta = {
+    description = "PocketBase database backend for Wanderer trail database";
+    homepage = "https://github.com/open-wanderer/wanderer";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "wanderer-db";
+    maintainers = with lib.maintainers; [ maartenbehn ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/wa/wanderer/package.nix
+++ b/pkgs/by-name/wa/wanderer/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+  makeWrapper,
+}:
+
+buildNpmPackage rec {
+  pname = "wanderer";
+  version = "0.20.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "open-wanderer";
+    repo = "wanderer";
+    rev = "v${version}";
+    hash = "sha256-Z4oKOf8bLyoYqjsg/bWWc8GYai2ZUYISFBiu4AHGexY=";
+  };
+
+  sourceRoot = "${src.name}/web";
+
+  npmDepsHash = "sha256-G+Ozwt8ir2StIFU/I4cMF77alNkW4sp28WJeTnBnBFk=";
+  inherit nodejs;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/wanderer
+    cp -r build package.json node_modules $out/share/wanderer/
+
+    makeWrapper ${nodejs}/bin/node $out/bin/wanderer \
+      --chdir "$out/share/wanderer" \
+      --add-flags "$out/share/wanderer/build/index.js"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Web interface for Wanderer trail database";
+    homepage = "https://github.com/open-wanderer/wanderer";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "wanderer";
+    maintainers = with lib.maintainers; [ maartenbehn ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
- Add package derivation for Wanderer web frontend
- Add package derivation for Wanderer PocketBase backend
- Add NixOS module services.wanderer
- Add module documentation in wanderer.md
- Add test for wanderer.service
- Add maartenbehn to maintainer-list.nix

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
