### PR TITLE
omasnap: init at 1.12.0

### DIFF
--- a/pkgs/by-name/om/omasnap/package.nix
+++ b/pkgs/by-name/om/omasnap/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  bash,
+  cmake,
+  coreutils,
+  fetchFromGitHub,
+  grim,
+  hyprland,
+  kdePackages,
+  ninja,
+  pkg-config,
+  tesseract,
+  wayland,
+  wayland-protocols,
+  wl-clipboard,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omasnap";
+  version = "1.12.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tobi";
+    repo = "omasnap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5xmgIOFzvStMRpzgMy8fBdm34UVrCATYT+s+ZAR/odc=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "/usr/share/wayland-protocols" \
+        "${wayland-protocols}/share/wayland-protocols"
+    substituteInPlace transform-smoke.cpp \
+      --replace-fail "/usr/bin/env bash" "${coreutils}/bin/env bash"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.wrapQtAppsHook
+    ninja
+    pkg-config
+    wayland
+  ];
+
+  buildInputs = [
+    kdePackages.layer-shell-qt
+    kdePackages.qtbase
+    wayland
+  ];
+
+  nativeCheckInputs = [
+    bash
+    coreutils
+    tesseract
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    QT_QPA_PLATFORM=offscreen ./omasnap-smoke "$TMPDIR/omasnap-smoke"
+    runHook postCheck
+  '';
+
+  qtWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      grim
+      hyprland
+      tesseract
+      wl-clipboard
+    ])
+  ];
+
+  meta = {
+    description = "Fast native Wayland screenshot and annotation overlay for Hyprland";
+    homepage = "https://github.com/tobi/omasnap";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yechielw ];
+    mainProgram = "omasnap";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A native Wayland screenshot and annotation overlay designed for Omarchy and Hyprland by @tobi 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
