### PR TITLE
octavePackages.datatypes: 1.2.6 -> 1.3.3

### DIFF
--- a/pkgs/development/octave-modules/datatypes/default.nix
+++ b/pkgs/development/octave-modules/datatypes/default.nix
@@ -2,6 +2,9 @@
   buildOctavePackage,
   lib,
   fetchFromGitHub,
+  zip,
+  unzip,
+  writableTmpDirAsHomeHook,
   nix-update-script,
 }:
 
@@ -15,6 +18,12 @@ buildOctavePackage rec {
     tag = "release-${version}";
     sha256 = "sha256-8gOBjU9YJbS90iR/dgUzg5DHdb3x5PmEqmaDUbRZAyM=";
   };
+
+  nativeOctavePkgTestInputs = [
+    zip
+    unzip
+    writableTmpDirAsHomeHook
+  ];
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
 

--- a/pkgs/development/octave-modules/datatypes/default.nix
+++ b/pkgs/development/octave-modules/datatypes/default.nix
@@ -10,13 +10,13 @@
 
 buildOctavePackage rec {
   pname = "datatypes";
-  version = "1.2.6";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     owner = "pr0m1th3as";
     repo = "datatypes";
     tag = "release-${version}";
-    sha256 = "sha256-8gOBjU9YJbS90iR/dgUzg5DHdb3x5PmEqmaDUbRZAyM=";
+    sha256 = "sha256-Odjx44GYvQOZhPFWQ0ueKpDkXaWeN2mufpLARBhZqic=";
   };
 
   nativeOctavePkgTestInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added inputs to `passthru.tests` environment to make `octavePackages.datatypes` pass their built-in unit tests inside Nix build environments. Incorporates several r-ryantm's updaates to the `datatypes` package which have not been merged (from #546626). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
