### PR TITLE
coursier: fix update script, restrict platforms, misc cleanup

### DIFF
--- a/pkgs/by-name/co/coursier/package.nix
+++ b/pkgs/by-name/co/coursier/package.nix
@@ -4,8 +4,9 @@
   fetchurl,
   makeWrapper,
   jre,
-  writeScript,
+  writeShellApplication,
   common-updater-scripts,
+  gnugrep,
   coreutils,
   git,
   gnused,
@@ -43,28 +44,72 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = writeScript "update.sh" ''
-    #!${stdenv.shell}
-    set -o errexit
-    PATH=${
-      lib.makeBinPath [
+  passthru.updateScript = {
+    command = lib.getExe (writeShellApplication {
+      name = "update-coursier";
+
+      runtimeInputs = [
         common-updater-scripts
         coreutils
         git
+        gnugrep
         gnused
         nix
-      ]
-    }
-    oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
-    latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags https://github.com/coursier/coursier.git 'v*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3 | sed 's|^v||g')"
-    if [ "$oldVersion" != "$latestTag" ]; then
-      nixpkgs="$(git rev-parse --show-toplevel)"
-      default_nix="$nixpkgs/pkgs/development/tools/coursier/default.nix"
-      update-source-version ${pname} "$latestTag" --version-key=version --print-changes
-    else
-      echo "${pname} is already up-to-date"
-    fi
-  '';
+      ];
+
+      text = ''
+        # stdout is reserved for the JSON --print-changes emits below, everything
+        # else has to go to stderr.
+        attr_path="''${UPDATE_NIX_ATTR_PATH:-coursier}"
+
+        nixpkgs=$(git rev-parse --show-toplevel)
+        position=$(nix-instantiate --eval --raw --attr "$attr_path.meta.position" "$nixpkgs")
+        package_nix="''${position%:*}"
+        old_version=$(nix-instantiate --eval --raw --attr "$attr_path.version" "$nixpkgs")
+
+        # 'v*.*.*' also matches milestones such as v2.1.25-M26, which are not
+        # releases, so keep only plain X.Y.Z and take the highest.
+        new_version=$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs \
+          --sort='version:refname' --tags https://github.com/coursier/coursier.git 'v*.*.*' \
+          | cut --delimiter='/' --fields=3 \
+          | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+          | tail --lines=1 \
+          | sed 's|^v||')
+
+        if [[ -z "$new_version" ]]; then
+          echo "no plain X.Y.Z tag found upstream" >&2
+          exit 1
+        fi
+
+        order=$(nix-instantiate --eval \
+          --expr "builtins.compareVersions \"$new_version\" \"$old_version\"")
+
+        case "$order" in
+          0)
+            echo "$attr_path is already at the latest version $new_version." >&2
+            echo '[]'
+            exit 0
+            ;;
+          -1)
+            echo "refusing to downgrade $attr_path from $old_version to $new_version." >&2
+            exit 1
+            ;;
+        esac
+
+        # update-source-version rewrites package.nix with a fake hash and rebuilds
+        # to discover the real one, so put the file back if that fails.
+        backup=$(mktemp)
+        cp "$package_nix" "$backup"
+        trap 'cp "$backup" "$package_nix"; rm -f "$backup"' EXIT
+
+        update-source-version "$attr_path" "$new_version" --version-key=version --print-changes
+
+        trap - EXIT
+        rm -f "$backup"
+      '';
+    });
+    supportedFeatures = [ "commit" ];
+  };
 
   meta = {
     homepage = "https://get-coursier.io/";

--- a/pkgs/by-name/co/coursier/package.nix
+++ b/pkgs/by-name/co/coursier/package.nix
@@ -68,8 +68,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://get-coursier.io/";
+    changelog = "https://github.com/coursier/coursier/releases/tag/v${version}";
     description = "Scala library to fetch dependencies from Maven / Ivy repositories";
     mainProgram = "cs";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       adelbertc

--- a/pkgs/by-name/co/coursier/package.nix
+++ b/pkgs/by-name/co/coursier/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     patchShebangs $out/bin/cs
     wrapProgram $out/bin/cs \
       --prefix PATH ":" ${lib.makeBinPath [ jre ]} \
+      --set JAVA_HOME ${jre.home} \
       --prefix LD_LIBRARY_PATH ":" ${libPath}
 
     runHook postInstall

--- a/pkgs/by-name/co/coursier/package.nix
+++ b/pkgs/by-name/co/coursier/package.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       adelbertc
+      agilesteel
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/co/coursier/package.nix
+++ b/pkgs/by-name/co/coursier/package.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
       adelbertc
       agilesteel
     ];
-    platforms = lib.platforms.all;
+    # a shell script wrapping a java launcher, so it runs wherever the jre does
+    platforms = jre.meta.platforms;
   };
 }


### PR DESCRIPTION
The headline fix is the update script: the old one sorted tags without filtering, so its next run would have proposed the milestone **v2.1.25-M26** as an update to 2.1.24. The reworked script keeps only plain `X.Y.Z` tags, refuses downgrades, and supports the `commit` updateScript protocol.

Also:

- `meta.platforms` was the 79-entry default; coursier is a shell script wrapping a java launcher, so it now follows `jre.meta.platforms`.
- The wrapper sets `JAVA_HOME` to the packaged jre so `override { jre = ...; }` governs what actually runs; coursier's own JVM management (`cs java --jvm ...`, `cs java-home`) still works as the escape hatch — verified.
- meta gains `changelog` and `sourceProvenance`; adds myself as maintainer.

Built on x86_64-linux; `cs version` / `cs java-home` / `cs fetch` exercised by hand, including under a hostile `JAVA_HOME=/nonexistent` and on Java 8 (coursier deliberately has no Java-version floor — it runs on the shell's own JDK, which is its job); `nixpkgs-vet` passes. One of nine independent per-tool cleanups of the Scala toolchain.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: the commits (see their `Assisted-by:` trailers) and this summary were prepared with assistance from Claude Code (Claude Opus 5). All changes were reviewed, built, and manually exercised by the author.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
