### PR TITLE
rPackages.Rserve: use symlink instead of copying to $out

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -2221,11 +2221,21 @@ let
     Rrdrand = old.Rrdrand.override { platforms = lib.platforms.x86_64 ++ lib.platforms.x86; };
 
     Rserve = old.Rserve.overrideAttrs (attrs: {
-      patches = [ ./patches/Rserve.patch ];
       configureFlags = [
         "--with-server"
         "--with-client"
       ];
+
+      patches = [
+        # Don't try to copy the Rserve binaries into $R_HOME/bin
+        ./patches/Rserve.patch
+      ];
+
+      # Instead, we symlink them into $out/bin
+      postInstall = ''
+        mkdir -p "$out/bin/"
+        ln -s "$out"/library/Rserve/libs/Rserve{,.dbg} "$out/bin/"
+      '';
     });
 
     SAIGEgds = old.SAIGEgds.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/patches/Rserve.patch
+++ b/pkgs/development/r-modules/patches/Rserve.patch
@@ -1,15 +1,13 @@
-diff -ru -x '*~' Rserve_orig/src/Makevars.in Rserve/src/Makevars.in
---- Rserve_orig/src/Makevars.in	2013-08-22 06:09:33.000000000 +0900
-+++ Rserve/src/Makevars.in	2014-11-09 21:36:31.184590320 +0900
-@@ -12,8 +12,9 @@
- 	$(CC) -DSTANDALONE_RSERVE -DRSERV_DEBUG -DNODAEMON -I. -Iinclude $(ALL_CPPFLAGS) $(ALL_CFLAGS) $(PKG_CPPFLAGS) $(PKG_CFLAGS) -o Rserve.dbg $(SERVER_SRC) $(ALL_LIBS) $(PKG_LIBS)
+diff --git a/src/Makevars.in b/src/Makevars.in
+index e20c4eb..1013e21 100644
+--- a/src/Makevars.in
++++ b/src/Makevars.in
+@@ -14,8 +14,6 @@ server:	$(SERVER_SRC) $(SERVER_H)
+ 	$(CC) -DSTANDALONE_RSERVE -DRSERV_DEBUG -DNODAEMON -I. -Iinclude $(ALL_CPPFLAGS) $(ALL_CFLAGS) $(PKG_CPPFLAGS) $(EMBED_CPPFLAGS) $(PKG_CFLAGS) -o Rserve.dbg $(SERVER_SRC) $(LDFLAGS) $(ALL_LIBS) $(PKG_LIBS)
  
  # merging to bin/Rserve works only if installed from sources, won't work for binary
 -	-./mergefat Rserve "$(R_HOME)/bin/Rserve"
 -	-./mergefat Rserve.dbg "$(R_HOME)/bin/Rserve.dbg"
-+	mkdir $(out)/bin
-+	-./mergefat Rserve "$(out)/bin/Rserve"
-+	-./mergefat Rserve.dbg "$(out)/bin/Rserve.dbg"
  
  client: config.h
  	cp config.h client/cxx/


### PR DESCRIPTION
Targeting https://github.com/NixOS/nixpkgs/pull/552051

Feels funny touching a .patch file from 2014

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
