### PR TITLE
[Backport release-26.05] picard: backport recent nix package updates

### DIFF
--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -45,17 +45,13 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform qt5.qtwayland) [
     qt5.qtwayland
   ]
-  ++ lib.optionals (pyqt5.multimediaEnabled) (
-    [
-      qt5.qtmultimedia.bin
-      gst_all_1.gst-libav
-      gst_all_1.gst-plugins-base
-      gst_all_1.gst-plugins-good
-    ]
-    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform gst_all_1.gst-vaapi) [
-      gst_all_1.gst-vaapi
-    ]
-  );
+  ++ lib.optionals (pyqt5.multimediaEnabled) [
+    qt5.qtmultimedia.bin
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+  ];
 
   pythonRelaxDeps = lib.optionals stdenv.hostPlatform.isDarwin [
     # Should be resolved in the next version

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  python312Packages,
+  python313Packages,
   fetchFromGitHub,
 
   chromaprint,
@@ -16,7 +16,9 @@
 }:
 
 let
-  pythonPackages = python312Packages;
+  # A few more tests fail with python314Pacakges, indicating the code isn't
+  # ready for it yet.
+  pythonPackages = python313Packages;
   pyqt5 = if enablePlayback then pythonPackages.pyqt5-multimedia else pythonPackages.pyqt5;
 in
 pythonPackages.buildPythonApplication (finalAttrs: {

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -61,7 +61,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     "pyobjc-framework-Cocoa"
   ];
 
-  propagatedBuildInputs =
+  dependencies =
     with pythonPackages;
     [
       charset-normalizer

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  # A few more tests fail with python314Pacakges, indicating the code isn't
+  # A few more tests fail with python314Packages, indicating the code isn't
   # ready for it yet.
   pythonPackages = python313Packages;
   pyqt5 = if enablePlayback then pythonPackages.pyqt5-multimedia else pythonPackages.pyqt5;

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -12,6 +12,7 @@
   gst_all_1,
 
   writableTmpDirAsHomeHook,
+  nix-update-script,
 }:
 
 let
@@ -20,7 +21,6 @@ let
 in
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "picard";
-  # nix-update --commit picard --version-regex 'release-(.*)'
   version = "2.13.3";
   pyproject = true;
   strictDeps = true;
@@ -107,6 +107,13 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   + lib.optionalString (pyqt5.multimediaEnabled) ''
     makeWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://picard.musicbrainz.org";

--- a/pkgs/by-name/pi/picard/package.nix
+++ b/pkgs/by-name/pi/picard/package.nix
@@ -47,7 +47,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform qt5.qtwayland) [
     qt5.qtwayland
   ]
-  ++ lib.optionals (pyqt5.multimediaEnabled) [
+  ++ lib.optionals pyqt5.multimediaEnabled [
     qt5.qtmultimedia.bin
     gst_all_1.gst-libav
     gst_all_1.gst-plugins-base
@@ -106,7 +106,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   ''
-  + lib.optionalString (pyqt5.multimediaEnabled) ''
+  + lib.optionalString pyqt5.multimediaEnabled ''
     makeWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
   '';
 


### PR DESCRIPTION
Backports #544655 to release-26.05. Also includes the slightly more recent commit 5506449838d522a39a08636e287778e30d0f0de1 .

The main motivation is because the package in release-26.05 depends on Python 3.12, requiring local compilation of pyqt5. By bumping up to Python 3.13, we can use the binary cache.

Resubmission of #553517 to add the `Not-cherry-picked-because:` reasons to two of the commits, as the nixpkgs-commit-check bot was complaining. The commits weren't cherry picked because they modified many files, including picard, leading to merge conflicts with simple cherry-picks. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
