### PR TITLE
anilibria-winmaclinux: fix darwin build

### DIFF
--- a/pkgs/by-name/an/anilibria-winmaclinux/package.nix
+++ b/pkgs/by-name/an/anilibria-winmaclinux/package.nix
@@ -11,6 +11,7 @@
   makeDesktopItem,
   copyDesktopItems,
   mpv-unwrapped,
+  makeWrapper,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,7 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./0001-disable-version-check.patch
     (fetchpatch {
-      name = "0002-fixed-qt6-folder-modal.patch";
+      # https://github.com/anilibria/anilibria-winmaclinux/pull/231
+      name = "0002-do_not_override_pkg-config_when_building_via_nix.patch";
+      url = "https://github.com/anilibria/anilibria-winmaclinux/commit/5ce7429c35fb05334496b5a200058b7952e9aef6.patch";
+      hash = "sha256-OgQLOmHnRZiyH11YIoCx1XeIVLi6wWdoeuV9K80Lgio=";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      name = "0003-fixed-qt6-folder-modal.patch";
       url = "https://github.com/anilibria/anilibria-winmaclinux/commit/adb4f7e5447d733fc3042f4bff25224ed726f3e6.patch";
       hash = "sha256-6/oXAObmXS+GKjjLNneMIj2gtKNvz6zHshWDYPv4agY=";
       stripLen = 1;
@@ -57,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     qt6Packages.wrapQtAppsHook
     copyDesktopItems
+    makeWrapper
   ];
 
   buildInputs = [
@@ -72,6 +81,12 @@ stdenv.mkDerivation (finalAttrs: {
     gst-libav
     gstreamer
   ]);
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir $out/Applications
+    mv $out/AniLiberty.app $out/Applications/
+    makeWrapper $out/Applications/AniLiberty.app/Contents/MacOS/AniLiberty $out/bin/${finalAttrs.meta.mainProgram}
+  '';
 
   desktopItems = [
     (makeDesktopItem {


### PR DESCRIPTION
1. fixed build for darwin
2. added postInstall phase to add compat with nix run (and move binary to more appropriate place (as i understand)

tests:
* build tested on github ci
* build and application functionality itself tested on real device (not mine)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
