### PR TITLE
badkeys: fix tests

### DIFF
--- a/pkgs/by-name/ba/badkeys/package.nix
+++ b/pkgs/by-name/ba/badkeys/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   python3Packages,
   testers,
+  fetchpatch2,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -17,6 +18,20 @@ python3Packages.buildPythonApplication (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-i6wKe3djZL2tHjq3UrC+edU6Gz8EYSXSUry61BaI0v4=";
   };
+
+  patches = [
+    # TODO: remove on version > 0.0.19
+    (fetchpatch2 {
+      name = "Adapt-tests-for-rsainvalid-check-for-latest-Python-c.patch";
+      url = "https://github.com/badkeys/badkeys/commit/0bdcc68378bf389aebcc714b8c24de1c8a88a4e9.patch?full_index=1";
+      hash = "sha256-K0AsRNxfDQ/qC7abt0rr8tKNP9cfvWJ75DscdyoxF08=";
+    })
+    (fetchpatch2 {
+      name = "Add-test-for-Diffie-Hellman-DH-key.patch";
+      url = "https://github.com/badkeys/badkeys/commit/4e16c47dc79dd98865f4e3ec4b981306630a57a3.patch?full_index=1";
+      hash = "sha256-6F4lfUOmSkCF4XuiPwnJGD2RrxT5/jsillAyW9vzXMw=";
+    })
+  ];
 
   build-system = with python3Packages; [
     setuptools


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/553294

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
