### PR TITLE
tiktok-sans: init at 4.000

### DIFF
--- a/pkgs/by-name/ti/tiktok-sans/package.nix
+++ b/pkgs/by-name/ti/tiktok-sans/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  python3,
+  installFonts,
+}:
+
+let
+  pythonEnv =
+    (python3.override {
+      packageOverrides = self: super: {
+        fonttools = super.fonttools.overridePythonAttrs (old: {
+          propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ self.brotli ];
+        });
+      };
+    }).withPackages
+      (ps: [ ps.gftools ]);
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tiktok-sans";
+  version = "4.000";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "tiktok";
+    repo = "TikTokSans";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TT56I8G2yK6FEReNvpicwuanY25afvraIjydhbprA1c=";
+  };
+
+  nativeBuildInputs = [
+    pythonEnv
+    installFonts
+  ];
+
+  makeFlags = [ "build" ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "build.stamp: venv sources/config.yaml" "build.stamp: sources/config.yaml" \
+      --replace-fail ". venv/bin/activate; " "" \
+      --replace-fail "python3.10 " "python3 "
+  '';
+
+  # remove proprietary VTT-hinted font
+  postBuild = ''
+    rm -f sources/hinting/TikTok-VTT.ttf
+  '';
+
+  # skip default `make install`.
+  installPhase = ''
+    runHook preInstall
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://tiktok.com/font";
+    changelog = "https://github.com/tiktok/TikTokSans/releases/tag/v${finalAttrs.version}";
+    description = "A free and open-source font by TikTok";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ yarn ];
+  };
+})


### PR DESCRIPTION
https://tiktok.com/font
https://github.com/tiktok/TikTokSans

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
