### PR TITLE
minimal-bootstrap: Ensure packages are not newer than top-level packages

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -20,11 +20,18 @@
 let
   inherit (import ./common.nix { inherit lib; }) meta;
   pname = "binutils-static";
-  version = "2.47";
+  # TODO: need to set version to 2.46, but binutils tarball is named as
+  # "2.46.0"
+  # This is due to a mismatch between binutils-with-gold, which is
+  # named as 2.46. The top-level package follows binutils-with-gold,
+  # and the version here is asserted to be older or equal. The version
+  # comparison function from lib considers 2.46.0 to be "newer" than
+  # 2.46.
+  version = "2.46";
 
   src = fetchurl {
-    url = "mirror://gnu/binutils/binutils-${version}.tar.xz";
-    hash = "sha256-FUqyO2AHDo8nATwil38RKUJdZ9HorNbhMBDmF4EeTP8=";
+    url = "mirror://gnu/binutils/binutils-${version}.0.tar.xz";
+    hash = "sha256-11qU9Nc+ekCG91E+Z+Q56Pzcu3Jv/mP0ZhdE5iVrLPI=";
   };
 
   patches = [
@@ -93,7 +100,7 @@ bash.runCommand "${pname}-${version}"
   ''
     # Unpack
     tar xf ${src}
-    cd binutils-${version}
+    cd binutils-${version}.0
 
     # Patch
     ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patches}

--- a/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
@@ -17,11 +17,11 @@
 }:
 let
   pname = "patchelf-static";
-  version = "0.19.1";
+  version = "0.15.2";
 
   src = fetchurl {
     url = "https://github.com/NixOS/patchelf/releases/download/${version}/patchelf-${version}.tar.gz";
-    sha256 = "sha256-SREIco8SDOBbU5k0tBp1AjUDGm34q8a0flev994VCU0=";
+    sha256 = "sha256-DWn63A3rY/5GZlu9qZ6gIJy4G7PWDPVRCE+dvsB8u2w=";
   };
 in
 bash.runCommand "${pname}-${version}"

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -877,6 +877,7 @@ in
     assert isBuiltByNixpkgsCompiler prevStage.coreutils;
     assert isBuiltByNixpkgsCompiler prevStage.gnugrep;
     assert isBuiltByNixpkgsCompiler prevStage.patchelf;
+    assert stage0.checkBootstrapPackages prevStage;
     {
       inherit (prevStage) config overlays stdenv;
     }

--- a/pkgs/stdenv/linux/stage0.nix
+++ b/pkgs/stdenv/linux/stage0.nix
@@ -10,6 +10,14 @@ let
     "x86_64-linux"
   ];
   minbootSupported = builtins.elem localSystem.system minbootSupportedSystems;
+  checkVersion =
+    topPackage: bootPackage:
+    let
+      versionOk = lib.versionAtLeast topPackage.version bootPackage.version;
+    in
+    lib.warnIfNot versionOk
+      "stdenv stage0: minimal-bootstrap.${bootPackage.pname} ${bootPackage.version} is newer than pkgs.${topPackage.pname} ${topPackage.version}"
+      versionOk;
 in
 if minbootSupported then
   let
@@ -94,6 +102,27 @@ if minbootSupported then
       };
     };
     bash = minimal-bootstrap.bash-static;
+    checkBootstrapPackages =
+      toplevelPkgs:
+      with minimal-bootstrap;
+      (localSystem.libc == "glibc" -> checkVersion toplevelPkgs.glibc glibc)
+      && checkVersion toplevelPkgs.musl musl-static
+      && checkVersion toplevelPkgs.bash bash-static
+      && checkVersion toplevelPkgs.binutils binutils-static
+      && checkVersion toplevelPkgs.bzip2 bzip2-static
+      && checkVersion toplevelPkgs.gcc compilerPackage
+      && checkVersion toplevelPkgs.coreutils coreutils-static
+      && checkVersion toplevelPkgs.diffutils diffutils-static
+      && checkVersion toplevelPkgs.findutils findutils-static
+      && checkVersion toplevelPkgs.gawk gawk-static
+      && checkVersion toplevelPkgs.gnugrep gnugrep-static
+      && checkVersion toplevelPkgs.gnumake gnumake-static
+      && checkVersion toplevelPkgs.gnupatch gnupatch-static
+      && checkVersion toplevelPkgs.gnused gnused-static
+      && checkVersion toplevelPkgs.gnutar gnutar-static
+      && checkVersion toplevelPkgs.gzip gzip-static
+      && checkVersion toplevelPkgs.patchelf patchelf-static
+      && checkVersion toplevelPkgs.xz xz-static;
     initialPath = with minimal-bootstrap; [
       bash-static
       binutils-static
@@ -184,4 +213,7 @@ else
     bash = bootstrapTools;
     initialPath = [ bootstrapTools ];
     disallowedInFinalStdenv = [ bootstrapTools ];
+
+    # no-op. We don't have eval-time version information on bootstrap packages here.
+    checkBootstrapPackages = _: true;
   }


### PR DESCRIPTION
Follow-up to #552117, to prevent future regressions caused by minimal-bootstrap packages getting ahead of top-level versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
