### PR TITLE
vtm: 0.9.99.61 -> 2026.07.30

### DIFF
--- a/pkgs/by-name/vt/vtm/package.nix
+++ b/pkgs/by-name/vt/vtm/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/directvt/vtm";
     license = lib.licenses.mit;
     mainProgram = "vtm";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ _3JlOy-PYCCKUi ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/vt/vtm/package.nix
+++ b/pkgs/by-name/vt/vtm/package.nix
@@ -3,26 +3,47 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  freetype,
+  harfbuzz,
+  lua5_4,
+  lunasvg,
+  plutovg,
+  stb,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vtm";
-  version = "0.9.99.61";
+  version = "2026.07.30";
 
   src = fetchFromGitHub {
     owner = "directvt";
     repo = "vtm";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-IlJbJw2c2Zgl+W5Jh01Iga8duiLgl/GurT620IhPh68=";
+    hash = "sha256-ff4JwJzRZKH+XM+iH3v17RkYMOwmxLlk7OzL+1Q5QHw=";
   };
 
   nativeBuildInputs = [
     cmake
   ];
 
+  buildInputs = [
+    freetype
+    harfbuzz
+    lua5_4
+    lunasvg
+    plutovg
+    stb
+  ];
+
+  env.STB_INCLUDE_DIR = "${stb}/include/stb";
+
+  cmakeFlags = [
+    (lib.cmakeBool "FORCE_VENDORED_DEPS" false)
+  ];
+
   meta = {
     description = "Terminal multiplexer with window manager and session sharing";
-    homepage = "https://vtm.netxs.online/";
+    homepage = "https://github.com/directvt/vtm";
     license = lib.licenses.mit;
     mainProgram = "vtm";
     maintainers = [ ];


### PR DESCRIPTION
1. updated from 0.9.99.61 to 2026.07.30
2. changed homepage to github repo, since site is down
3. adopted

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
