### PR TITLE
mdbook-rss-feed: tell the difference with the full package

### DIFF
--- a/pkgs/by-name/md/mdbook-rss-feed-full/package.nix
+++ b/pkgs/by-name/md/mdbook-rss-feed-full/package.nix
@@ -1,0 +1,12 @@
+{
+  mdbook-rss-feed,
+  ...
+}@args:
+
+mdbook-rss-feed.override (
+  {
+    withAtom = true;
+    withJsonFeed = true;
+  }
+  // removeAttrs args [ "mdbook-rss-feed" ]
+)

--- a/pkgs/by-name/md/mdbook-rss-feed/package.nix
+++ b/pkgs/by-name/md/mdbook-rss-feed/package.nix
@@ -7,6 +7,11 @@
   withJsonFeed ? false,
 }:
 
+let
+  buildFeatures = lib.optional withAtom "atom" ++ lib.optional withJsonFeed "json-feed";
+  hasOptionalFeatures = buildFeatures != [ ];
+  withOptionalFeatures = lib.optionalString hasOptionalFeatures " with ${lib.strings.concatStringsSep " and " buildFeatures} features";
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdbook-rss-feed";
   version = "1.8.1";
@@ -21,12 +26,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-UkoNcwEq2Ga3PEF04Xly++VdBekdCBKSHggIGXjTMXU=";
 
-  buildFeatures = lib.optional withAtom [ "atom" ] ++ lib.optional withJsonFeed [ "json-feed" ];
+  inherit buildFeatures;
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "mdBook preprocessor that generates a full-content RSS 2.0 feed";
+    description =
+      "mdBook preprocessor that generates a full-content RSS 2.0 feed" + withOptionalFeatures;
     homepage = "https://github.com/saylesss88/mdbook-rss-feed";
     changelog = "https://github.com/saylesss88/mdbook-rss-feed/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7331,11 +7331,6 @@ with pkgs;
   inherit (mailmanPackages) mailman mailman-hyperkitty;
   mailman-web = mailmanPackages.web;
 
-  mdbook-rss-feed-full = mdbook-rss-feed.override {
-    withAtom = true;
-    withJsonFeed = true;
-  };
-
   micro-full = micro.wrapper.override {
     extraPackages = [
       wl-clipboard


### PR DESCRIPTION
There is many `*-minimal` / `*-full` packages where [NixOS Search](https://search.nixos.org/packages?) don't show any differences

To know the differences, we have to go to the source

I am lazy, so i don't like this and i don't want to add one more

So i added the differences to the full package

Also, i moved from `all-packages` to `pkgs/by-name` ; like the `curl` package does
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
