### PR TITLE
unifont: Don't ship sample font in default output

### DIFF
--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -42,9 +42,26 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildFlags = [ "BUILDFONT=1" ];
 
+  # The `sample` variants are not intended for general use.
+  #
+  # From the 2013 changelog:
+  #
+  # > These "Unifont Sample" fonts contain combining circles, and four-digit
+  # > hexadecimal glyphs for unassigned code points and Private Use Area glyphs.
+  # > Because of the inclusion of combining cirlces, "Unifont Sample" font
+  # > versions are only intended for illustrating individual glyphs, not for
+  # > general-purpose writing.
   postInstall = ''
     moveToOutput bin "$bin"
     moveToOutput share/unifont "$doc"
+
+    # Move `sample` into its own output.
+    mkdir -vp "$sample/share/fonts/X11/misc/"
+    mkdir -vp "$sample/share/fonts/opentype/unifont/"
+    mv -vt "$sample/share/fonts/X11/misc/" \
+      "$out"/share/fonts/X11/misc/*_sample.*
+    mv -vt "$sample/share/fonts/opentype/unifont/" \
+      "$out"/share/fonts/opentype/unifont/*_sample.*
   '';
 
   outputs = [
@@ -53,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
     "man"
     "info"
+    "sample"
   ];
 
   passthru.updateScript = ./update.sh;


### PR DESCRIPTION
The use-case for these font files is detailed in their 2013 changelog
entry:

> These "Unifont Sample" fonts contain combining circles, and four-digit
> hexadecimal glyphs for unassigned code points and Private Use Area glyphs.
> Because of the inclusion of combining cirlces, "Unifont Sample" font
> versions are only intended for illustrating individual glyphs, not for
> general-purpose writing.

What this means, in practice, is that since https://github.com/NixOS/nixpkgs/pull/550059 unifont *may* end-up
being picked rather than any other font that actually has a glyph,
instead of a replacement glyph.

And even if there was no proper glyph to use, a replacement glyph is
made on the fly anyway.

This regression can be checked with, for example, Font Awesome, on the
same config, Nixpkgs `b7c2ada94fe9..https://github.com/samueldr/nixpkgs/commit/0e251e24a4f24e036a084b6b4b2d2491af4167f4`.

Before regression:

```
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-font-awesome-7.2.0/share/fonts/opentype/Font Awesome 7 Free-Solid-900.otf: Font Awesome 7 Free,Font Awesome 7 Free Solid:style=Solid,Regular
```

Current:

```
 $ fc-list :charset=f244
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-font-awesome-7.2.0/share/fonts/opentype/Font Awesome 7 Free-Solid-900.otf: Font Awesome 7 Free,Font Awesome 7 Free Solid:style=Solid,Regular
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unifont-17.0.05/share/fonts/opentype/unifont/unifont_sample.otf: Unifont Sample:style=Regular
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-unifont-17.0.05/share/fonts/X11/misc/unifont_sample.pcf.gz: Unifont Sample:style=Sans-Serif
```

After fix:

```
 $ fc-list :charset=f244
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-font-awesome-7.2.0/share/fonts/opentype/Font Awesome 7 Free-Solid-900.otf: Font Awesome 7 Free,Font Awesome 7 Free Solid:style=Solid,Regular
```

* * *

cc @jopejoe1

If possible and not adding any delay, this probably should be handled at the same time as the following PRs:

 - #551378
 - #552574

(I have not verified those PRs.)

## Things done

I have built my system config with 0e251e24a4f2 + this commit.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
