### PR TITLE
pipewire: make package more configurable

### DIFF
--- a/pkgs/by-name/pi/pipewire/package.nix
+++ b/pkgs/by-name/pi/pipewire/package.nix
@@ -12,8 +12,8 @@
   elogind,
   libinotify-kqueue,
   epoll-shim,
-  systemd,
-  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, # enableSystemd=false maintained by maintainers.highghlow.
+  systemdLibs,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs, # enableSystemd=false maintained by maintainers.highghlow.
   pkg-config,
   docutils,
   doxygen,
@@ -157,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ (
     if enableSystemd then
-      [ systemd ]
+      [ systemdLibs ]
     else if stdenv.hostPlatform.isLinux then
       [
         elogind

--- a/pkgs/by-name/pi/pipewire/package.nix
+++ b/pkgs/by-name/pi/pipewire/package.nix
@@ -297,6 +297,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;
     maintainers = with lib.maintainers; [
+      aanderse
       k900
       qweered
     ];

--- a/pkgs/by-name/pi/pipewire/package.nix
+++ b/pkgs/by-name/pi/pipewire/package.nix
@@ -9,10 +9,16 @@
   meson,
   ninja,
   freebsd,
+  # session/seat tracking to arbitrate access to udev-discovered devices
+  # provided by logind (systemd) or elogind
+  # can be disabled entirely on systems without a logind provider, or when looking to minimize closure
+  # useful for non-systemd, linux based systems, like finix, sixos, micros, etc...
+  logindSupport ? udevSupport,
   elogind,
   libinotify-kqueue,
   epoll-shim,
   systemdLibs,
+  # dbus + socket activation, provides logind and udev dependencies by default
   enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs, # enableSystemd=false maintained by maintainers.highghlow.
   pkg-config,
   docutils,
@@ -23,6 +29,11 @@
   alsa-lib,
   libjack2,
   libusb1,
+  # dynamic hardware/device detection
+  # interchangeably provided by udev (systemd), eudev, or even libudev-zero/libudev-garden
+  # can be disabled entirely on systems without a compatible device manager, or when looking to minimize closure
+  # useful for non-systemd, linux based systems, like finix, sixos, micros, etc...
+  udevSupport ? stdenv.hostPlatform.isLinux,
   udev,
   libsndfile,
   vulkanSupport ? true,
@@ -155,17 +166,9 @@ stdenv.mkDerivation (finalAttrs: {
     readline
     bashNonInteractive
   ]
-  ++ (
-    if enableSystemd then
-      [ systemdLibs ]
-    else if stdenv.hostPlatform.isLinux then
-      [
-        elogind
-        udev
-      ]
-    else
-      [ ]
-  )
+  ++ lib.optional enableSystemd systemdLibs
+  ++ lib.optional (!enableSystemd && udevSupport) udev
+  ++ lib.optional (!enableSystemd && logindSupport) elogind
   ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
     libinotify-kqueue
     epoll-shim
@@ -222,7 +225,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "gstreamer" true)
     (lib.mesonEnable "gstreamer-device-provider" true)
     (lib.mesonOption "logind-provider" (if enableSystemd then "libsystemd" else "libelogind"))
-    (lib.mesonEnable "logind" stdenv.hostPlatform.isLinux)
+    (lib.mesonEnable "logind" logindSupport)
     (lib.mesonEnable "selinux" stdenv.hostPlatform.isLinux)
     (lib.mesonEnable "avb" stdenv.hostPlatform.isLinux)
     (lib.mesonEnable "v4l2" stdenv.hostPlatform.isLinux)
@@ -230,7 +233,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "libsystemd" enableSystemd)
     (lib.mesonEnable "systemd-system-service" enableSystemd)
     (lib.mesonEnable "systemd-user-service" enableSystemd)
-    (lib.mesonEnable "udev" stdenv.hostPlatform.isLinux)
+    (lib.mesonEnable "udev" udevSupport)
     (lib.mesonEnable "ffmpeg" true)
     (lib.mesonEnable "pw-cat-ffmpeg" true)
     (lib.mesonEnable "bluez5" bluezSupport)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

for systems not running `systemd` the options are a bit limiting and end up pulling a bit of unwanted software into the closure - let's expose a few more knobs

cc @unhighghlow

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
