### PR TITLE
mutter: apply patch to fix HDR with 50.4

### DIFF
--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -1,5 +1,6 @@
 {
   fetchurl,
+  fetchpatch,
   runCommand,
   lib,
   stdenv,
@@ -182,6 +183,17 @@ stdenv.mkDerivation (finalAttrs: {
       pp.pygobject3
       pp.argcomplete
     ]))
+  ];
+
+  patches = [
+    # Fix HDR corruption by reverting this commit. See:
+    # - https://gitlab.gnome.org/GNOME/mutter/-/work_items/4952
+    # - https://gitlab.gnome.org/GNOME/mutter/-/work_items/4967
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/a1ae71798ef1ab2e0d2f753f5c98b38b1039b056.patch";
+      hash = "sha256-J2eKhM3YEFEVmcpMq2SxSOsPeEWrJTv+UcBDO+gRC4M=";
+      revert = true;
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
mutter 50.4 introduced two regressions that effectively break HDR:
- https://gitlab.gnome.org/GNOME/mutter/-/work_items/4952 (Mutter 50.4 causes SDR colours to become grayish/unsaturated with HDR enabled)
- https://gitlab.gnome.org/GNOME/mutter/-/work_items/4967 (50.4 regression: artifacting when HDR is enabled)

Upstream is considering reverting the commit that causes this, the patch in this PR does exactly that. I can confirm it solves both issues for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
