### PR TITLE
bazecor: 1.10.0, udevadm in FHS sandbox, fix udev-check workaround for 1.10.0

### DIFF
--- a/pkgs/by-name/ba/bazecor/package.nix
+++ b/pkgs/by-name/ba/bazecor/package.nix
@@ -6,20 +6,23 @@
 }:
 let
   pname = "bazecor";
-  version = "1.9.0";
+  version = "1.10.0";
   src = appimageTools.extract {
     inherit pname version;
     src = fetchurl {
       url = "https://github.com/Dygmalab/Bazecor/releases/download/v${version}/Bazecor-${version}-x64.AppImage";
-      hash = "sha256-PSzcUirHoUJtNRSHw/53f+eGK7IgU1JnRcLuArMZJ+w=";
+      hash = "sha256-tdkuZ7YIdHetdLi5EUk9HMvW0mW0Oqsb28xseises2Q=";
     };
 
     # Workaround for https://github.com/Dygmalab/Bazecor/issues/370
+    # 1.10.0 refactored checkUdev (reads file `f`, compares to rules text `h`);
+    # with the bound-mount based FHS sandbox the udev rules file is never at the
+    # expected location, so keep the check bypassed.
     postExtract = ''
       substituteInPlace \
         $out/usr/lib/bazecor/resources/app/.webpack/main/index.js \
         --replace-fail \
-          'checkUdev=()=>{try{if(l.default.existsSync(h))return l.default.readFileSync(h,"utf-8").trim()===f.trim()}catch(e){d.default.error(e)}return!1}' \
+          'checkUdev=()=>{try{if(l.default.existsSync(f))return l.default.readFileSync(f,"utf-8").trim()===h.trim()}catch(e){d.default.error(e)}return!1}' \
           'checkUdev=()=>{return 1}'
     '';
   };
@@ -33,7 +36,13 @@ appimageTools.wrapAppImage {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  extraPkgs = pkgs: [ pkgs.glib ];
+  # udevadm must live inside the sandbox, otherwise Bazecor's device enumeration
+  # "find keyboard" fails with `spawn udevadm ENOENT` and Dygma keyboards are not
+  # detected at all.
+  extraPkgs = pkgs: [
+    pkgs.glib
+    pkgs.systemdMinimal
+  ];
 
   # Also expose the udev rules here, so it can be used as:
   #   services.udev.packages = [ pkgs.bazecor ];


### PR DESCRIPTION
**bazecor 1.10.0 + FHS-Sandbox-Fix**

3 independent small fixes, verified by a local build of `pkgs.bazecor`:

1. **Version bump 1.9.0 → 1.10.0** with updated SRI hash.
2. **udevadm in the FHS sandbox** — Bazecor's device enumeration ("find keyboard") spawns bare `udevadm`; inside the `buildFHSEnv` sandbox that fails with `spawn udevadm ENOENT` and neither Dygma Boost nor Raise is detected at all. Adding `pkgs.systemdMinimal` to `extraPkgs` puts udevadm into the sandbox `/bin` (already verified: `$rootfs/bin/udevadm` exists in the built output). This is the fix that makes Bazecor usable on non-NixOS hosts.
3. **Update checkUdev bypass for the 1.10.0 refactor** — the issue #370 workaround substitutes the `checkUdev` implementation with `()=>{return 1}`. In 1.10.0 Dygma refactored this function (it now reads file `f` and compares to rules text `h`, previously the other way around), so the old pattern matched nothing and the build failed with `ERROR: pattern ... doesn't match anything in file .../index.js`. The new pattern matches the 1.10.0 source; the bypass is still required because the udev-rules file is never at the location the app checks inside the sandbox.

**Test instructions:** local build of `pkgs.bazecor`, launched on niri (Wayland): keyboard detection works, config editor opens.

cc maintainers: @gcleroux
