### PR TITLE
dsksfzplayer: init at 1.0.28

### DIFF
--- a/pkgs/by-name/ds/dsksfzplayer/package.nix
+++ b/pkgs/by-name/ds/dsksfzplayer/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  freetype,
+  libGL,
+  libjack2,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
+  libxkbcommon,
+  libepoxy,
+}:
+
+let
+  juce-src = fetchFromGitHub {
+    owner = "juce-framework";
+    repo = "JUCE";
+    tag = "7.0.12";
+    hash = "sha256-/awe6D824ZjF17xjkt0wY7dcDuS/s8KKAv1UKHxF0FM=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dsksfzplayer";
+  version = "1.0.28";
+
+  src = fetchFromGitHub {
+    owner = "dskmusic";
+    repo = "DSKSFzPlayer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/QaH2jiE0Hzow/T0x0pmEseJt4R71SiGN9cNPe/vvGM=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    libGL
+    libjack2
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+    libxkbcommon
+    libepoxy
+  ];
+
+  cmakeFlags = [
+    "-DFETCHCONTENT_SOURCE_DIR_JUCE=${juce-src}"
+    "-DJUCE_COPY_PLUGIN_AFTER_BUILD=OFF"
+  ];
+
+  env = {
+    # JUCE dlopen's these at runtime, crashes without them
+    NIX_LDFLAGS = toString [
+      "-lX11"
+      "-lXext"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+    ];
+    NIX_CFLAGS_COMPILE = toString [
+      "-ffat-lto-objects"
+    ];
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3
+    mkdir -p $out/bin
+    mkdir -p $out/share/doc/dsksfzplayer
+
+    cp -r DSKSFzPlayer_artefacts/Release/VST3/DSK\ SFz\ player.vst3 $out/lib/vst3/
+    install -Dm755 "DSKSFzPlayer_artefacts/Release/Standalone/DSK SFz player" $out/bin/dsksfzplayer
+
+    # Copy documentation
+    cp DSKSFzPlayer_artefacts/Release/VST3/manual.md $out/share/doc/dsksfzplayer/
+    cp DSKSFzPlayer_artefacts/Release/VST3/install_notes.md $out/share/doc/dsksfzplayer/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "High-performance, 64-voice polyphonic SFZ/SF2/Decent Sampler sampler";
+    homepage = "https://github.com/dskmusic/DSKSFzPlayer";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ eymeric ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
