### PR TITLE
typescript-svelte-plugin: init at 0.3.52

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28320,6 +28320,12 @@
     githubId = 2084639;
     name = "Manu";
   };
+  Tenshock = {
+    email = "cedric.prezelin@gmail.com";
+    github = "Tenshock";
+    githubId = 8899608;
+    name = "Cédric Prezelin";
+  };
   tensor5 = {
     github = "tensor5";
     githubId = 1545895;

--- a/pkgs/by-name/ty/typescript-svelte-plugin/package.nix
+++ b/pkgs/by-name/ty/typescript-svelte-plugin/package.nix
@@ -1,0 +1,92 @@
+{
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  lib,
+  nix-update-script,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_10,
+  stdenv,
+}:
+
+let
+  pnpm = pnpm_10;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "typescript-svelte-plugin";
+  version = "0.3.52";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "sveltejs";
+    repo = "language-tools";
+    tag = "typescript-svelte-plugin@${finalAttrs.version}";
+    hash = "sha256-qcY8ikS7spfbMk1zJ1pu+yyBsFYIFCWB/YqANyCZrVc=";
+  };
+
+  pnpmWorkspaces = [ "typescript-svelte-plugin..." ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-u78ndXZcWIjJbn6lu010/0IWIWtqvFTYgrTZ++JWiQE=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run --filter=typescript-svelte-plugin... build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pnpm config set --location=project inject-workspace-packages true
+    pnpm --filter=typescript-svelte-plugin \
+      deploy $out/lib/node_modules/typescript-svelte-plugin/
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    node -e "require('$out/lib/node_modules/typescript-svelte-plugin')"
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--use-github-releases"
+      "--version-regex"
+      "typescript-svelte-plugin@(.*)"
+    ];
+  };
+
+  meta = {
+    description = "TypeScript plugin providing Svelte IntelliSense";
+    homepage = "https://github.com/sveltejs/language-tools/tree/master/packages/typescript-plugin";
+    changelog = "https://github.com/sveltejs/language-tools/blob/typescript-svelte-plugin@${finalAttrs.version}/packages/typescript-plugin/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Tenshock ];
+  };
+})


### PR DESCRIPTION
Package `typescript-svelte-plugin`, the TypeScript language service plugin providing Svelte IntelliSense.

The package is built from the Svelte `language-tools` monorepo and deployed as a standalone Node module at `$out/lib/node_modules/typescript-svelte-plugin`. Runtime peer dependencies are included so editor integrations can load the plugin without relying on an npm-managed project layout.

Homepage:
https://github.com/sveltejs/language-tools/tree/master/packages/typescript-plugin

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
      Not applicable: this package provides a Node module and no binaries.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test