### PR TITLE
python3Packages.qcodes-contrib-drivers: cleanup, fix

### DIFF
--- a/pkgs/development/python-modules/qcodes-contrib-drivers/default.nix
+++ b/pkgs/development/python-modules/qcodes-contrib-drivers/default.nix
@@ -13,8 +13,8 @@
   cffi,
   packaging,
   pandas,
-  qcodes,
   python-dotenv,
+  qcodes,
 
   # tests
   pytest-mock,
@@ -27,6 +27,7 @@ buildPythonPackage (finalAttrs: {
   pname = "qcodes-contrib-drivers";
   version = "0.25.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "QCoDeS";
@@ -34,6 +35,15 @@ buildPythonPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-4ZVNd1cHqM3tuGcOxlBN8WX9i9u3XFlJ0zr06n7zpmI=";
   };
+
+  postPatch =
+    # versioningit derives the version from git, which is unavailable in the sandbox
+    ''
+      substituteInPlace pyproject.toml \
+        --replace-fail \
+          'default-version = "0.0"' \
+          'default-version = "${finalAttrs.version}"'
+    '';
 
   build-system = [
     setuptools
@@ -45,8 +55,9 @@ buildPythonPackage (finalAttrs: {
     cffi
     packaging
     pandas
-    qcodes
     python-dotenv
+    qcodes
+    versioningit
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
