### PR TITLE
python3Packages.python-lsp-ruff: 2.3.2 -> 2.3.3

### DIFF
--- a/pkgs/development/python-modules/python-lsp-ruff/default.nix
+++ b/pkgs/development/python-modules/python-lsp-ruff/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-lsp-ruff";
-  version = "2.3.2";
+  version = "2.3.3";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -24,7 +24,7 @@ buildPythonPackage (finalAttrs: {
     owner = "python-lsp";
     repo = "python-lsp-ruff";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dTQw1j7nkwc2Usy1TzziBgMl5UmLJU/6JWt7P3qAzL8=";
+    hash = "sha256-KRA/yDZaDtxNV8X9nOGfE+H1EyNYtRwNzsRmIqJASmU=";
   };
 
   postPatch =


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/python-lsp/python-lsp-ruff/compare/v2.3.2...v2.3.3
Changelog: https://github.com/python-lsp/python-lsp-ruff/releases/tag/v2.3.3

cc @linsui

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test