### PR TITLE
python3Packages.ngff-zarr: 0.41.1 -> 0.42.1

### DIFF
--- a/pkgs/development/python-modules/ngff-zarr/default.nix
+++ b/pkgs/development/python-modules/ngff-zarr/default.nix
@@ -1,57 +1,46 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-
-  # build-system
-  hatchling,
-
-  # dependencies
-  dask,
-  importlib-resources,
-  itkwasm,
-  itkwasm-downsample,
-  numpy,
-  platformdirs,
-  psutil,
-  rich,
-  rich-argparse,
-  typing-extensions,
-  zarr,
-
-  # optional-dependencies
-  # dask-image:
   dask-image,
-  # cli:
+  dask,
+  deepdiff,
+  fetchFromGitHub,
+  hatchling,
   imagecodecs,
   imageio,
+  importlib-resources,
   itk,
+  itkwasm-downsample,
   itkwasm-image-io,
-  nibabel,
-  tifffile,
-  # tensorstore:
-  tensorstore,
-  # validate:
+  itkwasm,
   jsonschema,
-
-  # tests
-  deepdiff,
+  nibabel,
+  numpy,
+  platformdirs,
   pooch,
+  psutil,
   pytestCheckHook,
+  rich-argparse,
+  rich,
+  tensorstore,
+  tifffile,
+  typing-extensions,
   writableTmpDirAsHomeHook,
+  zarr,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "ngff-zarr";
-  version = "0.41.1";
+  version = "0.42.1";
   pyproject = true;
+
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "fideus-labs";
     repo = "ngff-zarr";
     tag = "py-v${finalAttrs.version}";
-    hash = "sha256-ScSTvN1Pmsl/NCRZ8MtvdCZ9au1mLeUbNy/BhC/pj0A=";
+    hash = "sha256-gioxY26IPQr9f917wYm24ned1/iQyGbASlOFSwkYflE=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/py/";
@@ -139,6 +128,7 @@ buildPythonPackage (finalAttrs: {
 
     # Missing dependencies
     "test/test_lif_to_ngff_image.py"
+    "test/test_itk_transform_resample_bounding_box.py"
   ];
 
   disabledTests = [


### PR DESCRIPTION
Diff: https://github.com/fideus-labs/ngff-zarr/compare/py-v0.41.1...py-v0.42.1

Changelog: https://github.com/fideus-labs/ngff-zarr/releases/tag/py-v0.42.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
