### PR TITLE
scala-cli: fish completions, rework update script, cleanup

### DIFF
--- a/pkgs/by-name/sc/scala-cli/package.nix
+++ b/pkgs/by-name/sc/scala-cli/package.nix
@@ -92,8 +92,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Command-line tool to interact with the Scala language";
     mainProgram = "scala-cli";
     maintainers = with lib.maintainers; [
-      kubukoz
       agilesteel
+      kubukoz
     ];
     inherit platforms;
   };

--- a/pkgs/by-name/sc/scala-cli/package.nix
+++ b/pkgs/by-name/sc/scala-cli/package.nix
@@ -16,7 +16,7 @@
 let
   pname = "scala-cli";
   sources = lib.importJSON ./sources.json;
-  inherit (sources) version assets;
+  inherit (sources) repo version assets;
 
   platforms = builtins.attrNames assets;
 in
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
           or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
     in
     fetchurl {
-      url = "https://github.com/Virtuslab/scala-cli/releases/download/v${version}/${asset.asset}";
+      url = "https://github.com/${repo}/releases/download/v${version}/${asset.asset}";
       inherit (asset) hash;
     };
   unpackPhase = ''
@@ -94,10 +94,15 @@ stdenv.mkDerivation {
     inherit platforms;
   };
 
-  passthru.updateScript = callPackage ./update.nix { } { inherit platforms pname version; };
+  passthru = {
+    updateScript = {
+      command = lib.getExe (callPackage ./update.nix { });
+      supportedFeatures = [ "commit" ];
+    };
 
-  passthru.tests.version = testers.testVersion {
-    package = scala-cli;
-    command = "scala-cli version --offline";
+    tests.version = testers.testVersion {
+      package = scala-cli;
+      command = "scala-cli version --offline";
+    };
   };
 }

--- a/pkgs/by-name/sc/scala-cli/package.nix
+++ b/pkgs/by-name/sc/scala-cli/package.nix
@@ -10,6 +10,9 @@
   callPackage,
   jre,
   testers,
+  runCommand,
+  zsh,
+  fish,
 }:
 
 let
@@ -104,5 +107,30 @@ stdenv.mkDerivation (finalAttrs: {
       package = finalAttrs.finalPackage;
       command = "scala-cli version --offline";
     };
+
+    tests.completions =
+      runCommand "${pname}-completions"
+        {
+          nativeBuildInputs = [
+            zsh
+            fish
+          ];
+        }
+        ''
+          share=${finalAttrs.finalPackage}/share
+
+          bash -n "$share/bash-completion/completions/scala-cli.bash"
+          zsh -n "$share/zsh/site-functions/_scala-cli"
+          fish -n "$share/fish/vendor_completions.d/scala-cli.fish"
+
+          # postFixup generates these by running the binary, which puts $0 in the
+          # output; without the PATH dance there, these would name a store path.
+          if grep -r /nix/store "$share"; then
+            echo "the completions above name a store path instead of scala-cli" >&2
+            exit 1
+          fi
+
+          touch $out
+        '';
   };
 })

--- a/pkgs/by-name/sc/scala-cli/package.nix
+++ b/pkgs/by-name/sc/scala-cli/package.nix
@@ -10,7 +10,6 @@
   callPackage,
   jre,
   testers,
-  scala-cli,
 }:
 
 let
@@ -20,7 +19,7 @@ let
 
   platforms = builtins.attrNames assets;
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
   nativeBuildInputs = [
     installShellFiles
@@ -101,8 +100,8 @@ stdenv.mkDerivation {
     };
 
     tests.version = testers.testVersion {
-      package = scala-cli;
+      package = finalAttrs.finalPackage;
       command = "scala-cli version --offline";
     };
   };
-}
+})

--- a/pkgs/by-name/sc/scala-cli/package.nix
+++ b/pkgs/by-name/sc/scala-cli/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
     in
     fetchurl {
       url = "https://github.com/Virtuslab/scala-cli/releases/download/v${version}/${asset.asset}";
-      sha256 = asset.sha256;
+      inherit (asset) hash;
     };
   unpackPhase = ''
     runHook preUnpack

--- a/pkgs/by-name/sc/scala-cli/package.nix
+++ b/pkgs/by-name/sc/scala-cli/package.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://scala-cli.virtuslab.org";
+    changelog = "https://github.com/${repo}/releases/tag/v${version}";
     downloadPage = "https://github.com/VirtusLab/scala-cli/releases/v${version}";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.asl20;

--- a/pkgs/by-name/sc/scala-cli/package.nix
+++ b/pkgs/by-name/sc/scala-cli/package.nix
@@ -76,7 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
 
       installShellCompletion --cmd scala-cli \
         --bash <(scala-cli completions bash) \
-        --zsh <(scala-cli completions zsh)
+        --zsh <(scala-cli completions zsh) \
+        --fish <(scala-cli completions fish)
     '';
 
   meta = {

--- a/pkgs/by-name/sc/scala-cli/sources.json
+++ b/pkgs/by-name/sc/scala-cli/sources.json
@@ -1,4 +1,5 @@
 {
+  "repo": "VirtusLab/scala-cli",
   "version": "1.16.0",
   "assets": {
     "aarch64-darwin": {

--- a/pkgs/by-name/sc/scala-cli/sources.json
+++ b/pkgs/by-name/sc/scala-cli/sources.json
@@ -3,15 +3,15 @@
   "assets": {
     "aarch64-darwin": {
       "asset": "scala-cli-aarch64-apple-darwin.gz",
-      "sha256": "1n04im0mzzfik8dkjmg9gad6lnkch97ni7h4ana5fk3g41l2xhkz"
+      "hash": "sha256-f8IuaCBvTFeUVQSeaE+CbFpqmnrpVTkbmtH9X0GNBNg="
     },
     "aarch64-linux": {
       "asset": "scala-cli-aarch64-pc-linux.gz",
-      "sha256": "0q9r3024847cgy9y6gskjb4k24rran6zbvz327mcfwcx8dbp459d"
+      "hash": "sha256-LRVyV0OdccfqEePv9Y1VORMxyZJTP+OTf+wQRAQYOWE="
     },
     "x86_64-linux": {
       "asset": "scala-cli-x86_64-pc-linux.gz",
-      "sha256": "093rag4iwfdlhsgdl6dxc85y1lygvyrpdi353zl9qjjx62vlqdin"
+      "hash": "sha256-NjZMtzBdSpzoH2XEdrPfz9PgC2K9GdqehrQ5HslTeSQ="
     }
   }
 }

--- a/pkgs/by-name/sc/scala-cli/update.nix
+++ b/pkgs/by-name/sc/scala-cli/update.nix
@@ -1,60 +1,156 @@
 {
-  lib,
-  curl,
-  writeShellScript,
-  jq,
-  gnused,
-  git,
-  nix,
+  writeShellApplication,
   coreutils,
+  curl,
+  git,
+  jq,
+  nix,
 }:
-{
-  platforms,
-  pname,
-  version,
-}:
 
-writeShellScript "${pname}-update-script" ''
-  set -o errexit
-  PATH=${
-    lib.makeBinPath [
-      curl
-      jq
-      gnused
-      git
-      nix
-      coreutils
-    ]
-  }
+writeShellApplication {
+  name = "update-scala-cli";
 
-  latest_version=$(curl -s "https://api.github.com/repos/VirtusLab/scala-cli/releases?per_page=1" | jq ".[0].tag_name" --raw-output | sed 's/^v//')
+  runtimeInputs = [
+    coreutils
+    curl
+    git
+    jq
+    nix
+  ];
 
-  if [[ "${version}" = "$latest_version" ]]; then
-      echo "The new version same as the old version."
-      exit 0
-  fi
+  text = ''
+    # stdout is reserved for the JSON expected by the `commit` updateScript
+    # feature, everything else has to go to stderr.
+    attr_path="''${UPDATE_NIX_ATTR_PATH:-scala-cli}"
 
-  nixpkgs=$(git rev-parse --show-toplevel)
-  sources_json="$nixpkgs/pkgs/by-name/sc/scala-cli/sources.json"
+    nixpkgs=$(git rev-parse --show-toplevel)
+    position=$(nix-instantiate --eval --json --attr "$attr_path.meta.position" "$nixpkgs" \
+      | jq --raw-output .)
 
-  platform_assets=()
+    # Everything else is read out of the file that is about to be rewritten.
+    sources_json="$(dirname "''${position%:*}")/sources.json"
+    repo=$(jq --raw-output .repo "$sources_json")
+    old_version=$(jq --raw-output .version "$sources_json")
 
-  for platform in ${lib.concatStringsSep " " platforms}; do
-    asset=$(jq ".assets.\"$platform\".asset" --raw-output < $sources_json)
-    release_asset_url="https://github.com/Virtuslab/scala-cli/releases/download/v$latest_version/$asset"
+    auth=()
+    if [[ -n "''${GITHUB_TOKEN:-}" ]]; then
+      auth=(--header "Authorization: Bearer $GITHUB_TOKEN")
+    fi
 
-    asset_hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$release_asset_url")")
+    release=$(curl --silent --show-error --fail "''${auth[@]}" \
+      "https://api.github.com/repos/$repo/releases/latest")
+    new_version=$(jq --raw-output '.tag_name // "" | ltrimstr("v")' <<< "$release")
 
-    asset_object=$(jq --compact-output --null-input \
-      --arg asset "$asset" \
-      --arg hash "$asset_hash" \
-      --arg platform "$platform" \
-      '{asset: $asset, hash: $hash, platform: $platform}')
-    platform_assets+=($asset_object)
-  done
+    # both versions end up inside Nix expressions below
+    version_pattern='^[0-9][0-9A-Za-z.+-]*$'
 
-  printf '%s\n' "''${platform_assets[@]}" | \
-    jq -s "map ( { (.platform): . | del(.platform) }) | add" | \
-    jq --arg version $latest_version \
-      '{ version: $version, assets: . }' > $sources_json
-''
+    if [[ ! "$new_version" =~ $version_pattern ]]; then
+      echo "$repo published an implausible version: '$new_version'" >&2
+      exit 1
+    fi
+
+    if [[ ! "$old_version" =~ $version_pattern ]]; then
+      echo "$sources_json holds an implausible version: '$old_version'" >&2
+      exit 1
+    fi
+
+    order=$(nix-instantiate --eval \
+      --expr "builtins.compareVersions \"$new_version\" \"$old_version\"")
+
+    case "$order" in
+      0)
+        echo "$attr_path is already at the latest version $new_version." >&2
+        echo '[]'
+        exit 0
+        ;;
+      -1)
+        echo "refusing to downgrade $attr_path from $old_version to $new_version." >&2
+        exit 1
+        ;;
+    esac
+
+    # An asset that disappeared would otherwise surface as a bare 404 from
+    # nix-prefetch-url further down.
+    known=$(jq '[ to_entries[] | .value | objects | .[].asset ]' "$sources_json")
+    missing=$(jq --raw-output --argjson published "$(jq '[ .assets[].name ]' <<< "$release")" \
+      '[ .[] | select(IN($published[]) | not) ] | join(", ")' <<< "$known")
+
+    if [[ -n "$missing" ]]; then
+      echo "v$new_version does not ship $missing, listed in $sources_json" >&2
+      exit 1
+    fi
+
+    prefetch() {
+      local hash
+      hash=$(nix-prefetch-url --type sha256 \
+        "https://github.com/$repo/releases/download/v$new_version/$1")
+
+      nix-hash --to-sri --type sha256 "$hash"
+    }
+
+    # <section> -> { "<key>": { asset, hash }, ... } for each key in that section
+    collect() {
+      local section="$1"
+      local objects=()
+      local key asset hash
+
+      while read -r key; do
+        asset=$(jq --raw-output --arg section "$section" --arg key "$key" \
+          '.[$section][$key].asset' "$sources_json")
+        hash=$(prefetch "$asset")
+
+        objects+=("$(jq --null-input --compact-output \
+          --arg key "$key" \
+          --arg asset "$asset" \
+          --arg hash "$hash" \
+          '{ ($key): { asset: $asset, hash: $hash } }')")
+      done < <(jq --raw-output --arg section "$section" '.[$section] | keys[]' "$sources_json")
+
+      if [[ ''${#objects[@]} -eq 0 ]]; then
+        echo '{}'
+        return
+      fi
+
+      printf '%s\n' "''${objects[@]}" | jq --slurp add
+    }
+
+    # Every object-valued key is a section of { <key>: { asset, hash } }, repo
+    # and version being strings. Which sections exist is therefore data too.
+    sections='{}'
+
+    while read -r section; do
+      entries=$(collect "$section")
+      sections=$(jq --arg section "$section" --argjson entries "$entries" \
+        '. + { ($section): $entries }' <<< "$sections")
+    done < <(jq --raw-output 'to_entries[] | select(.value | type == "object") | .key' "$sources_json")
+
+    # Write beside the target and move into place, so that a failure cannot
+    # leave a truncated sources.json and an unbuildable package behind.
+    tmp=$(mktemp "$sources_json.XXXXXX")
+    trap 'rm -f "$tmp"' EXIT
+
+    jq --null-input \
+      --arg repo "$repo" \
+      --arg version "$new_version" \
+      --argjson sections "$sections" \
+      '{ repo: $repo, version: $version } + $sections' \
+      > "$tmp"
+
+    chmod --reference="$sources_json" "$tmp"
+    mv "$tmp" "$sources_json"
+
+    jq --null-input --compact-output \
+      --arg attrPath "$attr_path" \
+      --arg oldVersion "$old_version" \
+      --arg newVersion "$new_version" \
+      --arg file "$sources_json" \
+      --arg repo "$repo" \
+      '[ {
+        attrPath: $attrPath,
+        oldVersion: $oldVersion,
+        newVersion: $newVersion,
+        files: [ $file ],
+        commitBody: "https://github.com/\($repo)/releases/tag/v\($newVersion)"
+      } ]'
+  '';
+}

--- a/pkgs/by-name/sc/scala-cli/update.nix
+++ b/pkgs/by-name/sc/scala-cli/update.nix
@@ -43,13 +43,13 @@ writeShellScript "${pname}-update-script" ''
     asset=$(jq ".assets.\"$platform\".asset" --raw-output < $sources_json)
     release_asset_url="https://github.com/Virtuslab/scala-cli/releases/download/v$latest_version/$asset"
 
-    asset_hash=$(nix-prefetch-url "$release_asset_url")
+    asset_hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$release_asset_url")")
 
     asset_object=$(jq --compact-output --null-input \
       --arg asset "$asset" \
-      --arg sha256 "$asset_hash" \
+      --arg hash "$asset_hash" \
       --arg platform "$platform" \
-      '{asset: $asset, sha256: $sha256, platform: $platform}')
+      '{asset: $asset, hash: $hash, platform: $platform}')
     platform_assets+=($asset_object)
   done
 


### PR DESCRIPTION
Completions and update-script improvements for scala-cli:

- **Fish completions are now installed** — upstream supports bash/zsh/fish, but only the first two were packaged.
- **A `passthru.tests.completions` syntax-checks all three installed completions** and guards against a regression where the `$0`-derived compdef would bake a store path into the generated files.
- **`sources.json` switched to SRI hashes**, and the update script was reworked: `writeShellApplication` (ShellCheck at build time), version validation before splicing into Nix expressions, an assets-exist check against the GitHub release before any prefetch, atomic rewrite of `sources.json`, downgrade refusal, and the `commit` protocol.
- `passthru.tests.version` now tests `finalAttrs.finalPackage` (so overrides are what actually get tested) via `scala-cli version --offline`.
- `meta.changelog` added; maintainer list sorted.

Built with all `passthru.tests` on x86_64-linux; the binary exercised by hand (`scala-cli version --offline`, compile+run of a real script), including under a hostile `JAVA_HOME=/nonexistent`; `nixpkgs-vet` passes. One of nine independent per-tool cleanups of the Scala toolchain.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: the commits (see their `Assisted-by:` trailers) and this summary were prepared with assistance from Claude Code (Claude Opus 5). All changes were reviewed, built, and manually exercised by the author.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
