### PR TITLE
opensplat: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/by-name/op/opensplat/package.nix
+++ b/pkgs/by-name/op/opensplat/package.nix
@@ -10,6 +10,8 @@
   nanoflann,
   glm,
   cxxopts,
+  zlib,
+  zstd,
   nix-update-script,
   config,
   cudaSupport ? config.cudaSupport,
@@ -17,7 +19,6 @@
   rocmSupport ? config.rocmSupport,
   rocmPackages,
   autoAddDriverRunpath,
-  fetchpatch2,
 }:
 let
   torch = python3.pkgs.torch.override { inherit cudaSupport rocmSupport; };
@@ -27,7 +28,7 @@ let
 in
 stdenv'.mkDerivation (finalAttrs: {
   pname = "opensplat";
-  version = "1.1.4";
+  version = "1.1.5";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -36,15 +37,8 @@ stdenv'.mkDerivation (finalAttrs: {
     owner = "pierotofy";
     repo = "OpenSplat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u2UmD0O3sUWELYb4CjQE19i4HUjLMcaWqOinQH0PPTM=";
+    hash = "sha256-quMsTtW0NeYxxGU3DRINuzxqPo1VR4Auhq5P5+X9VTA=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/pierotofy/OpenSplat/commit/7fb96e86a43ac6cfd3eb3a7f6be190c5f2dbeb73.patch";
-      hash = "sha256-hWJWU/n1pRAAbExAYUap6CoSjIu2dzCToUmacSSpa0I=";
-    })
-  ];
 
   postPatch = lib.optionalString rocmSupport (
     # Recent PyTorch HIP builds no longer hipify the caching allocator namespace:
@@ -95,6 +89,8 @@ stdenv'.mkDerivation (finalAttrs: {
     torch.cxxdev
     torch
     opencv
+    zlib
+    zstd
   ]
   ++ lib.optionals rocmSupport [
     rocmPackages.clr


### PR DESCRIPTION
[changelog](https://github.com/pierotofy/OpenSplat/releases/tag/v1.1.5)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (in cuda/rocm variant too)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
