### PR TITLE
mutli-scrobbler: fix docs output

### DIFF
--- a/pkgs/by-name/mu/multi-scrobbler/package.nix
+++ b/pkgs/by-name/mu/multi-scrobbler/package.nix
@@ -2,8 +2,10 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  fetchNpmDeps,
   makeWrapper,
   nodejs,
+  npmHooks,
   nix-update-script,
 }:
 
@@ -24,6 +26,27 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  # The docsite's OG-image plugin needs sharp's native binary, which sharp
+  # 0.32.6 fetches from a GitHub release at install time
+  postPatch = ''
+        substituteInPlace docsite/docusaurus.config.ts \
+          --replace-fail \
+    "    ],
+        [
+          '@bony_chops/docusaurus-og',
+          {
+            path: './preview-images', // relative to the build directory
+            imageRenderers: {
+                'docusaurus-plugin-content-docs': Renderers.docs,
+                'docusaurus-plugin-content-pages': Renderers.docs,
+            },
+          },
+        ]
+      ]," \
+    "    ],
+      ],"
+  '';
+
   # A storybook devDependency refuses to install outside of pnpm, and native
   # modules aren't needed regardless.
   npmRebuildFlags = [ "--ignore-scripts" ];
@@ -31,6 +54,18 @@ buildNpmPackage (finalAttrs: {
   # npm's --ignore-scripts skips patch-package too.
   preBuild = ''
     node_modules/.bin/patch-package
+
+    # Both invocations write their writable npm cache to
+    # the same $TMPDIR/cache
+    rm -rf "$TMPDIR/cache"
+    (
+      source ${npmHooks.npmConfigHook}/nix-support/setup-hook
+      npmRoot=docsite npmDeps=${finalAttrs.passthru.docsiteNpmDeps} npmConfigHook
+    )
+    (cd docsite && node_modules/.bin/patch-package)
+
+    npm run -s schema:docs
+    (cd docsite && CI=true npm run -s build)
   '';
 
   npmBuildScript = "build:frontend";
@@ -38,8 +73,10 @@ buildNpmPackage (finalAttrs: {
   postInstall = ''
     npmPkgDir="$out/lib/node_modules/${finalAttrs.pname}"
 
-    # dist/ is gitignored; npm pack omits.
+    # dist/ and docsite/build/ are gitignored; npm pack omits both.
     cp -r dist "$npmPkgDir/dist"
+    mkdir -p "$npmPkgDir/docsite"
+    cp -r docsite/build "$npmPkgDir/docsite/build"
 
     # node refuses type-stripping for any file under a "node_modules"
     pkgDir="$out/libexec/${finalAttrs.pname}"
@@ -56,7 +93,16 @@ buildNpmPackage (finalAttrs: {
       --chdir "$pkgDir"
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+
+    docsiteNpmDeps = fetchNpmDeps {
+      name = "multi-scrobbler-docsite-npm-deps";
+      src = "${finalAttrs.src}/docsite";
+      fetcherVersion = finalAttrs.npmDepsFetcherVersion;
+      hash = "sha256-hqpA8vmRHdUOwVXZgiem8rK19ZUtuPdkocamDldioYc=";
+    };
+  };
 
   meta = {
     description = "Scrobble music from many sources to many clients";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

fixes #553022

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
