### PR TITLE
libreswan: 5.3.2 -> 5.4

### DIFF
--- a/nixos/modules/services/networking/libreswan.nix
+++ b/nixos/modules/services/networking/libreswan.nix
@@ -157,17 +157,8 @@ in
     // policyFiles;
 
     systemd.services.ipsec = {
-      description = "Internet Key Exchange (IKE) Protocol Daemon for IPsec";
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ configFile ] ++ lib.mapAttrsToList (n: v: v.source) policyFiles;
-      path = with pkgs; [
-        libreswan
-        iproute2
-        procps
-        nssTools
-        iptables
-        net-tools
-      ];
       preStart = lib.optionalString cfg.disableRedirects ''
         # Disable send/receive redirects
         echo 0 | tee /proc/sys/net/ipv4/conf/*/send_redirects

--- a/nixos/tests/libreswan-nat.nix
+++ b/nixos/tests/libreswan-nat.nix
@@ -125,6 +125,7 @@ in
         leftid=@server
         leftsubnet=::/0
         leftupdown=${pkgs.writeScript "updown" ''
+          PATH=${pkgs.iproute2}/bin
           # act as NDP proxy for VPN clients
           if test "$PLUTO_VERB" = up-client-v6; then
             ip neigh add proxy "$PLUTO_PEER_CLIENT_NET" dev eth2

--- a/pkgs/by-name/li/libreswan/package.nix
+++ b/pkgs/by-name/li/libreswan/package.nix
@@ -23,7 +23,7 @@
   coreutils,
   gnused,
   gawk,
-  nss,
+  nss_latest,
   which,
   python3,
   libselinux,
@@ -44,18 +44,18 @@ let
     coreutils
     gnused
     gawk
-    nss.tools
+    nss_latest.tools
     which
   ];
 in
 
 stdenv.mkDerivation rec {
   pname = "libreswan";
-  version = "5.3.2";
+  version = "5.4";
 
   src = fetchurl {
     url = "https://download.libreswan.org/libreswan-${version}.tar.gz";
-    hash = "sha256-+5GK+gu5K9BDDB2oYe+AaIZNJdchMN8MYweh+dp2EIg=";
+    hash = "sha256-0mNAz2JTFsyRJ+BbOSIUokoQiJ9PHZlAwupkurcQqFU=";
   };
 
   strictDeps = true;
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
     libxcrypt
     curl
     nspr
-    nss
+    nss_latest
     ldns
     # needed to patch shebangs
     python3
@@ -95,6 +95,14 @@ stdenv.mkDerivation rec {
     # Replace wget with curl to save a dependency
     substituteInPlace programs/letsencrypt/letsencrypt.in \
       --replace-fail 'wget -q -P' '${curl}/bin/curl -s --remote-name-all --output-dir'
+
+    # Replace /bin/sh with runtimeShell for purity
+    substituteInPlace programs/pluto/extract.c \
+      --replace-fail '/bin/sh' '${runtimeShell}'
+
+    # Fix pluto running with empty PATH
+    substituteInPlace include/pluto_constants.h \
+      --replace-fail 'ipsec _updown' "$out/bin/ipsec _updown"
   '';
 
   makeFlags = [
@@ -102,6 +110,7 @@ stdenv.mkDerivation rec {
     "INITSYSTEM=systemd"
     "SYSTEMUNITDIR=$(out)/etc/systemd/system/"
     "TMPFILESDIR=$(out)/lib/tmpfiles.d/"
+    "SHELL_BINARY=${runtimeShell}"
     "LINUX_VARIANT=nixos"
     "DEFAULT_DNSSEC_ROOTKEY_FILE=${dns-root-data}/root.key"
     # Fix invalid XML files with libxml 2.14
@@ -123,7 +132,12 @@ stdenv.mkDerivation rec {
   postFixup = ''
     # Add a PATH to the main "ipsec" script
     sed -e '0,/^$/{s||export PATH=${binPath}:$PATH|}' \
-        -i $out/bin/ipsec
+        -i "$out/bin/ipsec"
+
+    # Add a PATH to all pluto hooks
+    hooks=$(find "$out/libexec" -type f -exec grep -qI . {} \; -print)
+    sed -e '0,/^$/{s||export PATH=${binPath}:${placeholder "out"}/bin:$PATH|}' \
+        -i $hooks
   '';
 
   passthru.tests = { inherit (nixosTests) libreswan libreswan-nat; };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
