### PR TITLE
haskell.packages.ghc914: misc fixes in preparation for HLS

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -136,6 +136,14 @@ with haskellLib;
 
   # https://github.com/maoe/ghc-trace-events/pull/17
   ghc-trace-events = doJailbreak super.ghc-trace-events; # base < 4.22
+  # HLS, for some reason, decided to remove the hie-compat library from its tree
+  # in https://github.com/haskell/haskell-language-server/pull/4613
+  # even though hiedb (a dependency of HLS) unconditionally depends on it
+  # for all GHC versions. As a result, no one has updated the base bound
+  # of hie-compat to allow building it with GHC 9.14 neither in tree
+  # (which no longer exists) nor on Hackage. Instead, HLS is updating their
+  # cabal.project: https://github.com/haskell/haskell-language-server/blob/a4cfaa80ca94beded6f01547a161b37be7b33558/cabal.project#L78
+  hie-compat = doJailbreak super.hie-compat; # base < 4.22
 
   ghc-exactprint_1_14_1_0 = addBuildDepends [
     # cabal2nix drops conditional block: impl (ghc >= 9.14)

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -147,6 +147,9 @@ with haskellLib;
     self.HUnit
   ] super.ghc-exactprint_1_14_1_0;
 
+  ormolu = doDistribute self.ormolu_0_8_2_0;
+  fourmolu = doDistribute self.fourmolu_0_20_1_0;
+
   #
   # Test suite issues
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -166,6 +166,15 @@ with haskellLib;
 
   # Fails to compile with GHC 9.14 https://github.com/snoyberg/mono-traversable/pull/261
   mono-traversable = dontCheck super.mono-traversable;
+  # doctests broke with GHC 9.14, something to do with error messages
+  # https://github.com/kcsongor/generic-lens/issues/174
+  generic-lens = overrideCabal {
+    testTargets = [
+      "generic-lens-bifunctor"
+      "inspection-tests"
+      "generic-lens-syb-tree"
+    ];
+  } super.generic-lens;
 
   # Too strict bound on containers in test suite
   # https://github.com/jaspervdj/blaze-markup/issues/69

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -134,6 +134,8 @@ with haskellLib;
     ] super.serialise
   );
 
+  # https://github.com/maoe/ghc-trace-events/pull/17
+  ghc-trace-events = doJailbreak super.ghc-trace-events; # base < 4.22
 
   ghc-exactprint_1_14_1_0 = addBuildDepends [
     # cabal2nix drops conditional block: impl (ghc >= 9.14)

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -76,6 +76,10 @@ with haskellLib;
 
   scrod = doDistribute (unmarkBroken super.scrod);
 
+  # haskell-debugger only works with ghc 9.14+
+  haskell-debugger-view = doDistribute (unmarkBroken super.haskell-debugger-view);
+  haskell-debugger = doDistribute (doJailbreak super.haskell-debugger); # hie-bios < 0.18, random >=1.3.1
+
   #
   # Version upgrades
   #
@@ -130,9 +134,6 @@ with haskellLib;
     ] super.serialise
   );
 
-  # haskell-debugger only works with ghc 9.14+
-  haskell-debugger-view = doDistribute (unmarkBroken super.haskell-debugger-view);
-  haskell-debugger = doDistribute (doJailbreak super.haskell-debugger); # hie-bios < 0.18, random >=1.3.1
 
   ghc-exactprint_1_14_1_0 = addBuildDepends [
     # cabal2nix drops conditional block: impl (ghc >= 9.14)

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -598,12 +598,7 @@ let
         # requires unix >= 2.8.1.0 which implies GHC >= 9.6 for us.
         compilerNames.ghc967
       ];
-      weeder = lib.subtractLists [
-        # Currently (2026-08-13) blocked on
-        # https://github.com/kcsongor/generic-lens/issues/174
-        compilerNames.ghc9141
-        compilerNames.ghc9142
-      ] released;
+      weeder = released;
 
       # MicroHs core packages
       ghc-compat = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
