### PR TITLE
sbomit: init at 0.2.1

### DIFF
--- a/pkgs/by-name/sb/sbomit/package.nix
+++ b/pkgs/by-name/sb/sbomit/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sbomit";
+  version = "0.2.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "SBOMit";
+    repo = "sbomit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/tst1XGwW8LTuEFbY1KA+C93TNapVJsYstFY9oPH8yA=";
+  };
+
+  vendorHash = "sha256-R3WBmmoh+YJMJlo+OgSXU50YcEfLQWAxkBYHPAT3NZM=";
+
+  ldflags = [ "-s" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to generate SBOMs";
+    homepage = "https://github.com/SBOMit/sbomit";
+    changelog = "https://github.com/SBOMit/sbomit/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "sbomit";
+  };
+})


### PR DESCRIPTION
Tool to generate SBOMs

https://github.com/SBOMit/sbomit


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
