### PR TITLE
wipeout-rewrite: Housekeeping, fix gamecontrollerdb loading

### DIFF
--- a/pkgs/by-name/wi/wipeout-rewrite/package.nix
+++ b/pkgs/by-name/wi/wipeout-rewrite/package.nix
@@ -3,25 +3,33 @@
   lib,
   fetchFromGitHub,
   unstableGitUpdater,
-  makeWrapper,
   glew,
+  makeWrapper,
+  pkg-config,
+  sdl_gamecontrollerdb,
   SDL2,
-  writeShellScript,
+  writeShellApplication,
 }:
 
 let
   datadir = "\"\${XDG_DATA_HOME:-$HOME/.local/share}\"/wipeout-rewrite";
-  datadirCheck = writeShellScript "wipeout-rewrite-check-datadir.sh" ''
-    datadir=${datadir}
+  datadirCheck = writeShellApplication {
+    name = "wipeout-rewrite-check-datadir";
+    text = ''
+      datadir=${datadir}
 
-    if [ ! -d "$datadir" ]; then
-      echo "[Wrapper] Creating data directory $datadir"
-      mkdir -p "$datadir"
-    fi
+      if [ ! -d "$datadir" ]; then
+        echo "[Wrapper] Creating data directory $datadir"
+        mkdir -p "$datadir"
+      fi
 
-    echo "[Wrapper] Remember to put your game assets into $datadir/wipeout if you haven't done so yet!"
-    echo "[Wrapper] Check https://github.com/phoboslab/wipeout-rewrite#running for the required format."
-  '';
+      echo "[Wrapper] Remember to put your game assets into $datadir/wipeout if you haven't done so yet!"
+      echo "[Wrapper] Check https://github.com/phoboslab/wipeout-rewrite#running for the required format."
+    '';
+  };
+
+  # Would be cool if this was a passthru attribute of sdl_gamecontrollerdb?
+  gameControllerDbPath = "${sdl_gamecontrollerdb}/share/gamecontrollerdb.txt";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wipeout-rewrite";
@@ -34,16 +42,39 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-X14rixCUJCQYxeLRpnSb3xWslwcwxoyLtYu1YH3O7WY=";
   };
 
-  enableParallelBuilding = true;
+  postPatch =
+    # Don't rely on sdl2-config (gives issues with strictDeps & cross)
+    ''
+      substituteInPlace Makefile \
+        --replace-fail 'sdl2-config' 'pkg-config sdl2'
+    ''
+    # Hardcode path to our sdl_gamecontrollerdb (with a check to make sure it actually exists)
+    + ''
+      if [ ! -f ${gameControllerDbPath} ]; then
+        echo "${gameControllerDbPath} does not exist!"
+        exit 1
+      fi
+
+      substituteInPlace src/platform_sdl.c \
+        --replace-fail \
+          'char *gcdb_path = strcat(strcpy(temp_path, path_assets), "gamecontrollerdb.txt")' \
+          'char *gcdb_path = "${gameControllerDbPath}"'
+    '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     makeWrapper
+    pkg-config
   ];
 
   buildInputs = [
     glew
     SDL2
   ];
+
+  enableParallelBuilding = true;
 
   # Force this to empty, so assets are looked up in CWD instead of $out/bin
   env.NIX_CFLAGS_COMPILE = "-DPATH_ASSETS=";
@@ -52,11 +83,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm755 wipegame $out/bin/wipegame
-
-    # I can't get --chdir to not expand the bash variables in datadir at build time (so they point to /homeless-shelter)
-    # or put them inside single quotes (breaking the expansion at runtime)
+  ''
+  # I can't get --chdir to not expand the bash variables in datadir at build time (so they point to /homeless-shelter)
+  # or put them inside single quotes (breaking the expansion at runtime)
+  + ''
     wrapProgram $out/bin/wipegame \
-      --run '${datadirCheck}' \
+      --run '${lib.getExe datadirCheck}' \
       --run 'cd ${datadir}'
 
     runHook postInstall


### PR DESCRIPTION
- Enable `__structuredAttrs` & `strictDeps`
- Fix building under the latter
- `writeShellScript` -> `writeShellApplication`
  For build-time syntax checking
- Patch in path to `gamecontrollerdb.txt` from `sdl_gamecontrollerdb`
  With a build-time check for its existence, to make sure this doesn't silently bitrot

---

https://github.com/NixOS/nixpkgs/pull/531556#pullrequestreview-4944180846

`strictDeps` being happy in a native build gives me some confidence that cross might work too, but I haven't checked. Would need afew hundred local builds, need to make space for that first…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
