### PR TITLE
tree-sitter-grammars.tree-sitter-fsharp_signature: init at 0.3.0-unstable-2026-04-16

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -748,6 +748,19 @@
     };
   };
 
+  fsharp_signature = {
+    version = "0.3.0-unstable-2026-04-16";
+    url = "github:ionide/tree-sitter-fsharp";
+    rev = "5247c1197cb290fcaea0e0a793d32829c1396831";
+    hash = "sha256-ntcLDSt6BPF9PtASx221hwZhKl3yKKrzbEYQD/ghYxw=";
+    meta = {
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        aciceri
+      ];
+    };
+  };
+
   fstar = {
     version = "0-unstable-2026-03-14";
     url = "github:sei40kr/tree-sitter-fstar";


### PR DESCRIPTION
[ionide/tree-sitter-fsharp](https://github.com/ionide/tree-sitter-fsharp) is a monorepo that declares two grammars in its `tree-sitter.json`: `fsharp` and `fsharp_signature` (the latter for `.fsi` signature files).
The existing `fsharp` entry only builds the former, so the `fsharp_signature` parser was missing from nixpkgs.
As a result, consumers such as Emacs `treesit-grammars.with-all-grammars` lacked `libtree-sitter-fsharp-signature.so`, which [fsharp-ts-mode](https://github.com/fsharp/fsharp-ts-mode) requires for `.fsi` files, and `(treesit-language-available-p 'fsharp-signature)` returned nil.

This PR adds a `fsharp_signature` entry sharing the same source as `fsharp`.
`build-grammar.nix` selects the matching grammar from `tree-sitter.json` by attribute name and builds it from its own subdirectory, so no other change is needed.
Since both entries pin the same rev, the source is shared in the store and no extra download occurs.

Verified locally:

```console
$ nix build .#tree-sitter-grammars.tree-sitter-fsharp_signature
$ nm -D --defined-only result/parser | grep tree_sitter
000000000002d4a0 T tree_sitter_fsharp_signature
...

$ nix build .#emacs.pkgs.treesit-grammars.with-all-grammars
$ ls result/lib | grep fsharp
libtree-sitter-fsharp-signature.so
libtree-sitter-fsharp.so
```

Result of `nixpkgs-review pr 553562` run on x86_64-linux:

4 packages built:

- `diffsitter`
- `python313Packages.tree-sitter-grammars.tree-sitter-fsharp_signature`
- `python314Packages.tree-sitter-grammars.tree-sitter-fsharp_signature`
- `tree-sitter-grammars.tree-sitter-fsharp_signature`

Functional check with Emacs 30.2 in batch mode: with the built `with-all-grammars` on `treesit-extra-load-path`, `(treesit-language-available-p 'fsharp-signature)` returns `t` and a sample `.fsi` file parses into a well-formed tree (root node `file`, no `ERROR` nodes).

Per the automation/AI policy: this change was prepared with the assistance of Claude Code (claude-fable-5), and reviewed by me.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

