### PR TITLE
vampire: 5.0.1 -> 5.1.0

### DIFF
--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -58,7 +58,7 @@ let
       stdenv = vampireStdenv;
       z3' = null;
     }).overrideAttrs
-      (_: {
+      (old: {
         pname = "vampire-for-isabelle";
         version = "4.8";
 
@@ -75,9 +75,8 @@ let
           mv $out/bin/vampire_rel $out/bin/vampire
         '';
 
-        cmakeFlags = [
+        cmakeFlags = old.cmakeFlags ++ [
           (lib.cmakeFeature "CMAKE_BUILD_HOL" "On")
-          (lib.cmakeFeature "CMAKE_DISABLE_FIND_PACKAGE_Z3" "On")
         ];
       });
 

--- a/pkgs/by-name/va/vampire/package.nix
+++ b/pkgs/by-name/va/vampire/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   cmake,
   z3,
+  # We use an older version of z3 because upstream pins this older version as a submodule
+  # And doesn't recommend using different versions unless you know specfically what you are doing
   z3' ? z3.overrideAttrs rec {
     version = "4.14.0";
     src = fetchFromGitHub {
@@ -13,34 +15,54 @@
       hash = "sha256-Bv7+0J7ilJNFM5feYJqDpYsOjj7h7t1Bx/4OIar43EI=";
     };
   },
+  vampire,
   nix-update-script,
+  buildType ? "Release",
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vampire";
-  version = "5.0.1";
+  version = "5.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "vprover";
     repo = "vampire";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Ka9HmicIf7b5VN9nbiCW604ZZrGpJuP57RPTzOnwJbU=";
+    hash = "sha256-zPE2GmaHupBhyPEZFcoRADzClPKYydlJ74dNkyQpJa8=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [
-    z3'
+  buildInputs = [ z3' ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" buildType)
+    (
+      if z3' != null then
+        lib.cmakeFeature "Z3_DIR" "${z3'.dev}/lib/cmake"
+      else
+        lib.cmakeFeature "CMAKE_DISABLE_FIND_PACKAGE_Z3" "On"
+    )
   ];
-
-  cmakeFlags = [ (lib.cmakeFeature "Z3_DIR" "${z3'.dev}/lib/cmake") ];
-
-  enableParallelBuilding = true;
 
   prePatch = ''
     rm -rf z3
   '';
 
-  passthru.updateScript = nix-update-script { };
+  doCheck = buildType == "Debug";
+  preCheck = ''
+    make vtest -j $NIX_BUILD_CORES
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    z3 = z3';
+    tests.debug-build-with-tests = vampire.override {
+      buildType = "Debug";
+    };
+  };
 
   meta = {
     homepage = "https://vprover.github.io/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Vampire update and cleanup. Most of the HOL stuff is merged upstream, so next isabelle may use this version. Just some cleanup included alongside the version bump.

Closes: #558080

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
