### PR TITLE
libconfuse: 3.3 -> 3.4

### DIFF
--- a/pkgs/by-name/li/libconfuse/package.nix
+++ b/pkgs/by-name/li/libconfuse/package.nix
@@ -2,33 +2,20 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   flex,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libconfuse";
-  version = "3.3";
+  version = "3.4";
 
   src = fetchFromGitHub {
-    sha256 = "1npfk5jv59kk4n8pkyx89fn9s6p8x3gbffs42jaw24frgxfgp8ca";
-    rev = "v${finalAttrs.version}";
-    repo = "libconfuse";
     owner = "libconfuse";
+    repo = "libconfuse";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-sC8O6vcMKvRdRCTXpKl6lgmzFUVG8/LBE7XsGX8F9e4=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2022-40320.patch";
-      urls = [
-        "https://sources.debian.org/data/main/libc/libconfuse/3.3-3/debian/patches/CVE-2022-40320.patch"
-        # files on sources.debian.org can disappear
-        "https://web.archive.org/web/20230107133212/https://sources.debian.org/data/main/libc/libconfuse/3.3-3/debian/patches/CVE-2022-40320.patch"
-      ];
-      sha256 = "sha256-ftfE9JFz4nyRSOb2xHb9BAtgWn5Yv2WLm4RegDLtiBw=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace tests/Makefile.am \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
