### PR TITLE
nixos/kubernetes: disambiguate kubelet cluster DNS options

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -129,13 +129,24 @@ in
     };
 
     clusterDns = mkOption {
-      description = "Use alternative DNS.";
+      description = ''
+        List of DNS resolvers (IP addresses) used inside containers.
+
+        Defaulted to {option}`services.kubernetes.addons.dns.clusterIp`
+        when {option}`services.kubernetes.addons.dns.enable` is `true`.
+
+        Refer to the list of configuration attributes for [KubeletConfiguration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration).
+      '';
       default = [ "10.1.0.1" ];
       type = listOf str;
     };
 
     clusterDomain = mkOption {
-      description = "Use alternative domain.";
+      description = ''
+        Search DNS domain used inside containers.
+
+        Refer to the list of configuration attributes for [KubeletConfiguration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration).
+      '';
       default = config.services.kubernetes.addons.dns.clusterDomain;
       defaultText = literalExpression "config.${options.services.kubernetes.addons.dns.clusterDomain}";
       type = str;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Addresses ~minor shortcomings in the current options' descriptions, in order of importance:

1. `kubelet.clusterDns` fails to mention that its default is influenced by `addons.dns.enable`. This matters because `addons.dns.enable == true` by default.
1. Both `kubelet.clusterDns` and `kubelet.clusterDomain` use the term "alternative" ambiguously. These options build upon the host's network configuration, they are not an _alternative_ to it.
1. Since these options map 1:1 to [KubeletConfiguration attributes](https://github.com/NixOS/nixpkgs/blob/0e251e24a4f24e036a084b6b4b2d2491af4167f4/nixos/modules/services/cluster/kubernetes/kubelet.nix#L73-L78), link to the canonical documentation page.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
