### PR TITLE
qemu: include xenfv patch

### DIFF
--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -287,7 +287,8 @@ stdenv.mkDerivation (finalAttrs: {
     # https://lists.gnu.org/archive/html/qemu-devel/2026-07/msg08469.html
     ./fix-tls-tests-without-tasn1.patch
   ]
-  ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;
+  ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch
+  ++ lib.optional xenSupport ./xenfv.patch;
 
   postPatch = ''
     # Otherwise tries to ensure /var/run exists.

--- a/pkgs/by-name/qe/qemu/xenfv.patch
+++ b/pkgs/by-name/qe/qemu/xenfv.patch
@@ -1,0 +1,12 @@
+diff --git a/hw/i386/pc_piix.c b/hw/i386/pc_piix.c
+index 82457bdb16..0a911ce59e 100644
+--- a/hw/i386/pc_piix.c
++++ b/hw/i386/pc_piix.c
+@@ -658,6 +658,7 @@ static void xenfv_machine_4_2_options(MachineClass *m)
+  {
+  pc_i440fx_machine_4_2_options(m);
+  m->desc = "Xen Fully-virtualized PC";
++m->alias = "xenfv";
+  m->max_cpus = HVM_MAX_VCPUS;
+  m->default_machine_opts = "accel=xen,suppress-vmdesc=on";
+  }


### PR DESCRIPTION
xenfv is a deprecated alias that was removed in QEMU 11. It is still used by some Xen toolstacks, so we have to keep it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
