### PR TITLE
makeSetupHook: use explicit substitution and enable structuredAttrs

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -136,6 +136,8 @@
   [pnpm `fetcherVersion` section](#javascript-pnpm-fetcherVersion) of the manual
   for details.
 
+- `makeSetupHook` now uses structured attributes and only makes substitutions based on the values of the `substitutions` argument - other derivation attributes are no longer considered.
+
 - `rebuilderd` has been updated to 0.27.0 introducing breaking changes. See upstream changelog for details: [0.26.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.26.0), [0.27.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.27.0)
 
 - Starting with v14, `flameshot` will primarily utilise xdg-desktop-portal calls for screenshotting. This will directly affect users on X11 window managers due to the lack of a compatible portal with Screenshot feature. See [upstream changelog](https://github.com/flameshot-org/flameshot/releases/tag/v14.0.0) or [NixOS Flameshot](https://wiki.nixos.org/wiki/Flameshot) wiki page for workarounds.

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -735,7 +735,6 @@ rec {
       meta ? { },
       passthru ? { },
       substitutions ? { },
-      __structuredAttrs ? false,
     }@args:
     script:
     runCommand name
@@ -745,10 +744,6 @@ rec {
           # Make the position of the derivation accurate.
           # Since not having `name` is deprecated, this should be fairly accurate.
           pos = lib.unsafeGetAttrPos "name" args;
-          # TODO(@Artturin:) substitutions should be inside the env attrset
-          # but users are likely passing non-substitution arguments through substitutions
-          # turn off __structuredAttrs to unbreak substituteAll
-          inherit __structuredAttrs;
           pname = name;
           version = "26.05pre-git";
           inherit meta;
@@ -756,6 +751,7 @@ rec {
           inherit propagatedBuildInputs;
           inherit propagatedNativeBuildInputs;
           strictDeps = true;
+          __structuredAttrs = true;
           # TODO 2023-01, no backport: simplify to inherit passthru;
           passthru =
             passthru
@@ -771,7 +767,9 @@ rec {
           recordPropagatedDependencies
         ''
         + lib.optionalString (substitutions != { }) ''
-          substituteAll ${script} $out/nix-support/setup-hook
+          substitute ${script} $out/nix-support/setup-hook ${
+            lib.concatMapAttrsStringSep " " (name: _: "--subst-var ${name}") substitutions
+          }
         ''
       );
 

--- a/pkgs/by-name/ch/checkPhaseThreadLimitHook/package.nix
+++ b/pkgs/by-name/ch/checkPhaseThreadLimitHook/package.nix
@@ -6,8 +6,6 @@
 makeSetupHook {
   name = "check-phase-thread-limit-hook";
 
-  __structuredAttrs = true;
-
   meta = {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ grimmauld ];

--- a/pkgs/by-name/pn/pnpmBuildHook/package.nix
+++ b/pkgs/by-name/pn/pnpmBuildHook/package.nix
@@ -6,5 +6,4 @@ makeSetupHook {
   # the config hook must also be used.
   name = "pnpm-build-hook";
 
-  __structuredAttrs = true;
 } ./pnpm-build-hook.sh


### PR DESCRIPTION
By avoiding the use of `substituteAll` we don't need the substutions to be exported when `__structuredAttrs` is enabled, and by using `--subst-var` I think we avoid argument length issues in practice (since we only use variable names as arguments, not their contents). There is also prior art in https://github.com/NixOS/nixpkgs/blob/ad466008250e04e2633c1a174fb1284840bdc6fb/pkgs/build-support/replace-vars/replace-vars-with.nix#L94 (that function uses `--replace-fail` instead to be more strict about failed substitutions, but using that in this PR would complicate things I think - maybe something to consider in future).

Alternatively, we could keep `substituteAll` and explicitly export all substitution variables beforehand, which is a bit uglier but avoids the argument length issues.

What we cannot do is keep `substituteAll` and put the substitions into `env`, because a substitution can have the same attrname as one of the derivation arguments (e.g. `pname` substitution appears in `nixpkgs`), which causes an eval failure. So I don't really understand the comment I removed.

I have tested this on top of https://github.com/NixOS/nixpkgs/pull/551108 (via the same tests) , so it should pass the sniff test, but it wasn't exhaustively tested on all hooks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
