### PR TITLE
python3Packages.fastmcp-slim: fix Python 3.14 partial hints

### DIFF
--- a/pkgs/development/python-modules/fastmcp-slim/default.nix
+++ b/pkgs/development/python-modules/fastmcp-slim/default.nix
@@ -1,6 +1,8 @@
 {
   lib,
   buildPythonPackage,
+  fetchpatch,
+  pythonAtLeast,
   fastmcp,
 
   # build-system
@@ -40,6 +42,9 @@
   uvicorn,
   watchfiles,
   websockets,
+
+  # tests
+  anyio,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -47,6 +52,17 @@ buildPythonPackage (finalAttrs: {
   inherit (fastmcp) version src;
   sourceRoot = "${finalAttrs.src.name}/fastmcp_slim";
   pyproject = true;
+
+  patches = [
+    # Fix python 3.14 compatibility (https://github.com/PrefectHQ/fastmcp/pull/4796)
+    # TODO: remove when updating to the next release
+    (fetchpatch {
+      url = "https://github.com/PrefectHQ/fastmcp/commit/6be0ac8e15d35ff8f5121266855bc34c1158c9a1.patch";
+      includes = [ "fastmcp/tools/function_tool.py" ];
+      stripLen = 1;
+      hash = "sha256-zAWIPAH7q9pIOmqWIup5DIDpVk1hOEDxdqQt7QuU8oI=";
+    })
+  ];
 
   build-system = [
     hatchling
@@ -119,8 +135,41 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "fastmcp" ];
 
-  # tests are done in fastmcp package
-  doCheck = false;
+  nativeInstallCheckInputs = [
+    anyio
+    griffelib
+    jsonref
+    mcp
+  ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cd "$TMPDIR"
+    python - <<'PY'
+    from functools import partial
+
+    from fastmcp.tools.function_tool import _resolve_param_hints
+
+
+    class Item:
+        pass
+
+
+    async def base(prefix: str, items: list[Item]) -> str:
+        return prefix
+
+
+    hints = _resolve_param_hints(partial(base, "bound"))
+    assert hints["items"] == list[Item]
+    assert "prefix" not in hints
+    PY
+
+    runHook postInstallCheck
+  '';
+
+  # upstream tests are done in fastmcp package
+  doCheck = pythonAtLeast "3.14";
 
   meta = {
     description = "Dependency-slim FastMCP package";


### PR DESCRIPTION
Apply FastMCP's upstream Python 3.14 `functools.partial` type-hint fix to the nested `fastmcp_slim` source tree.

Add a Python 3.14 install check that verifies the unbound `items: list[Item]` annotation is retained while the bound `prefix` parameter is omitted. The existing full-package patch remains unchanged.

Resolves #553478

## Verification

- `nix-build --no-out-link -A python314Packages.fastmcp-slim`
- `nix-build --no-out-link -A python314Packages.fastmcp` (`5787 passed, 8 skipped, 14 xfailed`)
- `nixpkgs-review wip --no-shell --print-result -p python314Packages.fastmcp-slim -p python314Packages.fastmcp`
- `./ci/nixpkgs-vet.sh master`
- `nix-shell --run 'treefmt pkgs/development/python-modules/fastmcp-slim/default.nix'`

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: OpenAI Codex (GPT-5). I reviewed and take responsibility for this contribution.
