### PR TITLE
phanpy: init at 2026.08.08.e6a2887

### DIFF
--- a/pkgs/by-name/ph/phanpy/package.nix
+++ b/pkgs/by-name/ph/phanpy/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  importNpmLock,
+  env ? { },
+}:
+let
+  commitHash = "e6a2887";
+  # Update this with: `git log -1 --format="%cI" <release tag>`
+  commitTime = "2026-08-08T11:57:34+08:00";
+  versionDate = lib.strings.replaceString "-" "." (lib.lists.head (lib.strings.split "T" commitTime));
+in
+buildNpmPackage (finalAttrs: {
+  pname = "phanpy";
+  version = "${versionDate}.${commitHash}";
+
+  src = fetchFromGitHub {
+    owner = "cheeaun";
+    repo = "phanpy";
+    rev = finalAttrs.version;
+    hash = "sha256-DB/TQAIEgXJajdTrXclbhGP4Ku8BZPpIoUNK8wT48WQ=";
+  };
+
+  npmDepsHash = "sha256-SsH0w4ySRobIwB63jrdg5u4d+5gOcwBYrMr1V2tcUxI=";
+  npmRebuildFlagsArray = [ "--ignore-scripts" ];
+
+  env = {
+    # This makes Vite behave in a sealed environment.
+    CI = true;
+    # The following environment variables are injected because Phanpy's build
+    # step tries to get them with `git`. As the ".git" directory is removed
+    # from the source, this doesn't work.
+    PHANPY_COMMIT_HASH = commitHash;
+    PHANPY_COMMIT_TIME = commitTime;
+    # Set the build time to the same as the commit time, as it will show up in
+    # the settings.
+    PHANPY_BUILD_TIME = commitTime;
+  }
+  // env; # The user-supplied environment variables take precedence.
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Run this part of the post-install script.
+    # We avoid `npm run postinstall` because it tries to download extra dependencies.
+    npm run generate-icons
+
+    # Build with Vite.
+    # We set `NODE_ENV` here, not globally, because we want dev dependencies to be installed.
+    NODE_ENV='production' npm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv ./dist $out
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "A minimalistic opinionated Mastodon web client";
+    homepage = "https://phanpy.social";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      SamirTalwar
+    ];
+  };
+})


### PR DESCRIPTION
Adds the package [Phanpy](https://github.com/cheeaun/phanpy) at version [2026.08.08.e6a2887](https://github.com/cheeaun/phanpy/releases/tag/2026.08.08.e6a2887).

Phanpy is "a minimalistic opinionated Mastodon web client".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
