### PR TITLE
matrix-hookshot: 7.3.3 -> 7.4.0

### DIFF
--- a/pkgs/by-name/ma/matrix-hookshot/package.nix
+++ b/pkgs/by-name/ma/matrix-hookshot/package.nix
@@ -18,23 +18,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "matrix-hookshot";
-  version = "7.3.3";
+  version = "7.4.0";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "matrix-hookshot";
     tag = finalAttrs.version;
-    hash = "sha256-SVQsXzQU3TTiKjd1manEsqL/Ui6s/sFoZPBf9mWp31k=";
+    hash = "sha256-Nsbs3m1sFQaJGqVW8Jk8kSMYXrRnqLBVs6glpuP76ps=";
   };
 
   offlineCache = fetchYarnDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-1J2a0ZRARYOEQE70WnKZlgwjIwafPfmgBtUVXX106lg=";
+    hash = "sha256-93g8DvTZACDhURoMCaeg5Zqpk1dnbOqscRkSV9lnYCI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-EMwrIo17d5+LTczv4/+4m6XALfH0dCHnWtBU17h+mxI=";
+    hash = "sha256-FKCzafDeqJs1o24H+Qy/9vRJeG5bEa+/y+yp4T2ADVg=";
   };
 
   buildInputs = [ openssl ];
@@ -62,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preBuild
 
     yarn run build:app:rs --target ${stdenv.hostPlatform.rust.rustcTargetSpec}
-    yarn run build:app:fix-defs
     yarn run build:app
     yarn run build:web
 
@@ -105,6 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "matrix-hookshot";
     maintainers = with lib.maintainers; [ chvp ];
     license = lib.licenses.asl20;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Diff: https://github.com/matrix-org/matrix-hookshot/compare/7.3.3...7.4.0

Changelog: https://github.com/matrix-org/matrix-hookshot/blob/7.4.0/CHANGELOG.md

Also includes a platforms tweak to permit building on darwin.

Tested by ensuring that bugfixes are applied by running the bumped service.

NOTE 1: I am aware that 7.4.4 is out. 7.4.1 changed the build system to pnpm, which I don't have experience with, so the inclined reviewer may feel free to follow it up.
NOTE 2: 7.3.3 and 7.4.0 will be backported once this PR is merged.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
