### PR TITLE
creality-print: init at 7.2.1

### DIFF
--- a/pkgs/by-name/cr/creality-print/package.nix
+++ b/pkgs/by-name/cr/creality-print/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  fontconfig,
+  libdeflate,
+  libsoup_3,
+  webkitgtk_4_1,
+  zstd,
+}:
+
+let
+  pname = "creality-print";
+  version = "7.2.1";
+  upstreamVersion = "${version}.5476";
+
+  src = fetchurl {
+    url = "https://github.com/CrealityOfficial/CrealityPrint/releases/download/v${version}/CrealityPrint-V${upstreamVersion}-x86_64-Release.AppImage";
+    hash = "sha256-so9mwl0MZlLtauSdB2Z4D0aluDm5POGWjmOYI+H24vM=";
+  };
+
+  # Creality statically links FreeType 2.12.1. Fontconfig 2.18 resolves
+  # against that copy and crashes while wxWidgets registers its private font.
+  fontconfigCompat = fontconfig.overrideAttrs (oldAttrs: {
+    version = "2.17.1";
+    src = fetchurl {
+      url = "https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/2.17.1/fontconfig-2.17.1.tar.xz";
+      hash = "sha256-n1yuk/T//B+8Ba6ZzfxwjNYN/WYS/8BRKCcCXAJvpUE=";
+    };
+    postInstall = oldAttrs.postInstall + ''
+      substituteInPlace "$out/etc/fonts/fonts.conf" \
+        --replace-fail '/etc/fonts/conf.d' "$out/etc/fonts/conf.d"
+    '';
+  });
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      substituteInPlace "$out/AppRun" \
+        --replace-fail 'export LD_LIBRARY_PATH="$DIR/bin:$DIR/usr/lib"' \
+        'export LD_LIBRARY_PATH="$DIR/bin:$DIR/usr/lib:/usr/lib64"'
+    '';
+  };
+in
+appimageTools.wrapAppImage {
+  inherit pname version;
+  src = appimageContents;
+
+  profile = ''
+    export FONTCONFIG_FILE=${fontconfigCompat.out}/etc/fonts/fonts.conf
+    export WEBKIT_DISABLE_COMPOSITING_MODE=1
+    export WEBKIT_DISABLE_DMABUF_RENDERER=1
+  '';
+
+  extraPkgs = _: [
+    fontconfigCompat
+    libdeflate
+    libsoup_3
+    webkitgtk_4_1
+    zstd
+  ];
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/CrealityPrint.desktop \
+      $out/share/applications/CrealityPrint.desktop
+    install -Dm444 ${appimageContents}/CrealityPrint.png \
+      $out/share/icons/hicolor/192x192/apps/CrealityPrint.png
+    substituteInPlace $out/share/applications/CrealityPrint.desktop \
+      --replace-fail 'Exec=AppRun %F' 'Exec=${pname} %F'
+  '';
+
+  passthru = { inherit src; };
+
+  meta = {
+    description = "Slicer for Creality FDM 3D printers";
+    homepage = "https://github.com/CrealityOfficial/CrealityPrint";
+    changelog = "https://github.com/CrealityOfficial/CrealityPrint/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ asamonik ];
+    mainProgram = pname;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Packages creality-print, a slicer software used by creality 3d printers. supersedes #308854


## Ai disclosue

Derivation was developed with assistance from gpt 5.6 sol. I manually checked the implementation and the test results. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
