### PR TITLE
python3Packages.customtkinter: 5.2.2 -> 6.0.0

### DIFF
--- a/pkgs/development/python-modules/customtkinter/0002-Fix-Copying-Fonts.patch
+++ b/pkgs/development/python-modules/customtkinter/0002-Fix-Copying-Fonts.patch
@@ -1,0 +1,13 @@
+diff --git a/customtkinter/windows/widgets/font/font_manager.py b/customtkinter/windows/widgets/font/font_manager.py
+index b3ef369d..ce097585 100644
+--- a/customtkinter/windows/widgets/font/font_manager.py
++++ b/customtkinter/windows/widgets/font/font_manager.py
+@@ -55,7 +55,7 @@ def load_font(cls, font_path: str) -> bool:
+         # Linux
+         elif sys.platform.startswith("linux"):
+             try:
+-                shutil.copy(font_path, os.path.expanduser(cls.linux_font_path))
++                shutil.copyfile(font_path, os.path.join(os.path.expanduser(cls.linux_font_path), os.path.basename(font_path)))
+                 return True
+             except Exception as err:
+                 sys.stderr.write("FontManager error: " + str(err) + "\n")

--- a/pkgs/development/python-modules/customtkinter/default.nix
+++ b/pkgs/development/python-modules/customtkinter/default.nix
@@ -8,19 +8,17 @@
   packaging,
   typing-extensions,
 }:
-let
+
+buildPythonPackage (finalAttrs: {
   pname = "customtkinter";
-  version = "5.2.2";
-in
-buildPythonPackage {
-  inherit pname version;
+  version = "6.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "TomSchimansky";
     repo = "CustomTkinter";
-    tag = "v${version}";
-    hash = "sha256-1g2wdXbUv5xNnpflFLXvU39s16kmwvuegKWd91E3qm4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rRkqyyWxWmJqXS9dT/T5K99+AGY6xDjtrKLRG/Yo7tc=";
   };
 
   build-system = [
@@ -34,7 +32,10 @@ buildPythonPackage {
     typing-extensions
   ];
 
-  patches = [ ./0001-Add-Missing-Cfg-Packages.patch ];
+  patches = [
+    ./0001-Add-Missing-Cfg-Packages.patch
+    ./0002-Fix-Copying-Fonts.patch
+  ];
 
   pythonImportsCheck = [ "customtkinter" ];
 
@@ -55,4 +56,4 @@ buildPythonPackage {
     '';
     maintainers = with lib.maintainers; [ _4evy ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Included a patch that I have https://github.com/TomSchimansky/CustomTkinter/pull/2852 for the fonts copying with write permission errors.

Was reviewing my NUR and forgot to upstream this. Don't actually use it anymore since the app I was maintaining stopped using it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
