### PR TITLE
nixos/tests/printing: migrate to remove PCRE usage

### DIFF
--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -103,7 +103,7 @@ in
         "${pkgs.groff.doc}/share/doc/*/examples/mom/penguin.pdf",
         "${pkgs.groff.doc}/share/doc/*/meref.ps",
         "${pkgs.cups.out}/share/doc/cups/images/cups.png",
-        "${pkgs.pcre.doc}/share/doc/pcre/pcre.txt",
+        "${pkgs.groff.doc}/share/doc/*/examples/mom/README.txt",
     ]:
         file_name = os.path.basename(file)
         with subtest(f"print {file_name}"):


### PR DESCRIPTION
## Things done

With PCRE getting deprecated #356387 the PCRE dependency is removed and replaced with a .txt file in `groff`  see https://github.com/NixOS/nixpkgs/pull/553268#issuecomment-5314709217. Making these tests independent from PCRE.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
