### PR TITLE
ceph.tests: Fix dashboard test timeout, move it to bluestore test

### DIFF
--- a/nixos/tests/ceph-single-node-bluestore.nix
+++ b/nixos/tests/ceph-single-node-bluestore.nix
@@ -92,6 +92,10 @@ let
           cfg.osd2.name
         ];
       };
+      rgw = {
+        enable = true;
+        daemons = [ cfg.monA.name ];
+      };
     };
   };
 
@@ -100,6 +104,8 @@ let
   # For other ways to deploy a ceph cluster, look at the documentation at
   # https://docs.ceph.com/docs/master/
   testScript = ''
+    import json
+
     start_all()
 
     monA.wait_for_unit("network.target")
@@ -194,6 +200,16 @@ let
         "ceph osd pool delete single-node-other-test single-node-other-test --yes-i-really-really-mean-it",
     )
 
+    # Bootstrap RGW
+    monA.succeed(
+        "sudo -u ceph mkdir -p /var/lib/ceph/radosgw/ceph-${cfg.monA.name}",
+        "ceph auth get-or-create client.${cfg.monA.name} osd 'allow rwx' mon 'allow rw' > /var/lib/ceph/radosgw/ceph-${cfg.monA.name}/keyring",
+        "chown ceph:ceph /var/lib/ceph/radosgw/ceph-${cfg.monA.name}/keyring",
+        "systemctl start ceph-rgw-${cfg.monA.name}",
+    )
+    monA.wait_for_unit("ceph-rgw-${cfg.monA.name}")
+    monA.wait_for_open_port(7480)
+
     # Shut down ceph by stopping ceph.target.
     monA.succeed("systemctl stop ceph.target")
 
@@ -204,6 +220,7 @@ let
     monA.wait_for_unit("ceph-osd-${cfg.osd0.name}")
     monA.wait_for_unit("ceph-osd-${cfg.osd1.name}")
     monA.wait_for_unit("ceph-osd-${cfg.osd2.name}")
+    monA.wait_for_unit("ceph-rgw-${cfg.monA.name}")
 
     # Ensure the cluster comes back up again
     monA.succeed("ceph -s | grep 'mon: 1 daemons'")
@@ -211,6 +228,56 @@ let
     monA.wait_until_succeeds("ceph osd stat | grep -e '3 osds: 3 up[^,]*, 3 in'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
+
+    # Enable the dashboard and recheck health
+    monA.succeed(
+        "ceph mgr module enable dashboard",
+        "ceph config set mgr mgr/dashboard/ssl false",
+        # default is 8080 but it's better to be explicit
+        "ceph config set mgr mgr/dashboard/server_port 8080",
+    )
+
+    # The dashboard does not listen on localhost:
+    # `server_addr` defaults to the wildcard address, but the dashboard module
+    # resolves that to the active mgr's own IP and binds only to it,
+    # so loopback is never bound.
+    # See https://github.com/ceph/ceph/blob/v20.2.2/src/pybind/mgr/dashboard/module.py#L213-L214
+    # Therefore address the dashboard via the mgr's IP instead of localhost.
+    dashboard = "http://${cfg.monA.ip}:8080"
+
+    monA.wait_for_open_port(8080, addr="${cfg.monA.ip}")
+    monA.wait_until_succeeds(f"curl -q --fail {dashboard}")
+    monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
+
+    # Initialize dashboard creds.
+    # In a the query below, we test the Dashboard's `/api/rgw/daemon`,
+    # which needs that the dashboard can talk to RGW.
+    # `set-rgw-credentials` needs a running RGW daemon.
+    monA.succeed(
+        "echo 'foo bar baz qux' > /tmp/dashboard_pw",
+        "ceph dashboard ac-user-create admin -i /tmp/dashboard_pw administrator",
+        "ceph dashboard set-rgw-credentials",
+    )
+
+    # Get dashboard auth token
+    auth_payload = json.dumps({"username": "admin", "password": "foo bar baz qux"})
+    auth_response = json.loads(monA.succeed(
+        f"curl --fail -s -X POST -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Content-Type: application/json' -d '{auth_payload}' {dashboard}/api/auth",
+    ))
+    token = auth_response["token"]
+
+    # Check cluster health via dashboard API
+    health = json.loads(monA.succeed(
+        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' {dashboard}/api/health/minimal",
+    ))
+    assert health["health"]["status"] == "HEALTH_OK"
+
+    # List daemons via REST API.
+    # This also requires a running RGW daemon, as it asserts on the first one.
+    rgw_daemons = json.loads(monA.succeed(
+        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' {dashboard}/api/rgw/daemon",
+    ))
+    assert rgw_daemons[0]["id"] == "${cfg.monA.name}"
   '';
 in
 {

--- a/nixos/tests/ceph-single-node-deprecated-filestore.nix
+++ b/nixos/tests/ceph-single-node-deprecated-filestore.nix
@@ -105,8 +105,6 @@ let
   # For other ways to deploy a ceph cluster, look at the documentation at
   # https://docs.ceph.com/docs/master/
   testScript = ''
-    import json
-
     start_all()
 
     monA.wait_for_unit("network.target")
@@ -229,52 +227,6 @@ let
     monA.wait_until_succeeds("ceph osd stat | grep -e '3 osds: 3 up[^,]*, 3 in'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
-
-    # Enable the dashboard and recheck health
-    monA.succeed(
-        "ceph mgr module enable dashboard",
-        "ceph config set mgr mgr/dashboard/ssl false",
-        # default is 8080 but it's better to be explicit
-        "ceph config set mgr mgr/dashboard/server_port 8080",
-    )
-
-    # The dashboard does not listen on localhost:
-    `server_addr` defaults to the wildcard address, but the dashboard module
-    # resolves that to the active mgr's own IP and binds only to it,
-    # so loopback is never bound.
-    # See https://github.com/ceph/ceph/blob/v20.2.2/src/pybind/mgr/dashboard/module.py#L213-L214
-    # Therefore address the dashboard via the mgr's IP instead of localhost.
-    dashboard = "http://${cfg.monA.ip}:8080"
-
-    monA.wait_for_open_port(8080, addr="${cfg.monA.ip}")
-    monA.wait_until_succeeds(f"curl -q --fail {dashboard}")
-    monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
-
-    # Initialize dashboard creds
-    monA.succeed(
-        "echo 'foo bar baz qux' > /tmp/dashboard_pw",
-        "ceph dashboard ac-user-create admin -i /tmp/dashboard_pw administrator",
-        "ceph dashboard set-rgw-credentials",
-    )
-
-    # Get dashboard auth token
-    auth_payload = json.dumps({"username": "admin", "password": "foo bar baz qux"})
-    auth_response = json.loads(monA.succeed(
-        f"curl --fail -s -X POST -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Content-Type: application/json' -d '{auth_payload}' {dashboard}/api/auth",
-    ))
-    token = auth_response["token"]
-
-    # Check cluster health via dashboard API
-    health = json.loads(monA.succeed(
-        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' {dashboard}/api/health/minimal",
-    ))
-    assert health["health"]["status"] == "HEALTH_OK"
-
-    # List daemons via REST API
-    rgw_daemons = json.loads(monA.succeed(
-        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' {dashboard}/api/rgw/daemon",
-    ))
-    assert rgw_daemons[0]["id"] == "a"
   '';
 in
 {

--- a/nixos/tests/ceph-single-node-deprecated-filestore.nix
+++ b/nixos/tests/ceph-single-node-deprecated-filestore.nix
@@ -237,8 +237,17 @@ let
         # default is 8080 but it's better to be explicit
         "ceph config set mgr mgr/dashboard/server_port 8080",
     )
-    monA.wait_for_open_port(8080)
-    monA.wait_until_succeeds("curl -q --fail http://localhost:8080")
+
+    # The dashboard does not listen on localhost:
+    `server_addr` defaults to the wildcard address, but the dashboard module
+    # resolves that to the active mgr's own IP and binds only to it,
+    # so loopback is never bound.
+    # See https://github.com/ceph/ceph/blob/v20.2.2/src/pybind/mgr/dashboard/module.py#L213-L214
+    # Therefore address the dashboard via the mgr's IP instead of localhost.
+    dashboard = "http://${cfg.monA.ip}:8080"
+
+    monA.wait_for_open_port(8080, addr="${cfg.monA.ip}")
+    monA.wait_until_succeeds(f"curl -q --fail {dashboard}")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
 
     # Initialize dashboard creds
@@ -251,19 +260,19 @@ let
     # Get dashboard auth token
     auth_payload = json.dumps({"username": "admin", "password": "foo bar baz qux"})
     auth_response = json.loads(monA.succeed(
-        f"curl --fail -s -X POST -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Content-Type: application/json' -d '{auth_payload}' http://localhost:8080/api/auth",
+        f"curl --fail -s -X POST -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Content-Type: application/json' -d '{auth_payload}' {dashboard}/api/auth",
     ))
     token = auth_response["token"]
 
     # Check cluster health via dashboard API
     health = json.loads(monA.succeed(
-        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' http://localhost:8080/api/health/minimal",
+        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' {dashboard}/api/health/minimal",
     ))
     assert health["health"]["status"] == "HEALTH_OK"
 
     # List daemons via REST API
     rgw_daemons = json.loads(monA.succeed(
-        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' http://localhost:8080/api/rgw/daemon",
+        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' {dashboard}/api/rgw/daemon",
     ))
     assert rgw_daemons[0]["id"] == "a"
   '';


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/548582#issuecomment-5266506577

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
