### PR TITLE
intel-npu-driver: 1.28.0 -> 1.35.0

### DIFF
--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -5,7 +5,6 @@
   openssl,
   boost,
   cmake,
-  git,
   level-zero,
   fetchFromGitHub,
 }:

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -4,6 +4,7 @@
   udev,
   openssl,
   boost,
+  pkg-config,
   cmake,
   level-zero,
   fetchFromGitHub,
@@ -11,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.28.0";
+  version = "1.35.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-aH7npJompKYlyq2RPXHn/lflQ1C/yYcTp2K+6kX/L0w=";
+    hash = "sha256-n23yb6ZEJ7bfLactFixBQTcRlSIsVMOJ1QESoHLIhPg=";
   };
 
   buildInputs = [
@@ -30,8 +31,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    pkg-config
   ];
-
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-missing-field-initializers";
+  };
   outputs = [
     "out"
     "validation"
@@ -39,17 +43,6 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    rm -rf third_party/level-zero
-    rm third_party/cmake/level-zero.cmake
-    rm third_party/cmake/FindLevelZero.cmake
-
-    substituteInPlace third_party/yaml-cpp/CMakeLists.txt --replace-fail \
-      "cmake_minimum_required" \
-      "# cmake_minimum_required"
-
-    substituteInPlace third_party/CMakeLists.txt --replace-fail \
-      "include(cmake/level-zero.cmake)" \
-      ""
     substituteInPlace third_party/level-zero-npu-extensions/ze_graph_ext.h --replace-fail \
     "#include \"ze_api.h\"" \
     "#include <level_zero/ze_api.h>"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update intel-npu-driver from 1.28.0 (8 months ago) to latest version [1.35.0](https://github.com/intel/linux-npu-driver/releases/tag/v1.35.0).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable: (note: this PR has no tests)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
