### PR TITLE
python3Packages.transformer-engine: 2.17.1 -> 2.18

### DIFF
--- a/pkgs/development/python-modules/transformer-engine/default.nix
+++ b/pkgs/development/python-modules/transformer-engine/default.nix
@@ -15,6 +15,7 @@
   # build-system
   cmake,
   ninja,
+  nvidia-cudnn-frontend,
   pybind11,
   setuptools,
   # jax-only
@@ -22,6 +23,9 @@
   jax,
   # pytorch-only:
   torch,
+
+  # buildInputs
+  nlohmann_json,
 
   # dependencies
   importlib-metadata,
@@ -82,7 +86,7 @@ let
 in
 buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
   pname = "transformer-engine";
-  version = "2.17.1";
+  version = "2.18";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -92,7 +96,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
     tag = "v${finalAttrs.version}";
     # Their CMakeLists.txt does not easily let us inject dependencies
     fetchSubmodules = true;
-    hash = "sha256-W9aWSmYCV7wYrLSAlYE2prfPfucXkPjWGA7NAMfBJ9E=";
+    hash = "sha256-NKky2b5grlfVdWsPf6HO4QZAvVuibCKvmfU0DxUIfvs=";
   };
 
   patches = optionals cudaSupport [
@@ -114,7 +118,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
     ''
       substituteInPlace pyproject.toml \
         --replace-fail "pybind11[global]" "pybind11" \
-        --replace-fail '"pip", "torch>=2.1", "jax>=0.5.0", "flax>=0.7.1"' ""
+        --replace-fail '"pip", "torch>=2.1", "jax>=0.5.0", "flax>=0.7.1",' ""
     ''
     # Hardcode the path to the output store path that transformer_engine will use to import
     # - libtransformer_engine.so
@@ -180,6 +184,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
   build-system = [
     cmake
     ninja
+    nvidia-cudnn-frontend
     pybind11
     setuptools
   ]
@@ -217,6 +222,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
     cudaPackages.libcusolver # cusolverDn.h
     cudaPackages.libcusparse # cusparse.h
     cudaPackages.nccl # nccl.h
+    nlohmann_json
     pybind11 # pybind11/pybind11.h
   ]
   ++ optionals withMpi [
@@ -298,6 +304,7 @@ buildPythonPackage.override { stdenv = backendStdenv; } (finalAttrs: {
     changelog = "https://github.com/NVIDIA/TransformerEngine/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
+    teams = [ lib.teams.cuda ];
     broken = !cudaSupport;
   };
 })


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/NVIDIA/TransformerEngine/compare/v2.17.1...v2.18
Changelog: https://github.com/NVIDIA/TransformerEngine/releases/tag/v2.18

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test