### PR TITLE
python3Packages.pyarrow: use pure tzdata in tests

### DIFF
--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -21,6 +21,7 @@
   scikit-build-core,
   setuptools,
   setuptools-scm,
+  tzdata,
 }:
 
 let
@@ -121,8 +122,6 @@ buildPythonPackage rec {
     "pyarrow/tests/test_csv.py::TestThreadedCSVTableRead::test_cancellation"
     # expects arrow-cpp headers to be bundled.
     "pyarrow/tests/test_cpp_internals.py::test_pyarrow_include"
-    # Searches for TZDATA in /usr.
-    "pyarrow/tests/test_orc.py::test_example_using_json"
     # AssertionError: assert 'Europe/Monaco' == 'Europe/Paris'
     "pyarrow/tests/test_types.py::test_dateutil_tzinfo_to_string"
     # These fail with xxx_fixture not found.
@@ -168,6 +167,13 @@ buildPythonPackage rec {
   disabledTests = [ "GcsFileSystem" ];
 
   preCheck = ''
+    # Prepare r/w zoneinfo that test_orc can then copy and modify.
+    export TZDIR="$TMPDIR/zoneinfo"
+    cp -R "${tzdata}/${python.sitePackages}/tzdata/zoneinfo" "$TZDIR"
+    chmod -R u+w "$TZDIR"
+    substituteInPlace pyarrow/tests/test_orc.py \
+      --replace-fail "Path('/usr/share/zoneinfo')" "Path('$TZDIR')"
+
     export PARQUET_TEST_DATA="${arrow-cpp.env.PARQUET_TEST_DATA}"
     shopt -s extglob
     rm -r pyarrow/!(conftest.py|tests)


### PR DESCRIPTION
test_orc.py tests may fail on darwin because they try to read from
/usr/share/zoneinfo which may not work in darwin sandbox.

This was reported multiple times, see:
https://github.com/NixOS/nixpkgs/pull/477944
https://github.com/NixOS/nixpkgs/pull/485004
https://github.com/NixOS/nixpkgs/issues/483241

I also hit it myself in my personal flake CI.

This patch switches the test to use pure tzdata to avoid the sandbox
issue for darwin and re-enables one of previously skipped test_orc.py
cases (for both platforms).

Fixes #483241

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
