### PR TITLE
curl: do not ask for a host shell where there is none

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -105,8 +105,36 @@ stdenv.mkDerivation (finalAttrs: {
   # necessary for FreeBSD code path in configure
   postPatch = ''
     substituteInPlace ./config.guess --replace-fail /usr/bin/uname uname
-    patchShebangs scripts
-  '';
+  ''
+  # `wcurl` is the one thing in `scripts` that is installed, so it is the one
+  # whose shebang has to suit the host platform. The rest are only used during
+  # the build, and want this platform's shell. Say which is which rather than
+  # patch them all one way and correct it afterwards.
+  #
+  # Where the host has no shell at all, `patchShebangs --host` finds nothing
+  # and leaves the shebang as shipped, which is the best available answer.
+  #
+  # TODO: take the first branch unconditionally --- in the spirit of strictDeps,
+  # it is good to always be defensive rather than do something unnecessarily
+  # that we can only get away with when build == host.
+  + (
+    if isCross then
+      ''
+        local f flag
+        for f in scripts/*; do
+          if [[ "$f" == scripts/wcurl ]]; then
+            flag=--host
+          else
+            flag=--build
+          fi
+          patchShebangs "$flag" "$f"
+        done
+      ''
+    else
+      ''
+        patchShebangs scripts
+      ''
+  );
 
   outputs = [
     "bin"
@@ -247,19 +275,27 @@ stdenv.mkDerivation (finalAttrs: {
     ln $out/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libcurl-gnutls${stdenv.hostPlatform.extensions.sharedLibrary}.4
     ln $out/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libcurl-gnutls${stdenv.hostPlatform.extensions.sharedLibrary}.4.4.0
   ''
-  # The wcurl shell script found in `''${!outputBin}/bin`, is located in the
-  # source along with all the scripts patched in `postPatch` above.
-  # `patchShebangs` at that stage causes the host intended wcurl script to get
-  # the buildPlatform's runtimeShell shebang, instead of the hostPlatform's. To
-  # make sure this doesn't happen we disallow it, and fix it above in the
-  # postInstall, and also with the conditional hostPlatform's
-  # runtimeShellPackage added in buildInputs.
+  # `postPatch` above should have pointed everything installed at the host's
+  # shell already. Do it again over what was installed, defensively.
   + lib.optionalString isCross ''
-    patchShebangs --update --host "''${!outputBin}/bin"
+    patchShebangs --host "''${!outputBin}/bin"
   '';
+
+  # Whether we patch the shebangs in the installed script or not, we should not
+  # have build platform software in the final runtime closure.
   outputChecks.bin.disallowedReferences = lib.optional isCross buildPackages.runtimeShellPackage;
   outputChecks.out.disallowedReferences = lib.optional isCross buildPackages.runtimeShellPackage;
-  buildInputs = lib.optional isCross runtimeShellPackage;
+
+  # Some hosts have no shell for the scripts to point at: MinGW is the one in
+  # tree, where `bash` is marked unsupported because it needs a POSIX layer. We
+  # cannot patch shebangs in that case.
+  #
+  # TODO: drop the isCross part of the condition --- in the spirit of
+  # `strictDeps` it is good to have the dep (when it is available), even if it
+  # is gratuitous in the `build = host` case.
+  buildInputs = lib.optional (
+    isCross && lib.meta.availableOn stdenv.hostPlatform runtimeShellPackage
+  ) runtimeShellPackage;
 
   passthru =
     let


### PR DESCRIPTION
`wcurl` is a shell script, so a cross build rewrites its shebang to the
host's `runtimeShell` and forbids the build one from being referenced.
But for platforms that don't *have* a shell (e.g. MinGW, where `bash`
needs Cygwin or similar) we still want to build curl.

See the comments for details, but the short version is:

- Don't even temporarily patch the installed script to the build
  shell --- that would be wrong.

- Make the runtime dep conditional on a shell being available for the
  host at all. `patchShebangs --host` gracefully does nothing when it
  is not, so the call site needs no condition of its own.

- Leave the disallowed references unconditional for cross: we never
  want to pollute the runtime closure with build tools, whether or not
  we patched anything.

Assisted-by: Claude Code (Claude Opus 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

