### PR TITLE
nixos/portunus: replace dex' callbackURL with redirectURIs which allows multiple entries

### DIFF
--- a/nixos/modules/services/misc/portunus.nix
+++ b/nixos/modules/services/misc/portunus.nix
@@ -6,7 +6,6 @@
 }:
 let
   cfg = config.services.portunus;
-
 in
 {
   options.services.portunus = {
@@ -79,9 +78,15 @@ in
         type = lib.types.listOf (
           lib.types.submodule {
             options = {
+              redirectURIs = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                description = "URLs where the OIDC client should redirect";
+              };
               callbackURL = lib.mkOption {
-                type = lib.types.str;
-                description = "URL where the OIDC client should redirect";
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "URL where the OIDC client should redirect (deprecated, use redirectURIs)";
               };
               id = lib.mkOption {
                 type = lib.types.str;
@@ -93,7 +98,7 @@ in
         default = [ ];
         example = [
           {
-            callbackURL = "https://example.com/client/oidc/callback";
+            redirectURIs = [ "https://example.com/client/oidc/callback" ];
             id = "service";
           }
         ];
@@ -227,7 +232,7 @@ in
 
           staticClients = lib.forEach cfg.dex.oidcClients (client: {
             inherit (client) id;
-            redirectURIs = [ client.callbackURL ];
+            redirectURIs = client.redirectURIs ++ lib.optional (client.callbackURL != null) client.callbackURL;
             name = "OIDC for ${client.id}";
             secretEnv = "DEX_CLIENT_${client.id}";
           });


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
