### PR TITLE
stackblaster: init

### DIFF
--- a/pkgs/by-name/st/stackblaster/package.nix
+++ b/pkgs/by-name/st/stackblaster/package.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+}:
+
+buildGoModule {
+  pname = "stackblaster";
+  version = "unstable-2026-08-14";
+
+  src = fetchFromGitHub {
+    owner = "fjij";
+    repo = "stackblaster";
+    rev = "b7df4fcbf703f1ee469b82dd049a934680c6c685";
+    hash = "sha256-9GEFqhvPlDmpfWIS6TzvxUlp1+Za32Dr6kIAJj98J7Q=";
+  };
+
+  vendorHash = "sha256-+m/P4ISOp+l/CDSW8yLbebSeedlSG7uDb4ngYSkApzA=";
+
+  subPackages = [ "cmd/sb" ];
+
+  nativeCheckInputs = [ git ];
+
+  meta = with lib; {
+    description = "TODO";
+    homepage = "https://github.com/fjij/stackblaster";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "stackblaster";
+  };
+}

--- a/pkgs/by-name/st/stackblaster/package.nix
+++ b/pkgs/by-name/st/stackblaster/package.nix
@@ -22,7 +22,7 @@ buildGoModule {
   nativeCheckInputs = [ git ];
 
   meta = with lib; {
-    description = "TODO";
+    description = "Graphite-flavored CLI for GitHub stacked PRs";
     homepage = "https://github.com/fjij/stackblaster";
     license = licenses.mit;
     maintainers = with lib.maintainers; [ ];


### PR DESCRIPTION
Add [stackblaster](https://github.com/fjij/stackblaster), a CLI tool for managing Github stacks.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
