### PR TITLE
yaziPlugins: update on 2026-08-17

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "0-unstable-2026-08-03";
+  version = "0-unstable-2026-08-12";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b9598e6cbe721aa29bf64836ce314584cfeb58fc";
-    hash = "sha256-mrQq3r1dzM3DmEyke8CvSLbacgLQ4tNiqYHCOyXaqp0=";
+    rev = "3f2b8822aa77f8699d70803ef1407ef7a2a77b0d";
+    hash = "sha256-ixdQLt8DJZRqoK4GqwaytxSrLGc+B5L+ILBs7eG6kLY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/gvfs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/gvfs/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "gvfs.yazi";
-  version = "0-unstable-2026-07-31";
+  version = "0-unstable-2026-08-09";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "gvfs.yazi";
-    rev = "cb7084d4bb0a72e4d3db8ff02eab1e5fbb358144";
-    hash = "sha256-GpcCITgdwn8pQHGPRHWeDwGkI1l9vwafmSSCIIIVvoQ=";
+    rev = "ebdb87c9783d302a0129911c31c0ae3eb27a5c9f";
+    hash = "sha256-0vW2LBv0r3N91wy5ajra8b0jPeLJ89iE0kP/meTVc7U=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mactag.yazi";
-  version = "0-unstable-2026-07-01";
+  version = "0-unstable-2026-08-07";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "65559fd3edc33cb0fd24ec92874c763fa5f68e3e";
-    hash = "sha256-SLfwFGOcmlZIUqlSSMk7dEEUZQbKqPMidknS3vtFzPo=";
+    rev = "0be29a913ad61c6d119abfaaf253e96e6af5db67";
+    hash = "sha256-IDmmXzQKFx3QZ9u5lMwcTOeWeMPWzIBeKBXkGAgJMaI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mime-ext.yazi";
-  version = "0-unstable-2026-01-12";
+  version = "0-unstable-2026-08-07";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "75f6f7276fadf306597c2d2b4e264335fa0937cf";
-    hash = "sha256-iiV6WSLdc7LPjXr+DRwVKzgJr+0Z8hO2eil5cdAgW4g=";
+    rev = "0be29a913ad61c6d119abfaaf253e96e6af5db67";
+    hash = "sha256-IDmmXzQKFx3QZ9u5lMwcTOeWeMPWzIBeKBXkGAgJMaI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "rich-preview.yazi";
-  version = "0-unstable-2026-02-11";
+  version = "0-unstable-2026-08-07";
 
   src = fetchFromGitHub {
     owner = "AnirudhG07";
     repo = "rich-preview.yazi";
-    rev = "7d616ad88498747b46124f32a35847324862cd83";
-    hash = "sha256-KHmjff7tHFLkPqOs8IdWQ0mCliSZn/mIKYof+ulnddk=";
+    rev = "02597c4a129a36e3ab013b1fd052cf0f555d5490";
+    hash = "sha256-8QfBzKyNmKFxwtOmhhpnxUZBRmrN3mPWV/n/0MZlsYo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
@@ -6,13 +6,13 @@
 
 mkYaziPlugin {
   pname = "split-tabs.yazi";
-  version = "0-unstable-2026-05-17";
+  version = "0-unstable-2026-08-17";
 
   src = fetchFromGitHub {
     owner = "terrakok";
     repo = "split-tabs.yazi";
-    rev = "da25bc0c02f669ef5d939bb03597f4ae557834ec";
-    hash = "sha256-Xb8XKEEZgNL5dZ8EAy9ELDcYGWGq2go+bwdlpydifi8=";
+    rev = "5adeacdbbbdf0907fdad3ea19adc3f4ece584245";
+    hash = "sha256-W+0wyc699FxBkrpvF68VjoFCZT8p70MJBGwYkaNq81U=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/yamb/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yamb/default.nix
@@ -5,7 +5,7 @@
 }:
 mkYaziPlugin {
   pname = "yamb.yazi";
-  version = "0-unstable-2026-08-11";
+  version = "0-unstable-2026-08-08";
 
   src = fetchFromGitHub {
     owner = "h-hg";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
