### PR TITLE
fail2ban: 1.1.0 -> 1.1.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -158,6 +158,8 @@
 
 - `services.gitlab.registry` has been modified so that the GitLab container registry runs in the `gitlab-container-registry` system user. This behavior can be modified with the `services.gitlab.registry.user` option.
 
+- `fail2ban` has been updated to 1.1.1, which has a few breaking changes compared to 1.1.0 ([changelog](https://github.com/fail2ban/fail2ban/blob/1.1.1/ChangeLog))
+
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.
 
 - `matrix-appservice-discord` was removed from nixpkgs along with its NixOS module (`services.matrix-appservice-discord`) as it is no longer actively maintained upstream. Use the actively-maintained puppeting bridge [`mautrix-discord`](#opt-services.mautrix-discord.enable) instead.

--- a/pkgs/by-name/fa/fail2ban/package.nix
+++ b/pkgs/by-name/fa/fail2ban/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   python3,
   installShellFiles,
   nixosTests,
@@ -10,7 +9,7 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "fail2ban";
-  version = "1.1.0";
+  version = "1.1.1";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -20,7 +19,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     owner = "fail2ban";
     repo = "fail2ban";
     tag = finalAttrs.version;
-    hash = "sha256-0xPNhbu6/p/cbHOr5Y+PXbMbt5q/S13S5100ZZSdylE=";
+    hash = "sha256-6L8lSoFdf/KL1AQfN0lfGthEfeLlxodVsMI3LXCq+XY=";
   };
 
   outputs = [
@@ -44,8 +43,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   dependencies =
     with python3.pkgs;
-    [ distutils ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
+    lib.optionals stdenv.hostPlatform.isLinux [
       systemd-python
       pyinotify
     ];
@@ -59,19 +57,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   doCheck = false;
 
-  patches = [
-    # Adjust sshd filter for OpenSSH 9.8 new daemon name - remove next release
-    (fetchpatch {
-      url = "https://github.com/fail2ban/fail2ban/commit/2fed408c05ac5206b490368d94599869bd6a056d.patch";
-      hash = "sha256-uyrCdcBm0QyA97IpHzuGfiQbSSvhGH6YaQluG5jVIiI=";
-    })
-    # filter.d/sshd.conf: ungroup (unneeded for _daemon) - remove next release
-    (fetchpatch {
-      url = "https://github.com/fail2ban/fail2ban/commit/50ff131a0fd8f54fdeb14b48353f842ee8ae8c1a.patch";
-      hash = "sha256-YGsUPfQRRDVqhBl7LogEfY0JqpLNkwPjihWIjfGdtnQ=";
-    })
-  ];
-
   preInstall = ''
     substituteInPlace setup.py --replace /usr/share/doc/ share/doc/
 
@@ -84,11 +69,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       sitePackages = "$out/${python3.sitePackages}";
     in
     ''
-      install -m 644 -D -t "$out/lib/systemd/system" build/fail2ban.service
+      install -m 644 -D -t "$out/lib/systemd/system" build/fail2ban.service build/fail2ban.socket
       # Replace binary paths
       sed -i "s#build/bdist.*/wheel/fail2ban.*/scripts/#$out/bin/#g" $out/lib/systemd/system/fail2ban.service
-      # Delete creating the runtime directory, systemd does that
-      sed -i "/ExecStartPre/d" $out/lib/systemd/system/fail2ban.service
 
       # see https://github.com/NixOS/nixpkgs/issues/4968
       rm -r "${sitePackages}/etc"


### PR DESCRIPTION
Upgrade fail2ban to [1.1.1](https://github.com/fail2ban/fail2ban/releases/tag/1.1.1), which includes the additional patches we applied to 1.1.0 and drops the `distutils` dependency.
The new socket activation functionality will be implemented in another pull request.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
