### PR TITLE
 fasmarm: init at 1.44

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8646,6 +8646,12 @@
     githubId = 330292;
     name = "Evan Richter";
   };
+  evanwporter = {
+    email = "evanwporter@gmail.com";
+    github = "evanwporter";
+    githubId = 115374841;
+    name = "Evan Porter";
+  };
   evax = {
     email = "nixos@evax.fr";
     github = "evax";

--- a/pkgs/by-name/fa/fasmarm/package.nix
+++ b/pkgs/by-name/fa/fasmarm/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  fasm,
+  makeBinaryWrapper,
+  unzip,
+}:
+
+stdenv.mkDerivation {
+  pname = "fasmarm";
+  version = "1.44";
+
+  # FASMARM is a source overlay, not a loadable add-on, so it must be built as
+  # a separate FASM-based executable.
+  src = fasm.src;
+
+  # Unfortunately the download URL is unversioned. New releases
+  # are rare so this should be fine most of the time. When there's
+  # a new release the hash needs to be regenerated
+  fasmarmOverlay = fetchurl {
+    url = "https://arm.flatassembler.net/FASMARM_small.ZIP";
+    hash = "sha256-5ZzGl/C+hHRVYVyYBRns7hl3gy+cy89Eiq+9/nokk4Q=";
+  };
+
+  prePatch = ''
+    unzip "$fasmarmOverlay"
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    fasm
+    makeBinaryWrapper
+    unzip
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    fasm -m 65536 source/linux${lib.optionalString stdenv.hostPlatform.isx86_64 "/x64"}/fasmarm.asm fasmarm
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 fasmarm $out/bin/fasmarm
+
+    # Both licenses require reproducing their notices with binary distributions.
+    install -Dm644 license.txt $doc/share/doc/fasmarm/LICENSE.fasm
+    sed -n '1,34p' source/armv8.inc > $doc/share/doc/fasmarm/LICENSE.fasmarm
+    install -Dm644 ReadMe.txt $doc/share/doc/fasmarm/README
+
+    mkdir -p $out/share/fasmarm
+    cp -r include $out/share/fasmarm
+
+    wrapProgram $out/bin/fasmarm \
+      --set-default INCLUDE "$out/share/fasmarm/include"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cat > test.asm <<'EOF'
+    include 'macro/armstruc.inc'
+    processor cpu64_v8
+    code64
+    mov x0,42
+    EOF
+    printf '\x40\x05\x80\xd2' > expected.bin
+
+    $out/bin/fasmarm test.asm test.bin
+    cmp expected.bin test.bin
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "FASM-based assembler for 32-bit and 64-bit ARM processors";
+    homepage = "https://arm.flatassembler.net/";
+    license = lib.licenses.bsd2;
+    mainProgram = "fasmarm";
+    maintainers = with lib.maintainers; [
+      evanwporter
+      iamanaws
+    ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds https://arm.flatassembler.net/, an arm assembler.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
