### PR TITLE
forgejo-mcp: 2.30.2 -> 2.33.0

### DIFF
--- a/pkgs/by-name/fo/forgejo-mcp/package.nix
+++ b/pkgs/by-name/fo/forgejo-mcp/package.nix
@@ -1,23 +1,24 @@
 {
   lib,
   buildGoModule,
-  fetchFromCodeberg,
+  fetchgit,
   nix-update-script,
   versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "forgejo-mcp";
-  version = "2.30.2";
+  version = "2.33.0";
 
-  src = fetchFromCodeberg {
-    owner = "goern";
-    repo = "forgejo-mcp";
+  # Plain git fetch: upstream's Forgejo instance has source-archive
+  # downloads disabled, so fetchFromForgejo (tarball-based) cannot be used.
+  src = fetchgit {
+    url = "https://git.b4mad.industries/agentic-forges/forgejo-mcp.git";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-czL2jfFalnbDzvtEAOLS82c+zuGpWgUrMFlu/vj1C8Q=";
+    hash = "sha256-yC2qBZLC0ArAwVULzFo5A7LlBRqLEhCZsFCW7o+7YSU=";
   };
 
-  vendorHash = "sha256-QDJRbF4mZzBv1vxvo1ZQJaUJayRHj1jMgjaRfAmLMik=";
+  vendorHash = "sha256-WoeTy80iC3j9LoekCF7f0yZ9GIQyl6Gx+KGvHABW7OM=";
 
   ldflags = [
     "-s"
@@ -35,9 +36,9 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Model Context Protocol (MCP) server for interacting with the Forgejo REST API";
-    longDescription = "This Model Context Protocol (MCP) server provides tools and resources for interacting with the Forgejo (specifically Codeberg.org) REST API";
-    homepage = "https://codeberg.org/goern/forgejo-mcp";
-    changelog = "https://codeberg.org/goern/forgejo-mcp/src/tag/${finalAttrs.src.tag}/CHANGELOG.md";
+    longDescription = "This Model Context Protocol (MCP) server provides tools and resources for interacting with the Forgejo REST API";
+    homepage = "https://git.b4mad.industries/agentic-forges/forgejo-mcp";
+    changelog = "https://git.b4mad.industries/agentic-forges/forgejo-mcp/src/tag/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ malik ];
     mainProgram = "forgejo-mcp";


### PR DESCRIPTION
Closes #551750.

Upstream has moved from `codeberg.org/goern/forgejo-mcp` — now a read-only mirror that will receive no further releases — to https://git.b4mad.industries/agentic-forges/forgejo-mcp. This points `src`, `homepage` and `changelog` at the new forge and updates to the latest release, which is only available there.

Changelog: https://git.b4mad.industries/agentic-forges/forgejo-mcp/src/tag/v2.33.0/CHANGELOG.md

Notes for review:

- The new Forgejo instance has source-archive downloads intentionally disabled (web and `refs/tags` archive URLs return 404), so `fetchFromForgejo`/`fetchFromGitea` cannot be used — the package now fetches via plain git (`fetchgit`), with a comment in the package explaining why. Side benefit: git-based fetching is immune to the known Gitea/Forgejo tarball hash-instability across server upgrades.
- `nix-update` (and thus presumably r-ryantm) updated the version but silently failed to refresh the hashes for this fetcher change; hashes were computed via `nix-prefetch-git` and a vendorHash TOFU build. Future automated bumps may need an eye kept on them.
- Dropped the "(specifically Codeberg.org)" wording from `longDescription`, which no longer applies.

cc @malikwirin — you offered to review if someone opened the PR (thanks!).

**AI disclosure** (per the [automation/AI policy]): this change was prepared with Claude Code (Claude Fable 5), verified by a local `nix-build -A forgejo-mcp` (versionCheckHook passes, binary reports 2.33.0, `--help` works), reviewed and submitted by me.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (versionCheckHook)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test