### PR TITLE
calamares-nixos-extensions: remove redundant wireplumber default

### DIFF
--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -259,9 +259,6 @@ cfgmisc = """\
     pulse.enable = true;
     # If you want to use JACK applications, uncomment this
     #jack.enable = true;
-
-    # Use the WirePlumber session manager
-    #wireplumber.enable = true;
   };
 
   # Enable touchpad support (enabled default in most desktopManager).

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -258,7 +258,7 @@ cfgmisc = """\
     alsa.support32Bit = true;
     pulse.enable = true;
     # If you want to use JACK applications, uncomment this
-    #jack.enable = true;
+    # jack.enable = true;
   };
 
   # Enable touchpad support (enabled default in most desktopManager).


### PR DESCRIPTION
`services.pipewire.wireplumber.enable = true` is already the default if `services.pipewire.enable` is true. Commenting it out would suggest that it isn't.

Tested by building and running the calamares installer for GNOME, basically following the full installation process on `x86_64-linux`. ISO generated via:

```
nix-build -A config.system.build.isoImage -I nixos-config=nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix nixos/default.nix
```

Follow-up to https://github.com/NixOS/nixpkgs/pull/536241#discussion_r3784626566

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — Plus ISO image, see command above
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
