### PR TITLE
postgresql: minor updates August 2026

### DIFF
--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,7 @@
 {
-  version = "14.23";
-  rev = "refs/tags/REL_14_23";
-  hash = "sha256-fjoboaUhrHFDqusmIXzSS5ZnIpSRHO9+qcqvkchl2dM=";
+  version = "14.24";
+  rev = "refs/tags/REL_14_24";
+  hash = "sha256-yfZJFXk10vJ4QEhbUXe1gtz8rBS2YOEcD3unEjSHzjk=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,7 @@
 {
-  version = "15.18";
-  rev = "refs/tags/REL_15_18";
-  hash = "sha256-tw1zzgLXx7Jr4bi8rMKRmTJzOSQFGvrP2nHr9FcVrjs=";
+  version = "15.19";
+  rev = "refs/tags/REL_15_19";
+  hash = "sha256-y5QarcJSMifu+ctjsQOdG/Njo9KvFvIgncBJBjCVG3Y=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,7 @@
 {
-  version = "16.14";
-  rev = "refs/tags/REL_16_14";
-  hash = "sha256-g2+OdB2dGIKBSFJ24Z3Yy7oRAFywNMSVDdWfnsaeJJQ=";
+  version = "16.15";
+  rev = "refs/tags/REL_16_15";
+  hash = "sha256-HHNROwOzfTatZif+hog/DZnDafV+mZ2Z9Jrq87XN0cY=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,7 @@
 {
-  version = "17.10";
-  rev = "refs/tags/REL_17_10";
-  hash = "sha256-3ZAqlT3R8ywhNH13oqz2VUbSwpOJ2JaICbxZ29awaMw=";
+  version = "17.11";
+  rev = "refs/tags/REL_17_11";
+  hash = "sha256-pkVBg4Rxku3rEnNhPvVoAoab55vqrDqZfW1z+umealE=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,7 @@
 {
-  version = "18.4";
-  rev = "refs/tags/REL_18_4";
-  hash = "sha256-Ac/Dqcj8vjcW3my5vsnKaMiQqTq/HPtUzckJ3SMyrfA=";
+  version = "18.6";
+  rev = "refs/tags/REL_18_6";
+  hash = "sha256-ySffxlG7jlNyzx++BmIN+WuaQ9TMAJt/qER9wIjd6B8=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/19.nix
+++ b/pkgs/servers/sql/postgresql/19.nix
@@ -1,7 +1,7 @@
 {
-  version = "19beta2";
-  rev = "refs/tags/REL_19_BETA2";
-  hash = "sha256-3bfWDt6+iXJG/Wy2i8R7B+H7fMbLsSSD3qzuOXTpmtc=";
+  version = "19beta3";
+  rev = "refs/tags/REL_19_BETA3";
+  hash = "sha256-Mcf46ksAzOn9hqCiF5kUwNskfFCBxrzqvznnxdwHfnM=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";


### PR DESCRIPTION
Release Notes: https://www.postgresql.org/about/news/postgresql-186-1711-1615-1519-1424-and-19-beta-3-released-3365/

Just your regular 28 CVEs fixed...

## Things done

- Built on platform:
  - [x] x86_64-linux (top-level, static, cross)
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran nixpkgs-review on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
