### PR TITLE
harmonist: fix src hash, modernize

### DIFF
--- a/pkgs/by-name/ha/harmonist/package.nix
+++ b/pkgs/by-name/ha/harmonist/package.nix
@@ -10,6 +10,8 @@ buildGoModule (finalAttrs: {
   pname = "harmonist";
   version = "1.0.3";
 
+  __structuredAttrs = true;
+
   src = fetchFromCodeberg {
     owner = "anaseto";
     repo = "harmonist";

--- a/pkgs/by-name/ha/harmonist/package.nix
+++ b/pkgs/by-name/ha/harmonist/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromCodeberg,
 }:
@@ -12,7 +13,13 @@ buildGoModule (finalAttrs: {
     owner = "anaseto";
     repo = "harmonist";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9cEKkvQze+hg4CwDe5epTpuQPevylwnSP5xQAVGJ/wQ=";
+    hash =
+      # darwin's case-insensitive filesystem produces a different source hash because of map-d vs map-D
+      # is this a correctness issue?
+      if stdenv.hostPlatform.isDarwin then
+        "sha256-yNPGoCvCdrmFaUjtA1p8pgPIC9ekIizhG6oMiYRFYGA="
+      else
+        "sha256-9cEKkvQze+hg4CwDe5epTpuQPevylwnSP5xQAVGJ/wQ=";
   };
 
   vendorHash = "sha256-wibNLDdykV2psOnJbMKu0EZSrrhKRxrN/OTWXmUz2FM=";

--- a/pkgs/by-name/ha/harmonist/package.nix
+++ b/pkgs/by-name/ha/harmonist/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildGoModule,
   fetchFromCodeberg,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -26,8 +27,10 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
-    "-w"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Stealth coffee-break roguelike game";


### PR DESCRIPTION
- **harmonist: fix Darwin src hash**
- **harmonist: add versionCheckHook**
- **harmonist: enable __structuredAttrs**

~~Not sure how but https://github.com/NixOS/nixpkgs/pull/550353 broke the build yet still passed ryantm...~~ ah... case insensitive filesystem quirk...


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
