### PR TITLE
anker-powerconf-c200-linux-tools: init at 0.1.0

### DIFF
--- a/pkgs/by-name/an/anker-powerconf-c200-linux-tools/package.nix
+++ b/pkgs/by-name/an/anker-powerconf-c200-linux-tools/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "anker-powerconf-c200-linux-tools";
+  version = "0.1.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "erans";
+    repo = "anker-powerconf-c200-linux-tools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-txIVTbqxnFQ8GcJgxTp89Qc3U5CXkYolXCO4E1PXHHA=";
+  };
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"/bin
+    cp ./build/anker-powerconf-c200-linux-tools "$out"/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linux CLI tools for the Anker PowerConf C200 webcam";
+    mainProgram = "anker-powerconf-c200-linux-tools";
+    homepage = "https://github.com/erans/anker-powerconf-c200-linux-tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fernsehmuell ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Linux CLI tools for the Anker PowerConf C200 webcam

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
