### PR TITLE
nixos/soju: Replace enableMessageLogging with messageStoreDriver

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -100,6 +100,8 @@
   Additionally, the kernel module tree used inside the VM has been split out of the `kernel` argument into a new `kernelModules` argument (defaulting to `kernel`).
   Callers that overrode `kernel` with a module tree (e.g. from `pkgs.aggregateModules`) to make extra modules available must now pass it via `kernelModules` instead, keeping `kernel` pointing at a bootable kernel derivation.
 
+- `service.soju.enableMessageLogging` option has been removed in favor of `messageStoreDriver` which supports enabling the `db` storage backend.
+
 - The ARMv5 Linux kernel build now uses a standard configuration and generates a standard compressed image instead of the deprecated legacy U‐Boot image format.
   `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
   Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.

--- a/nixos/modules/services/networking/soju.nix
+++ b/nixos/modules/services/networking/soju.nix
@@ -16,13 +16,15 @@ let
   tlsCfg = optionalString (
     cfg.tlsCertificate != null
   ) "tls ${cfg.tlsCertificate} ${cfg.tlsCertificateKey}";
-  logCfg = optionalString cfg.enableMessageLogging "message-store fs ${stateDir}/logs";
+
+  messageStoreCfg =
+    if cfg.messageStoreDriver == "fs" then "fs ${stateDir}/logs" else cfg.messageStoreDriver;
 
   configFile = pkgs.writeText "soju.conf" ''
     ${listenCfg}
     hostname ${cfg.hostName}
     ${tlsCfg}
-    ${logCfg}
+    message-store ${messageStoreCfg}
     http-origin ${concatStringsSep " " cfg.httpOrigins}
     accept-proxy-ip ${concatStringsSep " " cfg.acceptProxyIP}
 
@@ -34,6 +36,14 @@ let
   '';
 in
 {
+  imports = [
+    (lib.mkChangedOptionModule
+      [ "services" "soju" "enableMessageLogging" ]
+      [ "services" "soju" "messageStoreDriver" ]
+      (config: if config.services.soju.enableMessageLogging then "fs" else "memory")
+    )
+  ];
+
   ###### interface
 
   options.services.soju = {
@@ -72,10 +82,14 @@ in
       description = "Path to server TLS certificate key.";
     };
 
-    enableMessageLogging = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Whether to enable message logging.";
+    messageStoreDriver = mkOption {
+      type = types.enum [
+        "db"
+        "fs"
+        "memory"
+      ];
+      default = "fs";
+      description = "Set the storage backend for IRC messages.";
     };
 
     adminSocket.enable = mkOption {


### PR DESCRIPTION
I use Soju with the db message-store as recommended by the documentation of Halloy because the default `fs` store is lossy.

Configuring this is a bit awkward as it requires setting `enableMessageLogging = false` and then inserting a custom `message-store` line.

This patch drops the `enableMessageLogging` option and replaces it with a generic `messageStoreDriver` option. Setting neither keeps the current behaviour of `message-store fs`, including the file location. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
