### PR TITLE
python3Packages.shtab

### DIFF
--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenvNoCC,
   buildPythonPackage,
   fetchFromGitHub,
+  installShellFiles,
   pytestCheckHook,
   pytest-cov-stub,
   setuptools,
@@ -24,6 +26,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    installShellFiles
     setuptools
     setuptools-scm
   ];
@@ -37,6 +40,14 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "shtab" ];
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    for SUPPORTED_SHELL in "bash" "fish" "zsh"; do
+      installShellCompletion \
+        --cmd shtab \
+        "--$SUPPORTED_SHELL" <("$out/bin/shtab" --print-own-completion "$SUPPORTED_SHELL")
+    done
+  '';
 
   meta = {
     description = "Automagic shell tab completion for Python CLI applications";

--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -7,6 +7,8 @@
   setuptools,
   setuptools-scm,
   bashInteractive,
+  fish,
+  zsh,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -28,8 +30,10 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     bashInteractive
+    fish
     pytestCheckHook
     pytest-cov-stub
+    zsh
   ];
 
   pythonImportsCheck = [ "shtab" ];

--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "shtab";
-  version = "1.9.2";
+  version = "1.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tqdm";
     repo = "shtab";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+9M0IfiD5CJcg4AHqCfq1UON/E63etwzvx7Gc82H0PE=";
+    hash = "sha256-O4F7fW+anH/DVqLFpOlPlHX9dAv4S3sG6SAYZkyOdUw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytest-timeout,
   pytestCheckHook,
   pytest-cov-stub,
   setuptools,
@@ -29,7 +28,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     bashInteractive
-    pytest-timeout
     pytestCheckHook
     pytest-cov-stub
   ];


### PR DESCRIPTION
- **python3Packages.shtab: 1.9.2 -> 1.10.0**
  Diff: https://github.com/tqdm/shtab/compare/v1.9.2...v1.10.0
  
  Release note for v1.9.3: https://github.com/tqdm/shtab/releases/tag/v1.9.3
  Release note for v1.10.0: https://github.com/tqdm/shtab/releases/tag/v1.10.0
  

- **python3Packages.shtab: remove unused pytest-timeout dep**
  

- **python3Packages.shtab: test with fish and zsh too**
  

- **python3Packages.shtab: install completions for shtab command**
  