### PR TITLE
waterfox: init at 6.6.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25245,6 +25245,12 @@
     github = "saadndm";
     githubId = 88615188;
   };
+  safwannoobcoder = {
+    name = "Safwan";
+    email = "safwan201125@protonmail.com";
+    github = "safwannoobcoder";
+    githubId = 314005612;
+  };
   sagikazarmark = {
     name = "Mark Sagi-Kazar";
     email = "mark.sagikazar@gmail.com";

--- a/pkgs/by-name/wa/waterfox-bin-unwrapped/package.nix
+++ b/pkgs/by-name/wa/waterfox-bin-unwrapped/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  alsa-lib,
+  curl,
+  dbus-glib,
+  gtk3,
+  libxtst,
+  libva,
+  pciutils,
+  pipewire,
+  adwaita-icon-theme,
+  patchelfUnstable, # supports --no-clobber-old-sections, needed for Firefox-family relrhack
+}:
+
+let
+  binaryName = "waterfox";
+
+  # Waterfox's CDN only publishes x86_64 and aarch64 Linux tarballs today.
+  mozillaPlatforms = {
+    x86_64-linux = "Linux_x86_64";
+    aarch64-linux = "Linux_aarch64";
+  };
+
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  arch = mozillaPlatforms.${stdenv.hostPlatform.system} or throwSystem;
+
+  pname = "waterfox-bin-unwrapped";
+  version = "6.6.17";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://cdn.waterfox.com/waterfox/releases/${version}/${arch}/waterfox-${version}.tar.bz2";
+    hash = "sha256-9nQDEEaHowHif7Oh7+17/r9q3Zl60PPepGWleXy+oiA=";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    autoPatchelfHook
+    patchelfUnstable
+  ];
+
+  buildInputs = [
+    gtk3
+    adwaita-icon-theme
+    alsa-lib
+    dbus-glib
+    libxtst
+  ];
+
+  runtimeDependencies = [
+    curl
+    libva.out
+    pciutils
+  ];
+
+  appendRunpaths = [ "${pipewire}/lib" ];
+
+  # Firefox-family binaries use "relrhack" which patches relocations at a fixed
+  # offset; autoPatchelfHook needs this flag or it'll corrupt the binary.
+  patchelfFlags = [ "--no-clobber-old-sections" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/bin
+    cp -r . $out/lib/${pname}-${version}
+    ln -s $out/lib/${pname}-${version}/${binaryName} $out/bin/${binaryName}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit binaryName;
+    applicationName = "Waterfox";
+    libName = "${pname}-${version}";
+  };
+
+  meta = {
+    description = "Firefox-derived web browser focused on privacy and speed (upstream binary release)";
+    homepage = "https://www.waterfox.com";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ safwannoobcoder ];
+    platforms = builtins.attrNames mozillaPlatforms;
+    mainProgram = "waterfox";
+    hydraPlatforms = [ ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/wa/waterfox-bin-unwrapped/package.nix
+++ b/pkgs/by-name/wa/waterfox-bin-unwrapped/package.nix
@@ -33,6 +33,9 @@ let
   version = "6.6.17";
 in
 stdenv.mkDerivation {
+  strictDeps = true;
+  __structuredAttrs = true;
+
   inherit pname version;
 
   src = fetchurl {


### PR DESCRIPTION
Adds `waterfox-bin-unwrapped`, packaging the official prebuilt Linux binary
release of [Waterfox](https://www.waterfox.com), a Firefox-derived browser
focused on privacy and speed.

This is a binary-release package (fetches the official upstream tarball),
similar in structure to `librewolf-bin-unwrapped`. Waterfox has been
requested in nixpkgs multiple times over the years but was never packaged:

- https://github.com/NixOS/nixpkgs/issues/38617
- https://github.com/NixOS/nixpkgs/issues/153357
- https://github.com/NixOS/nixpkgs/issues/188883

I use this package myself daily on NixOS and have tested that it builds
and runs correctly.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested via `nix-build -A waterfox-bin-unwrapped`, confirmed the
      resulting binary launches correctly
- [x] Added myself as maintainer in `maintainers/maintainer-list.nix`