### PR TITLE
go-mockery: 3.7.2 -> 3.7.4

### DIFF
--- a/pkgs/by-name/go/go-mockery/package.nix
+++ b/pkgs/by-name/go/go-mockery/package.nix
@@ -10,17 +10,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "go-mockery";
-  version = "3.7.2";
+  version = "3.7.4";
 
   src = fetchFromGitHub {
     owner = "vektra";
     repo = "mockery";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lPyoWjLaRhE4SpVahJd8T3LsCyfdFMIsuxmWODRoLL0=";
+    hash = "sha256-2KhyuS6k8EyPnEVunAIamGJgePmvDVJqSyN0UlAFyvQ=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-izMi4MqbfKX1PmNMWyCwBOWqiPZfth/ZSzsuEcTN6Pg=";
+  vendorHash = "sha256-ockGzV+nj/O6iRcscmhfx220TqJ8LACER/pOPqs21tY=";
 
   ldflags = [
     "-s"
@@ -28,7 +28,14 @@ buildGoModule (finalAttrs: {
     "-X github.com/vektra/mockery/v${lib.versions.major finalAttrs.version}/internal/logging.SemVer=v${finalAttrs.version}"
   ];
 
-  env.CGO_ENABLED = 0;
+  env = {
+    CGO_ENABLED = 0;
+
+    # go.work pulls ./tools into the workspace, which raises mockery's own
+    # dependencies to the tools build list. Build and test against go.mod
+    # alone, matching what upstream's Taskfile does.
+    GOWORK = "off";
+  };
 
   subPackages = [ "." ];
 
@@ -45,12 +52,25 @@ buildGoModule (finalAttrs: {
   prePatch = ''
     # remove test.ci's dependency on lint since we don't need it and
     # it tries to use remote golangci-lint
+    #
     # remove test.ci's git-state check, which runs `git diff --exit-code`;
     # the source has no .git directory, so the check cannot work here
+    #
+    # use gotestsum from nativeCheckInputs rather than building it from the
+    # tools module, which would need network access
     substituteInPlace Taskfile.yml \
       --replace-fail "deps: [lint]" "" \
       --replace-fail "      - task: git-state" "" \
-      --replace-fail "go run gotest.tools/gotestsum" "gotestsum"
+      --replace-fail "    deps: [tools.gotestsum]" "" \
+      --replace-fail "./tools/gotestsum{{exeExt}}" "gotestsum"
+
+    # the e2e scripts reach go-task through the workspace, which GOWORK=off
+    # rules out; use go-task from nativeCheckInputs instead
+    substituteInPlace \
+      e2e/test_mockery_generation.sh \
+      e2e/test_infinite_mocking.sh \
+      e2e/test_missing_interface/run.sh \
+      --replace-fail "go run github.com/go-task/task/v3/cmd/task" "task"
 
     # patch scripts used in e2e testing
     patchShebangs e2e


### PR DESCRIPTION
Auto-update mockery from 3.7.2 to 3.7.4 using [nixpkgs-update](https://github.com/nix-community/nixpkgs-update).

Changelog: https://github.com/vektra/mockery/releases/tag/v3.7.4

AI Disclaimer: While nixpkgs-update did generate the update, I used Claude to generate the branch and help with the PR description.

Upstream reworked the Taskfile to run mockery's own build and tests with GOWORK=off, because the workspace includes an extra ./tools module. Set GOWORK in env so the module cache and the build agree, which also means the binary is built against the main go.mod. This changes vendorHash beyond the usual version bump.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
