### PR TITLE
python3Packages.mrcfile: init at 1.5.4

### DIFF
--- a/pkgs/development/python-modules/mrcfile/default.nix
+++ b/pkgs/development/python-modules/mrcfile/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  numpy,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mrcfile";
+  version = "1.5.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ccpem";
+    repo = "mrcfile";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-513R/R1Sa4lZq5a1Kf3phmmuCNz6YTp3wBdOXwidfkA=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  dependencies = [ numpy ];
+
+  pythonImportsCheck = [ "mrcfile" ];
+
+  disabledTestPaths = [
+    # NumPy 2.5 deprecation warnings become errors in these tests and cannot be overridden
+    "tests/test_bzip2mrcfile.py"
+    "tests/test_gzipmrcfile.py"
+    "tests/test_mrcfile.py"
+    "tests/test_mrcinterpreter.py"
+    "tests/test_mrcmemmap.py"
+    "tests/test_mrcobject.py"
+    "tests/test_validation.py"
+  ];
+
+  disabledTests = [
+    # Requires a large file omitted from the source distribution
+    "test_slow_async_opening"
+  ];
+
+  meta = {
+    changelog = "https://github.com/ccpem/mrcfile/releases/tag/${finalAttrs.src.tag}";
+    description = "MRC file I/O library";
+    homepage = "https://mrcfile.readthedocs.io";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ rdk31 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10894,6 +10894,8 @@ self: super: with self; {
 
   mqtt2influxdb = callPackage ../development/python-modules/mqtt2influxdb { };
 
+  mrcfile = callPackage ../development/python-modules/mrcfile { };
+
   mrjob = callPackage ../development/python-modules/mrjob { };
 
   mrsqm = callPackage ../development/python-modules/mrsqm { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
