### PR TITLE
llvmPackages.*: enable strict Deps, enable structuredAttrs

### DIFF
--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
   ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/llvm-tblgen")
   ]

--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -87,6 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://github.com/llvm/llvm-project/tree/main/bolt";
     description = "LLVM post-link optimizer";

--- a/pkgs/development/compilers/llvm/common/clang-tools/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang-tools/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "clang-tools";
   version = lib.getVersion clang-unwrapped;
   dontUnpack = true;
-  clang = if enableLibcxx then libcxxClang else clang;
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -41,7 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
       fi
 
       cp $toolPath $out/bin/$toolName-unwrapped
-      substituteAll ${./wrapper} $out/bin/$toolName
+      substitute ${./wrapper} $out/bin/$toolName \
+        --replace-fail "@clang@" "${if enableLibcxx then libcxxClang else clang}" \
+        --replace-fail "@out@" "$out"
       chmod +x $out/bin/$toolName
     done
 

--- a/pkgs/development/compilers/llvm/common/clang-tools/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang-tools/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   dontUnpack = true;
   clang = if enableLibcxx then libcxxClang else clang;
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -216,6 +216,8 @@ stdenv.mkDerivation (
       };
     };
 
+    __structuredAttrs = true;
+
     requiredSystemFeatures = [ "big-parallel" ];
     meta = llvm_meta // {
       homepage = "https://clang.llvm.org/";

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -93,6 +93,8 @@ stdenv.mkDerivation (
       libllvm
     ];
 
+    strictDeps = true;
+
     cmakeFlags = [
       (lib.cmakeFeature "CLANG_INSTALL_PACKAGE_DIR" "${placeholder "dev"}/lib/cmake/clang")
       (lib.cmakeBool "CLANGD_BUILD_XPC" false)

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -299,6 +299,8 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s $out/lib/*/libclang_rt.atomic-*.so $out/lib/
     '';
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://compiler-rt.llvm.org/";
     description = "Compiler runtime libraries";

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -125,6 +125,8 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isRiscV) linuxHeaders
     ++ lib.optional (stdenv.hostPlatform.isFreeBSD) freebsd.include;
 
+  strictDeps = true;
+
   env = {
     NIX_CFLAGS_COMPILE = toString (
       [

--- a/pkgs/development/compilers/llvm/common/flang-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang-rt/default.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
     libllvm
   ];
 
+  strictDeps = true;
+
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     MACOSX_DEPLOYMENT_TARGET = effectiveDarwinVersion;
     NIX_CFLAGS_COMPILE = "-mmacosx-version-min=${effectiveDarwinVersion}";

--- a/pkgs/development/compilers/llvm/common/flang-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang-rt/default.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_OSX_DEPLOYMENT_TARGET" effectiveDarwinVersion)
   ];
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://flang.llvm.org";
     description = "LLVM Fortran Runtime";

--- a/pkgs/development/compilers/llvm/common/flang/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang/default.nix
@@ -60,6 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
     libllvm.dev
     mlir.dev
   ];
+
+  strictDeps = true;
+
   preConfigure = ''
     ls -l ${libllvm.dev}/lib/cmake/llvm/LLVMConfig.cmake
     ls -l ${libclang.dev}/lib/cmake/clang/ClangConfig.cmake

--- a/pkgs/development/compilers/llvm/common/flang/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang/default.nix
@@ -104,6 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" ];
   requiredSystemFeatures = [ "big-parallel" ];
+
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://flang.llvm.org/";
     description = "LLVM-based Fortran frontend";

--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -101,6 +101,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit isFullBuild;
   };
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://libc.llvm.org/";

--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -71,15 +71,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall =
     lib.optionalString (!isFullBuild) ''
-      substituteAll ${./libc-shim.tpl} $out/lib/libc.so
+      substitute ${./libc-shim.tpl} $out/lib/libc.so \
+        --replace-fail "@out@" "$out" \
+        --replace-fail "@libc@" "${stdenv.cc.libc}"
     ''
     # LLVM libc doesn't recognize static vs dynamic yet.
     # Treat LLVM libc as a static libc, requires this symlink until upstream fixes it.
     + lib.optionalString (isFullBuild && stdenv.hostPlatform.isLinux) ''
       ln $out/lib/crt1.o $out/lib/Scrt1.o
     '';
-
-  libc = if (!isFullBuild) then stdenv.cc.libc else null;
 
   cmakeFlags = [
     (lib.cmakeBool "LLVM_LIBC_FULL_BUILD" isFullBuild)

--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = lib.optional (isFullBuild && stdenv.hostPlatform.isLinux) linuxHeaders;
 
+  strictDeps = true;
+
   outputs = [ "out" ] ++ (lib.optional isFullBuild "dev");
 
   postUnpack = lib.optionalString needHdrGen ''

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -203,6 +203,8 @@ stdenv.mkDerivation (finalAttrs: {
     isLLVM = true;
   };
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://libcxx.llvm.org/";
     description = "C++ standard library";

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -158,6 +158,8 @@ stdenv.mkDerivation (finalAttrs: {
     libunwind
   ];
 
+  strictDeps = true;
+
   # TODO: Possibly move back to `sourceRoot` on `staging`?
   postPatch = ''
     cd runtimes

--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeBool "LIBUNWIND_ENABLE_SHARED" enableShared)
     (lib.cmakeFeature "LLVM_ENABLE_RUNTIMES" "libunwind")

--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -76,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s $out/lib/libunwind.dll.a $out/lib/libgcc_s.dll.a
     '';
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     # Details: https://github.com/llvm/llvm-project/blob/main/libunwind/docs/index.rst
     homepage = "https://clang.llvm.org/docs/Toolchain.html#unwind-library";

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -76,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
     description = "LLVM linker (unwrapped)";

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -57,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
   ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeFeature "LLD_INSTALL_PACKAGE_DIR" "${placeholder "dev"}/lib/cmake/lld")
     (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/llvm-tblgen")

--- a/pkgs/development/compilers/llvm/common/lldb-plugins/llef.nix
+++ b/pkgs/development/compilers/llvm/common/lldb-plugins/llef.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  strictDeps = true;
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/development/compilers/llvm/common/lldb-plugins/llef.nix
+++ b/pkgs/development/compilers/llvm/common/lldb-plugins/llef.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "foundryzero";
     repo = "llef";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-pUZ2d9ch1mQzfWqHy0srOJwNULGH7dUgVapCaImLa0g=";
   };
 
@@ -34,6 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "LLEF is a plugin for LLDB to make it more useful for RE and VR";

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -109,6 +109,8 @@ stdenv.mkDerivation (
       darwin.bootstrap_cmds
     ];
 
+    strictDeps = true;
+
     hardeningDisable = [ "format" ];
 
     cmakeFlags = [

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -181,6 +181,8 @@ stdenv.mkDerivation (
     passthru.vscodeExtPublisher = "llvm";
     passthru.vscodeExtUniqueId = "llvm-org.${vscodeExt.name}-${vscodeExt.version}";
 
+    __structuredAttrs = true;
+
     meta = llvm_meta // {
       homepage = "https://lldb.llvm.org/";
       description = "Next-generation high-performance debugger";

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -616,6 +616,9 @@ stdenv.mkDerivation (
     };
 
     requiredSystemFeatures = [ "big-parallel" ];
+
+    __structuredAttrs = true;
+
     meta = llvm_meta // {
       homepage = "https://llvm.org/";
       description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -283,6 +283,8 @@ stdenv.mkDerivation (
     ]
     ++ lib.optional stdenv.hostPlatform.isDarwin sysctl;
 
+    strictDeps = true;
+
     postPatch =
       optionalString stdenv.hostPlatform.isDarwin (
         ''

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -98,6 +98,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   requiredSystemFeatures = [ "big-parallel" ];
+
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://mlir.llvm.org/";
     description = "Multi-Level IR Compiler Framework";

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -65,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
   ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeBool "LLVM_BUILD_TOOLS" true)
     # Install headers as well

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -93,6 +93,8 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs ../tools/archer/tests/deflake.bash
   '';
 
+  __structuredAttrs = true;
+
   meta = llvm_meta // {
     homepage = "https://openmp.llvm.org/";
     description = "Support for the OpenMP language";

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -71,6 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeBool "LIBOMP_ENABLE_SHARED" (
       !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.hasSharedLibraries

--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -95,6 +95,8 @@ let
       updateAutotoolsGnuConfigScriptsHook
     ];
 
+    strictDeps = true;
+
     cmakeFlags = [
       # Projects with tablegen-like tools.
       "-DLLVM_ENABLE_PROJECTS=${


### PR DESCRIPTION
This PR is part of an ongoing effort to prepare nixpkgs for a future where `strictDeps` and `__structuredAttrs` are enabled for all derivations, either by setting these attributes explicitly, or - hopefully - at some point setting them in builders for various package sets (and eventually `mkDerivation`), or by enabling `strictDepsByDefault` and `structuredAttrsByDefault` in the nixpkgs configuration. We are moving towards this future by having a ratchet in place in CI that forces new packages to have both options enabled.

Transitioning the rest of nixpkgs however is a lot of work, especially since rebuilds with `strictDepsByDefault` and `structuredAttrsByDefault` enabled are very expensive because they rebuild the world from the ground up. Over the last couple of weeks I have been working on setting `strictDeps` and `__structuredAttrs` for various low-level packages to have a foundation that is automatically built by Hydra as part of the normal process. This PR is part of that effort; both for llvm/clang as a compiler in its own right, but also because it is in the closure of the Rust compiler, another big chunk of (new) packages.

* When `strictDeps` are enabled, there is better separation between various types of `*Inputs`, which is both nice for general cleanliness, but also helps set up packages in a way that support cross-compilation more easily (`strictDeps` is enabled for cross, so it's nice to have it enabled for native builds as well). Since `llvmPackages` is part of the closure of various important low-level packages and its own compiler toolchain, I assume that these various `*Inputs` are well-separated already, so I would expect  that enabling `strictDeps` does not break anything.

* When `__structuredAttrs` are enabled, arguments to the (bash) builder are passed in a safer and more consistent way. One of the changes is that attributes of a derivation are only exported as variables if they are defined inside the `env` attrset (something [I already touched `llvmPackages` for](https://github.com/NixOS/nixpkgs/pull/473918)). This also affects `substituteAll`, which I've touched on in this PR - there is some consensus that [using `substituteAll` is a bad idea anyway](https://github.com/NixOS/nixpkgs/issues/237216). Another common source of potential migration issues is that lists in nix code will now actually be arrays on the bash side, so looping over them requires the `$var[@]` syntax now. I have gone through the files when setting `strictDeps` and `__structuredAttrs` and I didn't see anything that falls into that category, but I might've missed something.

I expect the impact of this PR to be both small and big: if all goes well, this is just a modernization of the implementation and shouldn't affect downstream packages or use(r)s at all. But it also is a big step in lowering the effort required to move forward with applying these two attributes everywhere.

In addition to the `nixpkgs-review` for the individual packages in the `llvmPackages` set I have anecdotally tested this change multiple times by rebuilding my existing system configurations (desktop / laptop / servers) with `strictDepsByDefault` and `structuredAttrsByDefault` enabled, and this did not expose any issues - a good smoke test if not firm proof that all is well. Note that this only exercised native compilation on `x86_64-linux` - I am not in a position to test other platforms and if there is doubt about this PR I hope someone else will be willing to run those tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
