### PR TITLE
arrow-cpp: fix test race; retry failed tests twice

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -329,7 +329,16 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       runHook preInstallCheck
 
-      ctest -L unittest --exclude-regex '^(${lib.concatStringsSep "|" disabledTests})$'
+      ctestArgs=(
+        -L unittest
+        --exclude-regex '^(${lib.concatStringsSep "|" disabledTests})$'
+      )
+
+      # Match ci/scripts/cpp_test.sh to fight flakiness.
+      # https://github.com/apache/arrow/issues/40121
+      ctestArgs+=(--repeat until-pass:3)
+
+      ctest "''${ctestArgs[@]}"
 
       runHook postInstallCheck
     '';

--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  fetchpatch,
   fetchFromGitHub,
   fixDarwinDylibNames,
   apache-orc,
@@ -94,6 +95,16 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   sourceRoot = "${finalAttrs.src.name}/cpp";
+
+  patches = [
+    # Fix flaky test racing on (not) waiting for azurite
+    # https://github.com/apache/arrow/pull/50878
+    (fetchpatch {
+      url = "https://github.com/apache/arrow/commit/e6a89be6c7cc537b04844796bd84ac8240942050.patch";
+      hash = "sha256-hB2ebq6a64FPBZeg7aS+tSZZIzhFs3w9A3n2NK+/ob8=";
+    })
+  ];
+  patchFlags = [ "-p2" ];
 
   # versions are all taken from
   # https://github.com/apache/arrow/blob/apache-arrow-${version}/cpp/thirdparty/versions.txt


### PR DESCRIPTION
Hydra log: https://hydra.nixos.org/log/gddq769pa1lyj3x3fnm9c0m13k26qsci-arrow-cpp-23.0.0.drv

Tested builds for x86_64-linux and Darwin on staging-next.

Commits:
- **arrow-cpp: fix test racing on (not) waiting for azurite**
- **arrow-cpp: retry failed tests twice**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
