### PR TITLE
various: switch appimageTools.wrapType2 to finalAttrs #1

### DIFF
--- a/pkgs/by-name/al/altair/package.nix
+++ b/pkgs/by-name/al/altair/package.nix
@@ -5,19 +5,14 @@
   fetchurl,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "altair";
   version = "8.5.3";
 
   src = fetchurl {
-    url = "https://github.com/altair-graphql/altair/releases/download/v${version}/altair_${version}_x86_64_linux.AppImage";
+    url = "https://github.com/altair-graphql/altair/releases/download/v${finalAttrs.version}/altair_${finalAttrs.version}_x86_64_linux.AppImage";
     sha256 = "sha256-XPw4NCtkInCes471as0Vtvr/SMRaJS6MNBGg0oo/Dro=";
   };
-
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit src pname version;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -25,10 +20,10 @@ appimageTools.wrapType2 {
     wrapProgram $out/bin/altair \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
-    install -m 444 -D ${appimageContents}/altair.desktop -t $out/share/applications
+    install -m 444 -D ${finalAttrs.contents}/altair.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/altair.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=altair'
-    cp -r ${appimageContents}/usr/share/icons $out/share
+    cp -r ${finalAttrs.contents}/usr/share/icons $out/share
   '';
 
   meta = {
@@ -39,4 +34,4 @@ appimageTools.wrapType2 {
     maintainers = with lib.maintainers; [ evalexpr ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/al/altus/package.nix
+++ b/pkgs/by-name/al/altus/package.nix
@@ -5,28 +5,21 @@
   makeWrapper,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "altus";
   version = "5.8.1";
 
   src = fetchurl {
-    name = "altus-${version}.AppImage";
-    url = "https://github.com/amanharwara/altus/releases/download/${version}/Altus-${version}.AppImage";
+    name = "altus-${finalAttrs.version}.AppImage";
+    url = "https://github.com/amanharwara/altus/releases/download/${finalAttrs.version}/Altus-${finalAttrs.version}.AppImage";
     hash = "sha256-FSyXs9thTQ5T5bvCfg/+QXBZMIOyoijAw0dUsvLRGH8=";
   };
-
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-  };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
 
   nativeBuildInputs = [ makeWrapper ];
 
   extraInstallCommands = ''
-    install -Dm 644 ${appimageContents}/Altus.desktop -t $out/share/applications
-    install -Dm 644 ${appimageContents}/Altus.png -t $out/share/icons/hicolor/256x256/apps
+    install -Dm 644 ${finalAttrs.contents}/Altus.desktop -t $out/share/applications
+    install -Dm 644 ${finalAttrs.contents}/Altus.png -t $out/share/icons/hicolor/256x256/apps
     substituteInPlace $out/share/applications/Altus.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=altus'
     wrapProgram "$out/bin/altus" \
@@ -36,9 +29,9 @@ appimageTools.wrapType2 {
   meta = {
     description = "Client for WhatsApp Web with themes, notifications and multiple accounts support";
     homepage = "https://github.com/amanharwara/altus";
-    changelog = "https://github.com/amanharwara/altus/releases/tag/v${version}";
+    changelog = "https://github.com/amanharwara/altus/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ johnrtitor ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/an/ankama-launcher/package.nix
+++ b/pkgs/by-name/an/ankama-launcher/package.nix
@@ -3,7 +3,8 @@
   appimageTools,
   fetchurl,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   pname = "ankama-launcher";
   version = "3.14.14";
 
@@ -16,18 +17,12 @@ let
     hash = "sha256-9w1ho9DZvDHXQbXjpMY1wnWDwYlMKO1igrJcCahQkVQ=";
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-
-in
-
-appimageTools.wrapType2 {
-  inherit pname version src;
   extraPkgs = pkgs: [ pkgs.wine ];
 
   extraInstallCommands = ''
-    desktop_file="${appimageContents}/zaap.desktop"
+    desktop_file="${finalAttrs.contents}/zaap.desktop"
 
-    nix_version="${version}"
+    nix_version="${finalAttrs.version}"
     archive_version=$(grep -oP '(?<=X-AppImage-Version=).*' $desktop_file)
 
     if [[ "$archive_version" != "$nix_version"* ]]; then
@@ -41,7 +36,7 @@ appimageTools.wrapType2 {
 
     install -m 444 -D "$desktop_file" $out/share/applications/ankama-launcher.desktop
     sed -i 's/.*Exec.*/Exec=ankama-launcher/' $out/share/applications/ankama-launcher.desktop
-    install -m 444 -D ${appimageContents}/zaap.png $out/share/icons/hicolor/256x256/apps/zaap.png
+    install -m 444 -D ${finalAttrs.contents}/zaap.png $out/share/icons/hicolor/256x256/apps/zaap.png
   '';
 
   meta = {
@@ -56,4 +51,4 @@ appimageTools.wrapType2 {
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/ap/apidog/package.nix
+++ b/pkgs/by-name/ap/apidog/package.nix
@@ -5,34 +5,14 @@
   makeDesktopItem,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "apidog";
   version = "2.8.42";
 
   src = fetchurl {
-    url = "https://file-assets.apidog.com/download/${version}/Apidog-${version}.AppImage";
+    url = "https://file-assets.apidog.com/download/${finalAttrs.version}/Apidog-${finalAttrs.version}.AppImage";
     hash = "sha256-BKhnOcJctfw3z3/q8RPq0OuAJcM1kF0e1LH3O9BI2Tw=";
   };
-
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-  };
-
-  desktopItem = makeDesktopItem {
-    name = "apidog";
-    exec = "apidog %U";
-    icon = "apidog";
-    desktopName = "Apidog";
-    comment = "All-in-One API Platform: Design, Debug, Mock, Test, and Document.";
-    categories = [
-      "Development"
-      "Utility"
-    ];
-    mimeTypes = [ "x-scheme-handler/apidog" ];
-  };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
 
   extraPkgs = pkgs: [
     pkgs.nss
@@ -50,11 +30,24 @@ appimageTools.wrapType2 {
   ];
 
   extraInstallCommands = ''
-    install -Dm444 ${appimageContents}/apidog.png \
+    install -Dm444 ${finalAttrs.contents}/apidog.png \
       $out/share/icons/hicolor/512x512/apps/apidog.png
   '';
 
-  desktopItems = [ desktopItem ];
+  desktopItems = [
+    (makeDesktopItem {
+      name = "apidog";
+      exec = "apidog %U";
+      icon = "apidog";
+      desktopName = "Apidog";
+      comment = "All-in-One API Platform: Design, Debug, Mock, Test, and Document.";
+      categories = [
+        "Development"
+        "Utility"
+      ];
+      mimeTypes = [ "x-scheme-handler/apidog" ];
+    })
+  ];
 
   meta = with lib; {
     description = "All-in-one API design, test, mock and documentation platform";
@@ -65,4 +58,4 @@ appimageTools.wrapType2 {
     mainProgram = "apidog";
     maintainers = with maintainers; [ DomagojAlaber ];
   };
-}
+})

--- a/pkgs/by-name/ar/artisan/package.nix
+++ b/pkgs/by-name/ar/artisan/package.nix
@@ -4,25 +4,19 @@
   fetchurl,
   nix-update-script,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   pname = "artisan";
   version = "4.0.2";
 
   src = fetchurl {
-    url = "https://github.com/artisan-roaster-scope/artisan/releases/download/v${version}/${pname}-linux-${version}.AppImage";
+    url = "https://github.com/artisan-roaster-scope/artisan/releases/download/v${finalAttrs.version}/artisan-linux-${finalAttrs.version}.AppImage";
     hash = "sha256-KmjqM3gYpxxjEBaXjF5zvL8bgfgD8IKvAX0xYf29J48=";
   };
 
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-  };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
-
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/org.artisan_scope.artisan.desktop $out/share/applications/org.artisan_scope.artisan.desktop
-    install -m 444 -D ${appimageContents}/artisan.png $out/share/applications/artisan.png
+    install -m 444 -D ${finalAttrs.contents}/org.artisan_scope.artisan.desktop $out/share/applications/org.artisan_scope.artisan.desktop
+    install -m 444 -D ${finalAttrs.contents}/artisan.png $out/share/applications/artisan.png
   '';
 
   passthru.updateScript = nix-update-script {
@@ -32,7 +26,7 @@ appimageTools.wrapType2 {
   meta = {
     description = "Visual scope for coffee roasters";
     homepage = "https://artisan-scope.org/";
-    changelog = "https://github.com/artisan-roaster-scope/artisan/releases/tag/v${version}";
+    changelog = "https://github.com/artisan-roaster-scope/artisan/releases/tag/v${finalAttrs.version}";
     downloadPage = "https://github.com/artisan-roaster-scope/artisan/releases";
     license = lib.licenses.gpl3Only;
     mainProgram = "artisan";
@@ -40,4 +34,4 @@ appimageTools.wrapType2 {
     maintainers = with lib.maintainers; [ bohreromir ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/ar/artix-games-launcher/package.nix
+++ b/pkgs/by-name/ar/artix-games-launcher/package.nix
@@ -1,27 +1,22 @@
 {
   appimageTools,
-  stdenv,
   fetchurl,
   lib,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   pname = "artix-games-launcher";
   version = "2.20";
+
   src = fetchurl {
     url = "https://web.archive.org/web/20250924101414/https://launch.artix.com/latest/Artix_Games_Launcher-x86_64.AppImage";
     hash = "sha256-8eVXOm5g92wErWa6lbTXrCL04MWYlObjonHJk+oUI3E=";
   };
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-  };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications
-    install -m 444 -D ${appimageContents}/ArtixGamesLauncher.desktop $out/share/applications/ArtixGamesLauncher.desktop
-    install -m 444 -D ${appimageContents}/ArtixLogo.png $out/share/icons/ArtixLogo.png
+    install -m 444 -D ${finalAttrs.contents}/ArtixGamesLauncher.desktop $out/share/applications/ArtixGamesLauncher.desktop
+    install -m 444 -D ${finalAttrs.contents}/ArtixLogo.png $out/share/icons/ArtixLogo.png
     substituteInPlace $out/share/applications/ArtixGamesLauncher.desktop --replace-fail 'Exec=ArtixGameLauncher %u' 'Exec=artix-games-launcher %u'
   '';
 
@@ -33,4 +28,4 @@ appimageTools.wrapType2 {
     maintainers = with lib.maintainers; [ jtliang24 ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/be/betterdiscord-installer/package.nix
+++ b/pkgs/by-name/be/betterdiscord-installer/package.nix
@@ -4,25 +4,23 @@
   fetchurl,
   nix-update-script,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   pname = "betterdiscord-installer";
   version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/BetterDiscord/Installer/releases/download/v${version}/Betterdiscord-Linux.AppImage";
+    url = "https://github.com/BetterDiscord/Installer/releases/download/v${finalAttrs.version}/Betterdiscord-Linux.AppImage";
     hash = "sha256-In5J6TWoJsFODDwMXd1lMg3341IZJD2OJebVtgISxP0=";
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
+  extraPkgs = pkgs: [ pkgs.libxshmfence ];
 
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/betterdiscord-installer.desktop -t $out/share/applications
+    install -m 444 -D ${finalAttrs.contents}/betterdiscord-installer.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/betterdiscord-installer.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=betterdiscord-installer'
-    cp -r ${appimageContents}/usr/share/icons $out/share
+    cp -r ${finalAttrs.contents}/usr/share/icons $out/share
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -36,4 +34,4 @@ appimageTools.wrapType2 {
     mainProgram = "betterdiscord-installer";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/be/beyond-all-reason/package.nix
+++ b/pkgs/by-name/be/beyond-all-reason/package.nix
@@ -4,24 +4,21 @@
   appimageTools,
   openal,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   version = "1.2988.0";
   pname = "beyond-all-reason";
 
   src = fetchurl {
-    url = "https://github.com/beyond-all-reason/BYAR-Chobby/releases/download/v${version}/Beyond-All-Reason-${version}.AppImage";
+    url = "https://github.com/beyond-all-reason/BYAR-Chobby/releases/download/v${finalAttrs.version}/Beyond-All-Reason-${finalAttrs.version}.AppImage";
     hash = "sha256-ZJW5BdxxqyrM2TJTO0SBp4BXt3ILyi77EZx73X8hqJE=";
   };
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
 
   extraPkgs = pkgs: [ openal ];
 
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/beyond-all-reason.desktop $out/share/applications/beyond-all-reason.desktop
-    install -m 444 -D ${appimageContents}/beyond-all-reason.png \
+    install -m 444 -D ${finalAttrs.contents}/beyond-all-reason.desktop $out/share/applications/beyond-all-reason.desktop
+    install -m 444 -D ${finalAttrs.contents}/beyond-all-reason.png \
       $out/share/icons/hicolor/256x256/apps/beyond-all-reason.png
     substituteInPlace $out/share/applications/beyond-all-reason.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=beyond-all-reason'
@@ -30,7 +27,7 @@ appimageTools.wrapType2 {
   meta = {
     homepage = "https://www.beyondallreason.info/";
     downloadPage = "https://www.beyondallreason.info/download";
-    changelog = "https://github.com/beyond-all-reason/BYAR-Chobby/releases/tag/v${version}";
+    changelog = "https://github.com/beyond-all-reason/BYAR-Chobby/releases/tag/v${finalAttrs.version}";
     description = "Free Real Time Strategy Game with a grand scale and full physical simulation in a sci-fi setting";
     license = lib.licenses.gpl2Plus;
     platforms = [ "x86_64-linux" ];
@@ -38,4 +35,4 @@ appimageTools.wrapType2 {
       kiyotoko
     ];
   };
-}
+})

--- a/pkgs/by-name/bl/bloomrpc/package.nix
+++ b/pkgs/by-name/bl/bloomrpc/package.nix
@@ -4,33 +4,26 @@
   appimageTools,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "bloomrpc";
   version = "1.5.3";
 
   src = fetchurl {
-    url = "https://github.com/uw-labs/${pname}/releases/download/${version}/BloomRPC-${version}.AppImage";
-    name = "${pname}-${version}.AppImage";
+    url = "https://github.com/uw-labs/bloomrpc/releases/download/${finalAttrs.version}/BloomRPC-${finalAttrs.version}.AppImage";
+    name = "bloomrpc-${finalAttrs.version}.AppImage";
     hash = "sha512-PebdYDpcplPN5y3mRu1mG6CXenYfYvBXNLgIGEr7ZgKnR5pIaOfJNORSNYSdagdGDb/B1sxuKfX4+4f2cqgb6Q==";
   };
-
-  appimageContents = appimageTools.extract {
-    inherit pname src version;
-  };
-in
-appimageTools.wrapType2 {
-  inherit pname src version;
 
   profile = ''
     export LC_ALL=C.UTF-8
   '';
 
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
-    install -m 444 -D ${appimageContents}/${pname}.png \
-      $out/share/icons/hicolor/512x512/apps/${pname}.png
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+    install -m 444 -D ${finalAttrs.contents}/bloomrpc.desktop $out/share/applications/bloomrpc.desktop
+    install -m 444 -D ${finalAttrs.contents}/bloomrpc.png \
+      $out/share/icons/hicolor/512x512/apps/bloomrpc.png
+    substituteInPlace $out/share/applications/bloomrpc.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=bloomrpc'
   '';
 
   meta = {
@@ -44,4 +37,4 @@ appimageTools.wrapType2 {
     maintainers = with lib.maintainers; [ zoedsoupe ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/bo/bootstrap-studio/package.nix
+++ b/pkgs/by-name/bo/bootstrap-studio/package.nix
@@ -4,25 +4,22 @@
   appimageTools,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "bootstrap-studio";
   version = "8.0.1";
+
   src = fetchurl {
-    url = "https://releases.bootstrapstudio.io/${version}/Bootstrap%20Studio.AppImage";
+    url = "https://releases.bootstrapstudio.io/${finalAttrs.version}/Bootstrap%20Studio.AppImage";
     sha256 = "sha256-uVeD6g3A9ITKkBp3AxTPUM3nyhCbW79gPVTU7bIDmhs=";
   };
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
 
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/bstudio.desktop -t $out/share/applications
+    install -m 444 -D ${finalAttrs.contents}/bstudio.desktop -t $out/share/applications
 
     substituteInPlace $out/share/applications/bstudio.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+      --replace-fail 'Exec=AppRun' 'Exec=bootstrap-studio'
 
-    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/0x0/apps/bstudio.png \
+    install -m 444 -D ${finalAttrs.contents}/usr/share/icons/hicolor/0x0/apps/bstudio.png \
       $out/share/icons/hicolor/512x512/apps/bstudio.png
   '';
 
@@ -33,4 +30,4 @@ appimageTools.wrapType2 {
     maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/bu/buckets/package.nix
+++ b/pkgs/by-name/bu/buckets/package.nix
@@ -26,25 +26,26 @@ let
     }
     .${system};
 
+in
+appimageTools.wrapType2 (finalAttrs: {
   pname = "buckets";
   version = "0.80.0";
+
   src = fetchurl {
-    url = "https://github.com/buckets/application/releases/download/v${version}/Buckets-linux-latest-${platform}-${version}.AppImage";
+    url = "https://github.com/buckets/application/releases/download/v${finalAttrs.version}/Buckets-linux-latest-${platform}-${finalAttrs.version}.AppImage";
     inherit hash;
   };
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
+
   extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libsodium ];
+
   extraInstallCommands = ''
     source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/buckets
-    install -m 444 -D ${appimageContents}/buckets.desktop -t $out/share/applications
+    install -m 444 -D ${finalAttrs.contents}/buckets.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/buckets.desktop \
         --replace-fail 'Exec=AppRun' 'Exec=buckets'
     for size in 16 32 48 64 128 256 512; do
-        install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/buckets.png \
+        install -m 444 -D ${finalAttrs.contents}/usr/share/icons/hicolor/''${size}x''${size}/apps/buckets.png \
           $out/share/icons/hicolor/''${size}x''${size}/apps/buckets.png
     done
   '';
@@ -60,4 +61,4 @@ appimageTools.wrapType2 {
     ];
     mainProgram = "buckets";
   };
-}
+})

--- a/pkgs/by-name/bu/buttercup-desktop/package.nix
+++ b/pkgs/by-name/bu/buttercup-desktop/package.nix
@@ -4,26 +4,22 @@
   appimageTools,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "buttercup-desktop";
   version = "2.28.1";
+
   src = fetchurl {
-    url = "https://github.com/buttercup/buttercup-desktop/releases/download/v${version}/Buttercup-linux-x86_64.AppImage";
+    url = "https://github.com/buttercup/buttercup-desktop/releases/download/v${finalAttrs.version}/Buttercup-linux-x86_64.AppImage";
     sha256 = "sha256-iCuvs+FisYPvCmPVg1dhYMX+Lw3WmrMSRytdy6TLrxg=";
   };
-  appimageContents = appimageTools.extract { inherit pname src version; };
-
-in
-appimageTools.wrapType2 {
-  inherit pname src version;
 
   extraPkgs = pkgs: [ pkgs.libsecret ];
 
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/buttercup.desktop -t $out/share/applications
+    install -m 444 -D ${finalAttrs.contents}/buttercup.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/buttercup.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
-    cp -r ${appimageContents}/usr/share/icons $out/share
+      --replace 'Exec=AppRun' 'Exec=buttercup-desktop'
+    cp -r ${finalAttrs.contents}/usr/share/icons $out/share
   '';
 
   meta = {
@@ -34,4 +30,4 @@ appimageTools.wrapType2 {
     maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/ca/cables/package.nix
+++ b/pkgs/by-name/ca/cables/package.nix
@@ -5,29 +5,19 @@
   stdenv,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "cables";
   version = "0.10.6";
 
   src = fetchurl {
-    url = "https://github.com/cables-gl/cables_electron/releases/download/v${version}/cables-${version}-linux-x64.AppImage";
+    url = "https://github.com/cables-gl/cables_electron/releases/download/v${finalAttrs.version}/cables-${finalAttrs.version}-linux-x64.AppImage";
     sha256 = "sha256-Pk6rtWzIWzAlp5WwI7cKAjAlhjqLZJUO+39v44ZD93k=";
   };
 
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
-    postExtract = ''
-      substituteInPlace $out/cables-${version}.desktop --replace 'Exec=AppRun' 'Exec=cables'
-    '';
-  };
-
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
-
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/cables-${version}.desktop $out/share/applications/cables.desktop
-    install -m 444 -D ${appimageContents}/cables-${version}.png $out/share/icons/hicolor/512x512/apps/cables.png
+    install -m 444 -D ${finalAttrs.contents}/cables-${finalAttrs.version}.desktop $out/share/applications/cables.desktop
+    install -m 444 -D ${finalAttrs.contents}/cables-${finalAttrs.version}.png $out/share/icons/hicolor/512x512/apps/cables.png
+      substituteInPlace $out/share/applications/cables.desktop --replace-fail 'Exec=AppRun' 'Exec=cables'
   '';
 
   meta = {
@@ -40,4 +30,4 @@ appimageTools.wrapType2 {
     broken = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64);
     mainProgram = "cables";
   };
-}
+})

--- a/pkgs/by-name/ca/caido-desktop/package.nix
+++ b/pkgs/by-name/ca/caido-desktop/package.nix
@@ -50,9 +50,7 @@ let
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-
-  linux = appimageTools.wrapType2 {
+  linux = appimageTools.wrapType2 (finalAttrs: {
     inherit
       pname
       version
@@ -64,19 +62,22 @@ let
     extraPkgs = pkgs: [ pkgs.libthai ];
 
     extraInstallCommands = ''
-      install -m 444 -D ${appimageContents}/caido.desktop \
+      install -m 444 -D ${finalAttrs.contents}/caido.desktop \
         -t $out/share/applications
+
       substituteInPlace $out/share/applications/caido.desktop \
         --replace-fail "Exec=AppRun --no-sandbox %U" "Exec=caido-desktop %U"
-      install -m 444 -D ${appimageContents}/caido.png \
+
+      install -m 444 -D ${finalAttrs.contents}/caido.png \
         $out/share/icons/hicolor/512x512/apps/caido.png
-      wrapProgram $out/bin/${pname} \
+
+      wrapProgram $out/bin/caido-desktop \
         --set WEBKIT_DISABLE_COMPOSITING_MODE 1 \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
     '';
-  };
+  });
 
-  darwin = stdenv.mkDerivation {
+  darwin = stdenv.mkDerivation (finalAttrs: {
     inherit
       pname
       version
@@ -91,7 +92,7 @@ let
 
     unpackPhase = ''
       runHook preUnpack
-      7zz x $src || true
+      7zz x ${finalAttrs.src} || true
       runHook postUnpack
     '';
 
@@ -101,11 +102,12 @@ let
       runHook preInstall
       mkdir -p $out/Applications/Caido.app $out/bin
       cp -R . $out/Applications/Caido.app/
+
       makeWrapper $out/Applications/Caido.app/Contents/MacOS/Caido \
-        $out/bin/${pname}
+        $out/bin/caido-desktop
       runHook postInstall
     '';
-  };
+  });
 
 in
 if stdenv.hostPlatform.isLinux then

--- a/pkgs/by-name/ca/capacities/package.nix
+++ b/pkgs/by-name/ca/capacities/package.nix
@@ -5,7 +5,8 @@
   imagemagick,
   lib,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   pname = "capacities";
   version = "1.65.13";
 
@@ -14,44 +15,29 @@ let
     hash = "sha256-ATiX1h9hXmKMFtY6OEyZEoJ/SxJGgbj5/QZwFF1sfFQ=";
   };
 
-  appimageContents = appimageTools.extract {
-    inherit
-      pname
-      src
-      version
-      ;
-  };
-in
-appimageTools.wrapType2 {
-  inherit
-    pname
-    src
-    version
-    ;
-
   extraInstallCommands = ''
     source "${makeWrapper}/nix-support/setup-hook"
     wrapProgram $out/bin/capacities \
       --add-flags "--ozone-platform-hint=auto"
 
     # Check for required desktop file
-    if [ ! -f ${appimageContents}/capacities.desktop ]; then
-      echo "Error: Missing .desktop file in ${appimageContents}"
+    if [ ! -f ${finalAttrs.contents}/capacities.desktop ]; then
+      echo "Error: Missing .desktop file in ${finalAttrs.contents}"
       exit 1
     else
       # Install and modify the desktop file
-      install -m 444 -D ${appimageContents}/capacities.desktop $out/share/applications/capacities.desktop
+      install -m 444 -D ${finalAttrs.contents}/capacities.desktop $out/share/applications/capacities.desktop
       substituteInPlace $out/share/applications/capacities.desktop \
         --replace-fail "Exec=AppRun" "Exec=capacities"
     fi
 
     # Check for required icon file
-    if [ ! -f ${appimageContents}/capacities.png ]; then
-      echo "Error: Missing icon file in ${appimageContents}"
+    if [ ! -f ${finalAttrs.contents}/capacities.png ]; then
+      echo "Error: Missing icon file in ${finalAttrs.contents}"
       exit 1
     else
       # Resize and install the icon
-      ${lib.getExe imagemagick} ${appimageContents}/capacities.png -resize 512x512 capacities_512.png
+      ${lib.getExe imagemagick} ${finalAttrs.contents}/capacities.png -resize 512x512 capacities_512.png
       install -m 444 -D capacities_512.png $out/share/icons/hicolor/512x512/apps/capacities.png
     fi
   '';
@@ -65,4 +51,4 @@ appimageTools.wrapType2 {
     mainProgram = "capacities";
     maintainers = [ lib.maintainers.keysmashes ];
   };
-}
+})

--- a/pkgs/by-name/ch/chatzone-desktop/package.nix
+++ b/pkgs/by-name/ch/chatzone-desktop/package.nix
@@ -2,25 +2,19 @@
   lib,
   appimageTools,
   fetchurl,
-  stdenvNoCC,
   makeDesktopItem,
   copyDesktopItems,
   makeWrapper,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "chatzone-desktop";
   version = "5.7.0";
+
   src = fetchurl {
     url = "https://ir.ozone.ru/s3/chatzone-clients/ci/5.7.0/1258/chatzone-desktop-linux-5.7.0.AppImage";
     hash = "sha256-t8qAdrvs1M9NuaQYZj+pCaYiSb4TZc7rY1rJVjSYaAE=";
   };
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-stdenvNoCC.mkDerivation {
-  inherit pname version;
-
-  src = appimageTools.wrapType2 { inherit pname version src; };
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -46,20 +40,13 @@ stdenvNoCC.mkDerivation {
     })
   ];
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/
-    cp -r bin $out/bin
-
+  extraInstallCommands = ''
     mkdir -p $out/share/chatzone-desktop/
-    cp ${appimageContents}/app_icon.png $out/share/chatzone-desktop/
-    cp -r ${appimageContents}/usr/share/icons $out/share
+    cp ${finalAttrs.contents}/app_icon.png $out/share/chatzone-desktop/
+    cp -r ${finalAttrs.contents}/usr/share/icons $out/share
 
     wrapProgram $out/bin/chatzone-desktop \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
-
-    runHook postInstall
   '';
 
   meta = {
@@ -72,4 +59,4 @@ stdenvNoCC.mkDerivation {
     maintainers = [ lib.maintainers.progrm_jarvis ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/ch/chrysalis/package.nix
+++ b/pkgs/by-name/ch/chrysalis/package.nix
@@ -4,17 +4,14 @@
   fetchurl,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "chrysalis";
   version = "0.13.3";
+
   src = fetchurl {
-    url = "https://github.com/keyboardio/chrysalis/releases/download/v${version}/chrysalis-${version}-x64.AppImage";
+    url = "https://github.com/keyboardio/chrysalis/releases/download/v${finalAttrs.version}/chrysalis-${finalAttrs.version}-x64.AppImage";
     hash = "sha512-F6Y87rgIclj1OA3gVX/gqqp9AvXKQlBXrbqk/26F1KHPF9NzHJgVmeszSo3Nhb6xg4CzWmzkqc8IW2H/Bg57kw==";
   };
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
 
   extraPkgs = pkgs: [ pkgs.glib ];
 
@@ -24,17 +21,17 @@ appimageTools.wrapType2 {
 
   extraInstallCommands = ''
     install -m 444 \
-      -D ${appimageContents}/usr/lib/chrysalis/resources/static/udev/60-kaleidoscope.rules \
+      -D ${finalAttrs.contents}/usr/lib/chrysalis/resources/static/udev/60-kaleidoscope.rules \
       -t $out/lib/udev/rules.d
 
     install -m 444 \
-        -D ${appimageContents}/Chrysalis.desktop \
+        -D ${finalAttrs.contents}/Chrysalis.desktop \
         -t $out/share/applications
     substituteInPlace \
         $out/share/applications/Chrysalis.desktop \
         --replace-fail 'Exec=Chrysalis' 'Exec=chrysalis'
 
-    cp -r ${appimageContents}/usr/share $out/share
+    cp -r ${finalAttrs.contents}/usr/share $out/share
   '';
 
   passthru.updateScript = ./update.sh;
@@ -52,4 +49,4 @@ appimageTools.wrapType2 {
     mainProgram = "chrysalis";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/cl/clickup/package.nix
+++ b/pkgs/by-name/cl/clickup/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenvNoCC,
   appimageTools,
   fetchurl,
   makeWrapper,
@@ -9,7 +8,8 @@
   common-updater-scripts,
   desktop-file-utils,
 }:
-let
+
+appimageTools.wrapType2 (finalAttrs: {
   pname = "clickup";
   version = "3.5.262";
 
@@ -19,46 +19,32 @@ let
     hash = "sha256-8stmEBpvU75JSMBZCjcObLndq+51bqTYb0PK1Yypudc=";
   };
 
-  appimage = appimageTools.wrapType2 {
-    inherit pname version src;
-    extraPkgs = pkgs: [ pkgs.libxkbfile ];
-  };
-
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-stdenvNoCC.mkDerivation {
-  inherit pname version;
-
-  src = appimage;
+  extraPkgs = pkgs: [
+    pkgs.libxkbfile
+  ];
 
   nativeBuildInputs = [
     makeWrapper
     desktop-file-utils
   ];
 
-  installPhase = ''
-    runHook preInstall
+  extraInstallCommands = ''
+    mkdir -p $out/share/clickup
+    cp -r ${finalAttrs.contents}/locales $out/share/clickup
+    cp -r ${finalAttrs.contents}/resources $out/share/clickup
 
-    mkdir -p $out/
-    cp -r bin $out/bin
-
-    mkdir -p $out/share/${pname}
-    cp -r ${appimageContents}/locales $out/share/${pname}
-    cp -r ${appimageContents}/resources $out/share/${pname}
-    cp -r --no-preserve=mode ${appimageContents}/usr/share/icons $out/share/
+    cp -r --no-preserve=mode ${finalAttrs.contents}/usr/share/icons $out/share/
     find $out/share/icons -name desktop.png -execdir mv {} clickup.png \;
 
-    install -m 444 -D ${appimageContents}/desktop.desktop $out/share/applications/clickup.desktop
+    install -m 444 -D ${finalAttrs.contents}/desktop.desktop $out/share/applications/clickup.desktop
 
     desktop-file-edit \
       --set-key=Exec --set-value=clickup \
       --set-key=Icon --set-value=clickup \
       "$out/share/applications/clickup.desktop"
 
-    wrapProgram $out/bin/${pname} \
+    wrapProgram $out/bin/clickup \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations,WebRTCPipeWireCapturer}} --no-update"
-
-    runHook postInstall
   '';
 
   passthru.updateScript = lib.getExe (writeShellApplication {
@@ -100,4 +86,4 @@ stdenvNoCC.mkDerivation {
     maintainers = with lib.maintainers; [ heisfer ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/co/codux/package.nix
+++ b/pkgs/by-name/co/codux/package.nix
@@ -4,24 +4,18 @@
   fetchurl,
 }:
 
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "codux";
   version = "15.42.0";
 
   src = fetchurl {
-    url = "https://github.com/wixplosives/codux-versions/releases/download/${version}/Codux-${version}.x86_64.AppImage";
+    url = "https://github.com/wixplosives/codux-versions/releases/download/${finalAttrs.version}/Codux-${finalAttrs.version}.x86_64.AppImage";
     hash = "sha256-rD0yXZAEUcPtxWlWuZD77gjw6JlcUvBsaDYGj+NgLss=";
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-
-appimageTools.wrapType2 {
-  inherit pname version src;
-
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/codux.desktop -t $out/share/applications
-    cp -r ${appimageContents}/usr/share/icons $out/share
+    install -m 444 -D ${finalAttrs.contents}/codux.desktop -t $out/share/applications
+    cp -r ${finalAttrs.contents}/usr/share/icons $out/share
     substituteInPlace $out/share/applications/codux.desktop  --replace 'Exec=AppRun' 'Exec=codux'
   '';
 
@@ -35,4 +29,4 @@ appimageTools.wrapType2 {
     ];
     mainProgram = "codux";
   };
-}
+})


### PR DESCRIPTION
This pull request refactors multiple Nix package definitions for AppImage-based applications to use a more modern and consistent pattern with `appimageTools.wrapType2`. The main focus is on improving maintainability and reducing code duplication by eliminating manual extraction of AppImage contents and standardizing the use of `finalAttrs`. No functional changes to the packaged applications are intended.

Key changes by theme:

**Migration to `appimageTools.wrapType2` and `finalAttrs`:**
* Refactored all affected packages to use `appimageTools.wrapType2 (finalAttrs: { ... })` instead of the previous `let ... in appimageTools.wrapType2 { ... }` pattern, removing manual extraction (`appimageTools.extract`) and direct attribute passing (`inherit pname version src`). This brings consistency and leverages the more robust attribute set provided by `finalAttrs`. [[1]](diffhunk://#diff-2282dd71e981c4d8ae0b455d9bdbd3816522bf7efa32c79860d4bace0856d8deL8-R26) [[2]](diffhunk://#diff-d6d1bd9ca7e87b8babe91ad60c37cd353d380d2e21ebc2d85ed5608f2bf76cffL8-R22) [[3]](diffhunk://#diff-8b382cd33cd86e337c55a8ab0ecf102a14e0cf99dbf1be0ff7aab91bbb7aa3d4L6-R7) [[4]](diffhunk://#diff-df2afd4dcbc46f64747fee8685d575c98d88e6719baf9ea950495201f17b12cfL8-L36) [[5]](diffhunk://#diff-e625e8a8a3064459943959084e0c378e86360ba4188858bd11363722075c95fbL7-R19) [[6]](diffhunk://#diff-edf871fe4d22fd41fdbaed06517b94be110bb65ad84625ceebdd9846ee6e4dd7L3-R19) [[7]](diffhunk://#diff-4cf5a7e5eca240bfe78f85d47d40877b757501c91432963492613f77d4c974a6L7-R23) [[8]](diffhunk://#diff-b9c1ac2e1e9d721c230f6fa954afee6944a85739f8639cf869110867f4160bbaL7-R21) [[9]](diffhunk://#diff-c14b1b5fe0f4cf325df763f6000397571d6346b89ff9f96e07d6a46844613356L7-R26) [[10]](diffhunk://#diff-905beab46f6d65cf5754451b2d520dab9599596470e344e74a6d6540aa4641baL7-R22) [[11]](diffhunk://#diff-8f904ff150fac950788fc8bcc2c75c00d6e40729c22ab38a2ad6006f1cdd8af8R29-R48)

**Standardization of variable usage:**
* Updated all references to `version`, `pname`, and extracted contents to use `finalAttrs.version`, `finalAttrs.contents`, etc., ensuring that all dynamic attributes are consistently sourced from the final attribute set. [[1]](diffhunk://#diff-2282dd71e981c4d8ae0b455d9bdbd3816522bf7efa32c79860d4bace0856d8deL8-R26) [[2]](diffhunk://#diff-d6d1bd9ca7e87b8babe91ad60c37cd353d380d2e21ebc2d85ed5608f2bf76cffL8-R22) [[3]](diffhunk://#diff-8b382cd33cd86e337c55a8ab0ecf102a14e0cf99dbf1be0ff7aab91bbb7aa3d4L19-R25) [[4]](diffhunk://#diff-df2afd4dcbc46f64747fee8685d575c98d88e6719baf9ea950495201f17b12cfL53-R50) [[5]](diffhunk://#diff-e625e8a8a3064459943959084e0c378e86360ba4188858bd11363722075c95fbL7-R19) [[6]](diffhunk://#diff-edf871fe4d22fd41fdbaed06517b94be110bb65ad84625ceebdd9846ee6e4dd7L3-R19) [[7]](diffhunk://#diff-4cf5a7e5eca240bfe78f85d47d40877b757501c91432963492613f77d4c974a6L7-R23) [[8]](diffhunk://#diff-b9c1ac2e1e9d721c230f6fa954afee6944a85739f8639cf869110867f4160bbaL7-R21) [[9]](diffhunk://#diff-c14b1b5fe0f4cf325df763f6000397571d6346b89ff9f96e07d6a46844613356L7-R26) [[10]](diffhunk://#diff-905beab46f6d65cf5754451b2d520dab9599596470e344e74a6d6540aa4641baL7-R22) [[11]](diffhunk://#diff-8f904ff150fac950788fc8bcc2c75c00d6e40729c22ab38a2ad6006f1cdd8af8R29-R48)

**Simplification and modernization of desktop integration:**
* Replaced manual desktop item creation and icon installation to use the new pattern, updating paths and commands to use `finalAttrs.contents` and ensuring all substitutions and file operations are robust (e.g., using `--replace-fail`). [[1]](diffhunk://#diff-2282dd71e981c4d8ae0b455d9bdbd3816522bf7efa32c79860d4bace0856d8deL8-R26) [[2]](diffhunk://#diff-d6d1bd9ca7e87b8babe91ad60c37cd353d380d2e21ebc2d85ed5608f2bf76cffL8-R22) [[3]](diffhunk://#diff-8b382cd33cd86e337c55a8ab0ecf102a14e0cf99dbf1be0ff7aab91bbb7aa3d4L19-R25) [[4]](diffhunk://#diff-df2afd4dcbc46f64747fee8685d575c98d88e6719baf9ea950495201f17b12cfL53-R50) [[5]](diffhunk://#diff-e625e8a8a3064459943959084e0c378e86360ba4188858bd11363722075c95fbL7-R19) [[6]](diffhunk://#diff-edf871fe4d22fd41fdbaed06517b94be110bb65ad84625ceebdd9846ee6e4dd7L3-R19) [[7]](diffhunk://#diff-4cf5a7e5eca240bfe78f85d47d40877b757501c91432963492613f77d4c974a6L7-R23) [[8]](diffhunk://#diff-b9c1ac2e1e9d721c230f6fa954afee6944a85739f8639cf869110867f4160bbaL7-R21) [[9]](diffhunk://#diff-c14b1b5fe0f4cf325df763f6000397571d6346b89ff9f96e07d6a46844613356L7-R26) [[10]](diffhunk://#diff-905beab46f6d65cf5754451b2d520dab9599596470e344e74a6d6540aa4641baL7-R22) [[11]](diffhunk://#diff-8f904ff150fac950788fc8bcc2c75c00d6e40729c22ab38a2ad6006f1cdd8af8R29-R48)

**Meta attribute improvements:**
* Updated `meta.changelog` and similar attributes to use `finalAttrs.version` for dynamic versioning in URLs, improving maintainability. [[1]](diffhunk://#diff-d6d1bd9ca7e87b8babe91ad60c37cd353d380d2e21ebc2d85ed5608f2bf76cffL39-R37) [[2]](diffhunk://#diff-e625e8a8a3064459943959084e0c378e86360ba4188858bd11363722075c95fbL35-R37) [[3]](diffhunk://#diff-b9c1ac2e1e9d721c230f6fa954afee6944a85739f8639cf869110867f4160bbaL33-R38)

**Removal of redundant code and improved readability:**
* Eliminated unnecessary `let` bindings, intermediate variables, and redundant code blocks, leading to cleaner and more maintainable package definitions. [[1]](diffhunk://#diff-2282dd71e981c4d8ae0b455d9bdbd3816522bf7efa32c79860d4bace0856d8deL42-R37) [[2]](diffhunk://#diff-d6d1bd9ca7e87b8babe91ad60c37cd353d380d2e21ebc2d85ed5608f2bf76cffL39-R37) [[3]](diffhunk://#diff-8b382cd33cd86e337c55a8ab0ecf102a14e0cf99dbf1be0ff7aab91bbb7aa3d4L44-R39) [[4]](diffhunk://#diff-8b382cd33cd86e337c55a8ab0ecf102a14e0cf99dbf1be0ff7aab91bbb7aa3d4L59-R54) [[5]](diffhunk://#diff-df2afd4dcbc46f64747fee8685d575c98d88e6719baf9ea950495201f17b12cfL68-R61) [[6]](diffhunk://#diff-e625e8a8a3064459943959084e0c378e86360ba4188858bd11363722075c95fbL35-R37) [[7]](diffhunk://#diff-edf871fe4d22fd41fdbaed06517b94be110bb65ad84625ceebdd9846ee6e4dd7L36-R31) [[8]](diffhunk://#diff-4cf5a7e5eca240bfe78f85d47d40877b757501c91432963492613f77d4c974a6L39-R37) [[9]](diffhunk://#diff-b9c1ac2e1e9d721c230f6fa954afee6944a85739f8639cf869110867f4160bbaL33-R38) [[10]](diffhunk://#diff-c14b1b5fe0f4cf325df763f6000397571d6346b89ff9f96e07d6a46844613356L47-R40) [[11]](diffhunk://#diff-905beab46f6d65cf5754451b2d520dab9599596470e344e74a6d6540aa4641baL36-R33) [[12]](diffhunk://#diff-8f904ff150fac950788fc8bcc2c75c00d6e40729c22ab38a2ad6006f1cdd8af8R29-R48)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
