### PR TITLE
python3Packages.torch-bin: relax the setuptools bound

### DIFF
--- a/pkgs/development/python-modules/torch/bin/default.nix
+++ b/pkgs/development/python-modules/torch/bin/default.nix
@@ -91,6 +91,9 @@ buildPythonPackage {
     "libcuda.so.1"
   ];
 
+  # the wheel declares setuptools<82, which torch does not import at runtime
+  pythonRelaxDeps = [ "setuptools" ];
+
   pythonRemoveDeps = [
     "cuda-toolkit"
     "nvidia-cublas"


### PR DESCRIPTION
The current `torch 2.12.1+cu130` wheel still declares `Requires-Dist: setuptools<82`, while nixpkgs provides setuptools 83. This change relaxes that upper bound with `pythonRelaxDeps` while retaining setuptools as a dependency.

`torch-bin` is not built by Hydra because it sets `hydraPlatforms = [ ]`. Testing also requires overriding `cudaPackages` to `cudaPackages_13`, since the default CUDA 12.9 is rejected by `torch.unsupported-cuda-version`.

Rebased onto current `master`. Verified without rebuilding the 3.2 GiB package:

- The upstream wheel metadata for `torch 2.12.1+cu130` still contains `Requires-Dist: setuptools<82`.
- Nix evaluation selects `pythonRelaxDeps = [ "setuptools" ]`.
- Nix parsing, `nixfmt --check`, and `git diff --check` pass.

The previous 2.12.0 revision was built and tested on x86_64-linux with `cudaPackages_13`; CI is running again for the rebased revision.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: Claude Code (claude-opus-5) and OpenCode (gpt-5.6-sol). I reviewed this description and take responsibility for it.
