### PR TITLE
terragrunt: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FzexCmOwZGqo1i2fhmEX+BlEB3S8/8vVKMUIsfymRrs=";
+    hash = "sha256-JovTD88P/9IUX1y1AG/NhkIRRPCa0eAwJSx5qfg+4Ck=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     make generate-mocks
   '';
 
-  vendorHash = "sha256-H6NF/V0wzPSusq606+BvORYxJFdMSFGoD8bl++WdoFM=";
+  vendorHash = "sha256-eqoT9On/nGwJIbWug4RQVmibbsqbTRa5MzOoFXgGmxc=";
 
   excludedPackages = [ "test/flake" ];
 


### PR DESCRIPTION
## Summary
- Bump terragrunt from 1.1.2 to 1.1.3

https://github.com/gruntwork-io/terragrunt/releases/tag/v1.1.3

## Test plan
- [x] `nix build .#terragrunt` succeeds
- [x] `terragrunt --version` reports `v1.1.3`