### PR TITLE
usagi: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5039,6 +5039,12 @@
     githubId = 18648043;
     name = "Daniel Cartwright";
   };
+  chickenchunk = {
+    email = "rhys@tumelty.co.uk";
+    name = "Rhys Tumelty";
+    github = "ChickenChunk579";
+    githubId = 87714759;
+  };
   Chili-Man = {
     email = "dr.elhombrechile@gmail.com";
     name = "Diego Rodriguez";

--- a/pkgs/by-name/us/usagi/package.nix
+++ b/pkgs/by-name/us/usagi/package.nix
@@ -1,0 +1,83 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+  pkg-config,
+  zlib,
+  cmake,
+
+  nix-update-script,
+  versionCheckHook,
+
+  libx11,
+  libxrandr,
+  libxinerama,
+  libxcursor,
+  libxi,
+  libglvnd,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "usagi";
+  version = "1.3.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "brettchalupa";
+    repo = "usagi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bGGcbkQIsJwRHhg0pizwq0Xfo11TkfTz1OWKke8Aj4E=";
+  };
+
+  cargoHash = "sha256-Tymk8PwkKumfMSR06CmiQ47nnldWuSiNwMwCyEwXgEs=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    zlib
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libx11
+    libxrandr
+    libxinerama
+    libxcursor
+    libxi
+    libglvnd
+  ];
+
+  checkFlags = [
+    # skip tests that require networking
+    "--skip=templates::tests::download_errors_on_404_with_status_and_url"
+    "--skip=templates::tests::download_then_extract_then_locate_round_trip"
+    "--skip=templates::tests::download_with_verify_errors_on_hash_mismatch"
+    "--skip=templates::tests::download_with_verify_errors_when_sidecar_missing"
+    "--skip=templates::tests::download_with_verify_passes_when_sidecar_matches"
+    "--skip=templates::tests::download_writes_response_body_to_dest"
+    "--skip=templates::tests::ensure_cached_fetches_extracts_on_cold_cache"
+    "--skip=templates::tests::ensure_cached_forces_redownload_when_no_cache"
+    "--skip=templates::tests::ensure_cached_surfaces_404_with_helpful_hint"
+  ];
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux "patchelf --add-rpath ${
+    lib.makeLibraryPath [ libglvnd ]
+  } $out/bin/usagi";
+
+  passthru.updateScript = nix-update-script { };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "2D game engine for making pixel art games in Lua 5.5";
+    homepage = "https://usagiengine.com";
+    changelog = "https://usagiengine.com/changelog";
+    license = lib.licenses.unlicense;
+    mainProgram = "usagi";
+    maintainers = with lib.maintainers; [ chickenchunk ];
+  };
+})


### PR DESCRIPTION
Add "usagi" as a package at version 1.3.0, and myself as a maintainer.

Usagi is a simple 2D game engine for rapid prototyping.

Continuation of #553332 after i accidentally messed up history.

[Source Code](https://codeberg.org/brettchalupa/usagi)
[Homepage](https://usagiengine.com)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test