### PR TITLE
python3Packages.nilearn: 0.13.1 -> 0.14.0, unbreak

### DIFF
--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage (finalAttrs: {
   pname = "nilearn";
   version = "0.14.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "nilearn";

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -9,30 +9,32 @@
 
   # dependencies
   joblib,
-  lxml,
   nibabel,
   numpy,
   pandas,
   requests,
   scikit-learn,
+  jinja2,
   scipy,
   packaging,
 
   pytestCheckHook,
   pytest-timeout,
+  pytest-rerunfailures,
   numpydoc,
+  polars,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "nilearn";
-  version = "0.13.1";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nilearn";
     repo = "nilearn";
     tag = finalAttrs.version;
-    hash = "sha256-AStjr+rQoUU4WjKbn+OgT+T+xQ3cTjkKxgF6jX3SX64=";
+    hash = "sha256-WG+ijSNur7XWF3D+MwQU/VUcMalKEEMkFtH0Meca+Mk=";
   };
 
   postPatch = ''
@@ -47,12 +49,12 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     joblib
-    lxml
     nibabel
     numpy
     pandas
     requests
     scikit-learn
+    jinja2
     scipy
     packaging
   ];
@@ -60,7 +62,9 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-timeout
+    pytest-rerunfailures
     numpydoc
+    polars
   ];
 
   # do subset of tests which don't fetch resources


### PR DESCRIPTION
Changelog: https://github.com/nilearn/nilearn/releases/tag/0.14.0

fixes https://hydra.nixos.org/build/341646474


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
