### PR TITLE
globalplatform: 2.4.2 -> 3.0.0

### DIFF
--- a/pkgs/by-name/gl/globalplatform/package.nix
+++ b/pkgs/by-name/gl/globalplatform/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "globalplatform";
-  version = "2.4.2";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "kaoh";
     repo = "globalplatform";
     tag = finalAttrs.version;
-    sha256 = "sha256-ikhncinibeQjcpYstduYhWS/bvwRah6+wrWF9kutSOI=";
+    sha256 = "sha256-ZnPu94q4wye9uH8A7N13Q5kt9M5sJjTEHpeveVUpLzc=";
   };
 
   nativeBuildInputs = [
@@ -49,11 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     cmocka
   ];
-
-  preCheck = ''
-    cp "$src/gpshell/helloworld.cap" globalplatform/src
-    cp "$src/globalplatform/src/rsa_pub_key_test.pem" globalplatform/src
-  '';
 
   # libglobalplatform.so uses dlopen() to load specified connection plugins at runtime.
   # Currently, libgppcscconnectionplugin.so is the only plugin included.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update to latest. Remove now obsolete preCheck (to fix build).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
