### PR TITLE
go-mockery: allow local networking in the darwin sandbox

### DIFF
--- a/pkgs/by-name/go/go-mockery/package.nix
+++ b/pkgs/by-name/go/go-mockery/package.nix
@@ -38,6 +38,10 @@ buildGoModule (finalAttrs: {
     gotestsum
   ];
 
+  # the e2e remote template tests serve fixtures from an httptest server on
+  # loopback, which the darwin sandbox blocks by default
+  __darwinAllowLocalNetworking = true;
+
   prePatch = ''
     # remove test.ci's dependency on lint since we don't need it and
     # it tries to use remote golangci-lint


### PR DESCRIPTION
The e2e remote template tests serve their fixtures from an httptest server on loopback, which the darwin sandbox denies with:

```
panic: httptest: failed to listen on a port: listen tcp6 [::1]:0: bind: operation not permitted
```

This only matters when building with sandbox = true, but several nix packages already set `__darwinAllowLocalNetworking` so we should also set it for mockery.

AI Disclaimer: This issue was discovered and fixed with the help of Claude Code.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
