### PR TITLE
Gcc checksum fixes

### DIFF
--- a/pkgs/development/compilers/gcc/common/checksum.nix
+++ b/pkgs/development/compilers/gcc/common/checksum.nix
@@ -4,7 +4,6 @@
   nukeReferences,
   langC,
   langCC,
-  runtimeShell,
   buildIsHost,
   hostIsTarget,
 }:
@@ -34,7 +33,7 @@ in
       postInstallSaveChecksumPhase = ''
         mv gcc/build/genchecksum gcc/build/.genchecksum-wrapped
         cat > gcc/build/genchecksum <<\EOF
-        #!${runtimeShell}
+        #!${stdenv.shell}
         ${nukeReferences}/bin/nuke-refs $@
         for INPUT in "$@"; do install -Dt $INPUT $checksum/inputs/; done
         exec build/.genchecksum-wrapped $@

--- a/pkgs/development/compilers/gcc/common/checksum.nix
+++ b/pkgs/development/compilers/gcc/common/checksum.nix
@@ -35,7 +35,7 @@ in
         cat > gcc/build/genchecksum <<\EOF
         #!${stdenv.shell}
         ${nukeReferences}/bin/nuke-refs $@
-        for INPUT in "$@"; do install -Dt $INPUT $checksum/inputs/; done
+        for INPUT in "$@"; do install -Dt $checksum/inputs/ $INPUT; done
         exec build/.genchecksum-wrapped $@
         EOF
         chmod +x gcc/build/genchecksum


### PR DESCRIPTION
I like to watch nixpkgs work its way through the bootstrap under `nix-output-monitor`, and was wondering why `xgcc` builds a copy of `bash`, but also its direct buildinput (`texinfo`) builds a different copy of `bash`. Since both `bash` builds can launch in parallel, at least one of them feels redundant. It turns out the checksum calculation was using `runtimeShell` when it probably doesn't need to, since it assembles a wrapper that runs at derivation build time, and does not persist in the store outputs.

Also, the arguments to `install` in this script were given in the wrong order, so I don't know when this last worked perfectly and who actually relies on this feature.

AI Disclosure: I had Claude Code 2.1.233 use Sonnet 5 to diagnose why `xgcc` was building multiple `bash` derivations. It identified the cause and flagged the `install` argument-order issue in passing; I verified the `install` arguments against the manpage and made both fixes by hand.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [X] Tested `nix build .#hello` to ensure that the toolchain continues to work in this nixpkgs.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
