### PR TITLE
build-dart-application: pass pubspec.lock as a store path

### DIFF
--- a/pkgs/build-support/dart/build-dart-application/default.nix
+++ b/pkgs/build-support/dart/build-dart-application/default.nix
@@ -82,7 +82,7 @@ lib.extendMkDerivation {
     let
       generators = callPackage ./generators.nix { inherit dart; } { buildDrvArgs = args; };
 
-      pubspecLockFile = builtins.toJSON pubspecLock;
+      pubspecLockFile = writeText "pubspec.lock" (builtins.toJSON pubspecLock);
       pubspecLockData = pub2nix.readPubspecLock {
         inherit
           src
@@ -194,14 +194,12 @@ lib.extendMkDerivation {
           builtins.attrValues pubspecLockData.dependencySources;
 
       preConfigure = args.preConfigure or "" + ''
-        ln -sf "$pubspecLockFilePath" pubspec.lock
+        ln -sf "$pubspecLockFile" pubspec.lock
       '';
 
       # When stripping, it seems some ELF information is lost and the dart VM cli
       # runs instead of the expected program. Don't strip if it's an exe output.
       dontStrip = args.dontStrip or (dartOutputType == "exe");
-
-      passAsFile = [ "pubspecLockFile" ];
 
       passthru = {
         pubspecLock = pubspecLockData;


### PR DESCRIPTION
## Description

`build-dart-application` hands the generated lock to the build with `passAsFile = [ "pubspecLockFile" ]`, and `preConfigure` links `$pubspecLockFilePath`. Nix ignores `passAsFile` when `__structuredAttrs` is enabled: `pubspecLockFile` then arrives as the JSON string itself, `$pubspecLockFilePath` is unset, and the build dies in `configurePhase`:

```
Running phase: configurePhase
ln: failed to create symbolic link pubspec.lock -> : No such file or directory
```

That blocks every **new** dart or flutter package, because nixpkgs-vet requires the flag of new top-level packages ("New top-level packages must evaluate with `__structuredAttrs = true`"), while none of the 46 `buildFlutterApplication` and 11 `buildDartApplication` users in the tree sets it today. I ran into it in #530513.

This writes the JSON with `writeText` at eval time and links that store path instead. It behaves the same with and without structured attributes, and it also keeps the lock (31 kB in my case) out of the derivation environment.

## Things done

- Built on x86_64-linux.
- **With structured attributes:** the package from #530513 sets `__structuredAttrs = true` and fails as shown above on master. With this patch and no other change it builds and runs — `knitcalc --version` → `knitcalc 1.8.79+102`, exit 0.
- **Regression, without structured attributes** (what every current dart package does): rebuilt `dart-sass` and `protoc-gen-dart` through an overlay replacing `buildDartApplication` with this version; both build, and `sass --version` prints `1.102.0`.
- `nixfmt --check` is clean on the changed file.
- Rebuilds every dart/flutter package (57 in the tree); no eval or interface change for them.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Disclosure for this pull request text, separate from the commits: written with Claude Code (claude-opus-5), reviewed by me before posting.
