### PR TITLE
R: prepend instead of overriding TCLLIBPATH

### DIFF
--- a/pkgs/by-name/r/R/package.nix
+++ b/pkgs/by-name/r/R/package.nix
@@ -163,8 +163,8 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + ''
     )
-    echo >>etc/Renviron.in "TCLLIBPATH=${tk}/lib"
-    echo >>etc/Renviron.in "TZDIR=${tzdata}/share/zoneinfo"
+    echo >>etc/Renviron.in 'TCLLIBPATH="${tk}/lib ''${TCLLIBPATH}"'
+    echo >>etc/Renviron.in 'TZDIR=${tzdata}/share/zoneinfo'
   '';
 
   installTargets = [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -854,7 +854,6 @@ let
       cargo
       rustc
     ];
-    rpanel = [ pkgs.tclPackages.bwidget ];
     rrd = [ pkgs.pkg-config ];
     rsamplr = with pkgs; [
       cargo
@@ -2790,12 +2789,13 @@ let
     });
 
     rpanel = old.rpanel.overrideAttrs (attrs: {
-      preConfigure = ''
-        export TCLLIBPATH="${pkgs.tclPackages.bwidget}/lib/bwidget${pkgs.tclPackages.bwidget.version}"
+      postPatch = ''
+        cat >> R/zzz.R <<EOF
+        .onLoad <- function(...) {
+          tcltk::tcl("lappend", "auto_path", "${pkgs.tclPackages.bwidget}/lib/bwidget${pkgs.tclPackages.bwidget.version}")
+        }
+        EOF
       '';
-      env = (attrs.env or { }) // {
-        TCLLIBPATH = "${pkgs.tclPackages.bwidget}/lib/bwidget${pkgs.tclPackages.bwidget.version}";
-      };
     });
 
     rstan = old.rstan.overrideAttrs (attrs: {


### PR DESCRIPTION
This way you can *actually* load Tcl packages other than `Tk`.
If `TCLLIBPATH` is unset, we'll get a stray space after ${tk}/lib, but AFAICT Tcl ignores it.

---

The 2nd commit is partially related:
previously, TCLLIBPATH was ignored so the override basically did nothing.
I *could* have just utilized the fact that the previous commit fixed `TCLLIBPATH` and just added `bwidget` as a propagatedBuildInput (because `bwidget` automatically adds itself to `TCLLIBPATH`).
But we gotta be careful with things like this, as that solution wouldn't have worked with e.g. rWrapper, which doesn't respect the `TCLLIBPATH` that gets set via propagation.

In any case, bwidget is no longer *required* for rpanel, only optional, but I set it so that we have an example of what a solution might look like.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
