### PR TITLE
nixos/displaylink: kill dlm promptly instead of waiting out the stop timeout

### DIFF
--- a/nixos/modules/hardware/video/displaylink.nix
+++ b/nixos/modules/hardware/video/displaylink.nix
@@ -73,6 +73,9 @@ in
         Restart = "always";
         RestartSec = 5;
         LogsDirectory = "displaylink";
+        # DisplayLinkManager ignores SIGTERM and has no state to flush, so
+        # systemd waits out the default 90s stop timeout before SIGKILLing it.
+        TimeoutStopSec = 5;
       };
     };
 


### PR DESCRIPTION
`DisplayLinkManager` doesn't respond to SIGTERM, so `dlm.service` sits out
systemd's default 90s stop timeout on every shutdown where that happens, then
gets SIGKILLed anyway. It has no state to flush, so killing it promptly is the
correct behaviour rather than a workaround.

I've been running `TimeoutStopSec = 5` locally for a few weeks on a Dell D6000
dock. From my journal, across 56 recorded stops:

```
31 × dlm.service: State 'stop-sigterm' timed out. Killing.   (55%)
25 × dlm.service: Deactivated successfully
```

So it needs the SIGKILL more often than not. A sample of the bad case:

```
17:15:15  Stopping DisplayLink Manager Service...
17:15:20  dlm.service: State 'stop-sigterm' timed out. Killing.
17:15:20  dlm.service: Killing process 1760 (.DisplayLinkMan) with signal SIGKILL
17:15:20  dlm.service: Failed with result 'timeout'
```

Those five seconds are the timeout set here; without it they'd be ninety.

When it does stop cleanly it takes 1–3s, so 5s leaves room and the shutdown
stall goes away.

Tested on x86_64-linux, dell latitude 5430 + D6000.

---

Disclosure per the automation/AI policy: prepared with Claude Code (Claude
Opus 5) — it went through my local config, pulled the numbers out of my
journal, and drafted this summary. The `TimeoutStopSec` value and the diagnosis
are my own, from running this on my machine; I reviewed the change before
submitting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
