### PR TITLE
tcl: Cross compile to MinGW and Cygwin

### DIFF
--- a/pkgs/development/interpreters/tcl/8.6-windows-disable-tzdata.patch
+++ b/pkgs/development/interpreters/tcl/8.6-windows-disable-tzdata.patch
@@ -1,0 +1,66 @@
+Backport of [4bd630]: --without-tzdata on windows
+
+Upstream fixed this on core-9-0-branch in check-in fd06472ef41e1d73:
+https://core.tcl-lang.org/tcl/info/fd06472ef41e1d73
+
+This branch's `win` build system is older -- `configure.in` rather than
+`configure.ac`, and no `INSTALL_*` target variables to hang this off --
+so this is the same option rather than the same diff.
+
+--- a/win/configure.in
++++ b/win/configure.in
+@@ -457,6 +457,34 @@
+ AC_SUBST(MAKE_DLL)
+ AC_SUBST(MAKE_EXE)
+ 
++#--------------------------------------------------------------------
++#	Timezone data
++#--------------------------------------------------------------------
++
++AC_MSG_CHECKING([for timezone data])
++AC_ARG_WITH(tzdata,
++    AC_HELP_STRING([--with-tzdata],
++	[install timezone data (default: yes)]),
++    [tcl_ok=$withval], [tcl_ok=yes])
++#
++# Unlike on Unix there is no system copy to fall back on, so the default is
++# to install ours. Saying no is for a build that supplies the data by some
++# other means.
++#
++case $tcl_ok in
++    no)
++	AC_MSG_RESULT([supplied by other means])
++    ;;
++    yes)
++	AC_MSG_RESULT([supplied by Tcl])
++	INSTALL_TZDATA=install-tzdata
++    ;;
++    *)
++	AC_MSG_ERROR([invalid argument: $tcl_ok])
++    ;;
++esac
++AC_SUBST(INSTALL_TZDATA)
++
+ # empty on win, but needs sub'ing
+ AC_SUBST(TCL_BUILD_LIB_SPEC)
+ AC_SUBST(TCL_CC_SEARCH_FLAGS)
+--- a/win/Makefile.in
++++ b/win/Makefile.in
+@@ -176,6 +176,8 @@
+ # it can be required to run make dist.
+ TCL_EXE			= @TCL_EXE@
+ 
++INSTALL_TZDATA		= @INSTALL_TZDATA@
++
+ @SET_MAKE@
+ 
+ # Setting the VPATH variable to a list of paths will cause the Makefile to
+@@ -702,7 +704,7 @@
+ 	    $(COPY) $(REG_LIB_FILE) "$(LIB_INSTALL_DIR)/reg${REGDOTVER}"; \
+ 	    fi
+ 
+-install-libraries: libraries install-tzdata install-msgs
++install-libraries: libraries $(INSTALL_TZDATA) install-msgs
+ 	@for i in "$(prefix)/lib" "$(INCLUDE_INSTALL_DIR)" \
+ 		"$(SCRIPT_INSTALL_DIR)" "$(MODULE_INSTALL_DIR)"; \
+ 	    do \

--- a/pkgs/development/interpreters/tcl/8.6.nix
+++ b/pkgs/development/interpreters/tcl/8.6.nix
@@ -1,4 +1,10 @@
-{ callPackage, fetchurl, ... }@args:
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchurl,
+  ...
+}@args:
 
 callPackage ./generic.nix (
   args
@@ -12,5 +18,12 @@ callPackage ./generic.nix (
       url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
       hash = "sha256-kcuPphdxxjwmLvtVMFm3x61nV6+lhXr2Jl5LC9wqFKU=";
     };
+
+    # Backport of upstream check-in `fd06472ef41e1d73`; see the patch.
+    # TODO apply unconditionally; only `win` is patched, but doing so
+    # today would be a mass rebuild for a no-op elsewhere.
+    patches = lib.optionals stdenv.hostPlatform.isWindows [
+      ./8.6-windows-disable-tzdata.patch
+    ];
   }
 )

--- a/pkgs/development/interpreters/tcl/9.0.nix
+++ b/pkgs/development/interpreters/tcl/9.0.nix
@@ -1,4 +1,11 @@
-{ callPackage, fetchzip, ... }@args:
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchpatch,
+  fetchzip,
+  ...
+}@args:
 
 callPackage ./generic.nix (
   args
@@ -12,5 +19,25 @@ callPackage ./generic.nix (
       url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
       hash = "sha256-2yfj4ddGX/QT601NKG5y30LToMBu3jomFGnNUdzRaNw=";
     };
+
+    # Gives the `win` build system the `--with-tzdata` the `unix` one always
+    # had. Drop once a 9.0.x release carries it.
+    #
+    # `includes` leaves out `win/configure`: it is generated, and we run
+    # `autoreconf` over the patched `configure.ac` ourselves.
+    #
+    # TODO apply unconditionally; only `win` is patched, but doing so
+    # today would be a mass rebuild for a no-op elsewhere.
+    patches = lib.optionals stdenv.hostPlatform.isWindows [
+      (fetchpatch {
+        name = "windows-disable-tzdata.patch";
+        url = "https://github.com/tcltk/tcl/commit/54b509164606717adb3fbeacf71524f0a6e940f4.patch";
+        includes = [
+          "win/configure.ac"
+          "win/Makefile.in"
+        ];
+        hash = "sha256-jEyT8GI8ZXNzL9OTX1z58fX8qlcixGwNlhFqxMiMga8=";
+      })
+    ];
   }
 )

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -64,10 +64,6 @@ let
         # Don't install tzdata because NixOS already has a more up-to-date copy.
         "--with-tzdata=no"
       ]
-      ++ lib.optionals (lib.versionOlder version "8.6") [
-        # configure check broke due to GCC 14
-        "ac_cv_header_stdc=yes"
-      ]
       ++ lib.optionals (lib.versionAtLeast version "9.0") [
         # By default, tcl libraries get zipped and embedded into libtcl*.so,
         # which gets `zipfs mount`ed at runtime. This is fragile (for example

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -3,7 +3,9 @@
   stdenv,
   callPackage,
   makeSetupHook,
+  buildPackages,
   runCommand,
+  autoreconfHook,
   tzdata,
   zip,
   zlib,
@@ -13,6 +15,7 @@
   version,
   src,
   extraPatch ? "",
+  patches ? [ ],
   ...
 }:
 
@@ -28,6 +31,8 @@ let
 
     setOutputFlags = false;
 
+    inherit patches;
+
     postPatch = ''
       substituteInPlace library/clock.tcl \
         --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
@@ -35,33 +40,101 @@ let
         --replace "/usr/lib/zoneinfo" "" \
         --replace "/usr/local/etc/zoneinfo" ""
     ''
+    # A shared Cygwin build tries to configure the windows build system
+    # to separately build these DLLs so it can load them later. That's
+    # not gonna work for us --- in Nixpkgs this would need to be a
+    # separate derivation with a separate wrapped C compiler --- so
+    # let's just drop this for now.
+    #
+    # Matching just the recursive `make` and not the whole `( cd ...; ... )`
+    # around it: 8.6 writes that without inner spaces and 9.0 with, and the
+    # part we care about is the same either way.
+    + lib.optionalString stdenv.hostPlatform.isCygwin ''
+      substituteInPlace unix/Makefile.in \
+        --replace-fail "\''${MAKE} winextensions" true
+    ''
     + extraPatch;
 
-    nativeBuildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
-      # Only used to detect the presence of zlib. Could be replaced with a stub.
-      zip
-    ];
+    nativeBuildInputs =
+      lib.optionals (lib.versionAtLeast version "9.0") [
+        # Only used to detect the presence of zlib. Could be replaced with a stub.
+        zip
+      ]
+      # In the windows build, `install-msgs` (and `install-tzdata`, but
+      # we don't do that) are done via TCL not via shell. This is for
+      # the sake of the "build = host = windows" case; we are merely
+      # doing build = unix, host = windows, where the old shell way would
+      # have worked.
+      ++ lib.optionals (stdenv.hostPlatform.isWindows && stdenv.buildPlatform != stdenv.hostPlatform) [
+        buildPackages.tcl
+      ]
+      # `patches` touches `configure.in`/`configure.ac` only, so the generated
+      # `configure` the tarball ships has to be rebuilt. The default hook is
+      # the newest autoconf that works for both, 8.6's 2.59-era
+      # `configure.in` included.
+      #
+      # TODO make unconditional, which means `preAutoreconf` must `cd unix`
+      # too. Only `win` needs regenerating today.
+      ++ lib.optionals stdenv.hostPlatform.isWindows [
+        autoreconfHook
+      ];
 
     buildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
       zlib
     ];
 
-    preConfigure = ''
+    # Windows has its own build system under `win`, autoconf like the one under
+    # `unix` but with its own `Makefile.in` and a smaller set of options. Cygwin
+    # is not Windows for this purpose: it is POSIX enough for the `unix` one.
+    #
+    # Whichever phase reaches it first does the `cd`; on Windows that is
+    # `autoreconfPhase`, below.
+    preConfigure = lib.optionalString (!stdenv.hostPlatform.isWindows) ''
       cd unix
     '';
 
+    # `null`, not `""`: an empty string is still a variable, and adding one to
+    # every other platform's derivation is a mass rebuild for nothing.
+    preAutoreconf =
+      if stdenv.hostPlatform.isWindows then
+        ''
+          cd win
+        ''
+      else
+        null;
+
+    # No `--install`: there is no automake here, and letting `autoreconf`
+    # regenerate `aclocal.m4` would lose the `tcl.m4` the build depends on.
+    autoreconfFlags = if stdenv.hostPlatform.isWindows then "--force --verbose" else null;
+
     # Note: pre-9.0 flags are temporarily interspersed to avoid a mass rebuild.
     configureFlags =
-      lib.optionals (lib.versionOlder version "9.0") [
+      lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+        # TODO make this unconditional
+        "tcl_cv_sys_version=${stdenv.hostPlatform.uname.system}"
+      ]
+      ++ lib.optionals (lib.versionOlder version "9.0") [
+        # Unlike the two `versionOlder` gates below, this one is real: enabled
+        # is merely the default pre-9.0, and 9.0 dropped the option entirely
+        # because threads are always on there.
         "--enable-threads"
       ]
       ++ [
         # Note: using $out instead of $man to prevent a runtime dependency on $man.
         "--mandir=${placeholder "out"}/share/man"
       ]
-      ++ lib.optionals (lib.versionOlder version "9.0") [
+      # Does not exist in the `win` build system.
+      #
+      # TODO drop the `versionOlder` here too, same mistake as below.
+      ++ lib.optionals (lib.versionOlder version "9.0" && !stdenv.hostPlatform.isWindows) [
         "--enable-man-symlinks"
-        # Don't install tzdata because NixOS already has a more up-to-date copy.
+      ]
+      # Don't install tzdata because NixOS already has a more up-to-date copy.
+      #
+      # TODO drop the `versionOlder`. 9.0 still has `--with-tzdata`; it was
+      # gated by mistake in ec6950e63a74, along with `--enable-threads` which
+      # really did go away. Correcting it rebuilds 9.0.
+      ++ lib.optionals (lib.versionOlder version "9.0" || stdenv.hostPlatform.isWindows) [
         "--with-tzdata=no"
       ]
       ++ lib.optionals (lib.versionAtLeast version "9.0") [
@@ -103,19 +176,44 @@ let
 
     enableParallelBuilding = true;
 
+    # TODO make this `lib.optionals` next rebuilds
+    allowedImpureDLLs =
+      if stdenv.hostPlatform.isWindows then
+        [ ]
+      else if stdenv.hostPlatform.isCygwin then
+        [ "USER32.dll" ]
+      else
+        null;
+
     postInstall =
       let
+        exeExtension = stdenv.hostPlatform.extensions.executable;
         dllExtension = stdenv.hostPlatform.extensions.sharedLibrary;
         staticExtension = stdenv.hostPlatform.extensions.staticLibrary;
+        # The `win` build system drops the dot from the version when naming
+        # files, so `tclsh86.exe` rather than `tclsh8.6`.
+        infix =
+          if stdenv.hostPlatform.isWindows then lib.replaceStrings [ "." ] [ "" ] release else release;
+        # On Cygwin, shared libs are in the bin directory. TODO dedup
+        # with this other packages, consider doing the same or Mingw.
+        # See #431820.
+        linkDir = if !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isCygwin then "bin" else "lib";
+        linkExtension = if stdenv.hostPlatform.isWindows then "${dllExtension}.a" else dllExtension;
+        # Tcl 9 names its Cygwin DLL the way that platform does, `cygtcl9.0.dll`;
+        # 8.6 called it `libtcl8.6.dll`. See the Cygwin `SHLIB_LD` in 9.0's
+        # `unix/tcl.m4`, which rewrites `cyg%.dll` to `lib%.dll` for the import
+        # library. Only the DLL is affected, not the static or import library.
+        dllPrefix =
+          if stdenv.hostPlatform.isCygwin && lib.versionAtLeast version "9.0" then "cyg" else "lib";
       in
       ''
         make install-private-headers
-        ln -s $out/bin/tclsh${release} $out/bin/tclsh
-        if [[ -e $out/lib/libtcl${release}${staticExtension} ]]; then
-          ln -s $out/lib/libtcl${release}${staticExtension} $out/lib/libtcl${staticExtension}
+        ln -s $out/bin/tclsh${infix}${exeExtension} $out/bin/tclsh${exeExtension}
+        if [[ -e $out/lib/libtcl${infix}${staticExtension} ]]; then
+          ln -s $out/lib/libtcl${infix}${staticExtension} $out/lib/libtcl${staticExtension}
         fi
         ${lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-          ln -s $out/lib/libtcl${release}${dllExtension} $out/lib/libtcl${dllExtension}
+          ln -s $out/${linkDir}/${dllPrefix}tcl${infix}${linkExtension} $out/lib/libtcl${linkExtension}
         ''}
       '';
 

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -89,10 +89,6 @@ tcl.mkTclDerivation {
 
   inherit tcl;
 
-  env = lib.optionalAttrs (lib.versionOlder tcl.version "8.6") {
-    NIX_CFLAGS_COMPILE = "-std=gnu17";
-  };
-
   passthru = rec {
     inherit (tcl) release version;
     libPrefix = "tk${tcl.release}";


### PR DESCRIPTION
Tcl has two separate build systems, in `win` and `unix`, which makes it hard to avoid conditional soup here. Cygwin is not Windows for this purpose -- it is POSIX enough to use the `unix` one -- so this is really three configurations, not two. MinGW gets the `win` one: its own configure directory, a smaller set of options, `tclsh86.exe` rather than `tclsh8.6`, and a native `tcl` to run `install-msgs`, which is written in Tcl there.

`win` had no `--with-tzdata`, so nothing could tell it to skip the timezone data we already have. I filed https://core.tcl-lang.org/tcl/tktview/4bd630f167e6708a48656a4db0e1f8ba01a642c5 and Jan Nijtmans fixed it, so 9.0 takes a `fetchpatch` of the upstream commit (from the git mirror, the fossil original is behind captchas) and 8.6 a backport of the same option. Both touch only `configure.ac`/`configure.in` and `Makefile.in`, leaving the generated `configure` to `autoreconfHook`. `--with-tzdata=no` therefore works everywhere now, rather than being something the `win` build could not be told.

`configureFlags` is still a mess of version and platform gates, some of them mistakes rather than intent, but untangling it is a mass rebuild. I will do that separately to staging. Nothing here changes an existing native derivation: it is all gated on `isWindows` or `isCygwin`.

Assisted-by: Claude Code (Claude Opus 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
     - [x] Mingw cross
     - [x] Cygwin cross 
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
