### PR TITLE
sv-lang_9: fix build against fmt 12

### DIFF
--- a/pkgs/by-name/sv/sv-lang_10/package.nix
+++ b/pkgs/by-name/sv/sv-lang_10/package.nix
@@ -36,14 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
       'set(mimalloc_min_version "2.2")' \
       'set(mimalloc_min_version "${lib.versions.majorMinor mimalloc.version}")'
   ''
-  # fmt 12 moved fmt::format's declaration out of the lightweight
-  # fmt/core.h into fmt/format.h (format.h is a strict superset, so this
-  # is safe everywhere it's used). Same fix as upstream slang applied for
-  # 11.0 (commit 5a898b4b9225d281902fcd59fe4732b1561677d2), backported here
-  # since nixpkgs pins slang 10.0 specifically for circt.
+  # fmt 12 moved fmt::format out of fmt/core.h into fmt/format.h
   + ''
-    grep -rl '#include <fmt/core.h>' --include='*.h' --include='*.cpp' . | \
-      xargs sed -i 's|#include <fmt/core.h>|#include <fmt/format.h>|'
+    substituteInPlace $(grep -rl '#include <fmt/core.h>' --include='*.cpp' --include='*.h' .) \
+      --replace-fail '#include <fmt/core.h>' '#include <fmt/format.h>'
   '';
 
   cmakeFlags = [

--- a/pkgs/by-name/sv/sv-lang_9/package.nix
+++ b/pkgs/by-name/sv/sv-lang_9/package.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace external/CMakeLists.txt --replace-fail \
       'set(mimalloc_min_version "2.2")' \
       'set(mimalloc_min_version "${lib.versions.majorMinor mimalloc.version}")'
+  ''
+  # fmt 12 moved fmt::format out of fmt/core.h into fmt/format.h
+  + ''
+    substituteInPlace $(grep -rl '#include <fmt/core.h>' --include='*.cpp' --include='*.h' .) \
+      --replace-fail '#include <fmt/core.h>' '#include <fmt/format.h>'
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
Resolving the build failure here: https://hydra.nixos.org/build/341689432

Same change as in: https://github.com/NixOS/nixpkgs/pull/551902. I touch sv-lang_10 to unify the approach between the two versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
