### PR TITLE
haskell.generic-builder: select matching Haddock when cross documentation is enabled

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -349,6 +349,7 @@ let
     "--with-hsc2hs=${ghc.targetPrefix}hsc2hs"
     "--with-strip=${stdenv.cc.bintools.targetPrefix}strip"
   ]
+  ++ optional doHaddock "--with-haddock=${ghc.targetPrefix}haddock"
   ++ optionals (!isHaLVM) [
     "--hsc2hs-option=--cross-compile"
     (optionalString enableHsc2hsViaAsm "--hsc2hs-option=--via-asm")


### PR DESCRIPTION
`crossCabalFlags` selects target tools explicitly but omits Haddock. Cabal can therefore use the native Haddock, which fails when it was built against a different GHC version:

```
Haddock's internal GHC version must match the configured GHC version.
```

Pass the target-prefixed Haddock when `doHaddock` is enabled.

Verified using an externally supplied wasm cross GHC bindist that includes a native `wasm32-wasi-haddock`. Current nixpkgs source-built cross GHCs do not include such an executable.

### Current nixpkgs impact

This does not change any current in-tree derivation. Native builds do not use `crossCabalFlags` while nixpkgs's source-built cross GHCs currently set `hasHaddock = false`, causing `doHaddock` to remain disabled.

The change supports consumers that instantiate nixpkgs's Haskell package-set machinery with an externally supplied cross GHC that includes a matching, target-prefixed Haddock. Without the explicit flag, Cabal can select an unrelated native Haddock from `PATH` and reject it because its internal GHC version differs.

It also prepares the generic builder for the existing common-hadrian.nix TODO to build Haddock for cross GHCs:
https://github.com/NixOS/nixpkgs/blob/be2c4b1e649869865a9727d68166fb786503577c/pkgs/development/compilers/ghc/common-hadrian.nix#L390-L392
If that is implemented, setting `hasHaddock = true` will be sufficient for package documentation to use the matching executable.

### How to test and verify the change

Create the `nixpkgs-review` checkout:
```sh
nixpkgs-review pr 553415
```

From the resulting review shell, run:
```sh
repro_flake="github:ilkecan/ghc-wasm-nix/b564684b802c4e8fb02982658fcf34db9f2c7fc9"
review_nixpkgs="git+file://$PWD/nixpkgs"
# before
nix build "$repro_flake#haddock-check" --override-input nixpkgs "$review_nixpkgs?rev=483daeee8c253622f6db7684620f83ceac268e89" --no-link -L
# after
nix build "$repro_flake#haddock-check" --override-input nixpkgs "$review_nixpkgs" --no-link -L
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
