### PR TITLE
zennotes-desktop: 2.27.0 -> 2.28.2

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.27.0";
-  npmDepsHash = "sha256-cSotsEeJp2/5t7me8ETs+1URHfUoM1boY5lsjUEi8WI=";
+  version = "2.28.2";
+  npmDepsHash = "sha256-t0+Z6kDPRa5wCxkmQfzzXS0Y22s9w8vNXYaxrYlf3+Y=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ViZHSH9m02NzexYNbeOuZJ623Nz8dvd2jGqAIj+lKRI=";
+    hash = "sha256-kSjCuKYbUaKtCqSTelJ02yO7FMgeTnChItNK1oaAIxc=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Updates ZenNotes Desktop from 2.27.0 to 2.28.2, superseding #552487 so nixpkgs tracks the latest release.

Release notes: https://github.com/ZenNotes/zennotes/releases/tag/v2.28.2

Notable changes include LaTeX completion, clickable frontmatter tags, Vim heading motions, safer atomic saves, Cloud conflict handling fixes, broader Linux Secret Service support, and several editor fixes.

The source and npm dependency hashes were reproduced from the `v2.28.2` source build. Verification on native `aarch64-linux`:

- `nix build --no-link -L --print-out-paths .#zennotes-desktop`
- The upstream production build and `verify-packaged-cli` check completed successfully.
- Evaluated package version `2.28.2`, main program `zennotes-desktop`, and confirmed the installed wrapper is executable.

Automation disclosure: this package update, hash calculation, build verification, commit, and PR text were prepared with OpenAI Codex (GPT-5). The PR is intentionally a draft pending the maintainer's manual review.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
