### PR TITLE
healthchecks: django compress before collectstatic

### DIFF
--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -239,11 +239,14 @@ in
 
           serviceConfig = commonConfig // {
             Restart = "always";
-            ExecStartPre = [
-              "${pkg}/opt/healthchecks/manage.py collectstatic --no-input"
-              "${pkg}/opt/healthchecks/manage.py remove_stale_contenttypes --no-input"
-            ]
-            ++ lib.optionals (cfg.settings.DEBUG != "True") [ "${pkg}/opt/healthchecks/manage.py compress" ];
+            ExecStartPre =
+              lib.optionals (cfg.settings.DEBUG != "True") [
+                "${pkg}/opt/healthchecks/manage.py compress"
+              ]
+              ++ [
+                "${pkg}/opt/healthchecks/manage.py collectstatic --no-input"
+                "${pkg}/opt/healthchecks/manage.py remove_stale_contenttypes --no-input"
+              ];
             ExecStart = ''
               ${pkgs.python3Packages.gunicorn}/bin/gunicorn hc.wsgi \
                 --bind ${cfg.listenAddress}:${toString cfg.port} \


### PR DESCRIPTION
Previously, collectstatic was called before compress, causing it to miss certain libraries (namely moment.js) that prevent the Events list from displaying properly. This also matches the suggested order in the healthchecks documentation:
> Management commands that need to be run during each version upgrade.
> - manage.py compress – creates combined JS and CSS bundles and places them in the static-collected directory.
> - manage.py collectstatic – collects static files in the static-collected directory.

I am using this patch locally and can confirm that it fixes the issue.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
