### PR TITLE
umple: 1.37.0 -> 1.37.1, tweak update script

### DIFF
--- a/pkgs/by-name/um/umple/deps.json
+++ b/pkgs/by-name/um/umple/deps.json
@@ -242,8 +242,8 @@
   "com/google/guava/guava/maven-metadata": {
    "xml": {
     "groupId": "com.google.guava",
-    "lastUpdated": "20260414193116",
-    "release": "33.6.0-jre"
+    "lastUpdated": "20260817142319",
+    "release": "33.7.0-jre"
    }
   },
   "com/google/inject#guice-parent/3.0": {

--- a/pkgs/by-name/um/umple/package.nix
+++ b/pkgs/by-name/um/umple/package.nix
@@ -28,13 +28,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "umple";
-  version = "1.37.0";
+  version = "1.37.1";
 
   src = fetchFromGitHub {
     owner = "umple";
     repo = "umple";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BPy1L3bzvKoywM0srv36SXVe8psaY/m0bljy30z5dr8=";
+    hash = "sha256-xrq3Qmoq0tWR+9vrp292H3WpcWCYjYeIu1LJPBLvhD4=";
   };
 
   patches = [

--- a/pkgs/by-name/um/umple/package.nix
+++ b/pkgs/by-name/um/umple/package.nix
@@ -12,7 +12,7 @@
 }:
 let
   versions = lib.importJSON ./versions.json;
-  inherit (versions.umple) version longVersion;
+  inherit (versions.umple) longVersion;
 
   # Required for bootstrapping
   umpleJar = fetchurl versions.umpleJar;
@@ -28,12 +28,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "umple";
-  inherit version;
+  version = "1.37.0";
 
   src = fetchFromGitHub {
     owner = "umple";
     repo = "umple";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BPy1L3bzvKoywM0srv36SXVe8psaY/m0bljy30z5dr8=";
   };
 

--- a/pkgs/by-name/um/umple/update.sh
+++ b/pkgs/by-name/um/umple/update.sh
@@ -42,17 +42,17 @@ umpleUrl="https://github.com/umple/umple/releases/download/$latestTag/$umpleName
 umpleHash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 \
   "$(nix-prefetch-url "$umpleUrl")")
 
-# Save version info
+# Save version info.
+# Note that the Nix package version is directly inlined so that nixpkgs-update
+# can properly detect when the version changes in the source
 jq -n \
-  --arg version "$latestVersion" \
   --arg longVersion "$longVersion" \
   --arg revision "$revision" \
-  --arg commitCount "$commitCount" \
+  --argjson commitCount "$commitCount" \
   --arg umpleUrl "$umpleUrl" \
   --arg umpleHash "$umpleHash" \
   '{
     "umple": {
-      "version": $version,
       "longVersion": $longVersion,
       "revision": $revision,
       "commitCount": $commitCount
@@ -63,5 +63,5 @@ jq -n \
     }
   }' > "$location/versions.json"
 
-# Version update is done; use nix-update for hashes and Gradle deps
-nix-update umple --version=skip
+# use nix-update for hashes and Gradle deps
+nix-update umple --version="$latestVersion"

--- a/pkgs/by-name/um/umple/versions.json
+++ b/pkgs/by-name/um/umple/versions.json
@@ -1,12 +1,11 @@
 {
   "umple": {
-    "version": "1.37.0",
-    "longVersion": "1.37.0.8543.1593c2b83",
-    "revision": "1593c2b83",
-    "commitCount": "8543"
+    "longVersion": "1.37.1.8673.860b8c752",
+    "revision": "860b8c752",
+    "commitCount": "8673"
   },
   "umpleJar": {
-    "url": "https://github.com/umple/umple/releases/download/v1.37.0/umple-1.37.0.8542.3a8c87689.jar",
-    "hash": "sha256-pBHHbURbe7B5A11tShvHGlSO4XMJPcdM7Iy+ph3PxAE="
+    "url": "https://github.com/umple/umple/releases/download/v1.37.1/umple-1.37.1.8672.ffc0b7ae3.jar",
+    "hash": "sha256-4EWhIxPPkwsS59ZSmpFkZXMRBa/3CTCyQuUWvYcVVC8="
   }
 }


### PR DESCRIPTION
Changelog: https://github.com/umple/umple/releases/tag/v1.37.1

This PR also changes the update script so that nixpkgs-update should succeed in the future. The second commit on this branch was generated using the modified update script to make sure that it works. Logs of the failed update attempt can be found here: https://nixpkgs-update-logs.nix-community.org/umple/2026-08-16.log

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
