### PR TITLE
lib.options: add `mkEnabledOption`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -516,6 +516,7 @@ let
       inherit (self.options)
         isOption
         mkEnableOption
+        mkEnabledOption
         mkSinkUndeclaredOptions
         mergeDefaultOption
         mergeOneOption

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -47,6 +47,46 @@ let
   prioritySuggestion = ''
     Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
   '';
+
+  /**
+    Creates a boolean option declaration with a configurable default value.
+
+    # Inputs
+
+    Structured function argument
+    : Attribute set containing the following attributes:
+
+      `default`
+      : Optional default value for the option (`true` or `false`). Default: `false`
+
+      `name`
+      : Name for the created option
+
+    # Examples
+    :::{.example}
+    ## `mkToggleOption` usage example
+
+    ```nix
+    mkToggleOption {
+      default = true;
+      name = "foo";
+    }
+    => { ...; default = true; example = false; description = "Whether to enable foo."; }
+    ```
+
+    :::
+  */
+  mkToggleOption =
+    {
+      default ? false,
+      name,
+    }:
+    lib.mkOption {
+      inherit default;
+      example = !default;
+      description = "Whether to enable ${name}.";
+      type = lib.types.bool;
+    };
 in
 rec {
 
@@ -186,11 +226,48 @@ rec {
   */
   mkEnableOption =
     name:
-    mkOption {
+    mkToggleOption {
       default = false;
-      example = true;
-      description = "Whether to enable ${name}.";
-      type = lib.types.bool;
+      inherit name;
+    };
+
+  /**
+    Creates an option declaration with a default value of `true`, and can be defined to `false`.
+
+    # Inputs
+
+    `name`
+
+    : Name for the created option
+
+    # Examples
+    :::{.example}
+    ## `lib.options.mkEnabledOption` usage example
+
+    ```nix
+    # module
+    let
+      eval = lib.evalModules {
+        modules = [
+          {
+            options.foo.enable = mkEnabledOption "foo";
+
+            config.foo.enable = false;
+          }
+        ];
+      };
+    in
+    eval.config
+    => { foo.enable = false; }
+    ```
+
+    :::
+  */
+  mkEnabledOption =
+    name:
+    mkToggleOption {
+      default = true;
+      inherit name;
     };
 
   /**

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -5221,4 +5221,46 @@ runTests {
       ))
     ];
   };
+
+  testMkEnableOption = {
+    expr =
+      let
+        opt = lib.mkEnableOption "foo";
+      in
+      {
+        inherit (opt)
+          default
+          example
+          description
+          type
+          ;
+      };
+    expected = {
+      default = false;
+      example = true;
+      description = "Whether to enable foo.";
+      type = lib.types.bool;
+    };
+  };
+
+  testMkEnabledOption = {
+    expr =
+      let
+        opt = lib.mkEnabledOption "foo";
+      in
+      {
+        inherit (opt)
+          default
+          example
+          description
+          type
+          ;
+      };
+    expected = {
+      default = true;
+      example = false;
+      description = "Whether to enable foo.";
+      type = lib.types.bool;
+    };
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

lib.options: add `mkEnabledOption`, a boolean option which defaults to true

Simplify the creation of boolean options enabled by default, which I would say is the third most common kind of option I have seen in NixOS and Home Manager after `mkEnableOption` and `mkPackageOption`

The current workaround is:
```nix
mkEnableOption ... // { default = true ; example = false; }
```

Which I've seen in many place, but here is an instance from the `direnv` option by @Gerg-L :
https://github.com/NixOS/nixpkgs/blob/e5bdc4a41d4c072fe1e3787eaa0320a384741d44/nixos/modules/programs/direnv.nix#L9-L15

And sometimes even with `example` forgotten to be toggled

I also created a common internal helper at https://github.com/NixOS/nixpkgs/pull/553735/changes#diff-b8abdbba66ddbc5583e31b562a5041d1977fd7fe7295d2d4cb8b0170fa1640f1R79-R89 :
```nix
  mkToggleOption =
    {
      default ? false,
      name,
    }:
    lib.mkOption {
      inherit default;
      example = !default;
      description = "Whether to enable ${name}.";
      type = lib.types.bool;
    };
```
Which might be _slightly_ overkill, but I'm a maniac.

An alternative would be to expose the `mkToggleOption` as a `default: name` so both `mkEnableOption` and `mkDisableOption` would be `mkToggleOption false "gh"` / `mkToggleOption true "git"`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. None used

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test