### PR TITLE
nunicode: 1.11.1 -> 1.12

### DIFF
--- a/pkgs/by-name/nu/nunicode/package.nix
+++ b/pkgs/by-name/nu/nunicode/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nunicode";
-  version = "1.11.1";
+  version = "1.12";
 
   strictDeps = true;
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "alekseyt";
     repo = "nunicode";
     tag = finalAttrs.version;
-    hash = "sha256-73jkbWbQGSya4hf+/5c2bpJsRmncgjA2m+6bud2UN0A=";
+    hash = "sha256-lYGO9WWywh3nJb7yryOnivw9MLYaldmPUr5/Pq5aie8=";
   };
 
   postPatch = ''
@@ -47,31 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ sqlite ];
 
-  # avoid name-clash on case-insensitive filesystems
-  cmakeBuildDir = "build-dir";
-
-  cmakeFlags = [
-    # fix compatibility with CMake (https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)
-    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "4.0")
-  ];
+  cmakeFlags = [ (lib.cmakeBool "NU_BUILD_SQLITE3_EXT" true) ];
 
   doCheck = true;
 
-  checkPhase = ''
-    runHook preCheck
-
-    (
-    echo running SQLite testsuite
-
-    cd sqlite3
-    RESULT=$(../../sqlite3/testsuite < ../../sqlite3/tests.sql | sqlite3)
-    grep <<<$RESULT FAILED && echo SQLite testsuite failed && false
-
-    echo SQLite testsuite succeeded
-    )
-
-    runHook postCheck
-  '';
+  checkTarget = "nusqlite3_test";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/nu/nunicode/package.nix
+++ b/pkgs/by-name/nu/nunicode/package.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "nunicode";
   version = "1.11.1";
 
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
   outputs = [
     "out"
     "sqlite"
@@ -37,10 +41,11 @@ stdenv.mkDerivation (finalAttrs: {
       'install(TARGETS nusqlite3 DESTINATION "${placeholder "sqlite"}/lib")'
   '';
 
-  nativeBuildInputs = [
-    cmake
-    sqlite
-  ];
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ sqlite ];
+
+  nativeCheckInputs = [ sqlite ];
 
   # avoid name-clash on case-insensitive filesystems
   cmakeBuildDir = "build-dir";


### PR DESCRIPTION
https://bitbucket.org/alekseyt/nunicode/src/1.12/CHANGELOG
https://bitbucket.org/alekseyt/nunicode/branches/compare/refs/tags/1.12%0Drefs/tags/1.11.1

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 553029`
Commit: `fe6ce2a70b436212a7e2b360367bbcdb4780214d`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>audiobookshelf</li>
    <li>nunicode</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test