### PR TITLE
mongodb-7_0: 7.0.39 -> 7.0.40

### DIFF
--- a/pkgs/servers/nosql/mongodb/7.0.nix
+++ b/pkgs/servers/nosql/mongodb/7.0.nix
@@ -21,8 +21,8 @@ let
 in
 buildMongoDB {
   inherit avxSupport;
-  version = "7.0.39";
-  hash = "sha256-VB20nhb0mMf9xVs/R4i+4wWoqHoDNWNouDw3FRehBP8=";
+  version = "7.0.40";
+  hash = "sha256-0KDqI/tMxklGkOvXcehmufiWvmNrf8Jj2llCH91gNlw=";
   patches = [
     # ModuleNotFoundError: No module named 'mongo_tooling_metrics':
     # NameError: name 'SConsToolingMetrics' is not defined:


### PR DESCRIPTION
https://www.mongodb.com/docs/manual/release-notes/7.0-changelog/#7040-changelog

Fixes: CVE-2026-18688
Fixes: CVE-2026-18690
Fixes: CVE-2026-18691
Fixes: CVE-2026-18693
Fixes: CVE-2026-18694
Fixes: CVE-2026-18695
Fixes: CVE-2026-18696
Fixes: CVE-2026-18697
Fixes: CVE-2026-18698
Fixes: CVE-2026-18699
Fixes: CVE-2026-18700
Fixes: CVE-2026-18701
Fixes: CVE-2026-18702
Fixes: CVE-2026-18705
Fixes: CVE-2026-18708
Fixes: CVE-2026-18709
Fixes: CVE-2026-18712


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
