### PR TITLE
Hexyl: install man page & shell completions

### DIFF
--- a/pkgs/by-name/he/hexyl/package.nix
+++ b/pkgs/by-name/he/hexyl/package.nix
@@ -46,10 +46,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
     homepage = "https://github.com/sharkdp/hexyl";
     changelog = "https://github.com/sharkdp/hexyl/blob/v${finalAttrs.version}/CHANGELOG.md";
-    license = with lib.licenses; [
-      asl20
-      mit
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
     maintainers = with lib.maintainers; [
       dywedir
       SuperSandro2000

--- a/pkgs/by-name/he/hexyl/package.nix
+++ b/pkgs/by-name/he/hexyl/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
+  installShellFiles,
   versionCheckHook,
   nix-update-script,
 }:
@@ -19,10 +21,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-/+0oRyA9gfucfBTdkN9Q5eUZOWNDIAOj634yAc7Hzn0=";
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    installShellFiles
+  ];
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd hexyl \
+      --bash <($out/bin/hexyl --completion bash) \
+      --fish <($out/bin/hexyl --completion fish) \
+      --zsh <($out/bin/hexyl --completion zsh)
+  '';
 
   meta = {
     description = "Command-line hex viewer";

--- a/pkgs/by-name/he/hexyl/package.nix
+++ b/pkgs/by-name/he/hexyl/package.nix
@@ -22,6 +22,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-/+0oRyA9gfucfBTdkN9Q5eUZOWNDIAOj634yAc7Hzn0=";
 
+  __structuredAttrs = true;
+
   nativeInstallCheckInputs = [
     versionCheckHook
     installShellFiles

--- a/pkgs/by-name/he/hexyl/package.nix
+++ b/pkgs/by-name/he/hexyl/package.nix
@@ -6,6 +6,7 @@
   installShellFiles,
   versionCheckHook,
   nix-update-script,
+  pandoc,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -24,12 +25,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
     installShellFiles
+    pandoc
   ];
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  # https://github.com/sharkdp/hexyl/blob/6ecc29b9c8c84d08a7e860f7f69c22b113b480ea/README.md?plain=1#L161-L163
+  postInstall = ''
+    installManPage --name hexyl.1 <(pandoc -s -f markdown -t man -o - doc/hexyl.1.md)
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd hexyl \
       --bash <($out/bin/hexyl --completion bash) \
       --fish <($out/bin/hexyl --completion fish) \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

As the title says. I also added the OR license combinator & enabled structuredAttrs while I was in there. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
