### PR TITLE
nixos/tandoor-recipes: add secretKeyFile option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -207,6 +207,8 @@
     and the default changed to a UNIX domain socket.
   - A cookie-cutter nginx vhost can be enabled at [](#opt-services.netbox.nginx.enable).
 
+- [services.tandoor-recipes](#opt-services.tandoor-recipes.enable) now has a [secretKeyFile](#opt-services.tandoor-recipes.secretKeyFile) option.
+
 - The [monero](#opt-services.monero.enable) systemd service has been security hardened.
 
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.

--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -26,11 +26,21 @@ let
   manage = pkgs.writeShellScript "manage" ''
     set -o allexport # Export the following env vars
     ${lib.toShellVars env}
+    if [ -f "${cfg.secretKeyFile}" ]; then
+      SECRET_KEY=$(cat "${cfg.secretKeyFile}")
+    fi
     # UID is a read-only shell variable
     eval "$(${config.systemd.package}/bin/systemctl show -pUID,GID,MainPID tandoor-recipes.service | tr '[:upper:]' '[:lower:]')"
     exec ${pkgs.util-linux}/bin/nsenter \
       -t $mainpid -m -S $uid -G $gid --wdns=${stateDir} \
       ${pkg}/bin/tandoor-recipes "$@"
+  '';
+
+  start = pkgs.writeShellScript "start" ''
+    if [ -z "''${CREDENTIALS_DIRECTORY}/tandoor_secret_key" ]; then
+      export SECRET_KEY=$(cat "''${CREDENTIALS_DIRECTORY}/tandoor_secret_key")
+    fi
+    ${pkg.python.pkgs.gunicorn}/bin/gunicorn recipes.wsgi
   '';
 in
 {
@@ -79,6 +89,12 @@ in
       example = {
         ENABLE_SIGNUP = "1";
       };
+    };
+
+    secretKeyFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to file containing the secret key.";
+      example = "config.age.secrets.tandoor-secret-key.path";
     };
 
     user = lib.mkOption {
@@ -130,7 +146,7 @@ in
 
       serviceConfig = {
         ExecStart = ''
-          ${pkg.python.pkgs.gunicorn}/bin/gunicorn recipes.wsgi
+          ${start}
         '';
         Restart = "on-failure";
 
@@ -142,6 +158,7 @@ in
         ++ lib.optional (env.MEDIA_ROOT == "/var/lib/tandoor-recipes/media") "tandoor-recipes/media";
         WorkingDirectory = stateDir;
         RuntimeDirectory = "tandoor-recipes";
+        LoadCredential = "tandoor_secret_key:${cfg.secretKeyFile}";
 
         BindReadOnlyPaths = [
           "${config.security.pki.caBundle}:/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
Allows the Django secret key to be passed securely as a systemd credential instead of set in plain-text in the Nix store in the process Environment.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
