### PR TITLE
nixos/ups: run killpower driver as root

### DIFF
--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -679,7 +679,7 @@ in
       environment = envVars;
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${cfg.package}/bin/upsdrvctl shutdown";
+        ExecStart = "${cfg.package}/bin/upsdrvctl -u root shutdown";
       };
     };
 


### PR DESCRIPTION
Long time user, (hopefully) first time contributor!

While doing some validation tests with my new UPS, I ran into a permissions error during shutdown tests:

```
Aug 14 10:32:31.462384 HOST usbhid-ups[22384]: Signal 15: exiting
Aug 14 10:32:31.462749 HOST upsd[19962]: Can't connect to UPS [cyberpower] (/var/lib/nut/usbhid-ups-cyberpower): No such file or directory
Aug 14 10:32:31.463509 HOST systemd[1]: upsdrv.service: Deactivated successfully.
Aug 14 10:32:31.635567 HOST upsdrvctl[30254]: Network UPS Tools upsdrvctl - UPS driver controller 2.8.4 release
Aug 14 10:32:31.636601 HOST upsdrvctl[30255]: Network UPS Tools 2.8.4 release - Generic HID driver 0.67
Aug 14 10:32:31.636601 HOST upsdrvctl[30255]: USB communication driver (libusb 1.0) 0.50
Aug 14 10:32:31.636807 HOST upsdrvctl[30255]: Can't chdir to /var/lib/nut (but we do not require that to force shutdown): Permission denied
# adding emphasis here
Aug 14 10:32:31.636807 HOST upsdrvctl[30255]: Can't open /var/lib/nut/usbhid-ups-cyberpower: Permission denied
Aug 14 10:32:31.644133 HOST upsdrvctl[30255]: libusb1: Could not open any HID devices: insufficient permissions on everything
Aug 14 10:32:31.644133 HOST upsdrvctl[30255]: No matching HID UPS found
Aug 14 10:32:31.644487 HOST upsdrvctl[30254]: Driver failed to start (exit status=1)
Aug 14 10:32:31.645586 HOST systemd[1]: ups-killpower.service: Main process exited, code=exited, status=1/FAILURE
Aug 14 10:32:31.645632 HOST systemd[1]: ups-killpower.service: Failed with result 'exit-code'.
```

Anyway, verified with an override on my tower that the supplied fix does the trick. Seems like #450541 had settled on the same permissions fix but got closed (this fix wasn't disputed, other stuff was).

Tracing it back, looks like the package gained `--with-user=nutmon/--with-group=nutmon` in #460445, leading to the regression (`/var/lib/nut` is owned by root) and matches the memory review [comment](https://github.com/NixOS/nixpkgs/pull/450541#pullrequestreview-3325930439) in #450541 by @bjornfor 
>About the permission and slice issues; I wonder when this broke / was changed, because I'm pretty sure I tested this in NixOS 25.05 or the release before that. Oh well :-)


## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
