### PR TITLE
mnemon: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8244,6 +8244,11 @@
     githubId = 5300871;
     name = "Leon Kowarschick";
   };
+  EllianCarlos = {
+    github = "EllianCarlos";
+    githubId = 17656878;
+    name = "Ellian Carlos";
+  };
   elliot = {
     email = "hack00mind@gmail.com";
     github = "Eliot00";

--- a/pkgs/by-name/mn/mnemon/package.nix
+++ b/pkgs/by-name/mn/mnemon/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mnemon";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "mnemon-dev";
+    repo = "mnemon";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BbD0jDdbwXNNiM8W9F+ijh7XYhtCxBcpguVfYnPnYe0=";
+  };
+
+  vendorHash = "sha256-nIXIk9j3duX0wbzwc8PALs3mJq88LEalYXLWRgWqfqE=";
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-s"
+    "-X github.com/mnemon-dev/mnemon/cmd.version=${finalAttrs.version}"
+  ];
+
+  checkFlags = [
+    # TestExecuteRoutesAgencyWithoutChangingItsExitCode checks an unstamped
+    # 'dev' version, but nixpkgs stamps the version with 'ldflags'.
+    "-skip"
+    "TestExecuteRoutesAgencyWithoutChagingItsExitCode"
+    # TestReleaseRepositoryHygiene runs `git ls-files` against the source
+    # tree to check for sensetive files.
+    "TestReleaseRepositoryHygiene"
+  ];
+
+  meta = {
+    description = "LLM-supervised persistent memory for AI agents";
+    homepage = "https://github.com/mnemon-dev/mnemon#readme";
+    changelog = "https://github.com/mnemon-dev/mnemon/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    mainProgram = "mnemon";
+    maintainers = with lib.maintainers; [ EllianCarlos ];
+  };
+})


### PR DESCRIPTION
mnemon is an LLM-supervised persistent memory daemon for AI agents (graph-based recall, cross-session knowledge). 

Homepage: https://github.com/mnemon-dev/mnemon

Add `pkgs.mnemon` built in go from source (Apache-2.0). Should support `x86_64-linux`, `aarch64-linux` and `aarch64-darwin`, although it was only tested in `x86_64-linux`.

## AI usage

On later version of this PR, AI (claude-code with Sonnet 5) was used to resolve conflicts between my fork branch and the master branch in nixpkgs, but all the code changes were done by me. The conflicts ended-up being corrected by just redoing the code changes rebasing to a parent commit, which was done by myself because the agent failed to do that also.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test