### PR TITLE
yargen-go: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ya/yargen-go/package.nix
+++ b/pkgs/by-name/ya/yargen-go/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
 }:
 buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "yargen-go";
   version = "0.1.0";
 

--- a/pkgs/by-name/ya/yargen-go/package.nix
+++ b/pkgs/by-name/ya/yargen-go/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "yargen-go";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Neo23x0";
+    repo = "yarGen-Go";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XQNEyjiv2v5coBksHqrTG1rkdtjaUEGsHLr8REEKx3Y=";
+  };
+
+  vendorHash = "sha256-FltSHAvR1IJL5UlXf+Cxpmhdr35JTrPhB2flh0bbZAY=";
+
+  subPackages = [
+    "cmd/yargen"
+    "cmd/yargen-util"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Automatic YARA rule generator (Go rewrite of yarGen)";
+    longDescription = ''
+      yarGen-Go generates YARA rules from strings found in malware
+      samples while filtering out strings that also occur in goodware.
+      It is a Go rewrite of the original Python yarGen by Florian Roth,
+      and ships two binaries: yargen (CLI + web UI rule generator) and
+      yargen-util (goodware database management).
+    '';
+    homepage = "https://github.com/Neo23x0/yarGen-Go";
+    changelog = "https://github.com/Neo23x0/yarGen-Go/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ ];
+    mainProgram = "yargen";
+  };
+})


### PR DESCRIPTION
Adds `yargen-go`, the Go rewrite of yarGen (YARA rule generator) by Florian Roth.
The current `yargen` package is deprecated.
See https://github.com/Neo23x0/yarGen-Go

AI assistance was used for debugging the `vendorHash` workflow and for English wording. The submitted package definition was manually reviewed and tested.

Successfully generated YARA rules end-to-end from both a WannaCry sample from theZoo and an EICAR test file.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test