### PR TITLE
buildDartApplication: rm passAsFile

### DIFF
--- a/pkgs/build-support/dart/build-dart-application/default.nix
+++ b/pkgs/build-support/dart/build-dart-application/default.nix
@@ -201,7 +201,10 @@ lib.extendMkDerivation {
       # runs instead of the expected program. Don't strip if it's an exe output.
       dontStrip = args.dontStrip or (dartOutputType == "exe");
 
-      passAsFile = [ "pubspecLockFile" ];
+      env = {
+        pubspecLockFilePath = writeText "pubspec.lock" pubspecLockFile;
+      }
+      // (args.env or { });
 
       passthru = {
         pubspecLock = pubspecLockData;

--- a/pkgs/by-name/co/commet-chat/package.nix
+++ b/pkgs/by-name/co/commet-chat/package.nix
@@ -50,7 +50,7 @@ flutter341.buildFlutterApplication (finalAttrs: {
   strictDeps = true;
   sourceRoot = "${finalAttrs.src.name}/commet";
 
-  pubspecLockFilePath = "../pubspec.lock";
+  env.pubspecLockFilePath = "../pubspec.lock";
   pubspecLock = lib.importJSON ./pubspec.lock.json;
 
   gitHashes = {


### PR DESCRIPTION
`passAsFile` won't work if `__structuredAttrs` is enabled.

Note that `env.pubspecLockFilePath` is compatible with `__structuredAttrs` regardless of this PR.

Encountered this when I try to update LocalSend.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
