### PR TITLE
bloop: fix completions and jre-less wrapper, add update script

### DIFF
--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
   platform =
     if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
       "x86_64-pc-linux"
-    else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then
-      "x86_64-apple-darwin"
     else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
       "aarch64-apple-darwin"
     else
@@ -43,8 +41,6 @@ stdenv.mkDerivation rec {
     sha256 =
       if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
         "sha256-F5wRihAwf/TNBSYortTCoK9qKqTI+1N5InJ+rqLFp8A="
-      else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then
-        "sha256-wQXAldzU6Typ6pZB8k3dfX7g+aaVF7jXvd0pnuk5gZU="
       else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
         "sha256-OrONKbC2l0jjfmguDmoiyEaJWdTrKBiP0ZEa5rhizDM="
       else

--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   bloop-fish = fetchurl {
     url = "https://github.com/scalacenter/bloop/releases/download/v${version}/fish-completions";
-    sha256 = "sha256-eFESR6iPHRDViGv+Fk3sCvPgVAhk2L1gCG4LnfXO/v4=";
+    sha256 = "sha256-RF6nZxbw4sLwCP4irKJLYCZnlkaRdEkmpYkOHBoSF/8=";
   };
 
   bloop-zsh = fetchurl {

--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -9,43 +9,34 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+let
   pname = "bloop";
-  version = "2.1.1";
+  sources = lib.importJSON ./sources.json;
+  inherit (sources)
+    repo
+    version
+    assets
+    completions
+    ;
 
-  platform =
-    if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
-      "x86_64-pc-linux"
-    else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
-      "aarch64-apple-darwin"
-    else
-      throw "unsupported platform";
+  platforms = builtins.attrNames assets;
 
-  bloop-bash = fetchurl {
-    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bash-completions";
-    sha256 = "sha256-2mt+zUEJvQ/5ixxFLZ3Z0m7uDSj/YE9sg/uNMjamvdE=";
-  };
+  fetchAsset =
+    { asset, hash }:
+    fetchurl {
+      url = "https://github.com/${repo}/releases/download/v${version}/${asset}";
+      inherit hash;
+    };
 
-  bloop-fish = fetchurl {
-    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/fish-completions";
-    sha256 = "sha256-RF6nZxbw4sLwCP4irKJLYCZnlkaRdEkmpYkOHBoSF/8=";
-  };
-
-  bloop-zsh = fetchurl {
-    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/zsh-completions";
-    sha256 = "sha256-WNMsPwBfd5EjeRbRtc06lCEVI2FVoLfrqL82OR0G7/c=";
-  };
-
-  bloop-binary = fetchurl {
-    url = "https://github.com/scalacenter/bloop/releases/download/v${version}/bloop-${platform}";
-    sha256 =
-      if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
-        "sha256-F5wRihAwf/TNBSYortTCoK9qKqTI+1N5InJ+rqLFp8A="
-      else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
-        "sha256-OrONKbC2l0jjfmguDmoiyEaJWdTrKBiP0ZEa5rhizDM="
-      else
-        throw "unsupported platform";
-  };
+  bloop-binary = fetchAsset (
+    assets.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}")
+  );
+  bloop-bash = fetchAsset completions.bash;
+  bloop-fish = fetchAsset completions.fish;
+  bloop-zsh = fetchAsset completions.zsh;
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
   dontUnpack = true;
   nativeBuildInputs = [
@@ -76,14 +67,12 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://scalacenter.github.io/bloop/";
+    changelog = "https://github.com/${repo}/releases/tag/v${version}";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.asl20;
     description = "Scala build server and command-line tool to make the compile and test developer workflows fast and productive in a build-tool-agnostic way";
     mainProgram = "bloop";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-darwin"
-    ];
+    inherit platforms;
     maintainers = with lib.maintainers; [
       agilesteel
       kubukoz

--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -7,6 +7,7 @@
   jre,
   lib,
   zlib,
+  runCommand,
 }:
 
 let
@@ -35,7 +36,7 @@ let
   bloop-fish = fetchAsset completions.fish;
   bloop-zsh = fetchAsset completions.zsh;
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
 
   dontUnpack = true;
@@ -65,6 +66,22 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru = {
+    tests.help = runCommand "${pname}-help" { nativeBuildInputs = [ finalAttrs.finalPackage ]; } ''
+      export HOME="$TMPDIR"
+
+      # Anything that reaches the build server, `bloop --version` and
+      # `bloop about` included, downloads it from Maven Central first and so
+      # cannot run in the sandbox. --help is answered by the native client
+      # alone, and still exercises the patched binary and its wrapper.
+      bloop --help > help.txt
+      grep -q 'Interact with Bloop' help.txt
+      grep -q -- '--java-home' help.txt
+
+      touch $out
+    '';
+  };
+
   meta = {
     homepage = "https://scalacenter.github.io/bloop/";
     changelog = "https://github.com/${repo}/releases/tag/v${version}";
@@ -79,4 +96,4 @@ stdenv.mkDerivation {
       tomahna
     ];
   };
-}
+})

--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -52,14 +52,17 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.getLib stdenv.cc.cc)
     zlib
   ];
-  propagatedBuildInputs = [ jre ];
 
   installPhase = ''
     runHook preInstall
 
     install -D -m 0755 ${bloop-binary} $out/.bloop-wrapped
 
-    makeWrapper $out/.bloop-wrapped $out/bin/bloop
+    # The client starts a jvm build server, so it needs a jre on PATH and in
+    # JAVA_HOME; propagating the jre put it in the closure but on nobody's PATH.
+    makeWrapper $out/.bloop-wrapped $out/bin/bloop \
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --set JAVA_HOME ${jre.home}
 
     #Install completions
     installShellCompletion --name bloop --bash ${bloop-bash}

--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -53,24 +53,29 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  installPhase = ''
-    runHook preInstall
+  # upstream documents JDK 17 or higher for the CLI, which is what this packages
+  installPhase =
+    assert lib.assertMsg (lib.versionAtLeast jre.version "17.0.0") ''
+      bloop requires Java 17 or newer, but ${jre.name} is ${jre.version}
+    '';
+    ''
+      runHook preInstall
 
-    install -D -m 0755 ${bloop-binary} $out/.bloop-wrapped
+      install -D -m 0755 ${bloop-binary} $out/.bloop-wrapped
 
-    # The client starts a jvm build server, so it needs a jre on PATH and in
-    # JAVA_HOME; propagating the jre put it in the closure but on nobody's PATH.
-    makeWrapper $out/.bloop-wrapped $out/bin/bloop \
-      --prefix PATH : ${lib.makeBinPath [ jre ]} \
-      --set JAVA_HOME ${jre.home}
+      # The client starts a jvm build server, so it needs a jre on PATH and in
+      # JAVA_HOME; propagating the jre put it in the closure but on nobody's PATH.
+      makeWrapper $out/.bloop-wrapped $out/bin/bloop \
+        --prefix PATH : ${lib.makeBinPath [ jre ]} \
+        --set JAVA_HOME ${jre.home}
 
-    #Install completions
-    installShellCompletion --name bloop --bash ${bloop-bash}
-    installShellCompletion --name _bloop --zsh ${bloop-zsh}
-    installShellCompletion --name bloop.fish --fish ${bloop-fish}
+      #Install completions
+      installShellCompletion --name bloop --bash ${bloop-bash}
+      installShellCompletion --name _bloop --zsh ${bloop-zsh}
+      installShellCompletion --name bloop.fish --fish ${bloop-fish}
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
   passthru = {
     updateScript = {

--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -9,6 +9,8 @@
   zlib,
   callPackage,
   runCommand,
+  zsh,
+  fish,
 }:
 
 let
@@ -86,6 +88,24 @@ stdenv.mkDerivation (finalAttrs: {
 
       touch $out
     '';
+
+    tests.completions =
+      runCommand "${pname}-completions"
+        {
+          nativeBuildInputs = [
+            zsh
+            fish
+          ];
+        }
+        ''
+          share=${finalAttrs.finalPackage}/share
+
+          bash -n "$share/bash-completion/completions/bloop"
+          zsh -n "$share/zsh/site-functions/_bloop"
+          fish -n "$share/fish/vendor_completions.d/bloop.fish"
+
+          touch $out
+        '';
   };
 
   meta = {

--- a/pkgs/by-name/bl/bloop/package.nix
+++ b/pkgs/by-name/bl/bloop/package.nix
@@ -7,6 +7,7 @@
   jre,
   lib,
   zlib,
+  callPackage,
   runCommand,
 }:
 
@@ -67,6 +68,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    updateScript = {
+      command = lib.getExe (callPackage ./update.nix { });
+      supportedFeatures = [ "commit" ];
+    };
+
     tests.help = runCommand "${pname}-help" { nativeBuildInputs = [ finalAttrs.finalPackage ]; } ''
       export HOME="$TMPDIR"
 

--- a/pkgs/by-name/bl/bloop/sources.json
+++ b/pkgs/by-name/bl/bloop/sources.json
@@ -1,0 +1,28 @@
+{
+  "repo": "scalacenter/bloop",
+  "version": "2.1.1",
+  "completions": {
+    "bash": {
+      "asset": "bash-completions",
+      "hash": "sha256-2mt+zUEJvQ/5ixxFLZ3Z0m7uDSj/YE9sg/uNMjamvdE="
+    },
+    "fish": {
+      "asset": "fish-completions",
+      "hash": "sha256-RF6nZxbw4sLwCP4irKJLYCZnlkaRdEkmpYkOHBoSF/8="
+    },
+    "zsh": {
+      "asset": "zsh-completions",
+      "hash": "sha256-WNMsPwBfd5EjeRbRtc06lCEVI2FVoLfrqL82OR0G7/c="
+    }
+  },
+  "assets": {
+    "aarch64-darwin": {
+      "asset": "bloop-aarch64-apple-darwin",
+      "hash": "sha256-OrONKbC2l0jjfmguDmoiyEaJWdTrKBiP0ZEa5rhizDM="
+    },
+    "x86_64-linux": {
+      "asset": "bloop-x86_64-pc-linux",
+      "hash": "sha256-F5wRihAwf/TNBSYortTCoK9qKqTI+1N5InJ+rqLFp8A="
+    }
+  }
+}

--- a/pkgs/by-name/bl/bloop/update.nix
+++ b/pkgs/by-name/bl/bloop/update.nix
@@ -1,0 +1,156 @@
+{
+  writeShellApplication,
+  coreutils,
+  curl,
+  git,
+  jq,
+  nix,
+}:
+
+writeShellApplication {
+  name = "update-bloop";
+
+  runtimeInputs = [
+    coreutils
+    curl
+    git
+    jq
+    nix
+  ];
+
+  text = ''
+    # stdout is reserved for the JSON expected by the `commit` updateScript
+    # feature, everything else has to go to stderr.
+    attr_path="''${UPDATE_NIX_ATTR_PATH:-bloop}"
+
+    nixpkgs=$(git rev-parse --show-toplevel)
+    position=$(nix-instantiate --eval --json --attr "$attr_path.meta.position" "$nixpkgs" \
+      | jq --raw-output .)
+
+    # Everything else is read out of the file that is about to be rewritten.
+    sources_json="$(dirname "''${position%:*}")/sources.json"
+    repo=$(jq --raw-output .repo "$sources_json")
+    old_version=$(jq --raw-output .version "$sources_json")
+
+    auth=()
+    if [[ -n "''${GITHUB_TOKEN:-}" ]]; then
+      auth=(--header "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+
+    release=$(curl --silent --show-error --fail "''${auth[@]}" \
+      "https://api.github.com/repos/$repo/releases/latest")
+    new_version=$(jq --raw-output '.tag_name // "" | ltrimstr("v")' <<< "$release")
+
+    # both versions end up inside Nix expressions below
+    version_pattern='^[0-9][0-9A-Za-z.+-]*$'
+
+    if [[ ! "$new_version" =~ $version_pattern ]]; then
+      echo "$repo published an implausible version: '$new_version'" >&2
+      exit 1
+    fi
+
+    if [[ ! "$old_version" =~ $version_pattern ]]; then
+      echo "$sources_json holds an implausible version: '$old_version'" >&2
+      exit 1
+    fi
+
+    order=$(nix-instantiate --eval \
+      --expr "builtins.compareVersions \"$new_version\" \"$old_version\"")
+
+    case "$order" in
+      0)
+        echo "$attr_path is already at the latest version $new_version." >&2
+        echo '[]'
+        exit 0
+        ;;
+      -1)
+        echo "refusing to downgrade $attr_path from $old_version to $new_version." >&2
+        exit 1
+        ;;
+    esac
+
+    # An asset that disappeared would otherwise surface as a bare 404 from
+    # nix-prefetch-url further down.
+    known=$(jq '[ to_entries[] | .value | objects | .[].asset ]' "$sources_json")
+    missing=$(jq --raw-output --argjson published "$(jq '[ .assets[].name ]' <<< "$release")" \
+      '[ .[] | select(IN($published[]) | not) ] | join(", ")' <<< "$known")
+
+    if [[ -n "$missing" ]]; then
+      echo "v$new_version does not ship $missing, listed in $sources_json" >&2
+      exit 1
+    fi
+
+    prefetch() {
+      local hash
+      hash=$(nix-prefetch-url --type sha256 \
+        "https://github.com/$repo/releases/download/v$new_version/$1")
+
+      nix-hash --to-sri --type sha256 "$hash"
+    }
+
+    # <section> -> { "<key>": { asset, hash }, ... } for each key in that section
+    collect() {
+      local section="$1"
+      local objects=()
+      local key asset hash
+
+      while read -r key; do
+        asset=$(jq --raw-output --arg section "$section" --arg key "$key" \
+          '.[$section][$key].asset' "$sources_json")
+        hash=$(prefetch "$asset")
+
+        objects+=("$(jq --null-input --compact-output \
+          --arg key "$key" \
+          --arg asset "$asset" \
+          --arg hash "$hash" \
+          '{ ($key): { asset: $asset, hash: $hash } }')")
+      done < <(jq --raw-output --arg section "$section" '.[$section] | keys[]' "$sources_json")
+
+      if [[ ''${#objects[@]} -eq 0 ]]; then
+        echo '{}'
+        return
+      fi
+
+      printf '%s\n' "''${objects[@]}" | jq --slurp add
+    }
+
+    # Every object-valued key is a section of { <key>: { asset, hash } }, repo
+    # and version being strings. Which sections exist is therefore data too.
+    sections='{}'
+
+    while read -r section; do
+      entries=$(collect "$section")
+      sections=$(jq --arg section "$section" --argjson entries "$entries" \
+        '. + { ($section): $entries }' <<< "$sections")
+    done < <(jq --raw-output 'to_entries[] | select(.value | type == "object") | .key' "$sources_json")
+
+    # Write beside the target and move into place, so that a failure cannot
+    # leave a truncated sources.json and an unbuildable package behind.
+    tmp=$(mktemp "$sources_json.XXXXXX")
+    trap 'rm -f "$tmp"' EXIT
+
+    jq --null-input \
+      --arg repo "$repo" \
+      --arg version "$new_version" \
+      --argjson sections "$sections" \
+      '{ repo: $repo, version: $version } + $sections' \
+      > "$tmp"
+
+    chmod --reference="$sources_json" "$tmp"
+    mv "$tmp" "$sources_json"
+
+    jq --null-input --compact-output \
+      --arg attrPath "$attr_path" \
+      --arg oldVersion "$old_version" \
+      --arg newVersion "$new_version" \
+      --arg file "$sources_json" \
+      --arg repo "$repo" \
+      '[ {
+        attrPath: $attrPath,
+        oldVersion: $oldVersion,
+        newVersion: $newVersion,
+        files: [ $file ],
+        commitBody: "https://github.com/\($repo)/releases/tag/v\($newVersion)"
+      } ]'
+  '';
+}


### PR DESCRIPTION
Fixes two real defects in the bloop package and adds the machinery to keep them fixed:

- **The fish completions had been stale since 2023**: the fetch was pinned to an old release's hash, so every bloop bump kept shipping the old file. Sources now live in a single `sources.json` (version, per-platform binaries, completions), and the new update script refreshes every hash in it — completions included — so this class of bug cannot recur. It also drops the `x86_64-darwin` asset, which upstream stopped shipping.
- **The wrapper referenced no jre at all**: `propagatedBuildInputs` put one in the closure but on nobody's PATH, so the CLI found a `java` for its build server only if the user happened to have one, and `override { jre = ...; }` changed nothing at run time. The wrapper now carries `PATH` and `JAVA_HOME`. Note the propagation is dropped with it, so bloop no longer pushes a `java` onto dependents' PATHs (`nix-shell -p bloop` included) — add a jre alongside if you relied on that.

Also: `passthru.tests` covering `--help` (the build server itself needs Maven Central, so `--version` cannot run sandboxed) and syntax-checking all three installed completions; an update script with downgrade refusal and the `commit` protocol; an eval-time assert for the documented Java 17 floor; `meta.platforms` derived from the assets table so the two cannot drift.

Built with all `passthru.tests` on x86_64-linux; `bloop --version`/`bloop about` exercised by hand against a real build server (correctly reports the overridden JVM, still works with a hostile `JAVA_HOME=/nonexistent`); `nixpkgs-vet` passes. One of nine independent per-tool cleanups of the Scala toolchain.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: the commits (see their `Assisted-by:` trailers) and this summary were prepared with assistance from Claude Code (Claude Opus 5). All changes were reviewed, built, and manually exercised by the author.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
