### PR TITLE
lib.options: add `optionToDoc`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -525,8 +525,8 @@ let
         getFiles
         optionAttrSetToDocList
         optionAttrSetToDocList'
-        optionAttrSetToDocTree
-        optionAttrSetToDocTree'
+        optionToDoc
+        optionToDoc'
         scrubOptionValue
         literalExpression
         showOption

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -526,7 +526,6 @@ let
         optionAttrSetToDocList
         optionAttrSetToDocList'
         optionToDoc
-        optionToDoc'
         scrubOptionValue
         literalExpression
         showOption

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -525,6 +525,8 @@ let
         getFiles
         optionAttrSetToDocList
         optionAttrSetToDocList'
+        optionAttrSetToDocTree
+        optionAttrSetToDocTree'
         scrubOptionValue
         literalExpression
         showOption

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -657,10 +657,8 @@ rec {
             subVisible = if isBool visible then visible else visible == "transparent";
           in
           onOption doc (if subVisible then subDocs else empty) tree
-        else if isAttrs tree then
-          onAttrSet recurse tree
         else
-          empty;
+          onAttrSet recurse tree;
     in
     recurse;
 

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -564,7 +564,7 @@ rec {
   */
   getFiles = catAttrs "file";
 
-  # Internal helper to transform a raw option set into a documentation attribute set.
+  # Internal helper to transform a raw option set into a base documentation attribute set.
   optionToDocItem =
     opt:
     let
@@ -572,8 +572,6 @@ rec {
       visible = opt.visible or true;
     in
     {
-      inherit (opt) loc;
-      inherit name;
       description = opt.description or null;
       declarations = filter (x: x != unknownModule) opt.declarations;
       internal = opt.internal or false;
@@ -627,7 +625,7 @@ rec {
             subDocs = if ss != { } then recurse ss else empty;
             subVisible = if isBool visible then visible else visible == "transparent";
           in
-          onOption doc (if subVisible then subDocs else empty)
+          onOption doc (if subVisible then subDocs else empty) tree
         else if isAttrs tree then
           onAttrSet recurse tree
         else
@@ -642,7 +640,18 @@ rec {
   optionAttrSetToDocList' =
     _: options:
     foldOptionSet {
-      onOption = doc: subDocs: [ doc ] ++ subDocs;
+      onOption =
+        doc: subDocs: opt:
+        [
+          (
+            {
+              inherit (opt) loc;
+              name = showOption opt.loc;
+            }
+            // doc
+          )
+        ]
+        ++ subDocs;
       onAttrSet = recurse: set: concatMap recurse (builtins.attrValues set);
       empty = [ ];
     } options;
@@ -652,7 +661,9 @@ rec {
   optionToDoc =
     options:
     foldOptionSet {
-      onOption = doc: subDocs: if subDocs != { } then doc // { "*" = subDocs; } else doc;
+      onOption =
+        doc: subDocs: _:
+        if subDocs != { } then doc // { "*" = subDocs; } else doc;
       onAttrSet = recurse: set: mapAttrs (_: recurse) set;
       empty = { };
     } options;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -649,9 +649,9 @@ rec {
 
   # Generate documentation template as a nested attribute set (tree)
   # preserving module option structure.
-  optionAttrSetToDocTree = optionAttrSetToDocTree' [ ];
+  optionToDoc = optionToDoc' [ ];
 
-  optionAttrSetToDocTree' =
+  optionToDoc' =
     _: options:
     foldOptionSet {
       onOption = doc: subDocs: if subDocs != { } then doc // { subOptions = subDocs; } else doc;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -649,10 +649,8 @@ rec {
 
   # Generate documentation template as a nested attribute set (tree)
   # preserving module option structure.
-  optionToDoc = optionToDoc' [ ];
-
-  optionToDoc' =
-    _: options:
+  optionToDoc =
+    options:
     foldOptionSet {
       onOption = doc: subDocs: if subDocs != { } then doc // { subOptions = subDocs; } else doc;
       onAttrSet = recurse: set: mapAttrs (_: recurse) set;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -652,7 +652,7 @@ rec {
   optionToDoc =
     options:
     foldOptionSet {
-      onOption = doc: subDocs: if subDocs != { } then doc // { subOptions = subDocs; } else doc;
+      onOption = doc: subDocs: if subDocs != { } then doc // { "*" = subDocs; } else doc;
       onAttrSet = recurse: set: mapAttrs (_: recurse) set;
       empty = { };
     } options;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -564,66 +564,100 @@ rec {
   */
   getFiles = catAttrs "file";
 
+  # Internal helper to transform a raw option set into a documentation attribute set.
+  optionToDocItem =
+    opt:
+    let
+      name = showOption opt.loc;
+      visible = opt.visible or true;
+    in
+    {
+      inherit (opt) loc;
+      inherit name;
+      description = opt.description or null;
+      declarations = filter (x: x != unknownModule) opt.declarations;
+      internal = opt.internal or false;
+      visible = if isBool visible then visible else visible == "shallow";
+      readOnly = opt.readOnly or false;
+      type = opt.type.description or "unspecified";
+    }
+    // optionalAttrs (opt ? example) {
+      example = builtins.addErrorContext "while evaluating the example of option `${name}`" (
+        renderOptionValue opt.example
+      );
+    }
+    //
+      optionalAttrs
+        (
+          opt ? defaultText
+          || opt ? default
+          # Render emptyValue-based defaults, but only for types without
+          # submodules (e.g. types.submodule). Submodules may evaluate to
+          # error without user defs, and their sub-options are documented
+          # individually, so best to skip those here.
+          || ((opt.type or { }).emptyValue or { }) ? value && (opt.type or { }).getSubModules or null == null
+        )
+        {
+          default =
+            builtins.addErrorContext
+              "while evaluating the ${
+                if opt ? defaultText then "defaultText" else "default value"
+              } of option `${name}`"
+              (renderOptionValue (opt.defaultText or opt.default or opt.type.emptyValue.value));
+        }
+    // optionalAttrs (opt ? relatedPackages && opt.relatedPackages != null) {
+      inherit (opt) relatedPackages;
+    };
+
+  # Generic traversal algebra over a module option attribute set hierarchy.
+  foldOptionSet =
+    {
+      onOption,
+      onAttrSet,
+      empty,
+    }:
+    let
+      recurse =
+        tree:
+        if isOption tree then
+          let
+            doc = optionToDocItem tree;
+            visible = tree.visible or true;
+            ss = tree.type.getSubOptions tree.loc;
+            subDocs = if ss != { } then recurse ss else empty;
+            subVisible = if isBool visible then visible else visible == "transparent";
+          in
+          onOption doc (if subVisible then subDocs else empty)
+        else if isAttrs tree then
+          onAttrSet recurse tree
+        else
+          empty;
+    in
+    recurse;
+
   # Generate documentation template from the list of option declaration like
   # the set generated with filterOptionSets.
   optionAttrSetToDocList = optionAttrSetToDocList' [ ];
 
   optionAttrSetToDocList' =
     _: options:
-    concatMap (
-      opt:
-      let
-        name = showOption opt.loc;
-        visible = opt.visible or true;
-        docOption = {
-          loc = opt.loc;
-          inherit name;
-          description = opt.description or null;
-          declarations = filter (x: x != unknownModule) opt.declarations;
-          internal = opt.internal or false;
-          visible = if isBool visible then visible else visible == "shallow";
-          readOnly = opt.readOnly or false;
-          type = opt.type.description or "unspecified";
-        }
-        // optionalAttrs (opt ? example) {
-          example = builtins.addErrorContext "while evaluating the example of option `${name}`" (
-            renderOptionValue opt.example
-          );
-        }
-        //
-          optionalAttrs
-            (
-              opt ? defaultText
-              || opt ? default
-              # Render emptyValue-based defaults, but only for types without
-              # submodules (e.g. types.submodule). Submodules may evaluate to
-              # error without user defs, and their sub-options are documented
-              # individually, so best to skip those here.
-              || ((opt.type or { }).emptyValue or { }) ? value && (opt.type or { }).getSubModules or null == null
-            )
-            {
-              default =
-                builtins.addErrorContext
-                  "while evaluating the ${
-                    if opt ? defaultText then "defaultText" else "default value"
-                  } of option `${name}`"
-                  (renderOptionValue (opt.defaultText or opt.default or opt.type.emptyValue.value));
-            }
-        // optionalAttrs (opt ? relatedPackages && opt.relatedPackages != null) {
-          inherit (opt) relatedPackages;
-        };
+    foldOptionSet {
+      onOption = doc: subDocs: [ doc ] ++ subDocs;
+      onAttrSet = recurse: set: concatMap recurse (builtins.attrValues set);
+      empty = [ ];
+    } options;
 
-        subOptions =
-          let
-            ss = opt.type.getSubOptions opt.loc;
-          in
-          if ss != { } then optionAttrSetToDocList' opt.loc ss else [ ];
-        subOptionsVisible = if isBool visible then visible else visible == "transparent";
-      in
-      # To find infinite recursion in NixOS option docs:
-      # builtins.trace opt.loc
-      [ docOption ] ++ optionals subOptionsVisible subOptions
-    ) (collect isOption options);
+  # Generate documentation template as a nested attribute set (tree)
+  # preserving module option structure.
+  optionAttrSetToDocTree = optionAttrSetToDocTree' [ ];
+
+  optionAttrSetToDocTree' =
+    _: options:
+    foldOptionSet {
+      onOption = doc: subDocs: if subDocs != { } then doc // { subOptions = subDocs; } else doc;
+      onAttrSet = recurse: set: mapAttrs (_: recurse) set;
+      empty = { };
+    } options;
 
   /**
     This function recursively removes all derivation attributes from

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -610,9 +610,12 @@ rec {
   # Generic traversal algebra over a module option attribute set hierarchy.
   foldOptionSet =
     {
-      onOption,
-      onAttrSet,
-      empty,
+      onOption ?
+        doc: subDocs: opt:
+        empty,
+      onAttrSet ? recurse: set: empty,
+      empty ? { },
+      ...
     }:
     let
       recurse =

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -564,7 +564,21 @@ rec {
   */
   getFiles = catAttrs "file";
 
-  # Internal helper to transform a raw option set into a base documentation attribute set.
+  /**
+    Transform a raw module option set into a base documentation attribute set.
+
+    # Inputs
+
+    `opt`
+
+    : An evaluated module option attribute set (e.g. from `evalModules`).
+
+    # Type
+
+    ```
+    optionToDocItem :: Option -> AttrSet
+    ```
+  */
   optionToDocItem =
     opt:
     let
@@ -607,7 +621,21 @@ rec {
       inherit (opt) relatedPackages;
     };
 
-  # Generic traversal algebra over a module option attribute set hierarchy.
+  /**
+    Generic traversal algebra over a module option attribute set hierarchy.
+
+    # Inputs
+
+    `handlers`
+
+    : An attribute set containing optional callback handlers (`onOption`, `onAttrSet`, `empty`).
+
+    # Type
+
+    ```
+    foldOptionSet :: AttrSet -> (OptionSet | Option) -> Any
+    ```
+  */
   foldOptionSet =
     {
       onOption ?
@@ -659,8 +687,42 @@ rec {
       empty = [ ];
     } options;
 
-  # Generate documentation template as a nested attribute set (tree)
-  # preserving module option structure.
+  /**
+    Generate documentation template as a nested attribute set (tree)
+    preserving module option structure.
+
+    Submodule sub-options are nested directly under the `"*"` wildcard key.
+
+    # Inputs
+
+    `options`
+
+    : Evaluated module options attribute set (e.g. `(evalModules { ... }).options`).
+
+    # Type
+
+    ```
+    optionToDoc :: (OptionSet | Option) -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## Generate a nested option documentation tree
+
+    ```nix
+    optionToDoc (evalModules { modules = [ module ]; }).options
+    => {
+      boot = {
+        enable = {
+          default = { _type = "literalExpression"; text = "false"; };
+          description = "Enable boot";
+          type = "boolean";
+        };
+      };
+    }
+    ```
+    :::
+  */
   optionToDoc =
     options:
     foldOptionSet {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3373,12 +3373,31 @@ runTests {
             default = false;
             description = "Enable boot";
           };
+          options.services.nginx.virtualHosts = lib.mkOption {
+            type = lib.types.attrsOf (
+              lib.types.submodule {
+                options.enableSSL = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = "Enable SSL";
+                };
+              }
+            );
+            default = { };
+            description = "Virtual hosts";
+          };
         };
         options = (evalModules { modules = [ module ]; }).options;
         optionDoc = optionToDoc options;
       in
-      optionDoc.boot.enable.name;
-    expected = "boot.enable";
+      [
+        optionDoc.boot.enable.name
+        optionDoc.services.nginx.virtualHosts."*".enableSSL.name
+      ];
+    expected = [
+      "boot.enable"
+      "services.nginx.virtualHosts.<name>.enableSSL"
+    ];
   };
 
   testFreeformOptions = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -88,6 +88,7 @@ let
     nameValuePair
     optionalDrvAttr
     optionAttrSetToDocList
+    optionAttrSetToDocTree
     overrideExisting
     packagesFromDirectoryRecursive
     pipe
@@ -3361,6 +3362,23 @@ runTests {
         "bar"
       ]
     ];
+  };
+
+  testOptionAttrSetToDocTree = {
+    expr =
+      let
+        module = {
+          options.boot.enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enable boot";
+          };
+        };
+        options = (evalModules { modules = [ module ]; }).options;
+        docTree = optionAttrSetToDocTree options;
+      in
+      docTree.boot.enable.name;
+    expected = "boot.enable";
   };
 
   testFreeformOptions = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -88,7 +88,7 @@ let
     nameValuePair
     optionalDrvAttr
     optionAttrSetToDocList
-    optionAttrSetToDocTree
+    optionToDoc
     overrideExisting
     packagesFromDirectoryRecursive
     pipe
@@ -3364,7 +3364,7 @@ runTests {
     ];
   };
 
-  testOptionAttrSetToDocTree = {
+  testOptionToDoc = {
     expr =
       let
         module = {
@@ -3375,9 +3375,9 @@ runTests {
           };
         };
         options = (evalModules { modules = [ module ]; }).options;
-        docTree = optionAttrSetToDocTree options;
+        optionDoc = optionToDoc options;
       in
-      docTree.boot.enable.name;
+      optionDoc.boot.enable.name;
     expected = "boot.enable";
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3386,17 +3386,32 @@ runTests {
             default = { };
             description = "Virtual hosts";
           };
+          options.tagTest = lib.mkOption {
+            type = lib.types.attrTag {
+              tagA = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Tag A";
+              };
+            };
+            description = "AttrTag test option";
+          };
         };
         options = (evalModules { modules = [ module ]; }).options;
         optionDoc = optionToDoc options;
+        customFold = optionAttrSetToDocList options;
       in
       [
         optionDoc.boot.enable.type
         optionDoc.services.nginx.virtualHosts."*".enableSSL.type
+        optionDoc.tagTest."*".tagA.type
+        (builtins.length customFold > 0)
       ];
     expected = [
       "boolean"
       "boolean"
+      "boolean"
+      true
     ];
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3399,20 +3399,44 @@ runTests {
         };
         options = (evalModules { modules = [ module ]; }).options;
         optionDoc = optionToDoc options;
-        customFold = optionAttrSetToDocList options;
+        docList = optionAttrSetToDocList options;
       in
-      [
-        optionDoc.boot.enable.type
-        optionDoc.services.nginx.virtualHosts."*".enableSSL.type
-        optionDoc.tagTest."*".tagA.type
-        (builtins.length customFold > 0)
-      ];
-    expected = [
-      "boolean"
-      "boolean"
-      "boolean"
-      true
-    ];
+      {
+        # Standard option schema verification (no loc, no name)
+        bootEnableDescription = optionDoc.boot.enable.description;
+        bootEnableType = optionDoc.boot.enable.type;
+        bootEnableDefaultText = optionDoc.boot.enable.default.text;
+        bootEnableHasNoLoc = !(optionDoc.boot.enable ? loc);
+        bootEnableHasNoName = !(optionDoc.boot.enable ? name);
+
+        # Submodule nesting via '*' key
+        vhostDescription = optionDoc.services.nginx.virtualHosts.description;
+        vhostType = optionDoc.services.nginx.virtualHosts.type;
+        vhostSubOptionType = optionDoc.services.nginx.virtualHosts."*".enableSSL.type;
+
+        # attrTag nesting via '*' key
+        attrTagDescription = optionDoc.tagTest.description;
+        attrTagSubOptionType = optionDoc.tagTest."*".tagA.type;
+
+        # Equivalent traversal via optionAttrSetToDocList
+        docListCount = builtins.length docList;
+      };
+    expected = {
+      bootEnableDescription = "Enable boot";
+      bootEnableType = "boolean";
+      bootEnableDefaultText = "false";
+      bootEnableHasNoLoc = true;
+      bootEnableHasNoName = true;
+
+      vhostDescription = "Virtual hosts";
+      vhostType = "attribute set of (submodule)";
+      vhostSubOptionType = "boolean";
+
+      attrTagDescription = "AttrTag test option";
+      attrTagSubOptionType = "boolean";
+
+      docListCount = 13;
+    };
   };
 
   testFreeformOptions = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3391,12 +3391,12 @@ runTests {
         optionDoc = optionToDoc options;
       in
       [
-        optionDoc.boot.enable.name
-        optionDoc.services.nginx.virtualHosts."*".enableSSL.name
+        optionDoc.boot.enable.type
+        optionDoc.services.nginx.virtualHosts."*".enableSSL.type
       ];
     expected = [
-      "boot.enable"
-      "services.nginx.virtualHosts.<name>.enableSSL"
+      "boolean"
+      "boolean"
     ];
   };
 


### PR DESCRIPTION
Adds `lib.optionToDoc` to generate module documentation templates as nested attribute sets preserving option tree hierarchy.

Also refactors `optionAttrSetToDocList'` and `optionToDoc` to share a generic single-pass traversal fold (`foldOptionSet`) and option doc item generator (`optionToDocItem`).

### Structural Comparison Example

Given options `boot.loader.grub.enable`, `boot.loader.grub.device`, and `services.nginx.virtualHosts`:

#### `lib.optionAttrSetToDocList` (Flat List)
```json
[
  {
    "default": { "_type": "literalExpression", "text": "\"nodev\"" },
    "description": "The device on which the GRUB boot loader will be installed.",
    "loc": ["boot", "loader", "grub", "device"],
    "name": "boot.loader.grub.device",
    "type": "string"
  },
  {
    "default": { "_type": "literalExpression", "text": "false" },
    "description": "Whether to enable the GNU GRUB boot loader.",
    "loc": ["boot", "loader", "grub", "enable"],
    "name": "boot.loader.grub.enable",
    "type": "boolean"
  },
  {
    "default": { "_type": "literalExpression", "text": "{ }" },
    "description": "Declarative vhost configuration.",
    "loc": ["services", "nginx", "virtualHosts"],
    "name": "services.nginx.virtualHosts",
    "type": "attribute set of (submodule)"
  },
  {
    "default": { "_type": "literalExpression", "text": "false" },
    "description": "Whether to enable SSL for this virtual host.",
    "loc": ["services", "nginx", "virtualHosts", "<name>", "enableSSL"],
    "name": "services.nginx.virtualHosts.<name>.enableSSL",
    "type": "boolean"
  }
]
```

#### `lib.optionToDoc` (Nested Attribute Set)
```json
{
  "$defs": {},
  "options": {
    "boot": {
      "loader": {
        "grub": {
          "device": {
            "_type": "option",
            "default": { "_type": "literalExpression", "text": "\"nodev\"" },
            "description": "The device on which the GRUB boot loader will be installed.",
            "type": "string"
          },
          "enable": {
            "_type": "option",
            "default": { "_type": "literalExpression", "text": "false" },
            "description": "Whether to enable the GNU GRUB boot loader.",
            "type": "boolean"
          }
        }
      }
    },
    "services": {
      "nginx": {
        "virtualHosts": {
          "*": {
            "enableSSL": {
              "_type": "option",
              "default": { "_type": "literalExpression", "text": "false" },
              "description": "Whether to enable SSL for this virtual host.",
              "type": "boolean"
            }
          },
          "_type": "option",
          "default": { "_type": "literalExpression", "text": "{ }" },
          "description": "Declarative vhost configuration.",
          "type": "attribute set of (submodule)"
        }
      }
    }
  }
}
```

Key features of `lib.optionToDoc`:
- **Top-level container**: Returns `{ options = { ... }; "$defs" = { }; }` to future-proof the schema for definitions and recursive types without breaking API consumers.
- **Node discrimination**: Option leaves carry `_type = "option"`, allowing consumers to distinguish option leaves from intermediate attribute sets (even if an option is named `type`, `example`, etc.).
- **Submodule pathing**: Sub-options of submodules and tagged options (`attrTag`) are nested under the wildcard `"*"` attribute name.
- **Normalized representation**: Omits redundant `name` and `loc` properties from tree leaves, as the path is naturally carried by the attribute set hierarchy.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. Using GPT 5.6 Luna Max on Codex TUI (originally, but largely not the case anymore)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
