### PR TITLE
python3Packages.nipreps-versions: 1.0.4 -> 1.2.0; python3Packages.nipype: cleanup, fix; python3Packages.niworkflows: cleanup

### DIFF
--- a/pkgs/development/python-modules/nipreps-versions/default.nix
+++ b/pkgs/development/python-modules/nipreps-versions/default.nix
@@ -2,39 +2,59 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-scm,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
   packaging,
   setuptools-scm,
+  vcs-versioning,
+
+  # tests
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nipreps-versions";
-  version = "1.0.4";
+  version = "1.2.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "nipreps";
     repo = "version-schemes";
-    tag = version;
-    hash = "sha256-B2wtLurzgk59kTooH51a2dewK7aEyA0dAm64Wp+tqhM=";
+    tag = finalAttrs.version;
+    hash = "sha256-SPJ4L68dFcSv1+Ytp3b3n+lr35Krq71fIlaReFux1nk=";
   };
 
-  nativeBuildInputs = [
-    flit-scm
-    setuptools-scm
+  build-system = [
+    hatch-vcs
+    hatchling
   ];
 
-  propagatedBuildInputs = [ packaging ];
+  dependencies = [
+    packaging
+    setuptools-scm
+    vcs-versioning
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
   pythonImportsCheck = [ "nipreps_versions" ];
+
+  disabledTests = [
+    # Rely on the current date, which is pinned to 1980 in the sandbox (`SOURCE_DATE_EPOCH`)
+    "invalid_branch_version"
+    "test_next_calver"
+  ];
 
   meta = {
     description = "Setuptools_scm plugin for nipreps version schemes";
     homepage = "https://github.com/nipreps/version-schemes";
-    changelog = "https://github.com/nipreps/version-schemes/blob/${src.rev}/CHANGES.md";
+    changelog = "https://github.com/nipreps/version-schemes/blob/${finalAttrs.src.tag}/CHANGES.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
 
   # build-system
   hatchling,
@@ -24,9 +24,6 @@
   puremagic,
   pybids,
   pydot,
-  pytestCheckHook,
-  pytest-xdist,
-  pytest-cov-stub,
   rdflib,
   scipy,
   simplejson,
@@ -35,33 +32,49 @@
   # optional-dependencies
   datalad,
   duecredit,
-  pandas,
   paramiko,
   psutil,
-  sphinx,
   xvfbwrapper,
 
-  # other dependencies
-  which,
+  # tests
   bash,
   glibcLocales,
+  pandas,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-doctestplus,
+  pytest-env,
+  pytest-timeout,
+  pytest-xdist,
+  sphinx,
+  which,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nipype";
   version = "1.11.0";
   pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-ZwfsTDz44Zg673+O6nlifue3q0qklkmZFVDhKcFlt6c=";
+  src = fetchFromGitHub {
+    owner = "nipy";
+    repo = "nipype";
+    tag = finalAttrs.version;
+    hash = "sha256-Xa7hoD+UvxozXsW4ztjQfKPmvHJL42EMuu95rWWlbe8=";
   };
 
   postPatch = ''
     substituteInPlace nipype/interfaces/base/tests/test_core.py \
-      --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
+      --replace-fail "/usr/bin/env bash" "${lib.getExe bash}"
     substituteInPlace nipype/pipeline/engine/tests/test_nodes.py \
-      --replace-fail "/bin/bash" "${bash}/bin/bash"
+      --replace-fail "/bin/bash" "${lib.getExe bash}"
+  ''
+  # `nilearn.input_data` was renamed to `nilearn.maskers` in nilearn 0.9 and dropped in 0.13
+  + ''
+    substituteInPlace nipype/interfaces/nilearn.py \
+      --replace-fail \
+        "import nilearn.input_data as nl" \
+        "import nilearn.maskers as nl"
   '';
 
   build-system = [
@@ -90,7 +103,7 @@ buildPythonPackage rec {
     traits
   ];
 
-  passthru.optional-dependencies = {
+  optional-dependencies = {
     data = [ datalad ];
     duecredit = [ duecredit ];
     profiler = [ psutil ];
@@ -104,6 +117,9 @@ buildPythonPackage rec {
     pandas
     pytestCheckHook
     pytest-cov-stub
+    pytest-doctestplus
+    pytest-env
+    pytest-timeout
     pytest-xdist
     sphinx
     which
@@ -119,11 +135,12 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    homepage = "https://nipy.org/nipype";
     description = "Neuroimaging in Python: Pipelines and Interfaces";
-    changelog = "https://github.com/nipy/nipype/releases/tag/${version}";
+    homepage = "https://nipy.org/nipype";
+    downloadPage = "https://github.com/nipy/nipype";
+    changelog = "https://github.com/nipy/nipype/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "nipypecli";
-    license = lib.licenses.bsd3;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ashgillman ];
   };
-}
+})

--- a/pkgs/development/python-modules/niworkflows/default.nix
+++ b/pkgs/development/python-modules/niworkflows/default.nix
@@ -44,6 +44,7 @@ buildPythonPackage (finalAttrs: {
   pname = "niworkflows";
   version = "1.14.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "nipreps";
@@ -55,13 +56,14 @@ buildPythonPackage (finalAttrs: {
   # fails to determine the version automatically
   env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
 
-  pythonRelaxDeps = [ "traits" ];
-
   build-system = [
     hatch-vcs
     hatchling
   ];
 
+  pythonRelaxDeps = [
+    "traits"
+  ];
   dependencies = [
     acres
     attrs


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.nipreps-versions: 1.0.4 -> 1.2.0**
- **python3Packages.nipype: cleanup, fix**
- **python3Packages.niworkflows: cleanup**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
