### PR TITLE
emacsPackages.wile: init at 0-unstable-2025-03-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13611,6 +13611,12 @@
     githubId = 32305209;
     name = "John Children";
   };
+  johnhamelink = {
+    email = "me@johnhame.link";
+    github = "johnhamelink";
+    githubId = 101739;
+    name = "John Hamelink";
+  };
   johnjohnstone = {
     email = "jjohnstone@riseup.net";
     github = "johnjohnstone";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wile/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wile/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  unstableGitUpdater,
+  melpaBuild,
+  fetchFromGitea,
+}:
+melpaBuild {
+  pname = "wile";
+  version = "0-unstable-2025-03-27";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "rahguzar";
+    repo = "wile";
+    rev = "d24f78ac8dac6b90acf7fcacdf8a09b849ba353c";
+    hash = "sha256-dLyOvijabSMFuOJiWGbMhAZiKXpppUWi5nKS7Q9ry+I=";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://codeberg.org/rahguzar/wile";
+    description = "Control iwd managed wifi devices from Emacs";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ johnhamelink ];
+  };
+
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wile/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wile/package.nix
@@ -15,6 +15,8 @@ melpaBuild {
     hash = "sha256-dLyOvijabSMFuOJiWGbMhAZiKXpppUWi5nKS7Q9ry+I=";
   };
 
+  files = "(\"*.el\" (:exclude \"bile.el\"))";
+
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[iwd](https://iwd.wiki.kernel.org/) project provides the executable iwctl to control WiFi devices on GNU/Linux. In addition it also provides dbus interfaces for doing the same tasks (iwctl uses these under the hood.) This package uses the dbus integration of Emacs to do various WiFi related operations directly from Emacs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
