### PR TITLE
tokscale: 4.0.4 -> 4.13.0

### DIFF
--- a/pkgs/by-name/to/tokscale/package.nix
+++ b/pkgs/by-name/to/tokscale/package.nix
@@ -11,7 +11,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tokscale";
-  version = "4.0.4";
+  version = "4.13.0";
 
   __structuredAttrs = true;
 
@@ -19,10 +19,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "junhoyeo";
     repo = "tokscale";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vFBIq7z0+bmMk2teDORrUVWrv7N3w1CsDrT2s85k6/U=";
+    hash = "sha256-0BQnoIDETgh6S806mHvxqDBpcJJQZbhl46yj6ctUTsk=";
   };
 
-  cargoHash = "sha256-iXHriY+Kyn5pSx3uwouH2rkMBXkJX6zH5/xiFeCMqbQ=";
+  cargoHash = "sha256-kuq1qT4OywO3miSoyMsTUo+o/3jcLjpzQ70lGHpvt+w=";
 
   nativeBuildInputs = [
     pkg-config
@@ -43,6 +43,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=test_pricing_command_json"
     "--skip=test_pricing_command_success"
     "--skip=test_pricing_command_with_provider"
+    "--skip=test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read"
+    "--skip=test_auto_pinning_recovers_from_a_bucket_timezone_that_names_no_zone"
+    "--skip=test_first_run_pins_the_host_timezone_without_changing_its_own_output"
+    "--skip=test_submit_dry_run_preserves_local_date_ahead_of_utc"
+    "--skip=test_submit_excluding_only_generic_gemini_usage_does_not_promise_submission"
+    "--skip=test_unpinned_first_scan_still_buckets_by_the_host_timezone"
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
## Description of changes

Updates `tokscale` from 4.0.4 to 4.13.0 (9 releases behind), and fixes the reason the nixpkgs-update bot (r-ryantm) could not auto-update this package since 2026-07-05.

### Why the bot stopped updating this package

The bot logs ([tokscale logs](https://nixpkgs-update-logs.nix-community.org/tokscale/)) show it detected every release since 4.0.10 and produced the correct diff, but then discarded it because `nix-build` failed. Example from the [2026-08-11 run](https://nixpkgs-update-logs.nix-community.org/tokscale/2026-08-11.log):

````
stderr=```
[tokscale] Warning: models.dev pricing fetch failed (models.dev network error: error sending request for url (https://models.dev/api.json)); continuing with the remaining pricing sources
Error: pricing data is unavailable for submission
```

failures:
    test_auto_pinning_never_overwrites_a_settings_file_it_could_not_read
    test_auto_pinning_recovers_from_a_bucket_timezone_that_names_no_zone
    test_first_run_pins_the_host_timezone_without_changing_its_own_output
    test_submit_dry_run_preserves_local_date_ahead_of_utc
    test_submit_excluding_only_generic_gemini_usage_does_not_promise_submission
    test_unpinned_first_scan_still_buckets_by_the_host_timezone
````

Upstream added 6 tests in `cli_tests` that fetch pricing data from `models.dev`, which the build sandbox blocks. This PR adds the same `--skip` treatment to those 6 tests that the file already applies to 4 older network tests, so `nix-build` passes again and the bot can resume auto-updates.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s):
  - [x] x86_64-linux (`nix-build -A tokscale .`: `cargo test` 144 passed, 10 filtered out, 0 failed; `versionCheckHook` reports `tokscale 4.13.0`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested basic functionality of all binary files (only `tokscale --version` checked; the CLI reports token usage and is interactive)
- [x] Tested compilation of all packages that depend on this change: no other package references `tokscale`; it is a leaf package
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the changed function
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Determined the impact on package disk size (by running `nix path-info -dS` before and after)
- [x] Ensured that relevant documentation is up to date (no docs in nixpkgs for this package)
- [x] Added a release notes entry if the change is major or breaking (routine update; none needed)
- [ ] Added a maintainer (maintainer `@kpbaks` unchanged)

Diff: https://github.com/junhoyeo/tokscale/compare/v4.0.4...v4.13.0
Changelog: https://github.com/junhoyeo/tokscale/releases/tag/v4.13.0