### PR TITLE
shiroa: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -255,6 +255,11 @@
     githubId = 882455;
     name = "Elliot Cameron";
   };
+  _3w36zj6 = {
+    github = "3w36zj6";
+    githubId = 52315048;
+    name = "3w36zj6";
+  };
   _404wolf = {
     email = "wolfmermelstein@gmail.com";
     github = "404Wolf";

--- a/pkgs/by-name/sh/shiroa/package.nix
+++ b/pkgs/by-name/sh/shiroa/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "shiroa";
+  version = "0.3.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Myriad-Dreamin";
+    repo = "shiroa";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-V0epGbMe4NSZznVTkuke1Vd9FCwhE99YtuQFSoU9xh0=";
+  };
+
+  cargoHash = "sha256-G99uZ5u7eiKaMW9YwpMmsP7RbfEi/tTiK9RyHQHEtlQ=";
+
+  cargoBuildFlags = [
+    "--package"
+    "shiroa"
+  ];
+
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  postInstall = ''
+    install -Dm644 LICENSE "$out/share/licenses/shiroa/LICENSE"
+    install -Dm644 assets/artifacts/LICENSE "$out/share/licenses/shiroa/artifacts/LICENSE"
+    install -Dm644 assets/artifacts/NOTICE "$out/share/licenses/shiroa/artifacts/NOTICE"
+    install -Dm644 themes/mdbook/LICENSE "$out/share/licenses/shiroa/mdbook/LICENSE"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Simple tool for creating modern online books in pure Typst";
+    homepage = "https://github.com/Myriad-Dreamin/shiroa";
+    changelog = "https://github.com/Myriad-Dreamin/shiroa/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      bitstreamVera
+      bsd0
+      bsd3
+      cc0
+      cc-by-40
+      gfl
+      mit
+      mpl20
+      ofl
+      ufl
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # WASM files in assets/artifacts
+      obfuscatedCode # minified JavaScript in assets/artifacts
+    ];
+    maintainers = with lib.maintainers; [ _3w36zj6 ];
+    mainProgram = "shiroa";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [shiroa](https://github.com/Myriad-Dreamin/shiroa), a CLI tool for creating online books from Typst sources. This packages the latest stable upstream release, [`0.3.0`](https://github.com/Myriad-Dreamin/shiroa/releases/tag/v0.3.0).

Upstream stores required runtime web assets in the [`assets/artifacts`](https://github.com/Myriad-Dreamin/shiroa/tree/v0.3.0/assets) submodule. This submodule contains a WASM file and minified JavaScript used by the generated book output, so this package fetches submodules and declares `meta.sourceProvenance` accordingly.

The license list reflects the licenses documented in upstream's [`assets/artifacts/NOTICE`](https://github.com/Myriad-Dreamin/typst/blob/35d94050627eb6f515ec04c8e6eee666f8724563/NOTICE) file, as well as the bundled [mdBook theme license](https://github.com/Myriad-Dreamin/shiroa/blob/v0.3.0/themes/mdbook/LICENSE).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
