### PR TITLE
gutenprint: remove `gimp2Support` since `gimp2` is deprecated

### DIFF
--- a/pkgs/by-name/gu/gutenprint/package.nix
+++ b/pkgs/by-name/gu/gutenprint/package.nix
@@ -7,7 +7,6 @@
   pkg-config,
   ijs,
   zlib,
-  gimp2Support ? false,
   gimp,
   cupsSupport ? true,
   cups,
@@ -37,10 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     ijs
     zlib
   ]
-  ++ lib.optionals gimp2Support [
-    gimp.gtk
-    gimp
-  ]
   ++ lib.optionals cupsSupport [
     cups
     libusb1
@@ -53,19 +48,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   # FIXME: hacky because we modify generated configure, but I haven't found a better way.
   # makeFlags doesn't change this everywhere (e.g. in cups-genppdupdate).
-  preConfigure =
-    lib.optionalString cupsSupport ''
-      sed -i \
-        -e "s,cups_conf_datadir=.*,cups_conf_datadir=\"$out/share/cups\",g" \
-        -e "s,cups_conf_serverbin=.*,cups_conf_serverbin=\"$out/lib/cups\",g" \
-        -e "s,cups_conf_serverroot=.*,cups_conf_serverroot=\"$out/etc/cups\",g" \
-        configure
-    ''
-    + lib.optionalString gimp2Support ''
-      sed -i \
-        -e "s,gimp2_plug_indir=.*,gimp2_plug_indir=\"$out/lib/gimp/${gimp.apiVersion}\",g" \
-        configure
-    '';
+  preConfigure = lib.optionalString cupsSupport ''
+    sed -i \
+      -e "s,cups_conf_datadir=.*,cups_conf_datadir=\"$out/share/cups\",g" \
+      -e "s,cups_conf_serverbin=.*,cups_conf_serverbin=\"$out/lib/cups\",g" \
+      -e "s,cups_conf_serverroot=.*,cups_conf_serverroot=\"$out/etc/cups\",g" \
+      configure
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
The project sourgeforge page state clearly that the gimp plugin is compatible with GIMP 2.x, so this has probably not been tested and doesn't work since GIMP 3.x is alias to the `gimp` package.

This is part of #410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
