### PR TITLE
writeTextFile: enable strictDeps, enable structuredAttrs

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -80,6 +80,8 @@
 
 - `tengine` has been removed as it has seen seriously delayed responses to security vulnerabilities.
 
+- `writeTextFile` now uses structured attributes and `passAsFile` is no longer used or supported.
+
 - `nix-serve-ng` (and `haskellPackages.nix-serve-ng`) is now built against Lix instead of CppNix, following upstream which has switched to Lix as its supported Nix implementation.
 
 - Linux kernel configuration has been moved out of the `linux-kernel` field of the platform structure into the kernel builders:

--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -84,7 +84,6 @@ let
           }
         }
       '';
-      __structuredAttrs = true;
     };
     checkPhase = ''
       printf "%s" "$expectScript" | ${lib.getExe pkgs.buildPackages.expect} -f -

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -108,9 +108,7 @@ rec {
 
     extendDrvArgs =
       let
-        defaultPassAsFile = [ "text" ];
         removedDerivationNames = [
-          "passAsFile"
           "meta"
           "passthru"
         ];
@@ -149,7 +147,9 @@ rec {
               Ensure that the path starts with a / and specifies at least the filename.
             '';
           destination;
-        passAsFile = defaultPassAsFile ++ derivationArgs.passAsFile or [ ];
+
+        __structuredAttrs = true;
+        strictDeps = true;
 
         buildCommand = ''
           target=$out$destination


### PR DESCRIPTION
~~As far as I can see the only point where `passAsFile` is used in a call to `writeTextFile` is https://github.com/NixOS/nixpkgs/pull/553316 , so this should be safe to merge after that?~~ Done.

We could also remove the `if [ -e "$textPath" ]; then` branch if we don't want to support `$textPath` at all?

`strictDeps` should be safe to enable since we don't have any `*Inputs`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
