### PR TITLE
amnezia-vpn: 4.8.21.0 -> 5.0.0.5

### DIFF
--- a/nixos/modules/programs/amnezia-vpn.nix
+++ b/nixos/modules/programs/amnezia-vpn.nix
@@ -23,6 +23,8 @@ in
       services."AmneziaVPN" = {
         wantedBy = [ "multi-user.target" ];
         path = with pkgs; [
+          gawk
+          iptables
           procps
           iproute2
           sudo

--- a/pkgs/by-name/am/amnezia-vpn/disable-conan-runtime-bundling.patch
+++ b/pkgs/by-name/am/amnezia-vpn/disable-conan-runtime-bundling.patch
@@ -1,0 +1,59 @@
+--- a/service/server/CMakeLists.txt
++++ b/service/server/CMakeLists.txt
+@@ -341,56 +341,6 @@
+     )
+ endif()
+ 
+-# install non-linked dependencies
+-if(WIN32)
+-    find_package(awg-windows REQUIRED)
+-    list(APPEND CONAN_EXECS $<TARGET_FILE:amnezia::awg-windows>)
+-
+-    find_package(wintun REQUIRED)
+-    list(APPEND CONAN_BINS $<TARGET_FILE:zx2c4::wintun>)
+-
+-    list(APPEND CONAN_BINS $<TARGET_FILE:OpenSSL::SSL> $<TARGET_FILE:OpenSSL::Crypto>)
+-else()
+-    find_package(awg-go REQUIRED)
+-    list(APPEND CONAN_EXECS $<TARGET_FILE:amnezia::awg-go>)
+-endif()
+-
+-find_package(openvpn REQUIRED)
+-list(APPEND CONAN_EXECS $<TARGET_FILE:openvpn::openvpn>)
+-
+-find_package(tun2socks REQUIRED)
+-list(APPEND CONAN_EXECS $<TARGET_FILE:xjasonlyu::tun2socks>)
+-
+-find_package(v2ray-rules-dat REQUIRED)
+-list(APPEND CONAN_BINS ${GEOSITE_DAT_PATH} ${GEOIP_DAT_PATH})
+-
+-add_custom_command(TARGET ${PROJECT} POST_BUILD
+-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+-        ${CONAN_EXECS} ${CONAN_BINS}
+-        "$<TARGET_FILE_DIR:${PROJECT}>"
+-)
+-if(WIN32)
+-    # using PERMISSIONS on Windows appends read-only flag
+-    # to the files so just omit it for it
+-    install(FILES ${CONAN_EXECS}
+-        DESTINATION ${CMAKE_INSTALL_BINDIR}
+-        COMPONENT AmneziaVPN
+-    )
+-else()
+-    install(FILES ${CONAN_EXECS}
+-        DESTINATION ${CMAKE_INSTALL_BINDIR}
+-        COMPONENT AmneziaVPN
+-        PERMISSIONS
+-            OWNER_READ OWNER_EXECUTE
+-            GROUP_READ GROUP_EXECUTE
+-            WORLD_READ WORLD_EXECUTE
+-    )
+-endif()
+-install(FILES ${CONAN_BINS}
+-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+-    COMPONENT AmneziaVPN
+-)
+-
+ # install drivers
+ if (WIN32)
+     find_package(tap-windows6 REQUIRED)

--- a/pkgs/by-name/am/amnezia-vpn/package.nix
+++ b/pkgs/by-name/am/amnezia-vpn/package.nix
@@ -2,69 +2,66 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
-  fetchurl,
   cmake,
   pkg-config,
   kdePackages,
-  qt6,
   libsecret,
   amneziawg-go,
   openvpn,
-  shadowsocks-rust,
-  cloak-pt,
   wireguard-tools,
   libssh,
-  zlib,
   openssl,
   tun2socks,
-  xray,
-  nix-update-script,
-  bash,
+  v2ray-rules-dat,
+  runtimeShell,
   callPackage,
+  nix-update-script,
 }:
 let
-  amneziawg' = amneziawg-go.overrideAttrs (
-    finalAttrs: prevAttrs: {
-      name = "amneziawg-go";
-      version = "0.2.16";
+  # These helper versions are part of upstream's runtime compatibility contract.
+  # Even minor updates can break VPN connections without failing the build.
+  amneziawg-go-pinned = amneziawg-go.overrideAttrs (
+    finalAttrs: _: {
+      version = "3.0.1";
 
       src = fetchFromGitHub {
         owner = "amnezia-vpn";
         repo = "amneziawg-go";
         tag = "v${finalAttrs.version}";
-        hash = "sha256-JGmWMPVgereSZmdHUHC7ZqWCwUNfxfj3xBf/XDDHhpo=";
+        hash = "sha256-wtjUJSTDWWgJLedyQPlPa+TtOztciyDWIbyZ24N5ELM=";
       };
 
-      vendorHash = "sha256-ZO8sLOaEY3bii9RSxzXDTCcwlsQEYmZDI+X1WPXbE9c=";
+      vendorHash = "sha256-Y2dCwlKMVLrkzDcNKyCPxFJwMbCA2mQKkakvzwbamCY=";
     }
   );
 
-  tun2socks' = tun2socks.overrideAttrs (
-    finalAttrs: prevAttrs: {
-      pname = "tun2socks";
-      version = "2.5.2-c8f8cb5";
+  tun2socks-pinned = tun2socks.overrideAttrs (
+    finalAttrs: _: {
+      version = "2.6.0";
 
       src = fetchFromGitHub {
         owner = "xjasonlyu";
         repo = "tun2socks";
-        rev = "c8f8cb5caf6796039a08d3ebad5354767795628b";
-        hash = "sha256-VF8Mm323w0dwhXyFAJVi67BWepury59sVq1+DDzBjU8=";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-ec4M107BE6MCnW/uz9S83JYJtY9tsQQXDFL98h951DA=";
       };
 
-      vendorHash = "sha256-fHwr/Hnqufgi3D93GLxd5lqNetJswWvQ0+MqPq3QxV4=";
+      vendorHash = "sha256-YAAdyV2p/Ci9RzgVWYXBwR/ctERSQ8SPK7AbwRuUJiI=";
+
+      ldflags = [
+        "-w"
+        "-s"
+        "-X github.com/xjasonlyu/tun2socks/v2/internal/version.Version=v${finalAttrs.version}"
+        "-X github.com/xjasonlyu/tun2socks/v2/internal/version.GitCommit=v${finalAttrs.version}"
+      ];
     }
   );
 
   amnezia-xray = callPackage ./xray-lib.nix { };
 
   # Amnezia Gateway (AGW) public keys for premium server list verification.
-  # These PEM-formatted RSA public keys are hardcoded in the upstream binary
-  # and used to verify signatures on server list responses from the AGW service.
-  # The original values were extracted from the upstream linux binary using
-  # `strings` command, as they are not present in any public source files.
-  # Newlines are escaped (\n -> \\n) to prevent Makefile generation failures
-  # during build when these variables are exported via preConfigure.
+  # These build-time values are not published in the source repository and
+  # were extracted from the official 5.0.0.5 Linux binary.
   dev-agw-public-key = lib.replaceStrings [ "\n" ] [ "\\n" ] (builtins.readFile ./dev_agw_public_key);
   dev-agw-endpoint = "http://gw.dev.amzsvc.com:80/";
   dev-s3-endpoint = "https://s3.eu-north-1.amazonaws.com/amnezia-dev/";
@@ -74,14 +71,20 @@ let
   );
   prod-s3-endpoint = lib.concatStringsSep ", " [
     "https://s3.eu-north-1.amazonaws.com/amnezia/"
-    "https://amnzstrg01.blob.core.windows.net/lambda-list/"
     "https://storage.googleapis.com/lambda-list/"
+    "https://amnzstrg01.blob.core.windows.net/lambda-list/"
     "https://objectstorage.eu-zurich-1.oraclecloud.com/n/zrhfyaq6qxvh/b/lambda-list/o/"
   ];
+  fallback-s3-endpoint = lib.concatStringsSep ", " [
+    "https://storage.mwsapis.ru/lambda-list/"
+    "https://46.8.209.252/lambda-list/"
+  ];
+  free-v2-endpoint = "13.248.139.44";
+  prem-v1-endpoint = "52.223.54.40";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "amnezia-vpn";
-  version = "4.8.21.0";
+  version = "5.0.0.5";
 
   __structuredAttrs = true;
 
@@ -89,89 +92,126 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "amnezia-vpn";
     repo = "amnezia-client";
     tag = finalAttrs.version;
-    hash = "sha256-xNmbXLl+71DhzbGdSobkV1aYbj1XqC9A/3VPjDLsF7A=";
+    hash = "sha256-knQgGyNkOV9CX1I0hJ8xEMRENBV35E2DwWUOgby3iUo=";
     fetchSubmodules = true;
+    # Preserve VCS metadata needed by the build before .git is removed.
+    postCheckout = ''
+      git -C "$out" rev-parse --short HEAD > "$out/.git-revision"
+      git -C "$out" show -s --format=%ct HEAD > "$out/.source-date-epoch"
+    '';
   };
 
+  # Runtime helpers are referenced through their immutable Nix store paths.
+  patches = [ ./disable-conan-runtime-bundling.patch ];
+
   postPatch = ''
+    # Conan performs network dependency resolution during CMake configuration.
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${CMAKE_SOURCE_DIR}/cmake/recipes_bootstrap.cmake" "" \
+      --replace-fail "\''${CMAKE_SOURCE_DIR}/cmake/conan_provider.cmake" ""
+
+    # Read the revision captured by postCheckout into upstream's GIT_COMMIT_HASH.
+    substituteInPlace client/CMakeLists.txt \
+      --replace-fail 'git rev-parse --short HEAD' '"''${CMAKE_COMMAND}" -E cat "''${CMAKE_SOURCE_DIR}/.git-revision"'
+
+    # Upstream expects these helper executables next to the application binaries.
+    substituteInPlace client/core/utils/utilities.cpp \
+      --replace-fail 'Utils::executable("openvpn", true)' 'Utils::executable("${openvpn}/bin/openvpn", false)' \
+      --replace-fail 'Utils::usrExecutable("wg-quick")' 'Utils::executable("${wireguard-tools}/bin/wg-quick", false)' \
+      --replace-fail 'Utils::executable("tun2socks", true)' 'Utils::executable("${tun2socks-pinned}/bin/tun2socks", false)'
+
     substituteInPlace client/platforms/linux/daemon/wireguardutilslinux.cpp \
-      --replace-fail 'm_tunnel.start(appPath.filePath("../../client/bin/wireguard-go"), wgArgs);' 'm_tunnel.start("${amneziawg'}/bin/amneziawg-go", wgArgs);'
-    substituteInPlace client/utilities.cpp \
-      --replace-fail 'return Utils::executable("../../client/bin/openvpn", true);' 'return Utils::executable("${openvpn}/bin/openvpn", false);' \
-      --replace-fail 'return Utils::executable("../../client/bin/tun2socks", true);' 'return Utils::executable("${tun2socks'}/bin/tun2socks", false);' \
-      --replace-fail 'return Utils::usrExecutable("wg-quick");' 'return Utils::executable("${wireguard-tools}/bin/wg-quick", false);'
-    substituteInPlace client/protocols/openvpnovercloakprotocol.cpp \
-      --replace-fail 'return Utils::executable(QString("/ck-client"), true);' 'return Utils::executable(QString("${cloak-pt}/bin/ck-client"), false);'
-    substituteInPlace client/protocols/shadowsocksvpnprotocol.cpp \
-      --replace-fail 'return Utils::executable(QString("/ss-local"), true);' 'return Utils::executable(QString("${shadowsocks-rust}/bin/sslocal"), false);'
-    substituteInPlace client/configurators/openvpn_configurator.cpp \
-      --replace-fail ".arg(qApp->applicationDirPath());" ".arg(\"$out/libexec\");" \
-      --replace-fail "int nVersion = 1;" "int nVersion = 0;"
-    substituteInPlace client/ui/qautostart.cpp \
-      --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "AmneziaVPN"
-    # https://github.com/amnezia-vpn/amnezia-client/pull/2372
-    substituteInPlace client/ui/systemtray_notificationhandler.cpp \
-      --replace-fail 'm_systemTrayIcon.show();' ''' \
-      --replace-fail 'setTrayState(Vpn::ConnectionState::Disconnected);' 'setTrayState(Vpn::ConnectionState::Disconnected); m_systemTrayIcon.show();'
+      --replace-fail 'QDir appPath(QCoreApplication::applicationDirPath());' "" \
+      --replace-fail 'appPath.filePath("amneziawg-go")' 'QString::fromUtf8("${amneziawg-go-pinned}/bin/amneziawg-go")'
+
+    # nixpkgs' libssh CMake config exports "ssh", while Conan exports "ssh::ssh".
+    substituteInPlace client/cmake/3rdparty.cmake \
+      --replace-fail 'list(APPEND LIBS ssh::ssh)' 'list(APPEND LIBS ssh)'
+
+    # The resolver script is installed in libexec instead of beside the GUI binary.
+    substituteInPlace client/core/configurators/openVpnConfigurator.cpp \
+      --replace-fail '.arg(qApp->applicationDirPath()))' ".arg(\"$out/libexec\"))"
+
+    substituteInPlace client/platforms/linux/daemon/linuxfirewall.cpp \
+      --replace-fail 'QStringLiteral("/bin/bash")' 'QStringLiteral("${runtimeShell}")'
+
+    # Use a stable PATH lookup so autostart does not point at the hidden Qt wrapper.
+    substituteInPlace client/ui/utils/qAutoStart.cpp \
+      --replace-fail '/usr/share/pixmaps/AmneziaVPN.png' 'AmneziaVPN' \
+      --replace-fail '"Exec=" << appPath()' '"Exec=AmneziaVPN --autostart"'
+
+    # The tray icon must be initialized before it is shown.
+    substituteInPlace client/ui/utils/systemTrayNotificationHandler.cpp \
+      --replace-fail 'm_systemTrayIcon.show();' "" \
+      --replace-fail 'setTrayState(Vpn::ConnectionState::Disconnected);' $'setTrayState(Vpn::ConnectionState::Disconnected);\n    m_systemTrayIcon.show();'
+
+    # Upstream does not set a window icon on Linux.
     substituteInPlace client/main.cpp \
       --replace-fail '#include "version.h"' $'#include "version.h"\n#include <QIcon>' \
       --replace-fail 'app.setApplicationDisplayName(APPLICATION_NAME);' $'app.setApplicationDisplayName(APPLICATION_NAME);\n    app.setWindowIcon(QIcon::fromTheme("AmneziaVPN"));'
-    substituteInPlace deploy/installer/config/AmneziaVPN.desktop.in \
-      --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "$out/share/icons/hicolor/512x512/apps/AmneziaVPN.png"
-    substituteInPlace deploy/data/linux/AmneziaVPN.service \
-      --replace-fail "ExecStart=/opt/AmneziaVPN/service/AmneziaVPN-service.sh" "ExecStart=$out/bin/AmneziaVPN-service" \
-      --replace-fail "Environment=LD_LIBRARY_PATH=/opt/AmneziaVPN/client/lib" ""
-    substituteInPlace client/cmake/3rdparty.cmake \
-      --replace-fail 'set(LIBSSH_LIB_PATH "''${LIBSSH_ROOT_DIR}/linux/x86_64/libssh.a")' 'set(LIBSSH_LIB_PATH "${libssh}/lib/libssh.so")' \
-      --replace-fail 'set(ZLIB_LIB_PATH "''${LIBSSH_ROOT_DIR}/linux/x86_64/libz.a")' 'set(ZLIB_LIB_PATH "${zlib}/lib/libz.so")' \
-      --replace-fail 'set(OPENSSL_INCLUDE_DIR "''${OPENSSL_ROOT_DIR}/linux/include")' 'set(OPENSSL_INCLUDE_DIR "${openssl.dev}/include")' \
-      --replace-fail 'set(OPENSSL_LIB_SSL_PATH "''${OPENSSL_ROOT_DIR}/linux/x86_64/libssl.a")' 'set(OPENSSL_LIB_SSL_PATH "${openssl.out}/lib/libssl.so")' \
-      --replace-fail 'set(OPENSSL_LIB_CRYPTO_PATH "''${OPENSSL_ROOT_DIR}/linux/x86_64/libcrypto.a")' 'set(OPENSSL_LIB_CRYPTO_PATH "${openssl.out}/lib/libcrypto.so")' \
-      --replace-fail 'set(OPENSSL_USE_STATIC_LIBS TRUE)' 'set(OPENSSL_USE_STATIC_LIBS FALSE)'
+
+    # Xray otherwise looks for geoip.dat and geosite.dat beside the service binary.
+    substituteInPlace service/server/xray.cpp \
+      --replace-fail 'qDebug() << "Xray::startXray()";' $'qDebug() << "Xray::startXray()";\n    qputenv("XRAY_LOCATION_ASSET", QByteArrayLiteral("${v2ray-rules-dat}/share/v2ray"));'
+
+    # Link the Nix-built bindings directly instead of using a Conan package.
     substituteInPlace service/server/CMakeLists.txt \
-      --replace-fail 'set(OPENSSL_INCLUDE_DIR "''${OPENSSL_ROOT_DIR}/linux/include")' 'set(OPENSSL_INCLUDE_DIR "${openssl.dev}/include")' \
-      --replace-fail 'set(OPENSSL_LIB_CRYPTO_PATH "''${OPENSSL_ROOT_DIR}/linux/x86_64/libcrypto.a")' 'set(OPENSSL_LIB_CRYPTO_PATH "${openssl.out}/lib/libcrypto.so")' \
-      --replace-fail 'set(OPENSSL_USE_STATIC_LIBS TRUE)' 'set(OPENSSL_USE_STATIC_LIBS FALSE)' \
-      --replace-fail 'set(AMNEZIA_XRAY_LIB_PATH "''${AMNEZIA_XRAY_ROOT_DIR}/linux/x86_64/amnezia_xray.a")' 'set(AMNEZIA_XRAY_LIB_PATH "${amnezia-xray}/lib/amnezia_xray.a")' \
-      --replace-fail 'set(AMNEZIA_XRAY_INCLUDE_DIR "''${AMNEZIA_XRAY_ROOT_DIR}/linux/x86_64")' 'set(AMNEZIA_XRAY_INCLUDE_DIR "${amnezia-xray}/include")'
+      --replace-fail 'find_package(amnezia-xray-bindings REQUIRED)' 'target_include_directories(''${PROJECT} PRIVATE "${amnezia-xray}/include")' \
+      --replace-fail 'amnezia::xray-bindings' '"${amnezia-xray}/lib/libamnezia_xray.a"'
+
+    substituteInPlace deploy/data/linux/AmneziaVPN.desktop \
+      --replace-fail 'Icon=/usr/share/pixmaps/AmneziaVPN.png' 'Icon=AmneziaVPN'
+    substituteInPlace deploy/data/linux/AmneziaVPN.service \
+      --replace-fail 'ExecStart=/opt/AmneziaVPN/bin/AmneziaVPN-service' "ExecStart=$out/bin/AmneziaVPN-service"
+    substituteInPlace deploy/data/linux/update-resolv-conf.sh \
+      --replace-fail '#!/usr/bin/env bash' '#!${runtimeShell}'
   '';
 
   strictDeps = true;
 
   nativeBuildInputs = [
     cmake
+    kdePackages.qttools
+    kdePackages.wrapQtAppsHook
     pkg-config
-    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
-    bash
     kdePackages.qt5compat
+    kdePackages.qtbase
+    kdePackages.qtdeclarative
     kdePackages.qtremoteobjects
     kdePackages.qtsvg
     libsecret
-    qt6.qtbase
-    qt6.qttools
+    libssh
+    openssl
   ];
 
-  # These environment variables are baked into the binary at build time.
-  # They configure which Amnezia Gateway servers and S3 endpoints the client
-  # uses for fetching verified server lists (premium functionality).
+  # These values are baked into the binary at build time. In addition to the
+  # AGW key and storage endpoints, the two legacy API markers are required to
+  # classify imported Free v2 and Premium v1 configurations correctly.
   preConfigure = ''
+    # Use the commit timestamp for reproducible __DATE__ and CMake timestamps.
+    export SOURCE_DATE_EPOCH="$(< .source-date-epoch)"
+
     export DEV_AGW_PUBLIC_KEY="${dev-agw-public-key}"
     export DEV_AGW_ENDPOINT="${dev-agw-endpoint}"
     export DEV_S3_ENDPOINT="${dev-s3-endpoint}"
     export PROD_AGW_PUBLIC_KEY="${prod-agw-public-key}"
     export PROD_S3_ENDPOINT="${prod-s3-endpoint}"
+    export FALLBACK_S3_ENDPOINT="${fallback-s3-endpoint}"
+    export FREE_V2_ENDPOINT="${free-v2-endpoint}"
+    export PREM_V1_ENDPOINT="${prem-v1-endpoint}"
   '';
 
   installPhase = ''
     runHook preInstall
 
     install -Dm555 client/AmneziaVPN service/server/AmneziaVPN-service -t $out/bin/
-    install -Dm555 ../deploy/data/linux/client/bin/update-resolv-conf.sh -t $out/libexec/
-    install -Dm444 ../AppDir/AmneziaVPN.desktop -t $out/share/applications/
-    install -Dm444 ../deploy/data/linux/AmneziaVPN.png -t $out/share/icons/hicolor/512x512/apps
+    install -Dm555 ../deploy/data/linux/update-resolv-conf.sh -t $out/libexec/
+
+    install -Dm444 ../deploy/data/linux/AmneziaVPN.desktop -t $out/share/applications/
+    install -Dm444 ../deploy/data/linux/AmneziaVPN.png -t $out/share/icons/hicolor/512x512/apps/
     install -Dm444 ../deploy/data/linux/AmneziaVPN.service -t $out/lib/systemd/system/
 
     runHook postInstall
@@ -185,7 +225,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Amnezia VPN Client";
     downloadPage = "https://amnezia.org/en/downloads";
     homepage = "https://github.com/amnezia-vpn/amnezia-client";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     mainProgram = "AmneziaVPN";
     maintainers = with lib.maintainers; [ sund3RRR ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/am/amnezia-vpn/xray-lib.nix
+++ b/pkgs/by-name/am/amnezia-vpn/xray-lib.nix
@@ -1,20 +1,20 @@
 {
   fetchFromGitHub,
-  buildGo126Module,
+  buildGoModule,
 }:
 
-buildGo126Module rec {
+buildGoModule rec {
   pname = "amnezia-xray";
-  version = "1.1.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "amnezia-vpn";
     repo = "amnezia-xray-bindings";
     tag = "v${version}";
-    hash = "sha256-HZ6qHHDMev8FoOIplWAaPOlCSfikpgKClvbxl+877S0=";
+    hash = "sha256-kGtRw5Ic/++1ehwLToZ96WfC3ULp+DIsPYArqjL06ck=";
   };
 
-  vendorHash = "sha256-ac+wJrwdTtLFJG+Ka1Ksb1P+3lI7sFwCh4Nr5+fPgq0=";
+  vendorHash = "sha256-JAHpQUMQT6tJKwGld0QCobDxgLVujA4KHkhOLXHS65w=";
 
   env.CGO_ENABLED = 1;
 
@@ -30,7 +30,7 @@ buildGo126Module rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm444 build/amnezia_xray.a -t $out/lib/
+    install -Dm444 build/amnezia_xray.a $out/lib/libamnezia_xray.a
     install -Dm444 build/amnezia_xray.h -t $out/include/
 
     runHook postInstall


### PR DESCRIPTION
## Description

Closes https://github.com/NixOS/nixpkgs/issues/549239

Update AmneziaVPN to the 5.0.0.5 major release and rework the source derivation for upstream's new CMake/Conan build system.

- Disable network-dependent Conan bootstrap and runtime bundling; use Nix-provided Qt, OpenSSL and libssh.
- Pin the runtime-sensitive helpers to upstream-tested versions: amneziawg-go 3.0.1 and tun2socks 2.6.0.
- Update amnezia-xray-bindings to 1.3.0 and use `v2ray-rules-dat` assets from nixpkgs.
- Adapt paths and installation layout to the upstream source tree refactor; remove obsolete Cloak and Shadowsocks dependencies.
- Update AGW endpoints and preserve the Git revision and commit date after fetch, fixing missing commit metadata and the `Jan 1 1980` build date.
- Fix Linux integration: autostart through the Qt wrapper, tray/window/desktop icons, systemd service path, resolver shell and Xray asset lookup.
- Add `iptables` and `gawk` to the NixOS service PATH, required by the default killswitch/firewall implementation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
