### PR TITLE
filen-desktop: 3.0.47 -> 3.0.53

### DIFF
--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -14,7 +14,7 @@
 }:
 let
   packageName = "filen-desktop";
-  packageVersion = "3.0.47";
+  packageVersion = "3.0.53";
   desktopName = "Filen Desktop";
   appName = "Filen";
 
@@ -46,7 +46,7 @@ buildNpmPackage {
     owner = "FilenCloudDienste";
     repo = packageName;
     rev = "v${packageVersion}";
-    hash = "sha256-WS9JqErfsRtt6zF+LrKkpiscJ25MRXmRxmIm3GH6xf0=";
+    hash = "sha256-uWh9/HOqSlin5kgVErLjRMHBZFY+eNxkKDKk4/AGUdg=";
   };
 
   npmDepsHash = "sha256-+Ul2z6faZvAeCHq35janVTUNoqTQ5JNDeLbCV220nFU=";


### PR DESCRIPTION
## Summary

Updated  from  to .



### 📜 Release Notes & Changelog for 

- **Update**:  ➔ 
- **Changelog Source**: *No direct release notes URL found*

#### 🌟 Key Highlights & Bullet Points:
- Recent Git Commits:

<details>
<summary>🔍 Expand Full Upstream Release Notes (Git Commit Log)</summary>

Recent Git Commits:
f9261980cd qtox: 1.18.3 -> 1.18.5 (#496933)
197a18c478 python3Packages.iamdata: 0.1.202608151 -> 0.1.202608161
1613d78aaa shelfmark: 1.3.7 -> 1.3.9
2dc063cf76 ananicy-cpp: fix missing <cstring> and <cstdint> headers for glibc 2.42
b5dfa59b2d zwave-js-ui: 11.22.2 -> 11.22.3
83b954ea1d pdfcpu: 0.13.0 -> 0.15.0 (#552008)
4f638b9ca8 diskwatch: 0.1.6 -> 0.3.2
9ee63c536c zashboard: 3.17.0 -> 3.19.0
0283bad944 rlottie: 0.2-unstable-2026-07-03 -> 0.2-unstable-2026-08-11
50ae7d3089 {python3Packages.,}gistyc: drop
56efa0b31b lightdm: Fix switching users
b632ac54b6 chsrc: 0.2.4 -> 0.2.6 (#503272)
a6c273d1d2 adl: drop
359eec7168 ocamlPackages.charon: 2026.08.06 -> 2026.08.15 (#553084)
88e27b11e6 upcloud-cli: 3.29.0 -> 3.36.0

</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [x] Package tests at .
  - [ ] Tests in lib/tests or pkgs/test for functions and core functionality.
  - [x] Ran usage: nixpkgs-review [-h] [--version] {post-result,approve,comments,merge,pr,rev,wip} ...

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit

subcommands:
  valid subcommands

  {post-result,approve,comments,merge,pr,rev,wip}
                        use --help on the additional subcommands
    post-result         post PR comments with results
    approve             Approve the current PR - meant to be used only inside a nixpkgs-review nix-shell
    comments            Show comments of the current PR - meant to be used only inside a nixpkgs-review nix-shell
    merge               Merge the current PR - meant to be used only inside a nixpkgs-review nix-shell
    pr                  review a pull request on nixpkgs
    rev                 review a change in the local pull request repository
    wip                 review the uncommitted changes in the working tree on this PR.
  - [x] Tested basic functionality of all binary files, usually in .
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.