### PR TITLE
zenoh: 1.9.0 -> 1.10.0

### DIFF
--- a/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-backend-filesystem";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-backend-filesystem";
     tag = finalAttrs.version;
-    hash = "sha256-xyGRL8cSTiObuFDZN+c7e9Sggfn5jx9555PU0JSPh6o=";
+    hash = "sha256-s0aEyU6Uj4I9Np6cek86YNQyNLFz9wmyZMS9YL0iweU=";
   };
 
-  cargoHash = "sha256-kbMOAL/CvmbOjKVpnZrZlRsl0sibTBwvqCq5GzXjGx8=";
+  cargoHash = "sha256-PGK43p0fJ1j/UrIO6asR2RKlQczwMLxawLsnX2tvQlU=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ze/zenoh-backend-influxdb/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-influxdb/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-backend-influxdb";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-backend-influxdb";
     tag = finalAttrs.version;
-    hash = "sha256-W+hrkmjvWPhUJgbPGwzo9159wd269P0vBIxDV+oX6H4=";
+    hash = "sha256-t8ob870cLWTfkuHlDXcuReP7K0/FM9d8HV8Sj4xaBOE=";
   };
 
-  cargoHash = "sha256-+wJqrGQhcrVW9un+2rPZwZl8/MzttduO9Nhn1w2cNag=";
+  cargoHash = "sha256-melqspwAzAqX68pSZ5E/MOFBAO1ObpspFFhflt7Lads=";
 
   meta = {
     description = "Backend and Storages for zenoh using InfluxDB";

--- a/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-backend-rocksdb";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-backend-rocksdb";
     tag = finalAttrs.version;
-    hash = "sha256-D+gc29pje4cXfIXP++572iqvzkHDrF6JVdRkdHnEY4E=";
+    hash = "sha256-m4Tnos5o/iBfJ+06ajUjJ51DFjYIvrwjgUsfRKHSWRc=";
   };
 
-  cargoHash = "sha256-IOdwGre7j5vyJ5Zut+Q3/548xAlXxbRTVePp9V5nssI=";
+  cargoHash = "sha256-QF3ojTyMsxxlxkQXNxcokqiv8InQ2iRAwqtz84fDefE=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ze/zenoh-c/package.nix
+++ b/pkgs/by-name/ze/zenoh-c/package.nix
@@ -10,20 +10,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zenoh-c";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-c";
-    # tag = version;
-    # Use 1.9.0 PR merge commit with up-to-date Cargo.lock file
-    rev = "8858e129271f4e05bb34d8ae6df3f3d221ef5299";
-    hash = "sha256-rNvtFFM9tRttuBAIrpaYTadFcUe1El7q5t7PNnMEJXA=";
+    tag = finalAttrs.version;
+    hash = "sha256-p16dbXgPcRcvu+N7OLSVWqFI8JfCWvzLA1iovWqEVSE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src pname version;
-    hash = "sha256-7xWu9wgZqDzd60buMnF9B6Y5LRkG5C2JWiG7VwgSCvU=";
+    hash = "sha256-6eDQBXTdA4CwWT3IKFq2RvOfOt3rq4RZrqn0Q6FWRgc=";
   };
 
   outputs = [

--- a/pkgs/by-name/ze/zenoh-cpp/package.nix
+++ b/pkgs/by-name/ze/zenoh-cpp/package.nix
@@ -2,30 +2,20 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   cmake,
   zenoh-c,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zenoh-cpp";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-cpp";
     tag = finalAttrs.version;
-    hash = "sha256-MwQKTxrQqfoASCRk+vBeS9EHvmh6sqrpqygQVrdGkWw=";
+    hash = "sha256-EX3TSm0gAaRS2mj8o90zKsFvSqv2bgjrCnW4b1cC4JM=";
   };
-
-  patches = [
-    # ref. https://github.com/eclipse-zenoh/zenoh-cpp/pull/790 merged upstream
-    (fetchpatch2 {
-      name = "fix-cmake-exports-and-pc.patch";
-      url = "https://github.com/eclipse-zenoh/zenoh-cpp/commit/a55543277ce93fa3d0871b5b30fb18c04a283db2.patch?full_index=true";
-      hash = "sha256-oaCeLTrQ7veWzpTEKGo4pDmNLKmnBIjBkuX71vRtjoo=";
-    })
-  ];
 
   cmakeFlags = [
     (lib.cmakeBool "ZENOHCXX_ZENOHC" true)

--- a/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
@@ -6,16 +6,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-plugin-dds";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-plugin-dds";
     tag = finalAttrs.version;
-    hash = "sha256-MOZmyZGaMJieWISZnnSTU+3+ER4FcGhg3YCTlmuWmuE=";
+    hash = "sha256-CPtIYxfiK/2Gs7yiXlzPUppDbd1R6cnbxZe/YIzX8fo=";
   };
 
-  cargoHash = "sha256-O7OrgEPPkWMYCtmtdgYIcE8YUa+YpHWttwW0Gu5BLJA=";
+  cargoHash = "sha256-nWk212kRNkz6YxW2pNed4PjKX2kJZlsaxm9KXUrh8/Q=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-plugin-mqtt";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-plugin-mqtt";
     tag = finalAttrs.version;
-    hash = "sha256-f5y9zCUTvNG/ubw0K+AwqfQlsfeLvoUL8gy3v9T0oQ4=";
+    hash = "sha256-GLSRs3qV8AwaSPPqAKt/PchIQnlDr0IeqbJkCqkDBY8=";
   };
 
-  cargoHash = "sha256-vL5lZOH8juX8zaLJZnw1y8aDZsdFC3gELNvp5MPft2o=";
+  cargoHash = "sha256-XteKnrfKrOGbjCz7njaDlxSPOZ73UWt91dg8R2hB3PM=";
 
   # Some test time out
   doCheck = false;

--- a/pkgs/by-name/ze/zenoh-plugin-webserver/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-webserver/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-plugin-webserver";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-plugin-webserver";
     tag = finalAttrs.version;
-    hash = "sha256-U2xcx3TVPkEgea2gdSdbEa+jDI6h6vftLUi8AZPY3fU=";
+    hash = "sha256-1slOQdefLmR1zMSIzpz8mz9SI3ycn7olPesFcXDogRo=";
   };
 
-  cargoHash = "sha256-PLmmOw2ZMPn/ODBJn1NBvWyeGEPOcKB+aepoDqhqzZc=";
+  cargoHash = "sha256-lbHXaGQaDY44CN/jEkpb/9Xow1CtB+xC0wNGkp3zjV4=";
 
   meta = {
     description = "Implements an HTTP server mapping URLs to zenoh paths";

--- a/pkgs/by-name/ze/zenoh/package.nix
+++ b/pkgs/by-name/ze/zenoh/package.nix
@@ -8,16 +8,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh";
     rev = finalAttrs.version;
-    hash = "sha256-sFHUphFu5a+buSa3GQvSmGo8SFtn3V5ZqTOnWMPlvs8=";
+    hash = "sha256-5cRS9N4MgVkCaydN1FBgzOXRhwyUESnk6UwIfsEnHXE=";
   };
 
-  cargoHash = "sha256-1PjtZ5/bAnLlMbkcKAA6DCKDafItGiATjct5Pv8muas=";
+  cargoHash = "sha256-qsULjxLwXcrJQbH2qf9rOhterde8G73hYlBbCQQUUYc=";
 
   cargoBuildFlags = [
     "--workspace"

--- a/pkgs/development/python-modules/zenoh/default.nix
+++ b/pkgs/development/python-modules/zenoh/default.nix
@@ -9,19 +9,19 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "eclipse-zenoh";
-  version = "1.9.0"; # nixpkgs-update: no auto update
+  version = "1.10.0"; # nixpkgs-update: no auto update
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-python";
     tag = finalAttrs.version;
-    hash = "sha256-rKWbJti5bgwAfc8LpQFsU6KhhcWyWAwOX+SF1UAGRbk=";
+    hash = "sha256-s5vINKV4RLtV/8rFZe7iqOks4wfXeDEY7aUOCeuJCUM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src pname version;
-    hash = "sha256-g7Om2QvlbwVmB0wGcbuafUELh53IJ2uM+miHyzBKQQI=";
+    hash = "sha256-gCdiJ7FoBa5oHQJJ9Alhl+3Zei2FwYMXOqIaBzN+hh0=";
   };
 
   build-system = [


### PR DESCRIPTION
Update of the 
Release notes: https://github.com/eclipse-zenoh/zenoh/releases

~~Waiting for the upgrade of zenoh-cpp~~
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
