### PR TITLE
arc-theme: reinit without gtk2 theme

### DIFF
--- a/pkgs/by-name/ar/arc-theme/package.nix
+++ b/pkgs/by-name/ar/arc-theme/package.nix
@@ -11,6 +11,7 @@
   makeFontsConf,
   cinnamon,
   gnome-shell,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -54,6 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
     # You will need to patch gdm to make use of this.
     "-Dgnome_shell_gresource=true"
   ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Flat theme with transparent elements for GTK 3, GTK 2 and Gnome Shell";

--- a/pkgs/by-name/ar/arc-theme/package.nix
+++ b/pkgs/by-name/ar/arc-theme/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  glib,
+  inkscape,
+  meson,
+  ninja,
+  python3,
+  sassc,
+  makeFontsConf,
+  cinnamon,
+  gnome-shell,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "arc-theme";
+  version = "20221218";
+
+  src = fetchFromGitHub {
+    owner = "jnsh";
+    repo = "arc-theme";
+    tag = finalAttrs.version;
+    hash = "sha256-7VmqsUCeG5GwmrVdt9BJj0eZ/1v+no/05KwGFb7E9ns=";
+  };
+
+  nativeBuildInputs = [
+    glib # for glib-compile-resources
+    inkscape
+    meson
+    ninja
+    python3
+    sassc
+  ];
+
+  postPatch = ''
+    patchShebangs meson/install-file.py
+  '';
+
+  preBuild = ''
+    # Shut up inkscape's warnings about creating profile directory
+    export HOME="$TMPDIR"
+  '';
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  mesonFlags = [
+    # Exclude gtk2 since it's no longer supported
+    "-Dthemes=cinnamon,gnome-shell,gtk3,gtk4,metacity,plank,unity,xfwm"
+    # "-Dvariants=light,darker,dark,lighter"
+    "-Dcinnamon_version=${cinnamon.version}"
+    "-Dgnome_shell_version=${gnome-shell.version}"
+    # You will need to patch gdm to make use of this.
+    "-Dgnome_shell_gresource=true"
+  ];
+
+  meta = {
+    description = "Flat theme with transparent elements for GTK 3, GTK 2 and Gnome Shell";
+    homepage = "https://github.com/jnsh/arc-theme";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      simonvandel
+      romildo
+    ];
+  };
+})

--- a/pkgs/by-name/ar/arc-theme/package.nix
+++ b/pkgs/by-name/ar/arc-theme/package.nix
@@ -14,15 +14,15 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "arc-theme";
-  version = "20221218";
+  version = "20221218-unstable-2025-10-18";
 
   src = fetchFromGitHub {
     owner = "jnsh";
     repo = "arc-theme";
-    tag = finalAttrs.version;
-    hash = "sha256-7VmqsUCeG5GwmrVdt9BJj0eZ/1v+no/05KwGFb7E9ns=";
+    rev = "94ac8c7d67d68de0cc688bbd4c3105b9815b446e";
+    hash = "sha256-vvZvJmsmeYcJT3xVQLg4tmYXEgHprWJls1fbxA3Jxnw=";
   };
 
   nativeBuildInputs = [
@@ -68,4 +68,4 @@ stdenv.mkDerivation (finalAttrs: {
       romildo
     ];
   };
-})
+}

--- a/pkgs/by-name/ar/arc-theme/package.nix
+++ b/pkgs/by-name/ar/arc-theme/package.nix
@@ -47,13 +47,25 @@ stdenv.mkDerivation {
   env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
   mesonFlags = [
-    # Exclude gtk2 since it's no longer supported
-    "-Dthemes=cinnamon,gnome-shell,gtk3,gtk4,metacity,plank,unity,xfwm"
-    # "-Dvariants=light,darker,dark,lighter"
-    "-Dcinnamon_version=${cinnamon.version}"
-    "-Dgnome_shell_version=${gnome-shell.version}"
+    (lib.mesonOption "themes" (
+      lib.concatStringsSep "," [
+        "cinnamon"
+        "gnome-shell"
+        # "gtk2" (no longer supported)
+        "gtk3"
+        "gtk4"
+        "metacity"
+        "plank"
+        "unity"
+        "xfwm"
+      ]
+    ))
+
+    (lib.mesonOption "cinnamon_version" cinnamon.version)
+    (lib.mesonOption "gnome_shell_version" gnome-shell.version)
+
     # You will need to patch gdm to make use of this.
-    "-Dgnome_shell_gresource=true"
+    (lib.mesonBool "gnome_shell_gresource" true)
   ];
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };

--- a/pkgs/by-name/ar/arc-theme/package.nix
+++ b/pkgs/by-name/ar/arc-theme/package.nix
@@ -76,8 +76,9 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      simonvandel
+      kira-bruneau
       romildo
+      simonvandel
     ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -330,7 +330,6 @@ mapAliases {
   appthreat-depscan = throw "'appthreat-depscan' has been renamed to/replaced by 'dep-scan'"; # Converted to throw 2025-10-27
   arangodb = throw "arangodb has been removed, as it was unmaintained and the packaged version does not build with supported GCC versions"; # Added 2025-08-12
   arc-browser = throw "arc-browser was removed due to being unmaintained"; # Added 2025-09-03
-  arc-theme = throw "'arc-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   arc_unpacker = throw "'arc_unpacker' has been moved to 'arc-unpacker'"; # Added 2026-07-28
   archi = throw "'archi' has been removed, since its upstream maintainers do not want it packaged"; # Added 2025-11-18
   archipelago-minecraft = throw "archipelago-minecraft has been removed, as upstream no longer ships minecraft as a default APWorld."; # Added 2025-07-15


### PR DESCRIPTION
This packaged was removed in #544598 since it depended on `gtk-engine-murrine`, but it's possible to build this without gtk2 support.

Also in this PR as separate commits:
- Add an updateScript
- Update to the latest commit (the latest release version is ~4 years out of date)
- Use lib.meson* helpers
- Add myself as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
