### PR TITLE
nixos/containers: fix warning messages for container registries

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -78,7 +78,7 @@ in
         description = ''
           List of repositories to search.
 
-          Deprecated, examine {option}`virtualisation.registries.settings` instead.
+          Deprecated, examine {option}`virtualisation.containers.registries.settings` instead.
         '';
       };
 
@@ -89,7 +89,7 @@ in
         description = ''
           List of insecure repositories.
 
-          Deprecated, examine {option}`virtualisation.registries.settings` instead.
+          Deprecated, examine {option}`virtualisation.containers.registries.settings` instead.
         '';
       };
 
@@ -100,7 +100,7 @@ in
         description = ''
           List of blocked repositories.
 
-          Deprecated, examine {option}`virtualisation.registries.settings` instead.
+          Deprecated, examine {option}`virtualisation.containers.registries.settings` instead.
         '';
       };
 
@@ -145,7 +145,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    warnings = lib.optional oldRegistriesOptionsUsed "the options virtualisation.registries.search / insecure / block are deprecated. See virtualisation.registries.settings instead.";
+    warnings = lib.optional oldRegistriesOptionsUsed "the options virtualisation.containers.registries.search / insecure / block are deprecated. See virtualisation.containers.registries.settings instead.";
 
     virtualisation.containers.registries.settings = lib.mkIf oldRegistriesOptionsUsed {
       registries = {


### PR DESCRIPTION
Fixed warning messages that were introduced in the change from `virtualisation.containers.registries.{search,insecure,block}` to `virtualisation.containers.registries.settings` to correctly add `.containers`

Old warning:
```
evaluation warning: the options virtualisation.registries.search / insecure / block are deprecated. See virtualisation.registries.settings instead.
```

New warning:
```
evaluation warning: the options virtualisation.containers.registries.search / insecure / block are deprecated. See virtualisation.containers.registries.settings instead.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
