### PR TITLE
secretspec-ffi: reduce library size

### DIFF
--- a/pkgs/by-name/se/secretspec-ffi/package.nix
+++ b/pkgs/by-name/se/secretspec-ffi/package.nix
@@ -27,10 +27,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ cargo-c ];
 
+  # Keep the static archive intact while removing non-exported symbols from the shared library.
+  stripDebugFlags = if stdenv.hostPlatform.isDarwin then [ "-x" ] else [ "--strip-unneeded" ];
+  stripExclude = [ "lib/libsecretspec_ffi.a" ];
+
   buildPhase = ''
     runHook preBuild
     ${buildPackages.rust.envVars.setEnv} cargo cbuild -p secretspec-ffi -j $NIX_BUILD_CORES \
-      --release --frozen --prefix=${placeholder "out"} \
+      --profile dist --frozen --prefix=${placeholder "out"} \
       --target ${stdenv.hostPlatform.rust.rustcTarget}
     runHook postBuild
   '';
@@ -38,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
     ${buildPackages.rust.envVars.setEnv} cargo cinstall -p secretspec-ffi -j $NIX_BUILD_CORES \
-      --release --frozen --prefix=${placeholder "out"} \
+      --profile dist --frozen --prefix=${placeholder "out"} \
       --target ${stdenv.hostPlatform.rust.rustcTarget}
     runHook postInstall
   '';
@@ -46,7 +50,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   checkPhase = ''
     runHook preCheck
     ${buildPackages.rust.envVars.setEnv} cargo ctest -p secretspec-ffi -j $NIX_BUILD_CORES \
-      --release --frozen --prefix=${placeholder "out"} \
+      --profile dist --frozen --prefix=${placeholder "out"} \
       --target ${stdenv.hostPlatform.rust.rustcTarget}
     runHook postCheck
   '';


### PR DESCRIPTION
Measured on `x86_64-linux` using the resulting Nix store paths:

| Artifact | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Shared library (`.so`) | 44.74 MiB | 32.66 MiB | 12.08 MiB (27.0%) |
| Static library (`.a`) | 257.30 MiB | 125.51 MiB | 131.79 MiB (51.2%) |
| Package output | 302.05 MiB | 158.18 MiB | 143.87 MiB (47.6%) |
| Runtime closure | 348.05 MiB | 204.18 MiB | 143.87 MiB (41.3%) |

The Cargo invocations now use the upstream `dist` profile, enabling cross-crate ThinLTO. Unneeded symbols are stripped from the shared library while preserving the static archive for downstream static linking.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
