### PR TITLE
mullvad{,-vpn}: 2026.3 -> 2026.4

### DIFF
--- a/pkgs/by-name/mu/mullvad-vpn/0001-distribution-configuration.patch
+++ b/pkgs/by-name/mu/mullvad-vpn/0001-distribution-configuration.patch
@@ -1,8 +1,8 @@
 diff --git a/desktop/packages/mullvad-vpn/tasks/distribution.cjs b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
-index 7b2bc36e08..ec027454a2 100644
+index ae1725c61d..1e51dcbad6 100644
 --- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
 +++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
-@@ -28,6 +28,7 @@ function newConfig() {
+@@ -30,6 +30,7 @@
      publish: null,
      asar: true,
      compression: noCompression ? 'store' : 'normal',
@@ -10,7 +10,7 @@ index 7b2bc36e08..ec027454a2 100644
      extraResources: [
        { from: distAssets('ca.crt'), to: '.' },
        { from: distAssets('relays/relays.json'), to: '.' },
-@@ -180,11 +181,7 @@
+@@ -171,11 +172,7 @@
      linux: {
        target: [
          {
@@ -23,7 +23,7 @@ index 7b2bc36e08..ec027454a2 100644
            arch: getLinuxTargetArch(),
          },
        ],
-@@ -185,9 +181,6 @@ function newConfig() {
+@@ -185,9 +182,6 @@
        icon: distAssets('icon.icns'),
        extraFiles: [{ from: distAssets('linux/mullvad-gui-launcher.sh'), to: '.' }],
        extraResources: [
@@ -33,19 +33,19 @@ index 7b2bc36e08..ec027454a2 100644
        ],
      },
  
-@@ -494,6 +487,7 @@ function getMacArch() {
+@@ -524,6 +518,7 @@
  // than a non-tilde version component
  // https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning
  function getLinuxVersion() {
 +  return "@version@";
-   const [version, ...prereleaseParts] = productVersion([]).split('-');
+   const [version, ...prereleaseParts] = productVersion().split('-');
    const [major, minor] = version.split('.');
    const prerelease = prereleaseParts.join('-');
-@@ -509,6 +503,7 @@ function getLinuxVersion() {
- // Returns the product version. The `args` argument is optional. Set it to `'semver'`
- // to get the version in semver format.
- function productVersion(extraArgs) {
+@@ -538,6 +533,7 @@
+ 
+ // Returns the product version.
+ function productVersion() {
 +  return "@version@";
-   const args = ['run', '-q', '--bin', 'mullvad-version', ...extraArgs];
+   const args = ['run', '-q', '--bin', 'mullvad-version'];
    return execFileSync('cargo', args, { encoding: 'utf-8' }).trim();
  }

--- a/pkgs/by-name/mu/mullvad-vpn/package.nix
+++ b/pkgs/by-name/mu/mullvad-vpn/package.nix
@@ -18,7 +18,7 @@ buildNpmPackage (finalAttrs: {
   inherit (mullvad) src version;
 
   nodejs = nodejs_22;
-  npmDepsHash = "sha256-DWLMf+fHCm3hqKt25vmoZ+uEL90/hEpQS+5k8sBFo/c=";
+  npmDepsHash = "sha256-9IfPNfo3MJ7Ipvvlqm76iTh1d1RYFJfVZiKlh5ia8TM=";
 
   __structuredAttrs = true;
   strictDeps = true;

--- a/pkgs/by-name/mu/mullvad/package.nix
+++ b/pkgs/by-name/mu/mullvad/package.nix
@@ -17,7 +17,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mullvad";
-  version = "2026.3";
+  version = "2026.4";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -27,10 +27,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     repo = "mullvadvpn-app";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-1Q+i7W0T0Qst5ziO9St6Pcg0GgHQC+NGtRNmyA3A33g=";
+    hash = "sha256-JEGxRNhPo4O7QJD2t1dMlmy/yo7y7TEpNz6EkpPb2U0=";
   };
 
-  cargoHash = "sha256-zcZjjAPiIfkbU1nKhjdxyWP6PvkLEUCNYwFzIzRXArE=";
+  cargoHash = "sha256-OZOoH6dgC9xU6l+2lt5m4+Pi4vWUumEK68v9S2o4IB4=";
 
   cargoBuildFlags =
     let


### PR DESCRIPTION
https://github.com/mullvad/mullvadvpn-app/releases/tag/2026.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
