### PR TITLE
lookout: init at 0.3.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5425,6 +5425,12 @@
     githubId = 69784758;
     matrix = "@clot27:matrix.org";
   };
+  cloudglides = {
+    name = "Cloud";
+    email = "cloudglides@proton.me";
+    github = "cloudglides";
+    githubId = 111557161;
+  };
   cloudripper = {
     email = "dev+nixpkgs@cldrpr.com";
     github = "cloudripper";

--- a/pkgs/by-name/lo/lookout/package.nix
+++ b/pkgs/by-name/lo/lookout/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  cargo-tauri,
+  glib-networking,
+  gst_all_1,
+  gtk3,
+  gdk-pixbuf,
+  libayatana-appindicator,
+  libclang,
+  libgbm,
+  librsvg,
+  nodejs,
+  npmHooks,
+  openssl,
+  pipewire,
+  pkg-config,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lookout";
+  version = "0.3.11";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hackclub";
+    repo = "lookout";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WF+1nUX+JmYZIeXYLdO5FbTh52FbdL77ob0kYnHTgl0=";
+  };
+
+  patches = [ ./remove-updater.patch ];
+
+  cargoRoot = "clients/desktop/src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoHash = "sha256-eNVTOu1KyM0aJX3X5/YNq4W6EKa2dfSBn6NZRtEJWbA=";
+
+  # upstream src/window_shape.rs doctest embeds ASCII-art (┌───┐) that the
+  # rustdoc lexer rejects; the real unit/integration tests all pass
+  cargoTestFlags = [
+    "--lib"
+    "--bins"
+    "--tests"
+  ];
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    fetcherVersion = 2;
+    hash = "sha256-1BYF8hfXNctFi/KZYj3j1lbAa/qyXU+4fEI4nYjuhGY=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    libclang.lib
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  env = {
+    LIBCLANG_PATH = "${libclang.lib}/lib";
+    BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${stdenv.cc.libc.dev}/include -isystem ${libclang.lib}/lib/clang/${lib.versions.major libclang.version}/include";
+  };
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-libav
+    gtk3
+    gdk-pixbuf
+    libayatana-appindicator
+    libgbm
+    librsvg
+    openssl
+    pipewire
+    webkitgtk_4_1
+  ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # libappindicator-sys dlopens "libayatana-appindicator3.so.1" at runtime;
+    # hardpoint it to the store path so the tray icon resolves.
+    substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
+      --replace "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+
+    # Drop beforeBuildCommand entirely: tauri would re-run the frontend
+    # build here, but nixpkgs already does it in preBuild.
+    substituteInPlace clients/desktop/src-tauri/tauri.conf.json \
+      --replace-fail '"beforeDevCommand": "npm run dev",' '"beforeDevCommand": "npm run dev"' \
+      --replace-fail '"beforeBuildCommand": "npm run build"' ""
+
+    # Neutralize the frontend background updater (30-min check + auto-install).
+    # The Rust plugin is gone, so `check()` would reject at runtime every
+    # launch; stub the hook to an idle phase instead. UpdatePill renders
+    # nothing for state === "idle", so the UI is unchanged.
+    cat > clients/desktop/src/hooks/useAppUpdate.ts <<'EOF'
+    export type UpdatePhase =
+      | { state: "idle" }
+      | { state: "downloading"; version: string; progress: number }
+      | { state: "ready"; version: string }
+      | { state: "installing"; version: string };
+
+    export function useAppUpdate(): { phase: UpdatePhase; restart: () => void } {
+      return { phase: { state: "idle" }, restart: () => {} };
+    }
+    EOF
+  '';
+
+  preBuild = ''
+    # npm workspaces: build deps in dependency order before `vite build`
+    npm run build -w @lookout/shared
+    npm run build -w @lookout/react
+    npm run build -w @lookout/desktop
+  '';
+
+  meta = {
+    description = "Hack Club time-tracking desktop app that captures periodic screenshots";
+    homepage = "https://github.com/hackclub/lookout";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ cloudglides ];
+    platforms = lib.platforms.linux;
+    mainProgram = "lookout-desktop";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})

--- a/pkgs/by-name/lo/lookout/remove-updater.patch
+++ b/pkgs/by-name/lo/lookout/remove-updater.patch
@@ -1,0 +1,49 @@
+diff --git a/clients/desktop/src-tauri/Cargo.toml b/clients/desktop/src-tauri/Cargo.toml
+index 1234567..abcdefg 100644
+--- a/clients/desktop/src-tauri/Cargo.toml
++++ b/clients/desktop/src-tauri/Cargo.toml
+@@ -17,6 +17,7 @@ debug = true
+ 
+ [package]
++# tauri-plugin-updater removed (nixpkgs policy: no self-updating apps)
+ name = "lookout-desktop"
+ version = "0.3.10"
+ edition = "2021"
+
+diff --git a/clients/desktop/src-tauri/src/lib.rs b/clients/desktop/src-tauri/src/lib.rs
+index 1234567..abcdefg 100644
+--- a/clients/desktop/src-tauri/src/lib.rs
++++ b/clients/desktop/src-tauri/src/lib.rs
+@@ -3671,7 +3671,7 @@ pub fn run() {
+         .plugin(tauri_plugin_http::init())
+         .plugin(tauri_plugin_macos_permissions::init())
+         .plugin(tauri_plugin_opener::init())
+         .plugin(tauri_plugin_liquid_glass::init())
+-        .plugin(tauri_plugin_updater::Builder::new().build())
++        // .plugin(tauri_plugin_updater::Builder::new().build()) // removed: nixpkgs policy
+         .plugin(tauri_plugin_notification::init())
+         .manage(AppState {
+diff --git a/clients/desktop/src-tauri/tauri.conf.json b/clients/desktop/src-tauri/tauri.conf.json
+index 1234567..abcdefg 100644
+--- a/clients/desktop/src-tauri/tauri.conf.json
++++ b/clients/desktop/src-tauri/tauri.conf.json
+@@ -38,7 +38,7 @@
+   "bundle": {
+     "active": true,
+-    "createUpdaterArtifacts": true,
++    "createUpdaterArtifacts": false,
+     "targets": [
+       "app",
+       "dmg",
+
+diff --git a/clients/desktop/src-tauri/capabilities/default.json b/clients/desktop/src-tauri/capabilities/default.json
+index 1234567..abcdefg 100644
+--- a/clients/desktop/src-tauri/capabilities/default.json
++++ b/clients/desktop/src-tauri/capabilities/default.json
+@@ -20,7 +20,6 @@
+     "deep-link:default",
+     "macos-permissions:default",
+-    "updater:default",
+     "notification:default",
+     "core:webview:allow-create-webview-window",
+     "core:window:allow-close",


### PR DESCRIPTION
Hack Club's time tracking desktop app

https://github.com/hackclub/lookout

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/tree/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/tree/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/tree/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).