### PR TITLE
optee-os: add Allwinner A64 and Rockchip RK3399/RK3588 instances

### DIFF
--- a/pkgs/misc/optee-os/default.nix
+++ b/pkgs/misc/optee-os/default.nix
@@ -55,6 +55,7 @@ let
         ];
 
         strictDeps = true;
+        __structuredAttrs = true;
 
         enableParallelBuilding = true;
 

--- a/pkgs/misc/optee-os/default.nix
+++ b/pkgs/misc/optee-os/default.nix
@@ -112,7 +112,10 @@ let
           homepage = "https://github.com/OP-TEE/optee_os";
           changelog = "https://github.com/OP-TEE/optee_os/blob/${defaultVersion}/CHANGELOG.md";
           license = lib.licenses.bsd2;
-          maintainers = [ lib.maintainers.jmbaur ];
+          maintainers = [
+            lib.maintainers.jmbaur
+            lib.maintainers.tomfitzhenry
+          ];
         }
         // extraMeta;
       }
@@ -132,6 +135,24 @@ in
   opteeQemuAarch64 = buildOptee {
     platform = "vexpress";
     extraMakeFlags = [ "PLATFORM_FLAVOR=qemu_armv8a" ];
+    extraMeta.platforms = [ "aarch64-linux" ];
+  };
+
+  opteeAllwinnerA64 = buildOptee {
+    platform = "sunxi";
+    extraMakeFlags = [ "PLATFORM_FLAVOR=sun50i_a64" ];
+    extraMeta.platforms = [ "aarch64-linux" ];
+  };
+
+  opteeRockchipRK3399 = buildOptee {
+    platform = "rockchip";
+    extraMakeFlags = [ "PLATFORM_FLAVOR=rk3399" ];
+    extraMeta.platforms = [ "aarch64-linux" ];
+  };
+
+  opteeRockchipRK3588 = buildOptee {
+    platform = "rockchip";
+    extraMakeFlags = [ "PLATFORM_FLAVOR=rk3588" ];
     extraMeta.platforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5183,8 +5183,11 @@ with pkgs;
 
   inherit (callPackage ../misc/optee-os { })
     buildOptee
-    opteeQemuArm
+    opteeAllwinnerA64
     opteeQemuAarch64
+    opteeQemuArm
+    opteeRockchipRK3399
+    opteeRockchipRK3588
     ;
 
   patchelf = callPackage ../development/tools/misc/patchelf { };


### PR DESCRIPTION
Adds three OP-TEE instances for SoCs where nixpkgs already ships matching u-boot and ATF firmware:

- `opteeAllwinnerA64` (PinePhone)
- `opteeRockchipRK3399`: tested on a RockPro64
- `opteeRockchipRK3588`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
