### PR TITLE
smlnj: 2026.1 -> 2026.2

### DIFF
--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -6,16 +6,17 @@
   fetchurl,
   automake,
   autoconf,
+  cmake,
   versionCheckHook,
 }:
 let
-  version = "2026.1";
+  version = "2026.2";
   src = fetchFromGitHub {
     owner = "smlnj";
     repo = "smlnj";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-n5oWhignhFl8B/cXSO3g/KQXInZqT1A0Mp8GzLeGqNc=";
+    hash = "sha256-1oiDdiGZvg8Dlz3InFLjOilvBTShuTFHz91Xmc1onMA=";
   };
 
   llvm = callPackage ./llvm.nix { inherit src version; };
@@ -24,12 +25,12 @@ let
     if stdenv.hostPlatform.isUnix && stdenv.hostPlatform.isx86_64 then
       fetchurl {
         url = "https://smlnj.cs.uchicago.edu/dist/working/${version}/boot.amd64-unix.tgz";
-        hash = "sha256-caFguKkhFOjgJDtcOcF6YAbzFl2nQYXbtWCjvaBjL6o=";
+        hash = "sha256-ug2Busk6aYeqEGh923ZG8c3xw1Cjmct2Fxv7K44cjOs=";
       }
     else if stdenv.hostPlatform.isUnix && stdenv.hostPlatform.isAarch64 then
       fetchurl {
         url = "https://smlnj.cs.uchicago.edu/dist/working/${version}/boot.arm64-unix.tgz";
-        hash = "sha256-qygH0n163jiwm4CsltPeCCpHqnBxCHKP5O20GZyq1/0=";
+        hash = "sha256-UQ8GxaabgJ3QoH6hlnWCNSsxyR73H2VdKsbsgt376k0=";
       }
     else
       throw "Unsupported host platform: ${stdenv.hostPlatform.config}";
@@ -42,28 +43,27 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     autoconf
     automake
+    cmake
   ];
 
   __structuredAttrs = true;
   strictDeps = true;
 
-  patchPhase = ''
-    runHook prePatch
-
-    unpackFile ${bootFile}
-    mkdir -pv runtime/bin runtime/lib
-    ln -s ${llvm}/bin/llvm-config     runtime/bin/llvm-config
-    ln -s ${llvm}/lib/libCFGCodeGen.a runtime/lib/libCFGCodeGen.a
-
-    runHook postPatch
-  '';
+  dontUseCmakeConfigure = true;
 
   buildPhase = ''
     runHook preBuild
 
-    export INSTALLDIR=$out
-    mkdir -pv $out
-    ./build.sh
+    unpackFile ${bootFile}
+    mkdir -pv $out/bin $out/lib bin lib
+    ln -s ${llvm}/bin/llvm-config     bin/llvm-config
+    ln -s ${llvm}/bin/llvm-config     $out/bin/llvm-config
+    ln -s ${llvm}/lib/libCFGCodeGen.a lib/libCFGCodeGen.a
+    ln -s ${llvm}/lib/libCFGCodeGen.a $out/lib/libCFGCodeGen.a
+
+    ./build.sh -install $out
+
+    rm $out/bin/llvm-config $out/lib/libCFGCodeGen.a
 
     runHook postBuild
   '';

--- a/pkgs/development/compilers/smlnj/llvm.nix
+++ b/pkgs/development/compilers/smlnj/llvm.nix
@@ -16,8 +16,8 @@ let
 in
 stdenv.mkDerivation {
   pname = "smlnj-llvm";
-  inherit src version;
-  sourceRoot = "${src.name}/runtime/llvm21";
+  inherit version;
+  src = "${src}/runtime/llvm21";
   strictDeps = true;
   __structuredAttrs = true;
 


### PR DESCRIPTION
homepage: https://smlnj.org
changelog: https://smlnj.org/dist/working/2026.2/HISTORY.html

Outside of updating the hashes, I had to add `cmake` as a build dependency, and modify the workaround to get staged builds working properly.

I moved all the linking to the buildPhase since it requires creating temporary symlinks in `$out/bin`, and creating the directory in `patchPhase` seems wrong.

The LLVM build now uses `src = "${src}/runtime/llvm21";`, since the build never needs to traverse upwards.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
