### PR TITLE
compressDrv: remove compressed sidecars if larger

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -24,6 +24,10 @@
 
 - `moon` has been updated to `2.x` and needs manual migration. See the [migration guide](https://moonrepo.dev/docs/migrate/2.0) for instructions.
 
+- `compressDrv` and `compressDrvWeb` now remove compressed sidecars that are
+  not smaller than their source files. Set `keepLarger = true` to preserve the
+  earlier behavior.
+
 - []{#x86_64-darwin-26.11}
 
   Support for `x86_64-darwin` has been dropped, due to Apple’s deprecation of the platform and limited build infrastructure and developer time.

--- a/pkgs/build-support/compress-drv/default.nix
+++ b/pkgs/build-support/compress-drv/default.nix
@@ -15,6 +15,11 @@
     This can be used to exclude certain files.
     For example: `-not -iregex ".*(\/apps\/.*\/l10n\/).*"`
 
+  `keepLarger` (Boolean; optional)
+
+  : Keep compressed sidecars even when they are not smaller than their source
+    files. Defaults to `false`.
+
   `compressors` ( { ${fileExtension} :: String })
 
   : Map a desired extension (e.g. `gz`) to a compress program.
@@ -28,10 +33,14 @@
     - read symlinks (thus --force is needed to gzip, zstd, xz).
     - keep the original file in place (--keep).
 
+    Unless `keepLarger` is enabled, a compressed sidecar that ends up not
+    smaller than its source file is deleted, since it has no legitimate use
+    over serving the original.
+
   # Type
 
   ```
-  compressDrv :: Derivation -> { formats :: [String]; compressors :: { ${fileExtension} :: String; } } -> Derivation
+  compressDrv :: Derivation -> { formats :: [String]; compressors :: { ${fileExtension} :: String; }; keepLarger :: Bool; } -> Derivation
   ```
 
   # Examples
@@ -57,6 +66,7 @@ drv:
   formats,
   compressors,
   extraFindOperands ? "",
+  keepLarger ? false,
 }:
 let
   validProg =
@@ -70,7 +80,16 @@ let
     assert validProg ext prog;
     ''
       find -L $out -type f -regextype posix-extended -iregex '.*\.(${formatsPipe})' ${extraFindOperands} -print0 \
-        | xargs -0 -P$NIX_BUILD_CORES -I{} ${prog}
+        | xargs -0 -P$NIX_BUILD_CORES -I{} sh -c '
+            set -e
+            ${prog}
+            ${lib.optionalString (!keepLarger) ''
+              # if compressed file is larger than the original, it has no purpose; remove.
+              if [ "$(stat -c%s "{}.${ext}")" -ge "$(stat -L -c%s "{}")" ]; then
+                rm -f "{}.${ext}"
+              fi
+            ''}
+          '
     '';
   formatsPipe = lib.concatStringsSep "|" formats;
 in

--- a/pkgs/build-support/compress-drv/test.nix
+++ b/pkgs/build-support/compress-drv/test.nix
@@ -2,18 +2,24 @@
   gzip,
   runCommand,
   compressDrv,
+  compressDrvWeb,
 }:
 let
   example = runCommand "sample-drv" { } ''
     mkdir $out
-    echo 42 > $out/1.txt
-    echo 43 > $out/1.md
+    # highly redundant, gzip shrinks it well, must be kept
+    printf '42\n%.0s' {1..1000} > $out/1.txt
+    printf '43\n%.0s' {1..1000} > $out/1.md
     touch $out/2.png
+    # too small to shrink under gzip's overhead, should be dropped
+    echo 42 > $out/tiny.txt
   '';
-  drv = compressDrv example {
+  compressTxtArgs = {
     formats = [ "txt" ];
     compressors.gz = "${gzip}/bin/gzip --force --keep --fast {}";
   };
+  drv = compressDrv example compressTxtArgs;
+  keepLargerDrv = compressDrvWeb example (compressTxtArgs // { keepLarger = true; });
   wrapped = compressDrv drv {
     formats = [ "md" ];
     compressors.gz = "${gzip}/bin/gzip --force --keep --fast {}";
@@ -28,7 +34,15 @@ runCommand "test-compressDrv" { } ''
   cmp ${drv}/1.txt <(${gzip}/bin/zcat ${drv}/1.txt.gz)
 
   test -h ${drv}/2.png
-  test ! -a ${drv}/2.png.gz
+  test ! -e ${drv}/2.png.gz
+
+  test -h ${drv}/tiny.txt
+  test ! -e ${drv}/tiny.txt.gz
+
+  test -h ${keepLargerDrv}/tiny.txt
+  test -f ${keepLargerDrv}/tiny.txt.gz
+  test "$(stat -c%s ${keepLargerDrv}/tiny.txt.gz)" -ge "$(stat -L -c%s ${keepLargerDrv}/tiny.txt)"
+  cmp ${keepLargerDrv}/tiny.txt <(${gzip}/bin/zcat ${keepLargerDrv}/tiny.txt.gz)
 
   # compressDrv always points to the final file, no matter how many times
   # it's been wrapped

--- a/pkgs/build-support/compress-drv/web.nix
+++ b/pkgs/build-support/compress-drv/web.nix
@@ -23,6 +23,10 @@
 
   : See compressDrv for details.
 
+  `keepLarger` (Boolean; optional)
+
+  : See compressDrv for details.
+
   `extraFormats` ([String])
 
   : Extra extensions to compress in addition to `formats`.
@@ -34,7 +38,7 @@
   # Type
 
   ```
-  compressDrvWeb :: Derivation -> { formats :: [String]; extraFormats :: [String]; compressors :: { ${fileExtension} :: String; } } -> Derivation
+  compressDrvWeb :: Derivation -> { formats :: [String]; extraFormats :: [String]; compressors :: { ${fileExtension} :: String; }; keepLarger :: Bool; } -> Derivation
   ```
 
   # Examples
@@ -137,9 +141,10 @@ drv:
     zstd = "${lib.getExe zstd} --force --keep --quiet -19 {}";
   },
   extraFindOperands ? "",
+  keepLarger ? false,
 }:
 compressDrv drv {
   formats = formats ++ extraFormats;
   compressors = compressors;
-  inherit extraFindOperands;
+  inherit extraFindOperands keepLarger;
 }


### PR DESCRIPTION
Some files are trivial and not worth compressing; some files compress worse, even if they have a compatible extension.

Remove such files, as they just waste disk space.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
