### PR TITLE
metals: fix env leaks, add update script, tests, misc cleanups

### DIFF
--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -5,13 +5,32 @@
   jre,
   makeWrapper,
   setJavaClassPath,
+  extraJavaOpts ? "-XX:+UseG1GC -XX:+UseStringDeduplication -Xss4m -Xms100m",
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "metals";
   version = "1.6.8";
 
-  deps = stdenv.mkDerivation {
+  nativeBuildInputs = [
+    makeWrapper
+    setJavaClassPath
+  ];
+  buildInputs = [ finalAttrs.passthru.deps ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    makeWrapper ${jre}/bin/java $out/bin/metals \
+      --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.Main"
+
+    makeWrapper ${jre}/bin/java $out/bin/metals-mcp \
+      --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.McpMain"
+  '';
+
+  passthru.deps = stdenv.mkDerivation {
     name = "metals-deps-${finalAttrs.version}";
     buildCommand = ''
       export COURSIER_CACHE=$(pwd)
@@ -23,26 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     outputHashAlgo = "sha256";
     outputHash = "sha256-LdZ6I7zOUTHgS/TTo0T6Dh+Kb3YpgJg8gK0UngsA7Gs=";
   };
-
-  nativeBuildInputs = [
-    makeWrapper
-    setJavaClassPath
-  ];
-  buildInputs = [ finalAttrs.deps ];
-
-  dontUnpack = true;
-
-  extraJavaOpts = "-XX:+UseG1GC -XX:+UseStringDeduplication -Xss4m -Xms100m";
-
-  installPhase = ''
-    mkdir -p $out/bin
-
-    makeWrapper ${jre}/bin/java $out/bin/metals \
-      --add-flags "${finalAttrs.extraJavaOpts} -cp $CLASSPATH scala.meta.metals.Main"
-
-    makeWrapper ${jre}/bin/java $out/bin/metals-mcp \
-      --add-flags "${finalAttrs.extraJavaOpts} -cp $CLASSPATH scala.meta.metals.McpMain"
-  '';
 
   meta = {
     homepage = "https://scalameta.org/metals/";

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -21,23 +21,29 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontUnpack = true;
 
-  installPhase = ''
-    runHook preInstall
+  # metals itself is class-file 61; its own docs' minimum of 11 is the floor for
+  # the jdk it indexes and builds against, which metals.javaHome still selects.
+  installPhase =
+    assert lib.assertMsg (lib.versionAtLeast jre.version "17.0.0") ''
+      metals requires Java 17 or newer, but ${jre.name} is ${jre.version}
+    '';
+    ''
+      runHook preInstall
 
-    mkdir -p $out/bin
+      mkdir -p $out/bin
 
-    makeWrapper ${jre}/bin/java $out/bin/metals \
-      --prefix PATH : ${lib.makeBinPath [ jre ]} \
-      --set JAVA_HOME ${jre.home} \
-      --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.Main"
+      makeWrapper ${jre}/bin/java $out/bin/metals \
+        --prefix PATH : ${lib.makeBinPath [ jre ]} \
+        --set JAVA_HOME ${jre.home} \
+        --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.Main"
 
-    makeWrapper ${jre}/bin/java $out/bin/metals-mcp \
-      --prefix PATH : ${lib.makeBinPath [ jre ]} \
-      --set JAVA_HOME ${jre.home} \
-      --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.McpMain"
+      makeWrapper ${jre}/bin/java $out/bin/metals-mcp \
+        --prefix PATH : ${lib.makeBinPath [ jre ]} \
+        --set JAVA_HOME ${jre.home} \
+        --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.McpMain"
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
   passthru.updateScript = {
     command = lib.getExe (callPackage ./update.nix { });

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -49,9 +49,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://scalameta.org/metals/";
+    changelog = "https://github.com/scalameta/metals/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     description = "Language server for Scala";
     mainProgram = "metals";
+    # a jar plus a launcher wrapper, so it runs wherever the jre does
+    platforms = jre.meta.platforms;
     maintainers = with lib.maintainers; [
       agilesteel
       fabianhjr

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -6,6 +6,7 @@
   makeWrapper,
   setJavaClassPath,
   callPackage,
+  testers,
   extraJavaOpts ? "-XX:+UseG1GC -XX:+UseStringDeduplication -Xss4m -Xms100m",
 }:
 
@@ -62,6 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     command = lib.getExe (callPackage ./update.nix { });
     supportedFeatures = [ "commit" ];
   };
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   passthru.deps = stdenv.mkDerivation {
     name = "metals-deps-${finalAttrs.version}";

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -27,9 +27,13 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
 
     makeWrapper ${jre}/bin/java $out/bin/metals \
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --set JAVA_HOME ${jre.home} \
       --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.Main"
 
     makeWrapper ${jre}/bin/java $out/bin/metals-mcp \
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --set JAVA_HOME ${jre.home} \
       --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.McpMain"
 
     runHook postInstall

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   dontUnpack = true;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
 
     makeWrapper ${jre}/bin/java $out/bin/metals \
@@ -28,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${jre}/bin/java $out/bin/metals-mcp \
       --add-flags "${extraJavaOpts} -cp $CLASSPATH scala.meta.metals.McpMain"
+
+    runHook postInstall
   '';
 
   passthru.deps = stdenv.mkDerivation {

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -15,9 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "metals-deps-${finalAttrs.version}";
     buildCommand = ''
       export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/cs fetch org.scalameta:metals_2.13:${finalAttrs.version} org.scalameta:metals-mcp_2.13:${finalAttrs.version} \
-        -r bintray:scalacenter/releases \
-        -r sonatype:snapshots > deps
+      ${coursier}/bin/cs fetch org.scalameta:metals_2.13:${finalAttrs.version} org.scalameta:metals-mcp_2.13:${finalAttrs.version} > deps
       mkdir -p $out/share/java
       cp $(< deps) $out/share/java/
     '';

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -45,6 +45,19 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postInstall
     '';
 
+  # --version reaches repo1.maven.org to list the Scala versions it supports,
+  # but tolerates being offline: the version line still prints and the exit
+  # code stays 0, which is what makes this safe inside the sandbox.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/metals --version | grep -q "${finalAttrs.version}"
+    $out/bin/metals-mcp --version | grep -q "${finalAttrs.version}"
+
+    runHook postInstallCheck
+  '';
+
   passthru.updateScript = {
     command = lib.getExe (callPackage ./update.nix { });
     supportedFeatures = [ "commit" ];

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -5,6 +5,7 @@
   jre,
   makeWrapper,
   setJavaClassPath,
+  callPackage,
   extraJavaOpts ? "-XX:+UseG1GC -XX:+UseStringDeduplication -Xss4m -Xms100m",
 }:
 
@@ -33,6 +34,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = {
+    command = lib.getExe (callPackage ./update.nix { });
+    supportedFeatures = [ "commit" ];
+  };
 
   passthru.deps = stdenv.mkDerivation {
     name = "metals-deps-${finalAttrs.version}";

--- a/pkgs/by-name/me/metals/package.nix
+++ b/pkgs/by-name/me/metals/package.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Language server for Scala";
     mainProgram = "metals";
     maintainers = with lib.maintainers; [
+      agilesteel
       fabianhjr
       jpaju
       tomahna

--- a/pkgs/by-name/me/metals/update.nix
+++ b/pkgs/by-name/me/metals/update.nix
@@ -1,0 +1,123 @@
+{
+  writeShellApplication,
+  coreutils,
+  curl,
+  git,
+  gnused,
+  jq,
+  nix,
+}:
+
+writeShellApplication {
+  name = "update-metals";
+
+  runtimeInputs = [
+    coreutils
+    curl
+    git
+    gnused
+    jq
+    nix
+  ];
+
+  text = ''
+    # stdout is reserved for the JSON expected by the `commit` updateScript
+    # feature, everything else has to go to stderr.
+    attr_path="''${UPDATE_NIX_ATTR_PATH:-metals}"
+    nixpkgs=$(git rev-parse --show-toplevel)
+
+    eval_attr() {
+      nix-instantiate --eval --json --attr "$attr_path.$1" "$nixpkgs" | jq --raw-output .
+    }
+
+    position=$(eval_attr meta.position)
+    package_nix="''${position%:*}"
+    old_version=$(eval_attr version)
+    changelog=$(eval_attr meta.changelog)
+    repo=$(sed -n 's|^https://github.com/\([^/]*/[^/]*\)/.*|\1|p' <<< "$changelog")
+
+    if [[ -z "$repo" ]]; then
+      echo "could not read a GitHub repository out of meta.changelog: $changelog" >&2
+      exit 1
+    fi
+
+    auth=()
+    if [[ -n "''${GITHUB_TOKEN:-}" ]]; then
+      auth=(--header "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+
+    release=$(curl --silent --show-error --fail "''${auth[@]}" \
+      "https://api.github.com/repos/$repo/releases/latest")
+    new_version=$(jq --raw-output '.tag_name // "" | ltrimstr("v")' <<< "$release")
+
+    # both versions end up inside Nix expressions below
+    version_pattern='^[0-9][0-9A-Za-z.+-]*$'
+
+    if [[ ! "$new_version" =~ $version_pattern ]]; then
+      echo "$repo published an implausible version: '$new_version'" >&2
+      exit 1
+    fi
+
+    if [[ ! "$old_version" =~ $version_pattern ]]; then
+      echo "$package_nix holds an implausible version: '$old_version'" >&2
+      exit 1
+    fi
+
+    order=$(nix-instantiate --eval \
+      --expr "builtins.compareVersions \"$new_version\" \"$old_version\"")
+
+    case "$order" in
+      0)
+        echo "$attr_path is already at the latest version $new_version." >&2
+        echo '[]'
+        exit 0
+        ;;
+      -1)
+        echo "refusing to downgrade $attr_path from $old_version to $new_version." >&2
+        exit 1
+        ;;
+    esac
+
+    # The dependency hash is only learnable from the failed build below, so edit
+    # first and restore on any failure.
+    backup=$(mktemp)
+    cp "$package_nix" "$backup"
+    trap 'cp "$backup" "$package_nix"; rm -f "$backup"' EXIT
+
+    sed -i "s|version = \"$old_version\"|version = \"$new_version\"|" "$package_nix"
+
+    if build_log=$(nix-build --no-out-link --attr "$attr_path" "$nixpkgs" 2>&1); then
+      echo "expected a hash mismatch for the new dependencies, but the build succeeded" >&2
+      exit 1
+    fi
+
+    new_hash=$(sed -n 's/^[[:space:]]*got:[[:space:]]*\(.*\)$/\1/p' <<< "$build_log" | head -1)
+
+    if [[ ! "$new_hash" =~ ^sha256-[A-Za-z0-9+/=]+$ ]]; then
+      echo "could not read the new dependency hash out of the build log:" >&2
+      echo "$build_log" >&2
+      exit 1
+    fi
+
+    sed -i "s|outputHash = \"[^\"]*\"|outputHash = \"$new_hash\"|" "$package_nix"
+
+    nix-build --no-out-link --attr "$attr_path" "$nixpkgs" > /dev/null
+
+    trap - EXIT
+    rm -f "$backup"
+
+    jq --null-input --compact-output \
+      --arg attrPath "$attr_path" \
+      --arg oldVersion "$old_version" \
+      --arg newVersion "$new_version" \
+      --arg file "$package_nix" \
+      --arg repo "$repo" \
+      '[ {
+        attrPath: $attrPath,
+        oldVersion: $oldVersion,
+        newVersion: $newVersion,
+        files: [ $file ],
+        commitBody: "https://github.com/\($repo)/releases/tag/v\($newVersion)"
+      } ]'
+  '';
+}


### PR DESCRIPTION
Cleans up the metals package and gives it tests, an update script, and predictable JVM handling:

- **Dead coursier resolvers dropped** from the deps fetch (bintray is long gone) — hash-neutral, verified.
- **`deps` and `extraJavaOpts` no longer leak into the builder as environment variables**: `deps` moves under `passthru` (same attribute path for consumers), and `extraJavaOpts` becomes a package argument with the same default, so `metals.override { extraJavaOpts = "-Xmx4g"; }` keeps working — verified both wrappers pick it up.
- **Both wrappers export `PATH` and `JAVA_HOME`** for the packaged jre, so the JDK metals spawns for builds is the one the derivation was given, not whatever the environment happens to contain.
- **Eval-time assert for the Java 17 floor** (metals itself is class-file 61) with a clear message instead of a runtime `UnsupportedClassVersionError`.
- **Install check runs both wrappers** — `metals --version` and `metals-mcp --version`. `testers.testVersion` only ever reaches `meta.mainProgram`, so without this `metals-mcp` would never be exercised. (`metals --version` contacts Maven Central for its supported-Scala listing but tolerates being offline — version still prints, exit 0 — which is what makes it sandbox-safe.)
- `passthru.tests.version`, `runHook` calls in installPhase, meta gains changelog/sourceProvenance, `platforms` follows the jre; adds myself as maintainer.

Built with `passthru.tests` on x86_64-linux; both binaries exercised by hand, including under a hostile `JAVA_HOME=/nonexistent`; `nixpkgs-vet` passes. One of nine independent per-tool cleanups of the Scala toolchain.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: the commits (see their `Assisted-by:` trailers) and this summary were prepared with assistance from Claude Code (Claude Opus 5). All changes were reviewed, built, and manually exercised by the author.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
