### PR TITLE
rush-lyrics: 6.5.2 -> 6.5.3

### DIFF
--- a/pkgs/by-name/ru/rush-lyrics/deps.json
+++ b/pkgs/by-name/ru/rush-lyrics/deps.json
@@ -2,6 +2,20 @@
  "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
  "!version": 1,
  "https://dl.google.com/dl/android/maven2": {
+  "androidx/annotation#annotation-iosarm64/1.9.1": {
+   "module": "sha256-gWifMc5Ndyzq5Nm4EKEPjSJlSrdSk/9EbJwgEfi6MjE=",
+   "pom": "sha256-JTmoAKO24c6Fefs5T7n0Yi81sDPGYvSj9Zc9+O+IilI="
+  },
+  "androidx/annotation#annotation-iosarm64/1.9.1/metadata": {
+   "jar": "sha256-OaXDj16Y5Bo8ZPG2BMoZdWxrpZ3IG4SK261O89t+hgE="
+  },
+  "androidx/annotation#annotation-iossimulatorarm64/1.9.1": {
+   "module": "sha256-OhLs8Xz/n9hGBAOEZm3Anu8RLJ9/5amhEMwKkPKUyf0=",
+   "pom": "sha256-IHXU+JyXjVY1e5Ns223yInIz4lx1wrgMVL+qxDLFdPo="
+  },
+  "androidx/annotation#annotation-iossimulatorarm64/1.9.1/metadata": {
+   "jar": "sha256-OaXDj16Y5Bo8ZPG2BMoZdWxrpZ3IG4SK261O89t+hgE="
+  },
   "androidx/annotation#annotation-jvm/1.10.0": {
    "jar": "sha256-3dBy3btVMXjiBVF853ey8Fqp5BKYLZ7LTu3HTxIS9pc=",
    "module": "sha256-Qq/KN0GUJz5AZ7k3z8RHvTyMT9RB9B1E+VQFDf1hBt0=",
@@ -22,10 +36,30 @@
    "module": "sha256-8gSwW3KKl1YXGLxxYkLkfGKcAIWoDudPylPU1ji8vj8=",
    "pom": "sha256-xzOIHC4X1ffIZhzAKpFZyxYLeyCUon1ZORbIfT4lBjY="
   },
+  "androidx/annotation/annotation-iosarm64/1.9.1/annotation-iosarm64-1.9.1": {
+   "klib": "sha256-f1tWyJuKy94lF4pIDeb2u43iPyrFxfdlRxs0lWf/qTw="
+  },
+  "androidx/annotation/annotation-iossimulatorarm64/1.9.1/annotation-iossimulatorarm64-1.9.1": {
+   "klib": "sha256-Nwq+riUaL2m8OM2+0uGe4vqxAsNzh1OGFBw064B1240="
+  },
   "androidx/arch/core#core-common/2.2.0": {
    "jar": "sha256-ZTCKBrHADuGGy54ZMhOD8EO5k4E/FSLEf0o+MwO9ukE=",
    "module": "sha256-7fQgDP3C2UYjIlLJnl3LnGG7kJ61RQsmE9HU/cl0uYE=",
    "pom": "sha256-HhfUr41kJb4qafivTWVKh+BFYlmp7vFUKGm8sCNUfig="
+  },
+  "androidx/collection#collection-iosarm64/1.5.0": {
+   "module": "sha256-4BI522AfrLPnQejEjT40+mO2B5dSljMhvdPhH0i7/FA=",
+   "pom": "sha256-aJXBVc/ZLR4Wbo8YWaQeFut3s7p6KhCShRY+z6MD5WE="
+  },
+  "androidx/collection#collection-iosarm64/1.5.0/metadata": {
+   "jar": "sha256-kjFOPgEstD7kswWjJDjOXEidBaEnpfomieFQAEn6fu0="
+  },
+  "androidx/collection#collection-iossimulatorarm64/1.5.0": {
+   "module": "sha256-nMsScGocgND1gPJzT6tjHL1S1R57uRaXb+W84J1Wcqw=",
+   "pom": "sha256-fKZKrcG1QM6ncxkcV638qdIJO7G18UD6fbdGWeejpSw="
+  },
+  "androidx/collection#collection-iossimulatorarm64/1.5.0/metadata": {
+   "jar": "sha256-kjFOPgEstD7kswWjJDjOXEidBaEnpfomieFQAEn6fu0="
   },
   "androidx/collection#collection-jvm/1.5.0": {
    "jar": "sha256-cLNZJOS6vN/6N9Dlde4DnFai2XEjNCYkxItgMjNwQ0E=",
@@ -37,89 +71,163 @@
    "module": "sha256-v+t72E8/fdp71ztnCdSh9h9aN/hDcouuCKBn49+aCu8=",
    "pom": "sha256-LWXI0LNtS0+q3ESv+breI9hx1xWe7fKz8C2AKzS3elc="
   },
-  "androidx/compose/runtime#runtime-annotation-jvm/1.12.0-beta02": {
+  "androidx/collection/collection-iosarm64/1.5.0/collection-iosarm64-1.5.0": {
+   "klib": "sha256-WLr0njduPemF7KMBl8LZ4H1akmIZFa4hcLTbzC8I26c="
+  },
+  "androidx/collection/collection-iossimulatorarm64/1.5.0/collection-iossimulatorarm64-1.5.0": {
+   "klib": "sha256-1DesF86jMSNAYLuQ/hcRjkjVhIcDTHGIH6CBw2fX9wM="
+  },
+  "androidx/compose/runtime#runtime-annotation-iosarm64/1.12.0-rc01": {
+   "module": "sha256-//+W6YFH5cDaBDFDIrZ+3Ndec2wmNh8NjYqmlj1Dbxs=",
+   "pom": "sha256-WzSsrjdldPdnmsJOTornMja7u3H/LyuHYkEP4WeaI/E="
+  },
+  "androidx/compose/runtime#runtime-annotation-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-Xa2E2ft6XskWm5NPUB6nJM8IT6gG5G21hf4fiAqoKzg="
+  },
+  "androidx/compose/runtime#runtime-annotation-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-EwEAcCte1bjKIG2GA3fKLXO6gr3xKQyn1uDozv2kiBY=",
+   "pom": "sha256-OkJInA19KGb0S3sSSBdMtFangnICfBPfThaNZ6js2nY="
+  },
+  "androidx/compose/runtime#runtime-annotation-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-Xa2E2ft6XskWm5NPUB6nJM8IT6gG5G21hf4fiAqoKzg="
+  },
+  "androidx/compose/runtime#runtime-annotation-jvm/1.12.0-rc01": {
    "jar": "sha256-4pGmrgGrcaf0ilaOyXRMa/mz9G73L7zesow0B65THF4=",
-   "module": "sha256-uvGViq0vgW3cJv/VKppJ9+VaZPj3VcJCQ6A9zjEvbs4=",
-   "pom": "sha256-ENE1juWe4dyF+NTjid77Mqm/FZQ47p/igOoDzLvHoUg="
+   "module": "sha256-p+ToKvren30HIY5hGSVcdd3zYXOX+87CSVomLIFTSnA=",
+   "pom": "sha256-fd/ArvPTRSi0xACPdZ9nx5T39a1MHmjlHlG/ZUBXPdA="
   },
   "androidx/compose/runtime#runtime-annotation-jvm/1.9.0": {
    "module": "sha256-BwRUw9jx/YX9sCztcMXdVbnJUGqfHJYwmVrWtUhbweY=",
    "pom": "sha256-kTdIOF0hz/MrNeJZUR7w4mo4lt9+4P8Sv2rGEOreq2A="
   },
-  "androidx/compose/runtime#runtime-annotation/1.12.0-beta02": {
+  "androidx/compose/runtime#runtime-annotation/1.12.0-rc01": {
    "jar": "sha256-GQ42On8pUXlPW08JhtpFTzmkJbh3mbLVksKniXLRdd8=",
-   "module": "sha256-nN8TxYHukAW7BakOFNfc0ZlbbMgTE3SaRaKqpfuPwMY=",
-   "pom": "sha256-B6SU/wyoqnoks/NdKOS3nzypiTBdzyFUdrBBdYzPtfk="
+   "module": "sha256-DIZWrSaXbPWDBpEAEh6cGTG+U+FpetM2VAH4d5r8Q/o=",
+   "pom": "sha256-OQLIYffdZSlMeVDqxmtyOot/peKh55JZtJ4TCCpiwkQ="
   },
   "androidx/compose/runtime#runtime-annotation/1.9.0": {
    "module": "sha256-aI/PepDHx6su4gF+reuc2inzWuF+aq3sct/QdA8C5iQ=",
    "pom": "sha256-0Vin/5qk2CFOCF+dXHndAAKjLRgWoCOqn6omucRtg6c="
   },
-  "androidx/compose/runtime#runtime-desktop/1.12.0-beta02": {
+  "androidx/compose/runtime#runtime-desktop/1.12.0-rc01": {
    "jar": "sha256-7TkNe/e9upUTWdEn9MHd0iP1NfWmpjB4xcWsa2kk6wg=",
-   "module": "sha256-eskhjuJSqX5p2jBLKi6m0qqyOQEJBEvUgE5ZGisgZ2A=",
-   "pom": "sha256-aGmw6Ct/5JuDqV88bcXLnmIzQmKyPOC3KCF+mUjp7j8="
+   "module": "sha256-i08jxocivBpbYiV8uA58nVg+Vy47FehjOsA8PZHB/6c=",
+   "pom": "sha256-tiSxRCpivH01VzDiVSaUWQBBeOAH0DI0GdxBqqYJagM="
   },
   "androidx/compose/runtime#runtime-desktop/1.9.5": {
    "module": "sha256-0uaVpFhXzQa/Z3AZUdOjzt2ERj9oWXl/ih7bx/JnGa8=",
    "pom": "sha256-TenpMz1cOCgcND5Uf7DSdIikLlCKSVu7tOc4IqR/tmI="
   },
-  "androidx/compose/runtime#runtime-retain-desktop/1.12.0-beta02": {
+  "androidx/compose/runtime#runtime-iosarm64/1.12.0-rc01": {
+   "module": "sha256-7nvHS+iB9srJv5DCfQ19DdODWvH8Zbr2mRFypA+qjWY=",
+   "pom": "sha256-UPei4stwwnOP9sKTNmftEQQQ8pUwmWN7xxy0YZaue+g="
+  },
+  "androidx/compose/runtime#runtime-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-FuIIbJApQEWVyNFnU6BpHb2Au2Jd7oeUjV2GnAsznVY="
+  },
+  "androidx/compose/runtime#runtime-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-zzuEpvJdI4Ihk9E0LaQ7I2fW8L08E4ZTxIcOcNiTE3U=",
+   "pom": "sha256-wATxZm5NKICTZtNkH7axUUH+VfTGKV4WZD95kdYnPqo="
+  },
+  "androidx/compose/runtime#runtime-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-FuIIbJApQEWVyNFnU6BpHb2Au2Jd7oeUjV2GnAsznVY="
+  },
+  "androidx/compose/runtime#runtime-retain-desktop/1.12.0-rc01": {
    "jar": "sha256-m35ip98zPDPv+eGm1sJQik2P5LekN3gHVTj+PaS8RIU=",
-   "module": "sha256-pp/Rnlr4Vw9VF1VBgrBDa+92fiJlvXcncrGamDI3GNQ=",
-   "pom": "sha256-3spdZYy8+0jRDj69fvJV61zvClm7M0UEzhqWFKGVmfo="
+   "module": "sha256-wc/fiU9T8rOhA1+2Lz0RdsKbdCwC5yCQavjqtiLwmSY=",
+   "pom": "sha256-JDwmm9h1UgDiCOv8779IRg0k5C90ThBabnA+SdhU3NA="
   },
-  "androidx/compose/runtime#runtime-retain/1.12.0-beta01": {
-   "module": "sha256-S2+uFBsB0C/REgOKv4sR6mYNg8pTbPfF9JK4mlrxpgo=",
-   "pom": "sha256-rO5rSf4jJN6l7RzKwx1A5+b/s7U7Y0+ctnFqCpGgqYs="
+  "androidx/compose/runtime#runtime-retain-iosarm64/1.12.0-rc01": {
+   "module": "sha256-g+KJnQXARZUxVXX+1Kz/J3pzal7tgxsgSCs5TMv9gXk=",
+   "pom": "sha256-yZ2//lgdrpjWk7yPzbYJJTee6eBvnRx+3Mqipygpmrg="
   },
-  "androidx/compose/runtime#runtime-retain/1.12.0-beta02": {
+  "androidx/compose/runtime#runtime-retain-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-cppGGU+23tpMHUMFgdBACN9V5b4l5xUSlSPLXhnpPNA="
+  },
+  "androidx/compose/runtime#runtime-retain-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-xZv5rk8JGYp4yWEr3WHqFzxLA0oVHSl/vE7gY3u9hUo=",
+   "pom": "sha256-yiePuRdDgMKIjgL7ViDF8pOrDx4xIU8xX/dH7LlK1zQ="
+  },
+  "androidx/compose/runtime#runtime-retain-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-cppGGU+23tpMHUMFgdBACN9V5b4l5xUSlSPLXhnpPNA="
+  },
+  "androidx/compose/runtime#runtime-retain/1.12.0-rc01": {
    "jar": "sha256-o2qxCWSG9aiFkeqG9u1S8RLD+E8b+cM0PcGS00EOhCo=",
-   "module": "sha256-qJbLAk2tHleIK2XEoiHi9Ldt1SqMGnyh13vLVGS/ERI=",
-   "pom": "sha256-ayRMTc5jSZQRdB5X/dn+y8z7ZtwlPbVOJccTZRoFtfc="
+   "module": "sha256-bFVNZ5QwYZlBVCrdPJFtMUC4JCM9YIcD/VZQYD0zau0=",
+   "pom": "sha256-RYeVrx+KKZuXQWo0w4EC2FMS4TzoLYz+oi6ywDxaFUo="
   },
   "androidx/compose/runtime#runtime-saveable-desktop/1.10.0": {
    "module": "sha256-MljlZxBp1oUtJ1CR+ZrpsWp8yL/jQmkGsi6zEDQBqIM=",
    "pom": "sha256-JI4r3g3cdk8m91WegRTy139e35IGddXXvXk1VD2N8sg="
   },
-  "androidx/compose/runtime#runtime-saveable-desktop/1.12.0-beta02": {
+  "androidx/compose/runtime#runtime-saveable-desktop/1.12.0-rc01": {
    "jar": "sha256-BplJZnQJq23iEFP5/b/whpriofcKchLNuJ59QJ/SVSw=",
-   "module": "sha256-sXqBNn1p/hYigmggx/N+PDosJrzswU454UYJs9Jeigk=",
-   "pom": "sha256-RUwf+LPgSRlUsRqitvzKhRW+x6deWdz3OI8xelBdOnU="
+   "module": "sha256-6CXJ/7IAb0XuqqJ8LAoXAcMD0kVvhFx+/TrhtZPTQ6A=",
+   "pom": "sha256-lo509J0vgCp0Ee+weiXPK3ysjW5CDDl5KJnUXqVZDTs="
   },
   "androidx/compose/runtime#runtime-saveable-desktop/1.9.5": {
    "module": "sha256-mbDLMWye4TS4llXWhVMNT7LEYuflQSxx9VHJ2Qz/7mQ=",
    "pom": "sha256-ECQS9QZxdiVSHLsR/IdrDPiG2GVkAuLQWLrQYx/5KRY="
   },
+  "androidx/compose/runtime#runtime-saveable-iosarm64/1.12.0-rc01": {
+   "module": "sha256-CUjmuNMnoopE5GstGUgPF0sGULGKPoM8Dy7bK5ix45k=",
+   "pom": "sha256-oGT4xyHxcTny2qYFs0hXWm9t7vovlvRFOjCPDIjrbK4="
+  },
+  "androidx/compose/runtime#runtime-saveable-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-jTF+RpsinmXZGksBd93lemdMRGiyZB8wuJn//ZRW2i0="
+  },
+  "androidx/compose/runtime#runtime-saveable-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-7BHsLirIzFIxOSxQkOFViqQ8aGOvQy/nddd1ekehOfA=",
+   "pom": "sha256-+lTEOF1TbiYmZXu9095lvpcQ8SlnSaPPdVIwKBI9T/I="
+  },
+  "androidx/compose/runtime#runtime-saveable-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-jTF+RpsinmXZGksBd93lemdMRGiyZB8wuJn//ZRW2i0="
+  },
   "androidx/compose/runtime#runtime-saveable/1.10.0": {
    "module": "sha256-g1iXF06+4evPAQAGYfbPzIrtyh2/TRfLdiRaU0e48Cg=",
    "pom": "sha256-E6DoMiUeWD1rRcrCBUZZBsJFlZR3z1W+u4N//gma7qw="
   },
-  "androidx/compose/runtime#runtime-saveable/1.11.0": {
-   "module": "sha256-O4vx5dcHURL4v1ItPOTGeJ5chS7h2JMooDSLeglBet8=",
-   "pom": "sha256-oPibpep6iKH60V2JT1kgig5Gha1uzdtPVz1SBcVk4p0="
-  },
-  "androidx/compose/runtime#runtime-saveable/1.12.0-beta01": {
-   "module": "sha256-QlglWLnMDYPdrk1H3kgCY2MW2D00MUK3Onp70hShg9k=",
-   "pom": "sha256-ZxMoU1HdtBSu0i61Bq5PJc0yS7TY2GKN0yGv2moSuNw="
-  },
-  "androidx/compose/runtime#runtime-saveable/1.12.0-beta02": {
+  "androidx/compose/runtime#runtime-saveable/1.12.0-rc01": {
    "jar": "sha256-16wwfVhrLKq/C97ElJohyPSaZT+miOZi2fSn6y2UdW4=",
-   "module": "sha256-EWORIicTI9rybCq+6U6gr0nOuEO3CP5hoFqX7u48yuo=",
-   "pom": "sha256-xQA5U8e23gofVEWoOVgyqiFPd8evA15WIfqpcrLrxNQ="
+   "module": "sha256-RYu6l2J4NqKtWtLbvPBxHJROOaT6bFS2mG/uzaHz7HY=",
+   "pom": "sha256-2ENMzc8uPY7oB6Jg/f3cida1OiWstHRMsk6Y7ctstN4="
   },
   "androidx/compose/runtime#runtime-saveable/1.9.5": {
    "module": "sha256-U27v7Z1ajxdLteMIqJ1tDpO9S/y5eEjqNZZORVtww1o=",
    "pom": "sha256-JPLaWMTm+Gj5naF/bYQQHUcQ/JCUDIL8Jy4QPg7pRnU="
   },
-  "androidx/compose/runtime#runtime/1.12.0-beta02": {
+  "androidx/compose/runtime#runtime/1.12.0-rc01": {
    "jar": "sha256-Uw3Kz0MR3smRhm/mzppi0Xvg4RBxk4t/sfmbLqdtcLQ=",
-   "module": "sha256-dPpFmW/CTuVU9Cva4qf1qUr6QRDsZ8Ff5CBkcNcqvZ8=",
-   "pom": "sha256-yZ2rFx6aDwb6EXEZeLqJYmvL8QJUatb2qUuYTjiCltU="
+   "module": "sha256-//MKRlmDx1eAUB2ofDNf/AlPtST6BVw0z2cGEJ9yVcQ=",
+   "pom": "sha256-B3zdDi65BsM7GKSRsQBAguW3odLojM9BmVgQ/SZWpD0="
   },
   "androidx/compose/runtime#runtime/1.9.5": {
    "module": "sha256-I9rsvdWexb/rQmWRtBtSaqjWlj58xU8i0sIjktld50I=",
    "pom": "sha256-UeXUZwzRCtjGC9vD3cMHMFo7l+mh+ntAXI52QJa6CxU="
+  },
+  "androidx/compose/runtime/runtime-annotation-iosarm64/1.12.0-rc01/runtime-annotation-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-2TJG2I7WKU4lRRK5ILACEFEAN5SiE6gSnSpW+j0Zsi0="
+  },
+  "androidx/compose/runtime/runtime-annotation-iossimulatorarm64/1.12.0-rc01/runtime-annotation-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-YdjPXdOP/eoZIFeY1VMo3/2MslqBB3zid0u4pS1FMmE="
+  },
+  "androidx/compose/runtime/runtime-iosarm64/1.12.0-rc01/runtime-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-wsevUWNOOCQ4HVpABKEZdIQUXHzS7RsXYlpW8Bq8guU="
+  },
+  "androidx/compose/runtime/runtime-iossimulatorarm64/1.12.0-rc01/runtime-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-B6xXtuVfG/vUqdgBdTcEL9CYrfRoSFqvj4v0NwGHy9Y="
+  },
+  "androidx/compose/runtime/runtime-retain-iosarm64/1.12.0-rc01/runtime-retain-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-0QfbEkSIPepCaVglHVcd1WfTS1T7zWWy//wjvfh6hl8="
+  },
+  "androidx/compose/runtime/runtime-retain-iossimulatorarm64/1.12.0-rc01/runtime-retain-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-AdWGI9GudgoFIkpRJ3BlL59NZubhzXDIPfZFi0g6vhI="
+  },
+  "androidx/compose/runtime/runtime-saveable-iosarm64/1.12.0-rc01/runtime-saveable-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-+P5MI3mPawQK5Iv0Zk5MDg9GSe3SestGN4kHX2Vi0Ks="
+  },
+  "androidx/compose/runtime/runtime-saveable-iossimulatorarm64/1.12.0-rc01/runtime-saveable-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-s5oiyq7N7z52bqSWq4nawo1LB5XxcJpLMYP6FlYN0q0="
   },
   "androidx/databinding#databinding-common/9.3.1": {
    "jar": "sha256-goFjgqKp3sTwqxfHnO8IqeT+S5fYlqwg1/IVtt14ixg=",
@@ -129,10 +237,38 @@
    "jar": "sha256-j0LeOrbWyuH7U6FNM5bEmwHWpEkhznDP0WQXe65e07g=",
    "pom": "sha256-ceJN+kTdsGtpuytUGR9PNm8VmfmJVnDcgseNisQcbnU="
   },
+  "androidx/datastore#datastore-core-iosarm64/1.2.1": {
+   "module": "sha256-l2ux5x5HqiUTO/KbcOtuFUcfb8Puhyj1O6bm8DVC2EE=",
+   "pom": "sha256-0SA3FFPR5W8TAem69/ueMdCea6S3jbH1z2RL4GmWY74="
+  },
+  "androidx/datastore#datastore-core-iosarm64/1.2.1/metadata": {
+   "jar": "sha256-gfTUouoERyYgKH8VHD0x6S6+ah6uGPqC0Ue8lb/LWhA="
+  },
+  "androidx/datastore#datastore-core-iossimulatorarm64/1.2.1": {
+   "module": "sha256-bVWY4S+YER9LPwhfTIp6BYV9F3U64ElTU6BXWGwqgAc=",
+   "pom": "sha256-XaHLuMv7XqD+WZPd6d+SVqI9vEy9oluZ8wp3g/F7krc="
+  },
+  "androidx/datastore#datastore-core-iossimulatorarm64/1.2.1/metadata": {
+   "jar": "sha256-gfTUouoERyYgKH8VHD0x6S6+ah6uGPqC0Ue8lb/LWhA="
+  },
   "androidx/datastore#datastore-core-jvm/1.2.1": {
    "jar": "sha256-3S0ID8FusL6h4C5VUdQ0lvueUXeFXFtyxqr24WqxxcE=",
    "module": "sha256-n5XebiGnr+uq44H79ZKtcX0PipLdfhVISq3z6SUaSoY=",
    "pom": "sha256-/HfBwerbtG10A85wFKe7JbQ55JuHr1OW24NF5OjQHUg="
+  },
+  "androidx/datastore#datastore-core-okio-iosarm64/1.2.1": {
+   "module": "sha256-FFHZB2tAP6ldvzT1FgTkSR/3w7OgVtAINbyLPVR9TjQ=",
+   "pom": "sha256-ZHBqiGXbTMZHa0rtxOgBOoMxAxOIi1pwlX85fXYViUU="
+  },
+  "androidx/datastore#datastore-core-okio-iosarm64/1.2.1/metadata": {
+   "jar": "sha256-3USz+8riqyBoD9t18Kpxczau//KdUEQlyevzoQ8zTwU="
+  },
+  "androidx/datastore#datastore-core-okio-iossimulatorarm64/1.2.1": {
+   "module": "sha256-c8lSONYpqQ5al0IhYpUaE2eIbWr7xxfGrwQbx4mQWhI=",
+   "pom": "sha256-Q8Rrd6HSxl2RArNEDJvQmBBCvGo+NsFEHAlzyLy2SKg="
+  },
+  "androidx/datastore#datastore-core-okio-iossimulatorarm64/1.2.1/metadata": {
+   "jar": "sha256-3USz+8riqyBoD9t18Kpxczau//KdUEQlyevzoQ8zTwU="
   },
   "androidx/datastore#datastore-core-okio-jvm/1.2.1": {
    "jar": "sha256-et5iOaZ2dINPVyRCjncsQXYintML4lOsflIIKikH7gU=",
@@ -148,6 +284,20 @@
    "jar": "sha256-724F4UniVvNgr6IJhajKUtjhGXBlfqKSpvu1cT95R9o=",
    "module": "sha256-PsuQuyXi5OZ09U4VSWSZINGzHPOcjKLCyREV6Pivje0=",
    "pom": "sha256-xQ8uSECCuGNRBn74OB07ApFTWjzbnlIgiRBZMPhNI7M="
+  },
+  "androidx/datastore#datastore-preferences-core-iosarm64/1.2.1": {
+   "module": "sha256-zess45jSI62jzsy1HXqWCL/kYFP8eVj8VbfWyHBCNZ4=",
+   "pom": "sha256-pIrTsFc7ZZZMF2Zcn37tUfjCjY14S8iOFzevqtFBJVI="
+  },
+  "androidx/datastore#datastore-preferences-core-iosarm64/1.2.1/metadata": {
+   "jar": "sha256-tvk3pPYJqVRfKvDSfkiHYj0w8iuMLcfSugKCY3ujAJk="
+  },
+  "androidx/datastore#datastore-preferences-core-iossimulatorarm64/1.2.1": {
+   "module": "sha256-nNROKhWMcTB8yIeB162DaPkxFwEXTIaMv5IGYX0LDw8=",
+   "pom": "sha256-8Gl471jiJwRJp1Yq2t8Tk2DltXAcwBYxyr03Q5RLO04="
+  },
+  "androidx/datastore#datastore-preferences-core-iossimulatorarm64/1.2.1/metadata": {
+   "jar": "sha256-tvk3pPYJqVRfKvDSfkiHYj0w8iuMLcfSugKCY3ujAJk="
   },
   "androidx/datastore#datastore-preferences-core-jvm/1.2.1": {
    "jar": "sha256-vINQxaOCo/aCYBSG9UUdYSLV/YwVr6Maznsi+pgAXqY=",
@@ -169,6 +319,24 @@
    "module": "sha256-XrEsUlySObPJ6F2WsXea3Qy4ZrD7AC+MBvWyh6DvkbQ=",
    "pom": "sha256-4vhhHTXgwleKQzM84/5eHLXlFo3XNDgQ0QrLZIhWbQY="
   },
+  "androidx/datastore/datastore-core-iosarm64/1.2.1/datastore-core-iosarm64-1.2.1": {
+   "klib": "sha256-EjL8HacUJ4N/DJ4JV7s2dkS4HeHneGWowD8GzZrVeSo="
+  },
+  "androidx/datastore/datastore-core-iossimulatorarm64/1.2.1/datastore-core-iossimulatorarm64-1.2.1": {
+   "klib": "sha256-NhdyRQJXEHlw5NqlFy0hVqHCo24RRM1rCkpoZJtuZY8="
+  },
+  "androidx/datastore/datastore-core-okio-iosarm64/1.2.1/datastore-core-okio-iosarm64-1.2.1": {
+   "klib": "sha256-rQY+0s1dHzC6zzvwypqoK4qa0UYncB4fJ7SwFr3ssyw="
+  },
+  "androidx/datastore/datastore-core-okio-iossimulatorarm64/1.2.1/datastore-core-okio-iossimulatorarm64-1.2.1": {
+   "klib": "sha256-NFgGV+VI2l/jcWs4MeyYzQmRKrwbRHzvVApYX/KBCYA="
+  },
+  "androidx/datastore/datastore-preferences-core-iosarm64/1.2.1/datastore-preferences-core-iosarm64-1.2.1": {
+   "klib": "sha256-CVlPlDcDWIrD0nMwynHi8ealGDNzKEhHGu1KKC67Wao="
+  },
+  "androidx/datastore/datastore-preferences-core-iossimulatorarm64/1.2.1/datastore-preferences-core-iossimulatorarm64-1.2.1": {
+   "klib": "sha256-z5m3rdHdN5DeeFBsyAmQjRUq9eN1YMUpfQMv59DjEf0="
+  },
   "androidx/graphics#graphics-shapes-desktop/1.1.0": {
    "jar": "sha256-jXpNOBLK4uPvgnLpf26ZF65Fkx8XzxOR8CRqkslV2fQ=",
    "module": "sha256-a6SpRlFaDJStVZIf172eLougCjYNsubcVf7aHLPTz9Y=",
@@ -178,6 +346,20 @@
    "jar": "sha256-arHbVlH6lEgwB/xf9BFpjsRJwhrkqJSMCm5F9k3nDcM=",
    "module": "sha256-hxE5RzzX+4Qdo9Zf/2EKpFdvxFyki3ArOjcu3dmJvSk=",
    "pom": "sha256-jQzF+/WBS5+r39wvoq3AZLuZN4xMsM0SVK7XZHQ3ylk="
+  },
+  "androidx/lifecycle#lifecycle-common-iosarm64/2.11.0": {
+   "module": "sha256-unz4Z1NU6JfSTd4uhy646cQMLkJZ8YK/Q/XuwixZpcs=",
+   "pom": "sha256-78RL57TXLKHMC2CAkL4W+lyzCSsxnj7lNo6ORqzEvlE="
+  },
+  "androidx/lifecycle#lifecycle-common-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-GNwmQ5pKDoiQ91Eh/k772J2N/NjNu2BSsP4PMeJ1/o4="
+  },
+  "androidx/lifecycle#lifecycle-common-iossimulatorarm64/2.11.0": {
+   "module": "sha256-O1bg2m6KGS15F6RwTj5/QXzzpY79pZuO8gKTjnPU9Sw=",
+   "pom": "sha256-Y5W66wDBHXLBGEzghQe2AJlmlm5SQP5+8q2m2p3yM0g="
+  },
+  "androidx/lifecycle#lifecycle-common-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-GNwmQ5pKDoiQ91Eh/k772J2N/NjNu2BSsP4PMeJ1/o4="
   },
   "androidx/lifecycle#lifecycle-common-jvm/2.11.0": {
    "jar": "sha256-5qZuZ7n2Og+2NE8WXB2HI3bl/m0jW/+xOK9FEiz0Uqk=",
@@ -216,6 +398,20 @@
    "module": "sha256-xANG1Q0gglWZKxsFPINcljYxhBtw34tvxp8kUpmI3MU=",
    "pom": "sha256-EHpGt+Pp/+28BWd4Ler5/3ZztYgdDFX72Bsv49r9CHQ="
   },
+  "androidx/lifecycle#lifecycle-runtime-compose-iosarm64/2.11.0": {
+   "module": "sha256-2oEVJNAporxQufVAhl3N/tlF1xbgDoGnPIbNH4RYTZ4=",
+   "pom": "sha256-5fLhVe3k/hPXDSMlRA3cvMIkEBxJ0HKIhulIDR3wAY4="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-9W9y4CYa07Kisj8zSFEE0sIMxmESd2GV5zx9uGNO+CY="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-iossimulatorarm64/2.11.0": {
+   "module": "sha256-ovi8Zyazs6W9bFOnug724FLgEbVp6ixX0bF6IPybDoQ=",
+   "pom": "sha256-RcLokWL8Lnj3eLx8KONSlllJXjz9yrYh5hZ/DSJdCkw="
+  },
+  "androidx/lifecycle#lifecycle-runtime-compose-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-9W9y4CYa07Kisj8zSFEE0sIMxmESd2GV5zx9uGNO+CY="
+  },
   "androidx/lifecycle#lifecycle-runtime-compose/2.10.0": {
    "module": "sha256-YyuoWyQ6BAT28zrW58mW97qaQvN32whHNK56MY6qbsg=",
    "pom": "sha256-D3kM4VGREBDVN80gRSZ1AX/yX9/x+1zfSZvzoFrULKo="
@@ -243,6 +439,20 @@
    "module": "sha256-+VLq6Qa8BiePYEGvs8EzPp1rAL5DeIV7zWahulg2eQk=",
    "pom": "sha256-+yriSTRTAzy/Kzp0qh36Z8/bwYmlTRkJg9/RVQLQtuc="
   },
+  "androidx/lifecycle#lifecycle-runtime-iosarm64/2.11.0": {
+   "module": "sha256-BIYTsnXifbO4RcnDuLAtyrl6ATsJvNp8UVUSYKel4BA=",
+   "pom": "sha256-K9ZxMFmuKsD2v1uWCG3tTy0D7041jYYz4nOoLZYpyFI="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-Qk99bj4uP8P4tF4H7eHppE+Q3PuLiM2dq9idMGZSFuc="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iossimulatorarm64/2.11.0": {
+   "module": "sha256-bBR1yaVfHe7PaVGrworYblw6Knt6Ns58kMtRS8jErJM=",
+   "pom": "sha256-ZArb0IN05U1k2BxEXo9GHxjp12VyhPt0CZ0Mp+bCQg8="
+  },
+  "androidx/lifecycle#lifecycle-runtime-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-Qk99bj4uP8P4tF4H7eHppE+Q3PuLiM2dq9idMGZSFuc="
+  },
   "androidx/lifecycle#lifecycle-runtime/2.10.0": {
    "module": "sha256-2oBfoBekrM4T9QFGmnWj8wYkjuvFj1vMKAGbABXfumU=",
    "pom": "sha256-Sote7FTV7N8JnqU7Lk6fJNspZ+pdOTCXtqbFSe1pMI0="
@@ -261,6 +471,20 @@
    "module": "sha256-lVGofsYwSTAkjZV4/Q3aynK6123kZ0hAWGajToJ6EsQ=",
    "pom": "sha256-plerhFij/3kbnpWMaV587OSLRNBL/GB63o7Lfjng2AA="
   },
+  "androidx/lifecycle#lifecycle-viewmodel-compose-iosarm64/2.11.0": {
+   "module": "sha256-JwRo4YxLrWtUGoNklQwqhSvsrpq4eOZklifqlKTNWd4=",
+   "pom": "sha256-82Njos2nRnBLJEzC55ie8RrlnnKQ7vsh0p0loEu9GMg="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-1tN2UlVZOkk3xXCPtpNbvNJCsZ0VF76FRmYSLVU0h78="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose-iossimulatorarm64/2.11.0": {
+   "module": "sha256-uHtIwsw9s+fkxkuqmmCp182H4Jh4tYlHFbDTsVeg7fI=",
+   "pom": "sha256-tXq006jCTy/8/FNf8WpHZ66QgdPo2C0aR05N6T7KbPw="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-compose-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-1tN2UlVZOkk3xXCPtpNbvNJCsZ0VF76FRmYSLVU0h78="
+  },
   "androidx/lifecycle#lifecycle-viewmodel-compose/2.11.0": {
    "jar": "sha256-srDoYppTvNkwi2ScNP4RO5AC8a6FLp97mYcxTaOb6SQ=",
    "module": "sha256-mXsqODMYP5TmATrUCYL89efIYA4QcJlPMwZFRipUbBg=",
@@ -276,6 +500,20 @@
    "module": "sha256-73aG2pDJWnP0A+vKyHzwbNdR5JGecf4gqRFFm8tIT1s=",
    "pom": "sha256-sLwaHSilS9d4oSYQRI0o/tYDh3gfHNWa+r40sdA0XSs="
   },
+  "androidx/lifecycle#lifecycle-viewmodel-iosarm64/2.11.0": {
+   "module": "sha256-eWKX1PsdfXGU3jNd533wibd8FB0qh/9VzYDgel6FWsQ=",
+   "pom": "sha256-L4ZIPzvTSsACGx+w+O6PBtVUSp/6X6yBP/0C/34QNnQ="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-sIxDvGj8Ieq2KBb8/GoK4ZvhTyS3nOFy5VWiTP0QPtc="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iossimulatorarm64/2.11.0": {
+   "module": "sha256-ioRwtvcUGDn9YXc8ae2Uwy4tf3c19xZSXaTIIsgZGg0=",
+   "pom": "sha256-bH0q6yI0dKIILBzBBw3h1g+c/PB9HJb2ZKTpqJpE7jU="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-sIxDvGj8Ieq2KBb8/GoK4ZvhTyS3nOFy5VWiTP0QPtc="
+  },
   "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.11.0": {
    "jar": "sha256-yiFyDOfzcMshyrtTKblZ7aYkEH7AYoLjvcklgpF7HSc=",
    "module": "sha256-ln0f2kJkS1Xo+PWU3aKHBJ0TE8H9JDehZiVnaD9+jAc=",
@@ -285,6 +523,20 @@
    "jar": "sha256-PgtE4lFOr91pONVFfZ9G5HhQd8RdO0NktcI8TcuT79M=",
    "module": "sha256-Zz9dNS3D2hsaNY5aMO9+FjIZs6HXA27hjJNQxT8F8rE=",
    "pom": "sha256-MV7u84MhWBlbUY4+zOEEWkqSmexIP1YYh2BuVf9qHLk="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iosarm64/2.11.0": {
+   "module": "sha256-ujSJrX/sCGWT35POFyuiJMa4iKIyT5HctUuxd2XwVek=",
+   "pom": "sha256-Q2dTMoRdQdNj8RY5N6gKFgQu7LSdhhvaRV7/QtudnG4="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-/cz/BFhaP0lv2I39EsPG9hz2EbyHWBzYPCBTfb20u04="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iossimulatorarm64/2.11.0": {
+   "module": "sha256-Xwtpvk7tldrRBm/VNJ0mYJkuJyxOt15bu0MflsiQSoc=",
+   "pom": "sha256-103u7dVoLtoBtWD27gIPFKNo+yg7JKur9C5hc2o/CLQ="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-/cz/BFhaP0lv2I39EsPG9hz2EbyHWBzYPCBTfb20u04="
   },
   "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.11.0": {
    "jar": "sha256-6slgN7pqI0mCgVTT0snJKuDJTzd+suuT6ZdU86f44nk=",
@@ -304,6 +556,42 @@
    "module": "sha256-lk1p1rh3KW6Lead7uCbvX7GGrsqnoaf/d2+yJQyZMAY=",
    "pom": "sha256-BU22+S2SMBA7OsqLDavMDWPeJuRA/5jrWxmiVV0+sDc="
   },
+  "androidx/lifecycle/lifecycle-common-iosarm64/2.11.0/lifecycle-common-iosarm64-2.11.0": {
+   "klib": "sha256-banignjdZse+Yz/PdmiWL3TOyiL/2Uom+H5zRCFaaBc="
+  },
+  "androidx/lifecycle/lifecycle-common-iossimulatorarm64/2.11.0/lifecycle-common-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-Gv2x/zZfWbSyZ5vaxW57mq58I52bK58QiRoD3JOFCjc="
+  },
+  "androidx/lifecycle/lifecycle-runtime-compose-iosarm64/2.11.0/lifecycle-runtime-compose-iosarm64-2.11.0": {
+   "klib": "sha256-MC67d0vj+WA+qwQ3IF/enISz0w/qNs3CbTLfGwkHxPU="
+  },
+  "androidx/lifecycle/lifecycle-runtime-compose-iossimulatorarm64/2.11.0/lifecycle-runtime-compose-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-0EsAL71rKK01oiorE9YDxi0oztv8JJ8wz9y48Pvq3Fo="
+  },
+  "androidx/lifecycle/lifecycle-runtime-iosarm64/2.11.0/lifecycle-runtime-iosarm64-2.11.0": {
+   "klib": "sha256-rUJLw6wb2Z3HLQl4+zCuMludP8ah86pmWBXgDXi5VBs="
+  },
+  "androidx/lifecycle/lifecycle-runtime-iossimulatorarm64/2.11.0/lifecycle-runtime-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-wHeH+G7vv8syzGPO8W4e2ci67TO0AebsxhPFIcIPWfo="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-compose-iosarm64/2.11.0/lifecycle-viewmodel-compose-iosarm64-2.11.0": {
+   "klib": "sha256-eTf1EzInaCzupuSgaSiGQ5rVxq3ZhSsZVWD9QaaLRSE="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-compose-iossimulatorarm64/2.11.0/lifecycle-viewmodel-compose-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-LlkLKhvlzzF4r/KucNW5DjmfEVHoL458YGOSOEI2dR4="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-iosarm64/2.11.0/lifecycle-viewmodel-iosarm64-2.11.0": {
+   "klib": "sha256-p89uS2KRc632j3eNKoo3nWLsjjmRYclr8PF9FOFLl28="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-iossimulatorarm64/2.11.0/lifecycle-viewmodel-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-m5u1oGczb+6E/WvXsPdPTvXJpsCXknppaybeiASmAtc="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-savedstate-iosarm64/2.11.0/lifecycle-viewmodel-savedstate-iosarm64-2.11.0": {
+   "klib": "sha256-xgQvoYLIPru4M5KCBuxslHy5gTaAg8Vef/ge6Uz04Rk="
+  },
+  "androidx/lifecycle/lifecycle-viewmodel-savedstate-iossimulatorarm64/2.11.0/lifecycle-viewmodel-savedstate-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-jc599sLYMY7sSqf+BlppMjLn3aPhMtMZdmu3rEqWyLs="
+  },
   "androidx/navigation3#navigation3-runtime-desktop/1.1.1": {
    "jar": "sha256-4IqYxfQ6WpU5ZFyuNiZciDkVGI9ardGznxXhmaU2OWQ=",
    "module": "sha256-8bvnJaWi37udRHy1rOjSJs96SD24466KlPO8sJdRDAo=",
@@ -318,6 +606,20 @@
    "jar": "sha256-HX0g14JqLMY6zphizd2KcIWhGj6iz/JYwos9WOV/FDs=",
    "module": "sha256-PyUHjvoV94YPFsnQOEzqAJ13qDkhODfIk7euVL/TU1Y=",
    "pom": "sha256-uBODgunrV5Puxp6WdD0vifnYsS6z2ljaY3aWd3YylF8="
+  },
+  "androidx/navigationevent#navigationevent-compose-iosarm64/1.1.1": {
+   "module": "sha256-5BsVH7TpL2PAvxNzuyPIffAI9OYsmEWQtZtneNoIwzc=",
+   "pom": "sha256-vKP5vFoTZLihKWLeCnPPYgfeVo/RsaZV0B/7Yfuhqkc="
+  },
+  "androidx/navigationevent#navigationevent-compose-iosarm64/1.1.1/metadata": {
+   "jar": "sha256-L6QojCYl5qElbY82Hbc8YDvj5tZyTQWgfEmYMawDl5Y="
+  },
+  "androidx/navigationevent#navigationevent-compose-iossimulatorarm64/1.1.1": {
+   "module": "sha256-KnaRdEVOCJy+R6MJ4vqBvLbJWUBiejx9KeJSgCDnu3g=",
+   "pom": "sha256-ac5Zoa9OZ26BlEk0oQ/Gso+1WJeBDSS3ok4J2A22qX4="
+  },
+  "androidx/navigationevent#navigationevent-compose-iossimulatorarm64/1.1.1/metadata": {
+   "jar": "sha256-L6QojCYl5qElbY82Hbc8YDvj5tZyTQWgfEmYMawDl5Y="
   },
   "androidx/navigationevent#navigationevent-compose/1.1.1": {
    "jar": "sha256-8Rs8jRsdDiytTJGwS2YeRhA/q9xifnjOGbqpMsoBz+w=",
@@ -334,6 +636,20 @@
    "module": "sha256-/x/yta0QMV/qKZTr+VYx1h1uB8m/P4nSTdIJbMADIJQ=",
    "pom": "sha256-0SRvQmBMp1ImrIQPOQNR9Pg20P18gcepj/OabU/NsHY="
   },
+  "androidx/navigationevent#navigationevent-iosarm64/1.1.1": {
+   "module": "sha256-K9SpK5AEcXd+zz/N3o86AquSsoO+m1B+hvvgECGEbJY=",
+   "pom": "sha256-H9gnWW68uiCiW5A3n2uM1yjmlup72xGJL5N4cXnZOKs="
+  },
+  "androidx/navigationevent#navigationevent-iosarm64/1.1.1/metadata": {
+   "jar": "sha256-+/BmbSwrQfe0DHlOG0vpbFlU9MuXH+WWzqTxJ6fet4E="
+  },
+  "androidx/navigationevent#navigationevent-iossimulatorarm64/1.1.1": {
+   "module": "sha256-hZmtf/JOyhOvnPnrtMDL4Fwbirut2bOM28MOyNs93gM=",
+   "pom": "sha256-kMO38MfNoZcn89OQLPjUhvHLzTeDapPSxjRxQEUsa2g="
+  },
+  "androidx/navigationevent#navigationevent-iossimulatorarm64/1.1.1/metadata": {
+   "jar": "sha256-+/BmbSwrQfe0DHlOG0vpbFlU9MuXH+WWzqTxJ6fet4E="
+  },
   "androidx/navigationevent#navigationevent/1.0.2": {
    "module": "sha256-hA2TsFuCeQbhZfcXoDeKDszN6z4NEUkOoU1atbEIJic=",
    "pom": "sha256-GwQqB6oi1U8GaFw38JPepPJtnvrlsgEDlLDGWE6IgUM="
@@ -343,8 +659,34 @@
    "module": "sha256-7YnWBP05Hd0YMzf2S4b/ApCSk9dR6rLbyvWNIKM/kw8=",
    "pom": "sha256-nc0ZmUWCIEQj5D3H8zVswiJdzA9ttBMPkH+Kynck8Vw="
   },
+  "androidx/navigationevent/navigationevent-compose-iosarm64/1.1.1/navigationevent-compose-iosarm64-1.1.1": {
+   "klib": "sha256-uawQuz5D5D/SGwdbSJYCd8cc0YIFlkHbzsssiNx2e7E="
+  },
+  "androidx/navigationevent/navigationevent-compose-iossimulatorarm64/1.1.1/navigationevent-compose-iossimulatorarm64-1.1.1": {
+   "klib": "sha256-mXKUtMlojzsX1sDGxA4//TF0+IPWwkVF5a0C+8YeY5w="
+  },
+  "androidx/navigationevent/navigationevent-iosarm64/1.1.1/navigationevent-iosarm64-1.1.1": {
+   "klib": "sha256-QeRUtLLtVAqwLpGA3CeaVKdaCg3WMM1nHW+OWritj38="
+  },
+  "androidx/navigationevent/navigationevent-iossimulatorarm64/1.1.1/navigationevent-iossimulatorarm64-1.1.1": {
+   "klib": "sha256-lVmW9YFQ+wFkrYQeQdQYHzQtPdfq+3ED36YK/Lca/X4="
+  },
   "androidx/room3#androidx.room3.gradle.plugin/3.0.1": {
    "pom": "sha256-T2y6kkt/t20aOnFgSgFd0PCaGdN3tx8LvQHR+XfKWss="
+  },
+  "androidx/room3#room3-common-iosarm64/3.0.1": {
+   "module": "sha256-RfgMkREF3F6KciLv/w/w5SLZSvg0Rss8S0aGqOq3Nu8=",
+   "pom": "sha256-nSlp8Pt5ddDOQ4s5hoYU741aNm6yPEjq4bcU7UMzrs4="
+  },
+  "androidx/room3#room3-common-iosarm64/3.0.1/metadata": {
+   "jar": "sha256-Z+30gdaixFEM7Xrf4+Qk5Nj2OIRRsSPicDwTxRJDRoM="
+  },
+  "androidx/room3#room3-common-iossimulatorarm64/3.0.1": {
+   "module": "sha256-0CbUi+VLati+wl3HSALEPHVp3B9WKl16lF+bYJmAAbU=",
+   "pom": "sha256-bqJHyEWHzdalVu8DDgDXWUq/kZnL94xNVsi1XJKsFYQ="
+  },
+  "androidx/room3#room3-common-iossimulatorarm64/3.0.1/metadata": {
+   "jar": "sha256-Z+30gdaixFEM7Xrf4+Qk5Nj2OIRRsSPicDwTxRJDRoM="
   },
   "androidx/room3#room3-common-jvm/3.0.1": {
    "jar": "sha256-i77GUB/cRNxD4B1KpDsrUJwVfDPqG9IROZyk+CMlLcs=",
@@ -385,6 +727,20 @@
    "module": "sha256-B77Omvzx7ZpZJBOD4MtoVcMgk1VbPs5WyMkJUATiMvA=",
    "pom": "sha256-gIAiju09BWSb9RgjVo/UP+12VD7wFcIBKGK+hx7eAVY="
   },
+  "androidx/room3#room3-runtime-iosarm64/3.0.1": {
+   "module": "sha256-ylAI1y3mivLoS9m6CQTS8XLlhLkaGI5Zf+Nr0Shb+6k=",
+   "pom": "sha256-WwbW1Su6OLzEC2bP62imBvssvPmDoIYc0/0U+ktcfVo="
+  },
+  "androidx/room3#room3-runtime-iosarm64/3.0.1/metadata": {
+   "jar": "sha256-r8JojbcTOYZxoJBVDMjrbo4dC0SYqErLgqjieFNfkOg="
+  },
+  "androidx/room3#room3-runtime-iossimulatorarm64/3.0.1": {
+   "module": "sha256-XS6wAQVNUQJEv5jgeTYOfBM01ePmPJ29xZzFd8MEFMI=",
+   "pom": "sha256-trKrD7VevVS2oHRrdRaUER2FTgcpy20fX5GV9zOU1VY="
+  },
+  "androidx/room3#room3-runtime-iossimulatorarm64/3.0.1/metadata": {
+   "jar": "sha256-r8JojbcTOYZxoJBVDMjrbo4dC0SYqErLgqjieFNfkOg="
+  },
   "androidx/room3#room3-runtime-jvm/3.0.1": {
    "jar": "sha256-fXJGUUpoX7a3UeblLZkglmACRGL6sdIW/YCBmpOWDB4=",
    "module": "sha256-oCgbrxXDGJfhUiOaLulWUcaQg2ei2Wu8z6GlOklFWSM=",
@@ -395,10 +751,36 @@
    "module": "sha256-Up8taG/1Bh4UgIAXfkeW6GFnET0NcJUBWBt1uV5UgJc=",
    "pom": "sha256-yL1NDdUOMOPkhQZmJzGniwiYxdwIrrNUMkWw1N+5HmE="
   },
+  "androidx/room3/room3-common-iosarm64/3.0.1/room3-common-iosarm64-3.0.1": {
+   "klib": "sha256-JRVC4HDPcHvVklH4qNAYjVLIAEBtbIk1zwSw0IN3vH4="
+  },
+  "androidx/room3/room3-common-iossimulatorarm64/3.0.1/room3-common-iossimulatorarm64-3.0.1": {
+   "klib": "sha256-vZJVv4wCx6Fq/S8imguZw60VW0Yic4v/ljWuBtdNxIg="
+  },
+  "androidx/room3/room3-runtime-iosarm64/3.0.1/room3-runtime-iosarm64-3.0.1": {
+   "klib": "sha256-T9rd6hMNcCVHbdfxve5p2JzzEGofdEV5HOZtEpXth3w="
+  },
+  "androidx/room3/room3-runtime-iossimulatorarm64/3.0.1/room3-runtime-iossimulatorarm64-3.0.1": {
+   "klib": "sha256-i+nV/ixAWn8O4U4KHoxLo3mN7xE3iKMYfMdoOPwgKNw="
+  },
   "androidx/savedstate#savedstate-compose-desktop/1.4.0": {
    "jar": "sha256-wCqYsMKzXN3iRcC/5uf/RTx7bQal64aB0lt/VLh06kg=",
    "module": "sha256-gI/3I6FTrM4WBImlvEtYyh1wM/6EqQYPUtF9sifqpM0=",
    "pom": "sha256-U+fXiRm8heHIjh5rDinQrjvGaT16jsVzGnJQRMdhdGE="
+  },
+  "androidx/savedstate#savedstate-compose-iosarm64/1.4.0": {
+   "module": "sha256-x+pXUretY4EqnI9cCYCV8OED4/wfDs+HdO4ojYuQ1Vk=",
+   "pom": "sha256-bJbEr75c72aG0mNTuBEIlenAOcNEVI5Apvdz7NyILw8="
+  },
+  "androidx/savedstate#savedstate-compose-iosarm64/1.4.0/metadata": {
+   "jar": "sha256-bJKd/5dK6SEDGj4tuDZvSQj1TEqjogAucHQAo7qV0Kw="
+  },
+  "androidx/savedstate#savedstate-compose-iossimulatorarm64/1.4.0": {
+   "module": "sha256-YfSqPNI5hMV3784AgLa/EwvveMnC5jB9KgJPujnEn2s=",
+   "pom": "sha256-4MNFgHd02TBdJnQ0kaRvy4GvH+Xv0SK/IDCqJTZTCR8="
+  },
+  "androidx/savedstate#savedstate-compose-iossimulatorarm64/1.4.0/metadata": {
+   "jar": "sha256-bJKd/5dK6SEDGj4tuDZvSQj1TEqjogAucHQAo7qV0Kw="
   },
   "androidx/savedstate#savedstate-compose/1.4.0": {
    "jar": "sha256-hk0ggwlx+wjC7Q/E+QKwX9AuOO8wvLZaQ7DJkQqsOIw=",
@@ -410,10 +792,50 @@
    "module": "sha256-5z8s+IGOzjR9i13/mQ0Ntjmn37j8yF7uyyYYOD9+zvc=",
    "pom": "sha256-jxFKQnNTWta9y+0Zhs/dmNlV6804oyqP7k7n3I4hH14="
   },
+  "androidx/savedstate#savedstate-iosarm64/1.4.0": {
+   "module": "sha256-wiGHCbRh3vIZ0cYCYJODqLNjLMoQanEzYZ1luxR5dpU=",
+   "pom": "sha256-teYUCzOIZRMswgLzZLQpeOfMfliGC+fSUGOmBXiUZwk="
+  },
+  "androidx/savedstate#savedstate-iosarm64/1.4.0/metadata": {
+   "jar": "sha256-z0Q2LP2v/PsN4NJXGmYOntDofICz2q9dzQrDOgSYEE0="
+  },
+  "androidx/savedstate#savedstate-iossimulatorarm64/1.4.0": {
+   "module": "sha256-a1+nxHOryber/aQ29x8j6+1p8zxt+ynkeTGRiauli/E=",
+   "pom": "sha256-bBh5rkY1OXVNjiTa/uondSZ/5FYk0F/zd988B1hYKw4="
+  },
+  "androidx/savedstate#savedstate-iossimulatorarm64/1.4.0/metadata": {
+   "jar": "sha256-z0Q2LP2v/PsN4NJXGmYOntDofICz2q9dzQrDOgSYEE0="
+  },
   "androidx/savedstate#savedstate/1.4.0": {
    "jar": "sha256-CYWWyN+6K+9EvgN/PT+JzdARWHUF7YL6Yl8qg6ItZBU=",
    "module": "sha256-oPKsWgdgY/DIE891pG37eAvVpaLIZ3JAvKhVFVTaj9I=",
    "pom": "sha256-0raKLQzHbyPOvG1Oqbvy1j+1Nv/ZTgVRStnabF9TBJI="
+  },
+  "androidx/savedstate/savedstate-compose-iosarm64/1.4.0/savedstate-compose-iosarm64-1.4.0": {
+   "klib": "sha256-NTppm4YYzOYqoC4srfetXAjmPy92T37M+aiCDXMOXUs="
+  },
+  "androidx/savedstate/savedstate-compose-iossimulatorarm64/1.4.0/savedstate-compose-iossimulatorarm64-1.4.0": {
+   "klib": "sha256-C2+XrP7oZMPKPtRnUNOXVzjcKMgeq5rFlT0vRSZWuV8="
+  },
+  "androidx/savedstate/savedstate-iosarm64/1.4.0/savedstate-iosarm64-1.4.0": {
+   "klib": "sha256-ZPP92l/5qlSa7iJKff63tU1Po/7RV4dPt4VQowXD9Xo="
+  },
+  "androidx/savedstate/savedstate-iossimulatorarm64/1.4.0/savedstate-iossimulatorarm64-1.4.0": {
+   "klib": "sha256-htb1WophJzx9orX9yBPuiKn6TCad2Zgf3E4pQMm+BDU="
+  },
+  "androidx/sqlite#sqlite-async-iosarm64/2.7.0": {
+   "module": "sha256-wN8jwqeb6ivIQWlJxIMYNR6OsW1cncNWNYADTPoYd1c=",
+   "pom": "sha256-+U9JSLJIYW++kPE2ryrQgJXegQCAk4uu++uxnWl8ZwM="
+  },
+  "androidx/sqlite#sqlite-async-iosarm64/2.7.0/metadata": {
+   "jar": "sha256-O2AJOc1dFD/pJS0miOndrqiIHv4SaHVqpDeC03wTSNY="
+  },
+  "androidx/sqlite#sqlite-async-iossimulatorarm64/2.7.0": {
+   "module": "sha256-VBXtvHMH5PPwPZ9ehXVgT8ICVBrFPa5NbIOWBrEHvp8=",
+   "pom": "sha256-0/PXXx4F6RtocY2fNwGX8lgAgYLIjHgcFq+UkJOeEsY="
+  },
+  "androidx/sqlite#sqlite-async-iossimulatorarm64/2.7.0/metadata": {
+   "jar": "sha256-O2AJOc1dFD/pJS0miOndrqiIHv4SaHVqpDeC03wTSNY="
   },
   "androidx/sqlite#sqlite-async-jvm/2.7.0": {
    "jar": "sha256-2nsEV0TrL5tUYtixpUVXqmoU1J3P7pc5nv0VukV2BdM=",
@@ -425,6 +847,20 @@
    "module": "sha256-KPSt33UdNRNuq6AZli3ovMCqJI+vQF6m76w46m1gTSo=",
    "pom": "sha256-KrYoTBOznISFYFxJ6W57mLwfFpZujbDTVyv0UDq5JMY="
   },
+  "androidx/sqlite#sqlite-bundled-iosarm64/2.7.0": {
+   "module": "sha256-PfTKqbsNi9BLfUyPi7luoOrxbU2JwWofmNBf8MwimQA=",
+   "pom": "sha256-f3WTfJjNq/oHZR+pewY0uKifW+Wr3G9BdHLuh5EMW20="
+  },
+  "androidx/sqlite#sqlite-bundled-iosarm64/2.7.0/metadata": {
+   "jar": "sha256-WY8vTIYP+niMMGOBwKhOKxYo4pJhzN9pwRTpD0N7UOA="
+  },
+  "androidx/sqlite#sqlite-bundled-iossimulatorarm64/2.7.0": {
+   "module": "sha256-9dMrWZD5GF0HYG86lEiGMNjzUwKBL57bzc62V+0vSE0=",
+   "pom": "sha256-QGgHyHzFSDMGFseGwlwuFcWTbMB70hglut1HzlMfgcs="
+  },
+  "androidx/sqlite#sqlite-bundled-iossimulatorarm64/2.7.0/metadata": {
+   "jar": "sha256-WY8vTIYP+niMMGOBwKhOKxYo4pJhzN9pwRTpD0N7UOA="
+  },
   "androidx/sqlite#sqlite-bundled-jvm/2.7.0": {
    "jar": "sha256-ZuUxtb9FyMR9jKRDZCWIV3/wJ+YQs/uLZQCglY9PEuQ=",
    "module": "sha256-UKXi5Rcb9JzIrG5wXociQMF9rKr0StkoH814hVc9g58=",
@@ -435,10 +871,38 @@
    "module": "sha256-KlDoUmOTiX4qwjwY8165cMqwAMKbI8Va3HpMSYrojwE=",
    "pom": "sha256-AfLfhZwT+KGCGTPNq95exswxO9ngJP/Wfyq/oi0yRT8="
   },
+  "androidx/sqlite#sqlite-framework-iosarm64/2.7.0": {
+   "module": "sha256-ClwXrCFBYxDVtKD7CCKHh+EUNL9BRiu0cEA/MSURXc8=",
+   "pom": "sha256-BL+eKUPrIqDUO4QDzch2gafJxGcfNBnQU/rSbJ3sUBE="
+  },
+  "androidx/sqlite#sqlite-framework-iosarm64/2.7.0/metadata": {
+   "jar": "sha256-hs0iMyRX6rmxrmUa+ppEi1QjHjq4Ac1VwrfVwcmCbXU="
+  },
+  "androidx/sqlite#sqlite-framework-iossimulatorarm64/2.7.0": {
+   "module": "sha256-NtwRNcafHn97qEgjr1WK9zgh6sAGoPpR39CeAaIxWI4=",
+   "pom": "sha256-wmIoEZSduce4iCJP+F875dHKm5J4UoLfok1TAEZ5Kds="
+  },
+  "androidx/sqlite#sqlite-framework-iossimulatorarm64/2.7.0/metadata": {
+   "jar": "sha256-hs0iMyRX6rmxrmUa+ppEi1QjHjq4Ac1VwrfVwcmCbXU="
+  },
   "androidx/sqlite#sqlite-framework/2.7.0": {
    "jar": "sha256-b4cmx0hNAEfUQuvkaokkdzXUd6GDoy/Nh+HJBLdyP9Q=",
    "module": "sha256-c+27amSfCkHQpaj4dGOCM2QHpBb3Q0qxQ2nzQGBU6+E=",
    "pom": "sha256-mOfzdmIR3Uetz/201EahXpX2egRIxSlNRRCOziIestQ="
+  },
+  "androidx/sqlite#sqlite-iosarm64/2.7.0": {
+   "module": "sha256-WmG9Rjr08aV4iAr/RCKtEaJW5fLXLkpJrtfCJ0QYvvM=",
+   "pom": "sha256-jGw4gO7X/vfCZZeUiBw65JaKYH6YTaN5YpHddrT5tYI="
+  },
+  "androidx/sqlite#sqlite-iosarm64/2.7.0/metadata": {
+   "jar": "sha256-oNte0ygQs8gEaXhSPgxZ/KbTEPzAxNV4c/nX+/5TI2c="
+  },
+  "androidx/sqlite#sqlite-iossimulatorarm64/2.7.0": {
+   "module": "sha256-AFI1XH9rX0TpRj0qcVdnjxHql2cjlHc4GL1JtFI4eAI=",
+   "pom": "sha256-tjuVBuvdOXJ3II2yMz3XyO+iqn7PYrUyDPS/LiHzZdc="
+  },
+  "androidx/sqlite#sqlite-iossimulatorarm64/2.7.0/metadata": {
+   "jar": "sha256-oNte0ygQs8gEaXhSPgxZ/KbTEPzAxNV4c/nX+/5TI2c="
   },
   "androidx/sqlite#sqlite-jvm/2.7.0": {
    "jar": "sha256-em2Nta42PZak9lybb2szYbF4xB4VpPBrss1ZQDgHR08=",
@@ -449,6 +913,42 @@
    "jar": "sha256-XuRUUAIvo7fPtdEDfgXQ0zKGxl9b4EdGEYkkc5iTCXE=",
    "module": "sha256-FsWdq4FkIGUQJACIfn+AwxEXavy09g64Llr28ps/3FY=",
    "pom": "sha256-MaLLF88w29Al7VDyW50l4PzXkGCbIUc18PrJR4z3va8="
+  },
+  "androidx/sqlite/sqlite-async-iosarm64/2.7.0/sqlite-async-iosarm64-2.7.0": {
+   "klib": "sha256-e6VWcotjM20UI4nh0NaYH7u/6iqxXuz+Km4V0hGALTA="
+  },
+  "androidx/sqlite/sqlite-async-iossimulatorarm64/2.7.0/sqlite-async-iossimulatorarm64-2.7.0": {
+   "klib": "sha256-a+XdD/NceppxXF9HG3iMa+4cK8xnKcKMb2SWqkJtPHo="
+  },
+  "androidx/sqlite/sqlite-bundled-iosarm64/2.7.0/sqlite-bundled-iosarm64-2.7.0": {
+   "klib": "sha256-FHyx3+/ck2Ww85SdYTCvjPYwQUdFNFyR8HQUkpBKp54="
+  },
+  "androidx/sqlite/sqlite-bundled-iosarm64/2.7.0/sqlite-bundled-iosarm64-2.7.0-cinterop-androidXBundledSqlite": {
+   "klib": "sha256-KsO2Ry8vxxb3r2dGYMiP1sqhWdU46DINHPXN3KLjg8k="
+  },
+  "androidx/sqlite/sqlite-bundled-iossimulatorarm64/2.7.0/sqlite-bundled-iossimulatorarm64-2.7.0": {
+   "klib": "sha256-Kh4YjCT9uF7KDeNwN0X339E4EjKAG5XrSlq049btpuA="
+  },
+  "androidx/sqlite/sqlite-bundled-iossimulatorarm64/2.7.0/sqlite-bundled-iossimulatorarm64-2.7.0-cinterop-androidXBundledSqlite": {
+   "klib": "sha256-5EImUdN3vg4zbl73fi64j9AZNQc75S/VmTE2YrSUqzc="
+  },
+  "androidx/sqlite/sqlite-framework-iosarm64/2.7.0/sqlite-framework-iosarm64-2.7.0": {
+   "klib": "sha256-DL6RnPzgPwe52NjGBk9WtjHA71qGOU3j0rLnq1jBeJQ="
+  },
+  "androidx/sqlite/sqlite-framework-iosarm64/2.7.0/sqlite-framework-iosarm64-2.7.0-cinterop-sqlite3": {
+   "klib": "sha256-oPdKQtnO6BKjXksJzzv3yICSGxx2hwgJiCef1VQVuj8="
+  },
+  "androidx/sqlite/sqlite-framework-iossimulatorarm64/2.7.0/sqlite-framework-iossimulatorarm64-2.7.0": {
+   "klib": "sha256-CJ2m4LnUljc+tSwrpuurk3XEpyelHKyTJVePru0CDGI="
+  },
+  "androidx/sqlite/sqlite-framework-iossimulatorarm64/2.7.0/sqlite-framework-iossimulatorarm64-2.7.0-cinterop-sqlite3": {
+   "klib": "sha256-dlQDvfnWSCb42SFZzpICqDK0tZdY3hre34xcZD+yZOA="
+  },
+  "androidx/sqlite/sqlite-iosarm64/2.7.0/sqlite-iosarm64-2.7.0": {
+   "klib": "sha256-43MTj678nkN/XhceYVTelSj6AjHiQNaIXbpQYJmvlZY="
+  },
+  "androidx/sqlite/sqlite-iossimulatorarm64/2.7.0/sqlite-iossimulatorarm64-2.7.0": {
+   "klib": "sha256-Xtm7uPfcM0uYNte8uY4dn2UtXwOGlAZPrp230r9JW0o="
   },
   "com/android#signflinger/9.3.1": {
    "jar": "sha256-fYISbJSDtUAXOmWwNU/ifwZ+yFyOZGdnlYc2QKBrKI0=",
@@ -627,6 +1127,20 @@
   }
  },
  "https://repo.maven.apache.org/maven2": {
+  "co/touchlab#stately-concurrency-iosarm64/2.1.0": {
+   "module": "sha256-pj+ggrL/5E6WHqh7IWlcDx5mnoPKi9udxLD1hHqVO7k=",
+   "pom": "sha256-GOUzK34ACxVKxv1lu6ENLz96ChLThgFl7s++38qxIJU="
+  },
+  "co/touchlab#stately-concurrency-iosarm64/2.1.0/metadata": {
+   "jar": "sha256-ZVLI8JoiYdZZuDrGxU+nTA312hphpwJPt033tdJEtvw="
+  },
+  "co/touchlab#stately-concurrency-iossimulatorarm64/2.1.0": {
+   "module": "sha256-h6BcPcNmIjApFkgwhk3WKTvcfeRGWuv+La5Xi9jCHaw=",
+   "pom": "sha256-Y3E01OvYCRBpx3ZOhd34qtkJ2AkFgc4ciu5jisVxPN8="
+  },
+  "co/touchlab#stately-concurrency-iossimulatorarm64/2.1.0/metadata": {
+   "jar": "sha256-ZVLI8JoiYdZZuDrGxU+nTA312hphpwJPt033tdJEtvw="
+  },
   "co/touchlab#stately-concurrency-jvm/2.1.0": {
    "jar": "sha256-hnOWdYkvscF9a9NtBTR+if8xOVdCG7AaRadDzndOjik=",
    "module": "sha256-D6llZC4JLY+zolZcFCgQBFrzO3twXmXE7XGoGKxrB8U=",
@@ -636,6 +1150,20 @@
    "jar": "sha256-F+cyIEDae75pvg1dhX3zVWZctlW1UIeVWRxrcM/qepA=",
    "module": "sha256-El5bZc1Vi4mhXnZF/6zCbBvMBuQdrw45XdMKcJKo2Xw=",
    "pom": "sha256-77jL8SXaldDjBfhpMKO0N5Ny3PtcWdnM6ZfN4M0yQVo="
+  },
+  "co/touchlab#stately-concurrent-collections-iosarm64/2.1.0": {
+   "module": "sha256-oqbB1Tppe46boRSvwz+nnmsg5fmFOrCCXX36BOfL6I0=",
+   "pom": "sha256-IHMuzrvvTLEGJNXQ+rPNCVhzUO0h5Vp5K7//uB9o5ss="
+  },
+  "co/touchlab#stately-concurrent-collections-iosarm64/2.1.0/metadata": {
+   "jar": "sha256-Os63HXH/GxNdpEn7D9uw15xac+0NSjcJ4vqEYSi8gvU="
+  },
+  "co/touchlab#stately-concurrent-collections-iossimulatorarm64/2.1.0": {
+   "module": "sha256-sqy1Z74AKDPI4jbz0INGmcyghAWyvIubA20QRotE1Us=",
+   "pom": "sha256-w09OdToA84yU2XsQDKvrUZVpqQ93Myoi9z5o85ds3fs="
+  },
+  "co/touchlab#stately-concurrent-collections-iossimulatorarm64/2.1.0/metadata": {
+   "jar": "sha256-Os63HXH/GxNdpEn7D9uw15xac+0NSjcJ4vqEYSi8gvU="
   },
   "co/touchlab#stately-concurrent-collections-jvm/2.1.0": {
    "jar": "sha256-Dg2efyDq7hj3hiMJBkyNtYzmo6hh2IcfVhVGr2PfGJM=",
@@ -647,6 +1175,20 @@
    "module": "sha256-25BCc0sQluadChT4YZXBx6t0FKGJEYXBpfSpNOjTfTk=",
    "pom": "sha256-Ja8IVdhWkxhR7HtHug/F4vSUthz0lpuHHveojfA0fjU="
   },
+  "co/touchlab#stately-strict-iosarm64/2.1.0": {
+   "module": "sha256-8UOjj43DzTJcUh82aMb3UuxN99vKlf/A4kJWhNubHN4=",
+   "pom": "sha256-80CheYAdvDwZ0/xiJNOnySnM+3NmfP2EujE5jtZDafY="
+  },
+  "co/touchlab#stately-strict-iosarm64/2.1.0/metadata": {
+   "jar": "sha256-+bB9/7uoqNWZrA/sYNwPzISrQds+NZh+ub4Q6OnrkR0="
+  },
+  "co/touchlab#stately-strict-iossimulatorarm64/2.1.0": {
+   "module": "sha256-HvYz59tOHPEu88DkMv3YAiaIBbb+M+0PSE1by2jplTw=",
+   "pom": "sha256-VhGaJG2F4fwijbx4TjMj7ld6FdxnVnykeHqKgbMbon4="
+  },
+  "co/touchlab#stately-strict-iossimulatorarm64/2.1.0/metadata": {
+   "jar": "sha256-+bB9/7uoqNWZrA/sYNwPzISrQds+NZh+ub4Q6OnrkR0="
+  },
   "co/touchlab#stately-strict-jvm/2.1.0": {
    "jar": "sha256-WBBw2ygCy62B9ubi2dJJSDVEMVOzFEWNU6pDxoJgyfo=",
    "module": "sha256-kqvZ5gAGmEz0eQqvhMedDzhChuMm7ODzkh9pPNoIm5Q=",
@@ -656,6 +1198,32 @@
    "jar": "sha256-0lwwD766GqrjWwuBcJkLTWK+/YNLLtg52BQZ2tQrDS0=",
    "module": "sha256-x5MXricP6pt1sugRZxQjoG+C+ogkTPlG/3lZhbTwtwE=",
    "pom": "sha256-FsSmQjGZoCtg7Q7PuzyvcImUdcO5ODT9Oyi4Bj6pb0A="
+  },
+  "co/touchlab/skie#co.touchlab.skie.gradle.plugin/0.10.14": {
+   "pom": "sha256-BAC5p54zeLQcQAPzV7n9vyJbrwgpA8cMMvxczwZg0iQ="
+  },
+  "co/touchlab/skie#gradle-plugin/0.10.14": {
+   "jar": "sha256-l+52vPv3CkmICDdmYfiMdrnFX4pf0jlRK9mXEln265E=",
+   "module": "sha256-teYlZTAUm8B5NxEm5xhf0qwDcktdHGA6sdnKAi3DWwc=",
+   "pom": "sha256-7ZKAbYPyJuVCX6l7NIj4SdtsSZsGh4JPHb0tHo1fhSU="
+  },
+  "co/touchlab/stately-concurrency-iosarm64/2.1.0/stately-concurrency-iosarm64-2.1.0": {
+   "klib": "sha256-EYYKsgPnNC7qBY/GSg2gA6H1T5oHWUe/9NfOB0+tvZ0="
+  },
+  "co/touchlab/stately-concurrency-iossimulatorarm64/2.1.0/stately-concurrency-iossimulatorarm64-2.1.0": {
+   "klib": "sha256-iVkZBuh9rx4MOa+CaEfsoXUTJYnyWL8EjDtaZMBNYlc="
+  },
+  "co/touchlab/stately-concurrent-collections-iosarm64/2.1.0/stately-concurrent-collections-iosarm64-2.1.0": {
+   "klib": "sha256-7D7ai7Cxr0gUrYKYopg8VWJdSyPaxAYi/FXg44q+j/8="
+  },
+  "co/touchlab/stately-concurrent-collections-iossimulatorarm64/2.1.0/stately-concurrent-collections-iossimulatorarm64-2.1.0": {
+   "klib": "sha256-640cNW8v/DepWl39T7vF0r9u/NQnvoqFZzCIpYOHIsg="
+  },
+  "co/touchlab/stately-strict-iosarm64/2.1.0/stately-strict-iosarm64-2.1.0": {
+   "klib": "sha256-marO91cQsYCIM9hlJVFY3HBiEUmdG0uyQF2pqomppbM="
+  },
+  "co/touchlab/stately-strict-iossimulatorarm64/2.1.0/stately-strict-iossimulatorarm64-2.1.0": {
+   "klib": "sha256-2USeNscDt8ZLEdmUXN2JnRpenDNOXhojdvScu2Y89e8="
   },
   "com/diffplug/durian#durian-collect/1.2.0": {
    "jar": "sha256-sZTAuIAhzBFsIcHcdvScLB/hda9by3TIume527+aSMw=",
@@ -689,6 +1257,20 @@
    "module": "sha256-Rdxah2UCG19mXf3ilysGO5Zgt0tySYdVqUVDQ0PYAOc=",
    "pom": "sha256-PNYQSZvqWU/zcOUC/g/oAAWXUNpyrGTsPlBnkM0hE0s="
   },
+  "com/fleeksoft/charset#charset-iosarm64/0.0.8": {
+   "module": "sha256-V8Uy9SUZRBEusEMLoGUv6CXHix6R9/eIWjeePvAhVpg=",
+   "pom": "sha256-SeKc4hHrZ9HCv+Pew0qEVlOUdgcXKbD3lMnKX/Oa6Y4="
+  },
+  "com/fleeksoft/charset#charset-iosarm64/0.0.8/metadata": {
+   "jar": "sha256-/jEVmRNRfTFDfFIYZjIJpGrZpa1YG8OIuCt8OYDx78o="
+  },
+  "com/fleeksoft/charset#charset-iossimulatorarm64/0.0.8": {
+   "module": "sha256-YP7y4Sul80pAFTH1Be7G1GZeEmHAsEy7mPoKHgBiqQI=",
+   "pom": "sha256-jSK6EdyvMZIlxC7VvM9bll+bhbRZL+hs4uGCGwCcM0o="
+  },
+  "com/fleeksoft/charset#charset-iossimulatorarm64/0.0.8/metadata": {
+   "jar": "sha256-/jEVmRNRfTFDfFIYZjIJpGrZpa1YG8OIuCt8OYDx78o="
+  },
   "com/fleeksoft/charset#charset-jvm/0.0.8": {
    "jar": "sha256-DjFsMXYnKAwlM3LhwrxfA3CZLzz6omt2bu11ckOdnjs=",
    "module": "sha256-9i20LIj9tSTD5kwEOX+fGTUmm/PL4+6y+2jUqwkBZqA=",
@@ -698,6 +1280,26 @@
    "jar": "sha256-CQSi/fWRkpxCpAm/xINAW/+nhPADaSQpSRK1P4L/BR4=",
    "module": "sha256-BctI/4gT7/nXO1/GGBOzn0bxHUe6SguS3jP8uxuaHrQ=",
    "pom": "sha256-ZtrxjFkKK8wqHQtaxgKxu8drkY0ff0wq+MsBDYbjCXw="
+  },
+  "com/fleeksoft/charset/charset-iosarm64/0.0.8/charset-iosarm64-0.0.8": {
+   "klib": "sha256-K2G1k75ais7wd6Vpxn3cogn5iOcoQfseD0c83gI+rq4="
+  },
+  "com/fleeksoft/charset/charset-iossimulatorarm64/0.0.8/charset-iossimulatorarm64-0.0.8": {
+   "klib": "sha256-4RMXhOmvVtTYS0IbMCCB++DVi+1YnlY3wIeXkv/eMhI="
+  },
+  "com/fleeksoft/io#io-core-iosarm64/0.0.8": {
+   "module": "sha256-uievk0cArIFZaao646yBrCdQTzBOspMvHrgoSylQgRE=",
+   "pom": "sha256-l8mIy67rI9s9TNp9MSo4YevfE3vN8zpslVpZr+vtpLY="
+  },
+  "com/fleeksoft/io#io-core-iosarm64/0.0.8/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "com/fleeksoft/io#io-core-iossimulatorarm64/0.0.8": {
+   "module": "sha256-Uu9sJtSB6aYmTdmGIiJx1YVCDHbBAzTDeJUJmqXWMu4=",
+   "pom": "sha256-yFVvu6Z+HAp4jZpAG80xewui1Q3x8uiXMCnpuljxdeI="
+  },
+  "com/fleeksoft/io#io-core-iossimulatorarm64/0.0.8/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "com/fleeksoft/io#io-core-jvm/0.0.8": {
    "jar": "sha256-wwkRVe46zY/zqCdOUrrw+OIAy60v1EChIZQ7/Ot9wfA=",
@@ -709,6 +1311,26 @@
    "module": "sha256-2uzcEgkgBt56v/FNAQzYFKpySKaXo/+wPH+6DL8saQw=",
    "pom": "sha256-cw0yymVrHyhWMxvIWolvdss5HwRcqfIODsaqF1wvrng="
   },
+  "com/fleeksoft/io/io-core-iosarm64/0.0.8/io-core-iosarm64-0.0.8": {
+   "klib": "sha256-N6lX6TofYvhFU+ZtC7uxjoHDqB0+eUlvPkl0v/5l4GA="
+  },
+  "com/fleeksoft/io/io-core-iossimulatorarm64/0.0.8/io-core-iossimulatorarm64-0.0.8": {
+   "klib": "sha256-yxyEZOXDjN7/gCMN30KakTDB5ECfT3Ne32bIwNn6g0U="
+  },
+  "com/fleeksoft/ksoup#ksoup-iosarm64/0.2.6": {
+   "module": "sha256-U7BspL0Ci1DQbVaIgGgQqLNdqNC93NGIIxJwyGkOh2o=",
+   "pom": "sha256-yHlH54n0DPWguMb/zMNme7dD5LlcKqT9xtIrR+/CLag="
+  },
+  "com/fleeksoft/ksoup#ksoup-iosarm64/0.2.6/metadata": {
+   "jar": "sha256-UoefCI1L5pjxxdikfYXjGVrlQjS6R+MBjZ+65LBU97g="
+  },
+  "com/fleeksoft/ksoup#ksoup-iossimulatorarm64/0.2.6": {
+   "module": "sha256-eMnQ7tlXnqPVj75sJ07OXKIBh2MtMJ1OGVxUdoySrJA=",
+   "pom": "sha256-Mrdwq79D9h7IK4ncGotr+LQTtSs/qzrOk77EFKyiK70="
+  },
+  "com/fleeksoft/ksoup#ksoup-iossimulatorarm64/0.2.6/metadata": {
+   "jar": "sha256-UoefCI1L5pjxxdikfYXjGVrlQjS6R+MBjZ+65LBU97g="
+  },
   "com/fleeksoft/ksoup#ksoup-jvm/0.2.6": {
    "jar": "sha256-7JwgvAjQyygpOjhYDG+xB1IbT9t4HBJRo/3Qp+j/H5I=",
    "module": "sha256-sLQl0vPgV10TFb8QdL3PJlSc/Aj36ywt74b8/zuoMs4=",
@@ -719,6 +1341,12 @@
    "module": "sha256-a4QhI9Qsaw2Iw4g23300o/GnSOw4qpq+XBLt5wMuE2U=",
    "pom": "sha256-1hEN6wWTTmObAcSRknUReqQRs1SWqwkt8pS7XUEQZi0="
   },
+  "com/fleeksoft/ksoup/ksoup-iosarm64/0.2.6/ksoup-iosarm64-0.2.6": {
+   "klib": "sha256-9o1yMKFC66atpUWDQ8yG64ZuKnDe6Yxl/zboR1bi7x4="
+  },
+  "com/fleeksoft/ksoup/ksoup-iossimulatorarm64/0.2.6/ksoup-iossimulatorarm64-0.2.6": {
+   "klib": "sha256-6zpokg5GBt0lhAdWwrKW+Q7lkHHfFI2okEru7GDYxEI="
+  },
   "com/github/ajalt/colormath#colormath-jvm/3.6.1": {
    "jar": "sha256-oYU+5KX+xjbbu4xElVt6MBXwLOj5z6HCNQeRwsLTY5w=",
    "module": "sha256-fHKvGnzj4EFMhBqBgWvDwVpy6X9lKMwHqp+lSFCHpYc=",
@@ -728,6 +1356,11 @@
    "jar": "sha256-vPPH5lLCbSLhEkcZR4Kf7kzJniocnihPgmaTv0Y3mHs=",
    "module": "sha256-xA0F1dTNksc2qxDVkR6HjjsIqBRa76mjy20/VUPM8Bc=",
    "pom": "sha256-uBYdwuDrGNPXm8koHtFxA3IcwcEvFYo1QydbqSlw/jg="
+  },
+  "com/github/ben-manes/caffeine#caffeine/2.9.3": {
+   "jar": "sha256-Hgp7vvHdeRZTFD8/BdDkiZNL9UgeWKh8nmGc1Gtocps=",
+   "module": "sha256-J9/TStZlaZDTxzF2NEsJkfLIJwn6swcJs93qj6MAMHA=",
+   "pom": "sha256-b6TxwQGSgG+O8FtdS+e9n1zli4dvZDZNTpDD/AkjI9w="
   },
   "com/github/gmazzo/buildconfig#com.github.gmazzo.buildconfig.gradle.plugin/6.0.10": {
    "pom": "sha256-I5A00EDL/0CQI8ttooMC81xSHsB1vxb4fR8NII7Yehk="
@@ -763,6 +1396,20 @@
    "module": "sha256-ztzCawdSlA2wxv6X/bNrBGGRE+V1jD+THU5gAh6J6UE=",
    "pom": "sha256-AGS/hZXe/oEWbgiGREfXwUeMJV0eClKNWoX2XqEsFmo="
   },
+  "com/github/skydoves#landscapist-coil3-iosarm64/2.11.0": {
+   "module": "sha256-DTupVUUvhhkjind70kET0UqtlH2uJ/QAVvJuAu9ABBo=",
+   "pom": "sha256-npHL9Sb1ryx7yPE96oL0UTE4uz0ekfgPb2RBKNF0rYE="
+  },
+  "com/github/skydoves#landscapist-coil3-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "com/github/skydoves#landscapist-coil3-iossimulatorarm64/2.11.0": {
+   "module": "sha256-ipQcJdti0GwpWNKlOFqJJxb1FJ0Jd+KE6WIDzhi9Srs=",
+   "pom": "sha256-ervi73uzU2ySTFVBWwPN1IWGYoI9njOzv2UC/XocOWo="
+  },
+  "com/github/skydoves#landscapist-coil3-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "com/github/skydoves#landscapist-coil3/2.11.0": {
    "jar": "sha256-RLF99DfKWNsSOPs/m/imNytZ5cSPwF1uP2Szb7zKpYY=",
    "module": "sha256-OER6Aeua9RSeTJTeUvDWuKv+4Ja4/LKNUrpROZ8raiE=",
@@ -772,6 +1419,20 @@
    "jar": "sha256-K9PhyHaUKby/7wyOQHptv/QnzJXIYEGeW61Esc13k84=",
    "module": "sha256-wCoZIpBTtI50j4FJEb4sS8DmLYnk8ecIxP2QGDnCXTY=",
    "pom": "sha256-ZYRd3s8oMAx8YBc40F7yW9oErvJxTJir8Uu+5SgsAzc="
+  },
+  "com/github/skydoves#landscapist-iosarm64/2.11.0": {
+   "module": "sha256-0sVJMzfj1QrbEdSfjaZcDSwZJAp99tmmxf+YfAQEjz0=",
+   "pom": "sha256-oPRnbwGM0fpH4lW65Wq9QxzbyAJnxscAUVk5VFGM86Y="
+  },
+  "com/github/skydoves#landscapist-iosarm64/2.11.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "com/github/skydoves#landscapist-iossimulatorarm64/2.11.0": {
+   "module": "sha256-9DqMBeKj4WnpsR5pE4vepn7FitLIqjAeWrGOSzc8Flg=",
+   "pom": "sha256-q498Yb8jRLkIgCfuI+ToMLn1yBapOULbOq7mtvUsNsw="
+  },
+  "com/github/skydoves#landscapist-iossimulatorarm64/2.11.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "com/github/skydoves#landscapist-placeholder-desktop/2.11.0": {
    "jar": "sha256-hAAzZaOHQqFEsos/ebOar7hnathZchlcz/FatGMuSoQ=",
@@ -787,6 +1448,18 @@
    "jar": "sha256-c8pLSVOGR9+/uUgRSjR5PHYQRTROHk3bUkaomm21H0w=",
    "module": "sha256-LJS+exXYoENGKEQEwN10NdEL5bqTPEAl29og4KLN8dM=",
    "pom": "sha256-rDBwjv2f2OwYzs42Lk9vJVR0hwOVdHZRZNghrtmq5qs="
+  },
+  "com/github/skydoves/landscapist-coil3-iosarm64/2.11.0/landscapist-coil3-iosarm64-2.11.0": {
+   "klib": "sha256-CsCrtTTmR2u7cf7hIeqIKljgJOc1Ouy3tVy54a3zLgI="
+  },
+  "com/github/skydoves/landscapist-coil3-iossimulatorarm64/2.11.0/landscapist-coil3-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-1vwUar4q7rv/ZyqJk4/q+kewx/9Hovn0nJ+MuI9tVBE="
+  },
+  "com/github/skydoves/landscapist-iosarm64/2.11.0/landscapist-iosarm64-2.11.0": {
+   "klib": "sha256-9jDrPpUe2/r8DXGNyNqPdeHhuMH8zcoZBSZFhkMl4Gg="
+  },
+  "com/github/skydoves/landscapist-iossimulatorarm64/2.11.0/landscapist-iossimulatorarm64-2.11.0": {
+   "klib": "sha256-Foppiez5XE9/RoInRh8wIR3kjpdUA4WJWnBc34hdQ3M="
   },
   "com/google/auto#auto-common/1.2.1": {
    "jar": "sha256-9D8p/ipuuvBLJZjN7sMqTjRtSalATpkPX8GcGfOijQ4=",
@@ -868,6 +1541,10 @@
   "com/google/errorprone#error_prone_annotations/2.27.0": {
    "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
   },
+  "com/google/errorprone#error_prone_annotations/2.28.0": {
+   "jar": "sha256-8/yKOgpAIHBqNzsA5/V8JRLdJtH4PSjH04do+GgrIx4=",
+   "pom": "sha256-DOkJ8TpWgUhHbl7iAPOA+Yx1ugiXGq8V2ylet3WY7zo="
+  },
   "com/google/errorprone#error_prone_annotations/2.3.1": {
    "pom": "sha256-PtzmtxG6No7+Frm3qssCFPvWSEFMublllTouftiagZo="
   },
@@ -883,6 +1560,9 @@
   },
   "com/google/errorprone#error_prone_parent/2.27.0": {
    "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
+  },
+  "com/google/errorprone#error_prone_parent/2.28.0": {
+   "pom": "sha256-rM79u1QWzvX80t3DfbTx/LNKIZPMGlXf5ZcKExs+doM="
   },
   "com/google/errorprone#error_prone_parent/2.3.1": {
    "pom": "sha256-dnUl2agRKc0IGWg4KYAzYye+QWKx4iUaGCkR2qczwSM="
@@ -965,6 +1645,20 @@
    "jar": "sha256-+KsTsUvggP4vYX+Q5VWZdg5KG03u6lxZXfY9DWN17W0=",
    "pom": "sha256-+vgt4NwC4MCuMnzWU/NyVUlrLlP84oCzq0yzRVOokIY="
   },
+  "com/kmpalette#androidx-palette-iosarm64/3.1.0": {
+   "module": "sha256-3DZnbdWllSDN9ggah22l+e/4CWuv6BWKLd/iehukNnI=",
+   "pom": "sha256-LUgyNW0Dc+lLxi4eyIHSE32ZA7J3hTTbO9MLg5lU578="
+  },
+  "com/kmpalette#androidx-palette-iosarm64/3.1.0/metadata": {
+   "jar": "sha256-rI5ayHu55mHi6fLi0TVC7JKyL0gnj7tIeCLVfgHr3N0="
+  },
+  "com/kmpalette#androidx-palette-iossimulatorarm64/3.1.0": {
+   "module": "sha256-17B07J8yDX6e8fbrEwQVcl089VPJFNMJB2p6tuIX+W8=",
+   "pom": "sha256-MuGKtciF9XI67xLOAJe/qkHjvGFzAwu5kQFjFy9oGKs="
+  },
+  "com/kmpalette#androidx-palette-iossimulatorarm64/3.1.0/metadata": {
+   "jar": "sha256-srC1qycatOWSINgUKsWOiWKvdbobsS15xwG5frZWpSM="
+  },
   "com/kmpalette#androidx-palette-jvm/3.1.0": {
    "jar": "sha256-OI2XHGyXupG9nSKNQOqX+tSsM3Cjq9t6oHYGufbWvlU=",
    "module": "sha256-s+Ys3uraSetYHl9qZoOj3PL2jyHgrQGtJbeBszGCmFs=",
@@ -974,6 +1668,20 @@
    "jar": "sha256-P5kEuSIfKp3IleDhNPWzOx8Wt7txZNj/vcKs140BXnk=",
    "module": "sha256-hN35LHWt43oH/V711b6Q8u2L82DUbEDsvpW4YI/SdcQ=",
    "pom": "sha256-6OeMj1knpnjSYm5v81uRo1h/0R2w4SKB+axJH4Z2Sls="
+  },
+  "com/kmpalette#kmpalette-bitmap-loader-iosarm64/3.1.0": {
+   "module": "sha256-Me93vjp/lOLgNXCCHPV5A0BoXGkx9icJSkdR5Ln+D5k=",
+   "pom": "sha256-AbL/+h93+EBsg21R1zcW6wQU00cd6EVmwE4LvuFbawg="
+  },
+  "com/kmpalette#kmpalette-bitmap-loader-iosarm64/3.1.0/metadata": {
+   "jar": "sha256-kUVKWdp0/b/UWHqKEWGxGOfhuygIqD38wnmlo1IhB1c="
+  },
+  "com/kmpalette#kmpalette-bitmap-loader-iossimulatorarm64/3.1.0": {
+   "module": "sha256-UuJJwvk+2X+zycLkxoCGOX101MkyBDeHPTxJre8MJDM=",
+   "pom": "sha256-WdHzMNiD7A64aGPQDCH/xztDIWW/nJDBoVITz0me6iw="
+  },
+  "com/kmpalette#kmpalette-bitmap-loader-iossimulatorarm64/3.1.0/metadata": {
+   "jar": "sha256-kUVKWdp0/b/UWHqKEWGxGOfhuygIqD38wnmlo1IhB1c="
   },
   "com/kmpalette#kmpalette-bitmap-loader-jvm/3.1.0": {
    "jar": "sha256-tE46bTMag0ML/dqv/8qoUEpZYcUBTBR3yf54J7U18sQ=",
@@ -985,6 +1693,20 @@
    "module": "sha256-3Uam5Z74nLo61J7Qi5HFGXNywJHq7gp8juAwaneezFs=",
    "pom": "sha256-rU3lO8453sS2wPYGHpPi/icZ645pz8oeFvy1g0T2uiw="
   },
+  "com/kmpalette#kmpalette-core-iosarm64/3.1.0": {
+   "module": "sha256-N7j9fl00po26ZKmaZRJnguXwO1jL+z5jiMqeZGgWarM=",
+   "pom": "sha256-P2HwWvPljp+POTMZYgbnwLFxllQzJZf5Lh1efCM1whE="
+  },
+  "com/kmpalette#kmpalette-core-iosarm64/3.1.0/metadata": {
+   "jar": "sha256-E41dQ/810A8+fpgsTK4mcSizPzjQt+WeBaXDd/28Hlk="
+  },
+  "com/kmpalette#kmpalette-core-iossimulatorarm64/3.1.0": {
+   "module": "sha256-RMLm7Z7pc1pu8euqyDT1HKTohPFhYgGoFel+i9OtDX8=",
+   "pom": "sha256-jr0nvai5P3Qc3tzEwkJrDdLyZpLfOLo3mVMj0mqTsb4="
+  },
+  "com/kmpalette#kmpalette-core-iossimulatorarm64/3.1.0/metadata": {
+   "jar": "sha256-E41dQ/810A8+fpgsTK4mcSizPzjQt+WeBaXDd/28Hlk="
+  },
   "com/kmpalette#kmpalette-core-jvm/3.1.0": {
    "jar": "sha256-qRg2Lwt190/di8vHRKqcgYkukASuV51YTGTVfumGTlg=",
    "module": "sha256-coGYza+LU47G9B1xZf30PX1ODaNIBMkpJ53QzFjrf8Y=",
@@ -994,6 +1716,24 @@
    "jar": "sha256-ww2oeSFtXBy6tvZTPe0aQCJTAdongm200JY99/uSdJc=",
    "module": "sha256-KoatDNSHDfLjlByjU58eVYVw1XUdfJyWZp+Nd/o7QX4=",
    "pom": "sha256-ScnYZxglKZYtjdiZpC4WR2xn7R1tLAYcV7iUD6sN7sk="
+  },
+  "com/kmpalette/androidx-palette-iosarm64/3.1.0/androidx-palette-iosarm64-3.1.0": {
+   "klib": "sha256-GjmMVMsIqnZi1ZDtVcK6VcOB05SAj9g+fCb/MijEWLg="
+  },
+  "com/kmpalette/androidx-palette-iossimulatorarm64/3.1.0/androidx-palette-iossimulatorarm64-3.1.0": {
+   "klib": "sha256-YL6SGPi4A4jQ/nmWc/aF4Uyuj/c4QX7CDZUKeHZAAUA="
+  },
+  "com/kmpalette/kmpalette-bitmap-loader-iosarm64/3.1.0/kmpalette-bitmap-loader-iosarm64-3.1.0": {
+   "klib": "sha256-u+cryjtb1+1LAroTNn2rBc3xLWIXiA/NtGXR+GxrAMc="
+  },
+  "com/kmpalette/kmpalette-bitmap-loader-iossimulatorarm64/3.1.0/kmpalette-bitmap-loader-iossimulatorarm64-3.1.0": {
+   "klib": "sha256-pGy4L7O78aXSCUzWwLOomJYNcLgo3Tg0AcHgMpNVgS8="
+  },
+  "com/kmpalette/kmpalette-core-iosarm64/3.1.0/kmpalette-core-iosarm64-3.1.0": {
+   "klib": "sha256-rHnb4UH7et3NAdP/rp45TYrHZ+swebT8bd5dTy/BszY="
+  },
+  "com/kmpalette/kmpalette-core-iossimulatorarm64/3.1.0/kmpalette-core-iossimulatorarm64-3.1.0": {
+   "klib": "sha256-An1SLVfVgJAFRKimIk9H5nOsF4bZH47oPMVR4u8oJPg="
   },
   "com/materialkolor#material-color-utilities-jvm/5.0.0": {
    "jar": "sha256-qZeui8vd3FuuygHGTQP41QFKGGrj86f5POmrvuk8f5o=",
@@ -1015,6 +1755,20 @@
    "module": "sha256-d89sODWNf+8BRKrKSNMD4c+M/8GgRESFfow3jhTC5zQ=",
    "pom": "sha256-dfrRWq97S6GiyFuUgBzSVpMe0R3e92Dx+rOwVbQi0ys="
   },
+  "com/soywiz/korlibs/kds#kds-iosarm64/4.0.10": {
+   "module": "sha256-XdzlG3DSu6IgFcfPbtnY3SXHrvHdOaU6LMFxRUnBaS8=",
+   "pom": "sha256-HkIkgHRXme56dYOeqAcoQ+lzEXLiGA5Ip2LCEmjoBzA="
+  },
+  "com/soywiz/korlibs/kds#kds-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-JtLKCyCDKJxKTBlyFnrZT/08hXdbgo5bB1GxHZ80KUk="
+  },
+  "com/soywiz/korlibs/kds#kds-iossimulatorarm64/4.0.10": {
+   "module": "sha256-jKcCUoQszx27YO2GheHkqd1lgSmamXQ5aK+/HTW19OY=",
+   "pom": "sha256-3YGGYM4ius21gHfs//Hq/YFgMHeZD+P1VRmk92nVdQ8="
+  },
+  "com/soywiz/korlibs/kds#kds-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-2emE80ZLKx/fkUw6a6HskBWuGCMOJk3oi/KZKl2O03k="
+  },
   "com/soywiz/korlibs/kds#kds-jvm/4.0.10": {
    "jar": "sha256-n/x+M9vLUBWCx3YpYQ7kAtGA54NX/ZmNgdx3ZEZvXRw=",
    "module": "sha256-pg6CLYJCjuZIeKpdVJwFo2B9gjnI5aa6JZ05ip8+mrE=",
@@ -1024,6 +1778,26 @@
    "jar": "sha256-CghDJ++W0n+trYHPQNYsrmFVjrM0P+TyGSdXcWTtbks=",
    "module": "sha256-BY5XdgGq2aPA+tMSvU+UX+XQyMDsoj7xL9AQYgMrTLw=",
    "pom": "sha256-sXyQHdWt6QW+8xFBzwOTcereY5Xcd4i4Gwb0K64WV+Y="
+  },
+  "com/soywiz/korlibs/kds/kds-iosarm64/4.0.10/kds-iosarm64-4.0.10": {
+   "klib": "sha256-s5p6PVhQvxwNF1cgGZv4j75cJkqZuU2XIxZUymkgYAQ="
+  },
+  "com/soywiz/korlibs/kds/kds-iossimulatorarm64/4.0.10/kds-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-rWJasHCY3f1dW1HCYJ8lWDOfOpgvLUNXX4GhiwzZcIg="
+  },
+  "com/soywiz/korlibs/klock#klock-iosarm64/4.0.10": {
+   "module": "sha256-f6v4tI0SY1LMt5Duo3r8oZASy2mO5lT8Ty7wUWll4jc=",
+   "pom": "sha256-qwEALTaHFKK6YScdlatB6AXLSiFxQlypwXvzyC88N4s="
+  },
+  "com/soywiz/korlibs/klock#klock-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-OH/hJMA3oERKoAORc6P6KYJk4n5CdAonJkdKjx0T2Us="
+  },
+  "com/soywiz/korlibs/klock#klock-iossimulatorarm64/4.0.10": {
+   "module": "sha256-rtxHeEkxeqsukSCidcUyPIVbR0NeXmS6n/UHytWcUCU=",
+   "pom": "sha256-tt80gK07cuJnwDnvQcNRrINNlo8GNZXrhwv0kPEJ1wI="
+  },
+  "com/soywiz/korlibs/klock#klock-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-f66LSSwQk+PPgElPil7TMRrp8F4tuCB7/DRuInQaCwY="
   },
   "com/soywiz/korlibs/klock#klock-jvm/4.0.10": {
    "jar": "sha256-jKemrXVmuztGmvlZEH3uqXfHmSTvL5yTq/jbIFBcjtA=",
@@ -1035,6 +1809,26 @@
    "module": "sha256-yu5BSm2slY6/N6kJKMkN6pumindYOQgcjRaEfW4msB8=",
    "pom": "sha256-gkAl96IkZ8XdyWav7hR3Eky6iShr0SnDygoqAeZ4r3c="
   },
+  "com/soywiz/korlibs/klock/klock-iosarm64/4.0.10/klock-iosarm64-4.0.10": {
+   "klib": "sha256-G1JP8BLlwAI1HBtUsMc/Toj/aNqF6CjFIehyjJ5DMUY="
+  },
+  "com/soywiz/korlibs/klock/klock-iossimulatorarm64/4.0.10/klock-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-h7mGqdDar6wfjc1byDUEqF6mANJ1REEBpF+fsB1ZszM="
+  },
+  "com/soywiz/korlibs/klogger#klogger-iosarm64/4.0.10": {
+   "module": "sha256-RWObIwVGgvfNdfdIh1YpYbiI0qBHZMZTyR8v/XtJFpE=",
+   "pom": "sha256-7Bq5QVVcx6DLBBMpEsyrhhwPuQsLruSNAVrgcoWOvlA="
+  },
+  "com/soywiz/korlibs/klogger#klogger-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-x7mhB/BHjvRGljWDxEO39xPreQjMLcteJIyDxxAGzKM="
+  },
+  "com/soywiz/korlibs/klogger#klogger-iossimulatorarm64/4.0.10": {
+   "module": "sha256-A27u3xPWrNpgwMvH/J8OEwOe52f/NnhjLneTj7qbmxk=",
+   "pom": "sha256-Bkh/Df77LpPNpa4iQb66Ad40rZrYLNXtWBYkIjK7h4w="
+  },
+  "com/soywiz/korlibs/klogger#klogger-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-BjJwst/k9UOiGoRaXLN++R084iHsijjwRwiKsHpy3gA="
+  },
   "com/soywiz/korlibs/klogger#klogger-jvm/4.0.10": {
    "jar": "sha256-JdRjXCKuQoAIWwPHTgk2wCfQ1A2mEJCJkvt8+zRyZKw=",
    "module": "sha256-4fwTUII025cJrbAdc76FVUbjk3inp3dohCeq9YgsgIk=",
@@ -1044,6 +1838,26 @@
    "jar": "sha256-vVWTOtlCbnXt5ITvV2KQ14pGpuSxgMX7LLuk6aq8wxw=",
    "module": "sha256-F6WbOcjc5J3Ty7V5S+mPCPMqMZ5mFHxf/f3/4+kR/Dw=",
    "pom": "sha256-p8/xa2eyxPIuNWSTIgcWVYe6OeCAUQ80m8R6DbB5EFQ="
+  },
+  "com/soywiz/korlibs/klogger/klogger-iosarm64/4.0.10/klogger-iosarm64-4.0.10": {
+   "klib": "sha256-QdDYTFMydoD+aPNCgnMM4A+sqT5Uf6mSCVELbd+OO3Q="
+  },
+  "com/soywiz/korlibs/klogger/klogger-iossimulatorarm64/4.0.10/klogger-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-8wBcCfUyJ/N5fK2mr0FWG/dMV92dkrMBbiS7r0xZidA="
+  },
+  "com/soywiz/korlibs/kmem#kmem-iosarm64/4.0.10": {
+   "module": "sha256-sqvt6FTVQK7XZpV/SHW6f9WwrVW9t2Lm385FrprkJKY=",
+   "pom": "sha256-GXEM6o7EDPL8HaEY92MuyoND9GW6QgmdMwkOwozJSqQ="
+  },
+  "com/soywiz/korlibs/kmem#kmem-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-76ZxE9IBc2kAbooeeXCEzkEhp2v93njJAGmuPgBBIHk="
+  },
+  "com/soywiz/korlibs/kmem#kmem-iossimulatorarm64/4.0.10": {
+   "module": "sha256-kPwFSZEEV9dhTDbr7kFeG7MEnx7HzVIHJn0z7Mrn+KQ=",
+   "pom": "sha256-zehf+qCoP3seUKtFXkSuoMsZgCy20Lh9HpwSFKKLZRw="
+  },
+  "com/soywiz/korlibs/kmem#kmem-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-0easuXgi2/8EeasKX3EUSWVI2cwtOAXJ3sbT7LVLFIE="
   },
   "com/soywiz/korlibs/kmem#kmem-jvm/4.0.10": {
    "jar": "sha256-HcGsk9ObjlXomHGuyedFI5h3/vUevsBDIF8GfXdEtWY=",
@@ -1055,6 +1869,26 @@
    "module": "sha256-DcnTovL1blWZWIk2bVVL3LdL5ZfFL7IP7KTY/Xd6ZII=",
    "pom": "sha256-zg8pae7z1yAUjFYOj2TdZAreXhauJbiT8lGIliMAuVo="
   },
+  "com/soywiz/korlibs/kmem/kmem-iosarm64/4.0.10/kmem-iosarm64-4.0.10": {
+   "klib": "sha256-nfl2HAxtWwxxPBMU/4exm/kCQm6n3czE9wtRQlRKlHM="
+  },
+  "com/soywiz/korlibs/kmem/kmem-iossimulatorarm64/4.0.10/kmem-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-Rr579waUjS3CbmvNeW9bFD8LpoEGZXpSQwzhWokLsds="
+  },
+  "com/soywiz/korlibs/korcoutines#korcoutines-iosarm64/4.0.10": {
+   "module": "sha256-cKKINYPXwkCA/8bpQPaDqvtpfx9mcok8ESunYr1OHtU=",
+   "pom": "sha256-COD57rZkZCJ012xc1uwp1JazYn864k+KOfiq+HRJUrQ="
+  },
+  "com/soywiz/korlibs/korcoutines#korcoutines-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-3hhoezofEy9aodJuhrwNTW7O7kM7OocJqzWqE53JGUc="
+  },
+  "com/soywiz/korlibs/korcoutines#korcoutines-iossimulatorarm64/4.0.10": {
+   "module": "sha256-qwtRRPHprtklYJJ4JZbqPzo70QLGUgmLXQnrBE0OdUI=",
+   "pom": "sha256-bA3FHFie2yQ8d1IJJ0nUS223KD24L8n2W1ihgdLfsOA="
+  },
+  "com/soywiz/korlibs/korcoutines#korcoutines-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-3hhoezofEy9aodJuhrwNTW7O7kM7OocJqzWqE53JGUc="
+  },
   "com/soywiz/korlibs/korcoutines#korcoutines-jvm/4.0.10": {
    "jar": "sha256-tDR6oe/w3oXfM+3NewYeG1pC0TWokc8mLc0Oc2hjMVE=",
    "module": "sha256-VfjB2LohvRxCB0EIvOR0HZpl5rGGbft+4NMGMgz5fEo=",
@@ -1064,6 +1898,26 @@
    "jar": "sha256-UZhQJBBydVUDuqZwik3Sxi2GUy5kTu3Pkdjfp7KoVP4=",
    "module": "sha256-+19P5Jlr0hOzeUbfqt9K3eEvfM7Eq6SiTMNNfLkVSUk=",
    "pom": "sha256-T8sSEIHKoOXsXZmstj6UQ+iIaVjUNN8eWCx/OxXZYmM="
+  },
+  "com/soywiz/korlibs/korcoutines/korcoutines-iosarm64/4.0.10/korcoutines-iosarm64-4.0.10": {
+   "klib": "sha256-Nlq2n6e8pbolecTfvja8O/utSmyfhjbpvnRN1GuC7tE="
+  },
+  "com/soywiz/korlibs/korcoutines/korcoutines-iossimulatorarm64/4.0.10/korcoutines-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-jkR9Z+CEZfR6TTUWdPCyy85QnTwUgVV8qhZ9rbclnwA="
+  },
+  "com/soywiz/korlibs/korim#korim-iosarm64/4.0.10": {
+   "module": "sha256-GchZGVOcdRU2jrhOj5fVp5WCfMrUbHbUrfSHo5lOxAc=",
+   "pom": "sha256-Ei8+uBT4ynqdtYyCKo+2yukM+rG30tDwIkNgNf/HucQ="
+  },
+  "com/soywiz/korlibs/korim#korim-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-9g1nqVWQqTlmggxqHO74Vp3IRZJW8acUemAlH6/ELxc="
+  },
+  "com/soywiz/korlibs/korim#korim-iossimulatorarm64/4.0.10": {
+   "module": "sha256-mhlCw1YtB8T04bjkfyJKxGM9BWauchQKo0tfFvvgxR4=",
+   "pom": "sha256-POVZDIe1dZiEWpOEIqRsi4bn3Cz8ZRJLbPJmKOW3aCM="
+  },
+  "com/soywiz/korlibs/korim#korim-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-9g1nqVWQqTlmggxqHO74Vp3IRZJW8acUemAlH6/ELxc="
   },
   "com/soywiz/korlibs/korim#korim-jvm/4.0.10": {
    "jar": "sha256-4gplxxjVLNXcsYl3tqpTUaDBlNaEnTUKBUXALEDYYLI=",
@@ -1075,6 +1929,32 @@
    "module": "sha256-w1nT1+0soXCH16W7tz0/Gj2WVvkugmx34ARWaIPapvs=",
    "pom": "sha256-+A4Ay7WoXkBCtu62uFlp33KEwq/3IeE3WvjwDawdKfM="
   },
+  "com/soywiz/korlibs/korim/korim-iosarm64/4.0.10/korim-iosarm64-4.0.10": {
+   "klib": "sha256-MxhPQGZgzXoglUQ6BOqh10UC0Qwtw1j/Mi5R7pm9LUk="
+  },
+  "com/soywiz/korlibs/korim/korim-iosarm64/4.0.10/korim-iosarm64-4.0.10-cinterop-stb_image": {
+   "klib": "sha256-B8xStNxhou44EWl7ry7D4EO0cTYhx6u9/xgIdU5KEFY="
+  },
+  "com/soywiz/korlibs/korim/korim-iossimulatorarm64/4.0.10/korim-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-h9spjWub2D9sFhff7GjQ5Hhn/juXkLM4UltYFQJ1MFk="
+  },
+  "com/soywiz/korlibs/korim/korim-iossimulatorarm64/4.0.10/korim-iossimulatorarm64-4.0.10-cinterop-stb_image": {
+   "klib": "sha256-v0IMl4WAuxqwD9joMIyY8GlK5d+Sj4mPHLEWBTlv0jk="
+  },
+  "com/soywiz/korlibs/korio#korio-iosarm64/4.0.10": {
+   "module": "sha256-gOG4pda/UtHEW/iFNfrV9767pV/hqhtnmRZ3eY++uTM=",
+   "pom": "sha256-JFojeGvS4I1pzNKkY1iFwTXLxEYjNQtGEGN6OUMpZkI="
+  },
+  "com/soywiz/korlibs/korio#korio-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-8D4pTKCT2ZNyUUrf70fFQiwp457LqDN8hdMt/QFxTs4="
+  },
+  "com/soywiz/korlibs/korio#korio-iossimulatorarm64/4.0.10": {
+   "module": "sha256-6vDCbrgeA/mdtXVx7XNbLza1AFneKVD8W6wqsO6+Ehw=",
+   "pom": "sha256-U5B5PQ9nzVTXnjIbAoPvk0F4G4J29yS7w9ArtJ2vYTo="
+  },
+  "com/soywiz/korlibs/korio#korio-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-8D4pTKCT2ZNyUUrf70fFQiwp457LqDN8hdMt/QFxTs4="
+  },
   "com/soywiz/korlibs/korio#korio-jvm/4.0.10": {
    "jar": "sha256-QqyYF86nVifbeI1XrKI7Bc2LTed7/XHJ/KCX/87TSMc=",
    "module": "sha256-4RwLDIWrj9z9v7UZMsKmXyeligqoP+IWMlSgR2XvOyY=",
@@ -1084,6 +1964,26 @@
    "jar": "sha256-Erqa6NvAnvNlB1Eeni6BxkH4ouVVPT4GEuw8A30QoXA=",
    "module": "sha256-ND+IqDvpWZx/xmeDhbM6kuG6LwSSynrFShAyhSbQtis=",
    "pom": "sha256-/YBfaEGcu6JJ5zxwd/2gWmCQrrS1c5ObGUWTNydYEEM="
+  },
+  "com/soywiz/korlibs/korio/korio-iosarm64/4.0.10/korio-iosarm64-4.0.10": {
+   "klib": "sha256-cBuTEzd/Fls+lybTnUcyaipyEVKUloxLmq8R2AkAseo="
+  },
+  "com/soywiz/korlibs/korio/korio-iossimulatorarm64/4.0.10/korio-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-K+dYSAphq1ug5//DeWoKpsaDRfdcBpBEnkuvSwLXXj0="
+  },
+  "com/soywiz/korlibs/korma#korma-iosarm64/4.0.10": {
+   "module": "sha256-mC3GzqD+WpS7Rgf8tANIJU8yhkYv0+1Bk4bgSANRpG8=",
+   "pom": "sha256-kcXv7hKMobYqhsfJpozDCgWesX9hc+prhAn6l/zv31E="
+  },
+  "com/soywiz/korlibs/korma#korma-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-sIT+2oyPKwFmFlHecHqXPXo6tS/EHUwPN/mJ2ZqPWJQ="
+  },
+  "com/soywiz/korlibs/korma#korma-iossimulatorarm64/4.0.10": {
+   "module": "sha256-rIxboLgaohh0W9r2nnSs7n89iG9FRSSXsOJ9/CjgWrc=",
+   "pom": "sha256-B2vr4gopQEAZZ3yGCDG5tTk+sFOFvbC2XacpmUemaEY="
+  },
+  "com/soywiz/korlibs/korma#korma-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-sIT+2oyPKwFmFlHecHqXPXo6tS/EHUwPN/mJ2ZqPWJQ="
   },
   "com/soywiz/korlibs/korma#korma-jvm/4.0.10": {
    "jar": "sha256-vB7qGeVCrEk2z2epBaoNwoQw3dn+J1fg3+MQPG5FYqQ=",
@@ -1095,6 +1995,26 @@
    "module": "sha256-7CHwHAsYjf55Xmu/d46euNnrHWmVB/8ynjzQd/0Bgis=",
    "pom": "sha256-81U3ChsasMGMJ8MFmvSU6XC28rITohGWc74+snfp1bY="
   },
+  "com/soywiz/korlibs/korma/korma-iosarm64/4.0.10/korma-iosarm64-4.0.10": {
+   "klib": "sha256-OS3sCLt0E/DJ6LByHPDciinRHMHMoCPJUTqbpdI+M/I="
+  },
+  "com/soywiz/korlibs/korma/korma-iossimulatorarm64/4.0.10/korma-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-cYK+BNnLiR9ax623Whdumd3carfqJs+ngKhhTr+efdg="
+  },
+  "com/soywiz/korlibs/krypto#krypto-iosarm64/4.0.10": {
+   "module": "sha256-hNspI9hsYMOtXk3+kJ/fHFuN5lwfmieMXPCIZk9mWpo=",
+   "pom": "sha256-JzOzyhpwHijMizGbX+IPSBXg+1tN4psUir3kjs+NO9Y="
+  },
+  "com/soywiz/korlibs/krypto#krypto-iosarm64/4.0.10/metadata": {
+   "jar": "sha256-Wkj3tdK6ZwdOZ19mdS5ta+xP6QbKIlNKct8Cxzdl0Uc="
+  },
+  "com/soywiz/korlibs/krypto#krypto-iossimulatorarm64/4.0.10": {
+   "module": "sha256-wloDswZ8y7wwMJ/fKeAGsyWfdDFz2fFa+ZUneiRN+TM=",
+   "pom": "sha256-m5vEVNakWSb/RZF3Vvp/Od8FuGtVyXgIh4c7mfnnG6w="
+  },
+  "com/soywiz/korlibs/krypto#krypto-iossimulatorarm64/4.0.10/metadata": {
+   "jar": "sha256-Wkj3tdK6ZwdOZ19mdS5ta+xP6QbKIlNKct8Cxzdl0Uc="
+  },
   "com/soywiz/korlibs/krypto#krypto-jvm/4.0.10": {
    "jar": "sha256-D+jc31SxO17Fb9tfY8BXNkJkuy9Rt/e8PCcdWxumjcs=",
    "module": "sha256-rSCTEPIZfnQDwlAMcqm9kcigys4hqwuxWvp+NB3CGSQ=",
@@ -1104,6 +2024,12 @@
    "jar": "sha256-gjcuxDvZE9gDn3CqlBXEpfRAAbA5M5KcjNYLBdzTrRU=",
    "module": "sha256-hoXcDIexz0ulj9oV1StdOUu6o2EsoWELTqmo4J8FlbQ=",
    "pom": "sha256-0HXY0iK2/e8zPKGznDP2HhYYPHWKy1ao8RuWUSsZqEQ="
+  },
+  "com/soywiz/korlibs/krypto/krypto-iosarm64/4.0.10/krypto-iosarm64-4.0.10": {
+   "klib": "sha256-sJ54RIGH4UtR/mzUfbrNCenK0knbmSp0TW9Mms40ub4="
+  },
+  "com/soywiz/korlibs/krypto/krypto-iossimulatorarm64/4.0.10/krypto-iossimulatorarm64-4.0.10": {
+   "klib": "sha256-ps9cYN9KAxaZ3Rxktg1AMtaonRKBmvTHFFD09lhEvlM="
   },
   "com/squareup#javapoet/1.13.0": {
    "jar": "sha256-THUX6EinGzbQadErs79Gpw/UzaMQXYIrDtLhnAC2kpE=",
@@ -1159,6 +2085,28 @@
    "module": "sha256-C3d0IDpza10i/EW1IuySe74skEh91YZbZOV+AGBeRxE=",
    "pom": "sha256-+Uc3LE3YSPdSrvaDfRUXRhxETB1Dr1rrFebyvXN7sHI="
   },
+  "com/squareup/okio#okio-iosarm64/3.17.0": {
+   "module": "sha256-ZYTvNKL+auoKCLusJHBZ+XhLMTzILmKiCrjaRHfiyAk=",
+   "pom": "sha256-OHrBfO99egDGuvDF5LUxGQOH8W8umQ9uCcWYGhsk8Ks="
+  },
+  "com/squareup/okio#okio-iosarm64/3.17.0/metadata": {
+   "jar": "sha256-qR5pVA4zFYLc0XcR4VGsjtiYgf0n407gYjJGDI0O7Wc="
+  },
+  "com/squareup/okio#okio-iosarm64/3.9.1": {
+   "module": "sha256-7q2cu3fMWwEsMmFBqcGubwrmlHLT+nHEVzt/YQnGU4g=",
+   "pom": "sha256-viFhS7FvP+F5pabViWzz2C2T0ju/Ny89GPexqH6S4U8="
+  },
+  "com/squareup/okio#okio-iossimulatorarm64/3.17.0": {
+   "module": "sha256-l88vZjBK7HGmFHC1O634rcSo9KewOYECnCZ24DMWfr0=",
+   "pom": "sha256-IQzE2qgS+avd/OqMBi+PfqvYK9DilmlRXKiumaAqAag="
+  },
+  "com/squareup/okio#okio-iossimulatorarm64/3.17.0/metadata": {
+   "jar": "sha256-qR5pVA4zFYLc0XcR4VGsjtiYgf0n407gYjJGDI0O7Wc="
+  },
+  "com/squareup/okio#okio-iossimulatorarm64/3.9.1": {
+   "module": "sha256-xWf9sxKEoY77CImjY3p8baBtFb5PvLsa2G1g7SP5tKc=",
+   "pom": "sha256-h7GUhSTsWUNCED+Atg2SM/xJkOV/Mo3DX6PztqEZCzY="
+  },
   "com/squareup/okio#okio-jvm/3.17.0": {
    "jar": "sha256-OxPcw+FXMEfC1Qf8T3/LC7DLzZ05XaIdIOCUBuLNanM=",
    "module": "sha256-1GF9DfcfIC5ymUcYSOYl9PNtf6ZNRsNQP3Cs9IIaRd4=",
@@ -1181,6 +2129,12 @@
   "com/squareup/okio#okio/3.9.1": {
    "module": "sha256-m5C0J0pa1gLdV01tS0iQNmOy3ppgufw0AiSCk9hD4SE=",
    "pom": "sha256-06DDd+epr8zbsCqrXgUNwhL/2pQNvUcOo5cSpDQt8I4="
+  },
+  "com/squareup/okio/okio-iosarm64/3.17.0/okio-iosarm64-3.17.0": {
+   "klib": "sha256-nwG0Wt+rzmAXsN0ZO0lyZ5WrZ3oVIhQKEK0yiZcYwC0="
+  },
+  "com/squareup/okio/okio-iossimulatorarm64/3.17.0/okio-iossimulatorarm64-3.17.0": {
+   "klib": "sha256-3w5J8OZZ+VK4vklYUX8u2j08NYxV9AG5/5nbdKnGaOM="
   },
   "com/sun/activation#all/1.2.1": {
    "pom": "sha256-NgiDv2RIbs7xYbjygvZQNTbdGmcNU6Coccj7IBcOZ5U="
@@ -1240,6 +2194,20 @@
    "module": "sha256-E2VOE42mFhYRwkOhaN4wEb1i3R8sEP7Fs8bgG6x02J0=",
    "pom": "sha256-GueknyaugyKYiuehSxnHB6P/UlDOc6kY98qQADF79zo="
   },
+  "dev/drewhamilton/poko#poko-annotations-iosarm64/0.15.2": {
+   "module": "sha256-E7EcnmODY1z1TWd/WvQm/QYR1gyhZs2friAsQEcTlrg=",
+   "pom": "sha256-Ld+CXgEWh/mg4yrH5RcQ1VIq2ICEhjBxUEYcG4lH4cA="
+  },
+  "dev/drewhamilton/poko#poko-annotations-iosarm64/0.15.2/metadata": {
+   "jar": "sha256-/HdX6gfm9EpIw39rnLqZRBKs7Cu/V59LnGh13Z4BVQQ="
+  },
+  "dev/drewhamilton/poko#poko-annotations-iossimulatorarm64/0.15.2": {
+   "module": "sha256-bCVfyg6TmgsRaK7OzonRrlIVd0PVRIbtyf5z6LB6ZlQ=",
+   "pom": "sha256-EW3VDz1CU/hblkQ4rGUVmfZ7KY+9+snzyyAIn5hr3ZM="
+  },
+  "dev/drewhamilton/poko#poko-annotations-iossimulatorarm64/0.15.2/metadata": {
+   "jar": "sha256-/HdX6gfm9EpIw39rnLqZRBKs7Cu/V59LnGh13Z4BVQQ="
+  },
   "dev/drewhamilton/poko#poko-annotations-jvm/0.15.2": {
    "jar": "sha256-O8uWdwrFIHXEMSAeKf1eZ5JENVVd8i9eWrJgK3t3NjU=",
    "module": "sha256-ZFxFBOI647Y2QStpkR6E8nK81dVDR+MStHVQPyKW/ow=",
@@ -1260,10 +2228,30 @@
    "module": "sha256-6IxTuqEOSD1fDnJ8LyZVqRSG/xJzRtEm/xfRGZ5xqWk=",
    "pom": "sha256-j8YmPFKf+bGiPETSy6SGPvzVm2/Nx0JTiYqbiLNlQsc="
   },
+  "dev/drewhamilton/poko/poko-annotations-iosarm64/0.15.2/poko-annotations-iosarm64-0.15.2": {
+   "klib": "sha256-Q9uVBFylB8CoZ4pxXnqzxuOzdMdW7Sr9SOkSci2g9ao="
+  },
+  "dev/drewhamilton/poko/poko-annotations-iossimulatorarm64/0.15.2/poko-annotations-iossimulatorarm64-0.15.2": {
+   "klib": "sha256-kfPLhgi7UDwrENztkYQK8S7gqcHojLKgek+/XmstOcA="
+  },
   "dev/equo/ide#solstice/1.8.2": {
    "jar": "sha256-nslXwJZgBSDcmfN6EEp/TJkNQMLdN17pYOt8bNUMEvM=",
    "module": "sha256-SrIVTJ83agthp6/i0djQJ+pvOQ08hyzkcKbZgqR+Wv4=",
    "pom": "sha256-70jsrBwclJAdj/ML8J16CClTQCNnLdXiVyek6Vh+oFM="
+  },
+  "io/coil-kt/coil3#coil-core-iosarm64/3.5.0": {
+   "module": "sha256-Lqtar2h7J5+HgrXilXDU0nhEOD8CkFSYJOAp4FK87/U=",
+   "pom": "sha256-ylGEoc1ZhdXnoVZFxzgZmZeSvrnpmJNUBsLxc+DQiTU="
+  },
+  "io/coil-kt/coil3#coil-core-iosarm64/3.5.0/metadata": {
+   "jar": "sha256-PcrguvV2EyW6aClHErXsJ7lQv6qEw56lEMfDxxcfxc0="
+  },
+  "io/coil-kt/coil3#coil-core-iossimulatorarm64/3.5.0": {
+   "module": "sha256-E9h+esi9X+QJDDz0QQH3j7tmbLXEZ5sZ5bp7C1zjjAw=",
+   "pom": "sha256-0/UMp7ym1FjZRAItup0lbncXKUAnIWVqSiHBSn6BYpA="
+  },
+  "io/coil-kt/coil3#coil-core-iossimulatorarm64/3.5.0/metadata": {
+   "jar": "sha256-PcrguvV2EyW6aClHErXsJ7lQv6qEw56lEMfDxxcfxc0="
   },
   "io/coil-kt/coil3#coil-core-jvm/3.5.0": {
    "jar": "sha256-R5MR31Z6Q12IrvT6u+wEWFVWdw54gdhsF1iwfVsSb0A=",
@@ -1275,10 +2263,38 @@
    "module": "sha256-rDdDBgllEqRfCBatYdtIYvjHRoID3GcL6mjaO9odZXE=",
    "pom": "sha256-mfQPAnIBPPsi7mW1AeZ/qlJtbxzarj1djVGR7jX3PsA="
   },
+  "io/coil-kt/coil3#coil-iosarm64/3.5.0": {
+   "module": "sha256-igBNAAUpztskfsPbr0C8ZMlPrGVH8WhjKdKE7ZcUeFM=",
+   "pom": "sha256-Ng6sRMok2E/Nb6EkS1sFZTLuRKM+rF5QgeIOoIkAv4s="
+  },
+  "io/coil-kt/coil3#coil-iosarm64/3.5.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/coil-kt/coil3#coil-iossimulatorarm64/3.5.0": {
+   "module": "sha256-7SeqSSQ1I4xDfO+ednTyyoVqrErUsSgSuCn8XeaeKjU=",
+   "pom": "sha256-FLgl/7XwRBbJl4Lp6IDZ5WkECqAv0AAUmZFxLx45o5U="
+  },
+  "io/coil-kt/coil3#coil-iossimulatorarm64/3.5.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/coil-kt/coil3#coil-jvm/3.5.0": {
    "jar": "sha256-ooDTOMsipr3C9/J6yh/szDFCpnwp9c2UW9lI1bMScnw=",
    "module": "sha256-vJMhGSQDbldwrvRUiFlDRD80ns8WiKX5g6xRzsz1mXw=",
    "pom": "sha256-rygl/tKTKae4577HmP6T9eEAXmdmh3K9V60LOSZeZO0="
+  },
+  "io/coil-kt/coil3#coil-network-core-iosarm64/3.5.0": {
+   "module": "sha256-YdqBZYeUeBOMSlb4VtCjl8M0wzNmNyJP4eh/HOxq/Wc=",
+   "pom": "sha256-krXSWaSFU84ArNuNyLaqNzLLNApKzyC225EQN4U0H4g="
+  },
+  "io/coil-kt/coil3#coil-network-core-iosarm64/3.5.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/coil-kt/coil3#coil-network-core-iossimulatorarm64/3.5.0": {
+   "module": "sha256-1Ay3gdmQ4H1JUzuScsiVjvVfVKP5pxGEQIu1sY49T3M=",
+   "pom": "sha256-88ZGCZfdTnUYZyBfB1Qk1bQJO1OjrIJHTGmcJQCR0M8="
+  },
+  "io/coil-kt/coil3#coil-network-core-iossimulatorarm64/3.5.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/coil-kt/coil3#coil-network-core-jvm/3.5.0": {
    "jar": "sha256-PrLqeCMkYMm5rl6+luO/s7ULLEGzknfvtK5FSthlLWo=",
@@ -1289,6 +2305,20 @@
    "jar": "sha256-GKOaO2nmBxn9Toueu8CQ+VPmDZC7EpIE54i4pN9QXY0=",
    "module": "sha256-l1jlB3oWnZZ66d7Zb+68dFU/eQVcT9r/emdvoxqHxJE=",
    "pom": "sha256-XaWUFSdgDZl2p+s2Of87LU5h3SKz3ljFBORe9C3ML+I="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-iosarm64/3.5.0": {
+   "module": "sha256-jH3DPxq01sdlJr+pOtABEYoAY9QkoWS3UtL8falML84=",
+   "pom": "sha256-ayc1VtPfTonDEJoNzbK2+5NbzfITKFGwpvMu1FoDuXw="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-iosarm64/3.5.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-iossimulatorarm64/3.5.0": {
+   "module": "sha256-9BqZhE3G6VHOxWvZxzzPu7N9+Td1gXxz6yZfgzTxDXk=",
+   "pom": "sha256-87y6yX5E9XpTZaTAZW4fH/P6poki+9hcAOXmw4pbUQA="
+  },
+  "io/coil-kt/coil3#coil-network-ktor3-iossimulatorarm64/3.5.0/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/coil-kt/coil3#coil-network-ktor3-jvm/3.5.0": {
    "jar": "sha256-D8jHwo1+OWVhEaT08zlQ4Q5BwG0ApDOWz6zug1opRF8=",
@@ -1305,6 +2335,30 @@
    "module": "sha256-biyG2PvnFnYnXmTVhqCU5+ObW71/dQEKLY23vPvcWgE=",
    "pom": "sha256-6vIl0PbBLtS+ahvU3skjAYplRAi2uFKW0ia7Yg21nTw="
   },
+  "io/coil-kt/coil3/coil-core-iosarm64/3.5.0/coil-core-iosarm64-3.5.0": {
+   "klib": "sha256-0NM+Z8MQ6zmCjrQK311Ru6zpWdXar4ZjWteATOMw7Z0="
+  },
+  "io/coil-kt/coil3/coil-core-iossimulatorarm64/3.5.0/coil-core-iossimulatorarm64-3.5.0": {
+   "klib": "sha256-r6wiBzuJ3gJrrgh9N1ODe6xLpYHANHY9tfa2g3lMbis="
+  },
+  "io/coil-kt/coil3/coil-iosarm64/3.5.0/coil-iosarm64-3.5.0": {
+   "klib": "sha256-HBOSIi9A4kwC0yNh8eft02y2pwOHcAOafBng9F6yNuU="
+  },
+  "io/coil-kt/coil3/coil-iossimulatorarm64/3.5.0/coil-iossimulatorarm64-3.5.0": {
+   "klib": "sha256-dQUoRC4BQBkGKFlh8b4qbBS+7IlBt3ZKn3jqGhGHZz4="
+  },
+  "io/coil-kt/coil3/coil-network-core-iosarm64/3.5.0/coil-network-core-iosarm64-3.5.0": {
+   "klib": "sha256-aJw3zh7AZfURaKLLCIl/yqeN3GBDxLS8BgB0uaE4ioU="
+  },
+  "io/coil-kt/coil3/coil-network-core-iossimulatorarm64/3.5.0/coil-network-core-iossimulatorarm64-3.5.0": {
+   "klib": "sha256-uf/CKtscwePb13cs/fB7kRcmNTxDNx87FYiKDLdOWqc="
+  },
+  "io/coil-kt/coil3/coil-network-ktor3-iosarm64/3.5.0/coil-network-ktor3-iosarm64-3.5.0": {
+   "klib": "sha256-Jrf9EfOPBJFilhMIHGLwIajvu2OCb+cBFYyopW4cBrI="
+  },
+  "io/coil-kt/coil3/coil-network-ktor3-iossimulatorarm64/3.5.0/coil-network-ktor3-iossimulatorarm64-3.5.0": {
+   "klib": "sha256-+gyH6bwmQcgi37Tg5iO7xRnJYs9tzBc9q/fNHNNplsk="
+  },
   "io/github/oshai#kotlin-logging-jvm/8.0.03": {
    "jar": "sha256-YL4NH596yVQSO9LOi8BLzijLlYKDG2mNBjtg5sr3zrY=",
    "module": "sha256-GeL+XQA3OvXpYBIFxXKIjkcl1SPgfKwU8hVZNXh1oJc=",
@@ -1314,35 +2368,49 @@
    "module": "sha256-r47Cbzag83hN4HfkIUgh96EVS1RuFZEba3YZmzNqPIM=",
    "pom": "sha256-ybI+IQltbdj+K3ATr0SlejCwIm+xAtwvGWNF02vc+Ng="
   },
-  "io/github/vinceglb#filekit-core-jvm/0.14.2": {
-   "jar": "sha256-IsUCwNr8IrzQPqUtwub+O8eSsjxUw30F2Ki8ebCxFco=",
-   "module": "sha256-t4KZZV1PhGGJftHEG3OVM3LNKVu8j1tLofoBzKwrUGo=",
-   "pom": "sha256-vhEKsxC4JX3FIW82qgUTKKTA6QtBhFItDyVUjdTHLhk="
+  "io/github/vinceglb#filekit-core-jvm/0.15.0": {
+   "jar": "sha256-D4Sta5Xm8+ngSofRLqcKdjh6A8iscS6yl+LIvP2ica0=",
+   "module": "sha256-DIwzib4StZUvKkwzO+8uMVCHiEHRK69saJx8wKy2VYI=",
+   "pom": "sha256-7sMVBHUnSBgNU05PFHS9+iJ3pPU8CeY6ghiRutAk4ys="
   },
-  "io/github/vinceglb#filekit-core/0.14.2": {
-   "jar": "sha256-PS/mkoAoodXaLltZD8e5tm8fxxebNtqbScFqjyNYkI4=",
-   "module": "sha256-+D65puF3NK6r64SBb/x5uZOW3xe9c4D0+8RlSsfgXKA=",
-   "pom": "sha256-Ts4Xdu/o48x2P0wSOc/RHaanYgy6X00wROOLjDynlo4="
+  "io/github/vinceglb#filekit-core/0.15.0": {
+   "jar": "sha256-vDWu+o3gA9nHIPLbEMd0X1gegXlhQfPphNus111Z/34=",
+   "module": "sha256-FHoIazv3oc1iRXprPbwrRs244zi2Yq+65SAdj84r8h0=",
+   "pom": "sha256-mYipb4vKyegMYPsSLduGKIGtX1nFWnwpd85Lonwg2CY="
   },
-  "io/github/vinceglb#filekit-dialogs-compose-jvm/0.14.2": {
-   "jar": "sha256-GCcb0qN6NPrIqRCy+mMpGON6bc9oOcKSJm6OKzCzLpI=",
-   "module": "sha256-Z+fHJlkUnl8wI8ePmAbCM+xuJwpyRjXDZsd02XeB7rw=",
-   "pom": "sha256-mIDK5zOnvIrek0w7apVtrjQDcdAHg94KL/tOg70hVXk="
+  "io/github/vinceglb#filekit-dialogs-compose-jvm/0.15.0": {
+   "jar": "sha256-3WsM8WzI5aWOlE5r/VVRE4TYDBlyLPUiapk3BegXzz4=",
+   "module": "sha256-zpLNDqSWl7fhvSkdhBGOSaBGJVV8iPcdbSBRjN8QnU0=",
+   "pom": "sha256-kJ0jZjOAEAfmWQFbjq3716tes5rppCHnjSqEd3/mI+Y="
   },
-  "io/github/vinceglb#filekit-dialogs-compose/0.14.2": {
-   "jar": "sha256-sfgcs80xIE7kyp78rYEMx+W5FbaIqFE21t5alVocwBI=",
-   "module": "sha256-r/MTrwGpNpEB8IuXdO+rU68xcLX0t9JVG6fLLnGOMPg=",
-   "pom": "sha256-qO1bJv06ijz1Zs+JS0o2fQRzl+oV0eBGSuMN0IxnJDI="
+  "io/github/vinceglb#filekit-dialogs-compose/0.15.0": {
+   "jar": "sha256-0p1/LsyGDpVzm+N7ezoRgbBouA6Eam3tEQyCpJQrlRc=",
+   "module": "sha256-fEOfkmPSIViHiNMC3GyCs5Y0VW/LhLrja3zKv4le/pg=",
+   "pom": "sha256-7seMUpes0wDXVaKYg0Iw0iZNbh0seZ0eoLLCV6oWEBs="
   },
-  "io/github/vinceglb#filekit-dialogs-jvm/0.14.2": {
-   "jar": "sha256-8qQrYcdN2LhFlPVS/v2+BxuTIg0ypTTPp9r56YSUGks=",
-   "module": "sha256-UTrIAlGO9jPwSzIGfXMKJ+6vkss6WsjfDhPGu2eqZFc=",
-   "pom": "sha256-SEYunbjZiqXG205FCnbwTTXFNZsibpu2H5jD5m0rRKo="
+  "io/github/vinceglb#filekit-dialogs-jvm/0.15.0": {
+   "jar": "sha256-eBQvppGV/TD0SPtVN5btc3MdHWaxuP1Z00VICyMIrqQ=",
+   "module": "sha256-yLVMAcY7fv5TIu8Nsy98BNMWEbqf6+SkE3pbRFqHKQk=",
+   "pom": "sha256-euVsmqFfc882VG751A7WCFSdCGZDPdHvWlPB5jRrKik="
   },
-  "io/github/vinceglb#filekit-dialogs/0.14.2": {
-   "jar": "sha256-31CaXnjWczeSvnaz8nijhvv6P1J0jnI1frDUWV5/ltE=",
-   "module": "sha256-5byjySuOt52TqMHCTthOqgMglpgjk8+JBByX6jiQlxY=",
-   "pom": "sha256-uP898ULlgecgnGtbdxTYNCwQCC/aEVmEnI+eCBnFKzk="
+  "io/github/vinceglb#filekit-dialogs/0.15.0": {
+   "jar": "sha256-3LPe1hHyBY8bUTfg+sRdTHLhf0iseynK3otf1R/ZzPU=",
+   "module": "sha256-O9SnhLIelix+RR+mhEiI5xvfvXl/JvID/3nYQGYaCh0=",
+   "pom": "sha256-b3V1kIcetiKQWkCaMPpdWr9EIbbrd2vtALA1DtGf1Ic="
+  },
+  "io/insert-koin#koin-annotations-iosarm64/4.2.2": {
+   "module": "sha256-gyASPQwGSSa913CMi/EAG4Re7Tgyn3gR0kzmfJ+qdxE=",
+   "pom": "sha256-kNvVKo8tXDRMnsKrwX9mFyL5pUPsBDFswauHc258NqE="
+  },
+  "io/insert-koin#koin-annotations-iosarm64/4.2.2/metadata": {
+   "jar": "sha256-LhpuNRKgOMPpY2A27vZbIkrv5cgtl7Kdn/dYfYm6zek="
+  },
+  "io/insert-koin#koin-annotations-iossimulatorarm64/4.2.2": {
+   "module": "sha256-+E5G4r8+6FNqllKrnAN348sDlIPDuVHmHeSwTDl95Jg=",
+   "pom": "sha256-QxO21xQrFmB7e0aIDTDVv+zM/F8hRIoI6PtLjB/rAJw="
+  },
+  "io/insert-koin#koin-annotations-iossimulatorarm64/4.2.2/metadata": {
+   "jar": "sha256-LdR0MhAaQ4Z+kUMBZ2ApPJbspEVXHl9BCse/QmiKX1g="
   },
   "io/insert-koin#koin-annotations-jvm/4.2.2": {
    "jar": "sha256-P20bANPgfW3F1m989CzdtSVhB4tKMFENUhtONhcwdXM=",
@@ -1364,15 +2432,57 @@
    "module": "sha256-yxDz5tA3cI0x6QKnHECMVPGfB6+i2fzMFb8S6u2iQUw=",
    "pom": "sha256-PfHzZ61iZMo11HwP8K46VG7S7YrzHzPWo1v9awzD6SE="
   },
+  "io/insert-koin#koin-compose-iosarm64/4.2.2": {
+   "module": "sha256-PeREAswBS7RZFh1mXjc5jzmeCKZ9a4AbXEL7Hx3jqfA=",
+   "pom": "sha256-Qz3IfBVTHKmIdlUWYwlvzE89j9uBpsC/0ceOoTbm2sM="
+  },
+  "io/insert-koin#koin-compose-iosarm64/4.2.2/metadata": {
+   "jar": "sha256-4XMDUu9+Bvfhqdf/C6R28aOJwM+dg3hPws1fXqooqbs="
+  },
+  "io/insert-koin#koin-compose-iossimulatorarm64/4.2.2": {
+   "module": "sha256-jcIUpzJLAVuk142FynqdYhvgxISskME8lRXa1ilx4qI=",
+   "pom": "sha256-AKKuxfUAVG7L68zV8QoOJGmFkOqIE3JqY2N/Hex9nOQ="
+  },
+  "io/insert-koin#koin-compose-iossimulatorarm64/4.2.2/metadata": {
+   "jar": "sha256-4XMDUu9+Bvfhqdf/C6R28aOJwM+dg3hPws1fXqooqbs="
+  },
   "io/insert-koin#koin-compose-jvm/4.2.2": {
    "jar": "sha256-O1x76W0z/ss3czczPI/5E9pjbFBtZu8MeXagvXJpSxw=",
    "module": "sha256-hHXtw8BLkycVL7edhAMqHKQ6Yky/Hzr0aga3/2WakYQ=",
    "pom": "sha256-0NJvbGX7fVGiF+wQbTxUoKU4LGI+0ce8anxvEH+jIeQ="
   },
+  "io/insert-koin#koin-compose-viewmodel-iosarm64/4.2.2": {
+   "module": "sha256-lPP29u2jYaRqTMaxcMxQAHNam6ZoPYkCUzkiIJWo5To=",
+   "pom": "sha256-JqnC1FKrk82bDuuQ7OSY84qyvKg/0B5w30EHiTmFyis="
+  },
+  "io/insert-koin#koin-compose-viewmodel-iosarm64/4.2.2/metadata": {
+   "jar": "sha256-cZO09u4nU6gzH8vgVxjU5Kop4mpabUVw1/2yx9ql290="
+  },
+  "io/insert-koin#koin-compose-viewmodel-iossimulatorarm64/4.2.2": {
+   "module": "sha256-plBOVuwMyWbyOjdeG5ROpwCtpczXd+6PMS3E1F920cg=",
+   "pom": "sha256-E6ygYP5krCnccCPc/0Lb3q0c89qVECGSdhqrzL6Ojic="
+  },
+  "io/insert-koin#koin-compose-viewmodel-iossimulatorarm64/4.2.2/metadata": {
+   "jar": "sha256-m9rOm23YTwoIuDE6MVIHUP9QlnyOLSuwHXO94154aEs="
+  },
   "io/insert-koin#koin-compose-viewmodel-jvm/4.2.2": {
    "jar": "sha256-zJafWxRfddrEE9nNu41/dmTok8xaZ5pKyIA6XOHi+hg=",
    "module": "sha256-sg/bCmOGhxlqxQo6zFBjzwt5d1bgeqFgQprauHPGIbU=",
    "pom": "sha256-FsblXyeSFwDU63uytxksxs5pudBnprmVJDmtgnIsK6Y="
+  },
+  "io/insert-koin#koin-compose-viewmodel-navigation-iosarm64/4.2.2": {
+   "module": "sha256-G+gnSnIvc0fAN182+X2njqa35VSs8bzHhsQvcFuZPBU=",
+   "pom": "sha256-Wc7F94zLFcApC7LFnrsro8vuc7ik5EkTUEoL1OMrMa4="
+  },
+  "io/insert-koin#koin-compose-viewmodel-navigation-iosarm64/4.2.2/metadata": {
+   "jar": "sha256-fkmtig4/LB8cKssw1MVeAFQXWqePucSXgNZ/UloHnDI="
+  },
+  "io/insert-koin#koin-compose-viewmodel-navigation-iossimulatorarm64/4.2.2": {
+   "module": "sha256-I+M7JJNMcBhLLdsHiTGM7IpwKfkAQjnrUL0sNLCav7o=",
+   "pom": "sha256-Locl7Gb4pGwbET32QSZRu89eKyhX1cQosxk6vs+e6w0="
+  },
+  "io/insert-koin#koin-compose-viewmodel-navigation-iossimulatorarm64/4.2.2/metadata": {
+   "jar": "sha256-XHtDrLPGcaXL9Oxe198qW7k+oZAqTrzqHJjbLWveoWU="
   },
   "io/insert-koin#koin-compose-viewmodel-navigation-jvm/4.2.2": {
    "jar": "sha256-KpZwkH/Gor4ancIxcNf+kPiW33O7NV0jZhRzd2EVz1Y=",
@@ -1394,6 +2504,20 @@
    "module": "sha256-o203BPJ8v2diZwyeXw9n9QV5dNww2p5Rb6li5m7HNz0=",
    "pom": "sha256-4VxSNo+UlmMLD4wQ7cERxrl8nnkceJqIRV6HTyuYPlM="
   },
+  "io/insert-koin#koin-core-annotations-iosarm64/4.2.2": {
+   "module": "sha256-UDr0LCxzd+hOCy7PXBTrqDnDyaqitOalkDc1TOuzrWs=",
+   "pom": "sha256-qCmnIyjRIpI13Tq7b5dDmlL9ybvmt92cJkIkvsBB+yc="
+  },
+  "io/insert-koin#koin-core-annotations-iosarm64/4.2.2/metadata": {
+   "jar": "sha256-LhpuNRKgOMPpY2A27vZbIkrv5cgtl7Kdn/dYfYm6zek="
+  },
+  "io/insert-koin#koin-core-annotations-iossimulatorarm64/4.2.2": {
+   "module": "sha256-vwX2R7tC6vPRV7nT/dSAQTrfV93uRz3hxtBGElt9bZE=",
+   "pom": "sha256-JteMIG7BLOm+GmwbKIzm29HSh6oFAIeu+UI/LAtNcDw="
+  },
+  "io/insert-koin#koin-core-annotations-iossimulatorarm64/4.2.2/metadata": {
+   "jar": "sha256-LhpuNRKgOMPpY2A27vZbIkrv5cgtl7Kdn/dYfYm6zek="
+  },
   "io/insert-koin#koin-core-annotations-jvm/4.2.2": {
    "jar": "sha256-UAeceafbu2vr6/WSKmO6R1n9kobc211QKjg8t8C8YMA=",
    "module": "sha256-Z6a16TvFz2Lqx2oGQkF2895ZhGH3Hy4hascusNSM6xs=",
@@ -1404,10 +2528,38 @@
    "module": "sha256-vzp7NP4bUdMwegA4iIv93+nAnwjOrEjagvuWAGA2brY=",
    "pom": "sha256-cUWWo0/rQG/f88kzk/6Q3lI5fgpXJSeniyz52Qck3Rc="
   },
+  "io/insert-koin#koin-core-iosarm64/4.2.2": {
+   "module": "sha256-fObrg8Z08hTdo4p7vjYTNKIy4Zj+EdOmQiOk5eDymMw=",
+   "pom": "sha256-UC2A9oyYYBROJEdrEE6nZvsi4eBfSWTqqMRjGahyEYg="
+  },
+  "io/insert-koin#koin-core-iosarm64/4.2.2/metadata": {
+   "jar": "sha256-ujlkEv6VdbbKEWxPQC68FZLpm0B2NqR6AqdeKzaSQXc="
+  },
+  "io/insert-koin#koin-core-iossimulatorarm64/4.2.2": {
+   "module": "sha256-VviTFQY4fOBz1jkZKHzSwvGa7+gD9LjF0S9buy+Q9E0=",
+   "pom": "sha256-nhqhKbsEsIieFkdFqab0fzs9y63FI3o/NW/NVVnO8zo="
+  },
+  "io/insert-koin#koin-core-iossimulatorarm64/4.2.2/metadata": {
+   "jar": "sha256-ujlkEv6VdbbKEWxPQC68FZLpm0B2NqR6AqdeKzaSQXc="
+  },
   "io/insert-koin#koin-core-jvm/4.2.2": {
    "jar": "sha256-bYiWa71+ZWMfapYvRqlZuFfjnm/MRbQIiZex1U/vAAQ=",
    "module": "sha256-zoEQ/gaKri5cxnLaU7xtO7kYgVpQec0uNWmWyseX1r0=",
    "pom": "sha256-EF5jA/yqSozDdDF9ywT69ktkFG4RMP6qwVdzAj4J0ro="
+  },
+  "io/insert-koin#koin-core-viewmodel-iosarm64/4.2.2": {
+   "module": "sha256-B+pfx8LFyibXXpB/DtVRj5CR9TJu+mKyAg/kFwnvUU8=",
+   "pom": "sha256-i6RcPHEwylr8CGbsSAAfl51fZfOp3Vhks0W1Vj/rhoM="
+  },
+  "io/insert-koin#koin-core-viewmodel-iosarm64/4.2.2/metadata": {
+   "jar": "sha256-WgbLOAWXg5QBTEd/sDfIGJN53EHctNzI/tWGA2+/VXE="
+  },
+  "io/insert-koin#koin-core-viewmodel-iossimulatorarm64/4.2.2": {
+   "module": "sha256-8afMblehC+1jr9krn7kmuzwN3WdBXE37f6zoAI4uSxQ=",
+   "pom": "sha256-2XQ9DpQ+7D+rEh1xa3ozP47i1j4j95riYCUKEnhREZU="
+  },
+  "io/insert-koin#koin-core-viewmodel-iossimulatorarm64/4.2.2/metadata": {
+   "jar": "sha256-WgbLOAWXg5QBTEd/sDfIGJN53EHctNzI/tWGA2+/VXE="
   },
   "io/insert-koin#koin-core-viewmodel-jvm/4.2.2": {
    "jar": "sha256-g0jutUUQW4o0WzYl9HAMnNdeCJmBFQuzmtzSmDfDgro=",
@@ -1427,6 +2579,62 @@
   "io/insert-koin/compiler/plugin#io.insert-koin.compiler.plugin.gradle.plugin/1.1.0": {
    "pom": "sha256-xrRQl+GBODi5ySoAsgKZED8rTdOCU9/EL0Qwh43c0zU="
   },
+  "io/insert-koin/koin-annotations-iosarm64/4.2.2/koin-annotations-iosarm64-4.2.2": {
+   "klib": "sha256-mJDq0PrSGN7LvWnpXIaMI2xVbfWr3ZWlTGJmB78nTTs="
+  },
+  "io/insert-koin/koin-annotations-iossimulatorarm64/4.2.2/koin-annotations-iossimulatorarm64-4.2.2": {
+   "klib": "sha256-eRZx9tLRpOEGrtNkTcJcqpM44H/tsq6r1RQROqnwSWU="
+  },
+  "io/insert-koin/koin-compose-iosarm64/4.2.2/koin-compose-iosarm64-4.2.2": {
+   "klib": "sha256-0iPtaBO214B4mvQVo8GCY/V8CWMf0Vk30LylovRyGRU="
+  },
+  "io/insert-koin/koin-compose-iossimulatorarm64/4.2.2/koin-compose-iossimulatorarm64-4.2.2": {
+   "klib": "sha256-QaLxBUVBPY+WEsi8gF3m0N5gW7C5TB3+bRUjBr99QoE="
+  },
+  "io/insert-koin/koin-compose-viewmodel-iosarm64/4.2.2/koin-compose-viewmodel-iosarm64-4.2.2": {
+   "klib": "sha256-DBlaPlLpuuGHchflhxOcxQUTHSpqzmSKyzcMKaohc4I="
+  },
+  "io/insert-koin/koin-compose-viewmodel-iossimulatorarm64/4.2.2/koin-compose-viewmodel-iossimulatorarm64-4.2.2": {
+   "klib": "sha256-9mGvBVxjEfvjFNmglnNYBn4Y8AMj/Ggey2YOF8c/KiE="
+  },
+  "io/insert-koin/koin-compose-viewmodel-navigation-iosarm64/4.2.2/koin-compose-viewmodel-navigation-iosarm64-4.2.2": {
+   "klib": "sha256-/ZiPd/HHIi/jEFtYW5hzbesO9pKuPiZr38P1U1NSUao="
+  },
+  "io/insert-koin/koin-compose-viewmodel-navigation-iossimulatorarm64/4.2.2/koin-compose-viewmodel-navigation-iossimulatorarm64-4.2.2": {
+   "klib": "sha256-XZZa4gS0pueIm7mpn5YqTYBkpHm79D8MdSwVf7JJ7lk="
+  },
+  "io/insert-koin/koin-core-annotations-iosarm64/4.2.2/koin-core-annotations-iosarm64-4.2.2": {
+   "klib": "sha256-KrXzxZ+o+roV44Wl9/alqFcHtfW/DDiCFq30snMABps="
+  },
+  "io/insert-koin/koin-core-annotations-iossimulatorarm64/4.2.2/koin-core-annotations-iossimulatorarm64-4.2.2": {
+   "klib": "sha256-E1tI02Bmptq8+n+sZ61uskJ5KYdEzQnzjLBLZBBgiMs="
+  },
+  "io/insert-koin/koin-core-iosarm64/4.2.2/koin-core-iosarm64-4.2.2": {
+   "klib": "sha256-74YGarbTteFf7K3BratRZCsCLdXz8kcs1+QsUpiS2xc="
+  },
+  "io/insert-koin/koin-core-iossimulatorarm64/4.2.2/koin-core-iossimulatorarm64-4.2.2": {
+   "klib": "sha256-MDjlwqWuAMaFp1BNyrKFwgLb/LEBSNrMRc9ti1KFhkQ="
+  },
+  "io/insert-koin/koin-core-viewmodel-iosarm64/4.2.2/koin-core-viewmodel-iosarm64-4.2.2": {
+   "klib": "sha256-2TcYku3ryyzmYeTK3q0iX4Yn9TlOUMPwY5hA8mBLLNM="
+  },
+  "io/insert-koin/koin-core-viewmodel-iossimulatorarm64/4.2.2/koin-core-viewmodel-iossimulatorarm64-4.2.2": {
+   "klib": "sha256-SvcEwc3UFD7TlRcjLTmvJ6DMtgO1gM3d0dT8VZZknGw="
+  },
+  "io/ktor#ktor-client-auth-iosarm64/3.5.2": {
+   "module": "sha256-MydHZ2l9sqTt3zF157VBUETb9YVnXefW03NUh724KpI=",
+   "pom": "sha256-mk5dtAfCp2QrhU7hvi/2YlZ0kippQCd2PDFXayzYkRo="
+  },
+  "io/ktor#ktor-client-auth-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-client-auth-iossimulatorarm64/3.5.2": {
+   "module": "sha256-cAc/CzFEBIp4G/CqHnpebRKI5JQjwRHHh/VeBejPf4Q=",
+   "pom": "sha256-WJpfwzUDMTM7leoe7EGrOFYF8fsxdTo4IVymcmfMrqA="
+  },
+  "io/ktor#ktor-client-auth-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/ktor#ktor-client-auth-jvm/3.5.2": {
    "jar": "sha256-IAFTH3SG5JMHRw67D5SDePyBrN594TWNZTzo0T/o+OY=",
    "module": "sha256-/hzHrbINeVFyrCfUC9UgS1e9+1Xx1SK1ISSiKXXzTTQ=",
@@ -1437,6 +2645,20 @@
    "module": "sha256-XXiRBUCjDTwwgezqXEsYrB2NRlIpn0djjHQMFX24mDc=",
    "pom": "sha256-VzMrQzpEK/11Anc35QVSAkX61WA3JI+y3GWs48KrgQ0="
   },
+  "io/ktor#ktor-client-content-negotiation-iosarm64/3.5.2": {
+   "module": "sha256-YcLAws6/rilmqbLD+Sb8H0bAbQ9Q1yZzvZAbhuvRoe0=",
+   "pom": "sha256-dYgr86SZ22nf1jiBM4fMRVoYfyjVcGDPkgd6AEuwUvM="
+  },
+  "io/ktor#ktor-client-content-negotiation-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-client-content-negotiation-iossimulatorarm64/3.5.2": {
+   "module": "sha256-HjzlKJy75h8y51azX+nu6fkEHOvlkcFjdXudpVynrCA=",
+   "pom": "sha256-sf20kTj5j/vv6JsTHbDDSfoDRf7XhbK6yM9TMH5KSCI="
+  },
+  "io/ktor#ktor-client-content-negotiation-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/ktor#ktor-client-content-negotiation-jvm/3.5.2": {
    "jar": "sha256-NzvI23rY6f3+jQtYKdaytSbWd3u5OhMcdWnS4CPlMuA=",
    "module": "sha256-Xl4QlftShnG4s/aFu0wbzwMK1elFw6xQLH611WRF9VY=",
@@ -1446,6 +2668,20 @@
    "jar": "sha256-UeMO+jd58uDTWigM1xusJc9uJxMHwOL8IkYhXJaD7So=",
    "module": "sha256-P/Bq0PnTBMlIHfZrppXOHuDufrahbf4Ny/OP2wTGmZQ=",
    "pom": "sha256-17LB1K7aE+jnw1pb4tWiY8SHmeOKLpRrTFTYJ9hoQjs="
+  },
+  "io/ktor#ktor-client-core-iosarm64/3.5.2": {
+   "module": "sha256-Vzr27DYPekVzAJhvClvDR72GDdruyfRLS89/W7EP9AM=",
+   "pom": "sha256-wPmmi8jQNByKkqH3NvXGA3KWRKSxqEGmJmouxMY016s="
+  },
+  "io/ktor#ktor-client-core-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-client-core-iossimulatorarm64/3.5.2": {
+   "module": "sha256-NXodkk+bxXficNIEouMq5M2fH/SmFo9DQliH5rLRsRc=",
+   "pom": "sha256-mVu1DTcg+ot+qpa1Qk7LfxFxRQ404n2Jjk/vMJp42e4="
+  },
+  "io/ktor#ktor-client-core-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/ktor#ktor-client-core-jvm/3.5.1": {
    "jar": "sha256-fWipfsyIPpPx1hp0EH5E7PY6X/vLq13AF3Pm2IQn6Fk=",
@@ -1467,10 +2703,43 @@
    "module": "sha256-IcCLNdRFVpQZMFgldjUiCS4E+9su9eOvQ2e/B47AzXw=",
    "pom": "sha256-ivRBpkstvC5MHwCNsqt6G9QglV4GH/iUQaDAViGbKCk="
   },
+  "io/ktor#ktor-client-darwin-iosarm64/3.5.2": {
+   "module": "sha256-uaKk/DVZeih/5qARjZsTXlGJ1YWvS30smygixGO67do=",
+   "pom": "sha256-ScY96WgdQPcfI+JovKUQiocXHYbSZ2OWAyzzo3CKcJk="
+  },
+  "io/ktor#ktor-client-darwin-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-2LCAaaZTiY7tzo/lqxG+4Iig8kka5l+//CISGO7GTd0="
+  },
+  "io/ktor#ktor-client-darwin-iossimulatorarm64/3.5.2": {
+   "module": "sha256-US6JcURQIwKyaFet4n0NTRqOGDdTLEFy5GYVTwSfCqg=",
+   "pom": "sha256-x+6C8jMJPt1KqvkGRomGStRRP1CYGOCO3ojZtSqTmhw="
+  },
+  "io/ktor#ktor-client-darwin-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-2LCAaaZTiY7tzo/lqxG+4Iig8kka5l+//CISGO7GTd0="
+  },
   "io/ktor#ktor-client-darwin/3.5.1": {
    "jar": "sha256-j8Zucfr1HjpVI6C8XNgH+conVWaK9awQcVHBg+s7484=",
    "module": "sha256-3gK2bac7FTyzXIjv/1o3Xq/dRxrpRE4shA0ZRRPqZ4A=",
    "pom": "sha256-bnckirF15S+1ju96AWeEpaa4hfYXXvUfRvtqMffUB1M="
+  },
+  "io/ktor#ktor-client-darwin/3.5.2": {
+   "jar": "sha256-j8Zucfr1HjpVI6C8XNgH+conVWaK9awQcVHBg+s7484=",
+   "module": "sha256-teJJuMpXh/I7+84IkvnzcCsRfCJSmD7kRbDWcpm1CT4=",
+   "pom": "sha256-EkrRKenivCUiUrlRFGWJ8kGh/lMZrl4+hi2xjghW0fk="
+  },
+  "io/ktor#ktor-client-logging-iosarm64/3.5.2": {
+   "module": "sha256-5ZTcwD42TvkOKbbcAuK9Ms+FMzC1Z9B12vwvt0sQqGg=",
+   "pom": "sha256-y//g0M0Cz7Fs9sfvEZKPx1nkuw99JQJt4pnad+AT4Zw="
+  },
+  "io/ktor#ktor-client-logging-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-client-logging-iossimulatorarm64/3.5.2": {
+   "module": "sha256-veosyiClFJZMK7rpJVps+WmOfZNXrt9z/bSLG3Iob08=",
+   "pom": "sha256-TMzkewCqTBherfvi1CSyG7irT7emNhNzvkSnJMqNMMU="
+  },
+  "io/ktor#ktor-client-logging-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/ktor#ktor-client-logging-jvm/3.5.2": {
    "jar": "sha256-1WK1k2hm/843hBPm1jKG2RrUnmoAfBDNQFL2iNWOzOk=",
@@ -1502,6 +2771,20 @@
    "module": "sha256-ON4oTdrRsLV/g09GFXk5+0wqVSXmebL81q+oChLCpws=",
    "pom": "sha256-gp4HOKA8rsNr+gPbr0dT+Lp43SC5VrM0i/l3ZlOuoOI="
   },
+  "io/ktor#ktor-events-iosarm64/3.5.2": {
+   "module": "sha256-j3+OLFwG02yaCyjTH92fbkMTf2DuGk7b4xT1LHxaEvc=",
+   "pom": "sha256-U1tiXo4/P8oMdwTTsYDVw4mP7DVLXuMoxPEmt6DE1ro="
+  },
+  "io/ktor#ktor-events-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-events-iossimulatorarm64/3.5.2": {
+   "module": "sha256-dMTc77d13je0S2VjAFfB9l/XTTOHR+d+Z/rxBAdg8UU=",
+   "pom": "sha256-iVAOB77Rnx9EdmkWyBKyxlrZqxpJqmhX6QeseUKK+8Y="
+  },
+  "io/ktor#ktor-events-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/ktor#ktor-events-jvm/3.4.3": {
    "jar": "sha256-DwShuDgBMaFOlwW/HcvJ3yMvEkFTP8W40avYMHR93KQ=",
    "module": "sha256-eeEIV/SWgUg1Pei+2HDfZqifPr8d6K4LaM9ff2T2+Gg=",
@@ -1530,6 +2813,20 @@
    "jar": "sha256-y2t/GV/ZyDsXJxL7E2i7me5gHCM66+/7nt8XK2oQKkA=",
    "module": "sha256-E8ITjdOBvsYoXxcKGqBf3XM6oVF2AR1WMOVSQzcqQVs=",
    "pom": "sha256-2dBbwHE8A1CJXfc4Re0v0U+Ip8BnL7K6xw8dULpxYDU="
+  },
+  "io/ktor#ktor-http-cio-iosarm64/3.5.2": {
+   "module": "sha256-ZUp2GqvDXYsWdQgInKw/GMzW09SqRn5M08e+Jdly3Ro=",
+   "pom": "sha256-arXKPLGByKPbqALrlFmfZomFpHQ+wYyWQMIUdt8rdwQ="
+  },
+  "io/ktor#ktor-http-cio-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-http-cio-iossimulatorarm64/3.5.2": {
+   "module": "sha256-V9v/qGy4sE5R8zFRqQlc+Oivj8y2VfHplXYS0CLl4gA=",
+   "pom": "sha256-+4QuTM0Ek5vJS6NKjGmwpedMl1BF2XA78U1Y+tbE49M="
+  },
+  "io/ktor#ktor-http-cio-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/ktor#ktor-http-cio-jvm/3.4.3": {
    "jar": "sha256-8ElYQSa29Nouk9fUMzYpYxLiqI1dUmPx0dJPG41m/zo=",
@@ -1560,6 +2857,20 @@
    "module": "sha256-Jir8yxjcNckKTj5CqUpS0DjNg7P+4PXs22YzPF1EEzQ=",
    "pom": "sha256-KEOq++mO0/BjjMQtRcYw7W/PtAU+P66zzz1Tg1W1pbA="
   },
+  "io/ktor#ktor-http-iosarm64/3.5.2": {
+   "module": "sha256-brV3Yi656/AFfhZfjaLDFW2sZtM2XUOcsaFeOglQlTY=",
+   "pom": "sha256-WLk8Xzb2Ee9M5p2OHhEdvHTtbNvmnmK+nZV5AgyJNxM="
+  },
+  "io/ktor#ktor-http-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-http-iossimulatorarm64/3.5.2": {
+   "module": "sha256-IJPHoJ9vz1vOO5dBLFfMSexuapqjFDEYW3KV1k5DLys=",
+   "pom": "sha256-mGEdnH77GazHfgeliyDlookqM3lbziLsavBcORDRyXw="
+  },
+  "io/ktor#ktor-http-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/ktor#ktor-http-jvm/3.4.3": {
    "jar": "sha256-sxNMLGxJvMl0ekJCeNByPtuiSiU7NkUOq8x/pWLirak=",
    "module": "sha256-gq5sIoutescyEwStMduZdvPP0zOPOazWtPNIKEAkvpo=",
@@ -1588,6 +2899,20 @@
    "jar": "sha256-Hf1GUk4bvz7XtPUjdlTYcY+RGGRYgoQlX7bLcv2FsnU=",
    "module": "sha256-LVImlZNGRAeVM9tEwjm+WtYU/b+XUDWYOjY5SWnWeq8=",
    "pom": "sha256-hEwLmtymxHJS7/uXhP2s21Cv27L6q5hEffkj+wZImUY="
+  },
+  "io/ktor#ktor-io-iosarm64/3.5.2": {
+   "module": "sha256-0LJX0TqXKYZvKYXB1dI6u4MeFVR+AZj6mFECjE5nxPA=",
+   "pom": "sha256-RJMGAxv6GM8eXMKmuybxOeYz91doIOE2/Ihe7bkFct0="
+  },
+  "io/ktor#ktor-io-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-yYi9/z9aTNTDtSc3bld79M0AN4216yY7fjpjvBd7B4M="
+  },
+  "io/ktor#ktor-io-iossimulatorarm64/3.5.2": {
+   "module": "sha256-R1HBZNwVYfPXLqGzZ++hwocL5FF26C80+BvMsuNX4FE=",
+   "pom": "sha256-/43xNvWfaaElI0gAoARDzwN87o3Wi8eY+auLgOunjaU="
+  },
+  "io/ktor#ktor-io-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-yYi9/z9aTNTDtSc3bld79M0AN4216yY7fjpjvBd7B4M="
   },
   "io/ktor#ktor-io-jvm/3.4.3": {
    "jar": "sha256-RdpGKS4cKwWAxIfrp2fX28tQRg3y1uiTf0PoddkrRN8=",
@@ -1618,6 +2943,20 @@
    "module": "sha256-jYyiWyCU/a75BQ5fAVbJfamBaUl3ZaBvXxvlqwoMyiY=",
    "pom": "sha256-egddBpj08lPqsBiULP7O1cJt4EeCHlMUolcCEIWeEg4="
   },
+  "io/ktor#ktor-network-iosarm64/3.5.2": {
+   "module": "sha256-28eROvq7NeCi5e5Dt+AWyuFk2eA1VXMfyMKdOauVp/Q=",
+   "pom": "sha256-XZWFYg5nuYYivr5giVKPTuXd9oC+kqVh/hlQl0qmYgM="
+  },
+  "io/ktor#ktor-network-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-83Ib758u6mIt1CDeMZZBUOUiClnwSTW1Mz6Ce46CD5U="
+  },
+  "io/ktor#ktor-network-iossimulatorarm64/3.5.2": {
+   "module": "sha256-+k3xlY+Fy9IRum+uKHTKw5QrZRgE1CgcqVFYI1Iq6mc=",
+   "pom": "sha256-7VFc630XMqBTgz7Pk9zR0wutYx2nTwZ6w32e+UpQA8w="
+  },
+  "io/ktor#ktor-network-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-83Ib758u6mIt1CDeMZZBUOUiClnwSTW1Mz6Ce46CD5U="
+  },
   "io/ktor#ktor-network-jvm/3.4.3": {
    "jar": "sha256-pro+Kta7OKI7CPCO3DLjpgBArZUsbDqeCIctXZbdi0U=",
    "module": "sha256-3wYcaZ9FR9LhGCepP0+I/lEfDK6/hXNOAU32gIkiqKA=",
@@ -1633,10 +2972,29 @@
    "module": "sha256-cdkgxBtzep9wlsdvj7XzadvPaMXf5+P5CcuijMFL07Q=",
    "pom": "sha256-oTdS54LS+mr2fVlbo9/1NZuOe/b5K7SJKjXT83Ut5ZA="
   },
+  "io/ktor#ktor-network-tls-iosarm64/3.5.2": {
+   "module": "sha256-OAhZ2B90x1iqoZnvKXMidYdBRZmpDGWl/oa+XDbthxk=",
+   "pom": "sha256-Ku8ObB7hOXzttiiSLkc8yyEUqdDEm+InjToUkR+72m8="
+  },
+  "io/ktor#ktor-network-tls-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-network-tls-iossimulatorarm64/3.5.2": {
+   "module": "sha256-WjZtIGNgTrDPf2byS3Qa/LccaXB40d46LFreptT1hoI=",
+   "pom": "sha256-l86u2k3MHqvGLxlkM3gkxbpQz8s/soVcet7hi8zFNpU="
+  },
+  "io/ktor#ktor-network-tls-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/ktor#ktor-network-tls/3.5.1": {
    "jar": "sha256-cu3Fh6DlhtyA9w2ipr9P4EGV9O4PgClpMF4quKQHVsk=",
    "module": "sha256-3BSH4grcT4ygNFx1gM8TGPF9q15FUy5ozvD5dW49Qng=",
    "pom": "sha256-S0C6maOc2xu3sF9ZKVd3UYQkKCPdjo73es1MaVIruY8="
+  },
+  "io/ktor#ktor-network-tls/3.5.2": {
+   "jar": "sha256-cu3Fh6DlhtyA9w2ipr9P4EGV9O4PgClpMF4quKQHVsk=",
+   "module": "sha256-qTwpg7p+QYY2qM/JBvICg9OTvirFCEX6yv8okl7ZSOs=",
+   "pom": "sha256-Fq1PzjXjowlyAdiNkz2zoY7mxM4FoZNZ1p8IosMqkLQ="
   },
   "io/ktor#ktor-network/3.4.3": {
    "module": "sha256-Mo0KmmgMefqIDSvcGGBNuOB3U2sT/lb2KM/ILbRWAxw=",
@@ -1648,8 +3006,23 @@
    "pom": "sha256-bzFQ0n63rKeUpb7T1Dh4XcXFTyPm8B6ZJDNn5Mc9jFw="
   },
   "io/ktor#ktor-network/3.5.2": {
+   "jar": "sha256-HINehsDVKyhOkT1gbzv/rO9a3kWhSoW2ZBr7kRVKx8k=",
    "module": "sha256-Qmohe+8iuGW1LQYAIS8s+nKARil27OVMHeN/3X5AwsE=",
    "pom": "sha256-8/+oqIvLu6poHERIAT1VgtTUbq2yzq9vvcvxAl4vJuI="
+  },
+  "io/ktor#ktor-serialization-iosarm64/3.5.2": {
+   "module": "sha256-gnCnLf8Qh/2aPD8jmf5gPfuNyFqE1/dVgI079dFJ0mI=",
+   "pom": "sha256-XAf5QfWx6SKxRmApscmVezW103fvSi+9fkhGYwsTCY4="
+  },
+  "io/ktor#ktor-serialization-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-serialization-iossimulatorarm64/3.5.2": {
+   "module": "sha256-rQQD/R68jE3A7afRHq5SNR7qHBWk3B2KE5KOxZpA+vU=",
+   "pom": "sha256-inoVfWgSWXY3L/bq5kRhvQhbJQeA13FfBu6hyplbz6I="
+  },
+  "io/ktor#ktor-serialization-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/ktor#ktor-serialization-jvm/3.4.3": {
    "jar": "sha256-WH37qUYnL2W0El/QpoJCxC2E3jn/wrguN7q/N+QtaRk=",
@@ -1665,6 +3038,34 @@
    "jar": "sha256-t8hdCHFM456cF6I1A43m+cKxIeX7V86QxaNJpl9h6fY=",
    "module": "sha256-CQtA2Ouf+GIu0BJUuDsGb5M08E07PEn2FCHqfJxbl8M=",
    "pom": "sha256-0M4BAEnK4tLNr/KZF0p+5hlt2bAmKFlzoQy4jMiboPQ="
+  },
+  "io/ktor#ktor-serialization-kotlinx-iosarm64/3.5.2": {
+   "module": "sha256-vr6suGqhtGkZ1rIBCTYQ+m65oWpFRwuegYVammng+jM=",
+   "pom": "sha256-CG8ltdnGiCcQkoQP5wRIMtjMYFs63mTa4Iqvsa5W1K0="
+  },
+  "io/ktor#ktor-serialization-kotlinx-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-serialization-kotlinx-iossimulatorarm64/3.5.2": {
+   "module": "sha256-zsu+ljN94DnNbQfTM2nbmxi9ozGfUzLcxASZSZiTv0A=",
+   "pom": "sha256-24AovMfLSXxHKQsG9G+mWKylZUXgjXcmEjVby//asiE="
+  },
+  "io/ktor#ktor-serialization-kotlinx-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-iosarm64/3.5.2": {
+   "module": "sha256-Z4HfZwQghsNAgW7RGoLeXuK7FnKVurveqOOdY/hs0R4=",
+   "pom": "sha256-+Y+4fuoZ2skDjQynPIbAWZMdye365978dtVaan1aqF0="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-iossimulatorarm64/3.5.2": {
+   "module": "sha256-BWWIvAOy1DL9mmqXImnA2/87i05x5xuqB8RdUmAw7wg=",
+   "pom": "sha256-/K5A0WylPrjIcH/XWaqmxNC8pPUpxvfdkztzTc/O04U="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/ktor#ktor-serialization-kotlinx-json-jvm/3.4.3": {
    "jar": "sha256-MoonKE5M3A0VVCFrfkrPhZ/jsM/UIcwgdcQ8E+PHYSc=",
@@ -1754,6 +3155,20 @@
    "module": "sha256-wFaghvLd+2Vs+9iY/Yt/sbKGEpDDeZUnqisZ/VPUdFk=",
    "pom": "sha256-ZO392HWOjdrQj97tLL6X7+So8gcOnv+WCXWfGzbSKVw="
   },
+  "io/ktor#ktor-sse-iosarm64/3.5.2": {
+   "module": "sha256-Z96h51pVBPlbUgA5XQrIGs+VllVT3Z2xAF7fwcinRg8=",
+   "pom": "sha256-6OcfhDr5a/VdConEAO9BVX2CSBnxKm+Z0EgZEeJHaCY="
+  },
+  "io/ktor#ktor-sse-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-sse-iossimulatorarm64/3.5.2": {
+   "module": "sha256-NvbXjBgIrFWy4LVuXmKm1Tay+byfsU49UhB6gTWFipU=",
+   "pom": "sha256-87i/G0cN6lSDPU39vSjzh3KkZjBXbpIFZibj+N1hxOw="
+  },
+  "io/ktor#ktor-sse-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/ktor#ktor-sse-jvm/3.4.3": {
    "jar": "sha256-qQaybsUziQFskuniSunXmXbj5YJncT0Muajyaj8/aQc=",
    "module": "sha256-GAzZFl4HYVhbtTmjRTR9zKw8hqE8dMRnL0ytITfoGsw=",
@@ -1782,6 +3197,20 @@
    "jar": "sha256-H0g43bfVfoS905E69LQGJ2Yqvbyi+6iSG4Z/GmLQv10=",
    "module": "sha256-dtbg1OksUQE/kx5cjtisyEFO9SWJFbcQ82Pam1TSEE0=",
    "pom": "sha256-xtqlT4TvVMpvXPIxYVYeDuTGuzlTQRRoUbb3nEzL1mM="
+  },
+  "io/ktor#ktor-utils-iosarm64/3.5.2": {
+   "module": "sha256-0fZnAFyJEhxyfxnExe9eYDB1AWzwsqFz4l5EmFXH5js=",
+   "pom": "sha256-dt6HrJojWYAmDH1jSXjLPo2USfPswZVOo26m1ZTadLM="
+  },
+  "io/ktor#ktor-utils-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xv3T970yJ7gzzqhQP2TAjIatEfpbvkuZzSugb3GSR+E="
+  },
+  "io/ktor#ktor-utils-iossimulatorarm64/3.5.2": {
+   "module": "sha256-9pgmvYCxjB6tnBUfo+vK+WNhR11Re8EEouWWTLW97uc=",
+   "pom": "sha256-8oM0581RqBjIBpJTqAA881trWqmMSnP0m5XzdFDiOR4="
+  },
+  "io/ktor#ktor-utils-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xv3T970yJ7gzzqhQP2TAjIatEfpbvkuZzSugb3GSR+E="
   },
   "io/ktor#ktor-utils-jvm/3.4.3": {
    "jar": "sha256-5Iuc5Rhw9BDHq1wEDI5tAmlIJ+v9/ForhPCGrQSbtWE=",
@@ -1812,6 +3241,20 @@
    "module": "sha256-wRMwbaxsKoNXqJVnkoneB+aXDkUiYxwz2Cdt/jNkKa8=",
    "pom": "sha256-ouwaroolZFKfkrtiUOjoDO3xech04+YJMoaghYalIFQ="
   },
+  "io/ktor#ktor-websocket-serialization-iosarm64/3.5.2": {
+   "module": "sha256-iRFzfhrUgWL8DanakyaVz4F0wOS5rp+YMO25wfwU3io=",
+   "pom": "sha256-ZNeZzkdNAMvDj2eNJu278LxBQ9KpgSzlC7CFjjmyHEA="
+  },
+  "io/ktor#ktor-websocket-serialization-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-websocket-serialization-iossimulatorarm64/3.5.2": {
+   "module": "sha256-387TMA2nizef7uABuk3+COFNWAo2rZF1pT10+saF+No=",
+   "pom": "sha256-fddfbRVSOcGPkTsKQX5vhcgxLDUfth1o6sVIPxGeXfs="
+  },
+  "io/ktor#ktor-websocket-serialization-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "io/ktor#ktor-websocket-serialization-jvm/3.4.3": {
    "jar": "sha256-2ZmnuQs9mtLvDRF8Ss5isQvXrBNFzRxqdoCkP/++DtA=",
    "module": "sha256-aA7NoHNJxf+3FzVwVRd7fehIpu690bXIhvlzzzpwgDg=",
@@ -1840,6 +3283,20 @@
    "jar": "sha256-t0VVWddBP5wLMIiSCfgkQBokNNj1zF6grTiLSFQ7dTs=",
    "module": "sha256-8hzBBuoyBD/+XLSdODYRhZcgwFnJT7yXrlqljxbNerc=",
    "pom": "sha256-seZOSnbwA6zcS27vILICFNefKrCtvJW7DYMrjSp5xpE="
+  },
+  "io/ktor#ktor-websockets-iosarm64/3.5.2": {
+   "module": "sha256-XnXof7a10iuj8WRADV+EVgMtx4X/4UcxRGWfCpQmdcY=",
+   "pom": "sha256-Vu7LhN+MMGDji3SFi4AJE8XWFF7x6Vcete7jLvv780I="
+  },
+  "io/ktor#ktor-websockets-iosarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "io/ktor#ktor-websockets-iossimulatorarm64/3.5.2": {
+   "module": "sha256-u9ip+Hgt89Ba+Rwiv9vKklXzY42/lCcO6Th9uhipsMw=",
+   "pom": "sha256-NiifnvfX3rmoWX1qKSgUQEbxfzVFSdrt7zzXxxxnoXI="
+  },
+  "io/ktor#ktor-websockets-iossimulatorarm64/3.5.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "io/ktor#ktor-websockets-jvm/3.4.3": {
    "jar": "sha256-7S+/uB0wKc8FpirHttRbOKhzoC+O5gsErmU0btUpnuQ=",
@@ -1870,6 +3327,138 @@
    "module": "sha256-IDcC1X3F44A0gwdDp0HmghRYC1b3KKLiwTlLWfBr3qo=",
    "pom": "sha256-GAZwy/stapHbc6Kb70B0wA6/EnRmy8DWaFK99dZZNO0="
   },
+  "io/ktor/ktor-client-auth-iosarm64/3.5.2/ktor-client-auth-iosarm64-3.5.2": {
+   "klib": "sha256-4w1OsMynwo9HUxj/M7cy2HSmKJbqUU/yQFA1IlHfE20="
+  },
+  "io/ktor/ktor-client-auth-iossimulatorarm64/3.5.2/ktor-client-auth-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-cBZS4YUvNwwqRxGuO3ZFL6lASSwYGLhfzHKTTLBhJKo="
+  },
+  "io/ktor/ktor-client-content-negotiation-iosarm64/3.5.2/ktor-client-content-negotiation-iosarm64-3.5.2": {
+   "klib": "sha256-nwglopYE27GRhMBdpFyP/tHN6ToZPwkUguW4WofvFug="
+  },
+  "io/ktor/ktor-client-content-negotiation-iossimulatorarm64/3.5.2/ktor-client-content-negotiation-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-UtVSP62fVCmIuLRuZtMA/+h7zQ714FJVwTUWxYFl0Y4="
+  },
+  "io/ktor/ktor-client-core-iosarm64/3.5.2/ktor-client-core-iosarm64-3.5.2": {
+   "klib": "sha256-k7lDcj+GwDAp9mrwVOlZbxj4gpXEGCbY1H/wSD3niaQ="
+  },
+  "io/ktor/ktor-client-core-iossimulatorarm64/3.5.2/ktor-client-core-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-XIT3U6d3DB40LIfdw2YDhehAhJHFi3HNGgmW+yDD+DE="
+  },
+  "io/ktor/ktor-client-darwin-iosarm64/3.5.2/ktor-client-darwin-iosarm64-3.5.2": {
+   "klib": "sha256-CuNuOp8LRzyr2xp5AvGZe8UJ2bkJkOdLJU/tFSBjtik="
+  },
+  "io/ktor/ktor-client-darwin-iossimulatorarm64/3.5.2/ktor-client-darwin-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-FCyJ8FZZdAQnh452rBNwG9ufaT6Wjaw7R7qTNuZnZcA="
+  },
+  "io/ktor/ktor-client-logging-iosarm64/3.5.2/ktor-client-logging-iosarm64-3.5.2": {
+   "klib": "sha256-tNwtsAxuMECJTQSAJ3c7LhH6vTJj4WQUY0crfuCIftk="
+  },
+  "io/ktor/ktor-client-logging-iossimulatorarm64/3.5.2/ktor-client-logging-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-xhS5ZekBkrQ5aYTQbqSR8ynC8FX8cgzC2kHMwEpJ4qg="
+  },
+  "io/ktor/ktor-events-iosarm64/3.5.2/ktor-events-iosarm64-3.5.2": {
+   "klib": "sha256-/Ec3q5WV8YHPz/bxiFGbiapCkszNsdWvBMmRp+LJT7U="
+  },
+  "io/ktor/ktor-events-iossimulatorarm64/3.5.2/ktor-events-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-AWsLrjVA63D9Wy0/BFgFXKpsLXnZ8uTBzjtXeo726iw="
+  },
+  "io/ktor/ktor-http-cio-iosarm64/3.5.2/ktor-http-cio-iosarm64-3.5.2": {
+   "klib": "sha256-j5jwR0XkAYEVeaBygrjpA390fJcIGziUjHbI09qVtXc="
+  },
+  "io/ktor/ktor-http-cio-iossimulatorarm64/3.5.2/ktor-http-cio-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-yxZeTLnhgBpedse2FkXzQpyZvCr4G3frerDByfUI+Pw="
+  },
+  "io/ktor/ktor-http-iosarm64/3.5.2/ktor-http-iosarm64-3.5.2": {
+   "klib": "sha256-XDI9gqB5EUinW2PrlZTrvKoQTgg24Icu+Fgpd0cjuwk="
+  },
+  "io/ktor/ktor-http-iossimulatorarm64/3.5.2/ktor-http-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-yoU6MJ0nef6M7zstSIXSiiL4bqgxMQEMx5zb7LkyOnA="
+  },
+  "io/ktor/ktor-io-iosarm64/3.5.2/ktor-io-iosarm64-3.5.2": {
+   "klib": "sha256-E6+sZF3R8KDNF++JqIMVVvP0iUbhl/OD36csW0D8FnU="
+  },
+  "io/ktor/ktor-io-iosarm64/3.5.2/ktor-io-iosarm64-3.5.2-cinterop-mutex": {
+   "klib": "sha256-V1ijst+J7pib6kcvKh10Oq58nuYZuHjqBF1yyskenQk="
+  },
+  "io/ktor/ktor-io-iossimulatorarm64/3.5.2/ktor-io-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-LcZ6E/Cj3zUcY7M9AzC886DB+Xmu2MA8OzT0KWOeIHE="
+  },
+  "io/ktor/ktor-io-iossimulatorarm64/3.5.2/ktor-io-iossimulatorarm64-3.5.2-cinterop-mutex": {
+   "klib": "sha256-iTj4m7q2KccscCWx1CTIlchPQWSdlNsV7rKdTFS/vZs="
+  },
+  "io/ktor/ktor-network-iosarm64/3.5.2/ktor-network-iosarm64-3.5.2": {
+   "klib": "sha256-RLA+ixuEf06/kjl4qNKoth5ThUHAmb5juPRLgK+sH6c="
+  },
+  "io/ktor/ktor-network-iosarm64/3.5.2/ktor-network-iosarm64-3.5.2-cinterop-network": {
+   "klib": "sha256-LJeCMHJOU8VwVB/UMXJ56Hz7+Gkzj4roUfEOC2Kgx8s="
+  },
+  "io/ktor/ktor-network-iosarm64/3.5.2/ktor-network-iosarm64-3.5.2-cinterop-un": {
+   "klib": "sha256-u0XvDmnlXJKlHPh1tjgA6PIuzbN+5b+DJarxLm8R1bU="
+  },
+  "io/ktor/ktor-network-iossimulatorarm64/3.5.2/ktor-network-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-7f9vp6+W+CxH9QXAT6iVwy2B+x9it4NNhuyeKL17dhA="
+  },
+  "io/ktor/ktor-network-iossimulatorarm64/3.5.2/ktor-network-iossimulatorarm64-3.5.2-cinterop-network": {
+   "klib": "sha256-Vw0Ks9BFQWv+J93Dvl7Gw1LjgeQdlulr2Lyy8HcvzUw="
+  },
+  "io/ktor/ktor-network-iossimulatorarm64/3.5.2/ktor-network-iossimulatorarm64-3.5.2-cinterop-un": {
+   "klib": "sha256-cquH0fyemEKVPwcOMcv4i7WSWRugttuar83ZIWLccII="
+  },
+  "io/ktor/ktor-network-tls-iosarm64/3.5.2/ktor-network-tls-iosarm64-3.5.2": {
+   "klib": "sha256-OsuELr36dQvAddDTI/sbyBtbJqbNuHM94uEijFfTS8k="
+  },
+  "io/ktor/ktor-network-tls-iossimulatorarm64/3.5.2/ktor-network-tls-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-6BX4NOHH0B3W/HmaTNmx++OvT5ErAh3lQeurJD5kbhM="
+  },
+  "io/ktor/ktor-serialization-iosarm64/3.5.2/ktor-serialization-iosarm64-3.5.2": {
+   "klib": "sha256-Yl5Afy1KuxAyXxpc5HjMFsVeB2/jxv+ZODkiRXctnAg="
+  },
+  "io/ktor/ktor-serialization-iossimulatorarm64/3.5.2/ktor-serialization-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-2oKexFKPsikqnz91UjgJCeGR8Rm6Y6FfyDj2qSN333I="
+  },
+  "io/ktor/ktor-serialization-kotlinx-iosarm64/3.5.2/ktor-serialization-kotlinx-iosarm64-3.5.2": {
+   "klib": "sha256-ViqXg21dq61XvNMTUJjtNxIEe0P7n8K46qcf/WLJt6M="
+  },
+  "io/ktor/ktor-serialization-kotlinx-iossimulatorarm64/3.5.2/ktor-serialization-kotlinx-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-VO+N2LIuRKdUUBaMYuvLpiAappt4/C+UWkYO32Wdfiw="
+  },
+  "io/ktor/ktor-serialization-kotlinx-json-iosarm64/3.5.2/ktor-serialization-kotlinx-json-iosarm64-3.5.2": {
+   "klib": "sha256-AsGHhBpT/JlQho3/otfJLONU076o5T6zcUuSF71RPm4="
+  },
+  "io/ktor/ktor-serialization-kotlinx-json-iossimulatorarm64/3.5.2/ktor-serialization-kotlinx-json-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-1/FQmYSVICZUOuiBUG4SZc6A+Odsu3RtZr2+Z2+ds2E="
+  },
+  "io/ktor/ktor-sse-iosarm64/3.5.2/ktor-sse-iosarm64-3.5.2": {
+   "klib": "sha256-tVB0Ii6vd12SfLmvmo0LLARXk6PSBD6l+oDpV6zrx3U="
+  },
+  "io/ktor/ktor-sse-iossimulatorarm64/3.5.2/ktor-sse-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-ZOieX3mJAUcb13BSmrvAvtR06S7D/veArgETCUfdYFE="
+  },
+  "io/ktor/ktor-utils-iosarm64/3.5.2/ktor-utils-iosarm64-3.5.2": {
+   "klib": "sha256-j8NDWkcSnksm3OGNmNAwtuj4WxayVAeBVT7PWoLxvls="
+  },
+  "io/ktor/ktor-utils-iosarm64/3.5.2/ktor-utils-iosarm64-3.5.2-cinterop-threadUtils": {
+   "klib": "sha256-UT5IuEZDRdxK4rloiALabb2Kf3pKo2PMUWsIse/Jt0o="
+  },
+  "io/ktor/ktor-utils-iossimulatorarm64/3.5.2/ktor-utils-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-coGq/+FYknR2N4DoHhmatoUipGPwCNz33Ie30kVg/uw="
+  },
+  "io/ktor/ktor-utils-iossimulatorarm64/3.5.2/ktor-utils-iossimulatorarm64-3.5.2-cinterop-threadUtils": {
+   "klib": "sha256-g60+l0oIx0Vx/7KCq1O7EZECfkXeFdrJDU5/BTDtHcg="
+  },
+  "io/ktor/ktor-websocket-serialization-iosarm64/3.5.2/ktor-websocket-serialization-iosarm64-3.5.2": {
+   "klib": "sha256-6DK2FQWG3u1AoigzVjbnyZYurS14y8ExtwMIVQWYjB0="
+  },
+  "io/ktor/ktor-websocket-serialization-iossimulatorarm64/3.5.2/ktor-websocket-serialization-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-bRbpLr4P+wric8p/iDKqpEjZyCUN2i6sUrTDg11vo5w="
+  },
+  "io/ktor/ktor-websockets-iosarm64/3.5.2/ktor-websockets-iosarm64-3.5.2": {
+   "klib": "sha256-P4CvTILL/W5tief0oJm1kadeQdE8rawsuYJ1auhYWoE="
+  },
+  "io/ktor/ktor-websockets-iossimulatorarm64/3.5.2/ktor-websockets-iossimulatorarm64-3.5.2": {
+   "klib": "sha256-bBr6oCsf3TNuG7GEAg6jNdZt/MSdZxLqOUD/4YLg4Yo="
+  },
   "io/modelcontextprotocol#kotlin-sdk-core-jvm/0.13.0": {
    "jar": "sha256-hT1iH4gmbDHtIcN0OvzVSR3dKjS5tabAixixpuoSXls=",
    "module": "sha256-+lwU3A5qQASE0jmiidUmZz4KF2Zz3bQD0wq6NJ1KLmY=",
@@ -1887,6 +3476,16 @@
   "io/modelcontextprotocol#kotlin-sdk-server/0.13.0": {
    "module": "sha256-2auRGosY8R3/V+OqjgpuPeli7tFcnQvsOwc2yagHmvI=",
    "pom": "sha256-YwAYy6jHAcr8goiZ7JrLLcBEVGB0NHUO2b4hUknx2Zg="
+  },
+  "io/opentelemetry#opentelemetry-api/1.41.0": {
+   "jar": "sha256-kzZmjziN5ooKLD4RQVT+vSnbGadkTyfE66VI9d6FIlg=",
+   "module": "sha256-JhRoWJyZO4j3zK2TOP/YFmud9Mw03jCAZpMrKlyd6VY=",
+   "pom": "sha256-vB7w93s71tsLem8WUv20IWmKDlQ3RQSnQZ+xvrRWKZM="
+  },
+  "io/opentelemetry#opentelemetry-context/1.41.0": {
+   "jar": "sha256-XjQypEZKQyq/2rc75xQuUW0lqEqoQm/OEZL/sFMvqjU=",
+   "module": "sha256-F03No+hAImE4rbjOkENXbdxDwoa2EtPb9kUx9nvY2Yc=",
+   "pom": "sha256-yzs5YlmYNClZTWLkdmdcwAuyUskNMU1keptW3sI+VSY="
   },
   "jakarta/activation#jakarta.activation-api/1.2.1": {
    "jar": "sha256-iwoPUvqLBcVDGSGgY+2GbvqkHa3y46fuPhlh8rDZZFs=",
@@ -2191,7 +3790,6 @@
    "pom": "sha256-4mWv9FITQAC70uwBu7o2wHx5bra3N2qvPx2PE37Nx30="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.6": {
-   "jar": "sha256-shoUn+KMzMfs43tVCY0QAnq6PS4Nsx0S083JB97SNoo=",
    "module": "sha256-gF5FIbAzeYEISMesMUzzyVT8jS3zSlsJEcRW1Djc2iY=",
    "pom": "sha256-0yUq74s29h2gYJD4T+URQCGCA0Tq0dZAw3NXohkYVBk="
   },
@@ -2205,13 +3803,34 @@
    "module": "sha256-h4v4qGH7h4NN834eunP946WSEV/A17pm6iPhkVcoMx4=",
    "pom": "sha256-LUvR/bTef5L9Bdav5YWZCJOLzBXsisNrKfafL1C+1fs="
   },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-iosarm64/2.11.0-beta01": {
+   "module": "sha256-huMbOfKHzv91P68PC1LCAaFDY5ekrco4yV/sWGwE1nk=",
+   "pom": "sha256-rAHViS6zPfluM01iLHxyFHL9iDVlQk6YxJLNlwRwpVc="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-iosarm64/2.11.0-beta01/metadata": {
+   "jar": "sha256-9W9y4CYa07Kisj8zSFEE0sIMxmESd2GV5zx9uGNO+CY="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-iossimulatorarm64/2.11.0-beta01": {
+   "module": "sha256-k8RrW5BvjN+/PCy70FK+s8wwBJQTcjPE5ttp3gmlqqk=",
+   "pom": "sha256-FuHXjZLWUjF9ejaRRpgYogIlkkPzP2PavuNDdlCT6yA="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-iossimulatorarm64/2.11.0-beta01/metadata": {
+   "jar": "sha256-9W9y4CYa07Kisj8zSFEE0sIMxmESd2GV5zx9uGNO+CY="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitarm64/2.9.6": {
+   "module": "sha256-QrJ3z/Ve2T0t55gczINl/M/Q8MWIzi668YvHk4d/bJI=",
+   "pom": "sha256-qh4nvNjDnK352CKcGHPRRUP3fej8rsVySSeJLr3ThqQ="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-uikitsimarm64/2.9.6": {
+   "module": "sha256-GwA7+gkTFa6uLikH1GRjCw/FGmDR9rUgup+v/MbULmE=",
+   "pom": "sha256-JrEH78gmH8DRsnnR+kvBEOqGiaki4Fz4RI5mDmgQrew="
+  },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.11.0-beta01": {
    "jar": "sha256-Cpun5dZCc6mlS4aRpO1A4qOAB4r0gsk8AqJ4v+XTiYU=",
    "module": "sha256-53UDYLuoJr678ZQuMO9EhSTGqsIii7KjORijVNRE1/0=",
    "pom": "sha256-2M1cgGUsEyWGUoVIXrFMXP8rjZ0dtScNql6uqSAbNMY="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.6": {
-   "jar": "sha256-rbdbK4nWjzONlCC4sk3ZulNohypPxw4yKCwvoPGToPw=",
    "module": "sha256-gAMMZAio8gsZVXh+GmE8tp8Fh26vW5GF++FZSAwPZyE=",
    "pom": "sha256-OFjDsK0gsHhobakHitFk7MbF5Y8wlvLS5vpmznPHg98="
   },
@@ -2221,7 +3840,6 @@
    "pom": "sha256-W8l3XQ4M96qyhq9yzz8mSNT9r2Ql4lL9ZX7XwTj6Tas="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.6": {
-   "jar": "sha256-ndWDtwkTbgqv5g4bkCSb9jvIDNe6bgZBznShqzYTxk8=",
    "module": "sha256-LSN78RA5ccVpZ6GVMbwI8QBuSZOoQxmpL04V+w+Qyhs=",
    "pom": "sha256-8ju8dgqLqe3xr4gbY7h84LcUMFl8DhLtXq9YJ2DTjnw="
   },
@@ -2234,6 +3852,28 @@
    "jar": "sha256-oTbDcc10jwa+OoRuUGn5g3/XWcTRP3wRlSk3vb17JVo=",
    "module": "sha256-tdA1ry4/i1DP4xYUd42XKzS8F3oySdXzP3itqqjeWCQ=",
    "pom": "sha256-5rrZm5ix3SrC5QxIG549b2f30pzND7hnNRhKcbtdttk="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-iosarm64/2.11.0-beta01": {
+   "module": "sha256-y1ASB8Bm69X8DwCqXhQTPUxNU7I7CaPQQqCW0Uv3qNY=",
+   "pom": "sha256-9w6XLJAVnkLziFPOwJeay/5pwStj0ZYYqunlLHofg4k="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-iosarm64/2.11.0-beta01/metadata": {
+   "jar": "sha256-1tN2UlVZOkk3xXCPtpNbvNJCsZ0VF76FRmYSLVU0h78="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-iossimulatorarm64/2.11.0-beta01": {
+   "module": "sha256-oAutSBvEaVx8dWBV5YW8WO3D/zwbfFIVihBZBYt5RM4=",
+   "pom": "sha256-LScdhbrRZyS+RGDJCYrvVXiqcu9IBBPonsudtsfh9dA="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-iossimulatorarm64/2.11.0-beta01/metadata": {
+   "jar": "sha256-1tN2UlVZOkk3xXCPtpNbvNJCsZ0VF76FRmYSLVU0h78="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-uikitarm64/2.9.6": {
+   "module": "sha256-GTjcCTTejgCEIygbnM9Oz3BAxJpx8niTs4PmGVNQLdo=",
+   "pom": "sha256-2yym+HTfCO0d2mqjbGGxyjrxN3yN0a3iWWdXX0LaIVk="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-uikitsimarm64/2.9.6": {
+   "module": "sha256-W+Lve7kz2Tks+zPp6lJ2MRpEd4NT1nPzFnNqCpOXzaA=",
+   "pom": "sha256-AIFYZ3VXJY26PcwhJjzmEXhm8v06e2yjsJHkeqhb+Lk="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose/2.11.0-beta01": {
    "jar": "sha256-7uex2O5C0l9erTccXwg+ciRy3z28+o1u51QhIkfzZ7g=",
@@ -2250,7 +3890,6 @@
    "pom": "sha256-io19cOazZ3NAVEq050HqQxzmK36zvyxipoLeyT+6mgc="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.6": {
-   "jar": "sha256-dCOTmMsfIKgROze5PTCfH1dJShT3DWV4ZI6LsIP4D10=",
    "module": "sha256-rQ264j3Z3KujqV0dCCwb+0xASxe7kySQ9ASayTgl3E8=",
    "pom": "sha256-hC0AC7vnoGloZw6B/tCSr3gLhtbjCLaqGo+QwjsrZ2w="
   },
@@ -2260,14 +3899,39 @@
    "pom": "sha256-2QO0fD7FLFouc+O1qruMFdBu9Op2v6TtSWDPF4zhEac="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.6": {
-   "jar": "sha256-ns0rxhNl+0+j9vKEq6khSNv9PRrKOGYq1UvOysKrVUY=",
    "module": "sha256-JMv8NlN1knXknL9Wl748L+fEpqHByk+CWAWk82EbYJU=",
    "pom": "sha256-oJpT4rFQ+ZKfyN33sZ0qhl1K8TRGnYFx5aiFhEA/zsM="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-runtime-compose-iosarm64/2.11.0-beta01/lifecycle-runtime-compose-iosarm64-2.11.0-beta01": {
+   "klib": "sha256-T5eL4fm3nM4V+2bBhP5klWPluzGO6Ny1zud2ub2zUr0="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-runtime-compose-iossimulatorarm64/2.11.0-beta01/lifecycle-runtime-compose-iossimulatorarm64-2.11.0-beta01": {
+   "klib": "sha256-verf00rqa4bkGNTjYd0xSTzJ0kPau52EYouma+MU96c="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-viewmodel-compose-iosarm64/2.11.0-beta01/lifecycle-viewmodel-compose-iosarm64-2.11.0-beta01": {
+   "klib": "sha256-AwHySQ37hXZFdzlQRcDzmLPdsdP5mOfI7rwA0i9WsMA="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-viewmodel-compose-iossimulatorarm64/2.11.0-beta01/lifecycle-viewmodel-compose-iossimulatorarm64-2.11.0-beta01": {
+   "klib": "sha256-Z9SXRnlLu7GS1vSIA+4a0Xs/wy8ZeLgjVOA47qoJ6O8="
   },
   "org/jetbrains/androidx/navigation#navigation-common-desktop/2.9.2": {
    "jar": "sha256-74woAB7xLiDawQcY/6BWI5KxtfI08fhWSuUWqeJagH8=",
    "module": "sha256-v1cEccAwP7UbyWfq6yBOne2OXqXTUCQvmfdQPsymc2c=",
    "pom": "sha256-SGl8a3JnwHYN3qGCfrMetZjePVvGGxcWgNzOq9ZScQU="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common-iosarm64/2.9.2": {
+   "module": "sha256-Nxrc9jguT9Ezpmxtk08Z4DGYzBuqFLEs6gksO7JC7RE=",
+   "pom": "sha256-pYMiV0DeXFLJHwUQGtgjhAqrOYbmnMYRIuUwNV2qvzg="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common-iosarm64/2.9.2/metadata": {
+   "jar": "sha256-5bxKPmLrXiYBKRvQZizkFnD8e+9bgq5Qs7EygQ491a8="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common-iossimulatorarm64/2.9.2": {
+   "module": "sha256-XDSIPKW25e9uruNNrzT1+owuvvvAK44Vib8hyE5JEEE=",
+   "pom": "sha256-1TxttY6sc6uLeBT14RbRZvP+OAbEAPZIg52NT3Pn6tI="
+  },
+  "org/jetbrains/androidx/navigation#navigation-common-iossimulatorarm64/2.9.2/metadata": {
+   "jar": "sha256-5bxKPmLrXiYBKRvQZizkFnD8e+9bgq5Qs7EygQ491a8="
   },
   "org/jetbrains/androidx/navigation#navigation-common/2.9.2": {
    "jar": "sha256-JItmVQ94lfuoSK+TUVP+6s5C+kWc78nIAKgQ3zzyToo=",
@@ -2279,6 +3943,20 @@
    "module": "sha256-pl+lSst6EwkVJ9rJCH216MGTMya5JWNK2oJVsbBnfww=",
    "pom": "sha256-4DdTuAx11pmjhqHKV3f2gesNHzZBcUXCU8EIcrH4/B0="
   },
+  "org/jetbrains/androidx/navigation#navigation-compose-uikitarm64/2.9.2": {
+   "module": "sha256-Lw2uzcE/zFVg04WS9p6sH89C3zLVHR8z1666Jlwwqqw=",
+   "pom": "sha256-hU2jUAPDdLpBe9hLNhzHmUgyAhigo/aPMKxFPB0k7pE="
+  },
+  "org/jetbrains/androidx/navigation#navigation-compose-uikitarm64/2.9.2/metadata": {
+   "jar": "sha256-+tom8TnKfbvQuRkyGQIoiQ2DIRkXiYjTFkHqVhYT2Rw="
+  },
+  "org/jetbrains/androidx/navigation#navigation-compose-uikitsimarm64/2.9.2": {
+   "module": "sha256-65kgEkt/VB+uBn9pnh6rEI7gD5I4qDowhoAoXThttEk=",
+   "pom": "sha256-XNA8qgGHAvaEVpJEoh65DAZ9NNhhddQp9d089VoQxcQ="
+  },
+  "org/jetbrains/androidx/navigation#navigation-compose-uikitsimarm64/2.9.2/metadata": {
+   "jar": "sha256-+tom8TnKfbvQuRkyGQIoiQ2DIRkXiYjTFkHqVhYT2Rw="
+  },
   "org/jetbrains/androidx/navigation#navigation-compose/2.9.2": {
    "jar": "sha256-JbpW2h2WOwK5wlG0vqVOywrNV1mwTi0XdKcwLm20Ezc=",
    "module": "sha256-X9LvB0ttX6IYIyrjMqVZn0g8V5GcS41fRQ+cOqNVE9E=",
@@ -2289,10 +3967,42 @@
    "module": "sha256-9NeKGu7I2VwsW4SEsyXuAogOwZERw31RakjVVAzFkJk=",
    "pom": "sha256-Cb87AoLVtWmekywGwKl7j6qZkoCjPaz2lNItKoubd0g="
   },
+  "org/jetbrains/androidx/navigation#navigation-runtime-iosarm64/2.9.2": {
+   "module": "sha256-pREQOI0ZTirUq/Mgesy319WDVdTu/z9VJfcq8OA7VWM=",
+   "pom": "sha256-vfLLlPnE5VzvQ0V3g065nPHZd6wf9ospKIEN1IZ7Aps="
+  },
+  "org/jetbrains/androidx/navigation#navigation-runtime-iosarm64/2.9.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "org/jetbrains/androidx/navigation#navigation-runtime-iossimulatorarm64/2.9.2": {
+   "module": "sha256-cepitkAKEqUu7cJF7oH0lYLrDZMlN/i91/QzKOV18hA=",
+   "pom": "sha256-Pji8G6qeCH93B7WmUmHWG7Adlbxj6BSMGhcrgO1GIDg="
+  },
+  "org/jetbrains/androidx/navigation#navigation-runtime-iossimulatorarm64/2.9.2/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
   "org/jetbrains/androidx/navigation#navigation-runtime/2.9.2": {
    "jar": "sha256-FTelpZZYgPf6ZH9z0gWEVUEnwDKLQDc84d8MPBGmejE=",
    "module": "sha256-uLziAf1EkSDTkgn27U8VsCI9p/KrwE8KBbYxE6uNzvY=",
    "pom": "sha256-Bj/lP1VK+ZQv4zl/idB2eA3I7Bd5DlSZ55W30+7QVOI="
+  },
+  "org/jetbrains/androidx/navigation/navigation-common-iosarm64/2.9.2/navigation-common-iosarm64-2.9.2": {
+   "klib": "sha256-dsxZp1sJftTB1GZoDGB8r15buh3NiuBAEvIEni5jktU="
+  },
+  "org/jetbrains/androidx/navigation/navigation-common-iossimulatorarm64/2.9.2/navigation-common-iossimulatorarm64-2.9.2": {
+   "klib": "sha256-u9ij9hDDofLYSNDnPjVtCt4f6NRUWapWF7eMxe/1TeQ="
+  },
+  "org/jetbrains/androidx/navigation/navigation-compose-uikitarm64/2.9.2/navigation-compose-uikitarm64-2.9.2": {
+   "klib": "sha256-US4crjHoIFx0Fd7rWl3vCxoBleCtcOAtGZiMEwYZysE="
+  },
+  "org/jetbrains/androidx/navigation/navigation-compose-uikitsimarm64/2.9.2/navigation-compose-uikitsimarm64-2.9.2": {
+   "klib": "sha256-U8wGq8H46EUi0KmjRCiUnk3ZzQT0FZwUKbceFRZt5LM="
+  },
+  "org/jetbrains/androidx/navigation/navigation-runtime-iosarm64/2.9.2/navigation-runtime-iosarm64-2.9.2": {
+   "klib": "sha256-98084qC+v8lBzvzlLqXusZGWZhb4p9WD0n3mG8HCJV8="
+  },
+  "org/jetbrains/androidx/navigation/navigation-runtime-iossimulatorarm64/2.9.2/navigation-runtime-iossimulatorarm64-2.9.2": {
+   "klib": "sha256-aXhMwPIFyA5HLZwiNa9twvBm93zlOSTaI3XMitWrius="
   },
   "org/jetbrains/androidx/navigation3#navigation3-ui-desktop/1.1.1": {
    "jar": "sha256-dkaaycGAVVRwt9IvlTc4WgUJpPiMOVjj6d7eMLCYsbs=",
@@ -2314,6 +4024,20 @@
    "module": "sha256-TRk1ZWQBQccW6qvjR2JffSepavMCaOPaNNL2aKEABLs=",
    "pom": "sha256-byAnPVlbDFYJ6c4CSaF9eoaxyGhLsc/aIa0afJUykRU="
   },
+  "org/jetbrains/androidx/navigationevent#navigationevent-compose-iosarm64/1.1.0": {
+   "module": "sha256-tp9au8jwxP0Xv7p157SioA1mzF3F5JfHwwxXNhHqkG0=",
+   "pom": "sha256-WxDscI0jMuIxW1e0/0XhOIL1aKEpbkQrR50Zj71IX/A="
+  },
+  "org/jetbrains/androidx/navigationevent#navigationevent-compose-iosarm64/1.1.0/metadata": {
+   "jar": "sha256-L6QojCYl5qElbY82Hbc8YDvj5tZyTQWgfEmYMawDl5Y="
+  },
+  "org/jetbrains/androidx/navigationevent#navigationevent-compose-iossimulatorarm64/1.1.0": {
+   "module": "sha256-VDMsfTPNNBLFQNNkRTBEzX9ASbk2N8J4zxUMp5jz254=",
+   "pom": "sha256-+a4YYWXkgW7iKJUGc76ZUPUuvcHSBF+QdP4Yc+BGUAA="
+  },
+  "org/jetbrains/androidx/navigationevent#navigationevent-compose-iossimulatorarm64/1.1.0/metadata": {
+   "jar": "sha256-L6QojCYl5qElbY82Hbc8YDvj5tZyTQWgfEmYMawDl5Y="
+  },
   "org/jetbrains/androidx/navigationevent#navigationevent-compose/1.0.1": {
    "module": "sha256-K12/6skxC/b5156pEXvJ5HY9Funl0eeHixkWiNkANlQ=",
    "pom": "sha256-1mlpfglQMjpTwtXcOA2+G9Fsms+SY4FH5MxssEyk/FI="
@@ -2323,10 +4047,30 @@
    "module": "sha256-zSpdihMYZ8M7G5TAOx3efWXQ3VpD24ucZKFXz8sWOaE=",
    "pom": "sha256-omQEzV33wf0tIDzcjWW1/VsAOt4pdqrW6Ac7QWvHXWI="
   },
+  "org/jetbrains/androidx/navigationevent/navigationevent-compose-iosarm64/1.1.0/navigationevent-compose-iosarm64-1.1.0": {
+   "klib": "sha256-WTH2vK6SP2kYs5djqc0dTY9mG5UvOPd6XVa1TCVhAMA="
+  },
+  "org/jetbrains/androidx/navigationevent/navigationevent-compose-iossimulatorarm64/1.1.0/navigationevent-compose-iossimulatorarm64-1.1.0": {
+   "klib": "sha256-NtqSfvCEqxlc2FQyWKNgsJucVgnA8QigRX03AxGtcGY="
+  },
   "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.3.6": {
    "jar": "sha256-Dz0EXF/X4TAatsOM0HeAZ7BITPOaysEjO+cacjpqgHU=",
    "module": "sha256-krjcB5kBhmwbUgx1DDHghRtQSZUkfa3yu1HPcLgO9pg=",
    "pom": "sha256-RJsKGtrBUXq3EzFIQN2vUqy/hz6shWCDsuLSGBPP0J8="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitarm64/1.3.6": {
+   "module": "sha256-ocQRE2gB973ixHxrZ/ZeuhV2nKfhSUofqfchJ0aREI0=",
+   "pom": "sha256-AJh7sp/qjOA5RqCXR9D6euWfhFEiom0KLlj8ti9VCg0="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitarm64/1.3.6/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitsimarm64/1.3.6": {
+   "module": "sha256-/FX3T+9m8rH8jLQeDGyLRiJ1U1+6gEuR6ll12i+dG+Y=",
+   "pom": "sha256-fG6jMnH+aORLysl88Nb14gO7W/gCCU6pVxP2O58IX3Y="
+  },
+  "org/jetbrains/androidx/savedstate#savedstate-compose-uikitsimarm64/1.3.6/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "org/jetbrains/androidx/savedstate#savedstate-compose/1.3.6": {
    "jar": "sha256-Ybi1HQS02ZLo4bYYrUzxFzJDAeSSrQagWPyWzfhht4A=",
@@ -2338,18 +4082,24 @@
    "module": "sha256-5Z+aDYcs4zt44W18XqY2lgRuYXKTSozo1Cdyawd5GTQ=",
    "pom": "sha256-+01/UV0FOzQ9G+gAao4Ehw3SFbi1L89/DJvIv+7WgMY="
   },
-  "org/jetbrains/compose#compose-gradle-plugin/1.12.0-beta03": {
-   "jar": "sha256-/STamWqkFCALSeRyFH1xqNSBeAScIx/qfwn2fbKkSAk=",
-   "module": "sha256-BsTgdCj1C34SSZv8kTiYIC1BzVsK2wIEzY9vMRBzIjw=",
-   "pom": "sha256-9pD1fTdBZbJiifGjFL2FEBAo4hN8JDI++DP44o5DeiM="
+  "org/jetbrains/androidx/savedstate/savedstate-compose-uikitarm64/1.3.6/savedstate-compose-uikitarm64-1.3.6": {
+   "klib": "sha256-3pVmyy+N0stYyMesXA33wSqV2BFm4AtNOA+7jNyoC3w="
+  },
+  "org/jetbrains/androidx/savedstate/savedstate-compose-uikitsimarm64/1.3.6/savedstate-compose-uikitsimarm64-1.3.6": {
+   "klib": "sha256-qwzrPPpNNHAaAwk3meTe6PqBvyqlSpfQ/0X8ZzWB86A="
+  },
+  "org/jetbrains/compose#compose-gradle-plugin/1.12.0-rc01": {
+   "jar": "sha256-GLREYvvajisNZ6nEWbeSND71kiBKBjfbnILeBI7govc=",
+   "module": "sha256-tKa/6AaK00f6dtmhhK0BvlkKe2Lv9y8BzKPgl09SAkI=",
+   "pom": "sha256-2tFW80Camhgd7nqgAEgdG5CYyde/KjLQ8EngCa88wWk="
   },
   "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.10.0": {
    "jar": "sha256-xJox16AUlF1BzaY8zpfbvbn+FOPScaTKfalmhKliDTY=",
    "module": "sha256-eoAK9PgqA9hgqpGo/7A7tqcK+1drO5hViYDYrS2PhZ0=",
    "pom": "sha256-L5XgUVmwXnU3x6doAaena/TqatKAlSc1KXtSWvAGtfc="
   },
-  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.12.0-beta03": {
-   "pom": "sha256-aPWCRlvhNwKsYMT0JAVtZxSkeoqQNXy1fKwXdz5GnBA="
+  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.12.0-rc01": {
+   "pom": "sha256-u6sM+jrKKErQtgKwV4njoLqrQUQtsIUcn3DspX5wvvk="
   },
   "org/jetbrains/compose/animation#animation-core-desktop/1.10.0": {
    "module": "sha256-LfYlAI/0oZQVU5lSH/slEwODLHlOB8vSro9mh9wMYRE=",
@@ -2364,14 +4114,36 @@
    "module": "sha256-Rph/TL1iXppweU70V5TDaS6KL6xOrxzJOSa9jg/t1i0=",
    "pom": "sha256-cWWFXBJR8MnoSRECCH5K54CALp31g6XJDfHx5AmDN7E="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/animation#animation-core-desktop/1.12.0-rc01": {
    "jar": "sha256-2Yi2t9hnFGglqdo44VIvxQWAqhSYarIqi3JPzc7xeHU=",
-   "module": "sha256-miksXjwQ5uueuCxrYGuA5QE+i5poUVvH1Sx+DCJWvnw=",
-   "pom": "sha256-zUQonCHoh1yKGmuptE9S61m0rm+vvX464Y/fqTW+g0Y="
+   "module": "sha256-QPGRpUd5xJEWCs8jQ3i3cZI/hy5UCi7rsxT4B9tZ6sc=",
+   "pom": "sha256-fSA2qV61/hSSZPNLpfMihborRRi4BV9wFQmtRJvCFkM="
   },
   "org/jetbrains/compose/animation#animation-core-desktop/1.8.2": {
    "module": "sha256-qxOVOtDhVv+Au9EXooS4EVYN46LMXQKvjWGDKM5xbIg=",
    "pom": "sha256-5BZ9JA37PUEKkRee2wCWUkkSqkdZLOk/SqbirF0g6uY="
+  },
+  "org/jetbrains/compose/animation#animation-core-iosarm64/1.12.0-rc01": {
+   "module": "sha256-2l2wFYqk8bBeVRPBlium/u9ceczm90geh+nwIHRwevQ=",
+   "pom": "sha256-h/NWoL1ljJjRhEantDWMDY9KHPOP6aN3OZ7aYGaOJ3o="
+  },
+  "org/jetbrains/compose/animation#animation-core-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-uLqqIXgdZEs68U8Dl2gGyiShRFON+O2khr6RE71PFKI="
+  },
+  "org/jetbrains/compose/animation#animation-core-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-l1VJO2HicW8sWy/Ylbfpq0wLqphsdh5NRwoBjxNPwH0=",
+   "pom": "sha256-hX6KOxzw/IpNCvtYbXTRytEuvFrk6eEO6Rel25z2WN8="
+  },
+  "org/jetbrains/compose/animation#animation-core-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-uLqqIXgdZEs68U8Dl2gGyiShRFON+O2khr6RE71PFKI="
+  },
+  "org/jetbrains/compose/animation#animation-core-uikitarm64/1.8.2": {
+   "module": "sha256-bTjXxDlLhCWds+oTWNjqLxb/imQkENDiTw+dNG0zClA=",
+   "pom": "sha256-QvGcSfLNNPJ+c+Ki7eRZp26OGaLbwAkJaae3yD2CRHU="
+  },
+  "org/jetbrains/compose/animation#animation-core-uikitsimarm64/1.8.2": {
+   "module": "sha256-M7sg06OJ7D6dCr0mbOADmYm0WP+5i02drjM9P/FHmBU=",
+   "pom": "sha256-sAxtfgBGChyp/HuStHqxoeL+M/D+2AwfBKy+/F80784="
   },
   "org/jetbrains/compose/animation#animation-core/1.10.0": {
    "module": "sha256-Ra/IUkPrfCOjjXvn/Hrwgh/jqcLsmTmgl/lvob74xv4=",
@@ -2385,10 +4157,10 @@
    "module": "sha256-UjXClMvph99Nuij0S8HfZY8R42FNTf/vsoSAN3xmOHg=",
    "pom": "sha256-MSxoDMiKNSbVmM/XK49Ic7rEv+sCyCrGxkgIIpEecpM="
   },
-  "org/jetbrains/compose/animation#animation-core/1.12.0-beta03": {
+  "org/jetbrains/compose/animation#animation-core/1.12.0-rc01": {
    "jar": "sha256-hWAww02ErbD+6mUe9V0FMgOuvSANvbgZKBXFATExYzY=",
-   "module": "sha256-21Eh1i39zxjAvwnHD8TfLzd6ItVWIKejUS52DJw9jMg=",
-   "pom": "sha256-rr0P+asZ0apR73S9Cx2CGleL9dYjUqiEvcXiEyHgQHs="
+   "module": "sha256-BsHebi78CiAVicTgoseKm2z3GiiNZc1dzHdY5q/A+xo=",
+   "pom": "sha256-pq/crXtArgowbBh49juiV4qQ7AiylXUfgBSWmnrEpZ0="
   },
   "org/jetbrains/compose/animation#animation-core/1.8.2": {
    "module": "sha256-tRGby7/TKMDcD8yKRynXk6g3vz4naSP1bRCtvifGSMk=",
@@ -2403,14 +4175,28 @@
    "module": "sha256-DEoL9Is7hj1v8jzT73kS97SpqHb3F3TPwiQKJ1YxKrg=",
    "pom": "sha256-o95ZtfTcd97jt5+shtFQ9gDiLORGcjj7WCIpX4UWKV8="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.12.0-beta03": {
-   "jar": "sha256-RhfpSIA7q6/EZW0Vn7UZaTTj/vcax9xxvR3SnKTcLcE=",
-   "module": "sha256-N9c4y86LYHBGwrHK7Woukvd015AmKBpDKO1IZlIKluM=",
-   "pom": "sha256-SVU1AFIt2FgZYk56hB9D27qdr73r/bH2zh9rfcYxZNA="
+  "org/jetbrains/compose/animation#animation-desktop/1.12.0-rc01": {
+   "jar": "sha256-BMCtsZYYUmcXPO9QZYo62ymHpPoDKHM8po8CkyToagk=",
+   "module": "sha256-44m/Oj3sVftEFu9aseQRoZ0lGSZb8Z4yIuy55Tm3Sf0=",
+   "pom": "sha256-o1dxJ6/7papUA9kIvwibRECgagtNXjldh/vdqN24pNs="
   },
   "org/jetbrains/compose/animation#animation-desktop/1.8.2": {
    "module": "sha256-vPH6Ul9Vl5pujum2UCMjOhSnfrY/4byJQwiTZTJm2I0=",
    "pom": "sha256-nef9zQzxwa0CmSS0INRqCxyz60RYwq8QhKxPs0+bv60="
+  },
+  "org/jetbrains/compose/animation#animation-iosarm64/1.12.0-rc01": {
+   "module": "sha256-Vm9xe2a4G6su7R0nXXxMNofiU2BG1kteTaRKzIrbVBE=",
+   "pom": "sha256-WgDnGrhgYjfCnlPJqcneNmmt1pMyqRddXbofr5ycT1Q="
+  },
+  "org/jetbrains/compose/animation#animation-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-GTHFdZLgybJz3iLWu/LtLk+X73rUCSVjn+MyVerP4v0="
+  },
+  "org/jetbrains/compose/animation#animation-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-S8XxdSHCfi/vAp8Zp4CG3yC/kahjsqWl6hCq3j5e3Zc=",
+   "pom": "sha256-Vkgo7nkdxz92QgCUryRU1SA4bN0y6Nd98O9eY3tjwEU="
+  },
+  "org/jetbrains/compose/animation#animation-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-GTHFdZLgybJz3iLWu/LtLk+X73rUCSVjn+MyVerP4v0="
   },
   "org/jetbrains/compose/animation#animation/1.10.0": {
    "module": "sha256-N85FDQJ65RiFUzuKznbXnQJHiUQMA/uCnyTd8MhyyC0=",
@@ -2424,14 +4210,26 @@
    "module": "sha256-ulAXgUxeI6owCHJZRKVCCvJKikD7cJJ7AEwcif01xX8=",
    "pom": "sha256-P5ZN3fZBLtcGUwp7bUfo2BS1dAL+kcMFvbRN+gPo+nk="
   },
-  "org/jetbrains/compose/animation#animation/1.12.0-beta03": {
-   "jar": "sha256-SpX7sTSn0Wz5I7DlcXbD7flxHo8jvH4NgQL0JgTx4/M=",
-   "module": "sha256-vFd1ax9EI2RIiQXxBuspdGnN6KAsHPJtElmp9r9Qugs=",
-   "pom": "sha256-ozr+8UIZ8/W9Qa61fVia8j3yharqRfjpNu+Hg6Qxfhc="
+  "org/jetbrains/compose/animation#animation/1.12.0-rc01": {
+   "jar": "sha256-2bXIupRzYi/l6KHGrlYWXh/AFKVX1foyuE+rPh8Trbw=",
+   "module": "sha256-JOXxWqcjOAV3wDAeVOeJwf1KMtHyo+4Vf+VTSu2ePZA=",
+   "pom": "sha256-7Xekod7m2/XE7tYOH/Uhkbk0oWZRqb9A0rg4Sxsd7b8="
   },
   "org/jetbrains/compose/animation#animation/1.8.2": {
    "module": "sha256-7RvWvOaffnnQdwZqUo1qKbH89/lh8CxTR5HrMl+BRmE=",
    "pom": "sha256-LNRhOg+sfyT5fbtCc3UTyge0NnCNnPgygVt+92XCeCg="
+  },
+  "org/jetbrains/compose/animation/animation-core-iosarm64/1.12.0-rc01/animation-core-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-U9o/7fiOmdKIokliaqEoyi8f6Y3E9EHCp0KXasVzrSw="
+  },
+  "org/jetbrains/compose/animation/animation-core-iossimulatorarm64/1.12.0-rc01/animation-core-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-6KDWD1+eTASRJLmRst7qees4FlQN/8TV7+zYVkA1NzQ="
+  },
+  "org/jetbrains/compose/animation/animation-iosarm64/1.12.0-rc01/animation-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-NPMwXo1BS3e0NgIWsO22AjHDsNl0lssYTNO5VCZgunM="
+  },
+  "org/jetbrains/compose/animation/animation-iossimulatorarm64/1.12.0-rc01/animation-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-c2ADJBndnPEU8hmX5CXH7pc8y9BDvrDmE8lm1Ev0AS4="
   },
   "org/jetbrains/compose/annotation-internal#annotation/1.10.0": {
    "jar": "sha256-WaDpt3s+H2HT4/Dfj5ntKhKxaN7YCeo55v117v+UvhI=",
@@ -2443,28 +4241,48 @@
    "module": "sha256-C6k3s06FAnNf+ds1y0RpAs8RooVgyGqmSDNlu9/548I=",
    "pom": "sha256-5FdZGCjqC+2jhllNlNsB49nX3XcypgY4eZrlkxzyNqM="
   },
-  "org/jetbrains/compose/components#components-resources-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/components#components-resources-desktop/1.12.0-rc01": {
    "jar": "sha256-nVrQfQgv/8GccoUW6H1R0+Q5wACHzAZ/ghoRbyfosp4=",
-   "module": "sha256-V2EnMB57C/uBCPBooeR4PNU0gq1/jIlv8GPew2dpEtE=",
-   "pom": "sha256-5w/ie/O+fUmNg30xGxU4Y5IZuEGymepIpVqldZHzKQ0="
+   "module": "sha256-6oiFn41zofN8bVOGx/8DKrt1rluxhpDigfNv+En/3f4=",
+   "pom": "sha256-1kopJHnUJljoyOndovh9NOAamqIEemrOkKVPIW40lrI="
   },
-  "org/jetbrains/compose/components#components-resources/1.12.0-beta03": {
+  "org/jetbrains/compose/components#components-resources-iosArm64/1.12.0-rc01": {
+   "module": "sha256-dcSwi6UfPynRCMfgHUSmkarBZW+sD9HI00tEUgQNXGg=",
+   "pom": "sha256-Yqjrz1BaohHP9sQfsdeuFUTovZtRlrDafl4G9rWfbW0="
+  },
+  "org/jetbrains/compose/components#components-resources-iosArm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-0nM7s3AubJhKiV+xNsnkPSfeCiqvWYzA5aRPqbQgADs="
+  },
+  "org/jetbrains/compose/components#components-resources-iosSimulatorArm64/1.12.0-rc01": {
+   "module": "sha256-jRsIY8x2FpB4B5kbGBW5Iqau2onYJ6Cyvd4P9UaXECk=",
+   "pom": "sha256-M/sBJp8bTQDxvDh7o9rroPDlkL1c1OxRvHnhKi7WrZA="
+  },
+  "org/jetbrains/compose/components#components-resources-iosSimulatorArm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-LmcvW0P4imeIjEIkJ7l9fJwe/H1N3M8dd5u0HxPS+HU="
+  },
+  "org/jetbrains/compose/components#components-resources/1.12.0-rc01": {
    "jar": "sha256-+o6gv03BQllsOmWHXWELEv7W+JltPxhjzfOdP7vQywg=",
-   "module": "sha256-Tce1XkXrlmSlsPoQYwJie+DMQ7gZBRQA2MJXK9Fmcl4=",
-   "pom": "sha256-Sn4GbmRnH9iR3qDGIccFr0Feqr/8gMvCSCgjw8t5kLE="
+   "module": "sha256-DWKTTe3tARwehG4Mdp3JQVkD769dKnKsuo5lsZGyZSI=",
+   "pom": "sha256-nLw03/OB6zZzpgZHyUeEvk9Jas/GF1ZrgP/ho6VVRD4="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.12.0-beta03": {
-   "pom": "sha256-h+U/zbZFVfpwga7H/kPRi9lJ6z01m1dmZRLB7ai3nWA="
+  "org/jetbrains/compose/components/components-resources-iosArm64/1.12.0-rc01/components-resources-iosArm64-1.12.0-rc01": {
+   "klib": "sha256-4krV0j7YRGDjNAcgKOh/rw5cAfE5RSUsP4lKWbwNvFw="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm/1.12.0-beta03": {
+  "org/jetbrains/compose/components/components-resources-iosSimulatorArm64/1.12.0-rc01/components-resources-iosSimulatorArm64-1.12.0-rc01": {
+   "klib": "sha256-ZD/Tr1EVZXHV426bmaL3BsGFbsETMhFiawSTJfRUkww="
+  },
+  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.12.0-rc01": {
+   "pom": "sha256-wC52ZNYbmukpR+4VEFJQGZJu+C8I18v0Fnr7V/AmwqU="
+  },
+  "org/jetbrains/compose/desktop#desktop-jvm/1.12.0-rc01": {
    "jar": "sha256-ra6m7GMEIHEtz9UqNWtGrvYDEpyn92y6IEVpES+oDhw=",
-   "module": "sha256-yL5sThflMkdtMimrcMVydAhxE7A7bo9druqguiv+BL8=",
-   "pom": "sha256-OXswlVEfw13gjQXmu3SV2DtC6ZkzDpJSt+3fU4Lc7p0="
+   "module": "sha256-L7wwRqlvxB/GfkprQcVk54o8dl70qculWBZxumRagX4=",
+   "pom": "sha256-uFp1EPUE7hkIe6ZNy8rexKJiHGSGw/WB6d1h6lXkdII="
   },
-  "org/jetbrains/compose/desktop#desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/desktop#desktop/1.12.0-rc01": {
    "jar": "sha256-FYbciOwaF305iDF3Ini+Y1s/1QUGxOZ4HjJluFmyi8U=",
-   "module": "sha256-PLmFYj2i/aJ5iCsOAc2PYmGlUC2RcK9aoxnEIGepQOE=",
-   "pom": "sha256-8l9O/ct3x0bKWygxW31a+2Q/dKTDxDqk+xL4J4OgsDA="
+   "module": "sha256-j1hC/CKUq32787ptkKPU9sJuqLt98jmGQvOI+sOThhE=",
+   "pom": "sha256-aXuBgOLC7j4Mb1UBqiRzlPcp0GDfxmJCHQSZmDi4nk0="
   },
   "org/jetbrains/compose/foundation#foundation-desktop/1.10.2": {
    "jar": "sha256-Opt7+ucvGpKoEj0ykLt9f2HZLlzeh3r1Nzw+XCys6ys=",
@@ -2475,10 +4293,24 @@
    "module": "sha256-0WjpPqO2A7KWO68telm06t7EPhy5ME+4Sga18Ttloc8=",
    "pom": "sha256-bh8LZjBjHF+l60Wd75khISStYcF9jZMokOmiHB+docQ="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.12.0-beta03": {
-   "jar": "sha256-IGDsEATO+r9iYbwdLjmWieLRX9sExnbjVdlrSo33Nco=",
-   "module": "sha256-1R+8k1bjjQ+5NPDywbR/RJpAHNDC/yeF7Qa+HkKccCA=",
-   "pom": "sha256-2mUTK5bOnh7L77DsWOjCU5JOAiJmdEd2qm5gLlUstJ8="
+  "org/jetbrains/compose/foundation#foundation-desktop/1.12.0-rc01": {
+   "jar": "sha256-F9OfyBgqtGHX71LNmGGLSJ6XCzpIpJs81oRBqCnhMx4=",
+   "module": "sha256-8dIw6U0Na8OlgZLH86PLOz9j7XxE/qz4dTMmFQd8AiY=",
+   "pom": "sha256-hMczLF6u3VJloHQZ11aa06MjoW8pplqRNnMlVcUAGfc="
+  },
+  "org/jetbrains/compose/foundation#foundation-iosarm64/1.12.0-rc01": {
+   "module": "sha256-gi/uYoBMvOEzLMEmShBgVYoFyi0OT2hN5HYC/F257GA=",
+   "pom": "sha256-OlhTQc16XVVhzcAXkk/ej1g8UkPdawZS8Q5pH+Hf8NA="
+  },
+  "org/jetbrains/compose/foundation#foundation-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-+47MctHcNL2MaqvY397/C3unb343tmAGxV35XydzKFk="
+  },
+  "org/jetbrains/compose/foundation#foundation-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-2RZGEGnhJ7O8NPqaaYDFbIWDI4iQI7LXxGrEhx66c5g=",
+   "pom": "sha256-sReFRX9llQJqO04BRtwJZ8o0Xl82z4Ef63bCHtmBbvk="
+  },
+  "org/jetbrains/compose/foundation#foundation-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-+47MctHcNL2MaqvY397/C3unb343tmAGxV35XydzKFk="
   },
   "org/jetbrains/compose/foundation#foundation-layout-desktop/1.10.2": {
    "jar": "sha256-jY4ABiqDoUdAn0L5F5g5TDwiHSKHeVPv99CoF2e10Pw=",
@@ -2489,10 +4321,24 @@
    "module": "sha256-pjOF4Z6L3JjB2V6Ovs6fYSd/erhFpjf7aTGEQQDorww=",
    "pom": "sha256-r51GM5B0KNs/wJTV8YrAH9hI/doadraNuJxQ8aKRzRk="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.12.0-rc01": {
    "jar": "sha256-V7VMEEuunuoOkLsmSH+LZOrQmkc/GzLL7YV5CE9IXns=",
-   "module": "sha256-QM0wr0zfMoTfeCa+63j+o93snZJYgPkJsebuyaascSY=",
-   "pom": "sha256-zGuyXIBnzWsoyRAt+sP495fCnZ2S5fiZ/7jwrf+4+t8="
+   "module": "sha256-/FpcmpO866WyxfM2hpJ4yqP5H9/5wUv9b6qa4avibDk=",
+   "pom": "sha256-b3wtbDEyI7lZxchskQ06FzM2Hldj84U89YwU1N8j2FU="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-iosarm64/1.12.0-rc01": {
+   "module": "sha256-M+7IAnTFh9JAMRfVKaXNz6lwtwYJbtxHZoP557lWeJ0=",
+   "pom": "sha256-X97mKnyVAB71qWL3CAxlXbuNf3SCAXklS3G6PLUL60w="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-VNDK0uBpHdGYy9AcpSc1NGWDSAw3saYH9Plj3yXIFew="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-25RYGNSfO61SM/bk7a5+Tf07C+FXA3u7Okvj/zyI6r8=",
+   "pom": "sha256-/SQXGEjwzY0LWJtlay3lzzvnzL2qUSdKdl1UT3lESKA="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-VNDK0uBpHdGYy9AcpSc1NGWDSAw3saYH9Plj3yXIFew="
   },
   "org/jetbrains/compose/foundation#foundation-layout/1.10.2": {
    "module": "sha256-z9jjcq0V1Wccv6bOg9DEDDiceJUNIZ66hYYRSrBXzig=",
@@ -2502,10 +4348,10 @@
    "module": "sha256-NEBGaZgZCwkMu6/5vsjgPcLu7k24BzooUhRZof5VIGE=",
    "pom": "sha256-FD3fSVUx1ispchkn1o1R6xkUSYPnJ+53UQ2BIg+7+Wo="
   },
-  "org/jetbrains/compose/foundation#foundation-layout/1.12.0-beta03": {
+  "org/jetbrains/compose/foundation#foundation-layout/1.12.0-rc01": {
    "jar": "sha256-7vah94vi86YyT3HpLUOW2/RaaTKKIiSUqf2Qj5J3Kzo=",
-   "module": "sha256-/u+iYAWVOphrrPRYFGbAlzqzI47fCbDy0YgoPkbpASU=",
-   "pom": "sha256-L2+TahIbf1qFAYrQMGTMz4BRcwQBBRpNviifyv2SQmU="
+   "module": "sha256-TWDpSreZB7uBA6BKTIRFlXK5K3t/lqtncdameWzHXrQ=",
+   "pom": "sha256-OslnYmwXaJ4nx6UVtSVmRRJnfh6lNTzUc78jDcRYEGs="
   },
   "org/jetbrains/compose/foundation#foundation/1.10.2": {
    "module": "sha256-Smr5jULzXCALfuumMz1YBIrS/Y6tmWt6lPRe9Y99rZg=",
@@ -2515,70 +4361,96 @@
    "module": "sha256-rDHX0W1aWSsRZMlyFgWcEdIYrpcAMvrXb56Rs1cZ3pE=",
    "pom": "sha256-qNVdTiO5tH5XLRC5LHVfnIXHpleKnYRlgJ2ev4YV6pw="
   },
-  "org/jetbrains/compose/foundation#foundation/1.12.0-beta03": {
+  "org/jetbrains/compose/foundation#foundation/1.12.0-rc01": {
    "jar": "sha256-3KinopzOW9jNgUsvpDPgF1fqwMRVSMMAAB52dWn2U2g=",
-   "module": "sha256-N2KaszEF4daYLmPQr2DlWgj98CCiI+n8kCuKXuviT0U=",
-   "pom": "sha256-04n3dF2DNj/xqSYHpm8sRrsGxx6TsB4Rr/swD6Rfhmo="
+   "module": "sha256-vWDiuPfN+gw5F0s5tnqc6xIS+5KmXC7FmGp+knkyr98=",
+   "pom": "sha256-Pe9GLxzRnyfqWxZZ5wj0A+PNS8uRJD1B8jw0kC+tAsk="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.2.0-rc01": {
+  "org/jetbrains/compose/foundation/foundation-iosarm64/1.12.0-rc01/foundation-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-hnv+dun0YtcVnUzBF4QKDRYNfjMs7iWSxYDQiaYjUjM="
+  },
+  "org/jetbrains/compose/foundation/foundation-iossimulatorarm64/1.12.0-rc01/foundation-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-tavXlmQEbb0fNJh4TeLH9v+YwBieLTrWtdgdx7/qztw="
+  },
+  "org/jetbrains/compose/foundation/foundation-layout-iosarm64/1.12.0-rc01/foundation-layout-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-+Jar7qyZzfxVvQVx5Ldd0fUUsuRrAgEyvO6tedRaarI="
+  },
+  "org/jetbrains/compose/foundation/foundation-layout-iossimulatorarm64/1.12.0-rc01/foundation-layout-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-Jdr35FoS4uEZw5pLbgTPuqxvy+nxgoIhybYUkRQvKdc="
+  },
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.2.0": {
    "jar": "sha256-9QbjmAxn+HbJUUvgIJW8rTvv969P3tu/WXlD2G3wcPM=",
-   "module": "sha256-ZBsWzojDRJ81xo7VyZBxAyOt50DykgFrQrmyhm15Rmg=",
-   "pom": "sha256-8tPgbD7kmSU0QYZ5HVhj4cmCfRpX3ao27NE1NaOc8j4="
+   "module": "sha256-6sJ2wzw36l8ryd3C3bzTHxSpT9QzM9W9CwoaNhbaHIQ=",
+   "pom": "sha256-/PfOyVwOTkFo5tDemdIcAGlrPeo6guQYstJ2qaIPJhU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.2.0-rc01": {
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.2.0": {
    "jar": "sha256-pegeEYe6ut0xH5a8FJtMNqK013MTrA5+kTybmRR3wOk=",
-   "module": "sha256-QlIiOA59dPIR8Nluv4Q73JtRIGV0/iAe+pyx51BUzPU=",
-   "pom": "sha256-NAsK2fIN3V8+x+T+6ZORtjyo34rzg5E7tAnsVvUBbyg="
+   "module": "sha256-LUoAHzWEnstTT5x9cqtMn3Onli6rs1f/cu2BHuo4Ml0=",
+   "pom": "sha256-5ABj8Go0vxpxFo9q0Ge+Zp4Ctls96xkXyKB9m/s5lzA="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-core/1.2.0-rc01": {
-   "jar": "sha256-E5IwFGoa1DxJ9mVeH/qmCaXxpp5RJvRxQV72QOwgpkk=",
-   "module": "sha256-fr2aWegxt3Tzcq/R/eqAo8ZPNb9qDTNvUZetYvOoY8E=",
-   "pom": "sha256-qFDFeemSJ9ygoEcAwTHSbQqkApeW4QGgoBvwmykQftk="
+  "org/jetbrains/compose/hot-reload#hot-reload-core/1.2.0": {
+   "jar": "sha256-6EhM7WBD8HZK5FohzdMu6TPGtCF9jtO8Rp5QXzpJvmY=",
+   "module": "sha256-JfmU/zdung5SuZ453BFybIFpB+H/sj0fw06GbibJLxk=",
+   "pom": "sha256-d5QCtwAArpDEP5KUWRjxkFD4Arg+JdPmohSqY3lNIbU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.2.0-rc01": {
-   "jar": "sha256-UPxQdWAXv95j16K9gRMpk4V+GTtJpLnsbTd7KkwP2sA=",
-   "module": "sha256-9PS9xyD0XLbkTU92KVBgHJJtDDzeKkYEJi/iSiSan/g=",
-   "pom": "sha256-rpTrZJdxNyY21CdTa53zekWv08Sm7zxGNw/aYvOaJHs="
+  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.2.0": {
+   "jar": "sha256-SQUmsczjRIpyz5N+jRxWamZn5RQKIdBTgFQP0U7heYM=",
+   "module": "sha256-71E906rmOcKiShpXMHPT+wjztmo7V3tFRQYfy5CMgw4=",
+   "pom": "sha256-fiELxVbDR7dDSxB2yZ+hLnLrzMWcMx8QW9aDBeThn+w="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.2.0-rc01": {
-   "jar": "sha256-1WsV7bVcorf6fvUgJI8Ecdulk9gb3Z4Ry4CQuFiF6ys=",
-   "module": "sha256-UuTx8HrWjTRvPr8rOJ9pB/UjHQ0+D34kr6QrGeMeQ/k=",
-   "pom": "sha256-tIbrt+FCPL7n5qhtzZx5eATACEGcRYYcbtFy+KAenuE="
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.2.0": {
+   "jar": "sha256-uVVQAfLcOguleam0zSBD4eQPR0r9tZj1QrU4x0vibyM=",
+   "module": "sha256-+6znweobGoMG9gzn/CazY/pOaJlWUPWkmGe6v76K5C8=",
+   "pom": "sha256-aeFs/NHgVN74Y0M4ySomi56z/bDjau2V3celF9UmQ/o="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-mcp/1.2.0-rc01": {
-   "jar": "sha256-82xIsgFRuAnDR6Wm3mr1Ei8NO6FZmYeA1ocoMCp+QRM=",
-   "module": "sha256-GHb6poPpV+p/JZJZYzyH1+TBhejjlUlPDe2sVVYjanw=",
-   "pom": "sha256-8+KNF4njIh7XtVdcnbc2TpSsb0zAglSbbB/qEPrEOwI="
+  "org/jetbrains/compose/hot-reload#hot-reload-mcp/1.2.0": {
+   "jar": "sha256-Mn5fZ1DuYY0TPV2Uj4Ik/g8ndlvmnaEy1EhAvAlcuQE=",
+   "module": "sha256-4mVvZEhRQ0foW8u8dAwYEK5rQ57tDmFQhBdbPVBsoJg=",
+   "pom": "sha256-BtoASnaBMf9OGd7i/hmTxgE5qZoiP0ZUi8B0vMCiAG8="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.2.0-rc01": {
-   "jar": "sha256-irI3rr/dpdUFM+rzfLYb/Ne1lAnLxzRdK8VO8zCu4Hc=",
-   "module": "sha256-aaxNJXh1QCv+ZV9ketrUSq4HBNr5C39YspQP6f33/sE=",
-   "pom": "sha256-aSov6mHZxYrrlAiOcm9CFlApYHijzbIvSpRMOjE0X/E="
+  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.2.0": {
+   "jar": "sha256-yOZtSk3a1ZdAj5MzyaMXyxGW8FH0SN46q8ykaCnIvtM=",
+   "module": "sha256-8gQ2e9dpVVrR5Sx6PmM8u3j0CTnN8v3cwZlGbopkmlg=",
+   "pom": "sha256-Om6GL2CmAfucgwxnpYNJ1b90C/vUrjl9NyHI/56La1I="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.2.0-rc01": {
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.2.0": {
    "jar": "sha256-VZULFPN7q8+qofWwGuOnuSICaK5Qdz3C6yYGp5NFx8g=",
-   "module": "sha256-buAh2b1S50EscLDnJvxBf79yj2gZpsxZvl4rRzQF0ss=",
-   "pom": "sha256-c4YX34A7efrh+HdWPDOcPTzftw0lHLyTzqlvt1BDpn8="
+   "module": "sha256-TW2/LEowtnxpSByeCqZ9uH+Rs3P03SuSGOfKVyZBqjk=",
+   "pom": "sha256-NE43XfoZK00COp3gB/+b3zx6ZjD6MNSCElmRb9NjDD4="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.2.0-rc01": {
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.2.0": {
    "jar": "sha256-EbyT08rBkVwpgax6pBAFkrW9DqAD26CxRHh7ykirStY=",
-   "module": "sha256-WEyJoLruweKgzh6prE09vR+HVMr1cu6A3Vc/vGRTxmE=",
-   "pom": "sha256-cAf+jdjKNfYUGr8Oe4+1cO9YnhjcWDm/YANSszJECVY="
+   "module": "sha256-MRRA+i1+dGIXzNkBzEmvjJpi2AptjIDv4S4Ia+iXeWs=",
+   "pom": "sha256-u3tY5TCAOzadUFZLkUYl4Nd2r5rdeMcaq3THLTmeK0c="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.2.0-rc01": {
-   "jar": "sha256-bmJofzv2sihDNyK5FuTJxCSREPdQ4XCeH5zFO4hmzeo=",
-   "module": "sha256-79FFKXYw/a89yecDFrCnvt/q+CikXXI/zQvxdNdLHD0=",
-   "pom": "sha256-x3hQVm+SuzjKJTZe5w7YmfnJh17kTVmI4O6wasvbw58="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.2.0": {
+   "jar": "sha256-cNtM0mJe/MisFe9bcV3MokvXH9hi0hvyS7EqJC3K6vY=",
+   "module": "sha256-nmudX05fD2FLZCe/DCxhPHGFB5iFCTfF3cHntsEzhT4=",
+   "pom": "sha256-f9znrEgz78W88ZBXQFJwlaFf3PPPOQ0MsFaBrMDd5sc="
   },
-  "org/jetbrains/compose/material#material-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/material#material-desktop/1.12.0-rc01": {
    "jar": "sha256-DB3Tl7RafNgwI03fMNJTtYYlnnJqXNgWzKLnkRmkf6I=",
-   "module": "sha256-ZTvTbrmmsl8wlO7XFl99U+dBR/nPVCjw7gp9uZaKKpk=",
-   "pom": "sha256-nrIsJ5UFGEe6EZ6T/JeORKqFYFJDt+fkuoj6NYYZwZU="
+   "module": "sha256-fx1RBtZ9K5syQyTXkT0wWqvJr4oEYEQQ76AuUJUV55Y=",
+   "pom": "sha256-1pZTUKUa1Ei3ZjaHmXiaV02jy2coMeP01gyGBJ+PhKY="
   },
   "org/jetbrains/compose/material#material-icons-core-desktop/1.5.12": {
    "jar": "sha256-7jqTNDei3XlJ4NnFcTh8wpdtYaen9ZhJDblUVu2P8B8=",
    "module": "sha256-kYI3T4zW8l2ufPH9WWH0gAfJ+85dnOvo1mGosZ6TBB4=",
    "pom": "sha256-WyRVrqT13SrJjAHgtWpd6x8VMborM9wDgPsedQgT6RQ="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitarm64/1.5.12": {
+   "module": "sha256-zAnw/LUey8401Rt+1u76tboiyP/cbIhMnViPe6xyAaw=",
+   "pom": "sha256-RBePZ9PbwS+S8jI1Ng1r5lieA/f+F+h9JJq6ysUTTq8="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitarm64/1.5.12/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitsimarm64/1.5.12": {
+   "module": "sha256-Lx/95OlPveCHUBK46WU3hWTJOcgiMQlTZcE3afp479A=",
+   "pom": "sha256-nNSgeBeuMt+dabn6d4euK5SjpjUpSce+5HfsRHbI3cM="
+  },
+  "org/jetbrains/compose/material#material-icons-core-uikitsimarm64/1.5.12/metadata": {
+   "jar": "sha256-xt6tovrFO46mUj29p3WXsSgAZnRhbxQPBN8jJkxtGqM="
   },
   "org/jetbrains/compose/material#material-icons-core/1.5.12": {
    "jar": "sha256-sddTBP83QvWcWmUudIRKZv7zYWmwIgXeOkb8qARZG6g=",
@@ -2590,35 +4462,61 @@
    "module": "sha256-ihekSQIUm1I1ZRbxt4Ve+bmRtS5KsZJCdmxvJpgLxtg=",
    "pom": "sha256-moAEr4TjtQbC0bnnqPOeounvYlwKWAzOpDWrgVmZm1E="
   },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/material#material-ripple-desktop/1.12.0-rc01": {
    "jar": "sha256-BqxypfV7LnJOoSnvvHGXOiep4c7rf1aCgdyw0e9ESP0=",
-   "module": "sha256-x1xXJ9lHxPjNFDwZpZgAF9LlDDD0ubVT1tJug/h2Uw8=",
-   "pom": "sha256-/ahae8KMtfubYXO3XOK/EX2SPVGA9jDFPCk4ptoKNxM="
+   "module": "sha256-7Ou2IgxXpLKNGZbpel1ehpT6LXaaYAQ14Kov6IRy1N8=",
+   "pom": "sha256-9C4uQWD4iguf0VDFbC4ehAQOCeOBNbcedlLhWh5gQ2k="
   },
   "org/jetbrains/compose/material#material-ripple-desktop/1.5.12": {
    "jar": "sha256-alADYML/sY6CmLKPuRJwoFyyQ8X1CUf1dOZc+Nk9Jok=",
    "module": "sha256-8hvvfxINj2loiao1E3FnKQyCqNBuXCV6eceraF+psC0=",
    "pom": "sha256-bkX6I3O5CYthyvxjX0nLakcoMsU2aCSmvABM9EERN7M="
   },
+  "org/jetbrains/compose/material#material-ripple-uikitarm64/1.5.12": {
+   "module": "sha256-yaL796whqkToBfyHn0W35kBtWiDH1kRMDV1IwftvNd8=",
+   "pom": "sha256-UPLDksuqQwk2ECoVgKhhZ//aT50DEGonNxjGouUY4dw="
+  },
+  "org/jetbrains/compose/material#material-ripple-uikitarm64/1.5.12/metadata": {
+   "jar": "sha256-DIRyAHJKKRM2IxF9g4G3Ydt5ppIisYwbYUvgM9lAoFQ="
+  },
+  "org/jetbrains/compose/material#material-ripple-uikitsimarm64/1.5.12": {
+   "module": "sha256-Gj44NZYpvMmZDOsp+G7njXQANpeUPWx7ZrnqmGq+WVU=",
+   "pom": "sha256-Hk1h8zw2hqXZGKSMk3u/SNr+a5ZXsMPjCLt+fbayDDY="
+  },
+  "org/jetbrains/compose/material#material-ripple-uikitsimarm64/1.5.12/metadata": {
+   "jar": "sha256-DIRyAHJKKRM2IxF9g4G3Ydt5ppIisYwbYUvgM9lAoFQ="
+  },
   "org/jetbrains/compose/material#material-ripple/1.12.0-beta01": {
    "jar": "sha256-s/2P36bIzBZQaYimOK9jnMi3my2DabSUYKSHU+aMuRk=",
    "module": "sha256-GgBmeKLPSpdGfXommv8BGbGuLnMnYhOcPTRb8v4p5Fo=",
    "pom": "sha256-kVWgu/MfSK5IRDowYVYEWdIyrjOhBM1XJTWCvHI2gpM="
   },
-  "org/jetbrains/compose/material#material-ripple/1.12.0-beta03": {
+  "org/jetbrains/compose/material#material-ripple/1.12.0-rc01": {
    "jar": "sha256-s/2P36bIzBZQaYimOK9jnMi3my2DabSUYKSHU+aMuRk=",
-   "module": "sha256-cuvxr0GZN6Xc28KuxV8NbEKW+11Cxw+TbjvDVXrcGt8=",
-   "pom": "sha256-VwtTOK5QLPSWdaMbdaCy1zu9wkBPYxQCSITpwM+M2do="
+   "module": "sha256-w6mpZU/L4KWmAUNWJhiS88WLS4QQAVeSTZyLj7gRe2o=",
+   "pom": "sha256-rOD4viaEc8mkdITT8Fi8sidAGt9xgXJrxrzMEe6iTnU="
   },
   "org/jetbrains/compose/material#material-ripple/1.5.12": {
    "jar": "sha256-Y5HHORvwp+3X+QTKYiejB1F8csO7/KkuAANJ3RQhgQ8=",
    "module": "sha256-tlOm3j7g82ISgi0YtWTQ64tKb/bTh46FsOaxYTOoBUE=",
    "pom": "sha256-p9j9rHGRd39PxygiOT7GNytZstNv3WOf+8lAFtWnDaw="
   },
-  "org/jetbrains/compose/material#material/1.12.0-beta03": {
+  "org/jetbrains/compose/material#material/1.12.0-rc01": {
    "jar": "sha256-3PFkEq/mObT6V9adUaX8I4P5IyJz6DYcwHl/e9MDKEo=",
-   "module": "sha256-mXT8XDBouWWs6GR7smq5K2VvvUBkRuuLnzVfgsXZ1Vs=",
-   "pom": "sha256-+LrAmv6/hqcm6Mdoe6r7KPR+LL+P5GjvQeSUXxN9R7c="
+   "module": "sha256-5FKOwx+SfKFGYqaVtC+T2zDyUJ7YGAWSMGE8gofYggA=",
+   "pom": "sha256-ZSb5BedcIM/B2md+cOKuQyc7ifsIlLBO5NK0YvtABwU="
+  },
+  "org/jetbrains/compose/material/material-icons-core-uikitarm64/1.5.12/material-icons-core-uikitarm64-1.5.12": {
+   "klib": "sha256-NOvePnjK+UlqeCnfFhBFH8BySQh9sgjGtCV3VYg+sjM="
+  },
+  "org/jetbrains/compose/material/material-icons-core-uikitsimarm64/1.5.12/material-icons-core-uikitsimarm64-1.5.12": {
+   "klib": "sha256-AMvt1hvPdESJW69CxfhyYAq/AyqYUZ1Yk4inl18POBM="
+  },
+  "org/jetbrains/compose/material/material-ripple-uikitarm64/1.5.12/material-ripple-uikitarm64-1.5.12": {
+   "klib": "sha256-CJ3cpf4/gap3zrQ1MJLlVu/5A+JkMwE2UqD+QHhyE1w="
+  },
+  "org/jetbrains/compose/material/material-ripple-uikitsimarm64/1.5.12/material-ripple-uikitsimarm64-1.5.12": {
+   "klib": "sha256-wzv3BUOVQYzqzSt0HREFUV7IaSP0QrwdazXE7hJhIYM="
   },
   "org/jetbrains/compose/material3#material3-desktop/1.12.0-alpha03": {
    "jar": "sha256-J6yA2hw/ZbZzEb+uV9efEwt9TQrI4cW+HKfOiwS30Nc=",
@@ -2629,6 +4527,20 @@
    "jar": "sha256-YT5NtlCh397WcQq1SzMWYdrcMjhM3lVkHCGrSJJGKn0=",
    "module": "sha256-u0BsZLQ4mdU418PRj89juxa/Y35fA6cCL+THpgKs6lA=",
    "pom": "sha256-qXsqB8rVaeQDXfE2lNsw9CV4KhgsCd6LtAwV0+rAS/M="
+  },
+  "org/jetbrains/compose/material3#material3-uikitarm64/1.5.12": {
+   "module": "sha256-S0VUfneG883o6DchoiJb9y9R0xhr4ZaZBLyP0L+lwYk=",
+   "pom": "sha256-Ic+WmYMTHg6SUrOAoTiosUdPSdyKhCN0BhNjk5lZH9M="
+  },
+  "org/jetbrains/compose/material3#material3-uikitarm64/1.5.12/metadata": {
+   "jar": "sha256-Hl84NrcLiU8e9TTqhdusDuNmysvRJljbOqAaPPaMrjU="
+  },
+  "org/jetbrains/compose/material3#material3-uikitsimarm64/1.5.12": {
+   "module": "sha256-RDJLFZhyshgIlKOstPg2B8xCUyClcsdLDX5X7LVYvYc=",
+   "pom": "sha256-TRHGG3KE7IVLYNz4n5JP2leRhtwDp8xkzsVTLXJvefw="
+  },
+  "org/jetbrains/compose/material3#material3-uikitsimarm64/1.5.12/metadata": {
+   "jar": "sha256-Hl84NrcLiU8e9TTqhdusDuNmysvRJljbOqAaPPaMrjU="
   },
   "org/jetbrains/compose/material3#material3-window-size-class-desktop/1.12.0-alpha03": {
    "jar": "sha256-qEiEZbstZStHW4UYe7vQGRmoBl/FkoEgabR+L6HgUb0=",
@@ -2650,6 +4562,12 @@
    "module": "sha256-L2PkS5fRmBI2ro1KqHW0Rjo9K2XhrojDDtBZHx/7xb8=",
    "pom": "sha256-PEZxQHcBk2pYlRUW1zLaZTKaVWajFiMSuwd+DQHVsac="
   },
+  "org/jetbrains/compose/material3/material3-uikitarm64/1.5.12/material3-uikitarm64-1.5.12": {
+   "klib": "sha256-iP8r+CXmNUfQlbJ5kIANSPseU2aOqdYqYxGgeaGpt18="
+  },
+  "org/jetbrains/compose/material3/material3-uikitsimarm64/1.5.12/material3-uikitsimarm64-1.5.12": {
+   "klib": "sha256-XgjvYFxhb7SDaWdS54tvT8COqklinNuLBaaoRrdMpZg="
+  },
   "org/jetbrains/compose/runtime#runtime-desktop/1.10.2": {
    "module": "sha256-oaKNowIUkoW1jRVCJP1QXiop6FNh8/u91dWHgns7wS8=",
    "pom": "sha256-jZnPVbQT89n+PiMDcnTfkr02QqHc4YuMc4YmD6ZeC3w="
@@ -2658,32 +4576,56 @@
    "module": "sha256-VN/axM8YPGpjtg6jcT4RNnlGqcsET4QH+yHNdA8/7OM=",
    "pom": "sha256-5uRZg/PpGIa2P1BLiM/VdiZdp6yzR/VyZ149sKVXGTY="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/runtime#runtime-desktop/1.12.0-rc01": {
    "jar": "sha256-mkD7msm5ihsti+Uc5X289zPnaPoGqeSFmhd1y1K/aAY=",
-   "module": "sha256-IyQcN8w2d1SpSsFQiHdMV+dpAJorKoAE1o1OovoqAvI=",
-   "pom": "sha256-bTrlxoii2gxE8KzmqWjzfCi56ssNvJbqlTRUOw7ybJg="
+   "module": "sha256-5LpQr8092C6xSfPyzDWj0/gaRPs5RvZJ693D8izUrS4=",
+   "pom": "sha256-6g72B89XTtznQKzUA9PmiIAEZYixJO9/5zbcE61ZJ9k="
+  },
+  "org/jetbrains/compose/runtime#runtime-iosarm64/1.12.0-rc01": {
+   "module": "sha256-3029lxWQ+/106fdW4JjAgLYurBJZ6zvC8Z81LnLpUxk=",
+   "pom": "sha256-R7RvtnKyDWvoDwHr2mv1Ac85Dkvt/E83CEqgDqoyb34="
+  },
+  "org/jetbrains/compose/runtime#runtime-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-sQKT/tQYRAuhK0kuDkLKqhCWWBM0tLUG2uMZ+XErqG4="
+  },
+  "org/jetbrains/compose/runtime#runtime-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-C7dA6sXad806boSw16gg2iPEwAXDdl1NXud3Hr57Unw=",
+   "pom": "sha256-tOsm+61gghfa5lP27THTnVjCC6b1+vAiPtxmfvYUbZs="
+  },
+  "org/jetbrains/compose/runtime#runtime-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-sQKT/tQYRAuhK0kuDkLKqhCWWBM0tLUG2uMZ+XErqG4="
   },
   "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.10.0": {
    "module": "sha256-4y7c2cx6vAe/yA/F67aDp5uA2NhdRcWJUM7FvL8EZyU=",
    "pom": "sha256-7OTe747w7AS3p5VdQi8LOGFoId6ExWq+USc6xq3BcI8="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.12.0-rc01": {
    "jar": "sha256-2Blz3O0iPWrqe/n21OrShUlMZW6gA7WQcrq+/SVHDHs=",
-   "module": "sha256-9aIHNbhQLdP8Pa/IJW2BvED/pPdlEiRvaXp3TAj4nUU=",
-   "pom": "sha256-EOXdzqmk8+S0uttPC6I1/k2nKmhejwaGTzoIMC9J9MY="
+   "module": "sha256-TgcNGG0MBQcq6huihq6I/3CseSisVCmzbGcpOyN2BfM=",
+   "pom": "sha256-Y7CZwZ0Fj04Zy1k/KEp1v9zA37n6Sj9esCX8Cd8kDUI="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-iosarm64/1.12.0-rc01": {
+   "module": "sha256-6OB9xc6oxvAKzm9l0SKDo6cy9bbh8pUyupe8RedimmY=",
+   "pom": "sha256-K8Mw88LDP7/Ltd/cI3RNlPLms7cm2Q/0N/J68fmuZm8="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-GxtOEc7ORj17jjxMrr6Tk4pDcrZEK+YzZa5LwXuEwRk="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-2SlQ6L+2QYipBj4tIrn7pSf/cH5WGEF0USAruSqX0CA=",
+   "pom": "sha256-+BCVdUuSMrpZeW47nEsZLmz29+HiR2ms/AlQbJlK1LQ="
+  },
+  "org/jetbrains/compose/runtime#runtime-saveable-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-GxtOEc7ORj17jjxMrr6Tk4pDcrZEK+YzZa5LwXuEwRk="
   },
   "org/jetbrains/compose/runtime#runtime-saveable/1.10.0": {
    "module": "sha256-arj+tNQ/o5qZMoaY5NFHk+iu6nCcWmYc4bDfYkkbY+E=",
    "pom": "sha256-2aoJbEhWOhPKXTFsdvVHhgtk95prjz87NbDTOhBsjGo="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.12.0-beta01": {
-   "module": "sha256-A+ogrbSZX1clbMnGiwmnXjpB3DAjBHexhJKQ+2otUac=",
-   "pom": "sha256-ERJhRxTk/r2QxLb7insKkStP93aA1by5gfSJWtvrk00="
-  },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.12.0-beta03": {
+  "org/jetbrains/compose/runtime#runtime-saveable/1.12.0-rc01": {
    "jar": "sha256-33BvOcsMzqsbWAwywLh9hVIkdY36wtmN3WJD4rpiijY=",
-   "module": "sha256-abNk8hZkuVpNsMVdyV2xlI1U4inuYicZrLKBZnQAf4A=",
-   "pom": "sha256-2ecp3MCTFxelbqIYTb6q4wgBj7IadsN1oevh+9Teflw="
+   "module": "sha256-/5YTfohkgg7UrOET1NnUgIfbhg664pKtaBFFzfzLcnM=",
+   "pom": "sha256-hvPlgHHORtrJzjIbjTp1MWgl/ph3yjE4o4bxhE+LO6M="
   },
   "org/jetbrains/compose/runtime#runtime/1.10.2": {
    "module": "sha256-YVvm9uNuWeiDhCSGqspbi1NTFq+r8ltTi3nlyy74is8=",
@@ -2693,119 +4635,221 @@
    "module": "sha256-z9v1ZLTFXzLe4p+m+1v04zA+xdSwhcNoZ6Uz0l42ZEU=",
    "pom": "sha256-BI/26pMhJhvIUkUVOMImkjkCXZSiZDZSoeUB0qyI624="
   },
-  "org/jetbrains/compose/runtime#runtime/1.12.0-beta03": {
+  "org/jetbrains/compose/runtime#runtime/1.12.0-rc01": {
    "jar": "sha256-asCjxy8PIyQwi7sm0r83gftIIGsnVjgWj89UDmuljNQ=",
-   "module": "sha256-Xb08fn7yU4z2FU/vgL9Y9MctCyhpfDPuuveD3Le1bi0=",
-   "pom": "sha256-DXH0sayEXpX0vGzast3hVvyxhG1vqJNjPEKeSdB4x0Q="
+   "module": "sha256-Ef2ONZu3nkUXdrZhGwZO7MMCI/J3j6wks0IoUWoY6js=",
+   "pom": "sha256-/BIwHcC/k/GZn579lzBTYTfpjd3W2s4EYYvNHrAVsKg="
   },
-  "org/jetbrains/compose/runtime#runtime/1.9.3": {
-   "module": "sha256-RoPOYaDjW2fnQuNTqNRlcXglAxwQgc+7+zojate9s9o=",
-   "pom": "sha256-4yJMwKXBCThxJVp+fmcbXoXsxKLloEg1Q7o3Tc9awq4="
+  "org/jetbrains/compose/runtime/runtime-iosarm64/1.12.0-rc01/runtime-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-+a0nk79k38vyBCIBLysMrp0Mp7K+aTLu3qaG2YTseM8="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/runtime/runtime-iossimulatorarm64/1.12.0-rc01/runtime-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-fHs2SA5gvuNMUkZG0uctQht4MEw9pq1MTYD6115Mq0w="
+  },
+  "org/jetbrains/compose/runtime/runtime-saveable-iosarm64/1.12.0-rc01/runtime-saveable-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-7GnkKMd4uWct1v+FBtwo9bgCK7ASZwqD/vIFQcCpqIs="
+  },
+  "org/jetbrains/compose/runtime/runtime-saveable-iossimulatorarm64/1.12.0-rc01/runtime-saveable-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-YypMhg4HpgCZvgU13CUlrKbl4Pkh4gaGUndlgbnbwvQ="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.12.0-rc01": {
    "jar": "sha256-C8AhrMxhbCqZr+DDnKHsKQgvp4p7mYaO0SLRYuq4KL0=",
-   "module": "sha256-L6FgBi5GOAnbOg1zurl9zit6yDCZr97ex30ttBpA96s=",
-   "pom": "sha256-XsNLZzaqwPOpi5xOmikpBbOoljhBnSL4TxS3E9OyB9c="
+   "module": "sha256-zeWWgkDvPCJAqq4E8zrV9Dn/+KpjBqZoEJ8UKFWiEus=",
+   "pom": "sha256-PmGZYsbtmEhoX94Z5chDw4tbg/m4YSM+OALRy3cQZq8="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-iosarm64/1.12.0-rc01": {
+   "module": "sha256-QmgDm5LUMhCjixYTUzxOdXR6QReGbnUCRgIDPS3OCiY=",
+   "pom": "sha256-kU9Vx/0RFRsP6iOF/SWZmizkpz730dJuKBC0nY/D21Y="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-vUrFahmAkXvbjaDppN+snz738j56w0ibEPNT8bhTs0k="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-lL7qijS/czexQ0bKBrx9TUEg6chfpSMH8jZ9LBVSIE8=",
+   "pom": "sha256-cNyHQvxLxMQJP4ktzZEpWvuuGOfvCzjoc0sH73C80qg="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-vUrFahmAkXvbjaDppN+snz738j56w0ibEPNT8bhTs0k="
   },
   "org/jetbrains/compose/ui#ui-backhandler/1.12.0-beta01": {
    "module": "sha256-rxf4q7HNblwauAh28AzAFRJSsJKY+DmUDHIQySkB0sA=",
    "pom": "sha256-AqHIShqJBflEPUWloyalRv6QwOEVtgkLqeJwdyIhKig="
   },
-  "org/jetbrains/compose/ui#ui-backhandler/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-backhandler/1.12.0-rc01": {
    "jar": "sha256-HLx3/04wMfHX8dmuiuboLIHtCEuF+jjTU/FQVD1+jnc=",
-   "module": "sha256-zqdCOSmAlznSVJYHFUL0EVJ8wYbS1ALYjGwh1Dmxkes=",
-   "pom": "sha256-Xt/Gbzu6JVgqTRXmXoOW11TQ1ehNuxduGquqpfj/6FA="
+   "module": "sha256-hk2rxUQAy4Yw+4NFYT69D+lI6lJHhGIwhp5HTVQjpT8=",
+   "pom": "sha256-1plY33qf6h0kFZwexZUuhnhs/y1405RKCy9qc6Tmpus="
   },
   "org/jetbrains/compose/ui#ui-desktop/1.12.0-beta01": {
    "module": "sha256-Zy56ti3kJXNMKiWlv2lfPZv47mP0ymAarbXsaZtuXGM=",
    "pom": "sha256-mEyG5WpR1xWTqvneamY014eXVGMCHQHL6NtifxOMUvw="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.12.0-beta03": {
-   "jar": "sha256-q9H7UmmExjW5O1FZ6Axws7t4r+m1LNBwi60NPOy9FpI=",
-   "module": "sha256-mePfdglolhaXKM8dGLXbtjRo67AXhIb7XbQYhz54Tls=",
-   "pom": "sha256-8tndfwuznBdnbHcGEvd5YmKWoytkk81JwF8wMYml3l0="
+  "org/jetbrains/compose/ui#ui-desktop/1.12.0-rc01": {
+   "jar": "sha256-Z06Uvoh78h0m/0KP44o8mktDn+h4z9vG51/Cbecl7U8=",
+   "module": "sha256-rrJjWVzj08XtAmTfdSqwWxwl29QhmUlFld2YuV4wRWI=",
+   "pom": "sha256-e2Xg87MZUx+D2CQzdTslbfzSUt+u+7G31g1mImi85s8="
   },
   "org/jetbrains/compose/ui#ui-geometry-desktop/1.12.0-beta01": {
    "module": "sha256-KyLCtcbUa8viZZ4KAyfItoJwadXBzEbC7wvIkI1lyLg=",
    "pom": "sha256-nXrRyo2h9zlBb5CPy176aNkCogMVPqlA7BZfMNabCfw="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.12.0-rc01": {
    "jar": "sha256-LN5E2VuiFlTcztOjCYvdFxs+9bF+9/xs7A0lmD28n6A=",
-   "module": "sha256-dkcppcmhn9oLzTpw9OusVqCMAJxLwhivM3mPt2/Ftn0=",
-   "pom": "sha256-6bJzs+lZpJci5tLD6heERhC5arWtzaj5tCVWCUvTbxE="
+   "module": "sha256-l8ZinbTsADaIZc1VIscQK5EvpPbbr2CzR1FFNHiiuZI=",
+   "pom": "sha256-FRTNJVwFXjvxwdeNKHVMWmJ+KrxKh+vKpj1Fj+US7M4="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-iosarm64/1.12.0-rc01": {
+   "module": "sha256-jvGQRsCcEOIYTz+QCF+zkE4NlpcTJ693bw6Rj4ITZsQ=",
+   "pom": "sha256-8KWyIzAUov31tfayMkAaeFfuUb6esEF6pCJjVVlZ5fk="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-4d7AEOW69O1VRmheXefxFPVpYXSeWcexpwKztH0jFmo="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-s+4grUi5VUhatDZdJwgO04tv33VhowDqG/YvEsOtm54=",
+   "pom": "sha256-lewV3EZ9/pj22eUI6gsOjdkrMYbl46agMacsXw7l6Z0="
+  },
+  "org/jetbrains/compose/ui#ui-geometry-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-4d7AEOW69O1VRmheXefxFPVpYXSeWcexpwKztH0jFmo="
   },
   "org/jetbrains/compose/ui#ui-geometry/1.12.0-beta01": {
    "module": "sha256-aTXNXPQDzd0zdQbAc+CIvlmoAgyXRecCXwiN7YqNmfA=",
    "pom": "sha256-CRxaM9qCv3xmJnA+RKGDBw9hwbn5WhRU3zFPdGJFQNs="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-geometry/1.12.0-rc01": {
    "jar": "sha256-ucsT0NuZnVrT+42lptTwgTw5mM6vTeowMcIZZ3juPGA=",
-   "module": "sha256-ARA0g7ol3zghX8lpqIV1IG0hTZ2kwfEIRmQ2SEPTjv4=",
-   "pom": "sha256-HpyVurGL0t304oQ9syzZrtuLMgikQsGrZ11ZnT6ZdWY="
+   "module": "sha256-hENAgn3OaY4zsPqXXz1s2ZwWhF/YFg4U+uzI6xhjU5Y=",
+   "pom": "sha256-F+AMM2AdnzjvFm95gjT9jD4NaENr0mqUhDK0sif64SU="
   },
   "org/jetbrains/compose/ui#ui-graphics-desktop/1.12.0-beta01": {
    "module": "sha256-X7WbjlbhiJH0MYHHeeZObtRof0pbIXwJt5LmH9SmKKs=",
    "pom": "sha256-Ulu9afB4WGYIHCTpptUloTAYTXo0j94Z8peO3jjVg+M="
   },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.12.0-rc01": {
    "jar": "sha256-WuBG8HReT0hPOaAgLlVFuP/dGTDFUKYNdvbBypU06v8=",
-   "module": "sha256-lmeF6y+9lPCZpVUxNkmQIHvkkMqd8tKZ6eA5JieqJ3Q=",
-   "pom": "sha256-kHaruX1WdnN08Z1FGoCYTTRmx6Ee4TGP8Ej6sI5R1X8="
+   "module": "sha256-7BHDy2+omWDrBAGSw9AO4Yol37P1UAy7GwEE7HJQ4dI=",
+   "pom": "sha256-yOAxKZXZf25ZU24AQZZk+AtI+E+dEZvGBCnh/c1NK6M="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-iosarm64/1.12.0-rc01": {
+   "module": "sha256-Zx3yoHjTwtbYwIVFYxluGfGQz5M+rz89pERRd0N6Qj8=",
+   "pom": "sha256-SCA14YvyN/WN2wSNKkVW8mip6oZlDvzA/K5n2ikFb6M="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-IDxPwo9wfrJZbc8ve7b9ZHQL1aBdsD34ZPfH93GZ/Ig="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-GalNDhpY9Frr8qDthV3lZtcH1wu7L78aJPkdrdNGGGI=",
+   "pom": "sha256-zdBl4r3UWm3QQHxFgb3pmRBrY1wUDvfdXLDzbYfaZpQ="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-IDxPwo9wfrJZbc8ve7b9ZHQL1aBdsD34ZPfH93GZ/Ig="
   },
   "org/jetbrains/compose/ui#ui-graphics/1.12.0-beta01": {
    "module": "sha256-D79TptfH8DerHxyf1eJqCuQoIQlzo+yCpglnxhqnP2o=",
    "pom": "sha256-FwSF9Frqv3isLsnWS45+7vAmJcwMUNeU0hr8aAl7qZQ="
   },
-  "org/jetbrains/compose/ui#ui-graphics/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-graphics/1.12.0-rc01": {
    "jar": "sha256-xmrKI1Z3cOAnnyTpDXBXv70SgnMSExvHxmTcwQB0iNY=",
-   "module": "sha256-36WYs1CodFy3eEqWJkMbOg6JvXOLHgRYvUfzxgJ+OjI=",
-   "pom": "sha256-FKpk4uap2S7uTa0fZdXbf5sqWtfzVMXA2/x52WciBMo="
+   "module": "sha256-zht01JyhXx7lj603CrUxHYynEJ+JtOkhCFqtYb9jfUc=",
+   "pom": "sha256-W79z/8yuv1b10qyckMmNfd023yRCZO9C2uAMbHua75U="
+  },
+  "org/jetbrains/compose/ui#ui-iosarm64/1.12.0-rc01": {
+   "module": "sha256-tmrYlzRBdfuelNGggNcOhm5+zb5LG28V3qF94aZ4wTI=",
+   "pom": "sha256-NW08eEHU4craR+24jsEf/qTCZiav6I565PuBGN/PIk8="
+  },
+  "org/jetbrains/compose/ui#ui-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-ZeiyYX9l4oAFFJltAqkA4t+/WYrMeDNPWjWBoEX+MGU="
+  },
+  "org/jetbrains/compose/ui#ui-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-1UtmZZkcWNDIPS0LKSQ+OY1iLvdJ+cMV5fuN4ac1lNg=",
+   "pom": "sha256-97MIiyivzIsNaTbFnxTgfLzAXJhYbqJk/gcwrD/B1Qs="
+  },
+  "org/jetbrains/compose/ui#ui-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-ZeiyYX9l4oAFFJltAqkA4t+/WYrMeDNPWjWBoEX+MGU="
   },
   "org/jetbrains/compose/ui#ui-text-desktop/1.12.0-beta01": {
    "module": "sha256-Z3KdxoPm+WnVRZsXujSp4mIXuJEGGHWNGAEhUv/vH0k=",
    "pom": "sha256-uz6Vwfiy8QVK7ZbYb1DyVFwd2h+fbCCMbc62fIgZR6w="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-text-desktop/1.12.0-rc01": {
    "jar": "sha256-ZyMx1+FEDyQG9qm209YUdTFs9iLQ276RDke9vWmGHDg=",
-   "module": "sha256-QqgF20VPOIyTLRIdFnSpq8H5RE5fY9VPu6La7oTcFoI=",
-   "pom": "sha256-J/MkludOR22LXzO5YXidWxIfcjZA7xOGAWEdBpv0hCw="
+   "module": "sha256-vnKavfR0I8yI9vWdEpUoeTWM4uBKiI+BInS2xJ7/Fjo=",
+   "pom": "sha256-7x2pKkLkwS/5DhoAFbPkEaGbeT+pjU30R4m3enPvV+E="
+  },
+  "org/jetbrains/compose/ui#ui-text-iosarm64/1.12.0-rc01": {
+   "module": "sha256-fzX+UBWbyrPpdyhMm54ZgWTnhscZk9yQW7RFC7DmXkU=",
+   "pom": "sha256-W3NoHzFFvlK0/Jo/21aHSeWg3118DafAO7Ij0XO4BJc="
+  },
+  "org/jetbrains/compose/ui#ui-text-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-A/T2l84aAGhkwYUy/5212mPAMIJezjDx4F9+qRAgzys="
+  },
+  "org/jetbrains/compose/ui#ui-text-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-tGVuTlDHRQLmyg48JqIgP6KEe7b/20YMB47eGAOJK7w=",
+   "pom": "sha256-fnswyxbLWaOjmo3bXEiFJa0jFIUPK5R7Wy+CfNA4NkY="
+  },
+  "org/jetbrains/compose/ui#ui-text-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-A/T2l84aAGhkwYUy/5212mPAMIJezjDx4F9+qRAgzys="
   },
   "org/jetbrains/compose/ui#ui-text/1.12.0-beta01": {
    "module": "sha256-Q4UDw04lOzclHdBtiPABn0l7OHxIVNqIEdAbSqZM+W0=",
    "pom": "sha256-QFcPHSyBei3VaRzFAh4ai/1Zcd26dcI5/fUhdECtbXk="
   },
-  "org/jetbrains/compose/ui#ui-text/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-text/1.12.0-rc01": {
    "jar": "sha256-3eP5W0RVMybYYm4vdt2APUS0ZHKdRSy8onpRuP2Fz4k=",
-   "module": "sha256-E4Lm69yL0hwgmXvvazSRD1W3grJgRVLE5u3eA0jlee8=",
-   "pom": "sha256-dVYpB+sgXRFTOKKtgKrw7BURW+D9ZhCY/Nk9P8nBrGY="
+   "module": "sha256-9F0sxQPIEGpdNZpWatOpodTlqgiJ50HrEYncZZhJOQA=",
+   "pom": "sha256-REgOEQCdza79yBaR8la70u7N+AbTyaKZLbIiDObij1k="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.12.0-rc01": {
    "jar": "sha256-GfUAW6on378/Q1/u1E37qck4ujhqxnU9AKZ6JwzXIjE=",
-   "module": "sha256-DRobJVXmvGbh0LsMeOkr1YoXhXF/htzIGo0LkSJD2+c=",
-   "pom": "sha256-GGMNwmtVfASMt6S6zWyPg9g90Fjm/QsYAiNb9idqHQM="
+   "module": "sha256-ZBFAkJyDZLpoaw5vi9LAfbRjo1ndhlkQfMsdCJRQtbw=",
+   "pom": "sha256-ysOaNnMiRNLJUjgkiNRK6Pu30+f/IwYccnWSA/6g1/E="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-tooling-preview/1.12.0-rc01": {
    "jar": "sha256-2aTqcrJIW80TSYOl/AtcoQ9sj0u3pC+dVWxoMlS/Egk=",
-   "module": "sha256-rgoAwELrjVW9eLD1msQNA72xBVVR7mgmDsvGm3n3UsY=",
-   "pom": "sha256-jmXWhwjOsx3/wuNwBy4IIPhcFUorp7aGELeHnfkfTkE="
+   "module": "sha256-K4tgQRdEPFLwrqw1kAL7XWENFNeI4Qhw0Z1NFeAxKrs=",
+   "pom": "sha256-fZO5xL5qm0ycwR80hdEzKHzy6h5n/B5Wkn5F98UZsn0="
   },
-  "org/jetbrains/compose/ui#ui-uikit/1.12.0-beta01": {
-   "module": "sha256-Yzvk3sc5gf+RuIcTf8f6my6IOgubH5VQs1lgqOlcyyw=",
-   "pom": "sha256-b1cPK7lGljKfZkr6hd8O9tswEkI9aqlop81IiMSnY48="
+  "org/jetbrains/compose/ui#ui-uikit-iosarm64/1.12.0-rc01": {
+   "module": "sha256-2GSLJh9gH4wR09enZ0xJvn8YTOivlWt+jeOQWwOY/I0=",
+   "pom": "sha256-MMJT+qOPos0Q1+yoHHWWC4un/nRsJDOf+Gcc4tFTiM0="
   },
-  "org/jetbrains/compose/ui#ui-uikit/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-uikit-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-yF+3y+Xgloc9E6HGASmc8fbPfPZSi1mmU5sg1i/YLGU="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-YG9kp9+obHvr3iQKyubDJCCKt2+JSe3Fr8yfh4tiD2g=",
+   "pom": "sha256-gIcpYYvQLgmbMUXGBbxgA2xbbXLh+y6VyH+aLy1kFt8="
+  },
+  "org/jetbrains/compose/ui#ui-uikit-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-yF+3y+Xgloc9E6HGASmc8fbPfPZSi1mmU5sg1i/YLGU="
+  },
+  "org/jetbrains/compose/ui#ui-uikit/1.12.0-rc01": {
    "jar": "sha256-axl+MetJAS/Qvc0HxVjrXVpXYkZoXpVBvD0rcTNa7ug=",
-   "module": "sha256-Am9Q8ObCngfWoYjE3p0MTgT580r/JLEK4JApMyFclGc=",
-   "pom": "sha256-QsrN3GFgG9W33gggb/+jfkHuf5mwWthva00A9d8oozM="
+   "module": "sha256-MdjGiMvGb5Z3uhnHl9QwjbPTzR2l5NOVdHxVuUqkRJE=",
+   "pom": "sha256-B3B/3Me9PUefxSvjtlC3MSoc8wA5yvTIEVUcu0FcReA="
   },
   "org/jetbrains/compose/ui#ui-unit-desktop/1.12.0-beta01": {
    "module": "sha256-Zj6TGKv2xIlu/B5PA6A/bLF2xnd4d3wzrF+qBc+vAYw=",
    "pom": "sha256-OiwSj77Y7m8INI7PQE2lE5D1zAE/nh3v6li+sMx/6NI="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.12.0-rc01": {
    "jar": "sha256-fEmY8SJPJB2+iPpZcB1pfVmP6JeaSsrtcXuDZdTNkwA=",
-   "module": "sha256-3aefsIrPCug49Xu/obdObQLh2P2tE3nJohefXA7jj2Q=",
-   "pom": "sha256-RnDdF6vzVgyrYQwjwyvfw+5qYM7FDUXXS4qXMLOsgag="
+   "module": "sha256-Vcg566JIzgQfSUARcWp75o2wycYsCm8QDayvfusJ5Ks=",
+   "pom": "sha256-jvhZNS9AF+x6vsujCx7AnkzW8ngmT7NSgQZbw/OzUGY="
+  },
+  "org/jetbrains/compose/ui#ui-unit-iosarm64/1.12.0-rc01": {
+   "module": "sha256-e39FybE8dOXksZ2lrZpiace9HyGDHzJeBim3YSxfpuQ=",
+   "pom": "sha256-k0HRfAKqSEesrWL3PfI6H5gKqh17FBqlcxbqvUaayyE="
+  },
+  "org/jetbrains/compose/ui#ui-unit-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-a+TgIOEse0OQkcJ6wyeuPOBgIgE1zO0Q1G0CKFUbf8w="
+  },
+  "org/jetbrains/compose/ui#ui-unit-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-Ovk8DAaKYNiVYfhIVjmUfdYf+0iHWmkg9eQlL7HwMto=",
+   "pom": "sha256-xi+Hz0WzWXq9aB4zmDjHAfBnJIajojUshAZ+oLkJkB0="
+  },
+  "org/jetbrains/compose/ui#ui-unit-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-a+TgIOEse0OQkcJ6wyeuPOBgIgE1zO0Q1G0CKFUbf8w="
   },
   "org/jetbrains/compose/ui#ui-unit/1.10.0": {
    "module": "sha256-PODKlwhqnA3bqCKx7Q7M/n5AcNZCrQANU67aPbQWoPQ=",
@@ -2815,33 +4859,101 @@
    "module": "sha256-wMCx9bjzo8pK8AibCxQLKDoDsdMkdiJXKw6Ef6/IRmE=",
    "pom": "sha256-itG8VmgcM+0dKRRRP2Ewt3WB73BziPGUHEbBap8hEt0="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-unit/1.12.0-rc01": {
    "jar": "sha256-KjsSDfox2/o9Pd8yfP9KHBXwUP8MGeZPacHiQdtqByo=",
-   "module": "sha256-LlaQGlgN3brQvXRT1hDbVUnPjhPvXy1Rp/iw42+Ri5g=",
-   "pom": "sha256-sGNb9BGSIPHouNLWQLQFQE6lPEAMhxUYLY45mfExaBk="
+   "module": "sha256-5Eg8VRdjggAqtqmAG7sLSO0dftNbucOZBXaJQ+bNzvc=",
+   "pom": "sha256-63YrMmx9N1HI8dBQYHABfcSihPtG9s4lDRR9Y7uUw8k="
   },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-util-desktop/1.12.0-rc01": {
    "jar": "sha256-u4HpdIybyt6uuZurZH4hRC5i4lOjpJeiE8aOBAyys4U=",
-   "module": "sha256-BeNmmHiUs1vcv1FWo8VjFtoCSIvF9S2Laai1AbIzKAc=",
-   "pom": "sha256-IHhRkKErcu2D99ogLf4nQkFfUf1j21lRx6Jb5zj5Pnk="
+   "module": "sha256-ejnT8BpwlKWRZhrdZqRSmmP/B9ga+bj8rzUCyf2uSfI=",
+   "pom": "sha256-NB52u4ZSC7kX3vSkZQJZMdLMGCukgwh6r7hKED6MQqI="
+  },
+  "org/jetbrains/compose/ui#ui-util-iosarm64/1.12.0-rc01": {
+   "module": "sha256-FXZSJJwCr/0d+iCcDSFOQ+VWOaV56tY2YqYwf8ZTDdw=",
+   "pom": "sha256-G/EYO4kIgl3tdtcylhZVIcyJESk53kRuqR95rIXnOb0="
+  },
+  "org/jetbrains/compose/ui#ui-util-iosarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-XxJeX4ja4znxAP97gkanyn+IpK3PB7RSBUcZL6xnltI="
+  },
+  "org/jetbrains/compose/ui#ui-util-iossimulatorarm64/1.12.0-rc01": {
+   "module": "sha256-fQM/12a+CGXwHQHTQxDCo8hSP/Mw2zNOJ5QrQL/7Ulo=",
+   "pom": "sha256-/4hcmfq0yGllfq7E1EILNCuqCgnX9+VDWDyZuYAAgaQ="
+  },
+  "org/jetbrains/compose/ui#ui-util-iossimulatorarm64/1.12.0-rc01/metadata": {
+   "jar": "sha256-XxJeX4ja4znxAP97gkanyn+IpK3PB7RSBUcZL6xnltI="
   },
   "org/jetbrains/compose/ui#ui-util/1.12.0-beta01": {
    "module": "sha256-rhZw/wJQBWGnKswB42vKd7OhBcJLNCgY9m2vbXqv7O0=",
    "pom": "sha256-qwvHRsIUcr0Zq6utorC9+HaP7W2BQFaMyYloPhiMLY4="
   },
-  "org/jetbrains/compose/ui#ui-util/1.12.0-beta03": {
+  "org/jetbrains/compose/ui#ui-util/1.12.0-rc01": {
    "jar": "sha256-NlCCj991HvX5VnN2a3cLrIeKsojeCDWASHxHIK9mkD0=",
-   "module": "sha256-rqpb8fqUe3vkIy5Sl2AVLs2+WkiK9S4/L8gF8eGogiw=",
-   "pom": "sha256-wZih1REkQn1icDU/aoukTlEXQyUbHZQwG7BnKzuaGBk="
+   "module": "sha256-63Z0IDQD6QML01wKoPUCt2RIyhOrkwhGcyRaiJUOTYM=",
+   "pom": "sha256-nbhjUZbwnaPCvwJnZAqGLgoV3VwYWHDb24LoCJL9/K4="
   },
   "org/jetbrains/compose/ui#ui/1.12.0-beta01": {
    "module": "sha256-1U5ydKZzOy3GIRllYHOaOLCaDKsxA240VDTMf37DrII=",
    "pom": "sha256-5tThIvP6CJX4mevRiYhWi+cNYQB1dL3SVg7Q03u1nx0="
   },
-  "org/jetbrains/compose/ui#ui/1.12.0-beta03": {
-   "jar": "sha256-1hDfgzCyyn3sL7O56vR2NUwfc4T8+doJ0PpowMa+cQ4=",
-   "module": "sha256-72vmPQh8t2oI0wvYT0rNulaAbxz42nyNnWGKI938zM4=",
-   "pom": "sha256-58FDik42VWYMLiSZ+VFXWrl2HytfAX9/umUhZ6JTwRw="
+  "org/jetbrains/compose/ui#ui/1.12.0-rc01": {
+   "jar": "sha256-5XDWOGt6xOqxs4Bb0LdPgk5Ar3WwDn62RFMFnFcHhgo=",
+   "module": "sha256-jeEzlmNDsR0jDFIQaCpCSF0WgTXqykjxwai6IMPrCcc=",
+   "pom": "sha256-k4CU/cxm+ogDMHbXUFPo4ZLT5t7rFYL2XY8VkJL0lCE="
+  },
+  "org/jetbrains/compose/ui/ui-backhandler-iosarm64/1.12.0-rc01/ui-backhandler-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-dsKrq7Wnta/SWZsRHnx8VPQmrH4bKf2johtNeoPb+mU="
+  },
+  "org/jetbrains/compose/ui/ui-backhandler-iossimulatorarm64/1.12.0-rc01/ui-backhandler-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-+32pz3DiriOdH433y+DHtXHaiWbc7PbN5l930fxbQCc="
+  },
+  "org/jetbrains/compose/ui/ui-geometry-iosarm64/1.12.0-rc01/ui-geometry-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-zvBpBneQH+T/Cty8izY/5eOzoUbZcIOVYkfA6FUyI18="
+  },
+  "org/jetbrains/compose/ui/ui-geometry-iossimulatorarm64/1.12.0-rc01/ui-geometry-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-sJuf4fmliwQ7j1h1KlFlSyR14uZO8cRd/JRKmDPY9eM="
+  },
+  "org/jetbrains/compose/ui/ui-graphics-iosarm64/1.12.0-rc01/ui-graphics-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-iiiUIO8L/1VIQO5muhkcUx9JQQI5VG9jBFZgxefueJw="
+  },
+  "org/jetbrains/compose/ui/ui-graphics-iossimulatorarm64/1.12.0-rc01/ui-graphics-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-Y1h7badntX7CDouKTNueobZF6QiG04SXwsypujjj7+o="
+  },
+  "org/jetbrains/compose/ui/ui-iosarm64/1.12.0-rc01/ui-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-hC0bYSvgb7C+pz2KY+HpnABTBoBrbEXBT9hcSvgCp94="
+  },
+  "org/jetbrains/compose/ui/ui-iossimulatorarm64/1.12.0-rc01/ui-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-7ocd5PaaUdxhrtlT2QZnGY/aDn9u4qS2vuP88gLpCPY="
+  },
+  "org/jetbrains/compose/ui/ui-text-iosarm64/1.12.0-rc01/ui-text-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-AyCym4ZPUxkN0BpnLSF2x8mQGJ8bK5+8O2YGN7r/AmQ="
+  },
+  "org/jetbrains/compose/ui/ui-text-iossimulatorarm64/1.12.0-rc01/ui-text-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-6RfKjOEpVyHPSRb545Cvlti8WWFG2C1TL625AXZAkuA="
+  },
+  "org/jetbrains/compose/ui/ui-uikit-iosarm64/1.12.0-rc01/ui-uikit-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-g2Y5Xg52TK4yCJJR1FcYcB78PN1tf7nL+oUlFMVJZbo="
+  },
+  "org/jetbrains/compose/ui/ui-uikit-iosarm64/1.12.0-rc01/ui-uikit-iosarm64-1.12.0-rc01-cinterop-utils": {
+   "klib": "sha256-fRTOQqPdM3UXWbILAzFgmdXYA5CLPYsKLTrRvns+4vI="
+  },
+  "org/jetbrains/compose/ui/ui-uikit-iossimulatorarm64/1.12.0-rc01/ui-uikit-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-NksT4duSkjVZ4WfLRh4u4O0FeraFAiRI+LXyxgywtZg="
+  },
+  "org/jetbrains/compose/ui/ui-uikit-iossimulatorarm64/1.12.0-rc01/ui-uikit-iossimulatorarm64-1.12.0-rc01-cinterop-utils": {
+   "klib": "sha256-OsBcTXcW2vYtmkQCS5I99CBpxqPCNhZPBu/duOqSdQM="
+  },
+  "org/jetbrains/compose/ui/ui-unit-iosarm64/1.12.0-rc01/ui-unit-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-6UtH1PoeWc374kGd1Sn6SYoi3iQMbyAaK5aJwtZI3OA="
+  },
+  "org/jetbrains/compose/ui/ui-unit-iossimulatorarm64/1.12.0-rc01/ui-unit-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-T9ODSwRsKifVDptvOwWRPjk6KIbQOINsZYxIXgRmyDI="
+  },
+  "org/jetbrains/compose/ui/ui-util-iosarm64/1.12.0-rc01/ui-util-iosarm64-1.12.0-rc01": {
+   "klib": "sha256-S3tIAcGZJPyFpNP+roY7jkGaAeDtSRsPNqTcAHqHgBA="
+  },
+  "org/jetbrains/compose/ui/ui-util-iossimulatorarm64/1.12.0-rc01/ui-util-iossimulatorarm64-1.12.0-rc01": {
+   "klib": "sha256-OGx0Dc2Fcx0g6kIEzydBNpH+b+uN2WbP6P9X/gs1ojE="
   },
   "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.4.10": {
    "module": "sha256-ex+asAI2BHlhjuCapscAWgKCw55wXlYSUPNYaoKDcpY=",
@@ -2967,6 +5079,9 @@
   "org/jetbrains/kotlin#kotlin-metadata-jvm/2.3.20": {
    "jar": "sha256-FyZLlpD+7TSqi459VW+y55UfaABGLxFyQ/upYgEBT30=",
    "pom": "sha256-DF/7/5dG1Ca56GasBWviiSizGKJc3FaDkIHsRJspzZc="
+  },
+  "org/jetbrains/kotlin#kotlin-native-prebuilt/2.4.10": {
+   "pom": "sha256-eGZVBp/8wYCVLWGyZxQ5SZ8MukCOgmKFkAecRX2ybkc="
   },
   "org/jetbrains/kotlin#kotlin-native-utils/2.4.10": {
    "jar": "sha256-duxV+Wfcj1dIGiez54aMyXyzKWTW0oVReu8xDD11SkQ=",
@@ -3104,8 +5219,15 @@
    "jar": "sha256-QI070W4PUTrC9PBKeIcXAZJINggcLMd0qis/c5J45DA=",
    "pom": "sha256-Yx2/78467+od41c9jcHlSRm+mviMFCUF0zUhJ9hKu4Q="
   },
+  "org/jetbrains/kotlin#swift-export-embeddable/2.4.10": {
+   "jar": "sha256-0AVo1cKsIgNnopIXn5y1Du2nPv5dCCZungRwDB4HtGU=",
+   "pom": "sha256-Ll+XHNjRfTN0IBScaAfr9ZkX2ffOGf+G4MU4W/XZOmI="
+  },
   "org/jetbrains/kotlin/android#org.jetbrains.kotlin.android.gradle.plugin/2.4.10": {
    "pom": "sha256-GeLOVfnGhCiet+CLmfVjWSCwp2C9xSjXau4U/tHFSk0="
+  },
+  "org/jetbrains/kotlin/kotlin-native-prebuilt/2.4.10/kotlin-native-prebuilt-2.4.10-linux-x86_64": {
+   "tar.gz": "sha256-yeNW6FGBRPJ18VFM/jiwfblJ+T5H4FSDK4l0//H9M+A="
   },
   "org/jetbrains/kotlin/multiplatform#org.jetbrains.kotlin.multiplatform.gradle.plugin/2.4.10": {
    "pom": "sha256-gjDYT7eB0WFCSJtYWWymc1mJOdooe1Vs9gEq7Qq4EsY="
@@ -3116,15 +5238,56 @@
   "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.4.10": {
    "pom": "sha256-PuZ5adgb3vNw+DHx1T7Z9jjR/q0DL8ZAX98Bg8pR2vU="
   },
+  "org/jetbrains/kotlinx#atomicfu-iosarm64/0.32.1": {
+   "module": "sha256-9qwYG3ceHuqtlcS/OlSX8ZQs9xvWms/QMQcgy5vUL0I=",
+   "pom": "sha256-fS0/vy9mLkEA6IFrRyO1k4pl8qbyWf9DYShdyNJavbo="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iosarm64/0.32.1/metadata": {
+   "jar": "sha256-v7t7p9HjO4Wzn47NBA7So++BOrY1NWYNEvj88SVvE/I="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iosarm64/0.33.0": {
+   "module": "sha256-ECCQGH6ig/cSyCQdgtYlSyGllGBKUeT2+BbXnnvc51U=",
+   "pom": "sha256-P1WPIHvIE/mLfsbNhSWTulTEwbKOHmV6LpU3xua3C38="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iosarm64/0.33.0/metadata": {
+   "jar": "sha256-LtUCBV05dpx2TUZCKEVbisjzmwXJhuVNyl29sQUQdac="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iossimulatorarm64/0.32.1": {
+   "module": "sha256-Xcsor4TPwswgItLJXIa7cLx5MJ4zTm7xTDFinX55zFo=",
+   "pom": "sha256-3kf54oagDaT84KD3z7q0P1QSaUKGnWrdmeJqnKFkC+w="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iossimulatorarm64/0.32.1/metadata": {
+   "jar": "sha256-v7t7p9HjO4Wzn47NBA7So++BOrY1NWYNEvj88SVvE/I="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iossimulatorarm64/0.33.0": {
+   "module": "sha256-bQpYyS3pEdNiRPUzNa9/K4K+G9ruB3ITS17K8bht6Xw=",
+   "pom": "sha256-Z2bg7Q+v1fViJ6nICskrAuEYJBRDzGOdorSEd8gqpyE="
+  },
+  "org/jetbrains/kotlinx#atomicfu-iossimulatorarm64/0.33.0/metadata": {
+   "jar": "sha256-LtUCBV05dpx2TUZCKEVbisjzmwXJhuVNyl29sQUQdac="
+  },
   "org/jetbrains/kotlinx#atomicfu-jvm/0.28.0": {
    "jar": "sha256-OVduxGuDQS/3opCdJMzLupBADpH5qmeyUDCbwIcuz1I=",
    "module": "sha256-NLYjr5wlyn8uUkBvEElcRub0EINdegWMYLo2kj1oljU=",
    "pom": "sha256-3X+tXV1LIcqdsHiHULCZe6HbaILe2G5SEvXIP8UfrOw="
   },
+  "org/jetbrains/kotlinx#atomicfu/0.23.1": {
+   "jar": "sha256-fbhmDr5LkbtHjts2FsTjpQulnAfcpRfR4ShMA/6GrFc=",
+   "module": "sha256-Pokf5ja1UQgZIQD884saObzRwlM+I8Ri/AdkTur8sg8=",
+   "pom": "sha256-aIt5ABn0F87APmldZWexc7o7skGJVBZi8U/2ZEG1Pas="
+  },
   "org/jetbrains/kotlinx#atomicfu/0.28.0": {
    "jar": "sha256-09oifhoGwZVcEQFM3vpZlpqwygUHqB6ooP0Fq2xNvJw=",
    "module": "sha256-U1VoySkaPadwXEtAU16s7fhrJI31cKxSZpyQfUu4VYs=",
    "pom": "sha256-yboB7z5omdQs8HDVm6OdVy/FhjvylscpqZciwGR99so="
+  },
+  "org/jetbrains/kotlinx#atomicfu/0.32.1": {
+   "module": "sha256-htPO3BvyNdmn9ik0T53P5bvB2m6hmOQpLa6MXbppgoU=",
+   "pom": "sha256-X35VrO6MGiJq4/+A+etKyg7uAmFWUcuKQTkYk3Z7fRs="
+  },
+  "org/jetbrains/kotlinx#atomicfu/0.33.0": {
+   "module": "sha256-KUuP4lx+NQ3P2dJzwhMZMBgjTzgeYFTU3komi/MSLfA=",
+   "pom": "sha256-XQ3+5z/D7mWxq/9Pkhg7IZcERh8SyWbcvUBXXdlmzRE="
   },
   "org/jetbrains/kotlinx#kotlinx-browser/0.5.0": {
    "jar": "sha256-pZr+a8slswkUsKLQrp7Zunrc+vmRG3MkpaW9mBUK8QI=",
@@ -3152,6 +5315,20 @@
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.9.0": {
    "pom": "sha256-vqVRHpAB8sWTq1CA3xMbIZq14ghcxZec5YPqzUlG/Xg="
   },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iosarm64/1.11.0": {
+   "module": "sha256-gQQjGh0eQEd1T9nG5S6hzacTo8nefYD0x95ZY9m47lI=",
+   "pom": "sha256-cd8IsKyy6jLaoUiKoWTE1NXhX0m9aL0UrzgRFIjdr4U="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iosarm64/1.11.0/metadata": {
+   "jar": "sha256-3BkLwQZCak0enxcDbLIFAhQgcvU6C+zVu4VbEHGV8gM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iossimulatorarm64/1.11.0": {
+   "module": "sha256-HaA5MIcV9FM96HMZzaTxus8suJcSplNlPchn18oO+eQ=",
+   "pom": "sha256-jFBZLgoCxKDMQQZ/4yeuDzecyOWroXa2ouU668NW1P0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-iossimulatorarm64/1.11.0/metadata": {
+   "jar": "sha256-29Ai3wJrEtfW2hSE779VtiWoFXg4ZXl0cL181g0bz5Y="
+  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.10.2": {
    "jar": "sha256-XKF1s43zMf1kFVs1zYyuElH6nuNpcJs21C4KKIzM4/0=",
    "module": "sha256-6eSnS02/4PXr7tiNSfNUbD7DCJQZsg5SUEAxNcLGTFM=",
@@ -3177,12 +5354,7 @@
    "module": "sha256-Hhl4XTRyi3Ul16d/8y6tRUfVHMekXUrETU3mCBabDA0=",
    "pom": "sha256-QbbnjBsNEbyZ3nlTkN+eTs5k3BE/SC1uMI8bekIcHTA="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.8.0": {
-   "module": "sha256-FE7s1TZd4+MNe0YibAWAUeOZVbXBieMfpMfP+5nWILo=",
-   "pom": "sha256-yglaS/iLR0+trOgzLBCXC3nLgBu/XfBHo5Ov4Ql28yE="
-  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.9.0": {
-   "jar": "sha256-cInDPBRYZQIHYNPbyl5GNBM8w91/65Jugw9t5u3iisY=",
    "module": "sha256-rVNANKlTtOEsvuuHTGat+LHKFN8V/g0uZUeqNOht/so=",
    "pom": "sha256-dw8nk9BeKwJ7nHmZOOwdLU7xQc5YGceAwyw5lcrbCkc="
   },
@@ -3195,6 +5367,20 @@
    "jar": "sha256-f2WP6VK1YXYRH6rYrCdSaJBGCJFdbHk3T6DID7KI+2A=",
    "module": "sha256-I4V4NJwX/DTVylTRIi8v6VR+Yb6FgnRQ93kAFoeCcdo=",
    "pom": "sha256-Xg1OSIf8gLFAcOMd62DIxY4lYRFvNro5rEuSAZP74Nk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-iosarm64/0.4.0": {
+   "module": "sha256-zmBZOAiPA82EtC9LdKxWNrHWxBRGDDyFzViL7KPeRQg=",
+   "pom": "sha256-a1OsfjvwiEUgdbYpcN0bYayRssU+jrL/tUHpxIJE0Ng="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-iosarm64/0.4.0/metadata": {
+   "jar": "sha256-LNLFi9miOtU6BzDU4qU5+QxoM8R2SQIZZKqXAY7nbDo="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-iossimulatorarm64/0.4.0": {
+   "module": "sha256-ymbDcWFfNRp8naOV0TBHuwo7ZLylGKKNEZODTwBerGU=",
+   "pom": "sha256-be0ntkSYqjSUtaS6V7RU58bA9ClXNm6sCDDh6vD+qag="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-iossimulatorarm64/0.4.0/metadata": {
+   "jar": "sha256-h733MffyUDtTJBZMctx3FuOtSJED0Pf85YcP3VLL6YI="
   },
   "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.4.0": {
    "jar": "sha256-B1ynWhbjVkhMB948x7znnankrbxnC7zyPF4T9OEu5uc=",
@@ -3218,6 +5404,28 @@
    "module": "sha256-R0gD1qR3t8OV7otCw0zK52ZftdIx/bBa0I7TCFwk03o=",
    "pom": "sha256-yiZ2PuBih00KtdOBzB0jBKjLm/VKUoI6wE7PA5oaMfw="
   },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iosarm64/0.9.0": {
+   "module": "sha256-Mlkmv8npPfAPSWlTnRGb9aw3C4OCb8KN8CKYeeRTx68=",
+   "pom": "sha256-uPe/cLMJglNR7/pHPCmhIMjOlF1LJSLIih3uOey/QNE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iosarm64/0.9.1": {
+   "module": "sha256-HF46q7PVLGbaeKc+OH46eDAv0jCsND7DtNW/SWE4j9c=",
+   "pom": "sha256-r/Amn4g3R5Oo7OTl/AJsGaa0hpgQkLreEhOIFiOUISY="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iosarm64/0.9.1/metadata": {
+   "jar": "sha256-0p/CkPFd6vLDFx+WotbZqXufH7dzsdYKdZ4eNf/Fitc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iossimulatorarm64/0.9.0": {
+   "module": "sha256-ChVymYGEfivQnwQhNV/sj7E1BwjaVxCpN80aNKnLJXQ=",
+   "pom": "sha256-MqOowEOrSYP4ap7lXZQQi19wzfikgi+BsRAGDlbBohQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iossimulatorarm64/0.9.1": {
+   "module": "sha256-hQZvey3uxikX3lhDAl6FfXEIBcVdg5mIbrDxhMlavWA=",
+   "pom": "sha256-20lloLFTAQX4vP5Jjh303yZ45skbHgoALzTaXOQGmzw="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-iossimulatorarm64/0.9.1/metadata": {
+   "jar": "sha256-0p/CkPFd6vLDFx+WotbZqXufH7dzsdYKdZ4eNf/Fitc="
+  },
   "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.9.0": {
    "jar": "sha256-Q6jJ18VGBiLE/+fnyUQ3Nq8aaRgzFrUy3nipqvqGtjY=",
    "module": "sha256-0RrPnfTLjwsBXNARZici1ySQwIiZhCJOpW3+TCc0rqQ=",
@@ -3229,7 +5437,6 @@
    "pom": "sha256-xC9KI5StvopK5ViFKPX2Tl1O3ddDQkCMLyU8xslcI6U="
   },
   "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.9.0": {
-   "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
    "module": "sha256-hhg+j506LZqCiIN4+tb5V1hhk1nkXfty7K9sCwcmOFA=",
    "pom": "sha256-1DAvY5qQe0AlwH89LuQ+3KC369+2rtWA2k0gdjQLIGc="
   },
@@ -3237,6 +5444,28 @@
    "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
    "module": "sha256-ACtgq7Zief9ZVJz6LnnHLI2uKeGbDEZJjtlZsOcClYE=",
    "pom": "sha256-kuCEpM0bw0w4gQNbC/dV9M44Tdg/2ddyZWCEuTEt3g8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iosarm64/0.6.0": {
+   "module": "sha256-g5Qd7Jkq/RHEi1eJPCx5Lmnsf1bfUWe3Volr+qt7Yfc=",
+   "pom": "sha256-0XwSWNpP8PEMEP3asBhGdfd8qu6NZnNgS/aM7RydF2U="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iosarm64/0.9.1": {
+   "module": "sha256-GRbiZ+ZvXAGj7n2x29cwnC5UWS/rG9AEYVw07z+BCuY=",
+   "pom": "sha256-Igm9ZYEyqpwhfPZspO/u2AnFvzUbo3iOSAY3tNqlDmU="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iosarm64/0.9.1/metadata": {
+   "jar": "sha256-iyJ3BCbpfLqzBaP5/XyBoioJp9Q++jR4rJNwhySCwjc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iossimulatorarm64/0.6.0": {
+   "module": "sha256-jhHQd97D7inzJbJ5RpfdnMu3Cr8F75zzgLZ2l/yngPg=",
+   "pom": "sha256-6MHt8U7YFaxJ/0zqS55pYiuhByBcZi/wiCfztHi6qaA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iossimulatorarm64/0.9.1": {
+   "module": "sha256-JjUpuKclkfK97cLW+Zpb8dBjU/cq8aSYG2xernod3wk=",
+   "pom": "sha256-hj4SwqGSYphFs6mgDr7GIJIVUtSOUkGO1t1ZgQdlxaM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core-iossimulatorarm64/0.9.1/metadata": {
+   "jar": "sha256-iyJ3BCbpfLqzBaP5/XyBoioJp9Q++jR4rJNwhySCwjc="
   },
   "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.6.0": {
    "module": "sha256-tZuXjCxEJJpnRkGmlONaKs7LqBLah9NlpRZzQqjKU0c=",
@@ -3257,7 +5486,6 @@
    "pom": "sha256-QIZ+EY9KW7uz291WZ3DY8Yu07w02MtyE+WyZ+2vD6oE="
   },
   "org/jetbrains/kotlinx#kotlinx-io-core/0.9.0": {
-   "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
    "module": "sha256-+QJWEkHN4gRxfh6u368DBumKuZZ5rLemY6rqgfFaNiA=",
    "pom": "sha256-rYa7iYQNaLA2Wz0hnRACStrUxkZOBBNsakKeG7do/qY="
   },
@@ -3265,6 +5493,20 @@
    "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
    "module": "sha256-kK017PfkovutRYa+tMcSQEgKB1ZPLCtcG773v3GJwb4=",
    "pom": "sha256-VKzgH5zhflCIiKWTQ8ZCzNUpgA8SZIay7GYBjV49/UQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-okio-iosarm64/0.9.0": {
+   "module": "sha256-NOFrMlTpo4Mxm068VQLa6qThjYxHZvrc8FMKTDLt+8Y=",
+   "pom": "sha256-wyhaBxGqqkCmB4muBbPwXZGb+t6ZSw9CF5mtHZWALoU="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-okio-iosarm64/0.9.0/metadata": {
+   "jar": "sha256-ywC+tLJ9OQ5T9YyVIZ7Yj+lqCduRVYPuzwY8UEZdeUo="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-okio-iossimulatorarm64/0.9.0": {
+   "module": "sha256-Gq1w4GlqYIoSFILF35+6iXW06x00npApBEI3LZgO8pM=",
+   "pom": "sha256-WL/EQP5bwQejg84JGPETv35dlXtHoRhlFin7jUQT5jg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-okio-iossimulatorarm64/0.9.0/metadata": {
+   "jar": "sha256-ywC+tLJ9OQ5T9YyVIZ7Yj+lqCduRVYPuzwY8UEZdeUo="
   },
   "org/jetbrains/kotlinx#kotlinx-io-okio/0.9.0": {
    "jar": "sha256-xapQ7H4/tmSRrRDEaim8sB/VZDEYFfdLKLZL41jb3EU=",
@@ -3274,9 +5516,6 @@
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.11.0": {
    "pom": "sha256-O+IhttqG3NpRysbEskBLielasJzI0GoFaJvi7zZzXew="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.6.2": {
-   "pom": "sha256-ew4dde6GIUmc+VQwyhL9qjL0p/kg1cMBv+lfoYfyczc="
-  },
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.7.3": {
    "pom": "sha256-QiakkcW1nOkJ9ztlqpiUQZHI3Kw4JWN8a+EGnmtYmkY="
   },
@@ -3285,6 +5524,20 @@
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.9.0": {
    "pom": "sha256-bX/zZcDvHNN2+1SxoWyAoh7Vj+tGwz80ULbPIuKxNT0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iosarm64/1.11.0": {
+   "module": "sha256-8+fqI9FUWv5oBFbaIzDCVDLtGbx+nVgmUm2e8wXqfBs=",
+   "pom": "sha256-w44dlWPxVpQ+VZ/lwDXBAU7WrY8wx5rCmlQ7ntAGKC0="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iosarm64/1.11.0/metadata": {
+   "jar": "sha256-XtU73G9Ur+mdMM8qeAWFR3r8/32cfiCJUGMpksv1qpU="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iossimulatorarm64/1.11.0": {
+   "module": "sha256-zCJ2VjlYtsTcxN4IfHPMaEDIr8WSRNjo9jKUHRfNyiI=",
+   "pom": "sha256-vob42vW2cgJPsYhRx8tF8ODpzso5TC8sdO9wZfsMiBk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-iossimulatorarm64/1.11.0/metadata": {
+   "jar": "sha256-XtU73G9Ur+mdMM8qeAWFR3r8/32cfiCJUGMpksv1qpU="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.11.0": {
    "jar": "sha256-9KgBxkfUNRMnzZ4axBE+K+nqN6ZKsKuuJpwlpS4o810=",
@@ -3306,18 +5559,27 @@
    "module": "sha256-TgEUBvLCKFpam6jDtkcawWj26Cr4KxqTtxoHMdJwNk4=",
    "pom": "sha256-MTN3P7z5gip/Ol6FqxmUHme9KJv1/DGC2dtNHKuG6yI="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.6.2": {
-   "module": "sha256-arz0gTrJTfA3AS4xZzaKNEUHD9+OqyHQjYhtTtnC+2c=",
-   "pom": "sha256-BibddZLIUwKToOPoHgiBltNRh3o422hHaTY3S6ZJ+S8="
-  },
   "org/jetbrains/kotlinx#kotlinx-serialization-core/1.7.3": {
-   "jar": "sha256-SFBoLg5ZdoYmlTMNhOuGmfHcXVCEn2JSY5lcyIvG83s=",
    "module": "sha256-OdCabgLfKzJVhECmTGKPnGBfroxPYJAyF5gzTIIXfmQ=",
    "pom": "sha256-MdERd2ua93fKFnED8tYfvuqjLa5t1mNZBrdtgni6VzA="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-core/1.8.1": {
    "module": "sha256-eL3oMFSUrxs445ZrUleskINAFkk/i60hm4iGx/vbJdU=",
    "pom": "sha256-Rz8Ko+Sheqt4YNykkNxC6rthJPHSlT5qmVoIcX5QxxQ="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iosarm64/1.11.0": {
+   "module": "sha256-McJpwIJ4ctBuithEpZgettNxUlTUcMdttIjkOFSy/iU=",
+   "pom": "sha256-NXpm5s+4yP5OLipQcmBaJOZlcKMEvcdMoiKRtdBtv8s="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iosarm64/1.11.0/metadata": {
+   "jar": "sha256-tNvNjfwISvqaaD5W0nBCH7WNzqx2x1bpZFADNkYoRCc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iossimulatorarm64/1.11.0": {
+   "module": "sha256-3rNkl8NgY5EJVXZ8D1d+aaUU/d5iYknN1sotzdsxlw4=",
+   "pom": "sha256-N3biA9oQ02nVpXNx5MGxqIAi1380emYGsuzI7wHeVO4="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-iossimulatorarm64/1.11.0/metadata": {
+   "jar": "sha256-tNvNjfwISvqaaD5W0nBCH7WNzqx2x1bpZFADNkYoRCc="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-json-io-jvm/1.11.0": {
    "jar": "sha256-u/MAVSJCasS6Ks1tw49H6loydO6CuTK4hBg1x+rdq3Q=",
@@ -3336,6 +5598,20 @@
   "org/jetbrains/kotlinx#kotlinx-serialization-json-io/1.9.0": {
    "module": "sha256-vcVd2t2bARaFIanBk+KDkkGLOdZKalVdDbw163Jpltk=",
    "pom": "sha256-qLTanfNROjgysRYUhPrwPiKCN05MsOWvy1LLqX1RhOE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iosarm64/1.11.0": {
+   "module": "sha256-X0BQ9K4fla8M22yWhDzafdWgvvt247RGiHr66QYzNyA=",
+   "pom": "sha256-Z7gZc7/QFG5yqKWxhkpkfZzZ2FRo3BCeUkczulwv7Yc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iosarm64/1.11.0/metadata": {
+   "jar": "sha256-9vLGiF/sB387+dWR2Wzr4SX4mApvXaNs2QUj2znt9Q8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iossimulatorarm64/1.11.0": {
+   "module": "sha256-wtJwyY7W09/CXYmvE32WzN2sgILAQ5lfyNIOdCFHJYE=",
+   "pom": "sha256-EXv/8ZZ0C7843hTSYzGpKUn7/D5HN89dFhStlkuAzCk="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-iossimulatorarm64/1.11.0/metadata": {
+   "jar": "sha256-9vLGiF/sB387+dWR2Wzr4SX4mApvXaNs2QUj2znt9Q8="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.11.0": {
    "jar": "sha256-VjoltOtckSiunCR589GlxE3NF2ESuRzwNoLpBuulyTU=",
@@ -3356,13 +5632,104 @@
    "module": "sha256-f33wBUM932BPUqq9avsh65YJMZfLS90Hk8SEydPEtnU=",
    "pom": "sha256-x3AMmcg94CtGVBo9fktps4h0m3wPV9zrRU0UPyzYens="
   },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf-iosarm64/1.7.3": {
+   "module": "sha256-erq06RzSoQtFKuNZDPUQrmo55wC9/TJOe12DLRmemzA=",
+   "pom": "sha256-IRLMRjjpcWxEiGJ4hKcCVeolQZtVwy7Eg3H4qN6I6lU="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf-iosarm64/1.7.3/metadata": {
+   "jar": "sha256-tzVfdeU92AVujn0RfPrY2YcUQlCP3GcZV48d78BUr04="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf-iossimulatorarm64/1.7.3": {
+   "module": "sha256-D2FRDlHVOuBOmVN8SEx48Ih5aQ3sJifulbj19Gtx+5g=",
+   "pom": "sha256-eMzkWJFHfqarZQDkHNx/o2ro11ji8g1YSq8hORKSZsM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-protobuf-iossimulatorarm64/1.7.3/metadata": {
+   "jar": "sha256-tzVfdeU92AVujn0RfPrY2YcUQlCP3GcZV48d78BUr04="
+  },
   "org/jetbrains/kotlinx#kotlinx-serialization-protobuf/1.7.3": {
    "jar": "sha256-dMdtR+VdhmvBjZ7Yia45y859sLd95acgENqx8kR5NXc=",
    "module": "sha256-Mes2Fe5po0XkuEjgxBiDLAvNX8hGCk3gZsGG9Ss3oRA=",
    "pom": "sha256-PIUWIFu9DIjtNXCwnGS+f7WvEMGapgJFBu/Su7WSrMk="
   },
+  "org/jetbrains/kotlinx/atomicfu-iosarm64/0.32.1/atomicfu-iosarm64-0.32.1": {
+   "klib": "sha256-REEduw5KPv3UzC10237xhHf2X9ug1LeVbhZYVG/NlH0="
+  },
+  "org/jetbrains/kotlinx/atomicfu-iosarm64/0.32.1/atomicfu-iosarm64-0.32.1-cinterop-interop": {
+   "klib": "sha256-O4IzLQiMk4cUUQJW2BK+xcfjQGR1rsgM6jLJEIndE38="
+  },
+  "org/jetbrains/kotlinx/atomicfu-iosarm64/0.33.0/atomicfu-iosarm64-0.33.0": {
+   "klib": "sha256-HzTYq09z9CekcEzwyuGQdWHONBVoyKWEXcEQxAZuyTE="
+  },
+  "org/jetbrains/kotlinx/atomicfu-iosarm64/0.33.0/atomicfu-iosarm64-0.33.0-cinterop-interop": {
+   "klib": "sha256-0p+gJ/VOxOyPBTWWTqATtqPvGvKLZonU1NviSC32AwE="
+  },
+  "org/jetbrains/kotlinx/atomicfu-iossimulatorarm64/0.32.1/atomicfu-iossimulatorarm64-0.32.1": {
+   "klib": "sha256-EBAOHmjyXdIJ+gibvJNEw6qEMOhxIvHdnIuF4cxGx/I="
+  },
+  "org/jetbrains/kotlinx/atomicfu-iossimulatorarm64/0.32.1/atomicfu-iossimulatorarm64-0.32.1-cinterop-interop": {
+   "klib": "sha256-xro7WI/66QmsAhEFuoff3lqA3hniZ5QT828FuH5/qOI="
+  },
+  "org/jetbrains/kotlinx/atomicfu-iossimulatorarm64/0.33.0/atomicfu-iossimulatorarm64-0.33.0": {
+   "klib": "sha256-y7e38Gi1btHVOQNbAiy56+XRjeJ7pfALGfj4mb9V7pY="
+  },
+  "org/jetbrains/kotlinx/atomicfu-iossimulatorarm64/0.33.0/atomicfu-iossimulatorarm64-0.33.0-cinterop-interop": {
+   "klib": "sha256-594tgLLXJUFHdQBW4xfoRLr+D2mMe5g/m8EY0ht0vk8="
+  },
+  "org/jetbrains/kotlinx/kotlinx-coroutines-core-iosarm64/1.11.0/kotlinx-coroutines-core-iosarm64-1.11.0": {
+   "klib": "sha256-nQcaj1e1vzFIe6x1aOxP2FL8L9TCQWh2303z67ASntQ="
+  },
+  "org/jetbrains/kotlinx/kotlinx-coroutines-core-iossimulatorarm64/1.11.0/kotlinx-coroutines-core-iossimulatorarm64-1.11.0": {
+   "klib": "sha256-MgDVkhXn9Mb/zMMtMNBeVCXYAUSop7r7cPmdhrlAI3k="
+  },
+  "org/jetbrains/kotlinx/kotlinx-datetime-iosarm64/0.4.0/kotlinx-datetime-iosarm64-0.4.0": {
+   "klib": "sha256-sWbAT1j+hMLZlKMAiApJttraQbn1ge2F5lr26LsqT4U="
+  },
+  "org/jetbrains/kotlinx/kotlinx-datetime-iossimulatorarm64/0.4.0/kotlinx-datetime-iossimulatorarm64-0.4.0": {
+   "klib": "sha256-CWAtueHtwo/4tfzCNK84+8vIlMtQLP14q5ZApM/nMvk="
+  },
+  "org/jetbrains/kotlinx/kotlinx-io-bytestring-iosarm64/0.9.1/kotlinx-io-bytestring-iosarm64-0.9.1": {
+   "klib": "sha256-TIUeY5jme4g272tlYwZXUnWLvSmrhSL5lrxKuvBNj1Y="
+  },
+  "org/jetbrains/kotlinx/kotlinx-io-bytestring-iossimulatorarm64/0.9.1/kotlinx-io-bytestring-iossimulatorarm64-0.9.1": {
+   "klib": "sha256-2MZLjLRAPk4zOj/fIljtsgxgoDW4Egd3plltIwlEQ04="
+  },
+  "org/jetbrains/kotlinx/kotlinx-io-core-iosarm64/0.9.1/kotlinx-io-core-iosarm64-0.9.1": {
+   "klib": "sha256-saKUuP003doIcnDuK5JyZF+JyKfLmVPYrCpouCEVsVY="
+  },
+  "org/jetbrains/kotlinx/kotlinx-io-core-iossimulatorarm64/0.9.1/kotlinx-io-core-iossimulatorarm64-0.9.1": {
+   "klib": "sha256-9qWYjnrOSz2lDfvmTbOGLw3xoqrwOZA2h31L47Gv1Wg="
+  },
+  "org/jetbrains/kotlinx/kotlinx-io-okio-iosarm64/0.9.0/kotlinx-io-okio-iosarm64-0.9.0": {
+   "klib": "sha256-NFZtknGHtMm9lYcwH1ubqx7COifi7qvDqj1UcU87+38="
+  },
+  "org/jetbrains/kotlinx/kotlinx-io-okio-iossimulatorarm64/0.9.0/kotlinx-io-okio-iossimulatorarm64-0.9.0": {
+   "klib": "sha256-XZM76unlYrOV4qOGbxcgpFORvPA2vMb3I0g8PpR/CII="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-core-iosarm64/1.11.0/kotlinx-serialization-core-iosarm64-1.11.0": {
+   "klib": "sha256-xCMYE6WFOExJOUd1buH/u9TT4LdqyY0u2DNZCaoTFqI="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-core-iossimulatorarm64/1.11.0/kotlinx-serialization-core-iossimulatorarm64-1.11.0": {
+   "klib": "sha256-b027LStWoluOwP5iDS8Pb1yIUQ2B2DYc+fwYB8g+V6U="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-json-io-iosarm64/1.11.0/kotlinx-serialization-json-io-iosarm64-1.11.0": {
+   "klib": "sha256-ZYT8x2oa4CRpW/OHvi9fl9bc3h8NB11Z3a2qiBdiAHg="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-json-io-iossimulatorarm64/1.11.0/kotlinx-serialization-json-io-iossimulatorarm64-1.11.0": {
+   "klib": "sha256-+PbPJNrpoq4gj2A0mRTP5nxgfQSWJiUebBxgDyB7U7c="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-json-iosarm64/1.11.0/kotlinx-serialization-json-iosarm64-1.11.0": {
+   "klib": "sha256-tr3eRHusLckOnXOhB67bEwzEvYcyJ9h84wCWWUNPmQM="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-json-iossimulatorarm64/1.11.0/kotlinx-serialization-json-iossimulatorarm64-1.11.0": {
+   "klib": "sha256-QIPWjUw/MbnDCXLDv1sCptwnTz/K+xY3GC+pttsJvXM="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-iosarm64/1.7.3/kotlinx-serialization-protobuf-iosarm64-1.7.3": {
+   "klib": "sha256-Z7Qg6n9E4XTmjVjgmvPqpZOJjMSgKzb/E1rNXHDg/aY="
+  },
+  "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-iossimulatorarm64/1.7.3/kotlinx-serialization-protobuf-iossimulatorarm64-1.7.3": {
+   "klib": "sha256-VheRC7DBPQE/lfaHjmG7KXTk9eSO0V1is23HtL0S2Ss="
+  },
   "org/jetbrains/runtime#jbr-api/1.5.0": {
-   "jar": "sha256-ZX7efX+OF1yQmyPKoQ/NTUpREwT9k4qpzIRXtDeJUNU=",
    "pom": "sha256-/jziiqT0Ga0GcErRyoIzTQ6HFmfKWxE8UVfnUXzhMh4="
   },
   "org/jetbrains/runtime#jbr-api/1.9.0": {
@@ -3382,6 +5749,20 @@
    "module": "sha256-+AH6sle53AvXLZyc8JwwXYwm5ugD4GL9gL6k0jO/jFI=",
    "pom": "sha256-+md/vcKkkSlXhWtcrugtdGHkZPkv3mZMzpxgkdyj37Y="
   },
+  "org/jetbrains/skiko#skiko-iosarm64/0.150.1": {
+   "module": "sha256-8bIXjMH3Y1jApYtcdUZ6FDavhGMaKzXComFv/lBGyYA=",
+   "pom": "sha256-cbhX79m8p3//cmXZHiJINyk/eZXvFxyjAYaO4TKpcak="
+  },
+  "org/jetbrains/skiko#skiko-iosarm64/0.150.1/metadata": {
+   "jar": "sha256-NFcANaU5ILZ462FWM3fwkOd84LXYHzJqEbxmny2O/jM="
+  },
+  "org/jetbrains/skiko#skiko-iossimulatorarm64/0.150.1": {
+   "module": "sha256-3J/QZpat4c+XwkbNRDjoAuVm5v+dWs7F8V6s1TqzmIk=",
+   "pom": "sha256-DBV6cbHJebyI77c8INFuGdmaC/52GQJNsXUVKQy4SVg="
+  },
+  "org/jetbrains/skiko#skiko-iossimulatorarm64/0.150.1/metadata": {
+   "jar": "sha256-NFcANaU5ILZ462FWM3fwkOd84LXYHzJqEbxmny2O/jM="
+  },
   "org/jetbrains/skiko#skiko/0.150.0": {
    "module": "sha256-LSQqhSVtX2xk1xqlgFHmp/e8xyxW0ApoG9p6yggBh9o=",
    "pom": "sha256-aqkllp4vPtBNoa/tqoXy98loHXaiWiitINKTTHHMGU8="
@@ -3390,6 +5771,18 @@
    "jar": "sha256-f1EAu0qsmf9LiW3fWlnoxzz+TA+DxZUXYqCPhIVlqKg=",
    "module": "sha256-CxLkSe9Uyod3Gj7Q6EQvuvYp0mScYWReYafvaY8AHNY=",
    "pom": "sha256-eJoOVzN71/xJ7dIqcxGSQIwIGvW9BIeFYQs13jpOFiw="
+  },
+  "org/jetbrains/skiko/skiko-iosarm64/0.150.1/skiko-iosarm64-0.150.1": {
+   "klib": "sha256-ahAmohIealTbpp2RFZfFctM07lOOtIe1L+7t8EkohS8="
+  },
+  "org/jetbrains/skiko/skiko-iosarm64/0.150.1/skiko-iosarm64-0.150.1-cinterop-uikit": {
+   "klib": "sha256-GlwFBS4DIRZudRm3quwjBuqUBzLCjCSmefuN9BYd9yw="
+  },
+  "org/jetbrains/skiko/skiko-iossimulatorarm64/0.150.1/skiko-iossimulatorarm64-0.150.1": {
+   "klib": "sha256-9tVXyDzkMZiJEzQdEDDhiOSsMQy6ynGi85zE6+Nw8J8="
+  },
+  "org/jetbrains/skiko/skiko-iossimulatorarm64/0.150.1/skiko-iossimulatorarm64-0.150.1-cinterop-uikit": {
+   "klib": "sha256-v2DL8NaqjCeTDOXWbyYbD8qkTfLMJuirLjURF5nsbuM="
   },
   "org/jspecify#jspecify/1.0.0": {
    "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",

--- a/pkgs/by-name/ru/rush-lyrics/package.nix
+++ b/pkgs/by-name/ru/rush-lyrics/package.nix
@@ -34,13 +34,13 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   pname = "rush-lyrics";
-  version = "6.5.2";
+  version = "6.5.3";
 
   src = fetchFromGitHub {
     owner = "shub39";
     repo = "Rush";
     tag = finalAttrs.version;
-    hash = "sha256-+x42qGw2mQdUxRSq4r5kiPD9feE0DMhjUPk+8vLfLzw=";
+    hash = "sha256-LuI3i87ufGAm1hxrC8UdH7xfnubSRUIOoO9CVq5c6T4=";
   };
 
   patches = [

--- a/pkgs/by-name/ru/rush-lyrics/remove-android.patch
+++ b/pkgs/by-name/ru/rush-lyrics/remove-android.patch
@@ -12,7 +12,7 @@ index 1535716..ccca9fb 100644
 -
  include(":desktopApp")
 diff --git a/shared/core/build.gradle.kts b/shared/core/build.gradle.kts
-index 8c629be..4601950 100644
+index a4e7587..f2404ee 100644
 --- a/shared/core/build.gradle.kts
 +++ b/shared/core/build.gradle.kts
 @@ -17,7 +17,6 @@
@@ -36,9 +36,9 @@ index 8c629be..4601950 100644
 -
      jvm()
  
-     sourceSets {
+     listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
 diff --git a/shared/logic/build.gradle.kts b/shared/logic/build.gradle.kts
-index 3bcd708..5c6a9a8 100644
+index ef5a1dd..db72417 100644
 --- a/shared/logic/build.gradle.kts
 +++ b/shared/logic/build.gradle.kts
 @@ -19,7 +19,6 @@ import java.util.Properties
@@ -49,7 +49,7 @@ index 3bcd708..5c6a9a8 100644
      alias(libs.plugins.compose.multiplatform)
      alias(libs.plugins.compose.compiler)
      alias(libs.plugins.build.config)
-@@ -34,15 +33,6 @@ kotlin {
+@@ -35,15 +34,6 @@ kotlin {
          freeCompilerArgs.add("-Xexpect-actual-classes")
      }
  
@@ -62,27 +62,30 @@ index 3bcd708..5c6a9a8 100644
 -        androidResources { enable = true }
 -    }
 -
-     jvm()
- 
-     sourceSets {
-@@ -68,7 +58,6 @@ kotlin {
-             implementation(libs.bundles.ktor)
-             implementation(libs.ksoup)
+     listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+         iosTarget.binaries.framework {
+             baseName = "SharedLogic"
+@@ -81,10 +71,6 @@ kotlin {
+             implementation(libs.ktor.client.darwin)
+             implementation(libs.androidx.sqlite.bundled)
          }
--        androidMain.dependencies { implementation(projects.androidLibs.romanization) }
-         jvmMain.dependencies { implementation(libs.androidx.sqlite.bundled) }
-     }
- }
-@@ -98,7 +87,6 @@ room3 { schemaDirectory("$projectDir/schemas") }
+-        androidMain.dependencies {
+-            implementation(libs.ktor.client.okhttp)
+-            implementation(projects.androidLibs.romanization)
+-        }
+         jvmMain.dependencies {
+             implementation(libs.ktor.client.okhttp)
+             implementation(libs.androidx.sqlite.bundled)
+@@ -117,7 +103,6 @@ room3 { schemaDirectory("$projectDir/schemas") }
  
  dependencies {
      add("kspJvm", libs.androidx.room.compiler)
 -    add("kspAndroid", libs.androidx.room.compiler)
+     add("kspIosSimulatorArm64", libs.androidx.room.compiler)
+     add("kspIosArm64", libs.androidx.room.compiler)
  }
- 
- tasks.register("generateChangelog") {
 diff --git a/shared/ui/build.gradle.kts b/shared/ui/build.gradle.kts
-index cf0d519..7d72086 100644
+index cf0d519..9ab57e2 100644
 --- a/shared/ui/build.gradle.kts
 +++ b/shared/ui/build.gradle.kts
 @@ -18,7 +18,6 @@
@@ -107,7 +110,7 @@ index cf0d519..7d72086 100644
      jvm()
  
      sourceSets {
-@@ -79,20 +71,6 @@ kotlin {
+@@ -79,20 +71,9 @@ kotlin {
              implementation(libs.koin.compose.viewmodel.navigation)
              implementation(libs.koin.annotations)
          }
@@ -118,11 +121,11 @@ index cf0d519..7d72086 100644
      }
  }
  
--dependencies {
+ dependencies {
 -    androidRuntimeClasspath(libs.compose.ui.tooling)
 -    androidRuntimeClasspath(libs.compose.ui.tooling.preview)
--}
--
+ }
+ 
 -androidComponents {
 -    onVariants { variant ->
 -        variant.sources.res?.addStaticSourceDirectory("src/commonMain/composeResources")


### PR DESCRIPTION
Bump `rush-lyrics` [6.5.2 -> 6.5.3](https://github.com/shub39/Rush/compare/6.5.2...6.5.3), regenerate `deps.json` and update `remove-android.patch` since upstream Rush modified the build files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
