### PR TITLE
python3Packages.shtab: 1.9.2 -> 1.11.0

### DIFF
--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -8,6 +8,7 @@
   pytest-cov-stub,
   setuptools,
   setuptools-scm,
+  versionCheckHook,
   bashInteractive,
   fish,
   zsh,
@@ -36,6 +37,7 @@ buildPythonPackage (finalAttrs: {
     fish
     pytestCheckHook
     pytest-cov-stub
+    versionCheckHook
     zsh
   ];
 

--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -7,6 +7,8 @@
   setuptools,
   setuptools-scm,
   bashInteractive,
+  fish,
+  zsh,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -28,8 +30,10 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     bashInteractive
+    fish
     pytestCheckHook
     pytest-cov-stub
+    zsh
   ];
 
   pythonImportsCheck = [ "shtab" ];

--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenvNoCC,
   buildPythonPackage,
   fetchFromGitHub,
+  installShellFiles,
   pytestCheckHook,
   pytest-cov-stub,
   setuptools,
@@ -24,6 +26,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    installShellFiles
     setuptools
     setuptools-scm
   ];
@@ -37,6 +40,13 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "shtab" ];
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd shtab \
+        --bash <("$out/bin/shtab" --print-own-completion bash) \
+        --fish <("$out/bin/shtab" --print-own-completion fish) \
+        --zsh <("$out/bin/shtab" --print-own-completion zsh)
+  '';
 
   meta = {
     description = "Automagic shell tab completion for Python CLI applications";

--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytest-timeout,
   pytestCheckHook,
   pytest-cov-stub,
   setuptools,
@@ -29,7 +28,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     bashInteractive
-    pytest-timeout
     pytestCheckHook
     pytest-cov-stub
   ];

--- a/pkgs/development/python-modules/shtab/default.nix
+++ b/pkgs/development/python-modules/shtab/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "shtab";
-  version = "1.9.2";
+  version = "1.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tqdm";
     repo = "shtab";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+9M0IfiD5CJcg4AHqCfq1UON/E63etwzvx7Gc82H0PE=";
+    hash = "sha256-mbki7g0BuMfrSa107nXuvySbxp1AVhGfWFJSVQe6sYE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- **python3Packages.shtab: 1.9.2 -> 1.11.0**
  Diff: https://github.com/tqdm/shtab/compare/v1.9.2...v1.11.0
  Release note for v1.9.3: https://github.com/tqdm/shtab/releases/tag/v1.9.3
  Release note for v1.10.0: https://github.com/tqdm/shtab/releases/tag/v1.10.0
  Release note for v1.11.0: https://github.com/tqdm/shtab/releases/tag/v1.11.0
- **python3Packages.shtab: remove unused pytest-timeout dep**
- **python3Packages.shtab: test with fish and zsh too**
- **python3Packages.shtab: install completions for shtab command**
- **python3Packages.shtab: use versionCheckHook**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
