### PR TITLE
writers.makeDataWriter: remove

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -72,6 +72,8 @@
 
 - `alps` has been rewritten upstream, see [upstream repository](https://github.com/migadu/alps) for documentation.
 
+- `writers.makeDataWriter` has been removed. It has been deprecated since 2023. Use `pkgs.writeTextFile` instead.
+
 - `bosun` has been removed as it is no longer maintained upstream. the corresponding monitoring options has been removed.
 
 - `uhttpmock` providing 0.0 ABI was removed. `uhttpmock_1_0` providing 1.0 ABI was renamed to `uhttpmock` and `uhttpmock_1_0` was kept as an alias.

--- a/pkgs/build-support/writers/data.nix
+++ b/pkgs/build-support/writers/data.nix
@@ -12,55 +12,7 @@ let
     ;
 in
 {
-  /**
-    Creates a transformer function that writes input data to disk, transformed
-    by both the `input` and `output` arguments.
-
-    # Example
-
-    ```nix
-    writeJSON = makeDataWriter { input = builtins.toJSON; output = "cp $inputPath $out"; };
-    myConfig = writeJSON "config.json" { hello = "world"; }
-    ```
-
-    # Type
-
-    ```
-    makeDataWriter :: input -> output -> nameOrPath -> data -> (any -> string) -> string -> string -> any -> derivation
-
-    input :: T -> string: function that takes the nix data and returns a string
-    output :: string: script that takes the $inputFile and write the result into $out
-    nameOrPath :: string: if the name contains a / the files gets written to a sub-folder of $out. The derivation name is the basename of this argument.
-    data :: T: the data that will be converted.
-    ```
-  */
-  makeDataWriter = lib.warn "pkgs.writers.makeDataWriter is deprecated. Use pkgs.writeTextFile." (
-    {
-      input ? lib.id,
-      output ? "cp $inputPath $out",
-    }:
-    nameOrPath: data:
-    assert
-      (types.path.check nameOrPath)
-      || (builtins.match "([0-9A-Za-z._])[0-9A-Za-z._-]*" nameOrPath != null);
-    let
-      name = last (builtins.split "/" nameOrPath);
-    in
-    runCommand name
-      {
-        input = input data;
-        passAsFile = [ "input" ];
-      }
-      ''
-        ${output}
-
-        ${optionalString (types.path.check nameOrPath) ''
-          mv $out tmp
-          mkdir -p $out/$(dirname "${nameOrPath}")
-          mv tmp $out/${nameOrPath}
-        ''}
-      ''
-  );
+  makeDataWriter = throw "pkgs.writers.makeDataWriter has been removed. Use pkgs.writeTextFile instead.";
 
   inherit (pkgs) writeText;
 


### PR DESCRIPTION
This writer was deprecated in 2023 (e64f987fd6b922cfc0b42d2dd516c8e7924befd4) and is unused in nixpkgs. Time to remove it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
