### PR TITLE
factorio: make versions overriding more ergonomic

### DIFF
--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -21,7 +21,8 @@
   wayland,
 
   mods-dat ? null,
-  versionsJson ? ./versions.json,
+  versions ? null,
+  versionsJson ? null,
   username ? "",
   token ? "", # get/reset token at https://factorio.com/profile
   experimental ? false, # true means to always use the latest branch
@@ -36,7 +37,7 @@ assert
 
 let
 
-  inherit (lib) importJSON;
+  inherit (lib) defaultTo importJSON;
 
   mods = args.mods or [ ];
 
@@ -94,7 +95,8 @@ let
 
   # NB `experimental` directs us to take the latest build, regardless of its branch;
   # hence the (stable, experimental) pairs may sometimes refer to the same distributable.
-  versions = importJSON versionsJson;
+  versionsJson = defaultTo ./versions.json args.versionsJson or null;
+  versions = defaultTo (importJSON versionsJson) args.versions or null;
   binDists = makeBinDists versions;
 
   actual =
@@ -212,7 +214,10 @@ let
         $out/bin/factorio
     '';
 
-    passthru.updateScript = ./update.py;
+    passthru = {
+      updateScript = ./update.py;
+      inherit versionsJson versions;
+    };
 
     meta = {
       description = "Game in which you build and maintain factories";


### PR DESCRIPTION
- accept versions in imported attrset form (prioritised)
- expose versions and versionsJson in passthru

Use-case: [overlay that replaces download URLs with a proxy that holds the secrets](<https://codeberg.org/novenary/nicks/src/commit/4a19c2989f199e235e96be9890ba31db2a5bfea0/overlays/factorio/overlay.nix>).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
