### PR TITLE
proton-cli: 2.2.3 -> 2.5.0

### DIFF
--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -13,7 +13,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "proton-cli";
-  version = "2.2.3";
+  version = "2.4.1";
 
   __structuredAttrs = true;
 
@@ -21,12 +21,12 @@ buildGoModule (finalAttrs: {
     owner = "roman-16";
     repo = "proton-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Mw+hfBStq0Ga/FrKll92//YjFt0XreZ5tjqZGY0enzw=";
+    hash = "sha256-Kb7/KpTXJzbsBkF0SLqeF35dE6N693X9+hyDpSqreaE=";
   };
 
   vendorHash = "sha256-VjLuSaHW7C1Ar84vusMRjBWVikgVCdLBwd+OFT7ufiQ=";
 
-  subPackages = [ "." ];
+  subPackages = [ "cmd/proton" ];
 
   tags = [ "embed_hv" ];
 
@@ -55,10 +55,14 @@ buildGoModule (finalAttrs: {
   };
 
   postInstall = ''
+    ln -s proton $out/bin/proton-cli
+    installShellCompletion --cmd proton \
+      --bash <($out/bin/proton completion bash) \
+      --fish <($out/bin/proton completion fish) \
+      --zsh  <($out/bin/proton completion zsh)
     installShellCompletion --cmd proton-cli \
-      --bash <($out/bin/proton-cli completion bash) \
-      --fish <($out/bin/proton-cli completion fish) \
-      --zsh  <($out/bin/proton-cli completion zsh)
+      --bash <($out/bin/proton completion bash) \
+      --fish <(echo 'complete -c proton-cli -w proton')
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -71,7 +75,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/roman-16/proton-cli";
     changelog = "https://github.com/roman-16/proton-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    mainProgram = "proton-cli";
+    mainProgram = "proton";
     maintainers = with lib.maintainers; [ roman-16 ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -56,6 +56,8 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     ln -s proton $out/bin/proton-cli
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd proton \
       --bash <($out/bin/proton completion bash) \
       --fish <($out/bin/proton completion fish) \


### PR DESCRIPTION
The command this package installs is now `proton`. `proton-cli` stays as a
second name beside it, so nothing already typed or scripted stops working;
upstream puts both names on `PATH` through every install channel, and here
that is a symlink in `$out/bin`.

The package keeps its own name: `pkgs.proton-cli` is still what you install.

Three attributes follow from that:

- `subPackages` — `main` moved to `cmd/proton` upstream, so `[ "." ]` builds
  nothing.
- `mainProgram` — `versionCheckHook` resolves the binary through it, and it is
  what `nix run nixpkgs#proton-cli` executes.
- `postInstall` — completions for both names. bash and fish autoload by
  filename so each needs a file of its own; the generated zsh script already
  declares `#compdef proton proton-cli`, so one file covers both there.

The second commit is independent of the bump. `postInstall` generates the
completions by running the binary that was just built, which the build machine
cannot do when it is not the host platform. stdenv already disables
`doInstallCheck` on exactly that condition (`canExecuteHostOnBuild`), so this
applies the same predicate where it was missing. Natively it is a no-op: the
derivation is byte-identical and the store path does not change.

Changelog: https://github.com/roman-16/proton-cli/releases/tag/v2.4.1

Not flagged as a breaking package update, since the previous command name
keeps working and no existing configuration needs changing.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Disclosure per the automation/AI policy: this pull request summary and the
changes it describes were produced with the assistance of
pi 0.84.2 (Anthropic claude-opus-5). Both commits carry `Assisted-by:`
trailers, and I have reviewed the diff before submission.
