### PR TITLE
qlcplus: 4.14.4 -> 5.2.2

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -147,6 +147,8 @@
 
 - The deprecated `appimageTools.extractType1`, `appimageTools.extractType2`, and `appimageTools.wrapType1` aliases now emit warnings. Use `appimageTools.extract` and `appimageTools.wrapType2` instead.
 
+- `qlcplus` has been updated to 5.2.2 and now uses its new Qt 6 based interface.
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/by-name/ql/qlcplus/package.nix
+++ b/pkgs/by-name/ql/qlcplus/package.nix
@@ -2,62 +2,89 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
+  ninja,
   pkg-config,
   udevCheckHook,
   udev,
-  libsForQt5,
+  qt6,
   alsa-lib,
   ola,
   libftdi1,
-  libusb-compat-0_1,
+  libusb1,
   libsndfile,
-  libmad,
+  fftw,
 }:
 
 stdenv.mkDerivation rec {
   pname = "qlcplus";
-  version = "5.0.0";
+  version = "5.2.2";
 
   src = fetchFromGitHub {
     owner = "mcallegari";
     repo = "qlcplus";
     rev = "QLC+_${version}";
-    hash = "sha256-gEwcTIJhY78Ts0lUn4MVciV7sPIBkqlxPMa9I1nTHO0=";
+    hash = "sha256-e8KyuCnzTUz/f6cfT7LyUQ9snaFBnE5WTc4FP7jhdRY=";
   };
 
   nativeBuildInputs = [
-    libsForQt5.qmake
+    cmake
+    ninja
     pkg-config
     udevCheckHook
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
     udev
-    libsForQt5.qtmultimedia
-    libsForQt5.qtscript
-    libsForQt5.qtserialport
-    libsForQt5.qtwebsockets
     alsa-lib
     ola
     libftdi1
-    libusb-compat-0_1
+    libusb1
     libsndfile
-    libmad
-  ];
-
-  qmakeFlags = [ "INSTALLROOT=$(out)" ];
+    fftw
+  ]
+  ++ (with qt6; [
+    qtbase
+    qtdeclarative
+    qtmultimedia
+    qtserialport
+    qtsvg
+    qttools
+    qtwebsockets
+    qt3d
+  ]);
 
   postPatch = ''
     patchShebangs .
-    sed -i -e '/unix:!macx:INSTALLROOT += \/usr/d' \
-            -e "s@\$\$LIBSDIR/qt4/plugins@''${qtPluginPrefix}@" \
-            -e "s@/etc/udev/rules.d@''${out}/lib/udev/rules.d@" \
-      variables.pri
 
-    # Fix gcc-13 build failure by removing blanket -Werror.
-    fgrep Werror variables.pri
-    substituteInPlace variables.pri --replace-fail "QMAKE_CXXFLAGS += -Werror" ""
+    # Fix build failure caused by newer compilers/Qt turning on additional
+    # warnings (e.g. -Wunused-result for [[nodiscard]] QFile::open) by
+    # removing the blanket -Werror.
+    substituteInPlace variables.cmake --replace-fail 'set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} -Werror")' ""
+
+    # On Linux, QLC+'s build system hardcodes all of its installation
+    # directories (binaries, libraries, data files, ...) to be relative to
+    # "/usr", following the same "install root" convention used by its
+    # Debian packaging (see INSTALL_ROOT below). Drop that hardcoded "/usr"
+    # prefix so everything installs directly under $out in the conventional
+    # FHS-style layout instead of $out/usr.
+    substituteInPlace variables.cmake --replace-fail 'set(INSTALLROOT "/usr")' 'set(INSTALLROOT "")'
   '';
+
+  cmakeFlags = [
+    # QLC+ 5's QML-based UI, as opposed to the legacy Qt Widgets UI.
+    (lib.cmakeBool "qmlui" true)
+    # See the INSTALLROOT patch in postPatch above: this is prepended to it
+    # (and to a few paths that don't use INSTALLROOT, like the udev rules
+    # directory) to form the actual installation prefix.
+    (lib.cmakeFeature "INSTALL_ROOT" (placeholder "out"))
+    # nixpkgs' cmake setup-hook forces CMAKE_INSTALL_LIBDIR to the absolute
+    # path "$out/lib". QLC+ then prepends INSTALLROOT (i.e. $out again, see
+    # above) to it, resulting in a doubled-up, nested install path. Reset it
+    # back to a plain relative directory so it composes correctly with
+    # INSTALLROOT instead.
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Hey,

nobody seems to maintain this package anymore but I wanted to see this update happen.
https://github.com/mcallegari/qlcplus/releases/tag/QLC%2B_5.2.2

Since v5 qlcplus uses qt6 with cmake instead of qt5 with qmake.
https://github.com/mcallegari/qlcplus/wiki/QLC-Plus-5-build-HOWTO
https://github.com/mcallegari/qlcplus/wiki/Linux-build-(Qt6-&-cmake)

If necessary I could maintain qlcplus.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
