### PR TITLE
gnatPackages.gnatcoll-*(db): update substituteInPlace

### DIFF
--- a/pkgs/development/ada-modules/gnatcoll/db.nix
+++ b/pkgs/development/ada-modules/gnatcoll/db.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
   # as we usually do in nixpkgs where possible
   postPatch = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
     for f in gnatcoll_db2ada/Makefile gnatinspect/Makefile; do
-      substituteInPlace "$f" --replace "=static" "=relocatable"
+      substituteInPlace "$f" --replace-fail "=static" "=relocatable"
     done
   '';
 


### PR DESCRIPTION
Replaces --replace with --replace-fail.
Per https://github.com/NixOS/nixpkgs/issues/356002

I checked the output with diffoscope, and verified that the only differences were the embedded nix store path hashes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
