### PR TITLE
neuralrack: init at 0.4.1

### DIFF
--- a/pkgs/by-name/ne/neuralrack/package.nix
+++ b/pkgs/by-name/ne/neuralrack/package.nix
@@ -1,0 +1,69 @@
+{
+  alsa-lib,
+  cairo,
+  fetchFromGitHub,
+  lib,
+  libjack2,
+  libsndfile,
+  libx11,
+  lv2,
+  pkg-config,
+  stdenv,
+  xorgproto,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neuralrack";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = "NeuralRack";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-60b18rAj4Za0H1lzPzvRYQdLFMYCBkKGMmSYJGBOaIQ=";
+    fetchSubmodules = true;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    cairo
+    libjack2
+    libsndfile
+    libx11
+    lv2
+    xorgproto
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "INSTALL_DIR=$(out)/lib/lv2"
+    "EXE_INSTALL_DIR=$(out)/bin"
+    "CLAP_INSTAL_DIR=$(out)/lib/clap"
+    "VST2_INSTAL_DIR=$(out)/lib/vst"
+    "VST3_INSTALL_DIR=$(out)/lib/vst3"
+    "VST3_INSTAL_DIR=$(out)/lib/vst3"
+    "user=root"
+    "STRIP=:"
+  ];
+
+  postPatch = ''
+    substituteInPlace NeuralRack/makefile \
+      --replace-fail "-flto=auto" ""
+  '';
+
+  meta = {
+    homepage = "https://github.com/brummer10/NeuralRack";
+    description = "Neural Model and Impulse Response (IR) File loader";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ eymeric ];
+    platforms = lib.platforms.linux;
+    mainProgram = "Neuralrack";
+  };
+})


### PR DESCRIPTION
Package neuralrack in the same way that #526514

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
