### PR TITLE
xmpp-dns: 0.6.3 -> 0.6.4

### DIFF
--- a/pkgs/by-name/xm/xmpp-dns/package.nix
+++ b/pkgs/by-name/xm/xmpp-dns/package.nix
@@ -7,7 +7,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "xmpp-dns";
-  version = "0.6.3";
+  version = "0.6.4";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -16,9 +16,9 @@ buildGoModule (finalAttrs: {
     owner = "mdosch";
     repo = "xmpp-dns";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GLTAV8LtOtgYwb261m3gq+AwFQspFUjVl4Si/A5ZmzI=";
+    hash = "sha256-aqj6RpTuZxb5GdRoNTX2eSz9LwjNB+M/po5ZQKJv2A0=";
   };
-  vendorHash = "sha256-KFDnFD6g88zIRt08aL/0Obik70oELCDb7piKZaSXGY4=";
+  vendorHash = "sha256-vKhzDtY5zeZT2AcqdSMP/KdTIiXCFuGGLdb5VvlWXbM=";
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = "installManPage man/xmpp-dns.1";


### PR DESCRIPTION
Upstream changelog: https://salsa.debian.org/mdosch/xmpp-dns/-/blob/v0.6.4/CHANGELOG.md?ref_type=tags

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
