### PR TITLE
nixos/kvrocks: unwrap list-coerced settings

### DIFF
--- a/nixos/modules/services/databases/kvrocks.nix
+++ b/nixos/modules/services/databases/kvrocks.nix
@@ -21,10 +21,11 @@ let
   isDefaultDir = dataDir == defaultDir;
 
   # Defaults match upstream Config field defaults (config.cc).
-  workers = cfg.settings.workers or 8;
-  maxBackgroundJobs = cfg.settings."rocksdb.max_background_jobs" or 4;
-  maxclients = cfg.settings.maxclients or 10240;
-  maxOpenFiles = cfg.settings."rocksdb.max_open_files" or 8096;
+  # freeformType uses listsAsDuplicateKeys, so set values are singleton lists.
+  workers = lib.head (cfg.settings.workers or [ 8 ]);
+  maxBackgroundJobs = lib.head (cfg.settings."rocksdb.max_background_jobs" or [ 4 ]);
+  maxclients = lib.head (cfg.settings.maxclients or [ 10240 ]);
+  maxOpenFiles = lib.head (cfg.settings."rocksdb.max_open_files" or [ 8096 ]);
 
   # Thread inventory from server.cc ("Kvrocks threads list") + Server::Start:
   #   always-on: main, workers, task-runner (1), server-cron, compact-check,


### PR DESCRIPTION
`listsAsDuplicateKeys` turns settings such as `workers = 10` into `[ 10 ]`, so computing fails with `cannot add a list to an integer`. Unwrap them with `lib.head`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
