### PR TITLE
fetchdocker: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/build-support/fetchdocker/default.nix
+++ b/pkgs/build-support/fetchdocker/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   coreutils,
   bash,
@@ -56,9 +56,13 @@ let
     lib.concatStringsSep "\n" ((lib.unique imageLayers) ++ [ imageConfig ])
   );
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   builder = ./fetchdocker-builder.sh;
-  buildInputs = [ coreutils ];
+  nativeBuildInputs = [ coreutils ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
   preferLocalBuild = true;
 
   inherit

--- a/pkgs/build-support/fetchdocker/generic-fetcher.nix
+++ b/pkgs/build-support/fetchdocker/generic-fetcher.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   haskellPackages,
   writeText,
@@ -40,7 +40,7 @@ assert (if layerDigest != "" then !lib.hasPrefix "sha256:" layerDigest else true
 let
   layerDigestFlag = lib.optionalString (layerDigest != "") "--layer ${layerDigest}";
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   inherit name;
   builder = writeText "${fetcher}-builder.sh" ''
     echo "${fetcher} exporting to $out"
@@ -86,7 +86,10 @@ stdenv.mkDerivation {
       "${tag}"
   '';
 
-  buildInputs = [ haskellPackages.hocker ];
+  nativeBuildInputs = [ haskellPackages.hocker ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   outputHashAlgo = "sha256";
   outputHashMode = "flat";


### PR DESCRIPTION
I'm not quite sure how to test this - I kind of assumed that only `nativeBuildInputs` would make sense for a fetcher?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
