### PR TITLE
bintools-wrapper: improve performance of ld-wrapper

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -201,47 +201,68 @@ if [[ "$NIX_DONT_SET_RPATH_@suffixSalt@" != 1 && "$linkType" != static-pie ]]; t
     # It's important to add the rpath in the order of -L..., so
     # the link time chosen objects will be those of runtime linking.
     declare -A rpaths
+    declare -A processed
+
+    # Canonicalize all of the library directories.
+    if [[ ${#libDirs[@]} -gt 0 ]]; then
+        mapfile -t canonicalDirs < <(realpath -s -- "${libDirs[@]}")
+
+        # If canonicalDirs and libDirs do not match in length,
+        # then one of the paths does not exist.
+        # Degrade to the older (slower) behaviour.
+        if [[ ${#canonicalDirs[@]} -ne ${#libDirs[@]} ]]; then
+            canonicalDirs=()
+            for dir in "${libDirs[@]}"; do
+                if dir2=$(realpath -s "$dir"); then
+                    canonicalDirs+=("$dir2")
+                else
+                    canonicalDirs+=("")
+                fi
+            done
+        fi
+    else
+        canonicalDirs=()
+    fi
+
+    i=0
     for dir in ${libDirs+"${libDirs[@]}"}; do
+        canonicalDir="${canonicalDirs[i++]}"
+        # If the library's directory cannot be resolved, skip.
+        [[ -n "$canonicalDir" ]] || continue
+        dir="$canonicalDir"
+
+        # If the library has already been processed, don't process it a second time.
+        [[ ${processed[$dir]:-} ]] && continue
+        processed["$dir"]=1
+
         # If the path is in the store, do not resolve any symlinks and add it to the rpath.
         # Resolving symlinks in the store breaks bootstrapping, see issue #454199.
         # If it is outside the store, resolve symlinks step by step until it falls
         # into the store or it becomes not a symlink.
         # Always canonicalize the path before checking it is in the store or not.
-        if dir2=$(realpath -s "$dir"); then
-            dir="$dir2"
-        else
-            continue
-        fi
         while [ -z "${rpaths[$dir]:-}" ] && [[ "$dir" != "${NIX_STORE:-}"/* ]] && [ -L "$dir" ]; do
-            if dir2=$(readlink "$dir"); then
-                dir="dir2"
-            else
-                break
-            fi
-            if dir2=$(realpath -s "$dir"); then
-                dir="dir2"
-            else
-                break
-            fi
+            dir2=$(readlink "$dir") || break
+            dir="$dir2"
+            dir2=$(realpath -s "$dir") || break
+            dir="$dir2"
         done
+
         # If the path turns out to be outside the store, we do not add it to rpath.
         # This typically happens for libraries in /tmp that are later
         # copied to $out/lib. If not, we're screwed.
-        if [ -n "${rpaths[$dir]:-}" ] || [[ "$dir" != "${NIX_STORE:-}"/* ]]; then
-            continue
-        fi
-        for path in "$dir"/*; do
-            file="${path##*/}"
-            if [ "${libs[$file]:-}" ]; then
-                # This library may have been provided by a previous directory,
-                # but if that library file is inside an output of the current
-                # derivation, it can be deleted after this compilation and
-                # should be found in a later directory, so we add all
-                # directories that contain any of the libraries to rpath.
-                rpaths["$dir"]=1
-                extraAfter+=(-rpath "$dir")
-                break
-            fi
+        [[ -n "${rpaths[$dir]:-}" ]] && continue
+        [[ "$dir" != "${NIX_STORE:-}"/* ]] && continue
+
+        for file in "${!libs[@]}"; do
+            [[ -e "$dir/$file" || -L "$dir/$file" ]] || continue
+            # This library may have been provided by a previous directory,
+            # but if that library file is inside an output of the current
+            # derivation, it can be deleted after this compilation and
+            # should be found in a later directory, so we add all
+            # directories that contain any of the libraries to rpath.
+            rpaths["$dir"]=1
+            extraAfter+=(-rpath "$dir")
+            break
         done
     done
 


### PR DESCRIPTION
Drastically improves the performance of `ld-wrapper` with large `NIX_LDFLAGS`.

- Canonicalize all library paths at once. In the case where some of the library paths do not exist, then the implementation degrades to the slower behaviour. 
- Cache processed libraries to avoid unnecessary processing
- Avoid globbing all the files in a library, instead iterating over the passed `.so` files.

In testing, this decreased the execution time of the script (excluding the linker) from 0.8s to 0.03s.

Some additional context for why my `NIX_LDFLAGS` is so large: https://discourse.nixos.org/t/argument-list-too-long-due-to-inflated-nix-cflags-compile/77367
ROS has a bad habit of not really having a distinction between packages which are libraries and packages which aren't, so it's kinda a mess.

Note: this has not actually been tested in nixpkgs itself, rather I was testing this manually outside of nixpkgs.
I'm new(ish) to nix in general, and have not actually built this, however I'm like 95% sure that this should work and has identical behaviour.

I've PR'd against staging, as afaik this is going to require a rebuild of Everything.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
