### PR TITLE
nixos/nebula: Add user & group settings, and assertions for truncated TUN device names

### DIFF
--- a/nixos/modules/services/networking/nebula.nix
+++ b/nixos/modules/services/networking/nebula.nix
@@ -36,7 +36,7 @@ let
       };
       tun = {
         disabled = netCfg.tun.disable;
-        dev = if (netCfg.tun.device != null) then netCfg.tun.device else "nebula.${netName}";
+        dev = netCfg.tun.device;
       };
       firewall = {
         inbound = netCfg.firewall.inbound;
@@ -211,7 +211,7 @@ in
 
                 tun.device = lib.mkOption {
                   type = lib.types.nullOr lib.types.str;
-                  default = null;
+                  default = "nebula.${name}";
                   description = "Name of the tun device. Defaults to nebula.\${networkName}.";
                 };
 
@@ -289,6 +289,17 @@ in
 
   # Implementation
   config = lib.mkIf (enabledNetworks != { }) {
+    assertions = lib.mapAttrsToList (netName: netCfg: {
+      # IFNAMSIZ caps network device names to 16 chars (including NULL terminator).
+      # Without this check, users might end up with a truncated interface name.
+      assertion = !netCfg.tun.disable && builtins.stringLength netCfg.tun.device <= 15;
+      message = ''
+        Network device names can't be longer than 15 chars.
+        `config.services.nebula.networks.${netName}.tun.device` is set to "${netCfg.tun.device}" which is above the limit.
+        Please assign `tun.device` to something shorter.
+      '';
+    }) enabledNetworks;
+
     systemd.services = lib.mkMerge (
       lib.mapAttrsToList (
         netName: netCfg:

--- a/nixos/modules/services/networking/nebula.nix
+++ b/nixos/modules/services/networking/nebula.nix
@@ -75,187 +75,213 @@ in
         description = "Nebula network definitions.";
         default = { };
         type = lib.types.attrsOf (
-          lib.types.submodule {
-            options = {
-              enable = lib.mkOption {
-                type = lib.types.bool;
-                default = true;
-                description = "Enable or disable this network.";
-              };
+          lib.types.submodule (
+            { name, ... }: {
+              options = {
+                enable = lib.mkOption {
+                  type = lib.types.bool;
+                  default = true;
+                  description = "Enable or disable this network.";
+                };
 
-              package = lib.mkPackageOption pkgs "nebula" { };
+                package = lib.mkPackageOption pkgs "nebula" { };
 
-              ca = lib.mkOption {
-                type = lib.types.path;
-                description = "Path to the certificate authority certificate.";
-                example = "/etc/nebula/ca.crt";
-              };
+                ca = lib.mkOption {
+                  type = lib.types.path;
+                  description = "Path to the certificate authority certificate.";
+                  example = "/etc/nebula/ca.crt";
+                };
 
-              cert = lib.mkOption {
-                type = lib.types.path;
-                description = "Path to the host certificate.";
-                example = "/etc/nebula/host.crt";
-              };
+                cert = lib.mkOption {
+                  type = lib.types.path;
+                  description = "Path to the host certificate.";
+                  example = "/etc/nebula/host.crt";
+                };
 
-              key = lib.mkOption {
-                type = lib.types.oneOf [
-                  lib.types.nonEmptyStr
-                  lib.types.path
-                ];
-                description = "Path or reference to the host key.";
-                example = "/etc/nebula/host.key";
-              };
+                key = lib.mkOption {
+                  type = lib.types.oneOf [
+                    lib.types.nonEmptyStr
+                    lib.types.path
+                  ];
+                  description = "Path or reference to the host key.";
+                  example = "/etc/nebula/host.key";
+                };
 
-              enableReload = lib.mkOption {
-                type = lib.types.bool;
-                default = false;
-                description = ''
-                  Enable automatic config reload on config change.
-                  This setting is not enabled by default as nix cannot determine if the config change is reloadable.
-                  Please refer to the [config reference](https://nebula.defined.net/docs/config/) for documentation on reloadable changes.
-                '';
-              };
+                enableReload = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = ''
+                    Enable automatic config reload on config change.
+                    This setting is not enabled by default as nix cannot determine if the config change is reloadable.
+                    Please refer to the [config reference](https://nebula.defined.net/docs/config/) for documentation on reloadable changes.
+                  '';
+                };
 
-              staticHostMap = lib.mkOption {
-                type = lib.types.attrsOf (lib.types.listOf (lib.types.str));
-                default = { };
-                description = ''
-                  The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).
-                  A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel.
-                '';
-                example = {
-                  "192.168.100.1" = [ "100.64.22.11:4242" ];
+                staticHostMap = lib.mkOption {
+                  type = lib.types.attrsOf (lib.types.listOf (lib.types.str));
+                  default = { };
+                  description = ''
+                    The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).
+                    A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel.
+                  '';
+                  example = {
+                    "192.168.100.1" = [ "100.64.22.11:4242" ];
+                  };
+                };
+
+                isLighthouse = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = "Whether this node is a lighthouse.";
+                };
+
+                isRelay = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = "Whether this node is a relay.";
+                };
+
+                lighthouse.dns.enable = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = "Whether this lighthouse node should serve DNS.";
+                };
+
+                lighthouse.dns.host = lib.mkOption {
+                  type = lib.types.str;
+                  default = "localhost";
+                  description = ''
+                    IP address on which nebula lighthouse should serve DNS.
+                    'localhost' is a good default to ensure the service does not listen on public interfaces;
+                    use a Nebula address like 10.0.0.5 to make DNS resolution available to nebula hosts only.
+                  '';
+                };
+
+                lighthouse.dns.port = lib.mkOption {
+                  type = lib.types.nullOr lib.types.port;
+                  default = 5353;
+                  description = "UDP port number for lighthouse DNS server.";
+                };
+
+                lighthouses = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    List of IPs of lighthouse hosts this node should report to and query from. This should be empty on lighthouse
+                    nodes. The IPs should be the lighthouse's Nebula IPs, not their external IPs.
+                  '';
+                  example = [ "192.168.100.1" ];
+                };
+
+                relays = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    List of IPs of relays that this node should allow traffic from.
+                  '';
+                  example = [ "192.168.100.1" ];
+                };
+
+                listen.host = lib.mkOption {
+                  type = lib.types.str;
+                  default = "0.0.0.0";
+                  description = "IP address to listen on.";
+                };
+
+                listen.port = lib.mkOption {
+                  type = lib.types.nullOr lib.types.port;
+                  default = null;
+                  defaultText = lib.literalExpression ''
+                    if (config.services.nebula.networks.''${name}.isLighthouse ||
+                        config.services.nebula.networks.''${name}.isRelay) then
+                      4242
+                    else
+                      0;
+                  '';
+                  description = "Port number to listen on.";
+                };
+
+                tun.disable = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = ''
+                    When tun is disabled, a lighthouse can be started without a local tun interface (and therefore without root).
+                  '';
+                };
+
+                tun.device = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = "Name of the tun device. Defaults to nebula.\${networkName}.";
+                };
+
+                firewall.outbound = lib.mkOption {
+                  type = lib.types.listOf lib.types.attrs;
+                  default = [ ];
+                  description = "Firewall rules for outbound traffic.";
+                  example = [
+                    {
+                      port = "any";
+                      proto = "any";
+                      host = "any";
+                    }
+                  ];
+                };
+
+                firewall.inbound = lib.mkOption {
+                  type = lib.types.listOf lib.types.attrs;
+                  default = [ ];
+                  description = "Firewall rules for inbound traffic.";
+                  example = [
+                    {
+                      port = "any";
+                      proto = "any";
+                      host = "any";
+                    }
+                  ];
+                };
+
+                settings = lib.mkOption {
+                  type = format.type;
+                  default = { };
+                  description = ''
+                    Nebula configuration. Refer to
+                    <https://github.com/slackhq/nebula/blob/master/examples/config.yml>
+                    for details on supported values.
+                  '';
+                  example = lib.literalExpression ''
+                    {
+                      lighthouse.interval = 15;
+                    }
+                  '';
+                };
+
+                user = lib.mkOption {
+                  type = lib.types.str;
+                  default = nameToId name;
+                  description = ''
+                    User under which the nebula daemon is run for this network.
+
+                    ::: {.note}
+                    A user will be created if this config is left to the default value.
+                    :::
+                  '';
+                };
+
+                group = lib.mkOption {
+                  type = lib.types.str;
+                  default = nameToId name;
+                  description = ''
+                    Group under which the nebula daemon is run for this network.
+
+                    ::: {.note}
+                    The group will be created if this config is left to the default value.
+                    :::
+                  '';
                 };
               };
-
-              isLighthouse = lib.mkOption {
-                type = lib.types.bool;
-                default = false;
-                description = "Whether this node is a lighthouse.";
-              };
-
-              isRelay = lib.mkOption {
-                type = lib.types.bool;
-                default = false;
-                description = "Whether this node is a relay.";
-              };
-
-              lighthouse.dns.enable = lib.mkOption {
-                type = lib.types.bool;
-                default = false;
-                description = "Whether this lighthouse node should serve DNS.";
-              };
-
-              lighthouse.dns.host = lib.mkOption {
-                type = lib.types.str;
-                default = "localhost";
-                description = ''
-                  IP address on which nebula lighthouse should serve DNS.
-                  'localhost' is a good default to ensure the service does not listen on public interfaces;
-                  use a Nebula address like 10.0.0.5 to make DNS resolution available to nebula hosts only.
-                '';
-              };
-
-              lighthouse.dns.port = lib.mkOption {
-                type = lib.types.nullOr lib.types.port;
-                default = 5353;
-                description = "UDP port number for lighthouse DNS server.";
-              };
-
-              lighthouses = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
-                default = [ ];
-                description = ''
-                  List of IPs of lighthouse hosts this node should report to and query from. This should be empty on lighthouse
-                  nodes. The IPs should be the lighthouse's Nebula IPs, not their external IPs.
-                '';
-                example = [ "192.168.100.1" ];
-              };
-
-              relays = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
-                default = [ ];
-                description = ''
-                  List of IPs of relays that this node should allow traffic from.
-                '';
-                example = [ "192.168.100.1" ];
-              };
-
-              listen.host = lib.mkOption {
-                type = lib.types.str;
-                default = "0.0.0.0";
-                description = "IP address to listen on.";
-              };
-
-              listen.port = lib.mkOption {
-                type = lib.types.nullOr lib.types.port;
-                default = null;
-                defaultText = lib.literalExpression ''
-                  if (config.services.nebula.networks.''${name}.isLighthouse ||
-                      config.services.nebula.networks.''${name}.isRelay) then
-                    4242
-                  else
-                    0;
-                '';
-                description = "Port number to listen on.";
-              };
-
-              tun.disable = lib.mkOption {
-                type = lib.types.bool;
-                default = false;
-                description = ''
-                  When tun is disabled, a lighthouse can be started without a local tun interface (and therefore without root).
-                '';
-              };
-
-              tun.device = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
-                default = null;
-                description = "Name of the tun device. Defaults to nebula.\${networkName}.";
-              };
-
-              firewall.outbound = lib.mkOption {
-                type = lib.types.listOf lib.types.attrs;
-                default = [ ];
-                description = "Firewall rules for outbound traffic.";
-                example = [
-                  {
-                    port = "any";
-                    proto = "any";
-                    host = "any";
-                  }
-                ];
-              };
-
-              firewall.inbound = lib.mkOption {
-                type = lib.types.listOf lib.types.attrs;
-                default = [ ];
-                description = "Firewall rules for inbound traffic.";
-                example = [
-                  {
-                    port = "any";
-                    proto = "any";
-                    host = "any";
-                  }
-                ];
-              };
-
-              settings = lib.mkOption {
-                type = format.type;
-                default = { };
-                description = ''
-                  Nebula configuration. Refer to
-                  <https://github.com/slackhq/nebula/blob/master/examples/config.yml>
-                  for details on supported values.
-                '';
-                example = lib.literalExpression ''
-                  {
-                    lighthouse.interval = 15;
-                  }
-                '';
-              };
-            };
-          }
+            }
+          )
         );
       };
     };
@@ -267,7 +293,6 @@ in
       lib.mapAttrsToList (
         netName: netCfg:
         let
-          networkId = nameToId netName;
           settings = genSettings netName netCfg;
           generatedConfigFile = genConfigFile netName settings;
           configFile =
@@ -328,8 +353,8 @@ in
               ProtectSystem = true;
               RestrictNamespaces = true;
               RestrictSUIDSGID = true;
-              User = networkId;
-              Group = networkId;
+              User = netCfg.user;
+              Group = netCfg.group;
             };
             unitConfig.StartLimitIntervalSec = 0; # ensure Restart=always is always honoured (networks can go down for arbitrarily long)
           };
@@ -343,7 +368,7 @@ in
           "nebula/${netName}.yml" = {
             source = genConfigFile netName (genSettings netName netCfg);
             mode = "0440";
-            user = nameToId netName;
+            user = netCfg.user;
           };
         })
         (
@@ -362,19 +387,25 @@ in
 
     # Create the service users and groups.
     users.users = lib.mkMerge (
-      lib.mapAttrsToList (netName: netCfg: {
-        ${nameToId netName} = {
-          group = nameToId netName;
-          description = "Nebula service user for network ${netName}";
-          isSystemUser = true;
-        };
-      }) enabledNetworks
+      lib.mapAttrsToList (
+        netName: netCfg:
+        lib.optionalAttrs (netCfg.user == nameToId netName) {
+          ${nameToId netName} = {
+            group = netCfg.group;
+            description = "Nebula service user for network ${netName}";
+            isSystemUser = true;
+          };
+        }
+      ) enabledNetworks
     );
 
     users.groups = lib.mkMerge (
-      lib.mapAttrsToList (netName: netCfg: {
-        ${nameToId netName} = { };
-      }) enabledNetworks
+      lib.mapAttrsToList (
+        netName: netCfg:
+        lib.optionalAttrs (netCfg.group == nameToId netName) {
+          ${nameToId netName} = { };
+        }
+      ) enabledNetworks
     );
   };
 


### PR DESCRIPTION
Added settings for `services.nebula.networks.<name>.user` and  `services.nebula.networks.<name>.group`, which default to the same values as before this commit.

Also adds assertions against  `services.nebula.networks.<name>.tun.device` to prevent surprises where the device name gets truncated to 15 chars. Maybe this should be a warning instead ?

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
