### PR TITLE
rPackages.buildRPackage: fix structuredAttrs support

### DIFF
--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -91,8 +91,23 @@ stdenv.mkDerivation (
 
     installPhase = ''
       runHook preInstall
-      mkdir -p $out/library
-      $rCommand CMD INSTALL --built-timestamp='1970-01-01 00:00:00 UTC' ''${installFlags[@]} --configure-args="''${configureFlags[@]}" -l $out/library .
+
+      mkdir -p "$out/library"
+
+      # logic inside R CMD INSTALL essentially just expands `./configure $configureArgs` and runs it in a system shell
+      # so we need to escape configureFlags if we want to support things like spaces in arguments
+      local configureArgs=""
+      if ((''${#configureFlags[@]})); then
+        printf -v configureArgs '%q ' "''${configureFlags[@]}"
+      fi
+
+      $rCommand CMD INSTALL \
+        --library="$out/library" \
+        --built-timestamp='1970-01-01 00:00:00 UTC' \
+        --configure-args="$configureArgs" \
+        "''${installFlags[@]}" \
+        .
+
       runHook postInstall
     '';
 


### PR DESCRIPTION
I am not a bash expert so I did not realize that using `"--configure-args=${array[@]}"` will expand into `"--configure-args=arr0" "arr1" "arr2"`.

I intended to use `"--configure-args=${array[*]}"` which would have expanded into `"--configure-args=arr0 arr1 arr2"`.

However, this breaks if the array contains elements with spaces. So I ended up doing some escaping logic via `printf`'s `%q`

Also, I added some linebreaks into the command, expanded `-l` into `--library=` and added more quotes for the rare cases where there are spaces in the filepath.

---

This issue was causing e.g. `Rserve`, `ROracle` and `RVowpalWabbit` to not pick up both of their flags, only the first.
`Rserve` just didn't turn on the `with-client` feature.
`ROracle` actually broke, but since it was unfree, Hydra didn't build it, so we didn't know about it.
`RVowpalWabbit` is marked as broken, so it wasn't built

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
