### PR TITLE
[26.05] opencloud: 7.2.0 -> 7.2.3, opencloud.web: 7.2.0 -> 7.1.4

### DIFF
--- a/pkgs/by-name/op/opencloud/package.nix
+++ b/pkgs/by-name/op/opencloud/package.nix
@@ -92,6 +92,9 @@ buildGoModule (finalAttrs: {
     rm services/search/pkg/opensearch/*_test.go
   '';
 
+  # The activitylog tests start a local NATS server.
+  __darwinAllowLocalNetworking = true;
+
   env = {
     # avoids 'make generate' calling `git`, otherwise no-op
     STRING = finalAttrs.version;

--- a/pkgs/by-name/op/opencloud/package.nix
+++ b/pkgs/by-name/op/opencloud/package.nix
@@ -28,13 +28,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "opencloud";
-  version = "7.2.0";
+  version = "7.2.3";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "opencloud";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GAoDEXk7sBN7N0V/msi/fcJS72RqqlF6Qb5B9hArmvk=";
+    hash = "sha256-5wmXBLO6wmlBRu0FWDGMzFipRSARyK2LED1BR0Vwnt0=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -10,20 +10,20 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencloud-web";
-  version = "7.2.0";
+  version = "7.1.4";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BiOue8+zQ3+6RLiDbLMnxKEen2aav3bljji4d+0Hr5c=";
+    hash = "sha256-Wg4VGweWBiTRGDRIbe4spFQB1MEC25zXZBAIa4+YttY=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_11;
     fetcherVersion = 4;
-    hash = "sha256-gCsgnOEi9rvtwTZy8J/i63D92Gl2V9ZihxCJ+Y5hLUE=";
+    hash = "sha256-YEdZ5B11I6U140qam7e1TMOacRqUeINhr/TI13ddAa0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates OpenCloud in NixOS 26.05 from production release 7.2.0 to 7.2.3. Nixpkgs `master` follows rolling release 7.4.0, while upstream identifies 7.2.3 as the current production release. The production patch series includes fixes for storage ID-cache warmup and missing favorite flags in OpenSearch results.

This also aligns the separately packaged web assets with the 7.2 production line, which pins web 7.1.4 from `stable-7.1`. OpenCloud 7.3.0 is the first release that pins web 7.2.0.

Upstream release: https://github.com/opencloud-eu/opencloud/releases/tag/v7.2.3

Production web pin: https://github.com/opencloud-eu/opencloud/blob/v7.2.3/services/web/Makefile#L3-L4

Release lifecycle: https://docs.opencloud.eu/docs/admin/resources/lifecycle/

Darwin sandbox fix on `master`: #553925

Assisted-by: OpenAI Codex (GPT-5)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
