### PR TITLE
rPackages: strip binaries in common locations

### DIFF
--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -96,6 +96,12 @@ stdenv.mkDerivation (
       runHook postInstall
     '';
 
+    stripDebugList = [
+      "library/${attrs.pname}/libs"
+      # Note: this is non-standard, but some packages do place binaries here via custom install logic (e.g. via install.libs.R)
+      "library/${attrs.pname}/bin"
+    ];
+
     postFixup = ''
       if test -e $out/nix-support/propagated-build-inputs; then
         ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages


### PR DESCRIPTION
Targeting: https://github.com/NixOS/nixpkgs/pull/552051

Rethought version of https://github.com/NixOS/nixpkgs/pull/542871, which got reverted.

This PR does NOT add a check to see if all references to stdenv.cc or stdenv.cc.cc have been removed. We *could*, but why? It would just lead to what happened in https://github.com/NixOS/nixpkgs/pull/542871

Note: I did NOT add the default `$out/bin` or `$out/lib` to the strip list, only the R-specific stuff.
However, `Rserve` does actually copy binaries into `$out/bin` so those don't get stripped ATM.
Though, those binaries get installed there due to a patch in nixpkgs, so I think I'll just change it so that instead of copying, we're just symlinking.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
