### PR TITLE
emacs.pkgs.telega: use MELPA rolling instead of stable

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -489,6 +489,7 @@ let
               pkgs.zlib
             ];
             nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.pkg-config ];
+            propagatedUserEnvPkgs = old.propagatedUserEnvPkgs or [ ] ++ [ pkgs.qrencode ];
 
             postPatch = ''
               substituteInPlace telega-customize.el \

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -147,10 +147,6 @@ lib.makeScope pkgs'.newScope (
         # EXWM is not tagged very often, prefer it from elpa devel.
         inherit (elpaDevelPackages) exwm;
 
-        # Telega uploads packages incompatible with stable tdlib to melpa
-        # Prefer the one from melpa stable
-        inherit (melpaStablePackages) telega;
-
       }
     )
   ) { }


### PR DESCRIPTION
The Stable override introduced in #114251 originally avoided rolling telega
snapshots that required a newer TDLib than nixpkgs provided. It now selects an
incompatible pair: Stable 0.8.3 declares TDLib 1.8.0 as both its minimum and
maximum, while nixpkgs provides 1.8.66. The current rolling snapshot declares
1.8.66 as its minimum and has no maximum.

Remove the Stable priority override so `emacs.pkgs.telega` follows the normal
MELPA rolling package.

Also propagate `qrencode`, which telega [uses](https://github.com/zevlg/telega.el/blob/c7273cce799d60b6c8bb470cfa26ed267324ff02/telega-tdlib-events.el#L1356-L1372) to render the QR code for its
default first-run authentication flow. Without the executable, telega silently
falls back to phone-number authentication; including it makes the documented
default login method work out of the box.

Upstream version declarations:

- [Stable 0.8.3](https://github.com/zevlg/telega.el/blob/ac3634e2e7efe9c29c4311196e0ed67085d58f11/telega.el#L11-L17)
- [Current rolling snapshot](https://github.com/zevlg/telega.el/blob/c7273cce799d60b6c8bb470cfa26ed267324ff02/telega.el#L11-L17)

Tested on x86_64-linux.

cc @NixOS/emacs

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

 AI disclosure: The implementation, testing, commit message, and PR description
  were prepared with OpenAI Codex (GPT-5) and manually reviewed by @DzmingLi.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

