### PR TITLE
zig: fix build with `pkgsLLVM`

### DIFF
--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -17,7 +17,9 @@
   wrapBintoolsWith,
   ...
 }@args:
-
+let
+  inherit (stdenv.hostPlatform) useLLVM;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zig";
   inherit version;
@@ -33,9 +35,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    (lib.getDev llvmPackages.llvm.dev)
     ninja
   ]
+  ++ lib.optional useLLVM (lib.getDev llvmPackages.llvm)
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # provides xcode-select, which is required for SDK detection
     xcbuild
@@ -58,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "ZIG_TARGET_MCPU" "baseline")
     # always link against static build of LLVM
     (lib.cmakeBool "ZIG_STATIC_LLVM" true)
+    # use Zig's CMake logic to find the target libraries
+    (lib.cmakeBool "ZIG_USE_LLVM_CONFIG" useLLVM)
   ];
 
   outputs = [
@@ -88,6 +92,17 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       substituteInPlace lib/std/zig/system.zig \
         --replace-fail "/usr/bin/env" "${lib.getExe' coreutils "env"}"
+    ''
+    # Add missing libraries needed by LLVM.
+    + lib.optionalString (lib.versionAtLeast finalAttrs.version "0.16") ''
+      substituteInPlace cmake/Findllvm.cmake \
+        --replace-fail \
+          '  FIND_AND_ADD_LLVM_LIB(LLVMExtensions)' \
+          $'  FIND_AND_ADD_LLVM_LIB(LLVMExtensions)\n  FIND_AND_ADD_LLVM_LIB(Polly)\n  FIND_AND_ADD_LLVM_LIB(PollyISL)'
+      substituteInPlace CMakeLists.txt \
+        --replace-fail \
+          'find_package(lld 21)' \
+          $'find_package(lld 21)\n\nif(NOT ZIG_USE_LLVM_CONFIG)\n  list(APPEND LLVM_LIBRARIES -lrt -ldl -lm -lz -lxml2)\nendif()'
     ''
     # Zig tries to access xcrun and xcode-select at the absolute system path to query the macOS SDK
     # location, which does not work in the darwin sandbox.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
