### PR TITLE
python3Packages.xarray: skip distributed tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/xarray/default.nix
+++ b/pkgs/development/python-modules/xarray/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -124,6 +125,13 @@ buildPythonPackage (finalAttrs: {
     # Our h5py is built with hdf5 that is built without szip support, so we
     # skip these tests
     "not szip"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # These tests spin up a dask.distributed scheduler and workers that
+    # communicate over loopback TCP, which the Darwin build sandbox blocks
+    # (PermissionError: [Errno 1] Operation not permitted).
+    "xarray/tests/test_distributed.py"
   ];
 
   pythonImportsCheck = [ "xarray" ];


### PR DESCRIPTION
xarray/tests/test_distributed.py spins up a dask.distributed scheduler and workers that communicate over loopback TCP. The macOS build sandbox blocks this, so every test in the file fails with
"PermissionError: [Errno 1] Operation not permitted", breaking the build on Darwin.

These tests only started running on Darwin in commit 1fb2a0732be7 ("python3Packages.xarray: collect more tests with optional-dependencies"). Before that, distributed was not a check input, so the whole file was skipped at collection time via its top-level
pytest.importorskip("distributed"). That commit added optional-dependencies.parallel (= [ dask ] ++ dask.optional-dependencies.complete, which pulls in distributed) to nativeCheckInputs, so the file is now collected and executed.

Ignore the file on Darwin only, keeping full coverage on Linux where Hydra builds this package (mirroring how the distributed package itself sets doCheck = false).

Assisted-by: Anthropic Opus 4.8 in Kiro CLI 2.18.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
