### PR TITLE
octavePackages.symbolic: 3.2.1 -> 3.2.2

### DIFF
--- a/pkgs/development/octave-modules/symbolic/default.nix
+++ b/pkgs/development/octave-modules/symbolic/default.nix
@@ -4,6 +4,10 @@
   fetchFromGitHub,
   # Octave's Python (Python 3)
   python,
+  gnuplot,
+  writableTmpDirAsHomeHook,
+  makeFontsConf,
+  texinfo,
 }:
 
 let
@@ -25,6 +29,16 @@ buildOctavePackage rec {
   };
 
   propagatedBuildInputs = [ pythonEnv ];
+
+  nativeOctavePkgTestInputs = [
+    gnuplot
+    writableTmpDirAsHomeHook
+    texinfo
+  ];
+
+  octavePkgTestEnv.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/symbolic/";

--- a/pkgs/development/octave-modules/symbolic/default.nix
+++ b/pkgs/development/octave-modules/symbolic/default.nix
@@ -17,15 +17,15 @@ let
   ]);
 
 in
-buildOctavePackage rec {
+buildOctavePackage {
   pname = "symbolic";
   version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "cbm755";
     repo = "octsympy";
-    tag = "v${version}";
-    hash = "sha256-7SrTLb2DNeBIDC3yHRs+/ttSR/tCDhBD9lXCHuue6fw=";
+    rev = "0206197f77f6663720a0510c761110abeb2041cd";
+    hash = "sha256-P9E0ZgB06Y/bvYCWD7W9kYZVWfZPWyBKnXw+X5H4yLI=";
   };
 
   propagatedBuildInputs = [ pythonEnv ];

--- a/pkgs/development/octave-modules/symbolic/default.nix
+++ b/pkgs/development/octave-modules/symbolic/default.nix
@@ -19,13 +19,13 @@ let
 in
 buildOctavePackage rec {
   pname = "symbolic";
-  version = "3.2.1";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "cbm755";
     repo = "octsympy";
     tag = "v${version}";
-    hash = "sha256-H2242+1zlke4aLoS3gsHpDfopM5oSZ4IpVR3+xxQ0Dc=";
+    hash = "sha256-7SrTLb2DNeBIDC3yHRs+/ttSR/tCDhBD9lXCHuue6fw=";
   };
 
   propagatedBuildInputs = [ pythonEnv ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds packages required for running `octavePackages.symbolic`'s unit tests inside of Nix. Also pulls in r-ryantm's update from #481764.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
