### PR TITLE
gloomberb: init at 0.10.4

### DIFF
--- a/pkgs/by-name/gl/gloomberb/disable-autoupdate.patch
+++ b/pkgs/by-name/gl/gloomberb/disable-autoupdate.patch
@@ -1,0 +1,15 @@
+diff --git a/src/updater.ts b/src/updater.ts
+index 7ee2b1d8..5f1d7e3d 100644
+--- a/src/updater.ts
++++ b/src/updater.ts
+@@ -164,6 +164,10 @@ export function detectUpdateAction(
+   execPath = getRuntimeProcess()?.execPath ?? "",
+   argv = getRuntimeProcess()?.argv ?? [],
+ ): UpdateAction | null {
++  // Self-update rewrites the binary in place, which is impossible when running
++  // from the read-only Nix store. Disable it for nixpkgs builds.
++  if (execPath.includes("/nix/store/")) return null;
++
+   if (isMacAppBundleExecutable(execPath)) return null;
+   if (isBundledDesktopTuiRuntime(execPath, argv)) return null;
+ 

--- a/pkgs/by-name/gl/gloomberb/package.nix
+++ b/pkgs/by-name/gl/gloomberb/package.nix
@@ -1,0 +1,180 @@
+{
+  lib,
+  stdenv,
+  bun,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+let
+  # bun build --compile embeds the OpenTUI native package matching the
+  # platform the binary runs on (stdenv.hostPlatform); this mirrors how
+  # upstream scripts/build.ts picks it.
+  nativePackageFor =
+    {
+      x86_64-linux = {
+        target = "bun-linux-x64";
+        nativePackage = "@opentui/core-linux-x64";
+      };
+      aarch64-linux = {
+        target = "bun-linux-arm64";
+        nativePackage = "@opentui/core-linux-arm64";
+      };
+      x86_64-darwin = {
+        target = "bun-darwin-x64";
+        nativePackage = "@opentui/core-darwin-x64";
+      };
+      aarch64-darwin = {
+        target = "bun-darwin-arm64";
+        nativePackage = "@opentui/core-darwin-arm64";
+      };
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "gloomberb: Platform ${stdenv.hostPlatform.system} is not packaged yet.");
+
+  node_modules =
+    finalAttrs:
+    stdenv.mkDerivation {
+      pname = "${finalAttrs.pname}-node_modules";
+      inherit (finalAttrs) version src;
+
+      nativeBuildInputs = [
+        bun
+        writableTmpDirAsHomeHook
+      ];
+
+      dontConfigure = true;
+
+      buildPhase = ''
+        runHook preBuild
+
+        export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+        bun install \
+          --cpu="*" \
+          --frozen-lockfile \
+          --ignore-scripts \
+          --no-progress \
+          --os="*"
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -R ./node_modules $out/
+
+        runHook postInstall
+      '';
+
+      # The node_modules output is a fixed-output derivation so it can be
+      # fetched offline; the hash covers every platform's native packages
+      # fetched via --cpu="*" --os="*".
+      dontFixup = true;
+
+      outputHash = "sha256-ID6AwV15r+BvGTfRu7aPZN2cozFqyPO2NhqelcfVDPY=";
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+    };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gloomberb";
+  version = "0.10.4";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "gloom-sh";
+    repo = "gloomberb";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-wGGPV32lk4MteY1gvsR55pL7qtM0TLAapr46zuGr4m4=";
+  };
+
+  patches = [
+    # Self-update rewrites the binary in place; impossible in the read-only
+    # Nix store. Return no update action when running from /nix/store/.
+    ./disable-autoupdate.patch
+  ];
+
+  nativeBuildInputs = [
+    bun
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${node_modules finalAttrs}/node_modules .
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+        runHook preBuild
+
+        mkdir -p dist
+        cat > dist/.gloomberb-compile-entry.ts <<'EOF'
+    import "${nativePackageFor.nativePackage}";
+    import "../src/cli/entry.ts";
+    EOF
+        bun build \
+          --compile \
+          --target=${nativePackageFor.target} \
+          dist/.gloomberb-compile-entry.ts \
+          --outfile=dist/gloomberb
+
+        runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ./dist/gloomberb $out/bin/gloomberb
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    codesign --force --sign - $out/bin/gloomberb
+  '';
+
+  # strip removes the embedded JS bundle from the binary
+  dontStrip = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgramArg = "version";
+
+  doInstallCheck = true;
+
+  passthru = {
+    node_modules = node_modules finalAttrs;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "node_modules"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Open-source finance terminal";
+    homepage = "https://github.com/gloom-sh/gloomberb";
+    changelog = "https://github.com/gloom-sh/gloomberb/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ repparw ];
+    mainProgram = "gloomberb";
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
Add [gloomberb](https://github.com/gloom-sh/gloomberb), an open-source finance terminal (Bloomberg-style TUI), following the same packaging pattern as `opencode` / `filen-cli`:

- a fixed-output `node_modules` derivation that runs `bun install --frozen-lockfile` with `--os=* --cpu=*` (single hash across platforms),
- then `bun build --compile`, embedding the `@opentui/core` native package for the build platform.

Smoke-checked via `versionCheckHook` (`gloomberb version` → `0.10.4`) and the upstream OpenTUI native smoke command. `--os=* --cpu=*` keeps a single `node_modules` hash across `x86_64-linux`, `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`; Darwin builds are untested locally (added ad-hoc `codesign` like `opencode`).

> Disclosure: this contribution was prepared with assistance from opencode (deepseek-v4-flash); I reviewed and tested everything before submission. The commit carries the corresponding `Assisted-by:` trailer, per the [Automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
