### PR TITLE
nixos/tests: filter out nspawn tests on darwin

### DIFF
--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -1,4 +1,9 @@
-{ lib, options, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 let
   inherit (lib) types mkOption literalMD;
 
@@ -26,7 +31,7 @@ in
       '';
       apply = lib.filterAttrs (k: v: v != null);
       type = types.submodule (
-        { options, config, ... }:
+        { options, ... }:
         {
           options = {
             maintainers = mkOption {
@@ -71,7 +76,10 @@ in
             };
             platforms = mkOption {
               type = types.listOf types.raw;
-              default = lib.platforms.linux ++ lib.platforms.darwin;
+              default = lib.platforms.linux ++ lib.optionals (config.containers == { }) lib.platforms.darwin;
+              defaultText = literalMD ''
+                `lib.platforms.linux ++ lib.platforms.darwin` when no containers are configured; otherwise `lib.platforms.linux`.
+              '';
               description = ''
                 Sets the [`meta.platforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms) attribute on the [{option}`test`](#test-opt-test) derivation.
               '';

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -20,8 +20,12 @@ let
     isFunction
     mapAttrs
     elem
+    meta
     recurseIntoAttrs
     ;
+
+  callSupportedTest =
+    test: if meta.availableOn pkgs.stdenv.hostPlatform test then callTest test else { };
 
   # TODO: remove when handleTest is gone (make sure nixosTests and nixos/release.nix#tests are unaffected)
   # TODO: when removing, also deprecate `test` attribute in ../lib/testing/run.nix
@@ -29,7 +33,7 @@ let
     val:
     if isAttrs val then
       if (val ? test) then
-        callTest val
+        callSupportedTest val
       else
         mapAttrs (n: s: if n == "passthru" then s else discoverTests s) val
     else if isFunction val then
@@ -120,7 +124,7 @@ let
         if tree ? recurseForDerivations && tree.recurseForDerivations then
           mapAttrs (k: findTests) (removeAttrs tree [ "recurseForDerivations" ])
         else
-          callTest tree;
+          callSupportedTest tree;
 
       runTest =
         arg:


### PR DESCRIPTION
Without this patch, an attempt to build `git.tests` results in failure to eval
because of unsupported system (nspawn requires systemd).

Commits:

- **nixos/tests: mark nspawn tests as Linux-only**
- **nixos/tests: filter tests unavailable on the host**

How this can be tested:

For qemu based tests:

```
$ nix eval .#legacyPackages.aarch64-darwin.nixosTests.firefox.meta.platforms
[ "x86_64-linux" "aarch64-linux" ... "aarch64-darwin" ]
```

For nspawn based tests:

```
$ nix eval .#legacyPackages.aarch64-linux.git.tests.buildbot-integration.meta.platforms
[ "x86_64-linux" "aarch64-linux" ... ] # <- no darwin

$ nix eval .#legacyPackages.aarch64-darwin.git.tests.buildbot-integration.meta.platforms
error: flake 'git+file:///Users/ihrachyshka/src/nixpkgs' does not provide attribute 'packages.aarch64-darwin.legacyPackages.aarch64-darwin.git.tests.buildbot-integration.meta.platforms', 'legacyPackages.aarch64-darwin.legacyPackages.aarch64-darwin.git.tests.buildbot-integration.meta.platforms' or 'legacyPackages.aarch64-darwin.git.tests.buildbot-integration.meta.platforms'
```

This change should be zero rebuilds because it only shrinks the number of tests
marked as available on Darwin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
