### PR TITLE
gogcli: 0.29.0 -> 0.36.0

### DIFF
--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -23,15 +23,15 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/steipete/gogcli/internal/cmd.version=v${finalAttrs.version}"
-    "-X github.com/steipete/gogcli/internal/cmd.commit=${finalAttrs.src.rev}"
-    "-X github.com/steipete/gogcli/internal/cmd.date=1970-01-01T00:00:00Z"
+    "-X github.com/openclaw/gogcli/internal/cmd.version=v${finalAttrs.version}"
+    "-X github.com/openclaw/gogcli/internal/cmd.commit=${finalAttrs.src.rev}"
+    "-X github.com/openclaw/gogcli/internal/cmd.date=1970-01-01T00:00:00Z"
   ];
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
     command = "gog --version";
-    version = "v${finalAttrs.version}";
+    version = "v${finalAttrs.version} (${finalAttrs.src.rev} 1970-01-01T00:00:00Z)";
   };
 
   meta = {

--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "gogcli";
-  version = "0.29.0";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "openclaw";
     repo = "gogcli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JunPpEzbNp00uEiJ7AzouXyzFwyNLehLU7mwL3eh4bM=";
+    hash = "sha256-7XfjpAzUHH1VUJzgllKa/4GvQZhTCX8TePTXRB+oJRE=";
   };
 
-  vendorHash = "sha256-JrRIUYpw2lAD0ezi0HTZvS42OS7vP8DAHU3m0u3eCbM=";
+  vendorHash = "sha256-+Nbuwok3dY/82gUDKeGgrC0F1ZqXSW8IpV6Q1yzIPvo=";
 
   subPackages = [ "cmd/gog" ];
 


### PR DESCRIPTION
<!-- PR title: gogcli: 0.29.0 -> 0.36.0 -->

Supersedes #536328 by updating gogcli to the current v0.36.0 release and including the required linker-path fix.

cc @macalinao

Upstream changes: https://github.com/openclaw/gogcli/compare/v0.29.0...v0.36.0

The upstream Go module moved from `github.com/steipete/gogcli` to
`github.com/openclaw/gogcli`. The old `ldflags` targets were silently ignored,
leaving the embedded commit and build date empty even though the version itself
was present.

This update:

- updates gogcli from 0.29.0 to 0.36.0;
- updates all linker targets to the current Go module path;
- strengthens `passthru.tests.version` to verify the version, tag, and build date.

Verified on `x86_64-linux`:

- `nix build --no-link --print-out-paths .#gogcli`;
- `nix build --no-link --print-out-paths .#gogcli.tests.version`;
- `nix run nixpkgs#nixpkgs-review -- rev HEAD -b master -p gogcli --no-shell --print-result`
  at `e2fdd56864951db0cdecf79f1e68d17fb6a82d54`: one package built;
- installed on a NixOS system and confirmed:
  - direct and wrapped version metadata;
  - authenticated, bounded read-only Gmail search;
  - authenticated, bounded read-only Calendar event listing;
  - authenticated, bounded read-only Drive listing.

Verified on `aarch64-linux` under binfmt emulation:

- `nix build --no-link --print-out-paths .#legacyPackages.aarch64-linux.gogcli`;
- `nix build --no-link --print-out-paths .#legacyPackages.aarch64-linux.gogcli.tests.version`;
- confirmed the resulting binary is an ARM aarch64 ELF executable;
- executed the binary and confirmed its version, tag, and build date metadata.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (under binfmt emulation)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation/AI disclosure

The routine version and hash update was produced with `nix-update`. The
linker-path diagnosis, regression-test change, validation plan, and this pull
request summary were prepared with assistance from pi
(`openai-codex/gpt-5.6-sol`). I reviewed the changes and test results.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
