### PR TITLE
nixosTests: do not depend on nix by default

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -92,6 +92,10 @@ cd /my/git/clone/of/nixpkgs
 nix-build -A nixosTests.hostname
 ```
 
+In-tree tests run with a few changes to defaults, notably
+- The `pkgs.*` are read only by default. You can opt out with `node.pkgsReadOnly = false;` at the test level.
+- `nix.enable` defaults to `false` to reduce build closure size; in particular the reverse build closure of `nix` and its dependencies.
+
 ### Testing outside the NixOS project {#sec-call-nixos-test-outside-nixos}
 
 Outside the `nixpkgs` repository, you can use the `runNixOSTest` function from
@@ -109,6 +113,8 @@ pkgs.testers.runNixOSTest {
 ```
 
 `runNixOSTest` returns a derivation that runs the test.
+
+Out-of-tree tests evaluate with a set of defaults that balances the principle of least surprise in the general case, but has a few differences from in-tree NixOS tests. See [Testing within NixOS](#sec-call-nixos-test-in-nixos).
 
 ## Test machines {#ssec-nixos-test-machines}
 

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   utils,
   ...
@@ -201,8 +202,12 @@ let
       --notify-ready=yes \
       --kill-signal=SIGRTMIN+3 \
       --bind-ro=/nix/store:/nix/store$NIX_BIND_OPT \
-      --bind-ro=/nix/var/nix/db:/nix/var/nix/db$NIX_BIND_OPT \
-      --bind-ro=/nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket$NIX_BIND_OPT \
+      ${optionalString config.nix.enable "--bind-ro=/nix/var/nix/db:/nix/var/nix/db$NIX_BIND_OPT"} \
+      ${
+        optionalString (
+          config.nix.enable && config.nix.daemon.enable
+        ) "--bind-ro=/nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket$NIX_BIND_OPT"
+      } \
       --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles$NIX_BIND_OPT" \
       --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots$NIX_BIND_OPT" \
       ${optionalString (!cfg.ephemeral) "--link-journal=try-guest"} \
@@ -994,7 +999,10 @@ in
           mapper =
             name: cfg:
             optional (cfg.networkNamespace != null && (cfg.privateNetwork || cfg.interfaces != [ ]))
-              "containers.${name}.networkNamespace is mutally exclusive to containers.${name}.privateNetwork and containers.${name}.interfaces.";
+              "containers.${name}.networkNamespace is mutally exclusive to containers.${name}.privateNetwork and containers.${name}.interfaces."
+            ++
+              optional (cfg.config.nix.enable && cfg.config.nix.daemon.enable && !config.nix.daemon.enable)
+                "${options.containers}.${strings.escapeNixIdentifier name} requires a Nix daemon but the host does not provided it, as option ${options.nix.daemon.enable} is disabled";
         in
         mkMerge (mapAttrsToList mapper config.containers);
     }

--- a/nixos/tests/activation/nix-channel.nix
+++ b/nixos/tests/activation/nix-channel.nix
@@ -7,6 +7,10 @@
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine = {
+    # - nix.enable gates nix.channel.enable behaviors
+    # - disabled by default. See all-tests.nix / tag(no-nix-by-default)
+    nix.enable = true;
+
     nix.channel.enable = true;
   };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -442,6 +442,10 @@ in
   containers-macvlans = runTest ./containers-macvlans.nix;
   containers-names = runTest ./containers-names.nix;
   containers-nested = runTest ./containers-nested.nix;
+  containers-nested-nix = runTest {
+    imports = [ ./containers-nested.nix ];
+    params.nix = true;
+  };
   containers-physical_interfaces = runTest ./containers-physical_interfaces.nix;
   containers-portforward = runTest ./containers-portforward.nix;
   containers-reloadable = runTest ./containers-reloadable.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -105,6 +105,34 @@ let
       ];
     };
 
+  /**
+    The test framework as exposed through its [other entrypoints] has defaults
+    that are most suitable for external usage.
+
+    This module adjusts it for the particular, important use case of
+    NixOS *as packaged in the nixpkgs repo*.
+
+    [other entrypoints]: https://nixos.org/manual/nixos/stable/#sec-calling-nixos-tests
+  */
+  localTestOverrides =
+    { lib, ... }:
+    {
+      _class = "nixosTest";
+      # for error messages, pseudo-url in no particular format
+      _file = "nixpkgs/nixos/tests/all-tests.nix#localTestOverrides";
+      imports = [
+        ./read-only-pkgs.nix
+      ];
+      extraBaseModules = {
+        _file = "nixpkgs/nixos/tests/all-tests.nix#localTestOverrides-extraBaseModules";
+        # tag(no-nix-by-default): we exclude nix from the tests *here* to keep a
+        #   small reverse closure for nix package updates among other things.
+        #   Out-of-tree usages get nix by default as usual.
+        #   See https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos
+        config.nix.enable = lib.mkDefault false;
+      };
+    };
+
   inherit
     (rec {
       doRunTest =
@@ -112,7 +140,7 @@ let
         ((import ../lib/testing-python.nix { inherit system pkgs; }).evalTest {
           imports = [
             arg
-            ./read-only-pkgs.nix
+            localTestOverrides
           ];
         }).config.result;
       findTests =

--- a/nixos/tests/atticd.nix
+++ b/nixos/tests/atticd.nix
@@ -15,6 +15,8 @@ in
 
   nodes = {
     local = {
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
       services.atticd = {
         enable = true;
 
@@ -27,6 +29,8 @@ in
     };
 
     s3 = {
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
       services.atticd = {
         enable = true;
         settings = {

--- a/nixos/tests/binary-cache.nix
+++ b/nixos/tests/binary-cache.nix
@@ -7,6 +7,9 @@
     { pkgs, ... }:
     {
       imports = [ ../modules/installer/cd-dvd/channel.nix ];
+
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
       environment.systemPackages = with pkgs; [
         openssl
         python3

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -49,6 +49,7 @@ in
         localAddress = containerIp;
         localAddress6 = containerIp6;
         config = {
+          nix.enable = false; # disabled by default on the host. See all-tests.nix / tag(no-nix-by-default)
           services.httpd.enable = true;
           services.httpd.adminAddr = "foo@example.org";
           networking.firewall.allowedTCPPorts = [ 80 ];
@@ -60,6 +61,7 @@ in
         privateNetwork = true;
         hostBridge = "br0";
         config = {
+          nix.enable = false; # disabled by default on the host. See all-tests.nix / tag(no-nix-by-default)
           services.httpd.enable = true;
           services.httpd.adminAddr = "foo@example.org";
           networking.firewall.allowedTCPPorts = [ 80 ];

--- a/nixos/tests/containers-custom-pkgs.nix
+++ b/nixos/tests/containers-custom-pkgs.nix
@@ -37,6 +37,8 @@ in
           {
             nixpkgs.pkgs = customPkgs;
             system.extraDependencies = [ pkgs.hello ];
+
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
       };
     };

--- a/nixos/tests/containers-ephemeral.nix
+++ b/nixos/tests/containers-ephemeral.nix
@@ -26,6 +26,7 @@
             };
           };
           networking.firewall.allowedTCPPorts = [ 80 ];
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
         };
       };
     };

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -63,6 +63,7 @@
         };
         config = {
           networking.firewall.allowedTCPPorts = [ 80 ];
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
         };
       };
 

--- a/nixos/tests/containers-gateway.nix
+++ b/nixos/tests/containers-gateway.nix
@@ -39,9 +39,12 @@ in
       hostBridge = "br0";
       localAddress = containerIp4;
       localAddress6 = containerIp6;
-      config.networking = {
-        defaultGateway.address = hostIp4;
-        defaultGateway6.address = hostIp6;
+      config = {
+        networking = {
+          defaultGateway.address = hostIp4;
+          defaultGateway6.address = hostIp6;
+        };
+        nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
       };
     };
   };

--- a/nixos/tests/containers-hosts.nix
+++ b/nixos/tests/containers-hosts.nix
@@ -29,7 +29,9 @@
         localAddress = "10.10.0.1";
         hostAddress = "10.10.0.254";
 
-        config = { };
+        config = {
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
+        };
       };
 
       containers.netmask = {
@@ -38,7 +40,9 @@
         hostBridge = "br0";
         localAddress = "10.11.0.1/24";
 
-        config = { };
+        config = {
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
+        };
       };
     };
 

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -19,6 +19,7 @@
 
       boot.enableContainers = true;
 
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
       # XXX: Sandbox setup fails while trying to hardlink files from the host's
       #      store file system into the prepared chroot directory.
       nix.settings.sandbox = false;

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -8,6 +8,8 @@ let
         adminAddr = "foo@example.org";
       };
       networking.firewall.allowedTCPPorts = [ 80 ];
+
+      nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
     };
   };
 

--- a/nixos/tests/containers-ipv6-slaac.nix
+++ b/nixos/tests/containers-ipv6-slaac.nix
@@ -104,6 +104,8 @@ in
 
           services.httpd.enable = true;
           networking.firewall.allowedTCPPorts = [ 80 ];
+
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
         };
       };
     };

--- a/nixos/tests/containers-macvlans.nix
+++ b/nixos/tests/containers-macvlans.nix
@@ -47,6 +47,7 @@ in
                 }
               ];
             };
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
 
@@ -63,6 +64,7 @@ in
                 }
               ];
             };
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };

--- a/nixos/tests/containers-names.nix
+++ b/nixos/tests/containers-names.nix
@@ -19,7 +19,9 @@
             privateNetwork = true;
             hostAddress = "192.168.${subnet}.1";
             localAddress = "192.168.${subnet}.2";
-            config = { };
+            config = {
+              nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
+            };
           };
 
         in

--- a/nixos/tests/containers-nested.nix
+++ b/nixos/tests/containers-nested.nix
@@ -1,27 +1,54 @@
 # Test for NixOS' container nesting.
 
-{ pkgs, ... }:
 {
-  name = "nested";
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  system = config.nodes.machine.nixpkgs.hostPlatform.system;
+in
+{
+  options = {
+    params.nix = lib.mkOption {
+      description = "Whether to enable nix on host and containers - we test both variants";
+      type = lib.types.bool;
+      default = false; # In line with all-tests.nix / tag(no-nix-by-default)
+    };
+  };
+  config.name = "nested";
 
-  meta = with pkgs.lib.maintainers; {
+  config.meta = with pkgs.lib.maintainers; {
     maintainers = [ sorki ];
   };
 
-  nodes.machine =
+  config.nodes.machine =
     { lib, ... }:
     let
       makeNested = subConf: {
+        # NOTE: outer container is also called "nested"!
         containers.nested = {
           autoStart = true;
           privateNetwork = true;
-          config = subConf;
+          config = {
+            imports = [ subConf ];
+            nix.enable = config.params.nix;
+            nix.settings.substitute = false;
+          };
         };
+        # host or level 1
+        nix.enable = config.params.nix;
       };
     in
-    makeNested (makeNested { });
+    {
+      imports = [
+        (makeNested (makeNested { }))
+      ];
+      nix.settings.substitute = false;
+    };
 
-  testScript = ''
+  config.testScript = ''
     machine.start()
     machine.wait_for_unit("container@nested.service")
     machine.succeed("systemd-run --pty --machine=nested -- machinectl list | grep nested")
@@ -30,5 +57,62 @@
             "systemd-run --pty --machine=nested -- systemd-run --pty --machine=nested -- systemctl status"
         )
     )
+
+    ${lib.optionalString config.params.nix ''
+      def check_path(path):
+          # result is available on host
+          machine.succeed(f"""
+            stat {path}
+          """)
+          # result is available on container
+          # invocation by absolute path because systemd-run is quite minimal
+          machine.succeed(f"""
+            systemd-run --machine=nested --pipe --wait -- /run/current-system/sw/bin/stat {path}
+          """)
+          # result is available on nested container
+          machine.succeed(f"""
+            systemd-run --machine=nested --pipe --wait  -- systemd-run --machine=nested --pipe --wait -- /run/current-system/sw/bin/stat {path}
+          """)
+
+      with subtest("nix store sharing"):
+          with subtest("built on host"):
+              build = machine.succeed("""
+                nix-build --expr 'derivation {
+                  name = "buildprobe-0";
+                  system = "${system}";
+                  builder = "/bin/sh";
+                  args = [ "-c" "echo ok 0 >$out" ];
+                }'
+              """)
+              check_path(build)
+
+          with subtest("built on container layer 1"):
+              build = machine.succeed("""
+                systemd-run --machine=nested --pipe --wait -- \
+                  /bin/sh -l -c 'exec $0 "$@"' \
+                  /run/current-system/sw/bin/nix-build --expr 'derivation {
+                    name = "buildprobe-1";
+                    system = "${system}";
+                    builder = "/bin/sh";
+                    args = [ "-c" "echo ok 1 >$out" ];
+                  }'
+              """)
+              check_path(build)
+
+          with subtest("built on container layer 2"):
+              build = machine.succeed("""
+                systemd-run --machine=nested --pipe --wait -- \
+                  systemd-run --machine=nested --pipe --wait -- \
+                  /bin/sh -l -c 'exec $0 "$@"' \
+                  /run/current-system/sw/bin/nix-build --expr 'derivation {
+                    name = "buildprobe-2";
+                    system = "${system}";
+                    builder = "/bin/sh";
+                    args = [ "-c" "echo ok 2 >$out" ];
+                  }'
+              """)
+              check_path(build)
+
+    ''}
   '';
 }

--- a/nixos/tests/containers-physical_interfaces.nix
+++ b/nixos/tests/containers-physical_interfaces.nix
@@ -22,6 +22,7 @@
               }
             ];
             networking.firewall.enable = false;
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };
@@ -44,6 +45,7 @@
 
           config = {
             networking.firewall.enable = false;
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };
@@ -65,6 +67,7 @@
               }
             ];
             networking.firewall.enable = false;
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };
@@ -90,6 +93,7 @@
               }
             ];
             networking.firewall.enable = false;
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };
@@ -116,6 +120,7 @@
               }
             ];
             networking.firewall.enable = false;
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -36,6 +36,7 @@ in
           services.httpd.enable = true;
           services.httpd.adminAddr = "foo@example.org";
           networking.firewall.allowedTCPPorts = [ 80 ];
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
         };
       };
 

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -12,6 +12,7 @@
         containers.test1 = {
           autoStart = true;
           config.environment.etc.check.text = "client_base";
+          config.nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
         };
 
         # prevent make-test-python.nix to change IP
@@ -22,6 +23,7 @@
             environment.etc.check.text = lib.mkForce "client_c1";
             services.httpd.enable = true;
             services.httpd.adminAddr = "nixos@example.com";
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
 
@@ -29,6 +31,7 @@
           containers.test1.config = {
             environment.etc.check.text = lib.mkForce "client_c2";
             services.nginx.enable = true;
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };

--- a/nixos/tests/containers-require-bind-mounts.nix
+++ b/nixos/tests/containers-require-bind-mounts.nix
@@ -8,7 +8,9 @@
       bindMounts = {
         "/srv/data" = { };
       };
-      config = { };
+      config = {
+        nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
+      };
     };
 
     virtualisation.fileSystems = {

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -22,6 +22,7 @@
               prefixLength = 24;
             }
           ];
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
         };
       };
 

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -23,7 +23,9 @@
           # Add a tmpfs on a path that does not exist
           "/some/random/path"
         ];
-        config = { };
+        config = {
+          nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
+        };
       };
 
       virtualisation.additionalPaths = [ pkgs.stdenv ];

--- a/nixos/tests/containers-unified-hierarchy.nix
+++ b/nixos/tests/containers-unified-hierarchy.nix
@@ -11,7 +11,9 @@
       containers = {
         test-container = {
           autoStart = true;
-          config = { };
+          config = {
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
+          };
         };
       };
     };

--- a/nixos/tests/harmonia.nix
+++ b/nixos/tests/harmonia.nix
@@ -18,6 +18,7 @@
 
       # check that extra-allowed-users is effective for harmonia
       nix.settings.allowed-users = [ ];
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
 
     client01 = {
@@ -27,6 +28,7 @@
           "cache.example.com-1:eIGQXcGQpc00x6/XFcyacLEUmC07u4RAEHt5Y8vdglo="
         ];
       };
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
   };
 

--- a/nixos/tests/hydra/common.nix
+++ b/nixos/tests/hydra/common.nix
@@ -44,5 +44,6 @@
       };
       services.postfix.enable = true;
       nix.settings.substituters = [ ];
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
 }

--- a/nixos/tests/installed-tests/flatpak-builder.nix
+++ b/nixos/tests/installed-tests/flatpak-builder.nix
@@ -14,6 +14,7 @@ makeInstalledTest {
       with pkgs;
       [ flatpak-builder ] ++ flatpak-builder.installedTestsDependencies;
     virtualisation.diskSize = 2048;
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
   };
 
   testRunnerFlags = [

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -684,6 +684,9 @@ let
       nodes =
         let
           commonConfig = {
+            # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+            nix.enable = true;
+
             # builds stuff in the VM, needs more juice
             virtualisation.diskSize = 12 * 1024;
             virtualisation.cores = 8;

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -108,6 +108,8 @@ in
 
         system.extraDependencies = [ nodes.initiatorRootDisk.system.build.toplevel ];
 
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
         nix.settings = {
           substituters = lib.mkForce [ ];
           hashed-mirrors = null;

--- a/nixos/tests/lix.nix
+++ b/nixos/tests/lix.nix
@@ -2,6 +2,8 @@
   name = "lix";
 
   nodes.machine = { pkgs, ... }: {
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
     nix.package = pkgs.lix;
 
     environment.etc."test.nix".text = ''

--- a/nixos/tests/lorri/default.nix
+++ b/nixos/tests/lorri/default.nix
@@ -6,6 +6,8 @@ import ../make-test-python.nix {
     {
       imports = [ ../../modules/profiles/minimal.nix ];
       environment.systemPackages = [ pkgs.lorri ];
+
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
 
   testScript = ''

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -66,6 +66,7 @@ in
       boot.kernel.sysctl."vm.swappiness" = 1;
       boot.kernelParams = [ "vsyscall=emulate" ];
       system.extraDependencies = [ foo ];
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
 
   testScript = ''

--- a/nixos/tests/nar-serve.nix
+++ b/nixos/tests/nar-serve.nix
@@ -23,6 +23,8 @@
 
         networking.firewall.allowedTCPPorts = [ 8383 ];
 
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
         # virtualisation.diskSize = 2 * 1024;
       };
   };

--- a/nixos/tests/ncps.nix
+++ b/nixos/tests/ncps.nix
@@ -25,6 +25,8 @@
 
       networking.firewall.allowedTCPPorts = [ 5000 ];
       system.extraDependencies = [ pkgs.emptyFile ];
+
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
 
     ncps = {
@@ -49,6 +51,8 @@
       };
 
       networking.firewall.allowedTCPPorts = [ 8501 ];
+
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
 
     client = {
@@ -58,6 +62,7 @@
           "ncps:UtiE6C+3Tx0kgpP34vjyX/BKK6QZ/D1OzDYX72aCPJg="
         ];
       };
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
   };
 

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -116,8 +116,8 @@ runTest (
             )
 
             # Verify the local and remote copies of the file are identical.
-            client_hash = client.succeed("nix-hash testfile.bin").strip()
-            nextcloud_hash = nextcloud.succeed("nix-hash /var/lib/nextcloud-data/data/root/files/testfile.bin").strip()
+            client_hash = client.succeed("sha256sum <testfile.bin").strip()
+            nextcloud_hash = nextcloud.succeed("sha256sum </var/lib/nextcloud-data/data/root/files/testfile.bin").strip()
             t.assertEqual(client_hash, nextcloud_hash)
 
         with subtest("secrets"):

--- a/nixos/tests/nix-config.nix
+++ b/nixos/tests/nix-config.nix
@@ -9,6 +9,7 @@
         extra-nix-path = [ "extra=/etc/value.nix" ];
       };
       environment.etc."value.nix".text = "42";
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
   testScript = ''
     start_all()

--- a/nixos/tests/nix-daemon-firewall.nix
+++ b/nixos/tests/nix-daemon-firewall.nix
@@ -100,6 +100,7 @@ let
       # Gives us access inside the nix sandbox
       extra-sandbox-paths = [ "${pkgs.pkgsStatic.busybox}" ];
     };
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
 
     # Easy way to get files to the system
     environment.etc = {

--- a/nixos/tests/nix-daemon-unprivileged.nix
+++ b/nixos/tests/nix-daemon-unprivileged.nix
@@ -19,6 +19,7 @@
         "auto-allocate-uids"
       ];
     };
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
 
     # Easiest way to get a file onto the machine
     environment.etc."test.nix".text = ''

--- a/nixos/tests/nix-local-store.nix
+++ b/nixos/tests/nix-local-store.nix
@@ -7,6 +7,8 @@
       experimental-features = [ "nix-command" ];
       log-lines = 26;
     };
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
     # Easiest way to get a file onto the machine
     environment.etc."test.nix".text = ''
       derivation {

--- a/nixos/tests/nix-required-mounts/default.nix
+++ b/nixos/tests/nix-required-mounts/default.nix
@@ -16,6 +16,7 @@ in
       nix.settings.substituters = lib.mkForce [ ];
       nix.settings.system-features = [ "supported-feature" ];
       nix.settings.experimental-features = [ "nix-command" ];
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
       programs.nix-required-mounts.enable = true;
       programs.nix-required-mounts.allowedPatterns.supported-feature = {
         onFeatures = [ "supported-feature" ];

--- a/nixos/tests/nix-serve-ssh.nix
+++ b/nixos/tests/nix-serve-ssh.nix
@@ -12,6 +12,9 @@ in
 {
   name = "nix-ssh-serve";
   meta.maintainers = [ lib.maintainers.shlevy ];
+  defaults = {
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+  };
   nodes = {
     server.nix.sshServe = {
       enable = true;

--- a/nixos/tests/nix-serve.nix
+++ b/nixos/tests/nix-serve.nix
@@ -8,6 +8,7 @@
       environment.systemPackages = [
         pkgs.hello
       ];
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
     };
   testScript =
     let

--- a/nixos/tests/nix/upgrade.nix
+++ b/nixos/tests/nix/upgrade.nix
@@ -45,6 +45,8 @@ pkgs.testers.nixosTest {
     imports = [ nixos-module ];
 
     nix.package = nixVersions.stable;
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
     system.extraDependencies = [
       fallback-paths-external
     ];

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -19,6 +19,8 @@
         services.desktopManager.gnome.enable = true;
       ''
     ];
+
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
   };
   testScript = ''
     start_all()

--- a/nixos/tests/nixos-rebuild-specialisations.nix
+++ b/nixos/tests/nixos-rebuild-specialisations.nix
@@ -20,6 +20,7 @@
           hashed-mirrors = null;
           connect-timeout = 1;
         };
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
 
         system.includeBuildDependencies = true;
 

--- a/nixos/tests/nixos-rebuild-store-path.nix
+++ b/nixos/tests/nixos-rebuild-store-path.nix
@@ -20,6 +20,7 @@
           hashed-mirrors = null;
           connect-timeout = 1;
         };
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
 
         system.includeBuildDependencies = true;
 

--- a/nixos/tests/nixos-rebuild-target-host.nix
+++ b/nixos/tests/nixos-rebuild-target-host.nix
@@ -5,7 +5,9 @@
   # TODO: remove overlay from  nixos/modules/profiles/installation-device.nix
   #        make it a _small package instead, then remove pkgsReadOnly = false;.
   node.pkgsReadOnly = false;
-
+  defaults = {
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+  };
   nodes = {
     deployer =
       { lib, pkgs, ... }:

--- a/nixos/tests/nixseparatedebuginfod2.nix
+++ b/nixos/tests/nixseparatedebuginfod2.nix
@@ -1,6 +1,9 @@
 { pkgs, lib, ... }:
 {
   name = "nixseparatedebuginfod2";
+  defaults = {
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+  };
   # A binary cache with debug info and source for gnumake
   nodes.cache =
     { pkgs, ... }:

--- a/nixos/tests/qemu-vm-store.nix
+++ b/nixos/tests/qemu-vm-store.nix
@@ -5,6 +5,10 @@
 
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
+  defaults = {
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+  };
+
   nodes = {
     sharedWritable = {
       virtualisation.writableStore = true;

--- a/nixos/tests/replace-dependencies/default.nix
+++ b/nixos/tests/replace-dependencies/default.nix
@@ -8,6 +8,8 @@ import ../make-test-python.nix (
       { ... }:
       {
         nix.settings.experimental-features = [ "ca-derivations" ];
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
         system.extraDependencies = [ pkgs.stdenvNoCC ];
       };
 

--- a/nixos/tests/rstp.nix
+++ b/nixos/tests/rstp.nix
@@ -23,6 +23,7 @@
                 };
               };
             };
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };

--- a/nixos/tests/rsyncd.nix
+++ b/nixos/tests/rsyncd.nix
@@ -25,6 +25,8 @@
               };
             };
           };
+          # TODO: Remove dependency on nix. (Not needed, and I don't understand /nix/store above)
+          nix.enable = true;
         };
     in
     {

--- a/nixos/tests/rush.nix
+++ b/nixos/tests/rush.nix
@@ -7,6 +7,10 @@ in
   name = "rush";
   meta = { inherit (pkgs.rush.meta) maintainers platforms; };
 
+  defaults = {
+    nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+  };
+
   nodes = {
     client =
       { ... }:

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -41,6 +41,8 @@ let
       boot.loader.efi.canTouchEfiVariables = true;
       environment.systemPackages = [ pkgs.efibootmgr ];
       system.switch.enable = true;
+      nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
+
       # Needed for machine-id to be persisted between reboots.
       # Must be a valid (non-zero) ID, otherwise sd_id128_get_machine()
       # returns -ENOMEDIUM and dbus-broker refuses to start.

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -20,7 +20,9 @@
   nodes.containerCheck = {
     containers.c1 = {
       autoStart = true;
-      config = { };
+      config = {
+        nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
+      };
     };
   };
 

--- a/nixos/tests/varnish.nix
+++ b/nixos/tests/varnish.nix
@@ -23,6 +23,7 @@ in
         services.nix-serve = {
           enable = true;
         };
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
 
         services.varnish = {
           inherit package;
@@ -86,6 +87,7 @@ in
           require-sigs = false;
           substituters = lib.mkForce [ "http://varnish" ];
         };
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
       };
   };
 

--- a/nixos/tests/vinyl-cache.nix
+++ b/nixos/tests/vinyl-cache.nix
@@ -28,6 +28,7 @@ in
         services.nix-serve = {
           enable = true;
         };
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
 
         services.vinyl-cache = {
           inherit package;
@@ -97,6 +98,7 @@ in
           require-sigs = false;
           substituters = lib.mkForce [ "http://vinyl" ];
         };
+        nix.enable = true; # disabled by default. See all-tests.nix / tag(no-nix-by-default)
       };
   };
 

--- a/nixos/tests/yggdrasil.nix
+++ b/nixos/tests/yggdrasil.nix
@@ -138,6 +138,7 @@ in
             services.httpd.enable = true;
             services.httpd.adminAddr = "foo@example.org";
             networking.firewall.allowedTCPPorts = [ 80 ];
+            nix.enable = false; # disabled by default on the test's host. See all-tests.nix / tag(no-nix-by-default)
           };
         };
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Motivation

1. Reduce the reverse dependency closure so that nix, a critical component, can be released faster
2. Minimizing closures is good
3. Side catch: enable declarative containers on Nixless hosts (e.g. image based deployments)


## Things done

1. Disable Nix by default in all test framework entrypoints
2. Run on Hydra to find new failures, thank you infra!
3. Solve all failures (using e.g. [this](https://hydra.nixos.org/eval/1828190?compare=1828160#tabs-now-fail) as the *input* to my last iteration before (4)) (fixed without another hydra run)
4. Reenable Nix in the legacy endpoints, so that we don't break out-of-tree users. `runTest` still has Nix disabled.
5. Clean up the commit history.
6. Start another hydra eval to test with Nix enabled in the legacy endpoints. Some of the overrides become mere preparations for the switch to `runTest`.
7. Confirm [~0 regressions](https://hydra.nixos.org/eval/1828210?compare=1828160#tabs-now-fail) against tree-equivalent 2cdb5b3f03e35f97238205af97d8ec4cf932f843
    - `vsftpd` passes locally

End state:
- significantly fewer tests depend on Nix, on the order of 1/2 (haven't counted entrypoint calls)
- almost all of the actual nix enabling/disabling work done
- only remaining work is orthogonal and of a different kind: further minimize the Nix reverse dependency closure: https://github.com/NixOS/nixpkgs/issues/386873

-----

- Built on platform:
  - [x] x86_64-linux
    - all of them
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - new: `nixosTests.containers-nested-nix` :sparkles: 
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
