### PR TITLE
opencode: add baseline (x86-64-v2) variant for pre-Haswell CPUs

### DIFF
--- a/pkgs/by-name/op/opencode/baseline.nix
+++ b/pkgs/by-name/op/opencode/baseline.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  patchelf,
+  makeBinaryWrapper,
+  ripgrep,
+  glibc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opencode";
+  version = "1.18.18";
+
+  src = fetchurl {
+    url = "https://github.com/anomalyco/opencode/releases/download/v${finalAttrs.version}/opencode-linux-x64-baseline.tar.gz";
+    hash = "sha256-BZFGVYVMHatI8NUqivj3SWfk4m2vh9/mU09X55moU9c=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  # The upstream tarball has a single `opencode` file at the archive root
+  # (no subdir). With sourceRoot left as the default, the unpacker rejects
+  # tarballs that don't produce any directories under it.
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    patchelf
+    makeBinaryWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # The upstream tarball extracts to a single `opencode` file at the root
+    # (no subdir). Install to $out/libexec/opencode so the wrapper below can
+    # safely create $out/bin/opencode without colliding.
+    install -Dm755 opencode $out/libexec/opencode
+
+    # patchelf --no-sort avoids autoPatchelf's program-header expansion, which
+    # corrupts Bun-compiled binaries (observed by the libexec binary
+    # reporting Bun's version instead of opencode's own after autoPatchelf).
+    patchelf --no-sort --set-interpreter "${lib.getLib glibc}/lib/ld-linux-x86-64.so.2" $out/libexec/opencode
+
+    # Shell wrapper so makeBinaryWrapper's ELF-vs-script heuristics don't
+    # fight us; also keeps ripgrep on PATH (opencode shells out to `rg`).
+    makeWrapper $out/libexec/opencode $out/bin/opencode \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = [
+    "nix-update"
+    "--flake"
+    "opencode"
+  ];
+
+  meta = {
+    description = "AI coding agent built for the terminal (pre-Haswell baseline x86_64 build)";
+    homepage = "https://github.com/anomalyco/opencode";
+    changelog = "https://github.com/anomalyco/opencode/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "opencode";
+  };
+})

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   bun,
+  callPackage,
   darwin,
   fetchFromGitHub,
   makeBinaryWrapper,
@@ -206,6 +207,10 @@ stdenv.mkDerivation (finalAttrs: {
       tui = "${finalAttrs.finalPackage}/share/tui.json";
     };
     node_modules = node_modules finalAttrs;
+    # Pre-built upstream `opencode-linux-x64-baseline.tar.gz` for hosts that
+    # can't run the v3 native build (e.g. Ivy Bridge, no BMI2/AVX2). Boots
+    # from V8's `SHLX` trap; see ./baseline.nix for details.
+    baseline = callPackage ./baseline.nix { };
     updateScript = nix-update-script {
       extraArgs = [
         "--subpackage"


### PR DESCRIPTION
### Summary

`pkgs.opencode` builds from source via Bun, but Bun's Linux x86_64 build is itself x86-64-v3 (Haswell+). The first call into V8 hits `SHLX` (BMI2) and SIGILLs on older CPUs like Ivy Bridge (Xeon E3-1220 V2, 2012). This is a hard incompatibility — for hosts that can't run the v3 native build, even *building* `pkgs.opencode` fails because the build itself uses Bun.

This PR adds `pkgs.opencode.passthru.baseline`, which downloads the upstream prebuilt `opencode-linux-x64-baseline.tar.gz` artifact and patchelfs it. No Bun involvement at build or run time, so it works on hosts that can't run the v3 native build or even execute Bun itself. The default `pkgs.opencode` is unchanged for Haswell+ hosts.

### Why this exists now

Upstream opencode already publishes both `opencode-linux-x64.tar.gz` and `opencode-linux-x64-baseline.tar.gz` from their release pipeline (see `build.ts` line 60 — `baselineFlag = process.argv.includes("--baseline")` — and the `avx2: false` target entries). The nixpkgs package rebuilds from source via Bun and only ever produces the native variant, so it cannot run on Ivy Bridge hosts without intervention.

There is a parallel PR for `pkgs.bun` upstream: [#547108](https://github.com/NixOS/nixpkgs/pull/547108). Once that lands, building `pkgs.opencode` on Ivy Bridge becomes possible in principle, but the runtime issue (V8 embedding BMI2 instructions) would still hit because `Bun.build` would still default to v3.

### How to use it

```nix
# Default path (Haswell+): builds from source via Bun, native v3 binary
pkgs.opencode

# Pre-Haswell path: downloads upstream prebuilt baseline tarball
pkgs.opencode.passthru.baseline
```

If a future PR wants to auto-select based on `/proc/cpuinfo` flags, that's a follow-up. This PR keeps the change minimal and lets users (or downstream module authors) opt in explicitly.

### Test plan

- [x] Built `pkgs.opencode.passthru.baseline` locally on x86_64-linux.
- [x] Verified `opencode --version` returns `1.18.18` (current version) and exits 0.
- [x] Verified `opencode providers list`, `opencode models`, and `opencode run "echo hello"` all work end-to-end (real model invocation confirmed — no SIGILL).
- [x] Verified `pkgs.opencode` (the default) still builds and is unchanged.
- [x] `nixpkgs-fmt --check` passes on both files.
- [x] `nixpkgs-review pr 553390` reports "Nothing to be built" — change is purely additive, no dependents triggered.
- [ ] Will check `ofborg` builds for `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`.

### Caveats

- The upstream `-baseline` tarball still has occasional runtime SIGILLs per [oven-sh/bun#30613](https://github.com/oven-sh/bun/issues/30613) and [bun#27844](https://github.com/oven-sh/bun/issues/27844). This PR fixes the *startup* trap, not the deeper runtime flakiness. Both are open upstream issues.
- `meta.sourceProvenance` is `binaryNativeCode` (the standard nixpkgs value for a prebuilt-binary download). The default `pkgs.opencode` remains `fromSource`.

### Related upstream issues

- [anomalyco/opencode#24876](https://github.com/anomalyco/opencode/issues/24876) — Ivy Bridge Mac SIGILL, assigned to jlongster
- [anomalyco/opencode#29039](https://github.com/anomalyco/opencode/issues/29039) — macOS `-baseline` byte-identical to v3, assigned to Brendonovich
- [oven-sh/bun#30613](https://github.com/oven-sh/bun/issues/30613) — Bun crashes on non-AVX2 CPUs after v1.3.8
- [oven-sh/bun#7179](https://github.com/oven-sh/bun/issues/7179) — Linux baseline build SIGILL on `bun --version`

### Related downstream

- [cline/cline#13167](https://github.com/cline/cline/pull/13167) — same approach for the cline CLI, with QEMU Nehalem verification harness
- [NixOS/nixpkgs#547108](https://github.com/NixOS/nixpkgs/pull/547108) — parallel PR for `pkgs.bun`