### PR TITLE
bitbake-setup: init at 2.19.0

### DIFF
--- a/pkgs/by-name/bi/bitbake-setup/package.nix
+++ b/pkgs/by-name/bi/bitbake-setup/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+
+  git,
+
+  nix-update-script,
+  versionCheckHook,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "bitbake-setup";
+  version = "2.19.0";
+  format = "wheel";
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "bitbake_setup";
+    inherit (finalAttrs) version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-tq53r8I02HL4mTgnIxcVf4VTYhRngYgl232/cDgLzdI=";
+  };
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ git ])
+  ];
+
+  pythonImportsCheck = [ "bitbake_setup" ];
+
+  versionCheckProgramArg = "--version";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--url"
+      "mirror://pypi/b/bitbake_setup/"
+    ];
+  };
+
+  meta = {
+    description = "Command that sets up a BitBake build environment from a published configuration";
+    homepage = "https://git.openembedded.org/bitbake/";
+    downloadPage = "https://pypi.org/project/bitbake-setup/";
+    license = with lib.licenses; [
+      gpl2Only
+      mit
+      psfl
+      zlib
+      lgpl21Plus
+      bsd3Clear
+    ];
+    mainProgram = "bitbake-setup";
+    maintainers = with lib.maintainers; [ otavio ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
`bitbake-setup` is the OpenEmbedded utility that creates a BitBake build environment from a published configuration. It replaces the manual `git clone` plus `oe-init-build-env` sequence: it fetches the configuration registry, lets you pick a configuration, clones the layers, and writes the build directory.

- Homepage: https://git.openembedded.org/bitbake/
- Documentation: https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-environment-setup.html
- PyPI: https://pypi.org/project/bitbake-setup/

### Packaging notes

**The source is the PyPI wheel.** PyPI publishes no sdist. The Git repository has no build files at the `2.19.0` tag; upstream added `packaging-pypi/bitbake-setup/` after that tag, and that directory assembles the distribution with a script that copies `lib/bb` and `bin/bitbake-setup` into a workspace rather than shipping a buildable source tree. The wheel is the only released source, so the package sets `format = "wheel"`.

**No Python dependencies.** The wheel bundles the whole BitBake `bb` library, including its vendored `bs4`, `ply` and `progressbar`. Upstream declares an empty `[project] dependencies` list.

**`git` at runtime.** The tool runs `git` to fetch the configuration registry and the layers, so the wrapper adds `git` to `PATH`.

**Update script.** `nix-update` cannot read the version from a `files.pythonhosted.org` wheel URL, so `extraArgs` pass `mirror://pypi/b/bitbake_setup/` instead. I verified that this resolves 2.19.0 from PyPI.

### Verification

- `nix-build -A bitbake-setup` succeeds.
- `versionCheckHook` passes; `bitbake-setup --version` reports `bitbake-setup 2.19.0`.
- `pythonImportsCheck` passes.
- `bitbake-setup list` works with an empty `PATH` and lists the four upstream configurations, which confirms the `git` wrapper.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Assisted-by: Claude Code (claude-opus-5)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

