### PR TITLE
nixos/fwupd, fwupd: move efi to and populate /run/fwupd-efi

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -205,6 +205,12 @@ in
     systemd = {
       packages = [ cfg.package ];
 
+      # fwupd looks for its EFI app in /run/fwupd-efi so that signed variants can
+      # be placed next to it; `C+` keeps those signed files across a rebuild.
+      tmpfiles.rules = [
+        "C+ /run/fwupd-efi - - - - ${cfg.package.fwupd-efi}/libexec/fwupd/efi"
+      ];
+
       # The upstream unit runs as User=fwupd-refresh; ensure it can take
       # ownership of /var/lib/fwupd.
       services.fwupd-refresh.serviceConfig = {

--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -31,8 +31,11 @@ let
   originalEtc =
     let
       mkEtcFile = n: lib.nameValuePair n { source = "${cfg.package}/etc/${n}"; };
+      etcFiles = lib.filter (
+        f: config.boot.loader.grub.enable || f != "grub.d/35_fwupd"
+      ) cfg.package.filesInstalledToEtc;
     in
-    lib.listToAttrs (map mkEtcFile cfg.package.filesInstalledToEtc);
+    lib.listToAttrs (map mkEtcFile etcFiles);
   extraTrustedKeys =
     let
       mkName = p: "pki/fwupd/${baseNameOf p}";

--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -187,7 +187,7 @@ in
   config = lib.mkIf cfg.enable {
     # Disable test related plug-ins implicitly so that users do not have to care about them.
     services.fwupd.daemonSettings = {
-      EspLocation = config.boot.loader.efi.efiSysMountPoint;
+      EspLocation = lib.mkDefault config.boot.loader.efi.efiSysMountPoint;
     };
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -506,21 +506,18 @@ in
 
     # Fwupd binary needs to be signed in secure boot mode
     (lib.mkIf (cfg.enable && cfg.secureBoot.enable && config.services.fwupd.enable) {
-      systemd.services.fwupd = {
-        environment.FWUPD_EFIAPPDIR = "/run/fwupd-efi";
-      };
-
       systemd.services.fwupd-efi = {
         description = "Sign fwupd EFI app for secure boot";
         wantedBy = [ "fwupd.service" ];
         partOf = [ "fwupd.service" ];
         before = [ "fwupd.service" ];
+        # /run/fwupd-efi is populated by the fwupd module.
+        after = [ "systemd-tmpfiles-setup.service" ];
 
         unitConfig.ConditionPathIsDirectory = "/var/lib/sbctl";
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
-          RuntimeDirectory = "fwupd-efi";
         };
 
         script = ''

--- a/nixos/tests/limine/secure-boot.nix
+++ b/nixos/tests/limine/secure-boot.nix
@@ -29,11 +29,20 @@
       boot.loader.limine.secureBoot.autoEnrollKeys.extraArgs = [ "--yes-this-might-brick-my-machine" ];
       boot.loader.timeout = 0;
 
+      services.fwupd.enable = true;
+
       environment.systemPackages = [ pkgs.mokutil ];
     };
 
   testScript = ''
     machine.start()
     assert "SecureBoot enabled" in machine.succeed("mokutil --sb-state")
+
+    # fwupd is D-Bus activated, so the signing unit only runs on demand.
+    machine.succeed("systemctl start fwupd.service")
+    machine.wait_for_unit("fwupd-efi.service")
+    # the unsigned app is copied in by the fwupd module, the signed one added here
+    machine.succeed("ls /run/fwupd-efi/fwupd*.efi")
+    machine.succeed("ls /run/fwupd-efi/fwupd*.efi.signed")
   '';
 }

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -233,8 +233,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--sysconfdir=/etc"
     (lib.mesonOption "sysconfdir_install" "${placeholder "out"}/etc")
     (lib.mesonOption "efi_os_dir" "nixos")
-    # Use the EFI app from the separate fwupd-efi package.
-    (lib.mesonOption "efi_app_location" "${fwupd-efi}/libexec/fwupd/efi")
+    # Signing setups (lanzaboote, sbctl, …) must place the signed EFI app next
+    # to the unsigned one, which the store does not allow.
+    # https://github.com/fwupd/fwupd/issues/10202
+    (lib.mesonOption "efi_app_location" "/run/fwupd-efi")
     # HSI is auto-disabled on non-x86 upstream; auto_features=enabled overrides
     # that, breaking the fwupdtool installed test which expects rc=1 on non-x86.
     (lib.mesonEnable "hsi" isx86)


### PR DESCRIPTION
Due to [RaitoBezarius](https://github.com/RaitoBezarius) unresponivness in #524756, i take his work and rebased it. Also adding some more changes from other prs that were stale or unreviewed here.

For changes see individual commits

Most importantly, fixes #534574 and closes #524756
Also closes #521378, closes #423231, fixes #423212

cc @RaitoBezarius @AntonLydike 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
