### PR TITLE
python3Packages.spsdk: fix build with setuptools-scm 10

### DIFF
--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -62,12 +62,18 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-eA18DvQ0IIZtseJXXXMiFYkaOwBIhVXNaWiAObIj55I=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools_scm<10" "setuptools_scm"
+  '';
+
   build-system = [
     setuptools
     setuptools-scm
   ];
 
   pythonRelaxDeps = [
+    "chardet"
     "cryptography"
     "filelock"
     "importlib-metadata"
@@ -75,6 +81,7 @@ buildPythonPackage (finalAttrs: {
     "prettytable"
     "requests"
     "ruamel.yaml.clib"
+    "setuptools"
     "setuptools_scm"
     "typing-extensions"
   ];


### PR DESCRIPTION
`python3Packages.spsdk` does not build on `master` or `nixos-unstable`. The build stops in `buildPhase`:

```
ERROR Unmet dependencies (checked against /nix/store/…-python3-3.14.7/bin/python3.14):
        setuptools_scm<10
                wanted: <10
              found: 10.0.5
error: Cannot build '/nix/store/…-python3.14-spsdk-3.9.0.drv'.
       Reason: builder failed with exit code 1.
```

`nixpkgs` now ships `setuptools-scm` 10.0.5, while `spsdk` declares `setuptools_scm<10`.

Downstream report: https://github.com/nix-community/zephyr-nix/issues/58

## Cause

`pypa/build` runs with `--no-isolation`, so it validates `[build-system] requires` against the build environment. The derivation already lists `setuptools_scm` in `pythonRelaxDeps`, but that mechanism rewrites the wheel's runtime metadata; it does not touch `[build-system] requires`. So the constraint has to be patched in the source.

A version bump does not help. Upstream still declares `setuptools_scm<10` on the `v3.10.0` tag and on `master`, so this patch stays until upstream changes it.

## Three pins, in two files

Fixing only the `[build-system]` pin uncovers two more failures in `pythonRuntimeDepsCheckHook`, because `pypa/build` stops at the first error and hides the rest:

```
Checking runtime dependencies for spsdk-3.9.0-py3-none-any.whl
  - chardet<6 not satisfied by version 6.0.0.post1
  - setuptools<81,>75 not satisfied by version 83.0.0
```

| Source file | Line | Pin | Fixed by |
| --- | --- | --- | --- |
| `pyproject.toml` | 87 | `setuptools_scm<10` | new `postPatch` |
| `requirements.txt` | 4 | `chardet<6` | `pythonRelaxDeps` |
| `requirements.txt` | 28 | `setuptools_scm<10` | `pythonRelaxDeps` (already present) |
| `requirements.txt` | 29 | `setuptools<81,>75` | `pythonRelaxDeps` |

`setuptools_scm` appears twice, which is why it needed both mechanisms.

I checked that neither new relaxation hides a real incompatibility:

- **`chardet`** — `spsdk` never imports it. `requirements.txt` marks the pin as a workaround for `psf/requests#7223`.
- **`setuptools`** — `spsdk/utils/plugins.py` reads entry points through `importlib_metadata`, not `pkg_resources`, so `spsdk` does not import `setuptools` at run time.

## A latent upstream problem, not fixed here

`spsdk/versioning.py:15` does `from setuptools_scm._log import log`. That module no longer exists in `setuptools-scm` 10; the code moved to `vcs_versioning._log`. The nixpkgs build never reaches it, for two reasons:

1. `pyproject.toml` sets `version_scheme = "spsdk.versioning:run"`, but the build sets `SETUPTOOLS_SCM_PRETEND_VERSION` to `3.9.0`, so `setuptools_scm` never calls the scheme.
2. `version_file = "spsdk/__version__.py"` ships in the wheel, so `get_spsdk_version()` reads that file instead of falling back to `setuptools_scm.get_version()`.

I left it alone to keep this change minimal. It belongs upstream.

## Test result

The full suite runs with `doCheck` enabled; I disabled nothing and added no `disabledTests` entries.

```
= 5351 passed, 94 skipped, 26 deselected, 1 xfailed, 6 xpassed, 74 warnings in 343.92s (0:05:43) =
```

`versionCheckHook` passes (`spsdk --version` reports 3.9.0) and `pythonImportsCheck` imports `spsdk`. The 26 deselected tests are the three `disabledTests` entries that already existed.

`nixpkgs-review` builds the change for both Python versions:

```
--------- Report for 'x86_64-linux' ---------
2 packages built:
python313Packages.spsdk python314Packages.spsdk
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Assisted-by: Claude Code (claude-opus-5)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

