### PR TITLE
ufbt: init at 0.2.6

### DIFF
--- a/pkgs/by-name/uf/ufbt/package.nix
+++ b/pkgs/by-name/uf/ufbt/package.nix
@@ -1,0 +1,41 @@
+{
+  python3Packages,
+  fetchPypi,
+  lib,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ufbt";
+  version = "0.2.6";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-TxqFiFhZjtLiW7q2ni6mBLwAdYw7Ho7PiXophmFXNjs=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools-git-versioning<2" "setuptools-git-versioning"
+  '';
+
+  doCheck = false;
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-git-versioning
+  ];
+
+  dependencies = with python3Packages; [
+    oslex
+  ];
+
+  meta = {
+    description = "Compact tool for building and debugging applications for Flipper Zero.";
+    homepage = "https://github.com/flipperdevices/flipperzero-ufbt";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ _0x2B ];
+    mainProgram = "ufbt";
+  };
+})


### PR DESCRIPTION
Initial packaging of ufbt at version 0.2.6.

ufbt (micro Flipper Build Tool) is a compact tool for building and debugging applications for Flipper Zero.

Rebound constraint on setuptools-git-versioning in postPatch to match current nixpkgs dependencies.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
