### PR TITLE
replaceVarsWith: enable strictDeps, enable structuredAttrs

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -111,6 +111,9 @@
     Users who must continue using ingress-nginx will now need to manually provide the rke2-images-ingress-nginx tarball.
   - Future Removal: The ingress-nginx chart will not receive any additional updates and will be completely removed in v1.37 for community users.
 
+- `replaceVarsWith` now enables `strictDeps` and `__structuredAttrs` and passing these attributes to the function is no longer allowed.
+   By extension, `replaceVars` now also enables `strictDeps` and `__structuredAttrs`.
+
 - `buildFHSEnvChroot` has been removed after deprecation in 23.05.
 
 - `leafnode` has been removed, as it was an unmaintained alpha-release of leafnode 2 and has a dependency on the EOL PRCE-library. Consider using `leafnode1` instead, which is still maintained.

--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -81,6 +81,8 @@ let
     dontUnpack = true;
     preferLocalBuild = true;
     allowSubstitutes = false;
+    strictDeps = true;
+    __structuredAttrs = true;
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
I have tested this on top of https://github.com/NixOS/nixpkgs/pull/551108 (via the same tests) , so it should pass the sniff test, but it wasn't exhaustively tested on everything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
