### PR TITLE
intel-graphics-compiler: 2.38.2 -> 2.40.13

### DIFF
--- a/pkgs/by-name/in/intel-graphics-compiler/fix-create-directories-to-apply-patches.diff
+++ b/pkgs/by-name/in/intel-graphics-compiler/fix-create-directories-to-apply-patches.diff
@@ -1,0 +1,12 @@
+diff --git a/external/llvm/llvm_patch_sources.cmake b/external/llvm/llvm_patch_sources.cmake
+index 5ffcfb260..0c488aec9 100644
+--- a/igc/external/llvm/llvm_patch_sources.cmake
++++ b/igc/external/llvm/llvm_patch_sources.cmake
+@@ -20,6 +20,7 @@ if(EXISTS "${IGC_LLVM_SOURCE_DIR}")
+ endif()
+ 
+ # Copy stock LLVM sources to IGC_LLVM_SOURCE_DIR to apply patches.
++file(MAKE_DIRECTORY ${IGC_LLVM_WORKSPACE_SRC})
+ message(STATUS "[LLVM] : Copying stock LLVM sources ${IGC_OPTION__LLVM_SOURCES_DIR} to ${IGC_LLVM_SOURCE_DIR}")
+ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${IGC_OPTION__LLVM_SOURCES_DIR}/.git ${IGC_LLVM_WORKSPACE_SRC}/.git)
+ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${IGC_OPTION__LLVM_SOURCES_DIR}/llvm ${IGC_LLVM_SOURCE_DIR})

--- a/pkgs/by-name/in/intel-graphics-compiler/package.nix
+++ b/pkgs/by-name/in/intel-graphics-compiler/package.nix
@@ -10,29 +10,16 @@
   zlib,
   intel-compute-runtime,
   python3,
+  spirv-headers,
   spirv-tools,
 }:
 
 let
   llvmVersion = "17.0.6";
-
-  spirv-headers = stdenv.mkDerivation {
-    pname = "spirv-headers";
-    version = "1.4.341.0-unstable-2026-04-29";
-
-    src = fetchFromGitHub {
-      owner = "KhronosGroup";
-      repo = "SPIRV-Headers";
-      rev = "948a3b0997e2dffea5484b3df7bd5590c5b844cc";
-      hash = "sha256-goQTZ4vR4R+bp3mcco10y4grB97aB7QJauO9ZaHJbU8=";
-    };
-
-    nativeBuildInputs = [ cmake ];
-  };
 in
 stdenv.mkDerivation rec {
   pname = "intel-graphics-compiler";
-  version = "2.38.2";
+  version = "2.40.13";
 
   # See the repository for expected versions:
   # <https://github.com/intel/intel-graphics-compiler/blob/v2.16.0/documentation/build_ubuntu.md#revision-table>
@@ -42,7 +29,7 @@ stdenv.mkDerivation rec {
       owner = "intel";
       repo = "intel-graphics-compiler";
       tag = "v${version}";
-      hash = "sha256-xLRQzXUSqRVAN0flRlcrsSFZTLFxmQi6ePbm5ks6vhI=";
+      hash = "sha256-koc3ee6ItemDkNpWlBhJX8Dr8Wa4Zpvo08LxiR6BNLE=";
     })
     (fetchFromGitHub {
       name = "llvm-project";
@@ -62,15 +49,15 @@ stdenv.mkDerivation rec {
       name = "opencl-clang";
       owner = "intel";
       repo = "opencl-clang";
-      tag = "v17.0.7";
-      hash = "sha256-7kQlH1Y4pnNvj/CS2qAVbYUl9FQWBuMew7i8CpORfKE=";
+      tag = "v17.0.9";
+      hash = "sha256-hnwUBOy+NebhPyBf4GtsXHdzKEWAFsq8sj0ssIlGjtw=";
     })
     (fetchFromGitHub {
       name = "llvm-spirv";
       owner = "KhronosGroup";
       repo = "SPIRV-LLVM-Translator";
-      tag = "v17.0.25";
-      hash = "sha256-WzazByTj9Pnk9ix6cyCtxT8aSh9kg0lK3geiokCqO8I=";
+      tag = "v17.0.26";
+      hash = "sha256-Q3tUr4FjHDjDRCyOqOKyVx29mMz/88POHs2rWnjBGb4=";
     })
   ];
 
@@ -84,6 +71,8 @@ stdenv.mkDerivation rec {
     # warnings within LLVM. This is in accordance with IGC disabling warnings
     # that originate from within LLVM (see `IGC/common/LLVMWarningsPush.hpp`).
     ./gcc15-allow-llvm-free-nonheap-object-warning.patch
+
+    ./fix-create-directories-to-apply-patches.diff
   ];
 
   sourceRoot = ".";
@@ -103,17 +92,14 @@ stdenv.mkDerivation rec {
     chmod +x igc/IGC/Scripts/igc_create_linker_script.sh
     patchShebangs --build igc/IGC/Scripts/igc_create_linker_script.sh
 
-    # The build system only applies patches when the sources are in a
-    # Git repository.
+    # The build system only applies patches when the sources are in a Git repository.
     git -C llvm-project init
-    git -C llvm-project -c user.name=nixbld -c user.email= commit --allow-empty -m stub
+    git -C llvm-project add .
+    git -C llvm-project -c user.name=nixbld -c user.email= commit -m stub
+
     substituteInPlace llvm-project/llvm/projects/opencl-clang/cmake/modules/CMakeFunctions.cmake \
       --replace-fail 'COMMAND ''${GIT_EXECUTABLE} am --3way --keep-non-patch --ignore-whitespace -C0 ' \
-                     'COMMAND patch -p1 --ignore-whitespace -i '
-
-    # match default LLVM version with our provided version to apply correct patches
-    substituteInPlace igc/external/llvm/llvm_preferred_version.cmake \
-      --replace-fail "17.0.6" "${llvmVersion}"
+                     'COMMAND ''${GIT_EXECUTABLE} apply --3way --ignore-whitespace -C0 '
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
