### PR TITLE
checkstyle: drop `nexus-codehaus-snapshot` plugin repository

### DIFF
--- a/pkgs/by-name/ch/checkstyle/drop-nexus-codehaus-snapshot-plugin-repository.patch
+++ b/pkgs/by-name/ch/checkstyle/drop-nexus-codehaus-snapshot-plugin-repository.patch
@@ -1,0 +1,30 @@
+From aada568827c9f619dabfab8bbc6522acc8f234f3 Mon Sep 17 00:00:00 2001
+From: Petr Portnov <mrjarviscraft@gmail.com>
+Date: Sun, 16 Aug 2026 17:19:49 +0300
+Subject: [PATCH] Issue #21241: Drop `nexus-codehaus-snapshot` plugin
+ repository
+
+---
+ pom.xml | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/pom.xml b/pom.xml
+index f78f97d802398a882ee99e2f3bf88e200c2094bd..3bc4fcf62de207acce7b5a4bdbe47f4c30bccb6e 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -529,15 +529,6 @@
+     </dependency>
+   </dependencies>
+ 
+-  <!-- that repositories are required for testing plugin's snapshot version -->
+-  <pluginRepositories>
+-    <pluginRepository>
+-      <id>nexus-codehaus-snapshot</id>
+-      <name>Codehaus Snapshots</name>
+-      <url>https://oss.sonatype.org/content/repositories/codehaus-snapshots/</url>
+-    </pluginRepository>
+-  </pluginRepositories>
+-
+   <build>
+     <pluginManagement>
+       <plugins>

--- a/pkgs/by-name/ch/checkstyle/package.nix
+++ b/pkgs/by-name/ch/checkstyle/package.nix
@@ -18,6 +18,11 @@ maven.buildMavenPackage (finalAttrs: {
     hash = "sha256-RJ0ALYE+X2wUdFB4WpGIKYYeRau7AHr5m2Qk3amiXX4=";
   };
 
+  patches = [
+    # PR: https://github.com/checkstyle/checkstyle/pull/21242
+    ./drop-nexus-codehaus-snapshot-plugin-repository.patch
+  ];
+
   mvnHash = "sha256-NWTabR7E3aXkLaERZmolOoWPzERnOT/1q7+DW815p9U=";
 
   nativeBuildInputs = [


### PR DESCRIPTION
`checkstyle` defines an extra `pluginRepository` `https://oss.sonatype.org/content/repositories/codehaus-snapshots/` in its `pom.xml` which has been deprecated for long time and seems to be unavailable at the moment causing builds of checkstyle to get stuck (upstream issue: checkstyle/checkstyle#21241).

I've proposed the fix to upstream (checkstyle/checkstyle#21242) which simply removes this extra repository (which is not needed), but since the PR has not been merged into any existing release yet, it is worth adding it as patch for now.

This is reopened #553342 which was emssed on force-push.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
