### PR TITLE
libcamera: refactor mesonFlags and other improvements

### DIFF
--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -15,13 +15,14 @@
   libyuv,
   gst_all_1,
   gtest,
-  graphviz,
-  doxygen,
   python3,
   python3Packages,
   udev,
   libpisp,
   libglvnd,
+  enableDocumentation ? false,
+  graphviz,
+  doxygen,
   withTracing ? lib.meta.availableOn stdenv.hostPlatform lttng-ust,
   lttng-ust, # withTracing
   withSoftispGPU ? true, # software ISP GPU acceleration
@@ -116,36 +117,43 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.jinja2
     python3Packages.pyyaml
     python3Packages.ply
+    openssl
+  ]
+  ++ lib.optionals enableDocumentation [
     python3Packages.sphinx
     graphviz
     doxygen
-    openssl
   ]
   ++ lib.optional withQcam qt6.wrapQtAppsHook;
 
-  mesonFlags = [
-    (lib.mesonEnable "v4l2" true)
-    (lib.mesonEnable "tracing" withTracing)
-    (lib.mesonEnable "qcam" withQcam)
-    (lib.mesonEnable "apps-output-dng" withQcam)
-    (lib.mesonEnable "cam-output-sdl2" withQcam)
-    (lib.mesonEnable "cam-jpeg" withQcam)
-    (lib.mesonEnable "softisp-gpu" withSoftispGPU)
-    (lib.mesonEnable "libunwind" false)
-    (lib.mesonEnable "libdw" false)
-    (lib.mesonEnable "lc-compliance" false) # tries unconditionally to download gtest when enabled
-    # Avoid blanket -Werror to evade build failures on less
-    # tested compilers.
-    (lib.mesonBool "werror" false)
-    # Documentation breaks binary compatibility.
-    # Given that upstream also provides public documentation,
-    # we can disable it here.
-    (lib.mesonEnable "documentation" false)
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isAarch [
-    # we don't have tensorflow-lite to build this
-    (lib.mesonEnable "rpi-awb-nn" false)
-  ];
+  mesonFlags =
+    lib.mapAttrsToList lib.mesonEnable {
+      v4l2 = true;
+      tracing = true;
+      pycamera = true;
+      qcam = true;
+      apps-output-dng = withQcam;
+      cam-output-sdl2 = withQcam;
+      cam-jpeg = withQcam;
+      softisp-gpu = withSoftispGPU;
+      libunwind = false;
+      libdw = false;
+      lc-compliance = false; # tries unconditionally to download gtest when enabled
+
+      # Documentation breaks binary compatibility.
+      # Given that upstream also provides public documentation,
+      # we can disable it here.
+      documentation = enableDocumentation;
+
+      rpi-awb-nn = false;
+    }
+    ++ [
+      (lib.mesonBool "test" finalAttrs.finalPackage.doCheck)
+
+      # Avoid blanket -Werror to evade build failures on less
+      # tested compilers.
+      (lib.mesonBool "werror" false)
+    ];
 
   env = {
     # Fixes error on a deprecated declaration

--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
-  fetchgit,
+  fetchFromGitLab,
+  nix-update-script,
   lib,
   meson,
   ninja,
@@ -31,13 +32,15 @@
   SDL2,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libcamera";
   version = "0.7.2";
 
-  src = fetchgit {
-    url = "https://git.libcamera.org/libcamera/libcamera.git";
-    rev = "v${version}";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "camera";
+    repo = "libcamera";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vhFkeT1j2KKm+CVvGrtH5BEYJSEdaX7N7DRdA0a9EWk=";
   };
 
@@ -151,10 +154,12 @@ stdenv.mkDerivation rec {
     FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
   };
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Open source camera stack and framework for Linux, Android, and ChromeOS";
     homepage = "https://libcamera.org";
-    changelog = "https://git.libcamera.org/libcamera/libcamera.git/tag/?h=${src.rev}";
+    changelog = "https://git.libcamera.org/libcamera/libcamera.git/tag/?h=${finalAttrs.src.rev}";
     license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [ citadelcore ];
     platforms = lib.platforms.linux;
@@ -163,4 +168,4 @@ stdenv.mkDerivation rec {
       lib.systems.inspect.platformPatterns.isStatic
     ];
   };
-}
+})

--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -161,7 +161,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://libcamera.org";
     changelog = "https://git.libcamera.org/libcamera/libcamera.git/tag/?h=${finalAttrs.src.rev}";
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ citadelcore ];
+    maintainers = with lib.maintainers; [
+      citadelcore
+      tmarkus
+    ];
     platforms = lib.platforms.linux;
     badPlatforms = [
       # Mandatory shared libraries.

--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -138,7 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
       softisp-gpu = withSoftispGPU;
       libunwind = false;
       libdw = false;
-      lc-compliance = false; # tries unconditionally to download gtest when enabled
+      lc-compliance = true;
 
       # Documentation breaks binary compatibility.
       # Given that upstream also provides public documentation,

--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchFromGitLab,
+  testers,
   nix-update-script,
   lib,
   meson,
@@ -154,13 +155,21 @@ stdenv.mkDerivation (finalAttrs: {
     FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Open source camera stack and framework for Linux, Android, and ChromeOS";
     homepage = "https://libcamera.org";
     changelog = "https://git.libcamera.org/libcamera/libcamera.git/tag/?h=${finalAttrs.src.rev}";
     license = lib.licenses.lgpl2Plus;
+    pkgConfigModules = [
+      "libcamera"
+      "libcamera-base"
+    ];
     maintainers = with lib.maintainers; [
       citadelcore
       tmarkus


### PR DESCRIPTION
* switch to fetchFromGitLab to allow using nix-update-script
* specify and test meta.pkgConfigModules
* refactor mesonFlags
* add myself as maintainer

Follow-up from #530557.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
