### PR TITLE
fluxer-canary: init at 2026.814.215154

### DIFF
--- a/pkgs/by-name/fl/fluxer-canary/package.nix
+++ b/pkgs/by-name/fl/fluxer-canary/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  libappindicator,
+  libnotify,
+  speechd-minimal,
+}:
+
+let
+  pname = "fluxer-canary";
+  version = "2026.814.215154";
+
+  # The version and matching sha256 for each architecture are served as JSON from
+  #   https://api.canary.fluxer.app/dl/desktop/canary/linux/<arch>/latest
+  # which is what passthru.updateScript reads. Both architectures are published
+  # from the same build and share a version.
+  sources = {
+    x86_64-linux = {
+      arch = "x64";
+      hash = "sha256-I7HPv5fgq3to9ubgiigwa64qp/yklVGE5PtXh+xnx90=";
+    };
+    aarch64-linux = {
+      arch = "arm64";
+      hash = "sha256-COICZoxcqENszlXcesOaPQtWyu8pJZjfVZfEms+wN+c=";
+    };
+  };
+
+  source = sources.${stdenv.hostPlatform.system} or sources.x86_64-linux;
+
+  src = fetchurl {
+    name = "${pname}-${version}.AppImage";
+    url = "https://api.canary.fluxer.app/dl/desktop/canary/linux/${source.arch}/${version}/appimage";
+    inherit (source) hash;
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [
+    # Electron dlopens these at runtime; they are not in appimageTools'
+    # default environment.
+    libnotify # desktop notifications
+    libappindicator # tray icon
+    speechd-minimal # Chromium text-to-speech
+  ];
+
+  # On launch the app writes its own desktop entry to
+  # $XDG_DATA_HOME/applications, with Exec pointing at the raw extracted
+  # binary. That path is not patchelf'd and has no FHS environment, so the
+  # entry never launches, and it shadows the one installed below. Upstream
+  # offers this opt-out for packagers; the fluxer:// protocol handler is
+  # still registered when it is set.
+  profile = ''
+    export FLUXER_DISABLE_DESKTOP_FILE=1
+  '';
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+
+    cp -r ${appimageContents}/usr/share/icons $out/share/
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Free and open source instant messaging and VoIP chat app (canary channel)";
+    longDescription = ''
+      Fluxer is a self-hostable chat platform with messaging, voice, video and
+      communities. This packages the canary channel, which receives frequent
+      pre-release builds.
+    '';
+    homepage = "https://fluxer.app";
+    downloadPage = "https://canary.fluxer.app/download";
+    changelog = "https://fluxer.app/blog";
+    license = lib.licenses.agpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ deekahy ];
+    platforms = lib.attrNames sources;
+    mainProgram = "fluxer-canary";
+  };
+}

--- a/pkgs/by-name/fl/fluxer-canary/update.sh
+++ b/pkgs/by-name/fl/fluxer-canary/update.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts nix
+set -euo pipefail
+
+while read -r system arch; do
+  latest=$(curl -sSf "https://api.canary.fluxer.app/dl/desktop/canary/linux/$arch/latest")
+
+  version=$(jq -r '.version' <<<"$latest")
+  hash=$(nix hash convert --hash-algo sha256 --to sri "$(jq -r '.files.appimage.sha256' <<<"$latest")")
+
+  update-source-version fluxer-canary "$version" "$hash" \
+    --system="$system" --ignore-same-version
+done <<'SYSTEMS'
+x86_64-linux x64
+aarch64-linux arm64
+SYSTEMS


### PR DESCRIPTION
### Why a binary repack rather than a source build

A source build was attempted in #497870 by @niklaskorz and closed with:

> The recently pushed refactored client has somewhat more complicated build requirements, so I'm unwilling to maintain this package for the time being.

I looked at reviving it and hit the same wall. `fluxer_desktop` now has a `workspace:*` dependency, so the `rootDir` approach in that PR no longer applies and the whole monorepo has to be fetched. `pnpm --filter=fluxer_desktop` keeps the install tractable (615 packages rather than 1979), but `scripts/build.mjs` then shells out to `cargo` against `tools/ci` to generate `src/common/BuildChannel.tsx`, and separately builds 22 local napi modules that are also Rust. Doing it properly means vendoring the workspaces 581-crate `Cargo.lock` alongside pnpm and electron-builder. I'm not signing up to maintain that, and a build with `FLUXER_SKIP_NATIVE=true` loses voice, video and screen capture, which is most of the point of the app.

### Why the canary channel

The stable download endpoint has served 0.0.8 (2026-01-06) for seven months and returns `"sha256": null`, so there has been nothing for an update script to track. Canary is the channel upstream actually publishes. Precedent: nixpkgs already ships `discord-canary` alongside stable.

### Notes

`FLUXER_DISABLE_DESKTOP_FILE=1` is set in the FHS profile. Without it the app writes its own `.desktop` entry into `$XDG_DATA_HOME/applications` on every launch, with `Exec` pointing at the extracted AppImage contents. Those have no FHS environment and fail with "Could not start dynamically linked executable", and the entry shadows the one installed by this package, so launching from a desktop menu silently does nothing. Upstream provides this opt-out for packagers and still registers the `fluxer://` protocol handler when it is set.

`passthru.updateScript` reads upstream's release metadata endpoint, which serves the version and matching sha256 directly, so no fixed-output rebuild cycle is needed. Note that canary moves several times a day.

x86_64-linux and aarch64-linux. Both AppImages come from the same upstream build and share a version. I built and ran the x86_64 one. @Tomuus built and ran the aarch64 one on Asahi (kernel 7.1.5).

Related: #490554 (stable channel, `fluxer-bin`), #497870 (source build, closed). If `fluxer-bin` lands and naming consistency is wanted, I'm happy to rename this to `fluxer-canary-bin`.

Disclosure per the automation/AI policy: this package was written with Claude Code assisting (claude-opus-5; final review with claude-fable-5). I reviewed every line, built and ran the result, and the commit carries an `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test