### PR TITLE
treewide: Mark packages with EOL vendored Electron as insecure

### DIFF
--- a/pkgs/by-name/be/beekeeper-studio/package.nix
+++ b/pkgs/by-name/be/beekeeper-studio/package.nix
@@ -160,5 +160,9 @@ stdenv.mkDerivation (finalAttrs: {
       "aarch64-darwin"
       "x86_64-darwin"
     ];
+    # https://github.com/beekeeper-studio/beekeeper-studio/blob/a19c6bc11aaad4692d44f303be150443734c7fb7/apps/studio/package.json#L200
+    knownVulnerabilities = [
+      "Electron 39 is EOL"
+    ];
   };
 })

--- a/pkgs/by-name/cy/cypress/package.nix
+++ b/pkgs/by-name/cy/cypress/package.nix
@@ -127,5 +127,9 @@ stdenv.mkDerivation rec {
       Crafter
       jonhermansen
     ];
+    # https://github.com/cypress-io/cypress/blob/3cbfbe76b02816280e1d9fa5bf1d30e0e39aaaf1/package.json#L144
+    knownVulnerabilities = [
+      "Electron 33 is EOL"
+    ];
   };
 }

--- a/pkgs/by-name/po/polar-bookshelf/package.nix
+++ b/pkgs/by-name/po/polar-bookshelf/package.nix
@@ -131,6 +131,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     maintainers = [ ];
+    knownVulnerabilities = [
+      "Electron version 7 is EOL"
+    ];
   };
 
 })

--- a/pkgs/by-name/po/polar-bookshelf1/package.nix
+++ b/pkgs/by-name/po/polar-bookshelf1/package.nix
@@ -117,5 +117,8 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.dansbandit ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    knownVulnerabilities = [
+      "Electron version 7 is EOL"
+    ];
   };
 })

--- a/pkgs/by-name/pu/publii/package.nix
+++ b/pkgs/by-name/pu/publii/package.nix
@@ -105,6 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     maintainers = [
     ];
+    # https://github.com/GetPublii/Publii/blob/b84444700eee742d1cd5631c2c4ca5d38efcb8db/package.json#L46
+    knownVulnerabilities = [
+      "Electron version 37 is EOL"
+    ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/by-name/th/thedesk/package.nix
+++ b/pkgs/by-name/th/thedesk/package.nix
@@ -67,5 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "thedesk";
+    knownVulnerabilities = [
+      "Electron version 37 is EOL"
+    ];
   };
 })

--- a/pkgs/by-name/wa/waveterm/package.nix
+++ b/pkgs/by-name/wa/waveterm/package.nix
@@ -47,6 +47,10 @@ let
       "x86_64-darwin"
     ];
     maintainers = [ ];
+    # https://github.com/wavetermdev/waveterm/blob/f6c47f9da51b1ed8bf9da65988cba433d40f8029/package.json#L52
+    knownVulnerabilities = [
+      "Uses EOL Electron 38"
+    ];
   };
 
   linux = stdenv.mkDerivation {

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -158,5 +158,9 @@ stdenv.mkDerivation rec {
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.bsd3;
+    # https://github.com/keybase/client/blob/19f9cfeddb22d7206404987aed5300bfd667d7df/shared/package.json#L172
+    knownVulnerabilities = [
+      "Electron 23 is EOL"
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Using nix-locate I got a list of package, then inspected them for what version of Electron they are using. If they are older than the oldest supported Electron (v41 right now), we mark them as insecure. This is what we do if they used Nixpkg's built Electron instead.

Some of these should be dropped on unstable as well as the upstreams are dead (bookshelf primarily). 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
