### PR TITLE
home-assistant-custom-components.homewhiz: init at 0.5.25

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/homewhiz/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/homewhiz/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+
+  aiohttp,
+  awsiotsdk,
+  bleak,
+  bleak-retry-connector,
+  bidict,
+  dacite,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "home-assistant-HomeWhiz";
+  domain = "homewhiz";
+  version = "0.5.25";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-HomeWhiz";
+    repo = "home-assistant-HomeWhiz";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rqjP09J1YPH2gSwFvgZBGGjRMwzcpjx83iCqDepbDY8=";
+  };
+
+  dependencies = [
+    aiohttp
+    awsiotsdk
+    bidict
+    bleak
+    bleak-retry-connector
+    dacite
+  ];
+
+  meta = {
+    changelog = "https://github.com/home-assistant-HomeWhiz/home-assistant-HomeWhiz/releases/tag/${finalAttrs.src.tag}";
+    description = "Home Assistant custom component for devices that can connect to HomeWhiz mobile app (Beko, Grundig, Arcelik)";
+    homepage = "https://github.com/home-assistant-HomeWhiz/home-assistant-HomeWhiz";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rdk31 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
