### PR TITLE
ci/OWNERS: assign kubernetes module to NixOS/kubernetes

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -423,6 +423,9 @@ nixos/tests/forgejo.nix               @adamcstephens @bendlas @christoph-heiss @
 /pkgs/test/dotnet                           @corngood
 /doc/languages-frameworks/dotnet.section.md @corngood
 
+# Kubernetes
+/nixos/modules/services/cluster/kubernetes @NixOS/kubernetes
+
 # Node.js
 /pkgs/build-support/node/build-npm-package      @winterqt
 /pkgs/build-support/node/prefetch-npm-deps      @winterqt


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Assigns PRs that touch the [`kubernetes` module](https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/services/cluster/kubernetes) to @NixOS/kubernetes.

Context: I noticed after opening #553266 that this module currently had no assigned owners/maintainers.

And if you folks need support with Kubernetes-related topics I'd be happy to lend a hand. :wave:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
