### PR TITLE
moon: 2.4.6 -> 2.5.2

### DIFF
--- a/pkgs/by-name/mo/moon/package.nix
+++ b/pkgs/by-name/mo/moon/package.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moon";
-  version = "2.4.6";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "moonrepo";
     repo = "moon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7gpFETidVK99Dtd22xCmKLdZHm6SBmxCuMqk6ganfe8=";
+    hash = "sha256-HR9C76TBmxLElZzNC/+Eyt61T2HYn6ElOGG50Oj3Eng=";
   };
 
-  cargoHash = "sha256-wcYk4Yz/PGhsiIHMNnyoHzBBhFHbrAmt+L9qX9HLb5Y=";
+  cargoHash = "sha256-6SgCcaPLQ6pj7bJU6iBV8mk8EsulCpFDL+26ip6TSgY=";
 
   env = {
     RUSTFLAGS = "-C strip=symbols";


### PR DESCRIPTION
Routine version bump of `moon` from 2.4.6 to 2.5.2.

Changelog: https://github.com/moonrepo/moon/releases/tag/v2.5.2

Only `version`, `src.hash` and `cargoHash` change; the derivation is otherwise untouched.

> **Updated 2026-08-20:** this PR originally bumped to 2.5.1 and was approved at that revision by @thufschmitt — thank you, and sorry for moving it underneath you. Upstream released [2.5.2](https://github.com/moonrepo/moon/releases/tag/v2.5.2) on 2026-08-19 and I would rather land the current release than immediately follow up. 2.5.2 is a patch release (no breaking changes); the diff is still the same three lines. Re-review appreciated.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Details on the boxes above:

- `nix-build -A moon` on x86_64-linux succeeded. The package sets `doInstallCheck` with `versionCheckHook`, so the build itself asserts the version:

  ```
  Successfully managed to find version 2.5.2 in the output of the command /nix/store/...-moon-2.5.2/bin/moon --version
  moon 2.5.2
  ```

- Both installed binaries run: `moon --version` → `moon 2.5.2`, `moonx --version` → `moon-exec 2.5.2`.

- `nixpkgs-review pr 553614` on x86_64-linux, against merge commit `22844c9` (this branch `1d0bb91` merged into master `d562afd`):

  ```
  --------- Report for 'x86_64-linux' ---------
  1 package built:
  moon
  ```

  `moon` is a leaf package, so it is the only rebuild. The merge commit evaluates to the same derivation as the standalone build above (`nixpkgs-review` resolved it from the local store rather than recompiling), so nothing in `stdenv`/`rustPlatform` has drifted under this package.

## Automation/AI disclosure

Per the [automation/AI policy], this contribution was assisted with Claude Code (Claude Opus 5), disclosed in the commit via an `Assisted-by:` trailer. The three-line diff and the build output above were reviewed by me before submission, and I take responsibility for the change. This summary is likewise assisted; the 2.5.2 hashes were derived with `nix-update`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



