### PR TITLE
proton-cli: 2.2.3 -> 3.4.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -87,6 +87,9 @@
 
 - `himalaya` has been updated from `v1.2.0` to `v2.0.0`, which introduces breaking changes. See the [release notes](https://github.com/pimalaya/himalaya/releases/tag/v2.0.0) and the [migration guide](https://github.com/pimalaya/himalaya/blob/master/MIGRATION.md).
 
+- `proton-cli` has been updated from `2.2.3` to `3.4.0`, and installs its command as `proton`, with `proton-cli` kept beside it as a symlink.
+  `3.0.0` reworked the command line - `--output` is now the response format, secrets are no longer accepted as flag values, and several subcommands moved - so scripts need a review against the [upstream changelog](https://github.com/roman-16/proton-cli/blob/main/CHANGELOG.md).
+
 - `tengine` has been removed as it has seen seriously delayed responses to security vulnerabilities.
 
 - `nix-serve-ng` (and `haskellPackages.nix-serve-ng`) is now built against Lix instead of CppNix, following upstream which has switched to Lix as its supported Nix implementation.

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -54,7 +54,7 @@ buildGoModule (finalAttrs: {
     preBuild = null;
   };
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd proton-cli \
       --bash <($out/bin/proton-cli completion bash) \
       --fish <($out/bin/proton-cli completion fish) \

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -52,8 +52,8 @@ buildGoModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Unofficial command-line client for the Proton suite (Mail, Drive, Calendar, Contacts, Pass)";
-    homepage = "https://github.com/roman-16/proton-cli";
+    description = "CLI for Proton Mail, Drive, Calendar, Pass and Contacts, end-to-end encrypted";
+    homepage = "https://proton-cli.lerchster.dev/";
     changelog = "https://github.com/roman-16/proton-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "proton";

--- a/pkgs/by-name/pr/proton-cli/package.nix
+++ b/pkgs/by-name/pr/proton-cli/package.nix
@@ -3,17 +3,14 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  pkg-config,
   stdenv,
-  webkitgtk_4_1,
-  gtk3,
   nix-update-script,
   versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "proton-cli";
-  version = "2.2.3";
+  version = "3.4.0";
 
   __structuredAttrs = true;
 
@@ -21,14 +18,12 @@ buildGoModule (finalAttrs: {
     owner = "roman-16";
     repo = "proton-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Mw+hfBStq0Ga/FrKll92//YjFt0XreZ5tjqZGY0enzw=";
+    hash = "sha256-qTT5f7udkrH+zEQ70bjWj1RbKNX5sKxEnuCS8usTlw4=";
   };
 
-  vendorHash = "sha256-VjLuSaHW7C1Ar84vusMRjBWVikgVCdLBwd+OFT7ufiQ=";
+  vendorHash = "sha256-/bUSjdXg+bb+HdBmWrE2M5PDDhivVdh5FfaRp/Nkcvw=";
 
-  subPackages = [ "." ];
-
-  tags = [ "embed_hv" ];
+  subPackages = [ "cmd/proton" ];
 
   ldflags = [
     "-s"
@@ -36,29 +31,19 @@ buildGoModule (finalAttrs: {
     "-X=github.com/roman-16/proton-cli/internal/cli.version=${finalAttrs.version}"
   ];
 
-  nativeBuildInputs = [
-    installShellFiles
-    pkg-config
-  ];
+  nativeBuildInputs = [ installShellFiles ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    webkitgtk_4_1
-    gtk3
-  ];
-
-  preBuild = ''
-    bash scripts/build-hv-helpers.sh
-  '';
-
-  overrideModAttrs = _: {
-    preBuild = null;
-  };
-
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = ''
+    ln -s proton $out/bin/proton-cli
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd proton \
+      --bash <($out/bin/proton completion bash) \
+      --fish <($out/bin/proton completion fish) \
+      --zsh  <($out/bin/proton completion zsh)
     installShellCompletion --cmd proton-cli \
-      --bash <($out/bin/proton-cli completion bash) \
-      --fish <($out/bin/proton-cli completion fish) \
-      --zsh  <($out/bin/proton-cli completion zsh)
+      --bash <($out/bin/proton completion bash) \
+      --fish <(echo 'complete -c proton-cli -w proton')
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -71,7 +56,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/roman-16/proton-cli";
     changelog = "https://github.com/roman-16/proton-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    mainProgram = "proton-cli";
+    mainProgram = "proton";
     maintainers = with lib.maintainers; [ roman-16 ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };


### PR DESCRIPTION
Upstream renamed the command to `proton` and keeps `proton-cli` as a second
name, so `subPackages`, `mainProgram` and the completions move with it and
`proton-cli` becomes a symlink in `$out/bin`. The attribute stays
`pkgs.proton-cli`.

2.10.0 dropped the embedded CAPTCHA webview - login opens the verification page
in your own browser instead. So the build tag, the `preBuild` script, the
`overrideModAttrs` that kept it out of the vendor fetch, `pkg-config` and the
whole GTK/WebKit `buildInputs` block go too. It's a plain Go build now, and the
closure drops from 843.8 MiB to 57.7 MiB.

3.0.0 reworks the command line, which is most of what the release note covers:
`--output` is the response format on every command and the commands that write
files take `--dest`/`--dest-dir`, no secret is accepted as a flag value any
more, Pass listings no longer print secrets under `--output json`, an empty
list is `[]`, and a few subcommands moved. 3.4.0 changes what an all-day
calendar event means.

`meta.description` follows the guidelines in the manual: one sentence, no
trailing punctuation. `meta.homepage` is now the documentation site upstream
publishes, which carries the docs, the changelog and an API reference.

The first commit is unrelated to the bump: `postInstall` runs the binary it
just built to generate completions, which the build machine can't do when
cross-compiling. It now uses the same predicate stdenv already applies to
`doInstallCheck`. No-op natively.

Changelog: https://github.com/roman-16/proton-cli/blob/main/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Disclosure per the automation/AI policy: this summary and the changes it
describes were written with pi 0.84.2, 0.84.4 and 0.85.0 (Anthropic
claude-opus-5), with `nix-update` for the version and hashes. Every commit
carries an `Assisted-by:` trailer, and I reviewed the diff before submitting.
