### PR TITLE
smath-studio: init at 1.5.0.9678

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9623,6 +9623,12 @@
     githubId = 44584365;
     name = "Francesco Vecchia";
   };
+  frajul = {
+    email = "frajul@comumail.de";
+    github = "Frajul";
+    githubId = 37769358;
+    name = "Julian Mutter";
+  };
   franciscod = {
     github = "franciscod";
     githubId = 726447;

--- a/pkgs/by-name/sm/smath-studio/package.nix
+++ b/pkgs/by-name/sm/smath-studio/package.nix
@@ -43,6 +43,8 @@ appimageTools.wrapType2 {
     done
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Tiny, powerful, free mathematical program with WYSIWYG editor and complete units of measurements support";
     homepage = "https://smath.com/";

--- a/pkgs/by-name/sm/smath-studio/package.nix
+++ b/pkgs/by-name/sm/smath-studio/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  libgdiplus,
+}:
+let
+  pname = "smath-studio";
+  version = "1.5.0.9678";
+
+  src = fetchurl {
+    # The code after /Download/ changes per release
+    url = "https://smath.com/en-US/files/Download/c4zCE/SMathStudioDesktop.1_5_0_9678.x86_64.ubuntu-22_04.glibc2.35.AppImage";
+    hash = "sha256-6lnuRnhoH6E+jIZXSgb/Pz9wE9nVAbduDHrkKCKKH+Y=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      gtk2
+    ];
+
+  profile = ''
+    export LD_PRELOAD="${libgdiplus}/lib/libgdiplus.so.0"
+  '';
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/*.desktop -t $out/share/applications
+    sed -i "s|^Exec=.*|Exec=smath-studio %U|" $out/share/applications/*.desktop
+
+    # Package icons into /apps directory
+    for icon in ${appimageContents}/usr/share/icons/hicolor/*/*.png; do
+      if [ -f "$icon" ]; then
+        size=$(basename $(dirname "$icon"))
+        install -m 444 -D "$icon" "$out/share/icons/hicolor/$size/apps/smath.png"
+      fi
+    done
+  '';
+
+  meta = with lib; {
+    description = "Tiny, powerful, free mathematical program with WYSIWYG editor and complete units of measurements support";
+    homepage = "https://smath.com/";
+    license = licenses.unfree; # SMath is freeware, but closed source
+    maintainers = with maintainers; [ frajul ];
+    mainProgram = "smath-studio";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/sm/smath-studio/update.sh
+++ b/pkgs/by-name/sm/smath-studio/update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq nix
+
+set -euo pipefail
+
+# Get the absolute path to the directory containing this script
+DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+PACKAGE_FILE="$DIR/package.nix"
+
+echo "Checking for updates..."
+
+HTML=$(curl -s "https://smath.com/en-US/view/SMathStudio/download")
+
+# Get the first .AppImage link
+REL_URL=$(echo "$HTML" | grep -oP 'href="\K([^"]+x86_64[^"]+\.AppImage)(?=")' | head -n 1)
+
+if [[ -z "$REL_URL" ]]; then
+  echo "Error: Could not find the AppImage download link on the page."
+  exit 1
+fi
+
+URL="https://smath.com$REL_URL"
+
+# Extract the version from the filename
+VERSION=$(echo "$REL_URL" | grep -oP 'SMathStudioDesktop\.\K(\d+_\d+_\d+_\d+)' | tr '_' '.')
+
+# Read the current version from package.nix
+CURRENT_VERSION=$(grep -oP 'version = "\K([^"]+)' "$PACKAGE_FILE")
+
+if [[ "$VERSION" == "$CURRENT_VERSION" ]]; then
+  echo "smath-studio is already up to date ($VERSION)."
+  exit 0
+fi
+
+echo "Updating smath-studio: $CURRENT_VERSION -> $VERSION"
+
+echo "Downloading $URL to calculate hash..."
+HASH=$(nix store prefetch-file "$URL" --json | jq -r .hash)
+
+# Update the package.nix file
+echo "Updating package.nix"
+sed -i "s|version = \".*\";|version = \"$VERSION\";|" "$PACKAGE_FILE"
+sed -i "s|url = \".*\";|url = \"$URL\";|" "$PACKAGE_FILE"
+sed -i "s|hash = \".*\";|hash = \"$HASH\";|" "$PACKAGE_FILE"
+
+echo "done"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add new package SMath Studio, a math WYSIWYG editor for engineers.
https://smath.com

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
