### PR TITLE
draw-things: init at 1.20260716.0

### DIFF
--- a/pkgs/by-name/dr/draw-things/package.nix
+++ b/pkgs/by-name/dr/draw-things/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "draw-things";
+  version = "1.20260716.0";
+
+  src = fetchurl rec {
+    # The CDN path carries the first eight hex digits of the archive's SHA-256.
+    url = "https://static.drawthings.ai/DrawThings-${finalAttrs.version}-${lib.substring 0 8 sha256}.zip";
+    sha256 = "4d534b3c75b4d759d12c25458c545ed534160e1c922c726426399a6aea55aeae";
+  };
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications" "$out/bin"
+    mv "Draw Things.app" "$out/Applications/"
+    ln -s "$out/Applications/Draw Things.app/Contents/MacOS/DrawThings" \
+      "$out/bin/draw-things"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "On-device Stable Diffusion image generator";
+    longDescription = ''
+      Draw Things runs Stable Diffusion and other diffusion models locally on
+      Apple silicon, without an account or a network round trip. It covers
+      text-to-image, image-to-image, inpainting, outpainting, ControlNet and
+      LoRA, and can import models in the usual Core ML, Diffusers and
+      safetensors formats.
+    '';
+    homepage = "https://drawthings.ai/";
+    changelog = "https://releases.drawthings.ai/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    mainProgram = "draw-things";
+    maintainers = with lib.maintainers; [ dfjay ];
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/dr/draw-things/update.sh
+++ b/pkgs/by-name/dr/draw-things/update.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p bash curl gnugrep gnused coreutils nix
+
+set -euo pipefail
+
+DIR="$(dirname "$(readlink -f "$0")")"
+BASEDIR="$DIR/../../../.."
+
+# Upstream publishes no version index; the downloads page lists every build.
+latestUrl=$(curl -fsSL "https://drawthings.ai/downloads" |
+    grep -oE 'https://static\.drawthings\.ai/DrawThings-[0-9.]+-[0-9a-f]{8}\.zip' |
+    sort -Vu | tail -1)
+
+if [[ -z "$latestUrl" ]]; then
+    echo "no download link found on https://drawthings.ai/downloads" >&2
+    exit 1
+fi
+
+latestVersion=${latestUrl##*/DrawThings-}
+latestVersion=${latestVersion%%-*}
+
+currentVersion=$(nix-instantiate --eval -E "with import $BASEDIR {}; lib.getVersion draw-things" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+hash=$(nix-hash --type sha256 --to-base16 "$(nix-prefetch-url "$latestUrl")")
+
+if [[ "${latestUrl##*-}" != "${hash:0:8}.zip" ]]; then
+    echo "$latestUrl is no longer named after its SHA-256 (${hash:0:8})" >&2
+    exit 1
+fi
+
+sed -i \
+    -e "s|^  version = \"[^\"]*\";|  version = \"$latestVersion\";|" \
+    -e "s|^    sha256 = \"[^\"]*\";|    sha256 = \"$hash\";|" \
+    "$DIR/package.nix"
+
+echo "updated to $latestVersion"


### PR DESCRIPTION
https://drawthings.ai/
https://drawthings.ai/downloads/

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].