### PR TITLE
lib.fetchers.normalizeHash: move assertions down to outputHash and outputHashAlgo values

### DIFF
--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -122,29 +122,29 @@ rec {
       args
     else
       let
-        # The argument hash, as a {name, value} pair
-        h =
-          # All hashes passed in arguments (possibly 0 or >1) as a list of {name, value} pairs
-          let
-            hashesAsNVPairs = attrsToList (intersectAttrs hashSet args);
-          in
-          if hashesAsNVPairs == [ ] then
-            if required then throw "fetcher called without `hash`" else null
+        # All hashes passed in arguments (possibly 0 or >1) as a list of {name, value} pairs
+        hashesAsNVPairs = attrsToList (intersectAttrs hashSet args);
+        unspecifiedHash = hashesAsNVPairs == [ ];
+        errorMessage =
+          if unspecifiedHash && required then
+            "fetcher called without `hash`"
           else if length hashesAsNVPairs != 1 then
-            throw "fetcher called with mutually-incompatible arguments: ${
+            "fetcher called with mutually-incompatible arguments: ${
               concatMapStringsSep ", " (a: a.name) hashesAsNVPairs
             }"
           else
-            head hashesAsNVPairs;
+            null;
+        # The argument hash, as a {name, value} pair
+        h = head hashesAsNVPairs;
       in
       removeAttrs args hashNames
-      // (optionalAttrs (h != null) {
-        outputHashAlgo = if h.name == "hash" then null else h.name;
-        outputHash =
-          if h.value == "" then
-            fakeH.${h.name} or (throw "no “fake hash” defined for ${h.name}")
-          else
-            h.value;
+      // (optionalAttrs (required || !unspecifiedHash) {
+        outputHashAlgo = lib.throwIf (errorMessage != null) errorMessage (
+          if h.name == "hash" then null else h.name
+        );
+        outputHash = lib.throwIf (errorMessage != null) errorMessage (
+          if h.value == "" then fakeH.${h.name} or (throw "no “fake hash” defined for ${h.name}") else h.value
+        );
       });
 
   /**

--- a/lib/tests/fetchers.nix
+++ b/lib/tests/fetchers.nix
@@ -89,10 +89,10 @@ let
       };
     };
 
-    "test${n}RejectsSha1ByDefault" = testingThrow (f { } { sha1 = ""; });
-    "test${n}RejectsSha512ByDefault" = testingThrow (f { } { sha512 = ""; });
+    "test${n}RejectsSha1ByDefault" = testingThrow (f { } { sha1 = ""; }).outputHash;
+    "test${n}RejectsSha512ByDefault" = testingThrow (f { } { sha512 = ""; }).outputHash;
 
-    "test${n}ThrowsOnMissing" = testingThrow (f { } { gibi = false; });
+    "test${n}ThrowsOnMissing" = testingThrow (f { } { gibi = false; }).outputHash;
   };
 in
 runTests (unionOfDisjoints [
@@ -159,7 +159,9 @@ runTests (unionOfDisjoints [
       };
     };
 
-    testRejectsMissingHashArg = testingThrow (withNormalizedHash { } ({ outputHashAlgo }: { }));
-    testRejectsMissingAlgoArg = testingThrow (withNormalizedHash { } ({ outputHash }: { }));
+    testRejectsMissingHashArg =
+      testingThrow
+        (withNormalizedHash { } ({ outputHashAlgo }: { })).outputHash;
+    testRejectsMissingAlgoArg = testingThrow (withNormalizedHash { } ({ outputHash }: { })).outputHash;
   }
 ])


### PR DESCRIPTION
When a build helper constructs its result derivation with `lib.fetchers.normalizeHash`, this change make other attributes of the result derivation accessible even when `lib.fetchers.normaliseHash` is throwing hash-related errors.

This change facilitates debugging and make the derivation attribute set more stable, allowing more flexible fixed-point implementation like `fetchFromGitProvider`.
This is the initial effort for PRs
- #462034

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
