### PR TITLE
nixos/traefik: update and revamp module

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -250,6 +250,42 @@
   "sec-nixos-test-vms-vs-containers": [
     "index.html#sec-nixos-test-vms-vs-containers"
   ],
+  "module-services-traefik": [
+    "index.html#module-services-traefik"
+  ],
+  "module-services-traefik-environment": [
+    "index.html#module-services-traefik-environment"
+  ],
+  "module-services-traefik-usage": [
+    "index.html#module-services-traefik-usage"
+  ],
+  "module-services-traefik-usage-install": [
+    "index.html#module-services-traefik-usage-install"
+  ],
+  "module-services-traefik-usage-install-file": [
+    "index.html#module-services-traefik-usage-install-file"
+  ],
+  "module-services-traefik-usage-install-settings": [
+    "index.html#module-services-traefik-usage-install-settings"
+  ],
+  "module-services-traefik-usage-routing": [
+    "index.html#module-services-traefik-usage-routing"
+  ],
+  "module-services-traefik-usage-routing-dir": [
+    "index.html#module-services-traefik-usage-routing-dir"
+  ],
+  "module-services-traefik-usage-routing-extrafiles": [
+    "index.html#module-services-traefik-usage-routing-extrafiles"
+  ],
+  "module-services-traefik-usage-routing-file": [
+    "index.html#module-services-traefik-usage-routing-file"
+  ],
+  "module-services-traefik-usage-routing-settings": [
+    "index.html#module-services-traefik-usage-routing-settings"
+  ],
+  "module-services-traefik-migrating-to-26.11": [
+    "index.html#module-services-traefik-migrating-to-26.11"
+  ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -138,6 +138,8 @@
 
 - The `extraArgs` and `check` arguments to `nixos/lib/eval-config.nix` (and therefore to `lib.nixosSystem`) have been removed after being deprecated with a warning since 2021. Passing them is now an evaluation error. Instead of `extraArgs`, set `config._module.args`; instead of `check = false`, set `config._module.check = false`. The `extraArgs` attribute on the resulting configuration has been removed as well.
 
+- `services.traefik.useEnvSubst` has been removed, as using environment variables to store secrets is already supported by the {option}`services.traefik.environmentFiles`. See the [manual](#module-services-traefik-environment) for more information.
+
 - Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.
 
 - The `jetty_11` package has been removed as it reached end of life. Use `jetty_12` instead.
@@ -247,6 +249,8 @@
 - `services.nginx` gained a [`lua`](#opt-services.nginx.lua.enable) option to enable Lua scripting via OpenResty's lua-nginx-module on a stock nginx, configuring `lua_package_path`/`lua_package_cpath` from the packages listed in [`services.nginx.lua.extraPackages`](#opt-services.nginx.lua.extraPackages). Use this to add Lua to a regular nginx; for the full OpenResty platform (libraries that rely on its bundled lualib, such as `lua-resty-openidc`), set `services.nginx.package` to `pkgs.openresty` instead — the option configures the Lua search path for it too.
 
 - `services.nginx.virtualHosts.<name>.locations.<name>` gained a new `useGrpcErrorPages` option. If enabled, it sets up error pages that are valid gRPC messages. This is useful if you proxy gRPC and want to emit errors from nginx, for example when adding authentication on top.
+
+- The `services.traefik` module has been revamped. More NixOS tests have been added, structured settings options have been improved, and the new option [`services.traefik.routing.extraFiles`](#opt-services.traefik.routing.extraFiles) has been introduced. See the [manual](#module-services-traefik-migrating-to-26.11) for migration instructions.
 
 - `security.polkit.settings` added for RFC42 style configuration of the polkitd daemon.
 

--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -457,7 +457,7 @@ in
       enable = true;
       group = "fossorial";
       dataDir = "${cfg.dataDir}/config/traefik";
-      staticConfigOptions = {
+      install.settings = {
         providers.http = {
           endpoint = "http://localhost:${toString finalSettings.server.internal_port}/api/v1/traefik-config";
           pollInterval = "5s";
@@ -495,7 +495,7 @@ in
           };
         };
       };
-      dynamicConfigOptions = {
+      routing.settings = {
         http = {
           middlewares.redirect-to-https.redirectScheme.scheme = "https";
           routers = {

--- a/nixos/modules/services/web-servers/traefik.md
+++ b/nixos/modules/services/web-servers/traefik.md
@@ -1,0 +1,196 @@
+# Traefik {#module-services-traefik}
+
+[Traefik][upstream-1] is an open-source, cloud-native reverse proxy configured using the {option}`services.traefik` option set.
+
+## Basic Usage {#module-services-traefik-usage}
+
+A key feature of Traefik is that the reverse proxy configuration is split into two:
+1. [**Install configuration**](#module-services-traefik-usage-install), previously "static" configuration
+2. [**Routing configuration**](#module-services-traefik-usage-routing), previously "dynamic" configuration
+
+The [upstream documentation][upstream-2] has a detailed overview on the difference between both configuration types.
+
+## Install Configuration {#module-services-traefik-usage-install}
+
+::: {.note}
+This was formerly known as the "static" configuration
+:::
+
+Install configuration is controlled by the {option}`services.traefik.install` option set.
+This defines parameters that require Traefik to restart when changed, including:
+- Entry points
+- Providers
+- API/dashboard settings
+- Logging levels
+
+
+### Install Configuration: file {#module-services-traefik-usage-install-file}
+
+{option}`services.traefik.install.file` allows you to pass a path to a file containing a Traefik configuration:
+
+```nix
+{
+  services.traefik.install.file = "/etc/traefik/install.yml";
+}
+```
+
+By default, this is set to a JSON file generated from {option}`services.traefik.install.settings`.
+
+### Install Configuration: settings {#module-services-traefik-usage-install-settings}
+
+{option}`services.traefik.install.settings` allows you to declare the install configuration directly in Nix syntax:
+
+```nix
+{
+  services.traefik.install.settings = {
+    log.level = "DEBUG";
+    global.checkNewVersion = false;
+    entryPoints."web" = {
+      address = ":80";
+      asDefault = true;
+    };
+  };
+}
+```
+
+## Routing Configuration {#module-services-traefik-usage-routing}
+
+::: {.note}
+This was formerly known as the "dynamic" configuration
+:::
+
+Routing configuration is controlled by the {option}`services.traefik.routing` option set.
+
+This involves elements that can be updated without restarting Traefik, such as:
+- Routers
+- Services
+- Middlewares
+
+### Routing Configuration: file {#module-services-traefik-usage-routing-file}
+
+{option}`services.traefik.routing.file` allows you to pass a path to a file containing routing configuration:
+
+```nix
+{
+  services.traefik.routing.file = "/etc/traefik/routing.yml";
+}
+```
+
+By default, this is set to the JSON file stored in {option}`services.traefik.routing.settingsDrv`
+
+### Routing Configuration: settings {#module-services-traefik-usage-routing-settings}
+
+{option}`services.traefik.routing.settings` allows you to declare routing configuration directly in Nix syntax:
+```nix
+{
+  services.traefik.routing.settings = {
+    http.routers."dashboard" = {
+      service = "api@internal";
+      rule = "Host(`traefik.example.com`)";
+    };
+  };
+}
+```
+
+### Routing Configuration: dir {#module-services-traefik-usage-routing-dir}
+
+::: {.warning}
+Files in this directory matching the glob `__nixos-*` (reserved for Nix-managed routing configurations) will be deleted as part of
+`systemd-tmpfiles-resetup.service`, _**regardless of their origin.**_
+:::
+
+{option}`services.traefik.routing.dir` allows you to set a directory containing multiple routing configuration files:
+
+```nix
+{
+  services.traefik.routing.dir = "/etc/traefik/routing";
+}
+```
+
+These can include imperative and [declaratively configured](#module-services-traefik-usage-routing-extrafiles) files.
+
+### Routing Configuration: extraFiles {#module-services-traefik-usage-routing-extrafiles}
+
+{option}`services.traefik.routing.extraFiles.<name>.settings` option allows you to create multiple named configuration submodules:
+
+```nix
+{
+  services.traefik.routing.extraFiles = {
+    "dashboard".settings = {
+      http.routers."dashboard" = {
+        service = "api@internal";
+        rule = "Host(`traefik.example.com`)";
+        middlewares = [ "private-only" ];
+      };
+    };
+    "middlewares".settings = {
+      http.middlewares."private-only".ipallowlist.sourcerange = [
+        "192.168.0.0/16"
+        "10.0.0.0/8"
+        "172.16.0.0/12"
+        "127.0.0.0/8"
+      ];
+    };
+  };
+}
+```
+
+These accept the same options as {option}`services.traefik.routing.settings`.
+
+::: {.note}
+- If {option}`services.traefik.routing.dir` **_is_** set:
+  - A JSON file will be generated from each submodule and symlinked there
+- If {option}`services.traefik.routing.dir` is **_not_** set, and {option}`services.traefik.routing.settings` **_is_**:
+  - all `settings` sets will be merged to form {option}`services.traefik.routing.settingsDrv`
+    - This is to allow NixOS modules to create `traefik.enable` options compatible with both `routing.extraFiles` and `routing.settings`
+:::
+
+{option}`services.traefik.routing.extraFiles` has a number of benefits compared to {option}`services.traefik.routing.settings`:
+- `extraFiles` allows mixing imperative and declarative routing configuration seamlessly
+- Since `extraFiles` are loaded from {option}`services.traefik.routing.dir` continually, the Traefik daemon does not need to be restarted for configuration changes to apply
+  - This allows long lived connections (such as VPN traffic) to remain uninterrupted
+- `extraFiles` can be manipulated at runtime without the need to rebuild the system. Applications could include:
+  - Taking down a bad service by deleting the symlink in {option}`services.traefik.routing.dir`
+    - Due to a [limitation in traefik][routing-limit], an error in *any* routing configuration will cause the entire `directory` provider to be ignored
+      - _The bad configuration symlink can be removed to restore service until the system can be rebuilt_
+  - Taking a service down for security reasons
+    - _Deleting a configuration symlink is often quicker than rebuilding the system_
+  - Editing service configurations for rapid iteration
+    - _Copy the file from the nix store and replace the symlink with it_
+  - Making temporary changes to the routing configuration that will be discarded upon the next system activation
+    - _Ensure any files involved have the prefix `__nixos-`. These will be deleted before the new configurations are linked_
+
+
+## Environment Files {#module-services-traefik-environment}
+
+Environment files can be used to provision secrets for ACME/Let's Encrypt and other certificate setups.
+See the [upstream documentation][upstream-4] for more information on passing ACME secrets for DNS-01 challenges.
+
+Although the Traefik module offers the {option}`services.traefik.environmentFiles`
+option to set up environment variables for the running server, *it is not recommended to use them as the install configuration source.*
+The configuration methods are mutually exclusive, and evaluated in the following order:
+
+- In a configuration file
+- In the command-line arguments
+- As environment variables
+
+
+
+## Migrating to 26.11 {#module-services-traefik-migrating-to-26.11}
+
+The Traefik module now features new ways to deploy the routing and install configuration, which were previously called dynamic and static configuration. For a simple migration, move your existing static and dynamic configurations to `services.traefik.install` and `services.traefik.routing` respectively:
+
+- `services.traefik.staticConfigFile` -> `services.traefik.install.file`
+- `services.traefik.staticConfigOptions` -> `services.traefik.install.settings`
+- `services.traefik.dynamicConfigFile` -> `services.traefik.routing.file`
+- `services.traefik.dynamicConfigOptions` -> `services.traefik.routing.settings`
+
+The option `useEnvSubst` has been removed, as using environment variables to store secrets is already supported by the {option}`services.traefik.environmentFiles`. Please open an issue if this incompatible with your setup.
+
+A new option submodule, `services.traefik.routing.extraFiles.<name>`, is now available. In conjunction with {option}`services.traefik.routing.dir`, this allows you to group settings into files that are linked to Traefik's `providers.file.directory`. This allows you to mix declarative and imperative configuration, and means that changes in the routing configuration can occur without restarting the Traefik daemon. Please see the [usage](#module-services-traefik-usage) section for a thorough description of the new options.
+
+[upstream-1]: https://traefik.io/traefik
+[upstream-2]: https://doc.traefik.io/traefik/getting-started/configuration-overview
+[upstream-3]: https://plugins.traefik.io/plugins
+[routing-limit]: https://github.com/traefik/traefik/issues/10890
+[upstream-4]: https://doc.traefik.io/traefik/https/acme/#providers

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -5,162 +5,532 @@
   ...
 }:
 
-with lib;
-
 let
+  inherit (lib.types)
+    attrsOf
+    listOf
+    nullOr
+    path
+    str
+    submodule
+    ;
+  inherit (lib)
+    converge
+    filterAttrsRecursive
+    getExe
+    literalExpression
+    mapAttrs'
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    nameValuePair
+    optional
+    recursiveUpdate
+    types
+    ;
+
   cfg = config.services.traefik;
-
-  format = pkgs.formats.toml { };
-
-  dynamicConfigFile =
-    if cfg.dynamicConfigFile == null then
-      format.generate "config.toml" cfg.dynamicConfigOptions
-    else
-      cfg.dynamicConfigFile;
-
-  staticConfigFile =
-    if cfg.staticConfigFile == null then
-      format.generate "config.toml" (
-        recursiveUpdate cfg.staticConfigOptions {
-          providers.file.filename = "${dynamicConfigFile}";
-        }
-      )
-    else
-      cfg.staticConfigFile;
-
-  finalStaticConfigFile =
-    if cfg.environmentFiles == [ ] then staticConfigFile else "/run/traefik/config.toml";
+  # Traefik accepts JSON as a valid YAML subset
+  json = pkgs.formats.json { };
 in
 {
+  imports = [
+    (mkRemovedOptionModule
+      [
+        "services"
+        "traefik"
+        "useEnvSubst"
+      ]
+      "Use `services.traefik.environmentFiles` instead, see https://nixos.org/manual/nixos/stable/#module-services-traefik-environment"
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "staticConfigFile"
+      ]
+      [
+        "services"
+        "traefik"
+        "install"
+        "file"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "staticConfigOptions"
+      ]
+      [
+        "services"
+        "traefik"
+        "install"
+        "settings"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "dynamicConfigFile"
+      ]
+      [
+        "services"
+        "traefik"
+        "routing"
+        "file"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "traefik"
+        "dynamicConfigOptions"
+      ]
+      [
+        "services"
+        "traefik"
+        "routing"
+        "settings"
+      ]
+    )
+  ];
   options.services.traefik = {
-    enable = mkEnableOption "Traefik web server";
+    enable = lib.mkEnableOption "Traefik, an open-source, cloud-native reverse proxy";
+    package = lib.mkPackageOption pkgs "traefik" { };
 
-    staticConfigFile = mkOption {
-      default = null;
-      example = literalExpression "/path/to/static_config.toml";
-      type = types.nullOr types.path;
-      description = ''
-        Path to traefik's static configuration to use.
-        (Using that option has precedence over `staticConfigOptions` and `dynamicConfigOptions`)
-      '';
-    };
-
-    staticConfigOptions = mkOption {
-      description = ''
-        Static configuration for Traefik.
-      '';
-      type = format.type;
-      default = {
-        entryPoints.http.address = ":80";
+    install = {
+      file = mkOption {
+        default = json.generate "install_config.json" (
+          # converge is needed to fully remove entire trees of empty attribute sets
+          converge (
+            # remove `null` (used for comparisons of unset values)
+            # and `{}` or `[]`, which is left behind by type checked submodule options
+            filterAttrsRecursive (_: val: val != null && val != { } && val != [ ])
+          ) cfg.install.settings
+        );
+        defaultText = literalExpression ''
+          (pkgs.formats.json { }).generate "install_config.json" (
+            # converge is needed to fully remove entire trees of empty attribute sets
+            converge (
+              # remove `null` (used for comparisons of unset values)
+              # and `{}` or `[]`, which is left behind by type checked submodule options
+              filterAttrsRecursive (_: val: val != null && val != { } && val != [ ])
+            ) config.services.traefik.install.settings
+          );
+        '';
+        example = literalExpression "/path/to/install_config.yml";
+        type = path;
+        description = ''
+          Path to Traefik's install configuration file, passed to the daemon with the `--configfile` flag
+        '';
       };
-      example = {
-        entryPoints.web.address = ":8080";
-        entryPoints.http.address = ":80";
+      settings = mkOption {
+        description = ''
+          Install configuration for Traefik, written in Nix.
 
-        api = { };
-      };
-    };
+          A full list of available options can be found in the [Traefik docs](https://doc.traefik.io/traefik/reference/install-configuration/configuration-options/)
 
-    dynamicConfigFile = mkOption {
-      default = null;
-      example = literalExpression "/path/to/dynamic_config.toml";
-      type = types.nullOr types.path;
-      description = ''
-        Path to traefik's dynamic configuration to use.
-        (Using that option has precedence over `dynamicConfigOptions`)
-      '';
-    };
+          ::: {.warning}
+          Empty values (`{}`, `[]`, and `null`) are filtered out by default, since they are used to represent
+          unset values in option defaults.
+          Instead of declaring empty but present attributes as `attr = {}`, declare them as `attr = true`.
+          To see exactly how this is handled, see the default value of `services.traefik.install.settings`
+          :::
 
-    dynamicConfigOptions = mkOption {
-      description = ''
-        Dynamic configuration for Traefik.
-      '';
-      type = format.type;
-      default = { };
-      example = {
-        http.routers.router1 = {
-          rule = "Host(`localhost`)";
-          service = "service1";
+          ::: {.note}
+          This will be serialized to JSON (which Traefik accepts JSON as a valid YAML subset) at build, and passed to Traefik with `--configfile`.
+          :::
+        '';
+        type = types.submodule {
+          freeformType = json.type;
+          options = {
+            providers = {
+              file = {
+                filename = mkOption {
+                  default = cfg.routing.file;
+                  defaultText = literalExpression "config.services.traefik.routing.file";
+                  description = "Load routing configuration from a file.";
+                };
+                directory = mkOption {
+                  default = cfg.routing.dir;
+                  defaultText = literalExpression "config.services.traefik.routing.dir";
+                  description = "Load routing configuration from one or more .yml or .toml files in a directory";
+                };
+              };
+            };
+          };
         };
+        default = { };
+        example = {
+          entryPoints = {
+            "web" = {
+              address = ":80";
+              http.redirections.entryPoint = {
+                permanent = true;
+                scheme = "https";
+                to = "websecure";
+              };
+            };
+            "websecure" = {
+              address = ":443";
+              asDefault = true;
+            };
+          };
+        };
+      };
 
-        http.services.service1.loadBalancer.servers = [ { url = "http://localhost:8080"; } ];
+    };
+
+    routing = {
+      file = mkOption {
+        default = cfg.routing.settingsDrv;
+        defaultText = literalExpression "config.services.traefik.routing.settingsDrv";
+        example = literalExpression "/path/to/routing_config.yml";
+        type = nullOr path;
+        description = ''
+          Path to Traefik's routing configuration file.
+        '';
+      };
+      dir = mkOption {
+        default = null;
+        example = literalExpression "/etc/traefik/routing";
+        type = nullOr path;
+        description = ''
+          Path to the directory Traefik should watch for configuration files.
+
+          ::: {.warning}
+          Files in this directory matching the glob `__nixos-*` (reserved for Nix-managed routing configurations) will be deleted as part of
+          `systemd-tmpfiles-resetup.service`, _**regardless of their origin.**_.
+          :::
+        '';
+      };
+      extraFiles = mkOption {
+        type = attrsOf (submodule {
+          options.settings = mkOption {
+            type = json.type;
+            description = ''
+              Routing configuration for Traefik, written in Nix.
+
+              Available options can be found in the [Traefik docs](https://doc.traefik.io/traefik/reference/routing-configuration/other-providers/file/)
+
+              ::: {.note}
+              This will be serialized to JSON (which Traefik accepts as a valid YAML subset)
+              at build, and symlinked to `services.traefik.routing.dir` if set
+              :::
+
+              ::: {.note}
+              If `services.traefik.routing.dir` is not defined, these will be merged
+              with `services.traefik.routing.settings` to form `services.traefik.routing.settingsDrv`
+              :::
+            '';
+            example = {
+              http.routers."api" = {
+                service = "api@internal";
+                rule = "Host(`localhost`)";
+              };
+            };
+          };
+        });
+        default = { };
+        example = {
+          "dashboard".settings = {
+            http.routers."api" = {
+              service = "api@internal";
+              rule = "Host(`198.51.100.1`)";
+            };
+          };
+        };
+        # TODO validate `extraFiles` and `settingsDrv` by json schema
+        # Traefik does not currently provide a schema, as they are "focused elsewhere"
+        # A third party schema has been created and added to https://schemastore.org, which was generated from the traefik source code:
+        # https://github.com/xunleii/traefik-json-schema
+        # This could be adapted to provide schema validation based on `cfg.package`, which Traefik seems to be open to
+        # https://github.com/traefik/traefik/issues/10889#issuecomment-2222821676
+        description = ''
+          Routing configuration files to write. These are symlinked in `services.traefik.routing.dir` upon activation,
+          allowing configuration to be updated without restarting the primary daemon.
+
+          ::: {.warning}
+          Due to [a limitation in Traefik](https://github.com/traefik/traefik/issues/10890); a syntax error in _**any**_ routing configuration will cause the _**entire file provider**_ to be ignored.
+          This may cause interruption in service, which may include access to the Traefik dashboard, if [enabled and configured](https://doc.traefik.io/traefik/reference/install-configuration/api-dashboard/).
+          :::
+        '';
+      };
+
+      settings = mkOption {
+        type = json.type;
+        description = ''
+          Routing configuration for Traefik, written in Nix.
+
+          Available options can be found in the [Traefik docs](https://doc.traefik.io/traefik/reference/routing-configuration/other-providers/file/)
+        '';
+        default = { };
+        example = {
+          http.routers."api" = {
+            service = "api@internal";
+            rule = "Host(`localhost`)";
+          };
+        };
+      };
+
+      settingsDrv = mkOption {
+        type = nullOr path;
+        readOnly = true;
+        description = ''
+          Final declarative routing configuration. If `services.traefik.routing.settings` is declared, this will contain it.
+          If `services.traefik.routing.extraFiles` is declared but `services.traefik.routing.dir` is not,
+          the contents of `services.traefik.routing.extraFiles.*.settings` will be merged with `services.traefik.routing.settings`.
+          This allows other modules to write `enableTraefik` options which are compatible with both `services.traefik.routing.extraFiles` and `services.traefik.routing.settings`
+
+          ::: {.note}
+          Modules implementing an `enableTraefik` option should list the following in its description, so that users may override values as needed:
+          - The names of any added:
+            - `extraFiles`
+            - `services`
+            - `routers`
+          - Whether they declare a router, service, or both
+          :::
+        '';
+        default =
+          if (cfg.routing.settings != { }) then
+            json.generate "traefik-routing-settings.yml" (
+              recursiveUpdate cfg.routing.settings (
+                lib.optionalAttrs (cfg.routing.extraFiles != { } && cfg.routing.dir == null) lib.foldAttrs (
+                  item: acc: recursiveUpdate item acc
+                ) { } (lib.mapAttrsToList (name: value: value.settings) cfg.routing.extraFiles)
+              )
+            )
+          else
+            null;
+        defaultText = literalExpression ''
+          if (config.services.traefik.routing.settings != { }) then
+            json.generate "traefik-routing-settings.yml" (
+              recursiveUpdate config.services.traefik.routing.settings (
+                lib.optionalAttrs (config.services.traefik.routing.extraFiles != { } && config.services.traefik.routing.dir == null) lib.foldAttrs (
+                  item: acc: recursiveUpdate item acc
+                ) { } (lib.mapAttrsToList (name: value: value.settings) config.services.traefik.routing.extraFiles)
+              )
+            )
+          else
+            null;
+        '';
       };
     };
 
     dataDir = mkOption {
       default = "/var/lib/traefik";
-      type = types.path;
+      type = path;
       description = ''
-        Location for any persistent data traefik creates, ie. acme
+        Location for any persistent data Traefik creates, such as the ACME certificate store.
+
+        ::: {.note}
+        If left as the default value, this directory will automatically be created
+        before the Traefik server starts, otherwise you are responsible for ensuring
+        the directory exists with appropriate ownership and permissions.
+        :::
+      '';
+    };
+
+    user = mkOption {
+      default = "traefik";
+      type = str;
+      description = ''
+        User under which Traefik runs.
+
+        ::: {.note}
+        If left as the default value this user will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the user exists before the Traefik service starts.
+        :::
       '';
     };
 
     group = mkOption {
       default = "traefik";
-      type = types.str;
-      example = "docker";
+      type = str;
       description = ''
-        Set the group that traefik runs under.
-        For the docker backend this needs to be set to `docker` instead.
+        Primary group under which Traefik runs.
+        For the Docker backend, use {option}`services.traefik.supplementaryGroups` instead of overriding this option.
+
+        ::: {.note}
+        If left as the default value this group will automatically be created
+        on system activation, otherwise you are responsible for
+        ensuring the group exists before the Traefik service starts.
+        :::
       '';
     };
 
-    package = mkPackageOption pkgs "traefik" { };
+    supplementaryGroups = mkOption {
+      default = [ ];
+      type = listOf str;
+      example = [ "docker" ];
+      description = ''
+        Additional groups under which Traefik runs.
+        This can be used to give additional permissions, such as the group required by the `docker` provider.
+
+        ::: {.note}
+        With the `docker` routing provider, Traefik manages connection to containers via the Docker socket,
+        which requires membership of the `docker` group for write access.
+        :::
+      '';
+    };
 
     environmentFiles = mkOption {
       default = [ ];
-      type = types.listOf types.path;
+      type = listOf path;
       example = [ "/run/secrets/traefik.env" ];
       description = ''
-        Files to load as environment file. Environment variables from this file
-        will be substituted into the static configuration file using envsubst.
+        Files to load as an environment file just before Traefik starts.
+        This can be used to pass secrets such as [DNS challenge API tokens][dns-secrets] or [ENV variables][env-vars].
+
+        ```
+        DESEC_TOKEN=
+        TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EAB_HMACENCODED=
+        TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EAB_KID=
+        ```
+
+        ::: {.warn}
+        The traefik install configuration methods (env, CLI, and file) are mutually exclusive.
+        It’s crucial to choose one method and stick to it, as mixing different configuration options is not supported and can lead to unexpected behavior.
+        :::
+
+        [dns-secrets]: https://doc.traefik.io/traefik/reference/install-configuration/tls/certificate-resolvers/acme/#providers
+        [env-vars]: https://doc.traefik.io/traefik/reference/install-configuration/boot-environment/#environment-variables
       '';
     };
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [ "d '${cfg.dataDir}' 0700 traefik traefik - -" ];
+    assertions = [
+      {
+        assertion = cfg.routing.file != null -> cfg.routing.dir == null;
+        message = ''
+          The 'services.traefik.routing.file' and 'services.traefik.routing.dir' options are mutually exclusive.
+          It is recommended to use 'services.traefik.routing.dir' with 'services.traefik.routing.extraFiles'.
+        '';
+      }
+      {
+        assertion = cfg.routing.extraFiles != { } && cfg.routing.settings == { } -> cfg.routing.dir != null;
+        message = ''
+          'services.traefik.routing.extraFiles' requires the routing file provider to be set
+          to a directory. Please set a path for 'services.traefik.routing.dir'.
+        '';
+      }
+      {
+        assertion = cfg.group != "docker";
+        message = ''
+          Setting the primary group to 'docker' will cause files, such as those generated
+          by 'services.traefik.routing.extraFiles', to be owned by the group 'docker', which
+          may be a security risk. Use 'services.traefik.supplementaryGroups' instead.
+        '';
+      }
+      {
+        assertion = (lib.collect (val: val == { })) cfg.install.settings == [ ];
+        message = ''
+          `services.traefik.install.settings` contains empty attribute sets, which are now reserved for filtering unset typed options.
+          Instead of e.g. `services.traefik.install.settings.api = {};`, use `services.traefik.install.settings.api = true;`
+        '';
+      }
+    ];
+
+    warnings =
+      optional (!(builtins.elem "docker" cfg.supplementaryGroups -> config.virtualisation.docker.enable))
+        "'services.traefik.supplementaryGroups' contains the 'docker' group, but 'virtualisation.docker.enable' is not enabled. If this is intentional, please open an issue notifying the Traefik NixOS module maintainers";
+
+    # https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+    boot.kernel.sysctl = {
+      "net.core.rmem_max" = mkDefault 7500000;
+      "net.core.wmem_max" = mkDefault 7500000;
+    };
 
     systemd.services.traefik = {
-      description = "Traefik web server";
+      description = "Traefik reverse proxy";
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       startLimitIntervalSec = 86400;
       startLimitBurst = 5;
+      unitConfig.Documentation = "https://doc.traefik.io/traefik/";
       serviceConfig = {
         EnvironmentFile = cfg.environmentFiles;
-        ExecStartPre = lib.optional (
-          cfg.environmentFiles != [ ]
-        ) "${pkgs.envsubst}/bin/envsubst -i '${staticConfigFile}' -o '${finalStaticConfigFile}'";
-        ExecStart = "${cfg.package}/bin/traefik --configfile=${finalStaticConfigFile}";
-        Type = "simple";
-        User = "traefik";
+        ExecStart = "${getExe cfg.package} --configfile=${cfg.install.file}";
+        Type = "notify";
+        User = cfg.user;
         Group = cfg.group;
-        Restart = "on-failure";
+        SupplementaryGroups = cfg.supplementaryGroups;
+        Restart = "always";
         AmbientCapabilities = "cap_net_bind_service";
         CapabilityBoundingSet = "cap_net_bind_service";
         NoNewPrivileges = true;
-        LimitNPROC = 64;
+        TasksMax = 64;
         LimitNOFILE = 1048576;
         PrivateTmp = true;
         PrivateDevices = true;
         ProtectHome = true;
-        ProtectSystem = "full";
+        ProtectSystem = "strict";
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
         ReadWritePaths = [ cfg.dataDir ];
+        ReadOnlyPaths = optional (cfg.routing.dir != null) cfg.routing.dir;
         RuntimeDirectory = "traefik";
         RuntimeDirectoryMode = "0700";
         WorkingDirectory = cfg.dataDir;
+        WatchdogSec = "1s";
       };
     };
 
-    users.users.traefik = {
-      group = "traefik";
-      home = cfg.dataDir;
-      createHome = true;
-      isSystemUser = true;
-    };
+    systemd.tmpfiles.settings."10-traefik" = mkMerge [
+      (mkIf (cfg.user == "traefik" || cfg.group == "traefik") {
+        ${cfg.dataDir}.d = {
+          user = mkIf (cfg.user == "traefik") cfg.user;
+          group = mkIf (cfg.group == "traefik") cfg.group;
+          mode = "0770";
+        };
+      })
+      (mkIf (cfg.routing.dir != null && (cfg.user == "traefik" || cfg.group == "traefik")) {
+        ${cfg.routing.dir}.d = {
+          user = mkIf (cfg.user == "traefik") cfg.user;
+          group = mkIf (cfg.group == "traefik") cfg.group;
+          # Traefik doesn't need write perms on this, only read/execute. Global read isn't a security risk
+          # because the files that are linked within are already in /nix/store
+          mode = "0555";
+        };
+      })
+      (mkIf (cfg.routing.dir != null) (
+        {
+          # Remove previous declarative routing configuration files
+          "${cfg.routing.dir}/__nixos-*".r = { };
+        }
+        // (mapAttrs' (
+          name: value:
+          nameValuePair "${cfg.routing.dir}/__nixos-${name}.yml" {
+            "L+".argument = toString (json.generate name value.settings);
+          }
+        ) cfg.routing.extraFiles)
+      ))
+    ];
 
-    users.groups.traefik = { };
+    users = {
+      users = mkIf (cfg.user == "traefik") {
+        traefik = {
+          inherit (cfg) group;
+          isSystemUser = true;
+        };
+      };
+      groups = mkIf (cfg.group == "traefik") { traefik = { }; };
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      jackr
+      therealgramdalf
+    ];
+    doc = ./traefik.md;
   };
 }

--- a/nixos/tests/authelia.nix
+++ b/nixos/tests/authelia.nix
@@ -54,7 +54,7 @@
         services.traefik = {
           enable = true;
 
-          dynamicConfigOptions = {
+          dynamic.settings = {
             tls.certificates =
               let
                 certDir = pkgs.runCommand "selfSignedCerts" { buildInputs = [ pkgs.openssl ]; } ''
@@ -128,7 +128,7 @@
             };
           };
 
-          staticConfigOptions = {
+          install.settings = {
             global = {
               checkNewVersion = false;
               sendAnonymousUsage = false;

--- a/nixos/tests/pangolin.nix
+++ b/nixos/tests/pangolin.nix
@@ -99,7 +99,7 @@ in
             };
           };
           # set up local ca server, so we can get our certs signed without going on the internet
-          traefik.staticConfigOptions.certificatesResolvers.letsencrypt.acme.caServer =
+          traefik.install.settings.certificatesResolvers.letsencrypt.acme.caServer =
             lib.mkForce "https://${nodes.acme.test-support.acme.caDomain}/dir";
         };
       };

--- a/nixos/tests/traefik.nix
+++ b/nixos/tests/traefik.nix
@@ -1,107 +1,225 @@
 # Test Traefik as a reverse proxy of a local web service
 # and a Docker container.
-{ pkgs, ... }:
+{ lib, ... }:
 {
   name = "traefik";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ joko ];
+  meta = with lib.maintainers; {
+    maintainers = [
+      joko
+      jackr
+      therealgramdalf
+    ];
   };
 
-  nodes = {
-    client =
-      { config, pkgs, ... }:
+  # Debugging
+  # To view the configuration of a container, load nixpkgs into `nix repl` and access
+  # `outputs.legacyPackages.x86_64-linux.nixosTests.traefik.containers.<name>.config`
+
+  # Prevent devnet being enabled automatically by declaring both nodes and containers in the same test
+  # since this feature isn't enabled on nixpkgs infrastructure
+  requiredFeatures.devnet = lib.mkForce false;
+
+  defaults = {
+    services.traefik.install.settings = {
+      global = {
+        checkNewVersion = false;
+        sendAnonymousUsage = false;
+      };
+
+      entryPoints."web".address = ":80";
+    };
+
+    networking.firewall.allowedTCPPorts = [ 80 ];
+  };
+
+  containers = {
+    # Central client
+    # This emulates a network request coming in to the server over the network, rather than
+    # routing everything through localhost. #defenseindepth.
+    "client" =
+      { pkgs, ... }:
       {
         environment.systemPackages = [ pkgs.curl ];
       };
-    traefik =
-      { config, pkgs, ... }:
+
+    # Reusable http server
+    # Note that this doesn't cover the case of proxying a service hosted on the same machine through localhost,
+    # that could be added to the docker test without much overhead
+    "simplehttp" =
+      { pkgs, ... }:
       {
-        virtualisation.oci-containers = {
-          backend = "docker";
-          containers.nginx = {
-            extraOptions = [
-              "-l"
-              "traefik.enable=true"
-              "-l"
-              "traefik.http.routers.nginx.entrypoints=web"
-              "-l"
-              "traefik.http.routers.nginx.rule=Host(`nginx.traefik.test`)"
-            ];
-            image = "nginx-container";
-            imageStream = pkgs.dockerTools.examples.nginxStream;
-          };
-        };
-
-        networking.firewall.allowedTCPPorts = [ 80 ];
-
-        services.traefik = {
-          enable = true;
-
-          dynamicConfigOptions = {
-            http.routers.simplehttp = {
-              rule = "Host(`simplehttp.traefik.test`)";
-              entryPoints = [ "web" ];
-              service = "simplehttp";
-            };
-
-            http.services.simplehttp = {
-              loadBalancer.servers = [
-                {
-                  url = "http://127.0.0.1:8000";
-                }
-              ];
-            };
-          };
-
-          staticConfigOptions = {
-            global = {
-              checkNewVersion = false;
-              sendAnonymousUsage = false;
-            };
-
-            entryPoints.web.address = ":\${HTTP_PORT}";
-
-            providers.docker.exposedByDefault = false;
-          };
-          environmentFiles = [
-            (pkgs.writeText "traefik.env" ''
-              HTTP_PORT=80
-            '')
-          ];
-        };
-
         systemd.services.simplehttp = {
-          script = "${pkgs.python3}/bin/python -m http.server 8000";
+          script = "${pkgs.python3}/bin/python -m http.server 80";
           serviceConfig.Type = "simple";
           wantedBy = [ "multi-user.target" ];
         };
-
-        users.users.traefik.extraGroups = [ "docker" ];
       };
+
+    # Test objectives:
+    # - Declarative install/routing configuration through routing.settings (is this actually being loaded by traefik?)
+    # - Auto merge of dangling `routing.extraFiles` (has the merge logic been foiled somehow?)
+    #   - Do multiple extraFiles get merged properly (without overwriting eachother)
+    "declare" = {
+      services.traefik = {
+        enable = true;
+        routing.settings = {
+          http.routers."declarativehttp" = {
+            rule = "Host(`declarativehttp.declare`)";
+            entryPoints = [ "web" ];
+            service = "declarativehttp";
+          };
+
+          http.services."declarativehttp".loadBalancer.servers = [
+            {
+              url = "http://simplehttp";
+            }
+          ];
+        };
+
+        routing.extraFiles = {
+          "extrahttp1".settings = {
+            http.routers."extrahttp1" = {
+              rule = "Host(`extrahttp1.declare`)";
+              entryPoints = [ "web" ];
+              service = "extrahttp1";
+            };
+
+            http.services."extrahttp1".loadBalancer.servers = [
+              {
+                url = "http://simplehttp";
+              }
+            ];
+          };
+          "extrahttp2".settings = {
+            http.routers."extrahttp2" = {
+              rule = "Host(`extrahttp2.declare`)";
+              entryPoints = [ "web" ];
+              service = "extrahttp2";
+            };
+
+            http.services."extrahttp2".loadBalancer.servers = [
+              {
+                url = "http://simplehttp";
+              }
+            ];
+          };
+        };
+
+      };
+    };
+
+    # Test objectives:
+    # - Ensure that `routing.extraFiles` are being:
+    #   - generated
+    #   - loaded by traefik
+    #   - given the correct permissions in the simple case of `user == traefik` and `group == traefik`
+    "extra" = {
+      services.traefik = {
+        enable = true;
+
+        routing = {
+          dir = "/etc/traefik/routing";
+
+          extraFiles."extrahttp".settings = {
+            http.routers."extrahttp" = {
+              rule = "Host(`extrahttp.extra`)";
+              entryPoints = [ "web" ];
+              service = "extrahttp";
+            };
+
+            http.services."extrahttp".loadBalancer.servers = [
+              {
+                url = "http://simplehttp";
+              }
+            ];
+          };
+        };
+      };
+    };
   };
+
+  # Test objectives:
+  # - Ensure that `providers.docker` functions as intended in the simplest case:
+  #   - labels are parsed by `traefik`
+  #   - networking between containers and the traefik daemon is functional
+  # - If no `routing` configuration is defined, the default logic of install options do not error
+  # Note that to [@therealgramdalf's] knowledge, this setup relies on containers joining the
+  # default network created by docker. I am unsure if this is the case when traefik is running in a container as well.
+  nodes."docker" =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.curl ];
+
+      services.traefik = {
+        enable = true;
+        supplementaryGroups = [ "docker" ];
+        # Prevent traefik from creating a router automatically based on EXPOSE directives in the docker image
+        install.settings.providers.docker.exposedByDefault = false;
+      };
+
+      virtualisation.oci-containers = {
+        backend = "docker";
+        containers."nginx" = {
+          labels = {
+            "traefik.enable" = "true";
+            # Service is automatically created
+            "traefik.http.routers.nginx.entrypoints" = "web";
+            "traefik.http.routers.nginx.rule" = "Host(`nginx.docker`)";
+          };
+          image = "nginx-container";
+          imageStream = pkgs.dockerTools.examples.nginxStream;
+        };
+      };
+    };
 
   testScript = ''
     start_all()
 
-    traefik.wait_for_unit("docker-nginx.service")
-    traefik.wait_until_succeeds("docker ps | grep nginx-container")
-    traefik.wait_for_unit("simplehttp.service")
-    traefik.wait_for_unit("traefik.service")
-    traefik.wait_for_open_port(80)
-    traefik.wait_for_unit("multi-user.target")
-
     client.wait_for_unit("multi-user.target")
+    simplehttp.wait_for_unit("simplehttp.service")
+    simplehttp.wait_for_open_port(80)
+    simplehttp.wait_for_unit("multi-user.target")
 
-    client.wait_until_succeeds("curl -sSf -H Host:nginx.traefik.test http://traefik/")
+    declare.wait_for_unit("traefik.service")
+    declare.wait_for_open_port(80)
+    declare.wait_for_unit("multi-user.target")
 
-    with subtest("Check that a container can be reached via Traefik"):
-        assert "Hello from NGINX" in client.succeed(
-            "curl -sSf -H Host:nginx.traefik.test http://traefik/"
+    extra.wait_for_unit("traefik.service")
+    extra.wait_for_open_port(80)
+    extra.wait_for_unit("multi-user.target")
+
+    with subtest("Check that the declarative routing configuration works"):
+        assert "Directory listing for " in client.succeed(
+            "curl -sSf -H Host:declarativehttp.declare http://declare/"
         )
 
-    with subtest("Check that dynamic configuration works"):
+    with subtest("Check that the first auto merged declarative extraFiles routing configuration works"):
         assert "Directory listing for " in client.succeed(
-            "curl -sSf -H Host:simplehttp.traefik.test http://traefik/"
+            "curl -sSf -H Host:extrahttp1.declare http://declare/"
+        )
+
+    with subtest("Check that the second auto merged declarative extraFiles routing configuration works"):
+        assert "Directory listing for " in client.succeed(
+            "curl -sSf -H Host:extrahttp2.declare http://declare/"
+        )
+
+    with subtest("Check that the declarative extraFiles routing configuration works"):
+        assert "Directory listing for " in client.succeed(
+            "curl -sSf -H Host:extrahttp.extra http://extra/"
+        )
+
+    docker.wait_for_unit("traefik.service")
+    docker.wait_for_open_port(80)
+    docker.wait_for_unit("docker-nginx.service")
+    docker.wait_until_succeeds("docker ps | grep nginx-container")
+    docker.wait_for_unit("multi-user.target")
+
+    # Not needed?
+    # client.wait_until_succeeds("curl -sSf -H Host:nginx.docker http://docker/")
+
+    with subtest("Check that a docker container can be reached via Traefik"):
+        assert "Hello from NGINX" in docker.succeed(
+            "curl -sSf -H Host:nginx.docker http://127.0.0.1/"
         )
   '';
 }


### PR DESCRIPTION
Updated the Traefik module to modernize it. Primary changes:
- Removed `useEnvSubst` in favor of `environmentFile`
- Rename `*ConfigOptions` and `*ConfigFile` to `*.settings` and `*.file`
- Rename `dynamic` to `routing` and `static` to `install` to remain consistent with upstream
- Introduce a new method of routing configuration, `routing.extraFiles`
- Update the NixOS tests to cover more cases
- Added documentation

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
_Note: I have been running an older variant of this PR on my server for the past two years without issue. It (primarily the extraFiles functionality) has worked seamlessly ever since, surviving many updates and continuing to proxy a slew of services. I have just updated the module to the version in this PR, and have not run into any issues. See the comment below._
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

## Full changelog
### The following changes have been implemented:


- [X] Increase UDP buffer sizes to the recommended modern value, ~7.5MB
  - Changed to use `mkDefault` to match the `kubo` and `caddy` modules
- [X] Add the module refactor note to notable changes (the refactor doesn't actually break configs, except for `envsubst`)
  - [X] Add removal of `useEnvSubst` as a breaking change
- [X] Add redirects to doc/redirects.json 
- Updated the NixOS tests to cover more cases
  - [X] A VM is used to test the `docker` provider
  - [X] The rest of the tests use `systemd-nspawn` containers, which are much faster. Multiple tests are run in parallel, using different configuration methods
- [X] Added documentation to the NixOS manual
  - I did my best to make this conform to the style guide, but it's by no means perfect. Suggestions are welcome
- [X] Added `mkRenamed`/`mkRemoved` option modules
- [X] Fixed the `enable` option description, which incorrectly called Traefik a web server
- [X] Updated the systemd service definition
  - See: https://github.com/traefik/traefik/blob/master/contrib/systemd/traefik.service 
  - [X] Fixed the description, which incorrectly called Traefik a web server
  - [X] Added a `unitConfig.documentation` link
  - [X] Set the service type to `notify`, allowing for more accurate unit status
  - [X] Set `ProtectSystem = "strict"`
  - [X] Rename `LimitNPROC` to `TasksMax`
    - [ ] Upstream this is set to `1`, not `64` - I haven't tested if that works or not. Upstream systemd service hasn't been updated in 6 years
  - [X] Protect cgroups and kernel tunables  
- [X] Add/use the `cfg.user` option
- [X] Only create user/group if it is the default value
- [X] Added `meta` attributes to the module
- [X] Renamed references to `static` and `dynamic` configuration to the new `install` and `routing` terminology
- [X] Use `settings` and `file` instead of `<method>ConfigOptions` and `<method>ConfigFile`
  - [X] Renamed all references in nixpkgs to the new values
- [X] Use `pkgs.formats.json` instead of `toml`
- [X] Add more information to `cfg.user` and `cfg.group` (matching the `redis` server options)
- [X] Add/use `supplementaryGroups` to give access to the `docker` daemon instead of setting the primary group
  - An assertion has been added to prevent this from happening, as it poses a security risk
- [X] Add instructions to the `environmentFiles` for usage in place of `envSubst`
- [X] Options directly under `routing` or `install` could be considered "vendored" options - they add extra glue to make the module feel better to use
- [X] Wherever reasonable, internal logic ("glue") have been exposed through `defaultText` or `readOnly` options
  - `install.settings` now houses most of the `mkIf` logic that adds the `file` provider
  - In order to make this work, `install.settings` is a submodule with `freeformtype`.
    - `install.file` now contains the logic to generate the install configuration from `install.settings`
    - empty lists (`[]`), attribute sets (`{}`), or null values (`null`) are now filtered out in the generation logic to allow definition of typed options with default values
- This replaces the following logic, which was only exposed through the `let ... in` block at the top of the module - it was not really documented anywhere
```nix
  dynamicConfigFile =
    if cfg.dynamicConfigFile == null then
      format.generate "config.toml" cfg.dynamicConfigOptions
    else
      cfg.dynamicConfigFile;

  staticConfigFile =
    if cfg.staticConfigFile == null then
      format.generate "config.toml" (
        recursiveUpdate cfg.staticConfigOptions {
          providers.file.filename = "${dynamicConfigFile}";
        }
      )
    else
      cfg.staticConfigFile;

  finalStaticConfigFile =
    if cfg.environmentFiles == [ ] then staticConfigFile else "/run/traefik/config.toml";
```

- [X] if services.traefik.routing.extraFiles are declared, routing.dir is **not** set, and routing.settings **is**, automatically merge contents of files.settings into routing.settings. Modules can declare `traefik.enable` options as `routing.extraFiles`, and it will work with either `routing.extraFiles` or `routing.settings`
  -  A new `readOnly` option, `routing.settingsDrv`, is used to merge everything together. 


### What remains to be done:

- [ ] Optional: In addition to the nixosTests, traefik provides unit tests (see: https://doc.traefik.io/traefik/contributing/building-testing/#testing). These could be added to the package directly (as part of the check phase)

### Final Checks - just before merge
- [ ] Ensure that options referenced in documentation (option descriptions, manuals) accurately reflect the final option trees
- [ ] Probably a good idea: Manually test migration from a config with the old system to the new module
- [ ] Probably a good idea: test the new system with an actual config (I can do this since I'm already using the option interface from the original PR, which is largely unchanged). This should hopefully catch any issues with a more complex system that the tests may not have
- [ ] Possibly a good idea: write a brief history of this and previous PRs for historical purposes
- [ ] Thorough review by a third party (not previously involved with this PR) as a sanity check (once everything is ready to merge)


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
