### PR TITLE
python313Packages.fnllm: fix build

### DIFF
--- a/pkgs/development/python-modules/fnllm/default.nix
+++ b/pkgs/development/python-modules/fnllm/default.nix
@@ -1,33 +1,23 @@
 {
   lib,
-  buildPythonPackage,
-  fetchPypi,
-  pythonAtLeast,
-
-  # build-system
-  hatchling,
-  uv-dynamic-versioning,
-
-  # dependencies
   aiolimiter,
-  httpx,
-  json-repair,
-  pydantic,
-  tenacity,
-
-  # optional-dependencies
-  # azure
   azure-identity,
   azure-storage-blob,
-  # openai
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  httpx,
+  json-repair,
   openai,
-  tiktoken,
-
-  # tests
   polyfactory,
+  pydantic,
   pytest-asyncio,
   pytest-cov-stub,
   pytestCheckHook,
+  pythonAtLeast,
+  tenacity,
+  tiktoken,
+  uv-dynamic-versioning,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -90,7 +80,7 @@ buildPythonPackage (finalAttrs: {
     "test_handles_common_errors"
     "test_children"
   ]
-  ++ lib.optionals (pythonAtLeast "3.14") [
+  ++ lib.optionals (pythonAtLeast "3.13") [
     # RuntimeError: There is no current event loop in thread 'MainThread'
     "test_call_batch_raises_if_response_length_mismatch"
   ];
@@ -98,6 +88,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Function-based LLM protocol and wrapper";
     homepage = "https://github.com/microsoft/essex-toolkit/tree/main/python/fnllm";
+    changelog = "https://github.com/microsoft/essex-toolkit/blob/fnllm-v${finalAttrs.version}/python/fnllm/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
- cleanup
- add changelog to meta


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
