### PR TITLE
{spaghettikart,starship-sf64}: fix building with fmt_12

### DIFF
--- a/pkgs/by-name/sp/spaghettikart/package.nix
+++ b/pkgs/by-name/sp/spaghettikart/package.nix
@@ -239,6 +239,10 @@ stdenv.mkDerivation (finalAttrs: {
     # We need to use GetAppDirectoryPath on nix or else it crashes
     substituteInPlace src/port/GameExtractor.cpp \
     --replace-fail "const std::string assets_path = Ship::Context::GetAppBundlePath();" "const std::string assets_path = Ship::Context::GetAppDirectoryPath();"
+
+    # fix building with fmt_12
+    substituteInPlace torch/lib/miniz/zip_file.hpp \
+    --replace-fail '#include <cstdint>' '#include <cstdint>''\n#include <cstring>'
   '';
 
   postBuild = ''

--- a/pkgs/by-name/st/starship-sf64/package.nix
+++ b/pkgs/by-name/st/starship-sf64/package.nix
@@ -201,6 +201,12 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "\''${STB_DIR}" "$(readlink -f ./stb)"
   '';
 
+  postPatch = ''
+    # fix building with fmt_12
+    substituteInPlace tools/Torch/lib/miniz/zip_file.hpp \
+      --replace-fail '#include <cstdint>' '#include <cstdint>''\n#include <cstring>'
+  '';
+
   postBuild = ''
     cp ${sdl_gamecontrollerdb}/share/gamecontrollerdb.txt gamecontrollerdb.txt
     ./TorchExternal/src/TorchExternal-build/torch pack ../port starship.o2r o2r


### PR DESCRIPTION
spdlog now uses fmt 12.2
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
