### PR TITLE
nixos/qemu-vm: 9p -> virtiofs

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -324,6 +324,24 @@ let
         ''
     )}
 
+    echo "Starting virtiofs daemons..."
+    NIX_VIRTIOFS_DIR=$(mktemp -d)
+    ${lib.concatLines (
+      lib.mapAttrsToList (tag: share: ''
+        ${lib.getExe hostPkgs.virtiofsd} \
+          --socket-path="$NIX_VIRTIOFS_DIR"/"${tag}" \
+          --shared-dir="${share.source}" \
+          ${if share.writable then "--writeback" else "--readonly"} \
+          --sandbox=none \
+          --seccomp=none \
+          --cache=always \
+          --no-announce-submounts \
+          --translate-uid=host:65534:0:1 \
+          --translate-gid=host:65534:0:1 \
+          &
+      '') cfg.sharedDirectories
+    )}
+
     # Start QEMU.
     exec ${
       qemu-common.qemuBinaryWith {
@@ -336,14 +354,6 @@ let
         -smp ${toString config.virtualisation.cores} \
         -device virtio-rng-pci \
         ${concatStringsSep " " config.virtualisation.qemu.networkingOptions} \
-        ${
-          concatStringsSep " \\\n    " (
-            mapAttrsToList (
-              tag: share:
-              "-virtfs local,path=${share.source},security_model=${share.securityModel},mount_tag=${tag}"
-            ) config.virtualisation.sharedDirectories
-          )
-        } \
         ${drivesCmdLine config.virtualisation.qemu.drives} \
         ${concatStringsSep " \\\n    " config.virtualisation.qemu.options} \
         $QEMU_OPTS \
@@ -424,6 +434,14 @@ in
       "virtualisation"
       "useSecureBoot"
     ] "The default OVMF now always supports Secure Boot.")
+    (mkRemovedOptionModule [
+      "virtualisation"
+      "msize"
+    ] "9p was replaced with virtiofs and thus this option is obsolete.")
+    (mkRemovedOptionModule [
+      "virtualisation"
+      "nixStore9pCache"
+    ] "9p was replaced with virtiofs and thus this option is obsolete.")
   ];
 
   options = {
@@ -435,16 +453,6 @@ in
       default = 1024;
       description = ''
         The memory size of the virtual machine in MiB (1024×1024 bytes).
-      '';
-    };
-
-    virtualisation.msize = mkOption {
-      type = types.ints.positive;
-      default = 16384;
-      description = ''
-        The msize (maximum packet size) option passed to 9p file systems, in
-        bytes. Increasing this should increase performance significantly,
-        at the cost of higher RAM usage.
       '';
     };
 
@@ -570,22 +578,8 @@ in
             type = types.path;
             description = "The mount point of the directory inside the virtual machine";
           };
-          options.securityModel = mkOption {
-            type = types.enum [
-              "passthrough"
-              "mapped-xattr"
-              "mapped-file"
-              "none"
-            ];
-            default = "mapped-xattr";
-            description = ''
-              The security model to use for this share:
-
-              - `passthrough`: files are stored using the same credentials as they are created on the guest (this requires QEMU to run as root)
-              - `mapped-xattr`: some of the file attributes like uid, gid, mode bits and link target are stored as file attributes
-              - `mapped-file`: the attributes are stored in the hidden .virtfs_metadata directory. Directories exported by this security model cannot interact with other unix tools
-              - `none`: same as "passthrough" except the sever won't report failures if it fails to set file attributes like ownership
-            '';
+          options.writable = lib.mkEnableOption "" // {
+            description = "Whether the directory is writable on the host and guest.";
           };
         }
       );
@@ -610,11 +604,10 @@ in
         A list of paths whose closure should be made available to
         the VM.
 
-        When 9p is used, the closure is registered in the Nix
-        database in the VM. All other paths in the host Nix store
-        appear in the guest Nix store as well, but are considered
-        garbage (because they are not registered in the Nix
-        database of the guest).
+        When the Nix store is mounted from the host, the closure is registered
+        in the Nix database in the VM. All other paths in the host Nix store
+        appear in the guest Nix store as well, but are considered garbage
+        (because they are not registered in the Nix database of the guest).
 
         When {option}`virtualisation.useNixStoreImage` is
         set, the closure is copied to the Nix store image.
@@ -867,7 +860,7 @@ in
       default = false;
       description = ''
         Build and use a disk image for the Nix store, instead of
-        accessing the host's one through 9p.
+        accessing the host's one.
 
         For applications which do a lot of reads from the store,
         this can drastically improve performance, but at the cost of
@@ -889,24 +882,7 @@ in
       default = !cfg.useNixStoreImage && !cfg.useBootLoader;
       defaultText = literalExpression "!cfg.useNixStoreImage && !cfg.useBootLoader";
       description = ''
-        Mount the host Nix store as a 9p mount.
-      '';
-    };
-
-    virtualisation.nixStore9pCache = mkOption {
-      type = types.enum [
-        "loose"
-        "none"
-        "fscache"
-      ];
-      default = "loose";
-      description = ''
-        Type of 9p cache to use when mounting host nix store. "none" provides
-        no caching. "loose" enables Linux's local VFS cache. "fscache" uses Linux's
-        fscache subsystem.
-
-        This option is only respected when {option}`virtualisation.mountHostNixStore`
-        is enabled.
+        Mount the host Nix store via a virtual filesystem.
       '';
     };
 
@@ -1242,22 +1218,20 @@ in
         # Always mount this to /nix/.ro-store because we never want to actually
         # write to the host Nix Store.
         target = "/nix/.ro-store";
-        securityModel = "none";
       };
       xchg = {
         source = ''"$TMPDIR"/xchg'';
-        securityModel = "none";
         target = "/tmp/xchg";
+        writable = true;
       };
       shared = {
         source = ''"''${SHARED_DIR:-$TMPDIR/xchg}"'';
         target = "/tmp/shared";
-        securityModel = "none";
+        writable = true;
       };
       certs = mkIf cfg.useHostCerts {
         source = ''"$TMPDIR"/certs'';
         target = "/etc/ssl/certs";
-        securityModel = "none";
       };
     };
 
@@ -1303,6 +1277,12 @@ in
         "-object memory-backend-memfd,id=mem0,size=${toString config.virtualisation.memorySize}M,share=on"
         "-machine memory-backend=mem0"
       ])
+      (lib.flatten (
+        lib.mapAttrsToList (tag: share: [
+          "-chardev socket,id=${tag},path=$NIX_VIRTIOFS_DIR/${tag}"
+          "-device vhost-user-fs-pci,chardev=${tag},tag=${tag}"
+        ]) cfg.sharedDirectories
+      ))
       (
         let
           alphaNumericChars = lowerChars ++ upperChars ++ (map toString (range 0 9));
@@ -1388,86 +1368,78 @@ in
 
     virtualisation.diskSizeAutoSupported = false;
 
-    virtualisation.fileSystems =
-      let
-        mkSharedDir = tag: share: {
-          name = share.target;
-          value.device = tag;
-          value.fsType = "9p";
-          value.neededForBoot = true;
-          value.options = [
-            "trans=virtio"
-            "version=9p2000.L"
-            "msize=${toString cfg.msize}"
-            "x-systemd.requires=modprobe@9pnet_virtio.service"
-          ]
-          ++ lib.optional (tag == "nix-store") "cache=${cfg.nixStore9pCache}";
+    virtualisation.fileSystems = lib.mkMerge [
+      (lib.mapAttrs' (tag: share: {
+        name = share.target;
+        value = {
+          device = tag;
+          fsType = "virtiofs";
+          neededForBoot = true;
+          options = lib.mkIf (!share.writable) [ "ro" ];
         };
-      in
-      lib.mkMerge [
-        (lib.mapAttrs' mkSharedDir cfg.sharedDirectories)
-        {
-          "/" = lib.mkIf cfg.useDefaultFilesystems (
-            if cfg.diskImage == null then
-              {
-                device = "tmpfs";
-                fsType = "tmpfs";
-                options = [ "mode=755" ];
-              }
-            else
-              {
-                device = cfg.rootDevice;
-                fsType = "ext4";
-              }
-          );
-          "/tmp" = lib.mkIf config.boot.tmp.useTmpfs {
-            device = "tmpfs";
-            fsType = "tmpfs";
-            neededForBoot = true;
-            # Sync with systemd's tmp.mount;
-            options = [
-              "mode=1777"
-              "strictatime"
-              "nosuid"
-              "nodev"
-              "size=${toString config.boot.tmp.tmpfsSize}"
-            ];
-          };
-          "/nix/store" = lib.mkIf (cfg.useNixStoreImage || cfg.mountHostNixStore) (
-            if cfg.writableStore then
-              {
-                overlay = {
-                  lowerdir = [ "/nix/.ro-store" ];
-                  upperdir = "/nix/.rw-store/upper";
-                  workdir = "/nix/.rw-store/work";
-                };
-              }
-            else
-              {
-                device = "/nix/.ro-store";
-                fsType = "none";
-                options = [ "bind" ];
-              }
-          );
-          "/nix/.ro-store" = lib.mkIf cfg.useNixStoreImage {
-            device = "/dev/disk/by-label/${nixStoreFilesystemLabel}";
-            fsType = "erofs";
-            neededForBoot = true;
-            options = [ "ro" ];
-          };
-          "/nix/.rw-store" = lib.mkIf (cfg.writableStore && cfg.writableStoreUseTmpfs) {
-            fsType = "tmpfs";
-            options = [ "mode=0755" ];
-            neededForBoot = true;
-          };
-          "${config.boot.loader.efi.efiSysMountPoint}" =
-            lib.mkIf (cfg.useBootLoader && cfg.bootPartition != null)
-              {
-                device = cfg.bootPartition;
-                fsType = "vfat";
+      }) cfg.sharedDirectories)
+      {
+        "/" = lib.mkIf cfg.useDefaultFilesystems (
+          if cfg.diskImage == null then
+            {
+              device = "tmpfs";
+              fsType = "tmpfs";
+              options = [ "mode=755" ];
+            }
+          else
+            {
+              device = cfg.rootDevice;
+              fsType = "ext4";
+            }
+        );
+        "/tmp" = lib.mkIf config.boot.tmp.useTmpfs {
+          device = "tmpfs";
+          fsType = "tmpfs";
+          neededForBoot = true;
+          # Sync with systemd's tmp.mount;
+          options = [
+            "mode=1777"
+            "strictatime"
+            "nosuid"
+            "nodev"
+            "size=${toString config.boot.tmp.tmpfsSize}"
+          ];
+        };
+        "/nix/store" = lib.mkIf (cfg.useNixStoreImage || cfg.mountHostNixStore) (
+          if cfg.writableStore then
+            {
+              overlay = {
+                lowerdir = [ "/nix/.ro-store" ];
+                upperdir = "/nix/.rw-store/upper";
+                workdir = "/nix/.rw-store/work";
               };
-        }
-      ];
+            }
+          else
+            {
+              device = "/nix/.ro-store";
+              fsType = "none";
+              options = [ "bind" ];
+            }
+        );
+        "/nix/.ro-store" = lib.mkIf cfg.useNixStoreImage {
+          device = "/dev/disk/by-label/${nixStoreFilesystemLabel}";
+          fsType = "erofs";
+          neededForBoot = true;
+          options = [ "ro" ];
+        };
+        "/nix/.rw-store" = lib.mkIf (cfg.writableStore && cfg.writableStoreUseTmpfs) {
+          fsType = "tmpfs";
+          options = [ "mode=0755" ];
+          neededForBoot = true;
+        };
+        "${config.boot.loader.efi.efiSysMountPoint}" =
+          lib.mkIf (cfg.useBootLoader && cfg.bootPartition != null)
+            {
+              device = cfg.bootPartition;
+              fsType = "vfat";
+            };
+      }
+    ];
 
     swapDevices = (if cfg.useDefaultFilesystems then mkVMOverride else mkDefault) [ ];
     boot.initrd.luks.devices = (if cfg.useDefaultFilesystems then mkVMOverride else mkDefault) { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -785,9 +785,7 @@ in
   healthchecks = runTest ./web-apps/healthchecks.nix;
   hedgedoc = runTest ./hedgedoc.nix;
   herbstluftwm = runTest ./herbstluftwm.nix;
-  # 9pnet_virtio used to mount /nix partition doesn't support
-  # hibernation. This test happens to work on x86_64-linux but
-  # not on other platforms.
+  # This test happens to work on x86_64-linux but not on other platforms.
   hibernate = handleTestOn [ "x86_64-linux" ] ./hibernate.nix {
     systemdStage1 = false;
   };

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -29,7 +29,9 @@ makeTest {
         powerManagement.resumeCommands = "systemctl --no-block restart backdoor.service";
 
         virtualisation.emptyDiskImages = [ (2 * config.virtualisation.memorySize) ];
+        # virtiofs doesn't support hibernation
         virtualisation.useNixStoreImage = true;
+        virtualisation.sharedDirectories = lib.mkForce { };
 
         swapDevices = lib.mkOverride 0 [
           {

--- a/nixos/tests/qemu-vm-store.nix
+++ b/nixos/tests/qemu-vm-store.nix
@@ -51,17 +51,16 @@
       sharedReadOnly.fail(build_derivation)
       imageReadOnly.fail(build_derivation)
 
-    # Checking whether the fs type is 9P is just a proxy to test whether the
-    # Nix Store is shared. If we switch to a different technology (e.g.
-    # virtiofs) for sharing, we need to adjust these tests.
+    # Checking whether the fs type is virtiofs is just a proxy to test whether the
+    # Nix Store is shared.
 
-    with subtest("Nix store is shared from the host via 9P"):
-      sharedWritable.succeed("findmnt --kernel --type 9P /nix/.ro-store")
-      sharedReadOnly.succeed("findmnt --kernel --type 9P /nix/.ro-store")
+    with subtest("Nix store is shared from the host via virtiofs"):
+      sharedWritable.succeed("findmnt --kernel --type virtiofs /nix/.ro-store")
+      sharedReadOnly.succeed("findmnt --kernel --type virtiofs /nix/.ro-store")
 
-    with subtest("Nix store is not shared via 9P"):
-      imageWritable.fail("findmnt --kernel --type 9P /nix/.ro-store")
-      imageReadOnly.fail("findmnt --kernel --type 9P /nix/.ro-store")
+    with subtest("Nix store is not shared via virtiofs"):
+      imageWritable.fail("findmnt --kernel --type virtiofs /nix/.ro-store")
+      imageReadOnly.fail("findmnt --kernel --type virtiofs /nix/.ro-store")
 
     with subtest("Nix store is not mounted separately"):
       rootDevice = fullDisk.succeed("stat -c %d /")

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -50,7 +50,7 @@
             )
           }
           mkdir -p /tmp/shared
-          mount -t 9p shared -o trans=virtio,version=9p2000.L /tmp/shared
+          mount -t virtiofs shared /tmp/shared
           touch /tmp/shared/shutdown-test
           umount /tmp/shared
         '';


### PR DESCRIPTION
Using virtiofs instead of 9P can give us massive performance boosts (especially for more complex tests). In the best case that I have benchmarked the test is almost 50% faster. Please see the benchmark section for more details.

I successfully ran all `systemd.nixosTests`, all `qemu-vm-*` tests and `nixos/release-small` tests (~120 tests).

## Benchmarks

<details>

<summary>All benchmarks</summary>

`nixosTests.simple-vm`

| Branch | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `master` | 18.172 ± 0.908 | 16.971 | 20.023 | 1.00 ± 0.07 |
| `virtiofs` | 18.106 ± 0.894 | 16.184 | 19.271 | 1.00 |

`nixosTests.systemd`

| Branch | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `master` | 81.203 ± 1.495 | 79.448 | 84.075 | 1.10 ± 0.04 |
| `virtiofs` | 73.871 ± 2.443 | 69.596 | 77.700 | 1.00 |

`nixosTests.switchTest`

| Branch | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `master` | 272.757 ± 2.953 | 268.665 | 279.877 | 1.44 ± 0.02 |
| `virtiofs` | 189.598 ± 0.804 | 188.175 | 191.007 | 1.00 |

`nixosTests.systemd-network`

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `master` | 27.423 ± 2.516 | 25.605 | 34.382 | 1.08 ± 0.10 |
| `virtiofs` | 25.407 ± 0.605 | 24.185 | 26.238 | 1.00 | 

`nixosTests.postgresql.postgresql.postgresql_18.postgresql-backup-all`

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `master` | 46.737 ± 1.545 | 45.031 | 50.475 | 1.14 ± 0.05 |
| `virtiofs` | 41.164 ± 0.960 | 40.013 | 43.197 | 1.00 |

`nixosTests.garage_2.with-3node-replication`

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `master` | 32.814 ± 2.803 | 30.891 | 40.080 | 1.11 ± 0.10 |
| `virtiofs` | 29.595 ± 0.556 | 28.777 | 30.448 | 1.00 |

`nixosTests.nginx`

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `master` | 26.674 ± 0.804 | 25.402 | 27.740 | 1.15 ± 0.06 |
| `virtiofs` | 23.255 ± 1.016 | 21.767 | 24.928 | 1.00 |

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
