### PR TITLE
lact: 0.9.1 -> 0.10.0

### DIFF
--- a/pkgs/by-name/la/lact/package.nix
+++ b/pkgs/by-name/la/lact/package.nix
@@ -26,16 +26,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lact";
-  version = "0.9.1";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "ilya-zlobintsev";
     repo = "LACT";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/b5Cfexi/RtE3DkON5J3dc4aEX6aLZvIcAhsg6Kdv7M=";
+    hash = "sha256-dLy/q+PfnHfNJ/PS7Y7MVfiZ5ZoYM+6PpHrUTpdvCp4=";
   };
 
-  cargoHash = "sha256-XV37VRbCaxySMgEqXmIA0TUpI9uR+6jGOzdMlEfWxDw=";
+  cargoHash = "sha256-h1czRa3xBXhQYZlNHo2psGD7r3AnDiplUWauO4+/l30=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Summary

Updated `lact` from `0.9.1` to `0.10.0`.
Closes #552950

Diff: https://github.com/ilya-zlobintsev/LACT/compare/v0.9.1...v0.10.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [x] Package tests at `passthru.tests`.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR.
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.