### PR TITLE
mkdocs-simple-blog: fix build & modernise

### DIFF
--- a/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
+++ b/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
@@ -5,6 +5,7 @@
   mkdocs,
   poetry-core,
   pytestCheckHook,
+  pyprojectVersionPatchHook,
   pytest-cov-stub,
 }:
 buildPythonPackage rec {
@@ -24,6 +25,8 @@ buildPythonPackage rec {
   dependencies = [
     mkdocs
   ];
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
+++ b/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
@@ -8,23 +8,24 @@
   pyprojectVersionPatchHook,
   pytest-cov-stub,
 }:
-buildPythonPackage rec {
+
+buildPythonPackage (finalAttrs: {
   pname = "mkdocs-simple-blog";
   version = "0.4.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "FernandoCelmer";
     repo = "mkdocs-simple-blog";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lp0+mJYyP7Qz/gJCI7+tKh9fZArWs2u1ZusnVUax7A4=";
   };
 
   build-system = [ poetry-core ];
 
-  dependencies = [
-    mkdocs
-  ];
+  dependencies = [ mkdocs ];
 
   nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
@@ -38,8 +39,8 @@ buildPythonPackage rec {
   meta = {
     description = "Simple blog generator plugin for MkDocs";
     homepage = "https://fernandocelmer.github.io/mkdocs-simple-blog/";
-    changelog = "https://github.com/FernandoCelmer/mkdocs-simple-blog/releases/tag/${src.tag}";
+    changelog = "https://github.com/FernandoCelmer/mkdocs-simple-blog/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ guelakais ];
   };
-}
+})

--- a/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
+++ b/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mkdocs-simple-blog";
-  version = "0.4.1";
+  version = "0.4.3";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -20,7 +20,7 @@ buildPythonPackage (finalAttrs: {
     owner = "FernandoCelmer";
     repo = "mkdocs-simple-blog";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lp0+mJYyP7Qz/gJCI7+tKh9fZArWs2u1ZusnVUax7A4=";
+    hash = "sha256-Z2+ou+bjE/glInl4of0gkoNEc9eGD8k/LDcQpKGWsB8=";
   };
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes build by adding the `pyprojectVersionPatchHook`. It should probably stay because upstream seems to be... "unique" in how they update the `pyproject.toml` to say the least :)

Also did some housekeeping

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
