### PR TITLE
home-assistant-custom-components.volkswagencarnet: 5.4.12 -> 5.5.1

### DIFF
--- a/pkgs/development/python-modules/volkswagencarnet/default.nix
+++ b/pkgs/development/python-modules/volkswagencarnet/default.nix
@@ -5,6 +5,7 @@
   setuptools-scm,
   aiohttp,
   beautifulsoup4,
+  json5,
   lxml,
   pyjwt,
   freezegun,
@@ -14,17 +15,22 @@
 
 buildPythonPackage rec {
   pname = "volkswagencarnet";
-  version = "5.4.11";
+  version = "5.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "robinostlund";
     repo = "volkswagencarnet";
     tag = "v${version}";
-    hash = "sha256-Ria6+dlxV0VA7zXb1eL0TgblxlUjRTYYgDaj/727eCA=";
+    hash = "sha256-0jjshQOqrqks0M3b6wXcF50iHZG7RmWSWvUt/Vsjtp8=";
   };
 
   postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=84.0.0" setuptools \
+      --replace-fail "setuptools_scm>=10.2.1" setuptools_scm \
+      --replace-fail "wheel>=0.48.0" wheel
+
     substituteInPlace tests/conftest.py \
       --replace-fail 'pytest_plugins = ["pytest_cov"]' 'pytest_plugins = []'
   '';
@@ -34,6 +40,7 @@ buildPythonPackage rec {
   dependencies = [
     aiohttp
     beautifulsoup4
+    json5
     lxml
     pyjwt
   ];

--- a/pkgs/development/python-modules/volkswagencarnet/default.nix
+++ b/pkgs/development/python-modules/volkswagencarnet/default.nix
@@ -13,7 +13,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "volkswagencarnet";
   version = "5.5.1";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "robinostlund";
     repo = "volkswagencarnet";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0jjshQOqrqks0M3b6wXcF50iHZG7RmWSWvUt/Vsjtp8=";
   };
 
@@ -54,10 +54,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/robinostlund/volkswagencarnet/releases/tag/${src.tag}";
+    changelog = "https://github.com/robinostlund/volkswagencarnet/releases/tag/${finalAttrs.src.tag}";
     description = "Python library for volkswagen carnet";
     homepage = "https://github.com/robinostlund/volkswagencarnet";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/servers/home-assistant/custom-components/volkswagencarnet/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/volkswagencarnet/package.nix
@@ -10,13 +10,13 @@
 buildHomeAssistantComponent rec {
   owner = "robinostlund";
   domain = "volkswagencarnet";
-  version = "5.4.12";
+  version = "5.5.1";
 
   src = fetchFromGitHub {
     owner = "robinostlund";
     repo = "homeassistant-volkswagencarnet";
     tag = "v${version}";
-    hash = "sha256-LtNyzWTyROXYcki/hhExD77Ah6Ka8G8zVLxV4RP0Z1w=";
+    hash = "sha256-2UNLDZLwpVMxdUCIVUlyedTfGxyioCZjMGaE5HK6NHg=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/robinostlund/homeassistant-volkswagencarnet/compare/v5.4.12...v5.5.1

Changelog: https://github.com/robinostlund/homeassistant-volkswagencarnet/releases/tag/v5.5.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
