### PR TITLE
ffcut: init at 2.0

### DIFF
--- a/pkgs/by-name/ff/ffcut/package.nix
+++ b/pkgs/by-name/ff/ffcut/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ffmpeg,
+  makeWrapper,
+  perlPackages,
+}:
+
+let
+  perlDeps = with perlPackages; [
+    TimeDate
+    FileWhich
+  ];
+  whichPatch = ./which.patch;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ffcut";
+  version = "2.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://youbroketheinternet.org/overlay/media-video/ffcut/files/ffcut";
+    hash = "sha256-XouN1zHUMpkPRvzWOAz/4OjmKULWhN7XSRQlowP92bs=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perlPackages.perl ];
+
+  patchPhase = ''
+    patch < ${whichPatch}
+  '';
+
+  unpackPhase = ''
+    sourceRoot=.
+    cp $src $sourceRoot/ffcut
+  '';
+
+  installPhase = ''
+    install -D $sourceRoot/ffcut $out/bin/ffcut
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/ffcut \
+      --set PERL5LIB "${perlPackages.makePerlPath perlDeps}" \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}
+  '';
+
+  meta = {
+    description = "Lossless video snipping CLI tool using ffmpeg or mp4box";
+    mainProgram = "ffcut";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.dvn0 ];
+  };
+})

--- a/pkgs/by-name/ff/ffcut/which.patch
+++ b/pkgs/by-name/ff/ffcut/which.patch
@@ -1,0 +1,49 @@
+--- ffcut	2026-04-03 06:01:49.000000000 -0500
++++ ffcut	2026-04-04 12:15:22.841303648 -0500
+@@ -13,6 +13,7 @@
+ sub debug() { 0 }
+ 
+ use File::stat;
++use File::Which;
+ use Date::Format;
+ use IPC::Open3 qw( open3 );
+ use Term::ANSIColor qw(:constants);
+@@ -34,8 +35,8 @@
+ $MPARMS .= ' -osdlevel 3' unless $opt_T;
+ my $DEFLEN = 10;
+ 
+-$has_mp4box = &which('MP4Box') || &which('mp4box');
+-$has_ffmpeg = &which('ffmpeg');
++$has_mp4box = which 'MP4Box' || which 'mp4box';
++$has_ffmpeg = which 'ffmpeg';
+ 
+ if (! -r $start) {
+ 	&ffcut($output, $start, $end);
+@@ -230,8 +231,8 @@
+ 	# Ideally they should be identical, but they frequently aren't.
+ 	return unless $opt_x or $opt_S or $opt_q;
+ 
+-	my $has_mplayer = &which('mplayer');
+-	#my $has_mpv = &which('mpv');
++	my $has_mplayer = which 'mplayer';
++	my $has_mpv = which 'mpv';
+ 	my $prefer_mpv = $has_mpv || $has_mplayer;
+ 	my $prefer_mplayer = $has_mplayer || $has_mpv;
+ 	die "Neither mpv nor mplayer available on this system"
+@@ -274,16 +275,6 @@
+ 	return $tmp < $min ? $tmp * 60 : $tmp;
+ }
+ 
+-# if your system doesn't have "which" we're in trouble
+-# even BSD has which in that place, so it is ok to use full path
+-sub which {
+-	my $cmd = shift;
+-	$_ = `/usr/bin/which $cmd 2>&1`;
+-	print STDERR "which $cmd: $_" if debug & 1;
+-	/^(\S+)\s*$/;
+-	return $1;
+-}
+-
+ __END__
+ 
+ =pod


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Lossless video snipping tool CLI using ffmpeg (or optionally mp4box). This derivation only puts ffmpeg in the path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
