### PR TITLE
lib.isFunction: add tests and avoid error on non-function __functor

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -978,6 +978,10 @@ runTests {
     expr = isFunction { __functor = _: null; };
     expected = false;
   };
+  testIsFunctionAttrsWithNonFunctionFunctor = {
+    expr = isFunction { __functor = null; };
+    expected = false;
+  };
 
   testIsStorePath = {
     expr =

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -68,6 +68,7 @@ let
     hasInfix
     id
     ifilter0
+    isFunction
     isStorePath
     join
     lazyDerivation
@@ -923,6 +924,59 @@ runTests {
   testPadVersionMore = {
     expr = versions.pad 3 "1.2.3.4";
     expected = "1.2.3";
+  };
+
+  testIsFunctionStr = {
+    expr = isFunction "a";
+    expected = false;
+  };
+  testIsFunctionInt = {
+    expr = isFunction 0;
+    expected = false;
+  };
+  testIsFunctionFloat = {
+    expr = isFunction 0.4;
+    expected = false;
+  };
+  testIsFunctionPath = {
+    expr = isFunction ./.;
+    expected = false;
+  };
+  testIsFunctionList = {
+    expr = isFunction [ ];
+    expected = false;
+  };
+  testIsFunctionAttrs = {
+    expr = isFunction { };
+    expected = false;
+  };
+  testIsFunctionBool = {
+    expr = isFunction false;
+    expected = false;
+  };
+  testIsFunctionDerivation = {
+    expr = isFunction (builtins.derivation { });
+    expected = false;
+  };
+  testIsFunctionNull = {
+    expr = isFunction null;
+    expected = false;
+  };
+  testIsFunctionFunction = {
+    expr = isFunction isFunction;
+    expected = true;
+  };
+  testIsFunctionAttrsWithValidFunctor = {
+    expr = isFunction { __functor = _: _: null; };
+    expected = true;
+  };
+  testIsFunctionDrvWithValidFunctor = {
+    expr = isFunction ((builtins.derivation { }) // { __functor = _: _: null; });
+    expected = true;
+  };
+  testIsFunctionAttrsWithFunctorArity1 = {
+    expr = isFunction { __functor = _: null; };
+    expected = false;
   };
 
   testIsStorePath = {

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1128,7 +1128,7 @@ in
     let
       isFunction = builtins.isFunction;
     in
-    f: isFunction f || (f ? __functor && isFunction (f.__functor f));
+    f: isFunction f || (f ? __functor && isFunction f.__functor && isFunction (f.__functor f));
 
   /**
     `mirrorFunctionArgs f g` creates a new function `g'` with the same behavior as `g` (`g' x == g x`)


### PR DESCRIPTION
Three separate commits to ease review.

Here's the use case. I was just actually bitten by this.
The value that reached `isFunction` has a string `__functor`.
I have not finished debugging and figuring out the entire value or where it originated,
but the value itself is `"function"`,
which makes me think that it is the result of a Nix value having been serialized.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
