### PR TITLE
open-adventure: 1.20 -> 1.22

### DIFF
--- a/pkgs/by-name/op/open-adventure/package.nix
+++ b/pkgs/by-name/op/open-adventure/package.nix
@@ -8,26 +8,27 @@
   cppcheck,
   coreutils,
   asciidoctor,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "open-adventure";
-  version = "1.20";
+  version = "1.22";
   src = fetchFromGitLab {
     owner = "esr";
     repo = "open-adventure";
     tag = finalAttrs.version;
-    hash = "sha256-xbsMz99CNLhpM6BSJVcRzxPB6tUYfPy/3Z+8BKt8b1E=";
+    hash = "sha256-mms4mSnJnXirnzw2UtIsnqejS2iyoNGQ5k1Ghvn2Ajc=";
   };
 
   nativeBuildInputs = [
     python3Packages.python
+    python3Packages.pyyaml
     pkg-config
     asciidoctor
   ];
 
   buildInputs = [
-    python3Packages.pyyaml
     libedit
   ];
 
@@ -40,10 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs --build make_dungeon.py
-
-    # https://gitlab.com/esr/open-adventure/-/issues/70
-    substituteInPlace Makefile --replace-fail "--template " "--template="
-
     substituteInPlace tests/tapview --replace-fail "/bin/echo" ${lib.getExe' coreutils "echo"}
   '';
 
@@ -62,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Forward-port of the Crowther/Woods Adventure 2.5 game from 1995";


### PR DESCRIPTION
https://gitlab.com/esr/open-adventure/-/raw/master/NEWS.adoc

Nix changes
- Added automatic package updates with nix-update-script
- Moved pyyaml from buildInputs to nativeBuildInputs


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

- Reviewed points:
   - [X] package name fits guidelines
   - [X] package version fits guidelines
   - [X] package builds on x86_64-linux
   - [X] executables tested on x86_64-linux
   - [X] any change of upstream are verified
   - [X] the motives for any special packaging choices are documented
   - [ ] all depending packages build
   - [ ] patches have a comment describing either the upstream URL or a reason why the patch wasn't upstreamed
   - [ ] patches that are remotely available are fetched rather than vendored