### PR TITLE
mill: 1.1.7 -> 1.1.8, rework update script

### DIFF
--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -6,13 +6,16 @@
   makeWrapper,
   stdenvNoCC,
   zlib,
-  writeScript,
+  writeShellApplication,
   stdenv,
+  common-updater-scripts,
   coreutils,
   curl,
+  git,
   gnugrep,
   gnused,
-  common-updater-scripts,
+  jq,
+  nix,
 }:
 
 let
@@ -71,50 +74,101 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = writeScript "${pname}-updater" ''
-    #!${stdenv.shell}
-    set -eu -o pipefail
-    PATH=${
-      lib.makeBinPath [
+  passthru.updateScript = {
+    command = lib.getExe (writeShellApplication {
+      name = "update-mill";
+
+      runtimeInputs = [
+        common-updater-scripts
         coreutils
         curl
+        git
         gnugrep
         gnused
-        common-updater-scripts
-      ]
-    }:$PATH
-    metadataUrl="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/maven-metadata.xml"
-    # Maven's <release>/<latest> just reflect whatever was published most recently, which
-    # for mill includes milestone (-M1, -M2, ...) and per-commit dev builds (-N-<sha>).
-    # Filter the full <version> list down to plain X.Y.Z semver and take the highest.
-    latestVersion="$(
-      curl -sS $metadataUrl \
-        | grep -oE '<version>[0-9]+\.[0-9]+\.[0-9]+</version>' \
-        | sed -E 's#</?version>##g' \
-        | sort -V \
-        | tail -n1
-    )"
+        jq
+        nix
+      ];
 
-    ${lib.strings.concatStrings (
-      builtins.map (
-        platform:
-        let
-          suffix = sources.${platform}.suffix;
-        in
-        ''
-          {
-            dlUrl="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist-${suffix}/$latestVersion/mill-dist-${suffix}-$latestVersion.exe"
+      text = ''
+        # stdout is reserved for the JSON expected by the `commit` updateScript
+        # feature, everything else has to go to stderr.
+        attr_path="''${UPDATE_NIX_ATTR_PATH:-mill}"
 
-            prefetch="$(nix-prefetch-url $dlUrl)"
-            hash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri $prefetch)
+        nixpkgs=$(git rev-parse --show-toplevel)
+        position=$(nix-instantiate --eval --raw --attr "$attr_path.meta.position" "$nixpkgs")
+        package_nix="''${position%:*}"
+        old_version=$(nix-instantiate --eval --raw --attr "$attr_path.version" "$nixpkgs")
 
+        # Maven's <release>/<latest> just reflect whatever was published most
+        # recently, which for mill includes milestones (-M1, -M2, ...) and
+        # per-commit dev builds (-N-<sha>). Filter the full <version> list down to
+        # plain X.Y.Z semver and take the highest.
+        new_version=$(curl --silent --show-error --fail \
+          "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/maven-metadata.xml" \
+          | grep -oE '<version>[0-9]+\.[0-9]+\.[0-9]+</version>' \
+          | sed -E 's#</?version>##g' \
+          | sort -V \
+          | tail -n1)
 
-            update-source-version mill "$latestVersion" "$hash" --system=${platform} --ignore-same-version
-          }
-        ''
-      ) meta.platforms
-    )}
-  '';
+        if [[ -z "$new_version" ]]; then
+          echo "no plain X.Y.Z release found in the maven metadata" >&2
+          exit 1
+        fi
+
+        order=$(nix-instantiate --eval \
+          --expr "builtins.compareVersions \"$new_version\" \"$old_version\"")
+
+        case "$order" in
+          0)
+            echo "$attr_path is already at the latest version $new_version." >&2
+            echo '[]'
+            exit 0
+            ;;
+          -1)
+            echo "refusing to downgrade $attr_path from $old_version to $new_version." >&2
+            exit 1
+            ;;
+        esac
+
+        # update-source-version rewrites package.nix in place, once per platform,
+        # so put the file back if any of them fails rather than leaving it half
+        # updated.
+        backup=$(mktemp)
+        cp "$package_nix" "$backup"
+        trap 'cp "$backup" "$package_nix"; rm -f "$backup"' EXIT
+
+        refresh() {
+          local system="$1" suffix="$2" hash
+          hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url \
+            "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist-$suffix/$new_version/mill-dist-$suffix-$new_version.exe")")
+
+          update-source-version "$attr_path" "$new_version" "$hash" \
+            --system="$system" --ignore-same-version >&2
+        }
+
+        ${lib.concatMapStrings (system: ''
+          refresh ${system} ${sources.${system}.suffix}
+        '') (builtins.attrNames sources)}
+
+        trap - EXIT
+        rm -f "$backup"
+
+        jq --null-input --compact-output \
+          --arg attrPath "$attr_path" \
+          --arg oldVersion "$old_version" \
+          --arg newVersion "$new_version" \
+          --arg file "$package_nix" \
+          '[ {
+            attrPath: $attrPath,
+            oldVersion: $oldVersion,
+            newVersion: $newVersion,
+            files: [ $file ],
+            commitBody: "https://github.com/com-lihaoyi/mill/releases/tag/\($newVersion)"
+          } ]'
+      '';
+    });
+    supportedFeatures = [ "commit" ];
+  };
 
   meta = {
     homepage = "https://com-lihaoyi.github.io/mill/";

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -123,6 +123,7 @@ stdenvNoCC.mkDerivation rec {
       modules (written in Java or Scala) or through an external subprocesses.
     '';
     maintainers = with lib.maintainers; [
+      agilesteel
       zenithal
     ];
     platforms = [

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -51,7 +51,7 @@ stdenvNoCC.mkDerivation rec {
   dontBuild = true;
 
   # this is mostly downloading a pre-built artifact
-  preferLocal = true;
+  preferLocalBuild = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -24,15 +24,15 @@ let
   sources = {
     aarch64-darwin = {
       suffix = "native-mac-aarch64";
-      hash = "sha256-tQpV0Goe9Oq16rm14mavS5ELl7z4Bsu7JBVbbFgauPE=";
+      hash = "sha256-zssJgQWY4QI0giYPGeviUbgZ2z8XtIyvkP0BoqcfRbc=";
     };
     aarch64-linux = {
       suffix = "native-linux-aarch64";
-      hash = "sha256-lq0mR0lFhl7ESY+BM6kVRjyI3bpZOSwj+bSo37dAkaI=";
+      hash = "sha256-dzIG8bO0vWtC/798LI0WjGIQ5PB1rgYIndz24P5dfbg=";
     };
     x86_64-linux = {
       suffix = "native-linux-amd64";
-      hash = "sha256-2GSLEvRTlH9QPzkGM52sYiJh6OqXQzn/V0sPQ+SA39s=";
+      hash = "sha256-umDQNXc4CpBsInPMp2VoKHBeJf71GaHpJ2Vq4Wfo9kQ=";
     };
   };
 
@@ -42,7 +42,7 @@ let
 in
 stdenvNoCC.mkDerivation rec {
   pname = "mill";
-  version = "1.1.7";
+  version = "1.1.8";
 
   src = fetchurl {
     url = "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist-${source.suffix}/${version}/mill-dist-${source.suffix}-${version}.exe";

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -62,17 +62,23 @@ stdenvNoCC.mkDerivation rec {
   # this is mostly downloading a pre-built artifact
   preferLocalBuild = true;
 
-  installPhase = ''
-    runHook preInstall
+  # the daemon mill starts is Java 17 bytecode; upstream's "every JVM from 11
+  # onward" is about the JVMs a build may target, not the one mill runs on
+  installPhase =
+    assert lib.assertMsg (lib.versionAtLeast jre.version "17.0.0") ''
+      mill requires Java 17 or newer, but ${jre.name} is ${jre.version}
+    '';
+    ''
+      runHook preInstall
 
-    install -Dm 555 $src $out/bin/.mill-wrapped
-    # can't use wrapProgram because it sets --argv0
-    makeWrapper $out/bin/.mill-wrapped $out/bin/mill \
-      --prefix PATH : "${lib.makeBinPath [ jre ]}" \
-      --set JAVA_HOME "${jre.home}"
+      install -Dm 555 $src $out/bin/.mill-wrapped
+      # can't use wrapProgram because it sets --argv0
+      makeWrapper $out/bin/.mill-wrapped $out/bin/mill \
+        --prefix PATH : "${lib.makeBinPath [ jre ]}" \
+        --set JAVA_HOME "${jre.home}"
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
   passthru.updateScript = {
     command = lib.getExe (writeShellApplication {

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -112,6 +112,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     homepage = "https://com-lihaoyi.github.io/mill/";
+    changelog = "https://github.com/com-lihaoyi/mill/releases/tag/${version}";
     license = lib.licenses.mit;
     description = "Build tool for Scala, Java and more";
     mainProgram = "mill";

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -16,13 +16,25 @@
 }:
 
 let
-  suffixMap = {
-    aarch64-darwin = "native-mac-aarch64";
-    aarch64-linux = "native-linux-aarch64";
-    x86_64-linux = "native-linux-amd64";
+  # One table per platform: the artifact suffix and its hash belong together, and
+  # meta.platforms is derived from it so the two cannot drift.
+  sources = {
+    aarch64-darwin = {
+      suffix = "native-mac-aarch64";
+      hash = "sha256-tQpV0Goe9Oq16rm14mavS5ELl7z4Bsu7JBVbbFgauPE=";
+    };
+    aarch64-linux = {
+      suffix = "native-linux-aarch64";
+      hash = "sha256-lq0mR0lFhl7ESY+BM6kVRjyI3bpZOSwj+bSo37dAkaI=";
+    };
+    x86_64-linux = {
+      suffix = "native-linux-amd64";
+      hash = "sha256-2GSLEvRTlH9QPzkGM52sYiJh6OqXQzn/V0sPQ+SA39s=";
+    };
   };
-  suffix =
-    suffixMap.${stdenv.hostPlatform.system}
+
+  source =
+    sources.${stdenv.hostPlatform.system}
       or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 in
 stdenvNoCC.mkDerivation rec {
@@ -30,14 +42,8 @@ stdenvNoCC.mkDerivation rec {
   version = "1.1.7";
 
   src = fetchurl {
-    url = "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist-${suffix}/${version}/mill-dist-${suffix}-${version}.exe";
-    sha256 =
-      {
-        aarch64-darwin = "sha256-tQpV0Goe9Oq16rm14mavS5ELl7z4Bsu7JBVbbFgauPE=";
-        aarch64-linux = "sha256-lq0mR0lFhl7ESY+BM6kVRjyI3bpZOSwj+bSo37dAkaI=";
-        x86_64-linux = "sha256-2GSLEvRTlH9QPzkGM52sYiJh6OqXQzn/V0sPQ+SA39s=";
-      }
-      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    url = "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist-${source.suffix}/${version}/mill-dist-${source.suffix}-${version}.exe";
+    inherit (source) hash;
   };
 
   buildInputs = [ zlib ];
@@ -93,7 +99,7 @@ stdenvNoCC.mkDerivation rec {
       builtins.map (
         platform:
         let
-          suffix = suffixMap.${platform} or (throw "Platform not in suffixMap: ${platform}");
+          suffix = sources.${platform}.suffix;
         in
         ''
           {
@@ -127,11 +133,7 @@ stdenvNoCC.mkDerivation rec {
       agilesteel
       zenithal
     ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
+    platforms = builtins.attrNames sources;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -68,8 +68,8 @@ stdenvNoCC.mkDerivation rec {
     install -Dm 555 $src $out/bin/.mill-wrapped
     # can't use wrapProgram because it sets --argv0
     makeWrapper $out/bin/.mill-wrapped $out/bin/mill \
-      --prefix PATH : "${jre}/bin" \
-      --set-default JAVA_HOME "${jre}"
+      --prefix PATH : "${lib.makeBinPath [ jre ]}" \
+      --set JAVA_HOME "${jre.home}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Updates mill 1.1.7 → 1.1.8 ([release](https://github.com/com-lihaoyi/mill/releases/tag/1.1.8)) and fixes what the update surfaced:

- **`preferLocal = true` was a typo** — the real attribute is `preferLocalBuild`, so the hint had been inert.
- **`JAVA_HOME` was wrong twice over**: `--set-default JAVA_HOME "${jre}"` pointed at the package root (a valid `JAVA_HOME` is `${jre.home}`, i.e. `lib/openjdk`), and `--set-default` meant any ambient `JAVA_HOME` silently defeated `mill.override { jre = ...; }`. Now `--set JAVA_HOME "${jre.home}"`. Projects still choose their own JDK the supported way (`.mill-jvm-version`).
- **Update script reworked**: Maven's `<latest>` reflects whatever was published most recently, which for mill includes milestones (`-M1`) and per-commit dev builds; the script now filters `maven-metadata.xml` down to plain `X.Y.Z`, refreshes every platform's hash with rollback on partial failure, refuses downgrades, and supports the `commit` protocol.
- **Eval-time assert for the Java 17 floor**: the daemon mill starts is Java 17 bytecode; upstream's "every JVM from 11 onward" is about the JVMs a *build* may target, not the one mill runs on.
- Platform tables collapsed into one (suffix + hash per system, `meta.platforms` derived from it so they cannot drift); `meta.changelog` added; adds myself as maintainer.

Built on x86_64-linux; `mill --version` and a real project build exercised by hand, including under a hostile `JAVA_HOME=/nonexistent`; `nixpkgs-vet` passes. One of nine independent per-tool cleanups of the Scala toolchain.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: the commits (see their `Assisted-by:` trailers) and this summary were prepared with assistance from Claude Code (Claude Opus 5). All changes were reviewed, built, and manually exercised by the author.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
