### PR TITLE
mediawiki: 1.45.4 -> 1.46.0

### DIFF
--- a/nixos/tests/mediawiki.nix
+++ b/nixos/tests/mediawiki.nix
@@ -4,12 +4,16 @@ let
   shared =
     { pkgs, ... }:
     {
-      services.mediawiki.enable = true;
-      services.mediawiki.httpd.virtualHost.hostName = "localhost";
-      services.mediawiki.httpd.virtualHost.adminAddr = "root@example.com";
-      services.mediawiki.passwordFile = pkgs.writeText "password" "correcthorsebatterystaple";
-      services.mediawiki.extensions = {
-        ParserFunctions = null;
+      services.mediawiki = {
+        enable = true;
+        httpd.virtualHost = {
+          hostName = "localhost";
+          adminAddr = "root@example.com";
+        };
+        passwordFile = pkgs.writeText "password" "correcthorsebatterystaple";
+        extensions = {
+          ParserFunctions = null;
+        };
       };
     };
 

--- a/nixos/tests/mediawiki.nix
+++ b/nixos/tests/mediawiki.nix
@@ -9,10 +9,6 @@ let
       services.mediawiki.httpd.virtualHost.adminAddr = "root@example.com";
       services.mediawiki.passwordFile = pkgs.writeText "password" "correcthorsebatterystaple";
       services.mediawiki.extensions = {
-        Matomo = pkgs.fetchzip {
-          url = "https://github.com/DaSchTour/matomo-mediawiki-extension/archive/v4.0.1.tar.gz";
-          sha256 = "0g5rd3zp0avwlmqagc59cg9bbkn3r7wx7p6yr80s644mj6dlvs1b";
-        };
         ParserFunctions = null;
       };
     };

--- a/nixos/tests/mediawiki.nix
+++ b/nixos/tests/mediawiki.nix
@@ -21,7 +21,7 @@ let
     t:
     runTest {
       imports = [
-        { nodes.machine.imports = [ shared ]; }
+        { containers.machine.imports = [ shared ]; }
         t
       ];
     };
@@ -29,7 +29,7 @@ in
 {
   mysql = makeTest {
     name = "mediawiki-mysql";
-    nodes.machine = {
+    containers.machine = {
       services.mediawiki.database.type = "mysql";
     };
     testScript = ''
@@ -44,7 +44,7 @@ in
 
   postgresql = makeTest {
     name = "mediawiki-postgres";
-    nodes.machine = {
+    containers.machine = {
       services.mediawiki.database.type = "postgres";
     };
     testScript = ''
@@ -59,7 +59,7 @@ in
 
   sqlite = makeTest {
     name = "mediawiki-sqlite";
-    nodes.machine = {
+    containers.machine = {
       services.mediawiki.database.type = "sqlite";
     };
     testScript = ''
@@ -74,29 +74,29 @@ in
 
   nohttpd = makeTest {
     name = "mediawiki-nohttpd";
-    nodes.machine = {
+    containers.machine = {
       services.mediawiki.webserver = "none";
     };
     testScript =
-      { nodes, ... }:
+      { containers, ... }:
       ''
         start_all()
         machine.wait_for_unit("phpfpm-mediawiki.service")
         env = (
           "SCRIPT_NAME=/index.php",
-          "SCRIPT_FILENAME=${nodes.machine.services.mediawiki.finalPackage}/share/mediawiki/index.php",
+          "SCRIPT_FILENAME=${containers.machine.services.mediawiki.finalPackage}/share/mediawiki/index.php",
           "REMOTE_ADDR=127.0.0.1",
           'QUERY_STRING=title=Main_Page',
           "REQUEST_METHOD=GET",
         );
-        page = machine.succeed(f"{' '.join(env)} ${lib.getExe nodes.machine.nixpkgs.pkgs.fcgi} -bind -connect ${nodes.machine.services.phpfpm.pools.mediawiki.socket}")
+        page = machine.succeed(f"{' '.join(env)} ${lib.getExe containers.machine.nixpkgs.pkgs.fcgi} -bind -connect ${containers.machine.services.phpfpm.pools.mediawiki.socket}")
         assert "MediaWiki has been installed" in page, f"no 'MediaWiki has been installed' in:\n{page}"
       '';
   };
 
   nginx = makeTest {
     name = "mediawiki-nginx";
-    nodes.machine = {
+    containers.machine = {
       services.mediawiki.webserver = "nginx";
     };
     testScript = ''

--- a/pkgs/by-name/me/mediawiki/keep-session-object-cache.diff
+++ b/pkgs/by-name/me/mediawiki/keep-session-object-cache.diff
@@ -1,0 +1,13 @@
+diff --git a/includes/Installer/DatabaseUpdater.php b/includes/Installer/DatabaseUpdater.php
+index 8ed996b9dee..733a3210096 100644
+--- a/includes/Installer/DatabaseUpdater.php
++++ b/includes/Installer/DatabaseUpdater.php
+@@ -1380,7 +1380,7 @@ public function purgeCache() {
+ 		// ObjectCache
+ 		$this->db->newDeleteQueryBuilder()
+ 			->deleteFrom( 'objectcache' )
+-			->where( ISQLPlatform::ALL_ROWS )
++			->where( "keyname NOT LIKE '%:MWSession:%'" )
+ 			->caller( __METHOD__ )
+ 			->execute();
+ 

--- a/pkgs/by-name/me/mediawiki/package.nix
+++ b/pkgs/by-name/me/mediawiki/package.nix
@@ -14,6 +14,12 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-rDleT/07Y7hqJC79Z5JXUD5GNEW6n5ibUU2dOzQsRWo=";
   };
 
+  patches = [
+    # NixOS runs the update script on every start as we might need to run some migrations.
+    # Normally this clears all active sessions, for usability we do not do that.
+    ./keep-session-object-cache.diff
+  ];
+
   postPatch = ''
     substituteInPlace includes/Installer/CliInstaller.php \
       --replace-fail '$vars = Installer::getExistingLocalSettings();' '$vars = null;'

--- a/pkgs/by-name/me/mediawiki/package.nix
+++ b/pkgs/by-name/me/mediawiki/package.nix
@@ -7,15 +7,15 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mediawiki";
-  version = "1.45.4";
+  version = "1.46.0";
 
   src = fetchurl {
     url = "https://releases.wikimedia.org/mediawiki/${lib.versions.majorMinor version}/mediawiki-${version}.tar.gz";
-    hash = "sha256-y3yCRGjrWlEacvCOYpHQncivEuCg/9wlMu4/drsMrXw=";
+    hash = "sha256-rDleT/07Y7hqJC79Z5JXUD5GNEW6n5ibUU2dOzQsRWo=";
   };
 
   postPatch = ''
-    substituteInPlace includes/installer/CliInstaller.php \
+    substituteInPlace includes/Installer/CliInstaller.php \
       --replace-fail '$vars = Installer::getExistingLocalSettings();' '$vars = null;'
   '';
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
