### PR TITLE
emacsPackages.nix3: init at 0-unstable-2025-03-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13611,6 +13611,12 @@
     githubId = 32305209;
     name = "John Children";
   };
+  johnhamelink = {
+    email = "me@johnhame.link";
+    github = "johnhamelink";
+    githubId = 101739;
+    name = "John Hamelink";
+  };
   johnjohnstone = {
     email = "jjohnstone@riseup.net";
     github = "johnjohnstone";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/nix3/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/nix3/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  unstableGitUpdater,
+  melpaBuild,
+  fetchFromGitHub,
+  promise,
+  magit-section,
+  s,
+}:
+melpaBuild {
+  pname = "nix3";
+  version = "0-unstable-2025-03-15";
+  src = fetchFromGitHub {
+    owner = "emacs-twist";
+    repo = "nix3.el";
+    rev = "6e8a7c3b2683a0fdae2a968e211c3585580fbca5";
+    hash = "sha256-2rg5S/ElHfXFgomnkjkoPjd37jH6c52TsBhNCFvIE+4=";
+  };
+
+  files = ''(:defaults "extra/*.el")'';
+
+  packageRequires = [
+    promise
+    magit-section
+    s
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/emacs-twist/nix3.el";
+    description = "Emacs interface to experimental commands of Nix";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ johnhamelink ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

nix3.el is an experimental Emacs interface to experimental commands of Nix. Its goal is to enable the user to easily work across multiple projects.

A typical use case is a complex application/program that consists of multiple repositories:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
