### PR TITLE
rPackages.{mongolite,openssl,websocket}: link openssl via pkg-config

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -763,6 +763,7 @@ let
     mixlink = [ pkgs.gsl ]; # for gsl-config
     mixture = [ pkgs.gsl ]; # for gsl-config
     mmpca = [ pkgs.gsl ]; # for gsl-config via RcppGSL
+    mongolite = [ pkgs.pkg-config ];
     monoreg = [ pkgs.gsl ]; # for gsl-config
     multibridge = [ pkgs.pkg-config ];
     mvabund = [ pkgs.gsl ]; # for gsl-config via RcppGSL
@@ -783,6 +784,7 @@ let
     ];
     odbc = [ pkgs.pkg-config ];
     opencv = [ pkgs.pkg-config ];
+    openssl = [ pkgs.pkg-config ];
     orbweaver = with pkgs; [
       cargo
       rustc
@@ -982,6 +984,7 @@ let
       rustc
     ];
     webp = [ pkgs.pkg-config ];
+    websocket = [ pkgs.pkg-config ];
     xactonomial = with pkgs; [
       cargo
       rustc
@@ -1477,6 +1480,11 @@ let
       zlib
     ];
     mixcat = [ pkgs.gsl ];
+    mongolite = with pkgs; [
+      cyrus_sasl
+      openssl
+      zlib
+    ];
     multibridge = [ pkgs.mpfr ];
     mutscan = [ pkgs.zlib ];
     mvabund = [ pkgs.gsl ];
@@ -1494,6 +1502,7 @@ let
     npRmpi = [ pkgs.mpi ];
     odbc = [ pkgs.unixodbc ];
     oligo = [ pkgs.zlib ];
+    openssl = [ pkgs.openssl ];
     otelsdk = with pkgs; [
       curl
       protobuf
@@ -1770,6 +1779,7 @@ let
     ];
     vdiffr = [ pkgs.libpng ];
     webp = [ pkgs.libwebp ];
+    websocket = [ pkgs.openssl ];
     writexl = with pkgs; [ zlib ];
     xdvir = [ pkgs.freetype ];
     xml2 = [ pkgs.libxml2 ];
@@ -2576,13 +2586,6 @@ let
       };
     });
 
-    mongolite = old.mongolite.overrideAttrs (attrs: {
-      env = (attrs.env or { }) // {
-        PKGCONFIG_CFLAGS = "-I${lib.getDev pkgs.openssl}/include -I${lib.getDev pkgs.cyrus_sasl}/include -I${lib.getDev pkgs.zlib}/include";
-        PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -L${pkgs.cyrus_sasl.out}/lib -L${pkgs.zlib.out}/lib -lssl -lcrypto -lsasl2 -lz";
-      };
-    });
-
     nanonext = old.nanonext.overrideAttrs (attrs: {
       env = (attrs.env or { }) // {
         NIX_LDFLAGS = "-lnng -lmbedtls -lmbedx509 -lmbedcrypto";
@@ -2628,10 +2631,11 @@ let
       });
 
     openssl = old.openssl.overrideAttrs (attrs: {
-      env = (attrs.env or { }) // {
-        PKGCONFIG_CFLAGS = "-I${lib.getDev pkgs.openssl}/include";
-        PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
-      };
+      # RPATH will be incorrect if the configure script replaces -lssl with -l:libssl.so.{n}
+      postPatch = ''
+        substituteInPlace configure \
+          --replace-fail 'PKG_LIBS="''${PKG_LIBS_VERSIONED}"' ':'
+      '';
     });
 
     pak = old.pak.overrideAttrs (attrs: {
@@ -2925,10 +2929,11 @@ let
     });
 
     websocket = old.websocket.overrideAttrs (attrs: {
-      env = (attrs.env or { }) // {
-        PKGCONFIG_CFLAGS = "-I${lib.getDev pkgs.openssl}/include";
-        PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
-      };
+      # RPATH will be incorrect if the configure script replaces -lssl with -l:libssl.so.{n}
+      postPatch = ''
+        substituteInPlace configure \
+          --replace-fail 'PKG_LIBS="''${PKG_LIBS_VERSIONED}"' ':'
+      '';
     });
 
     xslt = old.xslt.overrideAttrs (attrs: {


### PR DESCRIPTION
AFAICT rPackages.openssl has many backwards deps, so this change might rebuild many rPackages

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
