### PR TITLE
rPackages.buildRPackage: remove unneeded deps

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -140,7 +140,7 @@ let
   #
   # {
   #   foo = old.foo.overrideAttrs (attrs: {
-  #     nativeBuildInputs = attrs.nativeBuildInputs ++ [ pkgs.bar ];
+  #     nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ pkgs.bar ];
   #   });
   # }
   overrideNativeBuildInputs =
@@ -148,7 +148,7 @@ let
     lib.mapAttrs (
       name: value:
       (builtins.getAttr name old).overrideAttrs (attrs: {
-        nativeBuildInputs = attrs.nativeBuildInputs ++ value;
+        nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ value;
       })
     ) overrides;
 
@@ -163,7 +163,7 @@ let
   #
   # {
   #   foo = old.foo.overrideAttrs (attrs: {
-  #     buildInputs = attrs.buildInputs ++ [ pkgs.bar ];
+  #     buildInputs = (attrs.buildInputs or [ ]) ++ [ pkgs.bar ];
   #   });
   # }
   overrideBuildInputs =
@@ -171,7 +171,7 @@ let
     lib.mapAttrs (
       name: value:
       (builtins.getAttr name old).overrideAttrs (attrs: {
-        buildInputs = attrs.buildInputs ++ value;
+        buildInputs = (attrs.buildInputs or [ ]) ++ value;
       })
     ) overrides;
 
@@ -209,7 +209,6 @@ let
   #
   # {
   #   foo = old.foo.overrideAttrs (attrs: {
-  #     nativeBuildInputs = attrs.nativeBuildInputs ++ [ self.bar ];
   #     propagatedBuildInputs = attrs.propagatedBuildInputs ++ [ self.bar ];
   #   });
   # }
@@ -218,7 +217,6 @@ let
     lib.mapAttrs (
       name: value:
       (builtins.getAttr name old).overrideAttrs (attrs: {
-        nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ value;
         propagatedBuildInputs = (attrs.propagatedBuildInputs or [ ]) ++ value;
       })
     ) overrides;
@@ -2191,15 +2189,15 @@ let
     Rhdf5lib =
       let
         hdf5 = pkgs.hdf5.overrideAttrs (attrs: {
-          cmakeFlags = attrs.cmakeFlags ++ [ "-DHDF5_ENABLE_ROS3_VFD:BOOL=TRUE" ];
-          buildInputs = attrs.buildInputs ++ [ pkgs.curl ];
-          postInstall = attrs.postInstall or "" + ''
+          cmakeFlags = (attrs.cmakeFlags or [ ]) ++ [ "-DHDF5_ENABLE_ROS3_VFD:BOOL=TRUE" ];
+          buildInputs = (attrs.buildInputs or [ ]) ++ [ pkgs.curl ];
+          postInstall = (attrs.postInstall or "") + ''
             cp src/libhdf5.settings $dev/lib
           '';
         });
       in
       old.Rhdf5lib.overrideAttrs (attrs: {
-        propagatedBuildInputs = attrs.propagatedBuildInputs ++ [
+        propagatedBuildInputs = (attrs.propagatedBuildInputs or [ ]) ++ [
           hdf5
           pkgs.libaec
         ];
@@ -2370,7 +2368,7 @@ let
       src = pkgs.arrow-cpp.src;
       name = "r-arrow-${pkgs.arrow-cpp.version}";
       prePatch = "cd r";
-      buildInputs = attrs.buildInputs ++ [
+      buildInputs = (attrs.buildInputs or [ ]) ++ [
         pkgs.arrow-cpp
       ];
     });
@@ -2441,7 +2439,7 @@ let
     });
 
     geojsonio = old.geojsonio.overrideAttrs (attrs: {
-      buildInputs = [ cacert ] ++ attrs.buildInputs;
+      buildInputs = (attrs.buildInputs or [ ]) ++ [ cacert ];
     });
 
     geomorph = old.geomorph.overrideAttrs (attrs: {
@@ -2483,8 +2481,8 @@ let
     });
 
     hdf5r = old.hdf5r.overrideAttrs (attrs: {
-      nativeBuildInputs = attrs.nativeBuildInputs ++ [ new.Rhdf5lib.hdf5 ];
-      buildInputs = attrs.buildInputs ++ [ new.Rhdf5lib.hdf5 ];
+      nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ new.Rhdf5lib.hdf5 ];
+      buildInputs = (attrs.buildInputs or [ ]) ++ [ new.Rhdf5lib.hdf5 ];
     });
 
     immunotation =
@@ -2616,7 +2614,7 @@ let
         });
       in
       old.opencv.overrideAttrs (attrs: {
-        buildInputs = attrs.buildInputs ++ [ opencvGtk ];
+        buildInputs = (attrs.buildInputs or [ ]) ++ [ opencvGtk ];
       });
 
     openssl = old.openssl.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -25,7 +25,6 @@ let
 
   buildRPackage = pkgs.callPackage ./generic-builder.nix {
     inherit R;
-    inherit (pkgs) gettext gfortran;
   };
 
   # Generates package templates given per-repository settings

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -4,9 +4,6 @@
   R,
   xvfb-run,
   util-linux,
-  gettext,
-  gfortran,
-  libiconv,
 }:
 
 attrs:
@@ -25,25 +22,10 @@ stdenv.mkDerivation (
       (attrs.nativeBuildInputs or [ ])
       ++ [
         R
-        gettext
       ]
       ++ lib.optionals finalAttrs.requireX [
         util-linux
         xvfb-run
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        gfortran
-      ];
-
-    buildInputs =
-      (attrs.buildInputs or [ ])
-      ++ [
-        R
-        gettext
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        gfortran
-        libiconv
       ];
 
     enableParallelBuilding = true;
@@ -123,7 +105,6 @@ stdenv.mkDerivation (
     # if not listed, the passed value will override the default value
     "name"
     "nativeBuildInputs"
-    "buildInputs"
     "env"
     "installFlags"
     "postFixup"


### PR DESCRIPTION
Targeting https://github.com/NixOS/nixpkgs/pull/552051

`gfortran` was originally added in https://github.com/NixOS/nixpkgs/pull/17183 seemingly because the library search paths compiled into R on darwin were incorrect.
I checked them now (on linux, but you can still download and read stuff for darwin), and the proper search paths are present.

I'm not 100% sure about `libiconv` and `gettext` The former was added in https://github.com/NixOS/nixpkgs/pull/212539 and the latter in https://github.com/NixOS/nixpkgs/pull/17183

`gettext` was moved out of being darwin only, but that was part of a treewide change that moved it out so it was probably not needed on linux anyways.

Regarding `libiconv` and `gettext`: their search paths are also present in the R package: `lib/R/bin/libtool` contains their search paths in `sys_lib_search_path`. So *maybe* it's fine to remove it from the builder.

I checked and `gettext` is part of `sys_lib_search_path` on linux, but `libiconv` is not.

In any case I think it's worth a shot checking out what break/doesn't break with this change.
I have not yet found any breakages.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
