### PR TITLE
python3Packages.skan: init at 0.13.1

### DIFF
--- a/pkgs/development/python-modules/skan/default.nix
+++ b/pkgs/development/python-modules/skan/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  imageio,
+  matplotlib,
+  networkx,
+  numba,
+  numpy,
+  openpyxl,
+  pandas,
+  scikit-image,
+  scipy,
+  toolz,
+  tqdm,
+
+  # tests
+  hypothesis,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "skan";
+  version = "0.13.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jni";
+    repo = "skan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RhY46LeELnAH+s2/j8yF3ifNeOFqdwS0l5JYqtlRvBc=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  dependencies = [
+    imageio
+    matplotlib
+    networkx
+    numba
+    numpy
+    openpyxl
+    pandas
+    scikit-image
+    scipy
+    toolz
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "skan" ];
+
+  disabledTestPaths = [
+    # Requires the Napari Qt GUI test stack, which needs a display server.
+    "src/skan/test/test_napari_plugin.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/jni/skan/releases/tag/${finalAttrs.src.tag}";
+    description = "Python module to analyse skeleton (thin object) images";
+    homepage = "https://skeleton-analysis.org";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ rdk31 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18685,6 +18685,8 @@ self: super: with self; {
 
   sjcl = callPackage ../development/python-modules/sjcl { };
 
+  skan = callPackage ../development/python-modules/skan { };
+
   skein = callPackage ../development/python-modules/skein { };
 
   skia-pathops = callPackage ../development/python-modules/skia-pathops { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
