### PR TITLE
gcc: add passthru.tests.withCheck derivation running tests

### DIFF
--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -4,6 +4,7 @@
   enableMultilib,
   targetConfig,
   hostIsTarget,
+  dejagnu,
 }:
 
 let
@@ -21,6 +22,42 @@ originalAttrs:
   // {
     passthru = (originalAttrs.passthru or { }) // {
       inherit forceLibgccToBuildCrtStuff;
+
+      tests.withCheck = finalAttrs.finalPackage.overrideAttrs {
+        doCheck = true;
+
+        nativeCheckInputs = [
+          dejagnu
+        ];
+
+        checkPhase = ''
+          runHook preCheck
+
+          glibcLib=${lib.getLib stdenv.cc.libc}/lib
+
+          mkdir -p boards
+          cat > boards/unix.exp <<EOF
+              load_generic_config "unix"
+              set_board_info cflags  "-B$glibcLib"
+              set_board_info ldflags "-Wl,-rpath,$glibcLib"
+          EOF
+
+          export DEJAGNU="$PWD/site.exp"
+          cat > site.exp <<EOF
+              lappend boards_dir "$PWD/boards"
+          EOF
+
+          make -j$NIX_BUILD_CORES check-gcc \
+              RUNTESTFLAGS="compile.exp execute.exp dg.exp old-deja.exp --target_board=unix -v"
+
+          # make is not returning a non-zero exit code when tests fail, so we have to check the output ourselves
+          if grep -E '^(FAIL|XPASS|UNRESOLVED|ERROR):' gcc/testsuite/*/*.sum; then
+              exit 1
+          fi
+
+          runHook postCheck
+        '';
+      };
     };
     preUnpack = ''
       oldOpts="$(shopt -po nounset)" || true

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -61,6 +61,7 @@
   apple-sdk_14,
   apple-sdk_15,
   darwin,
+  dejagnu,
 }:
 
 let
@@ -138,6 +139,7 @@ let
       cargo
       withoutTargetLibc
       darwin
+      dejagnu
       disableBootstrap
       disableGdbPlugin
       enableDefaultPie


### PR DESCRIPTION
Adds a passthru.tests.withCheck derivation that runs a subset of the gcc testsuite. The selected subset is the one identified as "most important" in the [gcc project page](https://gcc.gnu.org/install/test.html).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
