### PR TITLE
umple-lsp: fix linker mismatch

### DIFF
--- a/pkgs/by-name/um/umple-lsp/package.nix
+++ b/pkgs/by-name/um/umple-lsp/package.nix
@@ -15,6 +15,11 @@ let
   # tree-sitter needs a wasi32 clang available at `bin/clang`
   wasi32cc = lib.getExe pkgsCross.wasi32.stdenv.cc;
   wasi-sdk = linkFarm "wasi-sdk" { "bin/clang" = wasi32cc; };
+  # tree-sitter invokes clang with `--target=wasm32-unknown-wasi`, so clang looks
+  # for an unprefixed `wasm-ld` instead of the prefixed one that the cross bintools ship
+  wasm-ld = linkFarm "wasm-ld" {
+    "bin/wasm-ld" = lib.getExe' pkgsCross.wasi32.buildPackages.llvmPackages.lld "wasm-ld";
+  };
 in
 buildNpmPackage (finalAttrs: {
   pname = "umple-lsp";
@@ -43,6 +48,7 @@ buildNpmPackage (finalAttrs: {
     nodejs
     pkgsCross.wasi32.stdenv.cc.bintools
     tree-sitter
+    wasm-ld
   ];
 
   # Stop tree-sitter from trying to fetch its own wasi-sdk


### PR DESCRIPTION
Fixes a linker issue for the wasi32 clang that is used to compile tree-sitter grammar.

AI was used to debug the issue and come up with a minimal solution.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
