### PR TITLE
bb-launcher: init at 16.10

### DIFF
--- a/pkgs/by-name/bb/bb-launcher/package.nix
+++ b/pkgs/by-name/bb/bb-launcher/package.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  qt6,
+  cryptopp,
+  fmt,
+  libarchive,
+  nlohmann_json,
+  pugixml,
+  sdl3,
+  toml11,
+  vulkan-headers,
+  vulkan-loader,
+  vulkan-volk,
+  zarchive,
+  zstd,
+  nix-update-script,
+  shadps4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bb-launcher";
+  version = "16.10";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "rainmakerv3";
+    repo = "BB_Launcher";
+    tag = "Release${finalAttrs.version}";
+    hash = "sha256-hyjMeRtZfEfhz0k1VNpgLN046cvbMWJfK8U5Jy+j1B4=";
+
+    # qmicroz is the only external left after unbundle-externals.patch, and
+    # qtstatic is a big prebuilt Qt for Windows only, so free some disk space.
+    postCheckout = ''
+      git -C "$out/externals" submodule update --init microz
+      rm -r "$out/qtstatic" "$out/WebView2SDK"
+    '';
+  };
+
+  patches = [
+    # Devendor various vendored dependencies in favor of linking against nixpkgs' versions.
+    # Only qmicroz and the miniz it carries stay vendored, being unpackaged.
+    # Of the forked pins there (fmt, sdl3, cryptopp) only cryptopp diverges, in
+    # clang-cl branches inactive here.
+    # Recheck if any divergence was added when updating.
+    ./unbundle-externals.patch
+  ]
+  # BB_Launcher otherwise only runs builds the user picks in its file dialog or
+  # downloads through it, and those downloads are dynamically linked binaries.
+  # Selecting a /nix/store path by hand would go stale quickly.
+  # This patch injects ${shadps4} if the set one either doesn't exist, or is a
+  # /nix/store path (which may be stale by now).
+  # If a user doesn't want that, they can simply do `bb-launcher.override { shadps4 = null; }`
+  ++ lib.optional (shadps4 != null) ./use-nix-shadps4.patch;
+
+  postPatch = lib.optionalString (shadps4 != null) ''
+    substituteInPlace settings/config.cpp \
+      --subst-var-by shadps4 ${lib.getExe shadps4} \
+      --subst-var-by storeDir ${builtins.storeDir}
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+    qt6.qttools
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtwebsockets
+    qt6.qtwebview
+    qt6.qtwebengine
+    qt6.qtwebchannel
+    cryptopp
+    fmt
+    libarchive
+    nlohmann_json
+    pugixml
+    sdl3
+    toml11
+    vulkan-headers
+    vulkan-volk
+    zarchive
+    zstd
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "USE_WEBENGINE" true)
+  ];
+
+  # volk dlopens the loader at runtime
+  qtWrapperArgs = [
+    "--prefix"
+    "LD_LIBRARY_PATH"
+    ":"
+    (lib.makeLibraryPath [ vulkan-loader ])
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "Release(.*)"
+    ];
+  };
+
+  meta = {
+    description = "Dedicated shadPS4 launcher focused entirely on Bloodborne";
+    longDescription = ''
+      BB_Launcher is a dedicated shadPS4 launcher focused entirely on
+      Bloodborne, with mod management, save/trophy management and a shadPS4
+      settings editor.
+
+      It runs the packaged shadPS4 by default. Override `shadps4` to run a
+      different build, or set `shadps4 = null` to manage builds entirely from
+      within the app.
+    '';
+    homepage = "https://github.com/rainmakerv3/BB_Launcher";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ kilyanni ];
+    mainProgram = "BB_Launcher";
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/bb/bb-launcher/unbundle-externals.patch
+++ b/pkgs/by-name/bb/bb-launcher/unbundle-externals.patch
@@ -1,0 +1,103 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11aba11..be7d500 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -106,6 +106,9 @@ find_package(pugixml 1.14 CONFIG)
+ find_package(fmt 10.2.0 CONFIG)
+ find_package(SDL3 3.1.2 CONFIG)
+ find_package(VulkanHeaders 1.4.324 CONFIG)
++find_package(nlohmann_json 3.11.0 CONFIG)
++find_package(volk 1.3.270 CONFIG)
++find_package(LibArchive 3.6.0)
+ if (APPLE)
+     find_package(date 3.0.1 CONFIG)
+ endif()
+@@ -284,8 +287,8 @@ target_include_directories(BB_Launcher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+ target_include_directories(BB_Launcher PRIVATE externals/microz/miniz)
+ 
+ target_link_libraries(BB_Launcher PRIVATE Qt6::Widgets Qt6::Network Qt6::Quick Qt6::QuickWidgets Qt6::WebView Qt6::WebSockets Qt6::Concurrent)
+-target_link_libraries(BB_Launcher PRIVATE fmt::fmt toml11::toml11 nlohmann_json::nlohmann_json pugixml::pugixml SDL3::SDL3 Vulkan::Headers volk_headers ZArchive::zarchive)
+-target_link_libraries(BB_Launcher PRIVATE qmicroz cryptopp::cryptopp liblzma archive_static)
++target_link_libraries(BB_Launcher PRIVATE fmt::fmt toml11::toml11 nlohmann_json::nlohmann_json pugixml::pugixml SDL3::SDL3 Vulkan::Headers volk::volk_headers ZArchive::zarchive)
++target_link_libraries(BB_Launcher PRIVATE qmicroz cryptopp::cryptopp LibArchive::LibArchive)
+ 
+ if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND USE_WEBENGINE)
+     target_link_libraries(BB_Launcher PRIVATE Qt6::WebEngineCore Qt6::WebEngineWidgets Qt6::WebChannel)
+diff --git a/externals/CMakeLists.txt b/externals/CMakeLists.txt
+index 2b2a8d0..0581b5a 100644
+--- a/externals/CMakeLists.txt
++++ b/externals/CMakeLists.txt
+@@ -41,17 +41,17 @@ endif()
+ # microz
+ add_subdirectory(microz)
+ 
+-# zlib from qmicroz
+-add_library(miniz_zlib STATIC microz/miniz/miniz.c)
+-target_compile_definitions(miniz_zlib PUBLIC MINIZ_NO_ZLIB_NAMESPACES)
+-add_library(ZLIB::ZLIB ALIAS miniz_zlib)
+-
+ #nlohmann json 
+-set(JSON_BuildTests OFF CACHE INTERNAL "")
+-add_subdirectory(json)
++if (NOT TARGET nlohmann_json::nlohmann_json)
++    set(JSON_BuildTests OFF CACHE INTERNAL "")
++    add_subdirectory(json)
++endif()
+ 
+ #volk
+-add_subdirectory(volk)
++if (NOT TARGET volk::volk_headers)
++    add_subdirectory(volk)
++    add_library(volk::volk_headers ALIAS volk_headers)
++endif()
+ 
+ # vulkan-headers
+ if (NOT TARGET Vulkan::Headers)
+@@ -77,6 +77,13 @@ if (NOT TARGET cryptopp::cryptopp)
+     endif()
+ endif()
+ 
++if (NOT TARGET LibArchive::LibArchive)
++
++# zlib from qmicroz
++add_library(miniz_zlib STATIC microz/miniz/miniz.c)
++target_compile_definitions(miniz_zlib PUBLIC MINIZ_NO_ZLIB_NAMESPACES)
++add_library(ZLIB::ZLIB ALIAS miniz_zlib)
++
+ # liblzma
+ set(ENABLE_NLS OFF CACHE BOOL "Disable NLS" FORCE)
+ add_subdirectory(xz)
+@@ -109,6 +116,24 @@ if (WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+     set(HAVE_WCSCPY 1 CACHE INTERNAL "Define to 1 if you have the wcscpy function" FORCE)
+ endif()
+ add_subdirectory(libarchive)
++add_library(LibArchive::LibArchive ALIAS archive_static)
++
++endif()
++
++# ZArchive ships no CMake config, only a pkg-config file.
++if (NOT TARGET zarchive)
++    find_package(PkgConfig QUIET)
++    if (PkgConfig_FOUND)
++        pkg_check_modules(zarchive IMPORTED_TARGET GLOBAL zarchive)
++        pkg_check_modules(libzstd IMPORTED_TARGET GLOBAL libzstd)
++    endif()
++endif()
++
++if (TARGET PkgConfig::zarchive)
++    set_property(TARGET PkgConfig::zarchive APPEND PROPERTY
++        INTERFACE_LINK_LIBRARIES PkgConfig::libzstd)
++    add_library(ZArchive::zarchive ALIAS PkgConfig::zarchive)
++else()
+ 
+ # zstd (dependency of ZArchive)
+ if (NOT TARGET libzstd_static)
+@@ -135,6 +160,8 @@ if (NOT TARGET zarchive)
+     add_library(ZArchive::zarchive ALIAS zarchive)
+ endif()
+ 
++endif()
++
+ if (APPLE)
+      # date
+     if (NOT TARGET date::date-tz)

--- a/pkgs/by-name/bb/bb-launcher/use-nix-shadps4.patch
+++ b/pkgs/by-name/bb/bb-launcher/use-nix-shadps4.patch
@@ -1,0 +1,16 @@
+diff --git a/settings/config.cpp b/settings/config.cpp
+index 3079300..8cdb50f 100644
+--- a/settings/config.cpp
++++ b/settings/config.cpp
+@@ -103,6 +103,11 @@ void LoadSettings() {
+         CustomUserFolder = toml::find_fs_path_or(launcher, "CustomUserFolder", {});
+     }
+ 
++    if (Common::shadPs4Executable.string().starts_with("@storeDir@/") ||
++        !std::filesystem::exists(Common::shadPs4Executable)) {
++        Common::shadPs4Executable = "@shadps4@";
++    }
++
+     if (std::filesystem::exists(Common::installPath)) {
+         Common::game_serial = Common::GetGameSerial(Common::installPath);
+     } else {


### PR DESCRIPTION
Packages [BBLauncher](https://github.com/rainmakerv3/BB_Launcher), a wrapper around shadps4 specifically for launching and modding Bloodborne.

Two notable patches:
- devendor various dependencies in favor of linking against nixpgks
- slightly alter its path resolution for shadps4, such that it can more easily use nixpkgs-packaged shadps4 without the path going stale on updates

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
