### PR TITLE
yt-dlp-nightly: init at 2026.07.04-unstable-2026-08-15

### DIFF
--- a/pkgs/by-name/yt/yt-dlp-nightly/package.nix
+++ b/pkgs/by-name/yt/yt-dlp-nightly/package.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  yt-dlp,
+}:
+
+yt-dlp.overrideAttrs (
+  finalAttrs: previousAttrs: {
+    pname = "yt-dlp-nightly";
+    version = "2026.07.04-unstable-2026-08-15";
+
+    src = fetchFromGitHub {
+      inherit (previousAttrs.src) owner repo;
+      rev = "d2dcbfc5747190ad83093c7364491526bb724516";
+      hash = "sha256-yW1Cc7y6/w9nYPrDA3rcsv5ddh6pGrIIJcCTVWQS5YM=";
+    };
+
+    postPatch = ''
+      version=${lib.replaceString "-" "." finalAttrs.version}
+      prefix=*unstable.
+      version="''${version#$prefix}"
+      python devscripts/update-version.py -c nightly -r NixOS/nixpkgs $version
+    ''
+    + previousAttrs.postPatch;
+
+    passthru = previousAttrs.passthru // {
+      updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    };
+
+    meta = previousAttrs.meta // {
+      changelog = "https://github.com/yt-dlp/yt-dlp-nightly-builds/releases";
+      maintainers = previousAttrs.meta.maintainers ++ (with lib.maintainers; [ RoGreat ]);
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The stable version is not working for me, but the nightly version is. So I made a package for it. Don't see a lot of precedent for this, so I don't know if there is anything problematic here. It is fairly straightforward, there's really only a patch prepended to include the nightly version.

I noticed there is another variant called `yt-dlp-light` that hasn't been moved over yet. Looks like it has simpler overrides than this, which I think is the norm.

Pinging yt-dlp maintainers:
@SuperSandro2000
@4evy 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
