### PR TITLE
ergochat: 2.17.0 -> 2.19.1

### DIFF
--- a/pkgs/by-name/er/ergochat/0001-Fix-systemd-reload.patch
+++ b/pkgs/by-name/er/ergochat/0001-Fix-systemd-reload.patch
@@ -1,0 +1,59 @@
+diff --git a/vendor/github.com/okzk/sdnotify/notify.go b/vendor/github.com/okzk/sdnotify/notify.go
+index f7d70e0d..8133617e 100644
+--- a/vendor/github.com/okzk/sdnotify/notify.go
++++ b/vendor/github.com/okzk/sdnotify/notify.go
+@@ -7,3 +7,8 @@ func SdNotify(state string) error {
+ 	// do nothing
+ 	return nil
+ }
++
++func Reloading() error {
++	return nil
++}
++
+diff --git a/vendor/github.com/okzk/sdnotify/notify_linux.go b/vendor/github.com/okzk/sdnotify/notify_linux.go
+index 91d1efac..e31e823b 100644
+--- a/vendor/github.com/okzk/sdnotify/notify_linux.go
++++ b/vendor/github.com/okzk/sdnotify/notify_linux.go
+@@ -1,8 +1,11 @@
+ package sdnotify
+ 
+ import (
++	"fmt"
+ 	"net"
+ 	"os"
++
++	"golang.org/x/sys/unix"
+ )
+ 
+ // SdNotify sends a specified string to the systemd notification socket.
+@@ -21,3 +24,13 @@ func SdNotify(state string) error {
+ 	_, err = conn.Write([]byte(state))
+ 	return err
+ }
++
++func Reloading() error {
++	var ts unix.Timespec
++	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
++		return fmt.Errorf("getting monotonic time: %w", err)
++	}
++	nsecs := ts.Sec*1e09 + ts.Nsec
++	return SdNotify(fmt.Sprintf("RELOADING=1\nMONOTONIC_USEC=%d",
++		nsecs/1000))
++}
+diff --git a/vendor/github.com/okzk/sdnotify/util.go b/vendor/github.com/okzk/sdnotify/util.go
+index 71e1e928..0ee19d67 100644
+--- a/vendor/github.com/okzk/sdnotify/util.go
++++ b/vendor/github.com/okzk/sdnotify/util.go
+@@ -18,11 +18,6 @@ func Stopping() error {
+ 	return SdNotify("STOPPING=1")
+ }
+ 
+-// Reloading sends RELOADING=1 to the systemd notify socket.
+-func Reloading() error {
+-	return SdNotify("RELOADING=1")
+-}
+-
+ // Errno sends ERRNO=? to the systemd notify socket.
+ func Errno(errno int) error {
+ 	return SdNotify(fmt.Sprintf("ERRNO=%d", errno))

--- a/pkgs/by-name/er/ergochat/package.nix
+++ b/pkgs/by-name/er/ergochat/package.nix
@@ -3,18 +3,39 @@
   fetchFromGitHub,
   lib,
   nixosTests,
+
+  mysqlSupport ? true,
+  postgresqlSupport ? true,
+  sqliteSupport ? true,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "ergo";
-  version = "2.17.0";
+  version = "2.19.1";
 
   src = fetchFromGitHub {
     owner = "ergochat";
     repo = "ergo";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-ajLecAgE74Et7XRGtpGoA9DAcSzBEtRzLm47nHn1Amo=";
+    sha256 = "sha256-yzGLOpECalSOv1zBpVkyDlHGaHSsQNsAoNa2jgLpsgM=";
   };
+
+  tags = [
+    "i18n"
+  ]
+  ++ lib.optional mysqlSupport "mysql"
+  ++ lib.optional postgresqlSupport "postgresql"
+  ++ lib.optional sqliteSupport "sqlite";
+
+  patches = [
+    # Fix systemd reload notifications
+    ./0001-Fix-systemd-reload.patch
+  ];
+
+  ldflags = [
+    "-X main.commit=${finalAttrs.src.rev}"
+    "-X main.version=${finalAttrs.version}"
+  ];
 
   vendorHash = null;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
