### PR TITLE
python3Packages.libvalkey: 4.0.1 -> 4.1.0

### DIFF
--- a/pkgs/development/python-modules/libvalkey/default.nix
+++ b/pkgs/development/python-modules/libvalkey/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "libvalkey";
-  version = "4.0.1";
+  version = "4.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -16,7 +16,7 @@ buildPythonPackage (finalAttrs: {
     repo = "libvalkey-py";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-tOq4SC9xA1rXfclqIzseedu7lyQ+7ZcVy/4ELTAorJ4=";
+    hash = "sha256-L8qbJxMbYL/0fujzm5aRQAD/gm8UO8USgiwsLeMs6Ag=";
   };
 
   build-system = [ setuptools ];
@@ -33,7 +33,7 @@ buildPythonPackage (finalAttrs: {
   '';
 
   meta = {
-    changelog = "https://github.com/valkey-io/libvalkey-py/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/valkey-io/libvalkey-py/releases/tag/${finalAttrs.src.tag}";
     description = "Python wrapper for libvalkey";
     homepage = "https://github.com/valkey-io/libvalkey-py";
     license = lib.licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/valkey-io/libvalkey-py/compare/v4.0.1...v4.1.0

Changelog: https://github.com/valkey-io/libvalkey-py/releases/tag/v4.1.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
