### PR TITLE
vulkan-profiles: init at 1.4.357.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31206,6 +31206,13 @@
     githubId = 68678258;
     name = "Renato German Chavez Chicoma";
   };
+  xdan7 = {
+    email = "dev@xda7.de";
+    github = "xDAN7";
+    githubId = 29778928;
+    matrix = "@xda7:matrix.org";
+    name = "Daniel";
+  };
   xddxdd = {
     email = "b980120@hotmail.com";
     github = "xddxdd";

--- a/pkgs/by-name/vu/vulkan-headers/update.sh
+++ b/pkgs/by-name/vu/vulkan-headers/update.sh
@@ -9,6 +9,7 @@ SDK_PACKAGES=(
     "vulkan-validation-layers"
     "vulkan-tools"
     "vulkan-tools-lunarg"
+    "vulkan-profiles"
     "vulkan-extension-layer"
     "vulkan-utility-libraries"
     "vulkan-volk"

--- a/pkgs/by-name/vu/vulkan-profiles/package.nix
+++ b/pkgs/by-name/vu/vulkan-profiles/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  python3,
+  vulkan-headers,
+  vulkan-utility-libraries,
+  valijson,
+  jsoncpp,
+  gtest,
+  vulkan-loader,
+  vulkan-tools,
+  mesa,
+  runCommand,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vulkan-profiles";
+  version = "1.4.357.0";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "Vulkan-Profiles";
+    tag = "vulkan-sdk-${finalAttrs.version}";
+    hash = "sha256-980RALIOpGw4JwkgcFni+zqlfLENGeKkmLr8cQkxAO4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    (python3.withPackages (
+      ps: with ps; [
+        jsonschema
+        pyinstaller
+        pyparsing
+      ]
+    ))
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-utility-libraries
+    valijson
+    # Upstream links against the static jsoncpp_static target, which nixpkgs
+    # only builds when explicitly requested.
+    (jsoncpp.override { enableStatic = true; })
+    gtest
+    vulkan-loader
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags = [
+    "-DUPDATE_DEPS=OFF"
+    "-DBUILD_TESTS=ON"
+    "-DVULKAN_HEADERS_INSTALL_DIR=${vulkan-headers}"
+  ];
+
+  nativeCheckInputs = [ mesa ];
+
+  doCheck = true;
+
+  # Tests create real VkInstance/VkDevice objects; point loader at Lavapipe
+  # (CPU software rasterizer) since the sandbox has no GPU/ICD.
+  preCheck = ''
+    export VK_ICD_FILENAMES="${mesa}/share/vulkan/icd.d/lvp_icd.${stdenv.hostPlatform.parsed.cpu.name}.json"
+    export LD_LIBRARY_PATH="${
+      lib.makeLibraryPath [ vulkan-loader ]
+    }''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/vulkan/explicit_layer.d/VkLayer_khronos_profiles.json \
+      --replace-fail '"library_path": "libVkLayer_khronos_profiles.so"' \
+                      '"library_path": "${placeholder "out"}/lib/libVkLayer_khronos_profiles.so"'
+  '';
+
+  passthru = {
+    tests.layer-loads =
+      runCommand "vulkan-profiles-layer-loads" { nativeBuildInputs = [ vulkan-tools ]; }
+        ''
+          export VK_ICD_FILENAMES="${mesa}/share/vulkan/icd.d/lvp_icd.${stdenv.hostPlatform.parsed.cpu.name}.json"
+          export VK_LAYER_PATH="${finalAttrs.finalPackage}/share/vulkan/explicit_layer.d"
+          vulkaninfo > vulkaninfo.log 2>&1 || { cat vulkaninfo.log; exit 1; }
+          grep -q "VK_LAYER_KHRONOS_profiles (Khronos Profiles layer)" vulkaninfo.log || {
+            echo "layer did not load:"; cat vulkaninfo.log; exit 1;
+          }
+          touch $out
+        '';
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Khronos toolset for building portable Vulkan applications using Vulkan Profiles";
+    homepage = "https://github.com/KhronosGroup/Vulkan-Profiles";
+    license = with lib.licenses; [
+      asl20
+      cc-by-40
+    ];
+    # doCheck and passthru.tests.layer-loads assume Mesa's Lavapipe (lvp) ICD,
+    # which only exists on Linux; Darwin's `mesa` builds "kosmickrisp" instead.
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.xdan7 ];
+  };
+})


### PR DESCRIPTION
[Vulkan-Profiles] is the official [Khronos Group] toolset that helps developers build portable Vulkan applications using the [Vulkan Profiles mechanism]. Packaging it because I need it as a build dependency for my own Vulkan project, and it isn't in Nixpkgs yet.

This PR uses AI assistance (Claude Sonnet 5, Anthropic); commits have been marked with `Assisted-by:`, and written code has been manually reviewed, tested and understood before submission.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
    - `meta.platforms` is restricted to Linux because `doCheck` and `passthru.tests.layer-loads` rely on Mesa's Lavapipe (`lvp`) software Vulkan driver, which only exists on Linux. Darwin's `mesa` only Vulkan driver is `kosmickrisp` (which is a Vulkan-on-Metal driver) and I have no Mac to verify the base build even compiles. Happy to widen this if someone can confirm.
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Package has no `./result/bin/`; tested instead via `vulkaninfo` that it is loading the built `VK_LAYER_KHRONOS_profiles` vulkan layer successfully on real hardware. Also automated this test as `passthru.tests.layer-loads` above on a software driver.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[Vulkan-Profiles]: https://github.com/KhronosGroup/Vulkan-Profiles/
[Khronos Group]: https://www.khronos.org/
[Vulkan Profiles mechanism]: https://docs.vulkan.org/guide/latest/vulkan_profiles.html