### PR TITLE
octavePackages.signal: 1.4.7 -> 1.4.8

### DIFF
--- a/pkgs/development/octave-modules/signal/default.nix
+++ b/pkgs/development/octave-modules/signal/default.nix
@@ -11,13 +11,13 @@
 
 buildOctavePackage rec {
   pname = "signal";
-  version = "1.4.7";
+  version = "1.4.8";
 
   src = fetchFromGitHub {
     owner = "gnu-octave";
     repo = "octave-signal";
-    tag = "${version}";
-    sha256 = "sha256-4E57x2hweO1TfpjBRRvsyQA/o83XJLrRKa5vqUA0t3s=";
+    tag = version;
+    sha256 = "sha256-0Nq/3TDsJ9b14so99z8Y9864JZThfORn4Bc8rtfMnBk=";
   };
 
   requiredOctavePackages = [

--- a/pkgs/development/octave-modules/signal/default.nix
+++ b/pkgs/development/octave-modules/signal/default.nix
@@ -3,6 +3,9 @@
   lib,
   fetchFromGitHub,
   control,
+  gnuplot,
+  makeFontsConf,
+  writableTmpDirAsHomeHook,
   nix-update-script,
 }:
 
@@ -20,6 +23,15 @@ buildOctavePackage rec {
   requiredOctavePackages = [
     control
   ];
+
+  nativeOctavePkgTestInputs = [
+    gnuplot
+    writableTmpDirAsHomeHook
+  ];
+
+  octavePkgTestEnv.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/signal/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates the `passthru.test` environment for `octavePackages.signal` so that r-ryantm's automatic update to `octavePackages.signal` (#553028) passes all unit tests in `passthru.tests`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
