### PR TITLE
python3Packages.anyio: Fetch patch for test_keyboard_interrupt_does_not_resume_test timeout

### DIFF
--- a/pkgs/development/python-modules/anyio/default.nix
+++ b/pkgs/development/python-modules/anyio/default.nix
@@ -3,6 +3,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   pythonOlder,
 
   # build-system
@@ -41,6 +42,14 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-MEU0c8/NI1vlyNtBsg/hGLv6DR619ZqoZzNY1eJLEWM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "0001-anyio-Fixed-timeout-in-test_keyboard_interrupt_does_not_resume_test.patch";
+      url = "https://github.com/agronholm/anyio/commit/61af6c65c4f047fe5f2d71ca0d4983537a18950c.patch";
+      hash = "sha256-xSyoq7B4u9ygc/fZGDyF5uHhZud8IQ84Yb+/C1oL8WM=";
+    })
+  ];
 
   build-system = [ setuptools-scm ];
 
@@ -92,8 +101,6 @@ buildPythonPackage rec {
     #  3 second timeout expired
     "test_keyboardinterrupt_during_test"
     "test_dynamic_async_fixture_access_does_not_hang"
-    # 5 second timeout expires on weak hardware
-    "test_keyboard_interrupt_does_not_resume_test"
     # racy with high thread count, see https://github.com/NixOS/nixpkgs/issues/448125
     "test_multiple_threads"
 


### PR DESCRIPTION
https://github.com/agronholm/anyio/issues/1244

Issue was "fixed" upstream by moving the 5 second timeout into the subprocess, to exclude the time it takes to set up & tear down the process: https://github.com/agronholm/anyio/commit/61af6c65c4f047fe5f2d71ca0d4983537a18950c

My machine seemed fine with that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (tested for upstream)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
