### PR TITLE
ethernet-connection-status: init at 1.0.0

### DIFF
--- a/pkgs/by-name/et/ethernet-connection-status/package.nix
+++ b/pkgs/by-name/et/ethernet-connection-status/package.nix
@@ -1,0 +1,112 @@
+{
+  actool,
+  darwin,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  swiftPackages,
+}:
+
+let
+  inherit (swiftPackages) stdenv swift;
+
+  infoPlist =
+    version:
+    lib.generators.toPlist { escape = true; } {
+      CFBundleDevelopmentRegion = "en";
+      CFBundleDisplayName = "Ethernet Connection Status";
+      CFBundleExecutable = "Ethernet Connection Status";
+      CFBundleIconFile = "AppIcon";
+      CFBundleIconName = "AppIcon";
+      CFBundleIdentifier = "com.example.EthernetConnectionStatus";
+      CFBundleInfoDictionaryVersion = "6.0";
+      CFBundleName = "Ethernet Connection Status";
+      CFBundlePackageType = "APPL";
+      CFBundleShortVersionString = version;
+      CFBundleVersion = "1";
+      LSApplicationCategoryType = "public.app-category.utilities";
+      LSMinimumSystemVersion = "13.0";
+      LSUIElement = true;
+      NSHumanReadableCopyright = "Copyright © 2025. All rights reserved.";
+    };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ethernet-connection-status";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "montanaflynn";
+    repo = "EthernetConnectionStatus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ecxliuc6U5tJjFYsZDT7LxvJlbuNgKSYF+nuQUDIxGQ=";
+  };
+
+  postPatch = ''
+    # Swift preview macros require Xcode's Swift compiler plugin.
+    sed -i '/^#Preview {$/,$d' SettingsView.swift
+  '';
+
+  nativeBuildInputs = [
+    actool
+    darwin.autoSignDarwinBinariesHook
+    swift
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    swiftc \
+      -O \
+      -swift-version 5 \
+      -parse-as-library \
+      -module-name EthernetConnectionStatus \
+      -Xlinker -platform_version -Xlinker macos -Xlinker 13.0 -Xlinker 14.0 \
+      -framework AppKit \
+      -framework Foundation \
+      -framework SwiftUI \
+      -framework SystemConfiguration \
+      EthernetIcon.swift \
+      MacMenuBarApp.swift \
+      NetworkMonitor.swift \
+      SettingsView.swift \
+      -o "Ethernet Connection Status"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    app="$out/Applications/Ethernet Connection Status.app"
+    mkdir -p "$app/Contents/"{MacOS,Resources}
+
+    cp "Ethernet Connection Status" "$app/Contents/MacOS/"
+    printf '%s' ${lib.escapeShellArg (infoPlist finalAttrs.version)} > "$app/Contents/Info.plist"
+    printf 'APPL????' > "$app/Contents/PkgInfo"
+
+    actool --compile "$app/Contents/Resources" \
+      --platform macosx \
+      --minimum-deployment-target 13.0 \
+      --app-icon AppIcon \
+      --output-partial-info-plist /dev/null \
+      Media.xcassets
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Native macOS menu bar app that monitors Ethernet connection status";
+    homepage = "https://github.com/montanaflynn/EthernetConnectionStatus";
+    changelog = "https://github.com/montanaflynn/EthernetConnectionStatus/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tpansino ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Packages [Ethernet Connection Status](https://github.com/montanaflynn/EthernetConnectionStatus), a native macOS menu bar app that monitors Ethernet connectivity.

Tested on aarch64-darwin through nix-darwin. The application launches through launchd and reports Ethernet connection status correctly.

AI disclosure: This package and pull request were prepared with assistance from Codex (GPT-5) and manually reviewed and tested.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test