### PR TITLE
john: fix `7z2john` script

### DIFF
--- a/pkgs/by-name/jo/john/package.nix
+++ b/pkgs/by-name/jo/john/package.nix
@@ -22,6 +22,7 @@
   enableUnfree ? false,
   replaceVars,
   makeWrapper,
+  writableTmpDirAsHomeHook,
 }:
 
 stdenv.mkDerivation {
@@ -36,37 +37,18 @@ stdenv.mkDerivation {
   };
 
   patches = lib.optionals withOpenCL [
+    # Load OpenCL from the Nix store instead of searching system library paths
     (replaceVars ./opencl.patch {
       ocl_icd = ocl-icd;
     })
   ];
 
-  postPatch = ''
-    sed -ri -e '
-      s!^(#define\s+CFG_[A-Z]+_NAME\s+).*/!\1"'"$out"'/etc/john/!
-      /^#define\s+JOHN_SYSTEMWIDE/s!/usr!'"$out"'!
-    ' src/params.h
-    sed -ri -e '/^\.include/ {
-      s!\$JOHN!'"$out"'/etc/john!
-      s!^(\.include\s*)<([^./]+\.conf)>!\1"'"$out"'/etc/john/\2"!
-    }' run/*.conf
-  '';
-
-  preConfigure = ''
-    cd src
-    # Makefile.in depends on AS and LD being set to CC, which is set by default in configure.ac.
-    # This ensures we override the environment variables set in cc-wrapper/setup-hook.sh
-    export AS=$CC
-    export LD=$CC
-  ''
-  + lib.optionalString withOpenCL ''
-    python ./opencl_generate_dynamic_loader.py  # Update opencl_dynamic_loader.c
-  '';
-  configureFlags = [
-    "--disable-native-tests"
-    "--with-systemwide"
-  ]
-  ++ lib.optionals (!enableUnfree) [ "--without-unrar" ];
+  nativeBuildInputs = [
+    gcc
+    python3Packages.wrapPython
+    perl
+    makeWrapper
+  ];
 
   buildInputs = [
     openssl
@@ -77,16 +59,11 @@ stdenv.mkDerivation {
     zlib
     libpcap
     re2
+    perl
   ]
   ++ lib.optionals withOpenCL [
     opencl-headers
     ocl-icd
-  ];
-  nativeBuildInputs = [
-    gcc
-    python3Packages.wrapPython
-    perl
-    makeWrapper
   ];
   propagatedBuildInputs =
     # For pcap2john.py
@@ -111,7 +88,39 @@ stdenv.mkDerivation {
     ]);
   # TODO: Get dependencies for radius2john.pl and lion2john-alt.pl
 
+  nativeInstallCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  configureFlags = [
+    "--disable-native-tests"
+    "--with-systemwide"
+  ]
+  ++ lib.optionals (!enableUnfree) [ "--without-unrar" ];
+
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
+
+  postPatch = ''
+    sed -ri -e '
+      s!^(#define\s+CFG_[A-Z]+_NAME\s+).*/!\1"'"$out"'/etc/john/!
+      /^#define\s+JOHN_SYSTEMWIDE/s!/usr!'"$out"'!
+    ' src/params.h
+    sed -ri -e '/^\.include/ {
+      s!\$JOHN!'"$out"'/etc/john!
+      s!^(\.include\s*)<([^./]+\.conf)>!\1"'"$out"'/etc/john/\2"!
+    }' run/*.conf
+  '';
+
+  preConfigure = ''
+    cd src
+    # Makefile.in depends on AS and LD being set to CC, which is set by default in configure.ac.
+    # This ensures we override the environment variables set in cc-wrapper/setup-hook.sh
+    export AS=$CC
+    export LD=$CC
+  ''
+  + lib.optionalString withOpenCL ''
+    python ./opencl_generate_dynamic_loader.py  # Update opencl_dynamic_loader.c
+  '';
 
   postInstall = ''
     mkdir -p "$out/bin" "$out/etc/john" "$out/share/john" "$out/share/doc/john" "$out/share/john/rules" "$out/share/john/opencl" "$out/${perlPackages.perl.libPrefix}"
@@ -131,6 +140,19 @@ stdenv.mkDerivation {
     for i in $out/bin/*.pl; do
       wrapProgram "$i" --prefix PERL5LIB : "$PERL5LIB:$out/${perlPackages.perl.libPrefix}"
     done
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out/bin/john" --help | grep "John the Ripper"
+
+    # The script has no help option, and passing no arguments exits with an
+    # error after printing usage. Reaching this output ensures it can import
+    # `Compress::Raw::Lzma`.
+    { "$out/bin/7z2john.pl" || true; } 2>&1 | grep "Usage:"
+
+    runHook postInstallCheck
   '';
 
   passthru.updateScript = unstableGitUpdater {


### PR DESCRIPTION
Currently it doesn't run.

```
> $ 7z2john.pl test.7z
Can't locate Compress/Raw/Lzma.pm in @INC (you may need to install the Compress::Raw::Lzma module) (@INC entries checked: /nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/lib/perl5/site_perl /nix/store/jsifli554jygbnl9502m3c8xhriwhsi7-perl5.42.0-Digest-MD4-1.9/lib/perl5/site_perl /nix/store/b6mjrcxq6lfr2h9ljggb48mwrcwv4v8v-perl5.42.0-Digest-SHA1-2.13/lib/perl5/site_perl /nix/store/8x0pgw4aib6pkqhb1ahy674rr510gd72-perl5.42.0-Getopt-Long-2.58/lib/perl5/site_perl /nix/store/n90rq0fvb6jis93imm4h31i8p3p3snv2-perl5.42.0-Compress-Raw-Lzma-2.206/lib/perl5/site_perl /nix/store/jb8p65ha66m8ia2svpv4hr20r9gakzp6-perl5.42.0-perl-ldap-0.68/lib/perl5/site_perl /nix/store/5kcc3ggkwydn1rj1m25y8ad9zw16lhwp-perl5.42.0-Convert-ASN1-0.34/lib/perl5/site_perl /nix/store/i17jy3glrin3jz4lpvb9jcrcpiqfg8j1-john-1.9.0-Jumbo-1-unstable-2026-07-07/lib/perl5/site_perl /usr/lib/perl5/5.42/site_perl /usr/share/perl5/site_perl /usr/lib/perl5/5.42/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/5.42/core_perl /usr/share/perl5/core_perl) at /nix/store/i17jy3glrin3jz4lpvb9jcrcpiqfg8j1-john-1.9.0-Jumbo-1-unstable-2026-07-07/bin/.7z2john.pl-wrapped line 6.
BEGIN failed--compilation aborted at /nix/store/i17jy3glrin3jz4lpvb9jcrcpiqfg8j1-john-1.9.0-Jumbo-1-unstable-2026-07-07/bin/.7z2john.pl-wrapped line 6.
```

The fix is adding `perl` to `buildInputs` so it patches the shebang:

https://github.com/NixOS/nixpkgs/blob/11711e0a28c4d107dd631768a70ca4310606169c/doc/stdenv/stdenv.chapter.md?plain=1#L207

Seems it needs to also remain in `nativeBuildInputs`:

https://github.com/NixOS/nixpkgs/blob/11711e0a28c4d107dd631768a70ca4310606169c/doc/stdenv/stdenv.chapter.md?plain=1#L200

Same situation as `blast`:

https://github.com/NixOS/nixpkgs/blob/c313869feeeed19562c7b9333325afee507d2544/pkgs/by-name/bl/blast/package.nix#L93-L102

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test