### PR TITLE
Remove timokau from sage team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -710,7 +710,6 @@ with lib.maintainers;
 
   sage = {
     members = [
-      timokau
       raskin
       collares
     ];

--- a/pkgs/by-name/ec/eclib/package.nix
+++ b/pkgs/by-name/ec/eclib/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   # sage tests to run:
   # src/sage/interfaces/mwrank.py
   # src/sage/libs/eclib
-  # ping @timokau for more info
+  # ping the sage team for more info
   src = fetchurl {
     # all releases for this project appear on its GitHub releases page
     # by definition! other distros sometimes update whenever they see

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "cypari2";
-  # upgrade may break sage, please test the sage build or ping @timokau on upgrade
+  # upgrade may break sage, please test the sage build or ping the sage team on upgrade
   version = "2.2.4";
   pyproject = true;
 

--- a/pkgs/development/python-modules/networkx/default.nix
+++ b/pkgs/development/python-modules/networkx/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "networkx";
-  # upgrade may break sage, please test the sage build or ping @timokau on upgrade
+  # upgrade may break sage, please test the sage build or ping the sage team on upgrade
   version = "3.6.1";
   pyproject = true;
 


### PR DESCRIPTION
I do not actually use sage anymore and I have not really maintained it in a long time. Nowadays this only generates a lot of emails for me that I have no useful input on.

Thanks a lot @collares for taking over! You are doing great work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
