### PR TITLE
mesa-libclc: fix cross compilation

### DIFF
--- a/pkgs/by-name/me/mesa-libclc/package.nix
+++ b/pkgs/by-name/me/mesa-libclc/package.nix
@@ -6,17 +6,18 @@
   cmake,
   llvmPackages_22,
   mesa,
-  spirv-llvm-translator,
+  buildPackages,
 }:
 let
-  spirv-llvm-translator' = spirv-llvm-translator.override {
-    inherit (llvmPackages_22) llvm;
+  llvmPackages_22' = buildPackages.llvmPackages_22;
+  spirv-llvm-translator' = buildPackages.spirv-llvm-translator.override {
+    inherit (llvmPackages_22') llvm;
   };
   tools = buildEnv {
     name = "mesa-libclc-tools";
     paths = [
-      llvmPackages_22.clang-unwrapped
-      llvmPackages_22.llvm
+      llvmPackages_22'.clang-unwrapped
+      llvmPackages_22'.llvm
     ];
     pathsToLink = [ "/bin" ];
   };

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   srcOnly,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   lit,


### PR DESCRIPTION
Properly handle cross compilation for `mesa-libclc` by getting `llvmPackages` and `spirv-llvm-translator` from `buildPackages` because splicing is otherwise broken in `tools` and `spirv-llvm-translator'`.

The following command currently fails on upstream/master, but succeeds in this PR:

```nix
nix build .#legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.mesa-libclc
```

I also removed an unused import in spirv-llvm-translator that nil was flagging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
