### PR TITLE
python3Packages.torchaudio: use cu130 wheels to match torch

### DIFF
--- a/pkgs/development/python-modules/torchaudio/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchaudio/binary-hashes.nix
@@ -10,28 +10,28 @@ builtins.getAttr version {
   "2.11.0" = {
     x86_64-linux-310 = {
       name = "torchaudio-2.11.0-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl";
-      hash = "sha256-A0+64QMGG3RpTrGWOl6Rh0m8o8DpmK1b0FElvP6QMSI=";
+      url = "https://download.pytorch.org/whl/cu130/torchaudio-2.11.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
+      hash = "sha256-kUl7ZSVWnc0IcZkdMrtL7akHdby+kFAyjqe4AiEG4vo=";
     };
     x86_64-linux-311 = {
       name = "torchaudio-2.11.0-cp311-cp311-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl";
-      hash = "sha256-ww4oVzu/6CsuiyFouId7+XgiWuI3iaEmMTBrrGUDPjo=";
+      url = "https://download.pytorch.org/whl/cu130/torchaudio-2.11.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
+      hash = "sha256-9uHjqzGr+oH1yIAaDqt2nVMIUU3GRLs53PCpBX82TxY=";
     };
     x86_64-linux-312 = {
       name = "torchaudio-2.11.0-cp312-cp312-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl";
-      hash = "sha256-eLhqF/Fkvaq9zuk/394lh/xDuevxXNYdz3MLT4YVF2s=";
+      url = "https://download.pytorch.org/whl/cu130/torchaudio-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+      hash = "sha256-P7qYj0MB/hNUf+XpnHbZrjaifhne2C7v/tnSRW4S7e8=";
     };
     x86_64-linux-313 = {
       name = "torchaudio-2.11.0-cp313-cp313-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl";
-      hash = "sha256-NDo1SLMpGt9VLNSgOp+UkNlsszZ6itktywuPAUNDLoA=";
+      url = "https://download.pytorch.org/whl/cu130/torchaudio-2.11.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
+      hash = "sha256-6cB8/atpFFQJL/EtId0UB6S7itCB048iLPb89qvMGMg=";
     };
     x86_64-linux-314 = {
       name = "torchaudio-2.11.0-cp314-cp314-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl";
-      hash = "sha256-DTT3JLG6w4NUIOunhWpe/hJQJzW3BtuNNlXpJoCkOXM=";
+      url = "https://download.pytorch.org/whl/cu130/torchaudio-2.11.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
+      hash = "sha256-N4tJZxtYERSi0l1Ako8SoVCHL+rfEWaaY/Vz6Bx4AZo=";
     };
     aarch64-darwin-310 = {
       name = "torchaudio-2.11.0-cp310-cp310-macosx_11_0_arm64.whl";

--- a/pkgs/development/python-modules/torchaudio/prefetch.sh
+++ b/pkgs/development/python-modules/torchaudio/prefetch.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 
 version=$1
 
-linux_cuda_version="cu128"
+linux_cuda_version="cu130"
 linux_cuda_bucket="https://download.pytorch.org/whl/${linux_cuda_version}"
 linux_cpu_bucket="https://download.pytorch.org/whl/cpu"
 darwin_bucket="https://download.pytorch.org/whl/cpu"


### PR DESCRIPTION
`torchaudio-bin` fetches its x86_64-linux wheels from the cu128 index while `torch-bin` and `torchvision-bin` are on cu130. torchaudio checks this at import time and refuses to load:

```
RuntimeError: Detected that PyTorch and TorchAudio were compiled with different CUDA versions.
PyTorch has CUDA version 13.0 whereas TorchAudio has CUDA version 12.8.
Please install the TorchAudio version that matches your PyTorch version.
```

The cause is one line: `torch/bin/prefetch.sh` and `torchvision/prefetch.sh` moved to `linux_cuda_version="cu130"` and torchaudio's did not, so the next regeneration of `binary-hashes.nix` produced cu128 URLs. `binary-hashes.nix` opens with `# Warning: Need to update at the same time as torch-bin`, which is exactly the invariant that slipped.

This fixes the script and regenerates the five `x86_64-linux-*` entries for 2.11.0 with it. The darwin and aarch64-linux entries come from the cpu bucket and are byte-identical to the ones already in the tree, which is also the check that the rerun was faithful.

Why CI did not catch it, despite `pythonImportsCheck = [ "torchaudio" ]` and no `hydraPlatforms` exclusion on this package: with the default `cudaPackages` (12.9) the whole `-bin` chain refuses to evaluate, because `torch/bin/default.nix` raises `torch.unsupported-cuda-version` demanding `cuda-bindings>=13.0.3`. The import check therefore never runs, and only someone who follows that message and overrides `cudaPackages` to 13 reaches the mismatch. #488766 would make this reachable by default.

Verified on x86_64-linux with `cudaPackages = cudaPackages_13`: `torch 2.12.0+cu130`, `torchaudio 2.11.0+cu130` and `torchvision 0.27.0+cu130` import together and a CUDA matmul runs on the GPU.

*Assisted-by: Claude Code (claude-opus-5). The commands above were run on my own machine and I have reviewed the report.*

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
