### PR TITLE
zennotes-desktop: 2.28.2 -> 2.29.0

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.28.2";
-  npmDepsHash = "sha256-t0+Z6kDPRa5wCxkmQfzzXS0Y22s9w8vNXYaxrYlf3+Y=";
+  version = "2.29.0";
+  npmDepsHash = "sha256-Hml6oEZxNY6jK+dEDeA6KxfWa7k3/iqkUtlGRwHkO7U=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kSjCuKYbUaKtCqSTelJ02yO7FMgeTnChItNK1oaAIxc=";
+    hash = "sha256-naLrqLe5ED5c9OWBAlyP+1ar8wrcAxCEVaAsRDnQpgs=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update zennotes-desktop 2.28.2 -> 2.29.0. I'm the upstream author of ZenNotes.

2.29.0 is the block-references release: `[[Note^block-id]]` links now navigate, complete, and embed the exact block (Obsidian's `[[Note#^id]]` spelling included), Typst math gains command completion, task forwarding carries a task's whole subtree, and the self-hosted server grows a workflow API. The desktop package builds from the same workspace as before; no packaging structure changed, only version and hashes.

Hash provenance: the `src` hash was computed with `nix-prefetch-url --unpack` against the `v2.29.0` tag on native `aarch64-linux`, and independently confirmed by the upstream repo's own Nix CI (its fixed-output check reports the same value). `npmDepsHash` was computed with `prefetch-npm-deps` from the tag's `package-lock.json` and matches the value the upstream packaging CI build-verified for this release.

Build verification on native `aarch64-linux`: `nix-build -A zennotes-desktop` with exactly this `package.nix` completed successfully (`/nix/store/...-zennotes-desktop-2.29.0`) and the installed `zennotes-desktop` wrapper is present and executable.

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.29.0

Automation disclosure: this update was prepared with Claude Code; the hashes and the build verification above were produced by real `nix` runs as described.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
