### PR TITLE
comodoro: 0.1.2 -> 2.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -112,6 +112,8 @@
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
+- `comodoro` has been updated from 0.1.2 to 2.0.0, which brings the breaking changes of both major releases; see the [upstream changelog](https://github.com/pimalaya/comodoro/blob/v2.0.0/CHANGELOG.md).
+
 - `services.pid-fan-controller` no longer provides deep configuration rewriting and adheres now fully to RFC42.
 
 - The `extraArgs` and `check` arguments to `nixos/lib/eval-config.nix` (and therefore to `lib.nixosSystem`) have been removed after being deprecated with a warning since 2021. Passing them is now an evaluation error. Instead of `extraArgs`, set `config._module.args`; instead of `check = false`, set `config._module.check = false`. The `extraArgs` attribute on the resulting configuration has been removed as well.

--- a/pkgs/by-name/co/comodoro/package.nix
+++ b/pkgs/by-name/co/comodoro/package.nix
@@ -1,55 +1,115 @@
 {
-  lib,
-  rustPlatform,
+  buildFeatures ? [ ],
+  buildNoDefaultFeatures ? false,
+  buildPackages,
+  dbus,
   fetchFromGitHub,
-  stdenv,
-  installShellFiles,
-  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
   installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-  withTcp ? true,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellFiles,
+  lib,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  withTcp ? null,
 }:
 
+let
+  notify = !buildNoDefaultFeatures || builtins.elem "notify" buildFeatures;
+
+  buildFeatures' = lib.warnIf (
+    withTcp != null
+  ) "comodoro withTcp is obsolete: TCP is always available since v2" buildFeatures;
+
+  # dbus calls libgcc outline atomics that the static aarch64 link cannot
+  # resolve (__aarch64_ldset4_sync & co), so inline them instead.
+  dbus' =
+    if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64 then
+      dbus.overrideAttrs (old: {
+        env = (old.env or { }) // {
+          NIX_CFLAGS_COMPILE = (old.env.NIX_CFLAGS_COMPILE or "") + " -mno-outline-atomics";
+        };
+      })
+    else
+      dbus;
+
+in
 rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  inherit buildNoDefaultFeatures;
+
   pname = "comodoro";
-  version = "0.1.2";
+  version = "2.0.0";
+  cargoHash = "sha256-GA1Snf7EEM5ue6HE1QquW0xXu/qwdhQITqBDjOP9+zk=";
 
   src = fetchFromGitHub {
     owner = "pimalaya";
-    repo = "comodoro";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-FnNNJ6WHR8KCsW+1hPIYddxQlUvpPc+SRbaxAcdVEUk=";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W/ZTgQ7JsVOjkbK8JjoTf154v5RTnQZ5d6AAlL/RTNs=";
   };
 
-  cargoHash = "sha256-2Drty/dj9HCG86rPt4RgexU83vKMnGFETbOT11Puy/0=";
+  # pkg-config hands the linker libdbus but no rpath, leaving a binary that
+  # cannot find it: not in postInstall, which runs it, nor once installed.
+  env.NIX_LDFLAGS = lib.optionalString (notify && !stdenv.hostPlatform.isWindows) (
+    "-rpath " + lib.getLib dbus' + "/lib"
+  );
 
-  nativeBuildInputs = lib.optional (installManPages || installShellCompletions) installShellFiles;
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
 
-  buildNoDefaultFeatures = true;
-  buildFeatures = [
-    "hook-command"
-    "hook-notify"
-  ]
-  ++ lib.optional withTcp "tcp";
+  # dbus is provided by vendors on windows
+  buildInputs = lib.optional (notify && !stdenv.hostPlatform.isWindows) dbus';
+
+  buildFeatures =
+    buildFeatures'
+    # dbus is provided by vendors on windows
+    ++ lib.optional (notify && stdenv.hostPlatform.isWindows) "vendored";
 
   postInstall =
-    lib.optionalString installManPages ''
-      mkdir -p $out/man
-      $out/bin/comodoro man $out/man
-      installManPage $out/man/*
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/${finalAttrs.pname}"
+        else
+          lib.getExe buildPackages.${finalAttrs.pname};
+    in
+    ''
+      mkdir -p $out/share/{completions,man,schemas}
+      ${exe} completion -d "$out"/share/completions bash elvish fish powershell zsh
+      ${exe} manual "$out"/share/man
+      ${exe} json-schema "$out"/share/schemas
+    ''
+    + lib.optionalString installManPages ''
+      installManPage "$out"/share/man/*
     ''
     + lib.optionalString installShellCompletions ''
-      installShellCompletion --cmd comodoro \
-        --bash <($out/bin/comodoro completion bash) \
-        --fish <($out/bin/comodoro completion fish) \
-        --zsh <($out/bin/comodoro completion zsh)
+      installShellCompletion --cmd ${finalAttrs.pname} \
+        --bash "$out"/share/completions/${finalAttrs.pname}.bash \
+        --fish "$out"/share/completions/${finalAttrs.pname}.fish \
+        --zsh "$out"/share/completions/_${finalAttrs.pname}
     '';
 
+  # disable impure integration tests: they bind sockets and spawn processes
+  cargoTestFlags = [
+    "--bins"
+    "--lib"
+  ];
+
   meta = {
-    description = "CLI to manage your time";
-    homepage = "https://github.com/pimalaya/comodoro";
-    changelog = "https://github.com/pimalaya/comodoro/blob/v${finalAttrs.version}/CHANGELOG.md";
-    license = lib.licenses.mit;
+    description = "CLI to manage timers";
+    mainProgram = finalAttrs.pname;
+    homepage = "https://github.com/pimalaya/${finalAttrs.pname}";
+    changelog = "https://github.com/pimalaya/${finalAttrs.pname}/releases/${finalAttrs.src.tag}";
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
     maintainers = with lib.maintainers; [ soywod ];
-    mainProgram = "comodoro";
   };
 })


### PR DESCRIPTION
https://github.com/pimalaya/comodoro/releases/tag/v2.0.0

The only change nix side is `withTcp` being obsoleted. The new structure of the module has been validated [in another module](https://github.com/NixOS/nixpkgs/pull/551635) recently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
