### PR TITLE
flatpak: 1.16.6 -> 1.16.7

### DIFF
--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchFromGitHub,
   pkgsCross,
   appstream,
   bison,
@@ -80,7 +81,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak";
-  version = "1.16.6";
+  version = "1.16.7";
 
   # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [
@@ -96,9 +97,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional finalAttrs.doCheck "installedTests"
   ++ lib.optional withMan "man";
 
-  src = fetchurl {
-    url = "https://github.com/flatpak/flatpak/releases/download/${finalAttrs.version}/flatpak-${finalAttrs.version}.tar.xz";
-    hash = "sha256-HmPn8/5EtgLzTZKm/kb9ijvGvpRgwDwmgeV5dsZY7sM=";
+  src = fetchFromGitHub {
+    owner = "flatpak";
+    repo = "flatpak";
+    rev = "187a5439b5712c5806b46988f0c2e35bccbaa1f8"; # flatpak-1.16.x
+    sha256 = "sha256-2eARgsiC/lDbV7LaQ9CaNTeuBbzbRav8dVsl+xrJG2g=";
   };
 
   patches = [


### PR DESCRIPTION
It's a follow up to the recent https://github.com/NixOS/nixpkgs/pull/551494

This fixes in particular [GHSA-8688-9x26-hhxj](https://github.com/flatpak/flatpak/security/advisories/GHSA-8688-9x26-hhxj)

There is no release issued for flatpak 1.16.7, and there might never be one. They say anything older than 1.18.x [isn't supported](https://github.com/flatpak/flatpak/security). But they also say that the fixes for the issue listed above are included in flatpak-1.16.x.

I only tested the change with an overlay on my config (x86_64-linux).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
