### PR TITLE
trailbase: init at 0.32.2

### DIFF
--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -27,6 +27,7 @@ let
       "<imports = [ pkgs.ktls-utils.services.default ]>" = fakeSubmodule pkgs.ktls-utils.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
       "<imports = [ pkgs.snid.services.default ]>" = fakeSubmodule pkgs.snid.services.default;
+      "<imports = [ pkgs.trailbase.services.default ]>" = fakeSubmodule pkgs.trailbase.services.default;
     };
   };
 in

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1795,6 +1795,7 @@ in
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };
   traefik = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./traefik.nix;
   trafficserver = runTest ./trafficserver.nix;
+  trailbase = runTest ./trailbase;
   tranquil-pds = runTest ./tranquil-pds.nix;
   transfer-sh = runTest ./transfer-sh.nix;
   transmission_4 = runTest ./transmission.nix;

--- a/nixos/tests/trailbase/api.py
+++ b/nixos/tests/trailbase/api.py
@@ -1,0 +1,67 @@
+import argparse
+from pathlib import Path
+
+from trailbase import Client, FetchException
+
+SITE = "http://127.0.0.1:4000"
+NOTES_SQL = (
+    "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL) STRICT;"
+)
+RECORD_API = """
+record_apis: [{
+  name: "notes"
+  table_name: "notes"
+  acl_authenticated: [CREATE, READ, UPDATE, DELETE]
+}]
+"""
+
+
+def connect(password):
+    client = Client(SITE)
+    client.login("admin@localhost", password)
+    user = client.user()
+    assert user is not None
+    assert user.email == "admin@localhost", user.email
+    return client
+
+
+def setup(password):
+    client = connect(password)
+    assert client.tokens() is not None
+    assert client.refresh_auth_tokens(force=True)
+    client.logout()
+    assert client.tokens() is None
+
+    client = connect(password)
+    client.fetch("api/_admin/query", method="POST", data={"query": NOTES_SQL})
+    with Path("/var/lib/trailbase/config.textproto").open("a") as cfg:
+        cfg.write(RECORD_API)
+
+
+def crud(password):
+    notes = connect(password).records("notes")
+    note_id = notes.create({"body": "hello from nixos"})
+    listed = notes.list()
+    found = any(note_id.id in str(row) for row in listed.records)
+    assert found, listed.records
+    assert "hello from nixos" in str(notes.read(note_id))
+    notes.update(note_id, {"body": "updated"})
+    assert "updated" in str(notes.read(note_id))
+    notes.delete(note_id)
+    try:
+        notes.read(note_id)
+    except FetchException:
+        return
+    raise SystemExit("deleted record still readable")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["setup", "crud"])
+    parser.add_argument("--password", required=True)
+    args = parser.parse_args()
+    (setup if args.command == "setup" else crud)(args.password)
+
+
+if __name__ == "__main__":
+    main()

--- a/nixos/tests/trailbase/default.nix
+++ b/nixos/tests/trailbase/default.nix
@@ -1,0 +1,50 @@
+{ lib, pkgs, ... }:
+{
+  _class = "nixosTest";
+  name = "trailbase";
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [
+          pkgs.curl
+          (pkgs.writers.writePython3Bin "trailbase-api" {
+            libraries = [ pkgs.python3Packages.trailbase ];
+          } (builtins.readFile ./api.py))
+        ];
+
+        system.services.trailbase = {
+          imports = [ pkgs.trailbase.services.default ];
+          trailbase.address = "127.0.0.1:4000";
+        };
+      };
+  };
+
+  testScript = ''
+    import re
+
+    start_all()
+    machine.wait_for_unit("trailbase.service")
+    machine.wait_for_open_port(4000)
+    machine.succeed("curl --fail http://127.0.0.1:4000/api/healthcheck")
+    machine.succeed("curl --fail -o /dev/null http://127.0.0.1:4000/_/admin/")
+
+    journal = machine.succeed("journalctl -u trailbase.service --no-pager")
+    match = re.search(r"password:\s*'([^']+)'", journal)
+    assert match, f"admin password not in journal:\n{journal}"
+    password = match.group(1)
+
+    machine.succeed(f"trailbase-api --password {password!r} setup")
+    machine.succeed("systemctl restart trailbase.service")
+    machine.wait_for_unit("trailbase.service")
+    machine.wait_for_open_port(4000)
+    machine.succeed("curl --fail http://127.0.0.1:4000/api/healthcheck")
+    machine.succeed(f"trailbase-api --password {password!r} crud")
+  '';
+
+  meta = {
+    maintainers = [ lib.maintainers.lucasew ];
+    teams = [ lib.teams.ngi ];
+  };
+}

--- a/pkgs/by-name/tr/trailbase/package.nix
+++ b/pkgs/by-name/tr/trailbase/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pkg-config,
+  protobuf,
+  cmake,
+  cacert,
+  geos,
+  nodejs,
+  pnpm_11,
+  pnpmConfigHook,
+  versionCheckHook,
+  nix-update-script,
+  nixosTests,
+}:
+
+let
+  pnpm = pnpm_11;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "trailbase";
+  version = "0.32.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "trailbaseio";
+    repo = "trailbase";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-b+HtxTg9UN5uvix9FkzRnRr7eP6dLVGz0v8UPqeTqaM=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-RUbP49jXJj8UC2Sww0UlH8uyEpkshi2gewNqZ7XYeG4=";
+
+  patches = [ ./skip-pnpm-install.patch ];
+
+  # Skip cargo's workspace-wide pnpm install; pnpmConfigHook already did it.
+  env.TRAILBASE_SKIP_PNPM_INSTALL = "1";
+
+  # Package plus its workspace dependencies:
+  # https://pnpm.io/filtering#--filter-package_name-1
+  pnpmWorkspaces = [ "trailbase-admin-ui..." ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-ue2hqveVMWEIB9GUD3NCohPO2VW2G+17L/OqLhz6UeE=";
+  };
+
+  # wasmtime's cargo-auditable build is broken:
+  # https://github.com/rust-secure-code/cargo-auditable/issues/124
+  auditable = false;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    protobuf
+    nodejs
+    pnpm
+    pnpmConfigHook
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [ geos ];
+
+  postPatch = ''
+    # `trail --version` prints the git tag. fetchFromGitHub has no .git.
+    substituteInPlace crates/build/src/version.rs \
+      --replace-fail 'get_output("git", &["describe", "--tags", "--match=v*", "--long"])' \
+      'Some("v${finalAttrs.version}".to_string())'
+  '';
+
+  cargoBuildFlags = [
+    "--bin"
+    "trail"
+  ];
+
+  # test_utils is behind `#[cfg(debug_assertions)]`.
+  checkType = "debug";
+
+  # reqwest/rustls refuses to build a client without a CA bundle,
+  # even for the local HTTP OAuth mock.
+  nativeCheckInputs = [ cacert ];
+
+  # Full client e2e needs a seeded depot, WASM guests, and email.
+  # The NixOS test covers login + record CRUD against the packaged server.
+  checkFlags = [ "--skip=client_integration_test" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) trailbase;
+    };
+    services.default = {
+      imports = [ (lib.modules.importApply ./service.nix { }) ];
+      trailbase.package = lib.mkDefault finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Single-executable Firebase alternative with type-safe APIs, auth, and an admin UI";
+    homepage = "https://trailbase.io";
+    changelog = "https://github.com/trailbaseio/trailbase/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.osl3;
+    maintainers = [ lib.maintainers.lucasew ];
+    teams = [ lib.teams.ngi ];
+    mainProgram = "trail";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/tr/trailbase/service.nix
+++ b/pkgs/by-name/tr/trailbase/service.nix
@@ -1,0 +1,84 @@
+# Non-module dependencies (`importApply`)
+{ }:
+
+# Service module
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkOption
+    types
+    ;
+  cfg = config.trailbase;
+in
+{
+  _class = "service";
+
+  meta = {
+    maintainers = [ lib.maintainers.lucasew ];
+    teams = [ lib.teams.ngi ];
+  };
+
+  options = {
+    trailbase = {
+      package = mkOption {
+        description = "Package to use for TrailBase.";
+        defaultText = "The package that provided this module.";
+        type = types.package;
+      };
+
+      address = mkOption {
+        description = "Authority (`<host>:<port>`) the HTTP server binds to.";
+        type = types.str;
+        default = "127.0.0.1:4000";
+        example = "0.0.0.0:4000";
+      };
+
+      depot = mkOption {
+        description = "Directory for runtime files including the databases.";
+        type = types.str;
+        default = "/var/lib/trailbase";
+      };
+
+      extraArgs = mkOption {
+        description = "Extra arguments to pass to `trail run`.";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+    };
+  };
+
+  config = {
+    process.argv = [
+      (getExe cfg.package)
+      "--depot"
+      cfg.depot
+      "run"
+      "--address"
+      cfg.address
+    ]
+    ++ cfg.extraArgs;
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.service = {
+      description = "TrailBase";
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        DynamicUser = true;
+        StateDirectory = "trailbase";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = "%S/trailbase";
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/tr/trailbase/skip-pnpm-install.patch
+++ b/pkgs/by-name/tr/trailbase/skip-pnpm-install.patch
@@ -1,0 +1,81 @@
+Skip workspace-wide `pnpm install` when JS deps are already installed.
+
+Nixpkgs installs the filtered admin UI workspace via pnpmConfigHook.
+A second install walks every workspace member and fails offline.
+
+--- a/crates/build/src/lib.rs
++++ b/crates/build/src/lib.rs
+@@ -92,39 +92,43 @@
+     Ok("TRUE") | Ok("true") | Ok("1")
+   );
+ 
+-  // Note that `--frozen-lockfile` and `-ignore-workspace` are practically exclusive
+-  // Because ignoring the workspace one, will require to create a new lockfile.
+-  let out_dir = std::env::var("OUT_DIR").unwrap();
+-  let build_result = if out_dir.contains("target/package") {
+-    // When we build cargo packages, we cannot rely on the workspace itself and prior installs.
+-    pnpm_run(&["--dir", &path, "install", "--ignore-workspace"])
+-  } else {
+-    // `trailbase-assets` and `trailbase-js` both build JS packages. We've seen issues with
+-    // parallel installs in the past. Our current approach is to recommend installing workspace
+-    // JS deps upfront in combination with `--prefer-offline`. We used to use plain `--offline`,
+-    // however this adds an extra mandatory step when vendoring trailbase for framework use-cases.
+-    let args = if strict_offline {
+-      ["--dir", &path, "install", "--frozen-lockfile", "--offline"]
++  // Packagers such as Nixpkgs install JS deps before `cargo build`.
++  // Skip the extra workspace-wide install in that case.
++  if std::env::var_os("TRAILBASE_SKIP_PNPM_INSTALL").is_none() {
++    // Note that `--frozen-lockfile` and `-ignore-workspace` are practically exclusive
++    // Because ignoring the workspace one, will require to create a new lockfile.
++    let out_dir = std::env::var("OUT_DIR").unwrap();
++    let build_result = if out_dir.contains("target/package") {
++      // When we build cargo packages, we cannot rely on the workspace itself and prior installs.
++      pnpm_run(&["--dir", &path, "install", "--ignore-workspace"])
+     } else {
+-      [
+-        "--dir",
+-        &path,
+-        "install",
+-        "--prefer-frozen-lockfile",
+-        "--prefer-offline",
+-      ]
++      // `trailbase-assets` and `trailbase-js` both build JS packages. We've seen issues with
++      // parallel installs in the past. Our current approach is to recommend installing workspace
++      // JS deps upfront in combination with `--prefer-offline`. We used to use plain `--offline`,
++      // however this adds an extra mandatory step when vendoring trailbase for framework use-cases.
++      let args = if strict_offline {
++        ["--dir", &path, "install", "--frozen-lockfile", "--offline"]
++      } else {
++        [
++          "--dir",
++          &path,
++          "install",
++          "--prefer-frozen-lockfile",
++          "--prefer-offline",
++        ]
++      };
++      let build_result = pnpm_run(&args);
++      if build_result.is_err() {
++        error!(
++          "`pnpm {}` failed. Make sure to install all JS deps first using `pnpm install`",
++          args.join(" ")
++        )
++      }
++      build_result
+     };
+-    let build_result = pnpm_run(&args);
+-    if build_result.is_err() {
+-      error!(
+-        "`pnpm {}` failed. Make sure to install all JS deps first using `pnpm install`",
+-        args.join(" ")
+-      )
+-    }
+-    build_result
+-  };
+ 
+-  let _ = build_result?;
++    let _ = build_result?;
++  }
+ 
+   // Enable source maps for debug builds:
+   // let build_output = pnpm_run(&["--dir", &path, "build", "--sourcemap", "inline"]);

--- a/pkgs/development/python-modules/mintotp/default.nix
+++ b/pkgs/development/python-modules/mintotp/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mintotp";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-0PTbXts4p0gRIBdqUm6MKVObnoBYHdLcwYEVV9d8+tU=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "mintotp" ];
+
+  meta = {
+    description = "Minimal TOTP generator";
+    homepage = "https://github.com/susam/mintotp";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.lucasew ];
+  };
+})

--- a/pkgs/development/python-modules/trailbase/default.nix
+++ b/pkgs/development/python-modules/trailbase/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  pythonOlder,
+  httpx,
+  pyjwt,
+  cryptography,
+  pytestCheckHook,
+  mintotp,
+  trailbase,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "trailbase";
+  version = "0.7.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.13";
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-iWdxMgjEPd5RkCRY3JnzuaJ1nW6LOESciTB6j2lzPzM=";
+  };
+
+  # Tests are not on PyPI.
+  prePatch = ''
+    cp -r ${trailbase.src}/client/python/tests tests
+    chmod -R u+w tests
+  '';
+
+  patches = [ ./use-packaged-server.patch ];
+
+  build-system = [ poetry-core ];
+
+  pythonRelaxDeps = [
+    "httpx"
+    "cryptography"
+  ];
+
+  dependencies = [
+    cryptography
+    httpx
+    pyjwt
+  ];
+
+  nativeCheckInputs = [
+    mintotp
+    pytestCheckHook
+    trailbase
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    export TRAILBASE_BIN=${lib.getExe trailbase}
+    export TRAILBASE_TESTFIXTURE="$TMPDIR/testfixture"
+    cp -r ${trailbase.src}/client/testfixture "$TRAILBASE_TESTFIXTURE"
+    chmod -R u+w "$TRAILBASE_TESTFIXTURE"
+
+    # promote_anonymous tries to send mail; the fixture has no SMTP.
+    mkdir -p "$TMPDIR/bin"
+    printf '%s\n' '#!/bin/sh' 'cat >/dev/null' > "$TMPDIR/bin/sendmail"
+    chmod +x "$TMPDIR/bin/sendmail"
+    export PATH="$TMPDIR/bin:$PATH"
+  '';
+
+  pythonImportsCheck = [ "trailbase" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TrailBase client for Python";
+    homepage = "https://pypi.org/project/trailbase/";
+    changelog = "https://github.com/trailbaseio/trailbase/releases";
+    license = with lib.licenses; [
+      asl20
+      osl3
+    ];
+    maintainers = [ lib.maintainers.lucasew ];
+    teams = [ lib.teams.ngi ];
+  };
+})

--- a/pkgs/development/python-modules/trailbase/use-packaged-server.patch
+++ b/pkgs/development/python-modules/trailbase/use-packaged-server.patch
@@ -1,0 +1,24 @@
+--- a/tests/test_client.py
++++ b/tests/test_client.py
+@@ -37,19 +37,12 @@
+     process: None | subprocess.Popen[bytes]
+ 
+     def __init__(self) -> None:
+-        cwd = os.getcwd()
+-        traildepot = "../testfixture" if cwd.endswith("python") else "client/testfixture"
+-
+-        logger.info("Building TrailBase")
+-        build = subprocess.run(["cargo", "build"])
+-        assert build.returncode == 0, f"{build.stderr}"
++        traildepot = os.environ["TRAILBASE_TESTFIXTURE"]
+ 
+         logger.info("Starting TrailBase")
+         self.process = subprocess.Popen(
+             [
+-                "cargo",
+-                "run",
+-                "--",
++                os.environ.get("TRAILBASE_BIN", "trail"),
+                 "--data-dir",
+                 traildepot,
+                 "run",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20699,6 +20699,8 @@ self: super: with self; {
 
   trafilatura = callPackage ../development/python-modules/trafilatura { };
 
+  trailbase = callPackage ../development/python-modules/trailbase { inherit (pkgs) trailbase; };
+
   trailrunner = callPackage ../development/python-modules/trailrunner { };
 
   trainer = callPackage ../development/python-modules/trainer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10592,6 +10592,8 @@ self: super: with self; {
 
   miniupnpc = callPackage ../development/python-modules/miniupnpc { };
 
+  mintotp = callPackage ../development/python-modules/mintotp { };
+
   mip = callPackage ../development/python-modules/mip { };
 
   mir-eval = callPackage ../development/python-modules/mir-eval { };


### PR DESCRIPTION
Adds [TrailBase](https://trailbase.io) 0.32.2. NLnet/NGI-funded single-executable Firebase alternative: auth, typed record APIs, admin UI.

Ships as a package plus a modular service (`pkgs.trailbase.services.default`), not a classic `services.trailbase.enable` module. I can add one if reviewers want it.

NixOS test (`nixosTests.trailbase`): health + admin UI, login/refresh/logout, then record CRUD after a restart. Ran locally on x86_64-linux.

Cargo `client_integration_test` is skipped. It wants a seeded depot, WASM guests, and email. The VM test covers login + CRUD against the packaged server.

Related: https://github.com/ngi-nix/projects/issues/2136

Assisted-by: Grok 4.6 (xAI). I reviewed the package, modular service, and test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test