### PR TITLE
cardwire: 0.12.0 -> 0.12.1

### DIFF
--- a/pkgs/by-name/ca/cardwire/package.nix
+++ b/pkgs/by-name/ca/cardwire/package.nix
@@ -18,10 +18,11 @@
   libxcb,
   libglvnd,
   versionCheckHook,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cardwire";
-  version = "0.12.0";
+  version = "0.12.1";
 
   __structuredAttrs = true;
 
@@ -29,9 +30,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "opengamingcollective";
     repo = "cardwire";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WuXFztiy6G2HYCu3KpKrjR8YCpcLePfGEZ+f71x1WnM=";
+    hash = "sha256-Jt8CxN99JSayN6UawAKEFrxU3wz5OiAFqYnBytLB1Xs=";
   };
-  cargoHash = "sha256-8eJSxL9RkHtbUxXuKPvyxhvSJD/0JeNaEM/oZf0n2Q4=";
+  cargoHash = "sha256-3wgdr9R5eY3BwdhzZ7LjlxHkJFRd2imqXIMlAszKvQY=";
 
   postPatch = ''
     # Workaround to build cardwire-ebpf, when RUSTC_BOOTSTRAP is set to 1
@@ -109,7 +110,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.tests.cardwire = nixosTests.cardwire;
+  passthru = {
+    tests.cardwire = nixosTests.cardwire;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "GPU manager for laptop and workstation";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump cardwire from 0.12.0 to 0.12.1 and add an update script for the ryantm bot

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
