### PR TITLE
ammonite: fix jre handling, rework update script, misc cleanup

### DIFF
--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -51,6 +51,11 @@ let
       installPhase = ''
         install -Dm755 $src $out/bin/amm
 
+        # Upstream ships a .bat/.sh polyglot with no interpreter directive, so
+        # without this execve gives ENOEXEC to every caller that does not retry
+        # under /bin/sh the way a shell does. patchShebangs pins it afterwards.
+        sed -i '1i #!/bin/sh' $out/bin/amm
+
         # The launcher prefers $JAVA_HOME over its own default, so both branches
         # have to be pinned; patching only the default leaves `override { jre = ...; }`
         # with no effect in any shell that sets JAVA_HOME. sed rather than
@@ -69,7 +74,6 @@ let
       ''
       + lib.optionalString disableRemoteLogging ''
         sed -i "0,/ammonite.Main/{s|ammonite.Main'|ammonite.Main' --no-remote-logging|}" $out/bin/amm
-        sed -i '1i #!/bin/sh' $out/bin/amm
       '';
 
       passthru = {

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -3,27 +3,47 @@
   stdenv,
   fetchurl,
   jre,
-  writeScript,
+  writeShellApplication,
   common-updater-scripts,
-  git,
-  nix,
   coreutils,
+  git,
+  gnugrep,
   gnused,
+  jq,
+  nix,
   disableRemoteLogging ? true,
 }:
 
 let
-  repo = "git@github.com:com-lihaoyi/Ammonite.git";
+  owner = "com-lihaoyi";
+  repo = "Ammonite";
+
+  # One table for every variant, so the update script cannot refresh some and
+  # miss others; it used to skip ammonite_3_3, which is what `ammonite` is.
+  variants = {
+    ammonite_2_12 = {
+      scalaVersion = "2.12";
+      hash = "sha256-gMyTQDPmHsl6b3CBCsIHb/8z2FwL3+Txuz0siFgvSws=";
+    };
+    ammonite_2_13 = {
+      scalaVersion = "2.13";
+      hash = "sha256-NCB5ZuW+CqxFlYY10mF6TUHdZl1E8QFygPdyW2FtCe4=";
+    };
+    ammonite_3_3 = {
+      scalaVersion = "3.3";
+      hash = "sha256-H3/wjBDA8b+a+4FISohLQ10eB7VOMUqj+M39bZOefbw=";
+    };
+  };
 
   common =
-    { scalaVersion, sha256 }:
+    { scalaVersion, hash }:
     stdenv.mkDerivation rec {
       pname = "ammonite";
       version = "3.0.9";
 
       src = fetchurl {
-        url = "https://github.com/com-lihaoyi/Ammonite/releases/download/${version}/${scalaVersion}-${version}";
-        inherit sha256;
+        url = "https://github.com/${owner}/${repo}/releases/download/${version}/${scalaVersion}-${version}";
+        inherit hash;
       };
 
       dontUnpack = true;
@@ -54,28 +74,99 @@ let
 
       passthru = {
 
-        updateScript = writeScript "update.sh" ''
-          #!${stdenv.shell}
-          set -o errexit
-          PATH=${
-            lib.makeBinPath [
+        updateScript = {
+          command = lib.getExe (writeShellApplication {
+            name = "update-ammonite";
+
+            runtimeInputs = [
               common-updater-scripts
               coreutils
               git
+              gnugrep
               gnused
+              jq
               nix
-            ]
-          }
-          oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
-          latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags ${repo} '*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3)"
-          if [ "$oldVersion" != "$latestTag" ]; then
-            update-source-version ${pname}_2_12 "$latestTag" --version-key=version --print-changes
-            sed -i "s|$latestTag|$oldVersion|g" "$(git rev-parse --show-toplevel)/pkgs/development/tools/ammonite/default.nix"
-            update-source-version ${pname}_2_13 "$latestTag" --version-key=version --print-changes
-          else
-            echo "${pname} is already up-to-date"
-          fi
-        '';
+            ];
+
+            text = ''
+              # stdout is reserved for the JSON expected by the `commit`
+              # updateScript feature, everything else has to go to stderr.
+              #
+              # $UPDATE_NIX_ATTR_PATH is deliberately ignored: one run refreshes
+              # every variant, and the driver would hand us whichever one it
+              # happened to walk into.
+              nixpkgs=$(git rev-parse --show-toplevel)
+              position=$(nix-instantiate --eval --raw --attr ammonite.meta.position "$nixpkgs")
+              package_nix="''${position%:*}"
+              old_version=$(nix-instantiate --eval --raw --attr ammonite.version "$nixpkgs")
+
+              new_version=$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs \
+                --sort='version:refname' --tags https://github.com/${owner}/${repo}.git '*.*.*' \
+                | cut --delimiter='/' --fields=3 \
+                | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+                | tail --lines=1)
+
+              if [[ -z "$new_version" ]]; then
+                echo "no plain X.Y.Z tag found upstream" >&2
+                exit 1
+              fi
+
+              order=$(nix-instantiate --eval \
+                --expr "builtins.compareVersions \"$new_version\" \"$old_version\"")
+
+              case "$order" in
+                0)
+                  echo "ammonite is already at the latest version $new_version." >&2
+                  echo '[]'
+                  exit 0
+                  ;;
+                -1)
+                  echo "refusing to downgrade ammonite from $old_version to $new_version." >&2
+                  exit 1
+                  ;;
+              esac
+
+              # Every variant shares the one version literal and has its own hash,
+              # so put the file back if any of them fails partway.
+              backup=$(mktemp)
+              cp "$package_nix" "$backup"
+              trap 'cp "$backup" "$package_nix"; rm -f "$backup"' EXIT
+
+              refresh() {
+                local attr="$1" scala_version="$2" hash
+                hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url \
+                  "https://github.com/${owner}/${repo}/releases/download/$new_version/$scala_version-$new_version")")
+
+                # --ignore-same-version because the version literal is shared, so
+                # only the first call changes it.
+                update-source-version "$attr" "$new_version" "$hash" \
+                  --version-key=version --ignore-same-version >&2
+              }
+
+              ${lib.concatStrings (
+                lib.mapAttrsToList (attr: variant: ''
+                  refresh ${attr} ${variant.scalaVersion}
+                '') variants
+              )}
+
+              trap - EXIT
+              rm -f "$backup"
+
+              jq --null-input --compact-output \
+                --arg oldVersion "$old_version" \
+                --arg newVersion "$new_version" \
+                --arg file "$package_nix" \
+                '[ {
+                  attrPath: "ammonite",
+                  oldVersion: $oldVersion,
+                  newVersion: $newVersion,
+                  files: [ $file ],
+                  commitBody: "https://github.com/${owner}/${repo}/releases/tag/\($newVersion)"
+                } ]'
+            '';
+          });
+          supportedFeatures = [ "commit" ];
+        };
       };
 
       doInstallCheck = true;
@@ -107,17 +198,4 @@ let
       };
     };
 in
-{
-  ammonite_2_12 = common {
-    scalaVersion = "2.12";
-    sha256 = "sha256-gMyTQDPmHsl6b3CBCsIHb/8z2FwL3+Txuz0siFgvSws=";
-  };
-  ammonite_2_13 = common {
-    scalaVersion = "2.13";
-    sha256 = "sha256-NCB5ZuW+CqxFlYY10mF6TUHdZl1E8QFygPdyW2FtCe4=";
-  };
-  ammonite_3_3 = common {
-    scalaVersion = "3.3";
-    sha256 = "sha256-H3/wjBDA8b+a+4FISohLQ10eB7VOMUqj+M39bZOefbw=";
-  };
-}
+lib.mapAttrs (_: common) variants

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -30,7 +30,22 @@ let
 
       installPhase = ''
         install -Dm755 $src $out/bin/amm
-        sed -i '0,/java/{s|java|${jre}/bin/java|}' $out/bin/amm
+
+        # The launcher prefers $JAVA_HOME over its own default, so both branches
+        # have to be pinned; patching only the default leaves `override { jre = ...; }`
+        # with no effect in any shell that sets JAVA_HOME. sed rather than
+        # substituteInPlace because the launcher has a jar appended to it.
+        sed -i \
+          -e 's|JAVACMD="java"|JAVACMD="${jre}/bin/java"|' \
+          -e 's|JAVACMD="$JAVA_HOME/bin/java"|JAVACMD="${jre}/bin/java"|' \
+          $out/bin/amm
+
+        # sed is silent when it matches nothing, which is how the JAVA_HOME
+        # branch went unpatched in the first place.
+        if grep -qa 'JAVACMD="$JAVA_HOME/bin/java"' $out/bin/amm; then
+          echo "the amm launcher still prefers JAVA_HOME; the substitution missed" >&2
+          exit 1
+        fi
       ''
       + lib.optionalString disableRemoteLogging ''
         sed -i "0,/ammonite.Main/{s|ammonite.Main'|ammonite.Main' --no-remote-logging|}" $out/bin/amm

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -83,7 +83,10 @@ let
         homepage = "https://github.com/com-lihaoyi/Ammonite";
         license = lib.licenses.mit;
         mainProgram = "amm";
-        maintainers = with lib.maintainers; [ tbutter ];
+        maintainers = with lib.maintainers; [
+          agilesteel
+          tbutter
+        ];
         platforms = lib.platforms.all;
       };
     };

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -195,7 +195,7 @@ let
       '';
 
       meta = {
-        description = "Improved Scala REPL";
+        description = "Improved Scala REPL, built for Scala ${scalaVersion}";
         longDescription = ''
           The Ammonite-REPL is an improved Scala REPL, re-implemented from first principles.
           It is much more featureful than the default REPL and comes

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -11,7 +11,6 @@
   gnused,
   jq,
   nix,
-  disableRemoteLogging ? true,
 }:
 
 let
@@ -71,9 +70,6 @@ let
           echo "the amm launcher still prefers JAVA_HOME; the substitution missed" >&2
           exit 1
         fi
-      ''
-      + lib.optionalString disableRemoteLogging ''
-        sed -i "0,/ammonite.Main/{s|ammonite.Main'|ammonite.Main' --no-remote-logging|}" $out/bin/amm
       '';
 
       passthru = {

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -47,40 +47,46 @@ let
 
       dontUnpack = true;
 
-      installPhase = ''
-        install -Dm755 $src $out/bin/amm
+      # ammonite.AmmoniteMain is class-file 55, so an older jre fails the install
+      # check below with UnsupportedClassVersionError rather than anything useful
+      installPhase =
+        assert lib.assertMsg (lib.versionAtLeast jre.version "11.0.0") ''
+          ammonite requires Java 11 or newer, but ${jre.name} is ${jre.version}
+        '';
+        ''
+          install -Dm755 $src $out/bin/amm
 
-        # Upstream ships a .bat/.sh polyglot with no interpreter directive, so
-        # without this execve gives ENOEXEC to every caller that does not retry
-        # under /bin/sh the way a shell does. patchShebangs pins it afterwards.
-        sed -i '1i #!/bin/sh' $out/bin/amm
+          # Upstream ships a .bat/.sh polyglot with no interpreter directive, so
+          # without this execve gives ENOEXEC to every caller that does not retry
+          # under /bin/sh the way a shell does. patchShebangs pins it afterwards.
+          sed -i '1i #!/bin/sh' $out/bin/amm
 
-        # The launcher prefers $JAVA_HOME over its own default, so both branches
-        # have to be pinned; patching only the default leaves `override { jre = ...; }`
-        # with no effect in any shell that sets JAVA_HOME. sed rather than
-        # substituteInPlace because the launcher has a jar appended to it.
-        sed -i \
-          -e 's|JAVACMD="java"|JAVACMD="${jre}/bin/java"|' \
-          -e 's|JAVACMD="$JAVA_HOME/bin/java"|JAVACMD="${jre}/bin/java"|' \
-          $out/bin/amm
+          # The launcher prefers $JAVA_HOME over its own default, so both branches
+          # have to be pinned; patching only the default leaves `override { jre = ...; }`
+          # with no effect in any shell that sets JAVA_HOME. sed rather than
+          # substituteInPlace because the launcher has a jar appended to it.
+          sed -i \
+            -e 's|JAVACMD="java"|JAVACMD="${jre}/bin/java"|' \
+            -e 's|JAVACMD="$JAVA_HOME/bin/java"|JAVACMD="${jre}/bin/java"|' \
+            $out/bin/amm
 
-        # sed is silent when it matches nothing, which is how the JAVA_HOME
-        # branch went unpatched in the first place.
-        if grep -qa 'JAVACMD="$JAVA_HOME/bin/java"' $out/bin/amm; then
-          echo "the amm launcher still prefers JAVA_HOME; the substitution missed" >&2
-          exit 1
-        fi
+          # sed is silent when it matches nothing, which is how the JAVA_HOME
+          # branch went unpatched in the first place.
+          if grep -qa 'JAVACMD="$JAVA_HOME/bin/java"' $out/bin/amm; then
+            echo "the amm launcher still prefers JAVA_HOME; the substitution missed" >&2
+            exit 1
+          fi
 
-        # Hand the same jre to whatever the repl spawns. makeWrapper is not an
-        # option here: the launcher passes itself as the classpath with -cp "$0",
-        # so a wrapper that changes $0 breaks it.
-        sed -i "/^exec /i export JAVA_HOME=\"${jre.home}\"\nexport PATH=\"${lib.makeBinPath [ jre ]}\''${PATH:+:\$PATH}\"" $out/bin/amm
+          # Hand the same jre to whatever the repl spawns. makeWrapper is not an
+          # option here: the launcher passes itself as the classpath with -cp "$0",
+          # so a wrapper that changes $0 breaks it.
+          sed -i "/^exec /i export JAVA_HOME=\"${jre.home}\"\nexport PATH=\"${lib.makeBinPath [ jre ]}\''${PATH:+:\$PATH}\"" $out/bin/amm
 
-        if ! grep -qa "^export JAVA_HOME=" $out/bin/amm; then
-          echo "failed to insert the environment ahead of exec" >&2
-          exit 1
-        fi
-      '';
+          if ! grep -qa "^export JAVA_HOME=" $out/bin/amm; then
+            echo "failed to insert the environment ahead of exec" >&2
+            exit 1
+          fi
+        '';
 
       passthru = {
 

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -102,7 +102,8 @@ let
           agilesteel
           tbutter
         ];
-        platforms = lib.platforms.all;
+        # a launcher script running a jar, so it runs wherever the jre does
+        platforms = jre.meta.platforms;
       };
     };
 in

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -70,6 +70,16 @@ let
           echo "the amm launcher still prefers JAVA_HOME; the substitution missed" >&2
           exit 1
         fi
+
+        # Hand the same jre to whatever the repl spawns. makeWrapper is not an
+        # option here: the launcher passes itself as the classpath with -cp "$0",
+        # so a wrapper that changes $0 breaks it.
+        sed -i "/^exec /i export JAVA_HOME=\"${jre.home}\"\nexport PATH=\"${lib.makeBinPath [ jre ]}\''${PATH:+:\$PATH}\"" $out/bin/amm
+
+        if ! grep -qa "^export JAVA_HOME=" $out/bin/amm; then
+          echo "failed to insert the environment ahead of exec" >&2
+          exit 1
+        fi
       '';
 
       passthru = {

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -186,8 +186,10 @@ let
           with a lot of ergonomic improvements and configurability
           that may be familiar to people coming from IDEs or other REPLs such as IPython or Zsh.
         '';
-        homepage = "https://github.com/com-lihaoyi/Ammonite";
+        homepage = "https://github.com/${owner}/${repo}";
+        changelog = "https://github.com/${owner}/${repo}/releases/tag/${version}";
         license = lib.licenses.mit;
+        sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
         mainProgram = "amm";
         maintainers = with lib.maintainers; [
           agilesteel


### PR DESCRIPTION
Fixes three real defects in the ammonite package and modernizes the rest:

- **`ammonite.override { jre = ...; }` was silently ineffective** in any shell with `JAVA_HOME` set: the launcher has two `JAVACMD=` branches and only the default one was patched, so the `$JAVA_HOME/bin/java` branch always won. Both branches are pinned now, with a guard that fails the build if the substitution ever stops matching (sed is silent on non-match, which is how this went unnoticed).
- **The launcher had no shebang** — upstream ships a `.bat`/`.sh` polyglot with no interpreter line, so `execve` returned ENOEXEC to any caller that is not a shell. It gets one unconditionally now.
- **The `disableRemoteLogging` argument was inert**: its sed matched a main class the 3.x launcher no longer uses, and upstream removed remote logging entirely. Passing `false` also skipped the shebang insertion. The argument is dropped; nothing in-tree passes it.

Also: the update script now refreshes *all* variants from one table (it used to skip `ammonite_3_3`, which is what `ammonite` points at), refuses downgrades, and supports the `commit` protocol; the packaged jre is exported to child processes (`JAVA_HOME`/`PATH`); an eval-time assert enforces the Java 11 floor with a clear message instead of a runtime `UnsupportedClassVersionError`; meta gains changelog/sourceProvenance, `platforms` follows the jre, and each variant's description names its Scala version.

Built with `amm` exercised by hand on x86_64-linux (`amm -c 'println(21*2)'`, including with a hostile `JAVA_HOME=/nonexistent`); the install check runs the REPL; `nixpkgs-vet` passes. One of nine independent per-tool cleanups of the Scala toolchain.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: the commits (see their `Assisted-by:` trailers) and this summary were prepared with assistance from Claude Code (Claude Opus 5). All changes were reviewed, built, and manually exercised by the author.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
