### PR TITLE
freqtweak: fix version, modernize

### DIFF
--- a/pkgs/by-name/fr/freqtweak/package.nix
+++ b/pkgs/by-name/fr/freqtweak/package.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  autoconf,
-  automake,
+  autoreconfHook,
   pkg-config,
   fftwFloat,
   libjack2,
@@ -15,18 +14,19 @@
 
 stdenv.mkDerivation {
   pname = "freqtweak";
-  version = "unstable-2019-08-03";
+  version = "0.6.1-unstable-2019-08-03";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "essej";
     repo = "freqtweak";
     rev = "d4205337558d36657a4ee6b3afb29358aa18c0fd";
-    sha256 = "10cq27mdgrrc54a40al9ahi0wqd0p2c1wxbdg518q8pzfxaxs5fi";
+    hash = "sha256-0RXdVXf/IoxCeW11Hpi4oGEOIlSJKkAUKSzn1+oRmIE=";
   };
 
   nativeBuildInputs = [
-    autoconf
-    automake
+    autoreconfHook
     pkg-config
   ];
   buildInputs = [
@@ -36,10 +36,6 @@ stdenv.mkDerivation {
     libxml2
     wxwidgets_3_2
   ];
-
-  preConfigure = ''
-    sh autogen.sh
-  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- (#541820)
  - [pinned commit](https://github.com/essej/freqtweak/commit/d4205337558d36657a4ee6b3afb29358aa18c0fd)
  - [version list](https://github.com/essej/freqtweak/blob/d4205337558d36657a4ee6b3afb29358aa18c0fd/NEWS#L8)
- I tried to enable `strictDeps`, but that quickly became more trouble than I wanted to deal with
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
