### PR TITLE
coin3d: link zlib instead of dlopening it at runtime

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19198,6 +19198,12 @@
     githubId = 42215704;
     name = "Moritz Böhme";
   };
+  mornepousse = {
+    email = "mornepousse.untitled262@passmail.com";
+    github = "mornepousse";
+    githubId = 48982737;
+    name = "Mae PUGIN";
+  };
   mortenmunk = {
     email = "mortenmunk97@gmail.com";
     github = "MortenMunk";

--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -8,6 +8,7 @@
   libGLU,
   libx11,
   expat,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,11 +29,15 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libGLU
     expat
+    zlib
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libx11;
 
   cmakeFlags = [
     (lib.cmakeBool "USE_EXTERNAL_EXPAT" true)
+    # Coin dlopens zlib by bare name at runtime otherwise, which never resolves
+    # on NixOS, so gzip-compressed VRML (.wrz) silently fails to load.
+    (lib.cmakeBool "ZLIB_RUNTIME_LINKING" false)
   ];
 
   meta = {

--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "High-level, retained-mode toolkit for effective 3D graphics development";
     mainProgram = "coin-config";
     license = lib.licenses.bsd3;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ mornepousse ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Coin builds with `ZLIB_RUNTIME_LINKING` on by default, which makes it `dlopen`
zlib by bare name at runtime (`src/glue/zlib.cpp` tries `"zlib1"`, `"zlib"`,
`"libz"`, `"libz.so"`). That never resolves on NixOS, so gzip-compressed VRML
(`.wrz`) silently fails to load — Coin says so on stderr, which GUI apps
swallow:

```
Coin error in zlib glue(): Unable to load zlib DLL/shared object.
Coin warning in SoInput_Reader::createReader(): File seems to be in gzip
format, but zlib support is not available.
Coin read error: Not a valid Inventor file.
```

Upstream provides the switch for exactly this, so linking zlib normally is a
two-line change.

### Before / after

Reading a plain `.wrl` and the same file gzipped as `.wrz`, via pivy:

```python
from pivy import coin
i = coin.SoInput(); i.openFile(path)
node = coin.SoDB.readAll(i)
```

|        | `.wrl` | `.wrz` |
|--------|--------|--------|
| before | 1 node | read fails |
| after  | 1 node | 1 node |

And the library actually links it now:

```
libz.so.1 => /nix/store/...-zlib-1.3.2/lib/libz.so.1
```

Also checked in the FreeCAD GUI (built against this change): a `.wrz` that
displayed nothing now renders.

### Scope

This addresses the FreeCAD side of #257313. That issue also mentions KiCad, but
kicad does not depend on coin3d — its `.wrz` handling is separate and not
touched here.

Flathub hit the same thing in their sandbox and came to the same conclusion
("I think we should disable the dynamic loading"):
https://github.com/flathub/org.freecad.FreeCAD/issues/11


---

Disclosure per the automation/AI policy: prepared with Claude Code (Claude Opus 5)
— investigation, the before/after testing above, and this summary. I made the
change, reviewed it, and verified the fix in the FreeCAD GUI myself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
