### PR TITLE
go2tv: 2.1.0 -> 2.5.0

### DIFF
--- a/pkgs/by-name/go/go2tv/package.nix
+++ b/pkgs/by-name/go/go2tv/package.nix
@@ -10,24 +10,32 @@
   libxcursor,
   libx11,
   libglvnd,
+  libxkbcommon,
+  pipewire,
   pkg-config,
+  wayland,
   withGui ? true,
 }:
 
 buildGoModule rec {
   pname = "go2tv" + lib.optionalString (!withGui) "-lite";
-  version = "2.1.0";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "alexballas";
     repo = "go2tv";
     tag = "v${version}";
-    hash = "sha256-nAvfWRXPYX5AcJ0S3QXlcOtEEIUQK0FZqSSBNxDtGu4=";
+    hash = "sha256-rNoQafBIxE0xoBFQNy6GoeIE93Uq3QEsktko77P2ps8=";
   };
 
-  vendorHash = "sha256-vxWvv7PE3VlU2Z9WEAvKiUgJCrK0a6QerMA3Vw+CLZo=";
+  vendorHash = "sha256-h8/DBqkaSSxIIFrdbun4doN3qyKbR3BhO4SwL5H/sfc=";
 
   nativeBuildInputs = [ pkg-config ];
+
+  env = {
+    # allow flag from `pkg-config --cflags libpipewire-0.3`
+    CGO_CFLAGS_ALLOW = "-fno-strict-overflow";
+  };
 
   buildInputs = [
     libx11
@@ -38,6 +46,9 @@ buildGoModule rec {
     libxext
     libxxf86vm
     libglvnd
+    libxkbcommon
+    pipewire
+    wayland
   ];
 
   ldflags = [


### PR DESCRIPTION
- pipewire was added as a dependency in 2.2.0

https://github.com/alexballas/go2tv/releases/tag/v2.5.0
https://github.com/alexballas/go2tv/releases/tag/v2.4.0
https://github.com/alexballas/go2tv/releases/tag/v2.3.0
https://github.com/alexballas/go2tv/releases/tag/v2.2.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].
