### PR TITLE
nixos/kvrocks: add automatic backup support

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -477,6 +477,7 @@
   ./services/backup/btrbk.nix
   ./services/backup/duplicati.nix
   ./services/backup/duplicity.nix
+  ./services/backup/kvrocks-backup.nix
   ./services/backup/libvirtd-autosnapshot.nix
   ./services/backup/mysql-backup.nix
   ./services/backup/pgbackrest.nix

--- a/nixos/modules/services/backup/kvrocks-backup.nix
+++ b/nixos/modules/services/backup/kvrocks-backup.nix
@@ -1,0 +1,185 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.kvrocks;
+in
+{
+  meta.maintainers = with lib.maintainers; [ xyenon ];
+
+  options.services.kvrocks.backup = {
+    enable = lib.mkEnableOption "Kvrocks backups";
+
+    startAt = lib.mkOption {
+      default = "*-*-* 01:15:00";
+      type = with lib.types; either (listOf str) str;
+      description = ''
+        When to run the backup (see {manpage}`systemd.time(7)`).
+        The default is 01:15 every day.
+      '';
+    };
+
+    location = lib.mkOption {
+      default = "/var/backup/kvrocks";
+      type = lib.types.path;
+      description = ''
+        Root directory for Kvrocks backups. The `BGSAVE` checkpoint is written
+        to {file}`checkpoint` and atomically promoted to {file}`current`.
+        Restore by stopping kvrocks, replacing the database directory with
+        {file}`current` in this location, and starting kvrocks again.
+        See <https://kvrocks.apache.org/docs/backup>.
+      '';
+    };
+
+    timeout = lib.mkOption {
+      default = "10m";
+      type = lib.types.str;
+      example = "30m";
+      description = ''
+        How long to wait for `BGSAVE` to finish.
+        Passed to {option}`systemd.services.kvrocks-backup.serviceConfig.TimeoutStartSec`.
+      '';
+    };
+
+    redisPasswordFile = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.path;
+      example = "/run/secrets/kvrocks-requirepass";
+      description = ''
+        File whose contents are used as `REDISCLI_AUTH` when talking to kvrocks.
+        Needed if {option}`services.kvrocks.settings.requirepass` is set.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.backup.enable {
+    assertions = [
+      {
+        assertion = cfg.enable;
+        message = "services.kvrocks.backup.enable requires services.kvrocks.enable.";
+      }
+    ];
+
+    services.kvrocks.settings.backup-dir = "${cfg.backup.location}/checkpoint";
+
+    systemd.tmpfiles.settings."10-kvrocks-backup"."${cfg.backup.location}".d = {
+      user = cfg.user;
+      group = cfg.group;
+      mode = "0700";
+    };
+
+    systemd.services.kvrocks-backup = {
+      description = "Backup of Kvrocks database";
+      documentation = [
+        "https://kvrocks.apache.org/docs/backup"
+      ];
+      requires = [ "kvrocks.service" ];
+      after = [
+        "kvrocks.service"
+        "systemd-tmpfiles-setup.service"
+        "systemd-tmpfiles-resetup.service"
+      ];
+
+      path = [
+        pkgs.coreutils
+        pkgs.gnugrep
+      ];
+
+      enableStrictShellChecks = true;
+
+      script =
+        let
+          redisCli = lib.getExe' pkgs.redis "redis-cli";
+          cliArgs =
+            if cfg.settings.unixsocket != "" then
+              [
+                "-s"
+                cfg.settings.unixsocket
+              ]
+            else
+              [
+                "-h"
+                (builtins.head cfg.settings.bind)
+                "-p"
+                (toString cfg.settings.port)
+              ];
+          cli = lib.concatMapStringsSep " " lib.escapeShellArg ([ redisCli ] ++ cliArgs);
+
+          checkpointDir = "${cfg.backup.location}/checkpoint";
+          currentDir = "${cfg.backup.location}/current";
+        in
+        ''
+          ${lib.optionalString (cfg.backup.redisPasswordFile != null) ''
+            REDISCLI_AUTH="$(tr -d '\n' < ${lib.escapeShellArg cfg.backup.redisPasswordFile})"
+            export REDISCLI_AUTH
+          ''}
+
+          info_field() {
+            local value
+            value="$( ${cli} INFO persistence | grep -m1 "^$1:" | cut -d: -f2- | tr -d '\r')"
+            if [ -z "$value" ]; then
+              echo "Missing INFO persistence field $1" >&2
+              exit 1
+            fi
+            printf '%s\n' "$value"
+          }
+
+          if [ "$(info_field bgsave_in_progress)" = 1 ]; then
+            echo "BGSAVE already in progress" >&2
+            exit 1
+          fi
+
+          reply="$( ${cli} BGSAVE)"
+          if [ "$reply" != OK ]; then
+            echo "BGSAVE failed: $reply" >&2
+            exit 1
+          fi
+
+          while [ "$(info_field bgsave_in_progress)" = 1 ]; do
+            sleep 1
+          done
+
+          status="$(info_field last_bgsave_status)"
+          if [ "$status" != ok ]; then
+            echo "BGSAVE failed (status=$status)" >&2
+            exit 1
+          fi
+
+          if [ ! -f ${lib.escapeShellArg checkpointDir}/CURRENT ]; then
+            echo "Missing checkpoint ${checkpointDir}/CURRENT" >&2
+            exit 1
+          fi
+
+          if [ -e ${lib.escapeShellArg currentDir} ]; then
+            mv --exchange --no-target-directory ${lib.escapeShellArg checkpointDir} ${lib.escapeShellArg currentDir}
+            rm -rf ${lib.escapeShellArg checkpointDir}
+          else
+            rm -rf ${lib.escapeShellArg currentDir}
+            mv --no-target-directory ${lib.escapeShellArg checkpointDir} ${lib.escapeShellArg currentDir}
+          fi
+
+          echo "Backed up ${checkpointDir} to ${currentDir}"
+        '';
+
+      startAt = cfg.backup.startAt;
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        TimeoutStartSec = cfg.backup.timeout;
+        UMask = "0077";
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        ReadWritePaths = [ cfg.backup.location ];
+        ReadOnlyPaths = lib.optional (cfg.backup.redisPasswordFile != null) cfg.backup.redisPasswordFile;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/databases/kvrocks.nix
+++ b/nixos/modules/services/databases/kvrocks.nix
@@ -19,6 +19,9 @@ let
   defaultDir = "/var/lib/kvrocks";
   dataDir = cfg.settings.dir;
   isDefaultDir = dataDir == defaultDir;
+  backupDir = cfg.settings.backup-dir or "${dataDir}/backup";
+  backupParentDir = builtins.dirOf backupDir;
+  isBackupDirUnderDataDir = lib.hasPrefix "${dataDir}/" backupDir;
 
   # Defaults match upstream Config field defaults (config.cc).
   workers = cfg.settings.workers or 8;
@@ -93,39 +96,59 @@ in
       };
 
       settings = lib.mkOption {
-        type = lib.types.submodule {
-          freeformType = format.type;
+        type = lib.types.submodule (
+          { config, ... }:
+          {
+            freeformType = format.type;
 
-          options = {
-            bind = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [
-                "127.0.0.1"
-                "::1"
-              ];
-              description = "The addresses to bind to.";
-            };
+            options = {
+              bind = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [
+                  "127.0.0.1"
+                  "::1"
+                ];
+                description = "The addresses to bind to.";
+              };
 
-            port = lib.mkOption {
-              type = lib.types.port;
-              default = 6666;
-              description = "Accept connections on the specified port.";
-            };
+              port = lib.mkOption {
+                type = lib.types.port;
+                default = 6666;
+                description = "Accept connections on the specified port.";
+              };
 
-            unixsocket = lib.mkOption {
-              type = lib.types.str;
-              default = "";
-              example = "/run/kvrocks/kvrocks.sock";
-              description = "Unix socket path.";
-            };
+              unixsocket = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                example = "/run/kvrocks/kvrocks.sock";
+                description = "Unix socket path.";
+              };
 
-            dir = lib.mkOption {
-              type = lib.types.str;
-              default = defaultDir;
-              description = "Directory for database files.";
+              dir = lib.mkOption {
+                type = lib.types.str;
+                default = defaultDir;
+                description = "Directory for database files.";
+              };
+
+              backup-dir = lib.mkOption {
+                type = lib.types.str;
+                default = "${config.dir}/backup";
+                defaultText = lib.literalExpression ''"''${config.services.kvrocks.settings.dir}/backup"'';
+                description = ''
+                  Directory written by `BGSAVE`.
+                  Defaults to {file}`backup` under {option}`services.kvrocks.settings.dir`.
+                  When {option}`services.kvrocks.backup.enable` is enabled, this
+                  is set to {file}`checkpoint` under
+                  {option}`services.kvrocks.backup.location`.
+
+                  Kvrocks first writes a sibling {file}`<backup-dir>.tmp` directory
+                  and then renames it into place, so the parent directory must
+                  already exist and be writable by {option}`services.kvrocks.user`.
+                '';
+              };
             };
-          };
-        };
+          }
+        );
         default = { };
         example = {
           workers = 8;
@@ -162,6 +185,10 @@ in
       {
         assertion = cfg.socketActivation -> builtins.length cfg.settings.bind == 1;
         message = "services.kvrocks.socketActivation requires exactly one settings.bind address.";
+      }
+      {
+        assertion = backupParentDir != "/";
+        message = "services.kvrocks.settings.backup-dir must not be a top-level path; BGSAVE writes <backup-dir>.tmp next to it.";
       }
     ];
 
@@ -212,7 +239,9 @@ in
         StateDirectoryMode = "0700";
         RuntimeDirectory = "kvrocks";
         RuntimeDirectoryMode = "0755";
-        BindPaths = lib.mkIf (!isDefaultDir) [ dataDir ];
+        BindPaths = lib.unique (
+          lib.optional (!isDefaultDir) dataDir ++ lib.optional (!isBackupDirUnderDataDir) backupParentDir
+        );
         LimitNPROC = lib.mkDefault (alwaysOnThreads + dynamicThreadMargin);
         # When rocksdb.max_open_files is -1 (unlimited), fall back to a high limit.
         LimitNOFILE = lib.mkDefault (

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -919,6 +919,7 @@ in
     inherit (pkgs) lib;
   };
   kvrocks = runTest ./kvrocks.nix;
+  kvrocks-backup = runTest ./kvrocks-backup.nix;
   labgrid = runTest ./labgrid.nix;
   lact = runTest ./lact.nix;
   ladybird = runTest ./ladybird.nix;

--- a/nixos/tests/kvrocks-backup.nix
+++ b/nixos/tests/kvrocks-backup.nix
@@ -1,0 +1,87 @@
+{ lib, pkgs, ... }:
+
+let
+  common = {
+    services.kvrocks = {
+      enable = true;
+      settings.log-level = "debug";
+      backup.enable = true;
+    };
+  };
+in
+{
+  name = "kvrocks-backup";
+  meta.maintainers = with lib.maintainers; [ xyenon ];
+
+  containers = {
+    tcp = common;
+
+    custom = {
+      imports = [ common ];
+      services.kvrocks.backup.location = "/srv/kvrocks-backups";
+    };
+
+    unix = {
+      imports = [ common ];
+      services.kvrocks.settings = {
+        bind = [ ];
+        unixsocket = "/run/kvrocks/kvrocks.sock";
+      };
+    };
+  };
+
+  testScript =
+    { containers, ... }:
+    let
+      inherit (containers.tcp.services) kvrocks;
+      port = toString kvrocks.settings.port;
+      redisCli = lib.getExe' pkgs.redis "redis-cli";
+      redisCliTcp = "${redisCli} -p ${port}";
+      unixsocket = "/run/kvrocks/kvrocks.sock";
+      redisCliUnix = "${redisCli} -s ${unixsocket}";
+      backupDir = kvrocks.backup.location;
+    in
+    ''
+      def restore_from_backup(node, cli, backup_dir, expected, wait_ready):
+          node.succeed(f"{cli} set backup-key overwritten | grep OK")
+          node.systemctl("stop kvrocks")
+          node.succeed("rm -rf /var/lib/kvrocks/db")
+          node.succeed(f"cp -a {backup_dir}/current /var/lib/kvrocks/db")
+          node.systemctl("start kvrocks")
+          node.wait_for_unit("kvrocks.service")
+          wait_ready()
+          node.succeed(f"{cli} get backup-key | grep {expected}")
+
+      tcp.start()
+      tcp.wait_for_unit("kvrocks.service")
+      tcp.wait_for_open_port(${port})
+      tcp.succeed("${redisCliTcp} ping | grep PONG")
+
+      with subtest("Test backup over TCP"):
+          tcp.succeed("${redisCliTcp} set backup-key tcp | grep OK")
+          tcp.systemctl("start kvrocks-backup.service")
+          tcp.succeed("test -f ${backupDir}/current/CURRENT")
+          restore_from_backup(tcp, "${redisCliTcp}", "${backupDir}", "tcp", lambda: tcp.wait_for_open_port(${port}))
+          tcp.shutdown()
+
+      with subtest("Test backup with non-default backup location"):
+          custom.start()
+          custom.wait_for_unit("kvrocks.service")
+          custom.wait_for_open_port(${port})
+          custom.succeed("${redisCliTcp} set backup-key custom | grep OK")
+          custom.systemctl("start kvrocks-backup.service")
+          custom.succeed("test -f /srv/kvrocks-backups/current/CURRENT")
+          restore_from_backup(custom, "${redisCliTcp}", "/srv/kvrocks-backups", "custom", lambda: custom.wait_for_open_port(${port}))
+          custom.shutdown()
+
+      with subtest("Test backup over unix socket"):
+          unix.start()
+          unix.wait_for_unit("kvrocks.service")
+          unix.wait_for_file("${unixsocket}")
+          unix.fail("${redisCliTcp} ping")
+          unix.succeed("${redisCliUnix} set backup-key unix | grep OK")
+          unix.systemctl("start kvrocks-backup.service")
+          unix.succeed("test -f ${backupDir}/current/CURRENT")
+          restore_from_backup(unix, "${redisCliUnix}", "${backupDir}", "unix", lambda: unix.wait_for_file("${unixsocket}"))
+    '';
+}

--- a/pkgs/by-name/kv/kvrocks/package.nix
+++ b/pkgs/by-name/kv/kvrocks/package.nix
@@ -344,7 +344,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     hook = callPackage ./hook.nix { kvrocks = finalAttrs.finalPackage; };
     tests = {
-      inherit (nixosTests) kvrocks;
+      inherit (nixosTests) kvrocks kvrocks-backup;
       hook = callPackage ./hook-test.nix { kvrocks = finalAttrs.finalPackage; };
     };
   };


### PR DESCRIPTION
Support backup for kvrocks.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
