### PR TITLE
taskwarrior3: 3.4.2 -> 3.5.0

### DIFF
--- a/nixos/tests/taskchampion-sync-server.nix
+++ b/nixos/tests/taskchampion-sync-server.nix
@@ -42,6 +42,13 @@
 
       # Useful for debugging
       client.copy_from_machine("/root/.task", "client")
-      server.copy_from_machine("${cfg.dataDir}", "server")
+      server.copy_from_machine(
+          # Ever since DynamicUser defaults to true[1], dataDir is a symlink
+          # into /var/lib/private, and symlink resolving is needed.
+          #
+          # [1]: https://github.com/NixOS/nixpkgs/commit/95fc26d18a19207b20acfee182db120efc36d1d3
+          server.succeed("readlink -f ${cfg.dataDir}").strip(),
+          "server",
+      )
     '';
 }

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
 
   # nativeBuildInputs
   cmake,
@@ -25,18 +26,26 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "taskwarrior";
-  version = "3.4.2";
+  version = "3.5.0";
   src = fetchFromGitHub {
     owner = "GothenburgBitFactory";
     repo = "taskwarrior";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Y0jnAW4OtPI9GCOSFRPf8/wo4qBB6O1FASj40S601+E=";
+    hash = "sha256-ckVYO7Z5nF2xvPU4K/dktx/ht4gKTASlzZNkDjXXKyg=";
     fetchSubmodules = true;
   };
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-03HG8AGe6PJ516zL23iNjGUYmGOZa8NuFljb1ll2pjs=";
+    hash = "sha256-vNi/gVzIzTXuuPkWNimDwPJG7COWJATzGaT6J4UrrTk=";
   };
+  patches = [
+    # Installs properly Bash scripts, just like fish. See:
+    # https://github.com/GothenburgBitFactory/taskwarrior/pull/4173
+    (fetchpatch {
+      url = "https://github.com/GothenburgBitFactory/taskwarrior/commit/c1958786deb9be8b245b4fc4c3efd0258cd70782.patch";
+      hash = "sha256-i/9m/ipF+yc2iMNoNWH4i2myUOilyKNqP2A5zWkCJaQ=";
+    })
+  ];
 
   # The CMakeLists files used by upstream issue a `cargo install` command to
   # install a rust tool (cxxbridge-cmd) that is supposed to be included in the Cargo.toml's and
@@ -81,32 +90,27 @@ stdenv.mkDerivation (finalAttrs: {
     libuuid
   ];
 
-  doCheck = true;
+  # The test suite is run as an installCheck instead of a check: since
+  # https://github.com/GothenburgBitFactory/taskwarrior/commit/76537e107da1654e81df9713df25dbb8fadf4320
+  # (3.5.0) the default config includes `default.theme`, which `task` looks
+  # up at its compiled-in $out/share/doc/task/rc (TASK_RCDIR). That path is
+  # only populated once `installPhase` has run, so the tests need to run
+  # after install, not before.
+  doInstallCheck = true;
   # See:
   # https://github.com/GothenburgBitFactory/taskwarrior/blob/v3.4.1/doc/devel/contrib/development.md#run-the-test-suite
-  preCheck = ''
+  preInstallCheck = ''
     make test_runner
   '';
-  nativeCheckInputs = [
-    python3
-  ];
-
-  doInstallCheck = true;
-
+  installCheckTarget = "test";
   nativeInstallCheckInputs = [
+    python3
     versionCheckHook
   ];
 
   versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
 
   postInstall = ''
-    # ZSH is installed automatically from some reason, only bash and fish need
-    # manual installation
-    installShellCompletion --cmd task \
-      --bash $out/share/doc/task/scripts/bash/task.sh \
-      --fish $out/share/doc/task/scripts/fish/task.fish
-    rm -r $out/share/doc/task/scripts/bash
-    rm -r $out/share/doc/task/scripts/fish
     # Install vim and neovim plugin
     mkdir -p $out/share/vim-plugins
     mv $out/share/doc/task/scripts/vim $out/share/vim-plugins/task


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test