### PR TITLE
python3Packages.itkwasm-*: 2.0.0 -> 2.0.2

### DIFF
--- a/pkgs/development/python-modules/itkwasm-downsample-emscripten/default.nix
+++ b/pkgs/development/python-modules/itkwasm-downsample-emscripten/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm-downsample-emscripten";
-  version = "2.0.0";
+  version = "2.0.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "itkwasm_downsample_emscripten";
     inherit (finalAttrs) version;
-    hash = "sha256-Gz4sO6udvY/5AZzQcB5DE6+pk2cmSMmuQor7wNj9Wv8=";
+    hash = "sha256-XXyuPiaiP6UIkOXlC/WzjfRIobfzBW7SQgLbBFV+zuQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/itkwasm-downsample-wasi/default.nix
+++ b/pkgs/development/python-modules/itkwasm-downsample-wasi/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm-downsample-wasi";
-  version = "2.0.0";
+  version = "2.0.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "itkwasm_downsample_wasi";
     inherit (finalAttrs) version;
-    hash = "sha256-5vqw+sb9Zb0npYiDtzUla3JT5zEimOD5gAnwxcYi4cM=";
+    hash = "sha256-sPYO5KJD7PuJdAaoCGwSVj0YRM9mVyKZTQyVqCYBt4U=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/itkwasm-downsample/default.nix
+++ b/pkgs/development/python-modules/itkwasm-downsample/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm-downsample";
-  version = "2.0.0";
+  version = "2.0.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "itkwasm_downsample";
     inherit (finalAttrs) version;
-    hash = "sha256-LP9sg4VFc1/niioRzAR9cbwdl6fiEkrOpGT7vjj+6LQ=";
+    hash = "sha256-2X//X492VXmV8t2w4BO936XjjkRTBLvPQ+7G82RLonk=";
   };
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
