### PR TITLE
noise-repellent: 0.2.0 -> 0.3.2

### DIFF
--- a/pkgs/by-name/li/libspecbleach/package.nix
+++ b/pkgs/by-name/li/libspecbleach/package.nix
@@ -2,36 +2,41 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  meson,
-  ninja,
+  cmake,
   pkg-config,
   fftwFloat,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "libspecbleach";
-  version = "0.2.0";
+  version = "0.3.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "lucianodato";
     repo = "libspecbleach";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-s8eHryJfLz63m08O7l3r2iXOAgFqiuVTEcD774C3iXE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l8qVSE8ZBb/IWDcN7wJALtOtjnXk6/FqjTi0xI6TlSk=";
   };
 
   nativeBuildInputs = [
-    meson
-    ninja
+    cmake
     pkg-config
   ];
-  buildInputs = [
-    fftwFloat
+
+  buildInputs = [ fftwFloat ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_FFTW" true)
+    (lib.cmakeBool "ENABLE_EXAMPLES" false)
   ];
 
   meta = {
     description = "C library for audio noise reduction";
     homepage = "https://github.com/lucianodato/libspecbleach";
-    license = lib.licenses.lgpl2;
+    changelog = "https://github.com/lucianodato/libspecbleach/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.lgpl2Plus;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/no/noise-repellent/package.nix
+++ b/pkgs/by-name/no/noise-repellent/package.nix
@@ -2,47 +2,80 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  meson,
-  ninja,
-  pkg-config,
   cmake,
+  pkg-config,
+  juce,
   libspecbleach,
-  lv2,
+  fftwFloat,
+  freetype,
+  alsa-lib,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "noise-repellent";
-  version = "0.2.5";
+  version = "0.3.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "lucianodato";
     repo = "noise-repellent";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GzOUcC161syjazazf+ywssWL0iH17eNhmhTBcjsuaQ0=";
+    hash = "sha256-DDURrWUcFaJxOEg8+51caYnYPXZZJhSqTJd9HGvzZ3g=";
   };
 
-  mesonFlags = [
-    "--prefix=${placeholder "out"}/lib/lv2"
-    "--buildtype=release"
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    juce # juceaide
   ];
 
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-    cmake
-  ];
   buildInputs = [
+    juce
     libspecbleach
-    lv2
+    fftwFloat
+    freetype
+    alsa-lib
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
   ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_JUCE" true)
+    (lib.cmakeBool "USE_SYSTEM_FFTW" true)
+    (lib.cmakeBool "USE_SYSTEM_FREETYPE" true)
+    (lib.cmakeBool "USE_SYSTEM_SPECBLEACH" true)
+  ];
+
+  # Upstream's install() rules use generator expressions inside
+  # install(DIRECTORY ...), which CMake does not expand, so the install phase
+  # looks for a literal "$<GENEX_EVAL:...>" directory and fails.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/lv2 $out/lib/vst3
+    cp -r "NoiseRepellent_artefacts/Release/LV2/Noise Repellent.lv2" $out/lib/lv2/
+    cp -r "NoiseRepellent_artefacts/Release/VST3/Noise Repellent.vst3" $out/lib/vst3/
+
+    runHook postInstall
+  '';
 
   meta = {
-    description = "LV2 plugin for broadband noise reduction";
+    description = "Audio plugin for broadband noise reduction (LV2, VST3)";
     homepage = "https://github.com/lucianodato/noise-repellent";
     changelog = "https://github.com/lucianodato/noise-repellent/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.magnetophon ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
