### PR TITLE
resonarium: 0.0.11 -> 0.1.0

### DIFF
--- a/pkgs/by-name/re/resonarium/package.nix
+++ b/pkgs/by-name/re/resonarium/package.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "resonarium";
-  version = "0.0.11";
+  version = "0.1.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "resonarium";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-/ezkq1er/OteoLrqXe60/QmC5BOqoRcoGvtr93wBioE=";
+    hash = "sha256-QR1EUCv7Mg52AEtfZikhnprUpPnTc/YPEssFnimfaPA=";
   };
 
   strictDeps = true;
@@ -69,15 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # Upstream forgot to bump the in-source version for v0.0.11; sync it
-    # to the git tag so the About screen and plugin metadata agree.
-    substituteInPlace CMakeLists.txt \
-    --replace-fail "set(PLUGIN_VERSION 0.0.10)" \
-                    "set(PLUGIN_VERSION ${finalAttrs.version})"
-    substituteInPlace plugin/Source/PluginProcessor.cpp \
-    --replace-fail '"0.0.10 (INST) ALPHA"' '"${finalAttrs.version} (INST) ALPHA"' \
-    --replace-fail '"0.0.10 (FX) ALPHA"'   '"${finalAttrs.version} (FX) ALPHA"'
-
     # melatonin_perfetto's CMakeLists fetches CPM.cmake and the Perfetto SDK
     # from the network at configure time, which the Nix sandbox blocks. The
     # PERFETTO compile-time switch is OFF here, so melatonin_perfetto.h


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
