### PR TITLE
python3Packages.pymisp: 2.5.34.1 -> 2.5.34.2

### DIFF
--- a/pkgs/development/python-modules/pymisp/default.nix
+++ b/pkgs/development/python-modules/pymisp/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pymisp";
-  version = "2.5.34.1";
+  version = "2.5.34.2";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -37,7 +37,7 @@ buildPythonPackage (finalAttrs: {
     owner = "MISP";
     repo = "PyMISP";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-68XJ6lqoNGnUneNIu0ZOKZhrumrt6CPLAt45UaZC5q0=";
+    hash = "sha256-d3veOFVQSA7jbiT02xmwIYYHdK+4gRkXOunc22YV20o=";
   };
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
Diff: https://github.com/MISP/PyMISP/compare/v2.5.34.1...v2.5.34.2

Changelog: https://github.com/MISP/PyMISP/blob/refs/tags/v2.5.34.2/CHANGELOG.txt


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
