### PR TITLE
fetchsvn, fetchsvnssh: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -66,7 +66,12 @@ else
     ]
     ++ lib.optional sshSupport openssh;
 
-    SVN_SSH = if sshSupport then "${buildPackages.openssh}/bin/ssh" else null;
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    env = lib.optionalAttrs sshSupport {
+      SVN_SSH = lib.getExe buildPackages.openssh;
+    };
 
     outputHashAlgo = if hash != "" then null else "sha256";
     outputHashMode = "recursive";

--- a/pkgs/build-support/fetchsvnrevision/default.nix
+++ b/pkgs/build-support/fetchsvnrevision/default.nix
@@ -2,7 +2,7 @@ runCommand: subversion: repository:
 import (
   runCommand "head-revision"
     {
-      buildInputs = [ subversion ];
+      nativeBuildInputs = [ subversion ];
       dummy = builtins.currentTime;
     }
     ''

--- a/pkgs/build-support/fetchsvnssh/builder.sh
+++ b/pkgs/build-support/fetchsvnssh/builder.sh
@@ -1,9 +1,5 @@
 echo "exporting $url (r$rev) into $out"
 
-if test "$sshSupport"; then
-    export SVN_SSH="$openssh/bin/ssh"
-fi
-
 # Pipe the "p" character into Subversion to force it to accept the
 # server's certificate.  This is perfectly safe: we don't care
 # whether the server is being spoofed --- only the cryptographic

--- a/pkgs/build-support/fetchsvnssh/default.nix
+++ b/pkgs/build-support/fetchsvnssh/default.nix
@@ -27,6 +27,10 @@ lib.fetchers.withNormalizedHash { } (
     strictDeps = true;
     __structuredAttrs = true;
 
+    env = lib.optionalAttrs sshSupport {
+      SVN_SSH = lib.getExe openssh;
+    };
+
     inherit outputHash outputHashAlgo;
     outputHashMode = "recursive";
 
@@ -37,8 +41,6 @@ lib.fetchers.withNormalizedHash { } (
       password
       url
       rev
-      sshSupport
-      openssh
       ;
   }
 )

--- a/pkgs/build-support/fetchsvnssh/default.nix
+++ b/pkgs/build-support/fetchsvnssh/default.nix
@@ -24,6 +24,9 @@ lib.fetchers.withNormalizedHash { } (
       expect
     ];
 
+    strictDeps = true;
+    __structuredAttrs = true;
+
     inherit outputHash outputHashAlgo;
     outputHashMode = "recursive";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
