### PR TITLE
gawkextlib: unstable-2022-10-20->0-unstable-2024-01-21; add versions

### DIFF
--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -35,14 +35,15 @@ let
       patches ? [ ],
       extraPostPatch ? "",
       env ? { },
+      version ? "0",
       broken ? null,
     }:
     let
       is_extension = gawkextlib != null;
     in
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation {
       pname = "gawkextlib-${name}";
-      version = "0-unstable-2024-01-21";
+      version = "${version}-unstable-2024-01-21";
 
       src = fetchgit {
         url = "git://git.code.sf.net/p/gawkextlib/code";
@@ -105,23 +106,28 @@ let
     abort = buildExtension {
       inherit gawkextlib;
       name = "abort";
+      version = "1.0.1";
     };
     aregex = buildExtension {
       inherit gawkextlib;
       name = "aregex";
+      version = "1.1.0";
       extraBuildInputs = [ tre ];
     };
     csv = buildExtension {
       inherit gawkextlib;
       name = "csv";
+      version = "1.0.0";
     };
     errno = buildExtension {
       inherit gawkextlib;
       name = "errno";
+      version = "1.1.1";
     };
     gd = buildExtension {
       inherit gawkextlib;
       name = "gd";
+      version = "1.0.3";
       extraBuildInputs = [ gd ];
       # GCC 14 makes this an error by default, remove when fixed upstream
       env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
@@ -129,6 +135,7 @@ let
     haru = buildExtension {
       inherit gawkextlib;
       name = "haru";
+      version = "1.0.2";
       extraBuildInputs = [ libharu ];
       patches = [
         # Renames references to two identifiers with typos that libharu fixed in 2.4.4
@@ -141,16 +148,19 @@ let
     json = buildExtension {
       inherit gawkextlib;
       name = "json";
+      version = "2.1.0";
       extraBuildInputs = [ rapidjson ];
     };
     lmdb = buildExtension {
       inherit gawkextlib;
       name = "lmdb";
+      version = "1.1.3";
       extraBuildInputs = [ lmdb ];
     };
     mbs = buildExtension {
       inherit gawkextlib;
       name = "mbs";
+      version = "1.0.0";
       extraBuildInputs = [ glibcLocales ];
       #! "spät": length: 5, mbs_length: 6, wcswidth: 4
       doCheck = !stdenv.hostPlatform.isDarwin;
@@ -158,6 +168,7 @@ let
     mpfr = buildExtension {
       inherit gawkextlib;
       name = "mpfr";
+      version = "1.1.0";
       extraBuildInputs = [
         gmp
         mpfr
@@ -166,28 +177,34 @@ let
     nl_langinfo = buildExtension {
       inherit gawkextlib;
       name = "nl_langinfo";
+      version = "1.1.0";
     };
     pgsql = buildExtension {
       inherit gawkextlib;
       name = "pgsql";
+      version = "1.1.2";
       extraBuildInputs = [ libpq ];
     };
     reclen = buildExtension {
       inherit gawkextlib;
       name = "reclen";
+      version = "1.0.1";
     };
     redis = buildExtension {
       inherit gawkextlib;
       name = "redis";
+      version = "1.7.4";
       extraBuildInputs = [ hiredis ];
     };
     select = buildExtension {
       inherit gawkextlib;
       name = "select";
+      version = "1.1.4";
     };
     xml = buildExtension {
       inherit gawkextlib;
       name = "xml";
+      version = "1.1.2";
       extraBuildInputs = [
         expat
         libiconv

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -42,12 +42,12 @@ let
     in
     stdenv.mkDerivation rec {
       pname = "gawkextlib-${name}";
-      version = "unstable-2022-10-20";
+      version = "0-unstable-2024-01-21";
 
       src = fetchgit {
         url = "git://git.code.sf.net/p/gawkextlib/code";
-        rev = "f6c75b4ac1e0cd8d70c2f6c7a8d58b4d94cfde97";
-        sha256 = "sha256-0p3CrQ3TBl7UcveZytK/9rkAzn69RRM2GwY2eCeqlkg=";
+        rev = "9f5761589277bc1270ff671aa3afcca5bbc45e57";
+        hash = "sha256-NxkgVkA9YHhHOb2weQ+veVk8/VD0YpaDPwK2cGkQRKQ=";
       };
 
       inherit patches;
@@ -118,9 +118,6 @@ let
     errno = buildExtension {
       inherit gawkextlib;
       name = "errno";
-      extraPostPatch = ''
-        substituteInPlace Makefile.am --replace-fail 'cpp -M' '${stdenv.cc.targetPrefix}cpp -M'
-      '';
     };
     gd = buildExtension {
       inherit gawkextlib;
@@ -149,15 +146,7 @@ let
     lmdb = buildExtension {
       inherit gawkextlib;
       name = "lmdb";
-      extraPostPatch = ''
-        substituteInPlace Makefile.am --replace-fail 'cpp -M' '${stdenv.cc.targetPrefix}cpp -M'
-      '';
       extraBuildInputs = [ lmdb ];
-      #  mdb_env_open(env, /dev/null)
-      #! No such device
-      #  mdb_env_open(env, /dev/null)
-      #! Operation not supported by device
-      doCheck = !stdenv.hostPlatform.isDarwin;
     };
     mbs = buildExtension {
       inherit gawkextlib;
@@ -183,6 +172,10 @@ let
       name = "pgsql";
       extraBuildInputs = [ libpq ];
     };
+    reclen = buildExtension {
+      inherit gawkextlib;
+      name = "reclen";
+    };
     redis = buildExtension {
       inherit gawkextlib;
       name = "redis";
@@ -191,13 +184,6 @@ let
     select = buildExtension {
       inherit gawkextlib;
       name = "select";
-      extraPostPatch = ''
-        substituteInPlace Makefile.am --replace-fail 'cpp -M' '${stdenv.cc.targetPrefix}cpp -M'
-      '';
-    };
-    timex = buildExtension {
-      inherit gawkextlib;
-      name = "timex";
     };
     xml = buildExtension {
       inherit gawkextlib;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2049,7 +2049,11 @@ with pkgs;
   gawk-with-extensions = callPackage ../tools/text/gawk/gawk-with-extensions.nix {
     extensions = gawkextlib.full;
   };
-  gawkextlib = callPackage ../tools/text/gawk/gawkextlib.nix { };
+  gawkextlib =
+    (callPackage ../tools/text/gawk/gawkextlib.nix { })
+    // lib.optionalAttrs config.allowAliases {
+      timex = throw "'gawkextlib.timex' has been removed because the funcionality is available in the core 'time' extension"; # Added 2026-08-15
+    };
 
   gawkInteractive = gawk.override { interactive = true; };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates and adds custom versioning for all the gawk extensions.  I got the versions from the `NEWS` file in the each plugin's directory.

- #541820

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
