### PR TITLE
es-de: init at 3.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22741,6 +22741,12 @@
     name = "Kevin Mullins";
     keys = [ { fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A"; } ];
   };
+  poacher = {
+    email = "poacherGoneWild@proton.me";
+    github = "poach3r";
+    githubId = 58641438;
+    name = "Henry Matonis";
+  };
   podium868909 = {
     email = "89096245@proton.me";
     github = "podium868909";

--- a/pkgs/by-name/es/es-de/package.nix
+++ b/pkgs/by-name/es/es-de/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+appimageTools.wrapType2 (finalAttrs: {
+  pname = "es-de";
+  version = "3.4.1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/es-de/emulationstation-de/-/package_files/288156961/download";
+    hash = "sha256-PGGkTXONVRY9qljt5wcgtCWg32JGDATcI908pYZyNYE=";
+  };
+
+  extraInstallCommands =
+    let
+      appimageContents = appimageTools.extract {
+        inherit (finalAttrs) pname version src;
+      };
+    in
+    ''
+      install -Dm 444 ${appimageContents}/org.es_de.frontend.desktop -t $out/share/applications
+      cp -r ${appimageContents}/usr/share/icons $out/share
+    '';
+
+  meta = {
+    description = "Frontend for browsing and launching games from your multi-platform collection.";
+    homepage = "https://es-de.org/";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ poacher ];
+    mainProgram = "es-de";
+  };
+})


### PR DESCRIPTION
This packages [es-de](https://es-de.org/) and adds poacher as a maintainer. I've packaged the AppImage instead of building it from source as libfreeimage (a dependency) is no longer in nixpkgs.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
