### PR TITLE
python3Packages.compliance-trestle: 3.12.0 -> 5.0.0

### DIFF
--- a/pkgs/development/python-modules/compliance-trestle/default.nix
+++ b/pkgs/development/python-modules/compliance-trestle/default.nix
@@ -24,55 +24,34 @@
   python-frontmatter,
   requests,
   ruamel-yaml,
+  rfc8785,
+  securesystemslib,
 
   # tests
   datamodel-code-generator,
   pytestCheckHook,
   mypy,
 }:
-
-let
-  # nist-content is a git submodule, but using fetchSubmodules in src fails while recursing into
-  # nist-content itself.
-  # Thus we simply inject it after the fact in postPatch.
-  nist-content = fetchFromGitHub {
-    name = "nist-content";
-    owner = "usnistgov";
-    repo = "oscal-content";
-    rev = "941c978d14c57379fbf6f7fb388f675067d5bff7";
-    hash = "sha256-sDvNMheZZhk09YEfY5ocmZmAC3t3KenqD3PaNsi0mMU=";
-  };
-in
 buildPythonPackage (finalAttrs: {
   pname = "compliance-trestle";
-  version = "3.12.0";
+  version = "5.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "oscal-compass";
     repo = "compliance-trestle";
     tag = "v${finalAttrs.version}";
-    # TODO: Try to fall back to fetchSubmodules at the next release
-    # fetchSubmodules = true;
-    hash = "sha256-4z+hJoykIwDRshtSyE94POy39cRNVqtT4L6KftNWG6w=";
+    fetchSubmodules = true;
+    hash = "sha256-8ObzK0P1syPw7L6m0LfCs507jruazxRNNwob5CzS6Zw=";
   };
 
   postPatch = ''
     substituteInPlace tests/trestle/misc/mypy_test.py \
       --replace-fail "trestle'," "${placeholder "out"}/bin/trestle',"
-  ''
-  # Replace the expected nist-content git submodule with the pre-fetched path.
-  + ''
-    rmdir ./nist-content
-    ln -s ${nist-content} ./nist-content
   '';
 
   build-system = [
     hatchling
-  ];
-
-  pythonRelaxDeps = [
-    "cryptography"
   ];
 
   dependencies = [
@@ -92,7 +71,10 @@ buildPythonPackage (finalAttrs: {
     python-frontmatter
     requests
     ruamel-yaml
+    securesystemslib
+    rfc8785
   ]
+  ++ securesystemslib.optional-dependencies.crypto
   ++ pydantic.optional-dependencies.email;
 
   nativeCheckInputs = [
@@ -106,6 +88,7 @@ buildPythonPackage (finalAttrs: {
     "test_import_from_url"
     "test_import_from_nist"
     "test_remote_profile_relative_cat"
+    "test_ssp_generate_missing_profile_param_value_origin_regression"
 
     # AssertionError
     "test_profile_generate_assemble_rev_5"


### PR DESCRIPTION
Update to address, among other things, #553592.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
