### PR TITLE
Deprecate grav package and introduce grav_2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -314,6 +314,10 @@
 
 - The `programs.fuse` module, which provides the `fusermount3` executable and the `/etc/fuse.conf` config file, is now opt-in. The obligation to enable it has been shifted to its various consumers (e.g. gvfs, flatpak, appimage, sshfs). This can break fuse consumers at runtime, that don't explicitly declare that dependency with a module, e.g the mounting functionality in various backup tools (borg, restic, rclone, ...).
 
+- The [Grav CMS][https://getgrav.org/] package `grav` is now deprecated and users are directed to `grav_2`.
+  Migrating sites to Grav 2 is a [manual process](https://learn.getgrav.org/20/migration/manual-migration) with this package since the migration plugin cannot modify the Nix store.
+  The [`services.grav.package`](#opt-services.grav.package) option defaults to `pkgs.grav_2` if [`system.stateVersion`](#opt-system.stateVersion) >=26.11.
+
 - `services.plausible` can now again seed an initial admin user declaratively via [`services.plausible.adminUser.email`](#opt-services.plausible.adminUser.email).
   This makes fully declarative deployments safer: Otherwise the user needed to either accept Plausible's unauthenticated "first launch" setup wizard, which lets anyone reaching the instance create the first admin account, or do more work (deploying with NixOS's default binding to `localhost` without exposing it publicly, going through the wizard, and then deploying Plausible exposed to the Internet).
   This option was previously removed with NixOS 25.05 due to an upstream Plausible change making declarative admin creation more difficult, but this change re-implements the admin creation directly.

--- a/nixos/modules/services/web-apps/grav.nix
+++ b/nixos/modules/services/web-apps/grav.nix
@@ -40,7 +40,21 @@ in
   options.services.grav = {
     enable = mkEnableOption "grav";
 
-    package = mkPackageOption pkgs "grav" { };
+    package =
+      let
+        stateVersionAtLeast = lib.versionAtLeast config.system.stateVersion;
+      in
+      mkPackageOption pkgs "grav" {
+        default = if stateVersionAtLeast "26.11" then "grav_2" else "grav";
+      }
+      // {
+        defaultText = lib.literalExpression ''
+          if versionAtLeast config.system.stateVersion "26.11" then
+            pkgs.grav_2
+          else
+            pkgs.grav
+        '';
+      };
 
     root = mkOption {
       type = types.path;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -783,7 +783,6 @@ in
   grafana = handleTest ./grafana { };
   grafana-to-ntfy = runTest ./grafana-to-ntfy.nix;
   graphite = runTest ./graphite.nix;
-  grav = runTest ./web-apps/grav.nix;
   graylog = runTest ./graylog.nix;
   greetd-no-shadow = runTest ./greetd-no-shadow.nix;
   grocy = runTest ./grocy.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -783,6 +783,7 @@ in
   grafana = handleTest ./grafana { };
   grafana-to-ntfy = runTest ./grafana-to-ntfy.nix;
   graphite = runTest ./graphite.nix;
+  grav = runTest ./web-apps/grav.nix;
   graylog = runTest ./graylog.nix;
   greetd-no-shadow = runTest ./greetd-no-shadow.nix;
   grocy = runTest ./grocy.nix;

--- a/nixos/tests/web-apps/grav.nix
+++ b/nixos/tests/web-apps/grav.nix
@@ -1,12 +1,15 @@
-{ pkgs, ... }:
+{ ... }:
 {
   name = "grav";
 
-  nodes = {
+  containers = {
     machine =
       { pkgs, ... }:
       {
-        services.grav.enable = true;
+        services.grav = {
+          enable = true;
+          package = pkgs.grav_2;
+        };
       };
   };
 
@@ -17,7 +20,7 @@
 
     # The first request to a fresh install should result in a redirect to the
     # admin page, where the user is expected to set up an admin user.
-    actual = machine.succeed("curl -v --stderr - http://localhost/", timeout=10).splitlines()
+    actual = machine.succeed("curl -v --stderr - http://localhost/").splitlines()
     expected = "< Location: /admin"
     assert expected in actual, \
       f"unexpected reply from Grav: '{actual}'"

--- a/pkgs/by-name/gr/grav/package.nix
+++ b/pkgs/by-name/gr/grav/package.nix
@@ -2,7 +2,6 @@
   stdenvNoCC,
   lib,
   fetchzip,
-  nixosTests,
 }:
 
 let
@@ -12,6 +11,10 @@ stdenvNoCC.mkDerivation {
   pname = "grav";
   inherit version;
 
+  # This is the final version in the version 1 series. If any patch release
+  # occurs, it should be manually updated.
+  #
+  # nixpkgs-update: no auto update
   src = fetchzip {
     url = "https://github.com/getgrav/grav/releases/download/${version}/grav-admin-v${version}.zip";
     hash = "sha256-6cQotHwIwWFR5phFQI9r79jpd+iYA1HpFBbYIzEVBsc=";
@@ -30,14 +33,26 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    grav = nixosTests.grav;
-  };
-
   meta = {
     description = "Fast, simple, and flexible, file-based web platform";
     homepage = "https://getgrav.com";
     maintainers = with lib.maintainers; [ rycee ];
     license = lib.licenses.mit;
+    knownVulnerabilities = [
+      ''
+        Grav 1 contains a number of known vulnerabilities, please upgrade to Grav 2.
+        This can be done by following the migration instructions[1].
+
+        Note, unfortunately using the automatic migration plugin does not work
+        since it cannot write to the Nix store.
+
+        If you use the NixOS module, then add
+
+          service.grav.package = pkgs.grav_2;
+
+        to your configuration to use Grav 2 after you have migrated your site.
+
+        [1]: https://learn.getgrav.org/20/migration/manual-migration.''
+    ];
   };
 }

--- a/pkgs/by-name/gr/grav_2/01-nix.patch
+++ b/pkgs/by-name/gr/grav_2/01-nix.patch
@@ -1,0 +1,36 @@
+diff -Nurp grav-src/system/src/Grav/Common/Cache.php grav-src-nixos/system/src/Grav/Common/Cache.php
+--- grav-src/system/src/Grav/Common/Cache.php	1970-01-01 01:00:01.000000000 +0100
++++ grav-src-nixos/system/src/Grav/Common/Cache.php	2024-11-22 15:46:47.481175690 +0100
+@@ -517,7 +517,7 @@ class Cache extends Getters
+ 
+         $output[] = '';
+ 
+-        if (($remove === 'all' || $remove === 'standard') && file_exists($user_config)) {
++        if (($remove === 'all' || $remove === 'standard') && file_exists($user_config) && is_writable($user_config)) {
+             touch($user_config);
+ 
+             $output[] = '<red>Touched: </red>' . $user_config;
+@@ -544,7 +544,7 @@ class Cache extends Getters
+     {
+         $user_config = USER_DIR . 'config/system.yaml';
+ 
+-        if (file_exists($user_config)) {
++        if (file_exists($user_config) && is_writable($user_config)) {
+             touch($user_config);
+         }
+ 
+diff -Nurp grav-src/system/src/Grav/Console/Gpm/SelfupgradeCommand.php grav-src-nixos/system/src/Grav/Console/Gpm/SelfupgradeCommand.php
+--- grav-src/system/src/Grav/Console/Gpm/SelfupgradeCommand.php	1970-01-01 01:00:01.000000000 +0100
++++ grav-src-nixos/system/src/Grav/Console/Gpm/SelfupgradeCommand.php	2024-11-22 16:05:13.752536788 +0100
+@@ -94,6 +94,11 @@ class SelfupgradeCommand extends GpmComm
+         $input = $this->getInput();
+         $io = $this->getIO();
+ 
++        # Adopted from Arch package.
++        $io->error('Grav cannot be upgraded this way as it has been installed with a distribution package.');
++        $io->writeln('Use Nix to upgrade.');
++        return 1;
++
+         if (!class_exists(ZipArchive::class)) {
+             $io->title('GPM Self Upgrade');
+             $io->error('php-zip extension needs to be enabled!');

--- a/pkgs/by-name/gr/grav_2/package.nix
+++ b/pkgs/by-name/gr/grav_2/package.nix
@@ -2,6 +2,7 @@
   stdenvNoCC,
   lib,
   fetchzip,
+  nixosTests,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -32,6 +33,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -R . $out/
     runHook postInstall
   '';
+
+  passthru.tests = {
+    grav = nixosTests.grav;
+  };
 
   meta = {
     description = "Fast, simple, and flexible, file-based web platform";

--- a/pkgs/by-name/gr/grav_2/package.nix
+++ b/pkgs/by-name/gr/grav_2/package.nix
@@ -1,0 +1,42 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "grav";
+  version = "2.0.24";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src =
+    let
+      v = finalAttrs.version;
+    in
+    fetchzip {
+      url = "https://github.com/getgrav/grav/releases/download/${v}/grav-admin-v${v}.zip";
+      hash = "sha256-Plow++quy9/77wVr/Thz6QcFAn+rIJercbUdhKDe0Qs=";
+    };
+
+  patches = [
+    # Disables functionality that attempts to edit files in Nix store. Also adds
+    # a block of the self-upgrade command.
+    ./01-nix.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/
+    cp -R . $out/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fast, simple, and flexible, file-based web platform";
+    homepage = "https://getgrav.com";
+    maintainers = with lib.maintainers; [ rycee ];
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
This introduces a new package `grav_2` replacing the `grav` package. The grav module is updated to use the `grav_2` from state version 26.11 onward. Note, migration is a manual process.

Fixes: #560184
Fixes: #560176
Fixes: #560708
Fixes: #542127
Fixes: #519389
Fixes: #534939
Fixes: #519369
Fixes: #519381
Fixes: #519357
Fixes: #537325
Fixes: #519365
Fixes: #519372
Fixes: #519380
Fixes: #519370
Fixes: #519713
Fixes: #519392
Fixes: #519377

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
