### PR TITLE
ci: Flag mass rebuilds on staging-nixos

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -159,8 +159,8 @@ jobs:
         run: ln -s "$PWD/trusted/ci/github-script/node_modules" untrusted/ci/github-script/node_modules
         working-directory: nixpkgs
 
-      - name: Type-check ci/github-script
-        run: tsc --build
+      - name: Check ci/github-script
+        run: npm test
         working-directory: nixpkgs/untrusted/ci/github-script
 
   owners:

--- a/ci/github-script/check-target-branch-policy.test.ts
+++ b/ci/github-script/check-target-branch-policy.test.ts
@@ -1,0 +1,203 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+const { decideTargetBranchReview } = require('./check-target-branch-policy.ts')
+
+type DecisionFacts = {
+  base: string
+  head: string
+  maxRebuildCount: number
+  rebuildsAllTests: boolean
+  isExemptKernelUpdate: boolean
+  isExemptHomeAssistantUpdate: boolean
+}
+
+type Decision =
+  | 'mass-rebuild'
+  | 'nixos-rebuild'
+  | 'possible-mass-rebuild'
+  | 'skip-development-merge'
+  | 'dismiss'
+
+const defaults: DecisionFacts = {
+  base: 'master',
+  head: 'topic-branch',
+  maxRebuildCount: 0,
+  rebuildsAllTests: false,
+  isExemptKernelUpdate: false,
+  isExemptHomeAssistantUpdate: false,
+}
+
+const cases: Array<{
+  name: string
+  facts: Partial<DecisionFacts>
+  expected: Decision
+}> = [
+  {
+    name: 'allows fewer than 500 rebuilds on master',
+    facts: { maxRebuildCount: 499 },
+    expected: 'dismiss',
+  },
+  {
+    name: 'flags 500 rebuilds on master as a possible mass rebuild',
+    facts: { maxRebuildCount: 500 },
+    expected: 'possible-mass-rebuild',
+  },
+  {
+    name: 'flags 999 rebuilds on master as a possible mass rebuild',
+    facts: { maxRebuildCount: 999 },
+    expected: 'possible-mass-rebuild',
+  },
+  {
+    name: 'flags 1000 rebuilds on master as a mass rebuild',
+    facts: { maxRebuildCount: 1000 },
+    expected: 'mass-rebuild',
+  },
+  {
+    name: 'does not check mass rebuilds on staging-nixos',
+    facts: { base: 'staging-nixos', maxRebuildCount: 24_000 },
+    expected: 'dismiss',
+  },
+  {
+    name: 'does not check mass rebuilds on a release staging-nixos branch',
+    facts: { base: 'staging-nixos-26.05', maxRebuildCount: 1000 },
+    expected: 'dismiss',
+  },
+  {
+    name: 'allows mass rebuilds on staging',
+    facts: { base: 'staging', maxRebuildCount: 1000 },
+    expected: 'dismiss',
+  },
+  {
+    name: 'flags a mass rebuild on a release branch',
+    facts: { base: 'release-26.05', maxRebuildCount: 1000 },
+    expected: 'mass-rebuild',
+  },
+  {
+    name: 'flags NixOS test rebuilds on master',
+    facts: { rebuildsAllTests: true },
+    expected: 'nixos-rebuild',
+  },
+  {
+    name: 'flags NixOS test rebuilds on a release branch',
+    facts: { base: 'release-26.05', rebuildsAllTests: true },
+    expected: 'nixos-rebuild',
+  },
+  {
+    name: 'allows NixOS test rebuilds on staging-nixos',
+    facts: { base: 'staging-nixos', rebuildsAllTests: true },
+    expected: 'dismiss',
+  },
+  {
+    name: 'does not flag a possible mass rebuild when staging-nixos rebuilds all NixOS tests',
+    facts: {
+      base: 'staging-nixos',
+      maxRebuildCount: 500,
+      rebuildsAllTests: true,
+    },
+    expected: 'dismiss',
+  },
+  {
+    name: 'does not check possible mass rebuilds on staging-nixos',
+    facts: { base: 'staging-nixos', maxRebuildCount: 500 },
+    expected: 'dismiss',
+  },
+  {
+    name: 'skips staging into master',
+    facts: {
+      head: 'staging',
+      maxRebuildCount: 24_000,
+    },
+    expected: 'skip-development-merge',
+  },
+  {
+    name: 'skips staging-nixos into master',
+    facts: {
+      head: 'staging-nixos',
+      maxRebuildCount: 24_000,
+    },
+    expected: 'skip-development-merge',
+  },
+  {
+    name: 'skips master into staging-nixos',
+    facts: {
+      base: 'staging-nixos',
+      head: 'master',
+      maxRebuildCount: 24_000,
+    },
+    expected: 'skip-development-merge',
+  },
+  {
+    name: 'skips staging into staging-nixos',
+    facts: {
+      base: 'staging-nixos',
+      head: 'staging',
+      maxRebuildCount: 24_000,
+    },
+    expected: 'skip-development-merge',
+  },
+  {
+    name: 'skips release staging-nixos into its release branch',
+    facts: {
+      base: 'release-26.05',
+      head: 'staging-nixos-26.05',
+      maxRebuildCount: 24_000,
+    },
+    expected: 'skip-development-merge',
+  },
+  {
+    name: 'skips a release branch into its staging-nixos branch',
+    facts: {
+      base: 'staging-nixos-26.05',
+      head: 'release-26.05',
+      maxRebuildCount: 24_000,
+    },
+    expected: 'skip-development-merge',
+  },
+  {
+    name: 'skips release staging into its staging-nixos branch',
+    facts: {
+      base: 'staging-nixos-26.05',
+      head: 'staging-26.05',
+      maxRebuildCount: 24_000,
+    },
+    expected: 'skip-development-merge',
+  },
+  {
+    name: 'kernel exemption suppresses a possible mass rebuild',
+    facts: { maxRebuildCount: 999, isExemptKernelUpdate: true },
+    expected: 'dismiss',
+  },
+  {
+    name: 'kernel exemption suppresses a definite mass rebuild',
+    facts: { maxRebuildCount: 1000, isExemptKernelUpdate: true },
+    expected: 'dismiss',
+  },
+  {
+    name: 'kernel exemption suppresses a NixOS test rebuild',
+    facts: { rebuildsAllTests: true, isExemptKernelUpdate: true },
+    expected: 'dismiss',
+  },
+  {
+    name: 'Home Assistant exemption suppresses a mass rebuild',
+    facts: {
+      maxRebuildCount: 1500,
+      isExemptHomeAssistantUpdate: true,
+    },
+    expected: 'dismiss',
+  },
+  {
+    name: 'Home Assistant exemption does not suppress a NixOS test rebuild',
+    facts: {
+      maxRebuildCount: 1500,
+      rebuildsAllTests: true,
+      isExemptHomeAssistantUpdate: true,
+    },
+    expected: 'nixos-rebuild',
+  },
+]
+
+for (const { name, facts, expected } of cases) {
+  test(name, () => {
+    assert.equal(decideTargetBranchReview({ ...defaults, ...facts }), expected)
+  })
+}

--- a/ci/github-script/check-target-branch-policy.test.ts
+++ b/ci/github-script/check-target-branch-policy.test.ts
@@ -53,14 +53,14 @@ const cases: Array<{
     expected: 'mass-rebuild',
   },
   {
-    name: 'does not check mass rebuilds on staging-nixos',
+    name: 'flags a mass rebuild on staging-nixos',
     facts: { base: 'staging-nixos', maxRebuildCount: 24_000 },
-    expected: 'dismiss',
+    expected: 'mass-rebuild',
   },
   {
-    name: 'does not check mass rebuilds on a release staging-nixos branch',
+    name: 'flags a mass rebuild on a release staging-nixos branch',
     facts: { base: 'staging-nixos-26.05', maxRebuildCount: 1000 },
-    expected: 'dismiss',
+    expected: 'mass-rebuild',
   },
   {
     name: 'allows mass rebuilds on staging',
@@ -97,9 +97,9 @@ const cases: Array<{
     expected: 'dismiss',
   },
   {
-    name: 'does not check possible mass rebuilds on staging-nixos',
+    name: 'flags other possible mass rebuilds on staging-nixos',
     facts: { base: 'staging-nixos', maxRebuildCount: 500 },
-    expected: 'dismiss',
+    expected: 'possible-mass-rebuild',
   },
   {
     name: 'skips staging into master',
@@ -127,13 +127,13 @@ const cases: Array<{
     expected: 'skip-development-merge',
   },
   {
-    name: 'skips staging into staging-nixos',
+    name: 'checks staging into staging-nixos',
     facts: {
       base: 'staging-nixos',
       head: 'staging',
       maxRebuildCount: 24_000,
     },
-    expected: 'skip-development-merge',
+    expected: 'mass-rebuild',
   },
   {
     name: 'skips release staging-nixos into its release branch',
@@ -154,13 +154,13 @@ const cases: Array<{
     expected: 'skip-development-merge',
   },
   {
-    name: 'skips release staging into its staging-nixos branch',
+    name: 'checks release staging into its staging-nixos branch',
     facts: {
       base: 'staging-nixos-26.05',
       head: 'staging-26.05',
       maxRebuildCount: 24_000,
     },
-    expected: 'skip-development-merge',
+    expected: 'mass-rebuild',
   },
   {
     name: 'kernel exemption suppresses a possible mass rebuild',

--- a/ci/github-script/check-target-branch-policy.test.ts
+++ b/ci/github-script/check-target-branch-policy.test.ts
@@ -1,14 +1,15 @@
 const assert = require('node:assert/strict')
 const test = require('node:test')
-const { decideTargetBranchReview } = require('./check-target-branch-policy.ts')
+const {
+  evaluateTargetBranchPolicy,
+} = require('./check-target-branch-policy.ts')
 
 type DecisionFacts = {
   base: string
   head: string
   maxRebuildCount: number
   rebuildsAllTests: boolean
-  isExemptKernelUpdate: boolean
-  isExemptHomeAssistantUpdate: boolean
+  onlyChangedFile: string | null
 }
 
 type Decision =
@@ -23,8 +24,7 @@ const defaults: DecisionFacts = {
   head: 'topic-branch',
   maxRebuildCount: 0,
   rebuildsAllTests: false,
-  isExemptKernelUpdate: false,
-  isExemptHomeAssistantUpdate: false,
+  onlyChangedFile: null,
 }
 
 const cases: Array<{
@@ -164,33 +164,47 @@ const cases: Array<{
   },
   {
     name: 'kernel exemption suppresses a possible mass rebuild',
-    facts: { maxRebuildCount: 999, isExemptKernelUpdate: true },
+    facts: {
+      maxRebuildCount: 999,
+      onlyChangedFile: 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix',
+    },
     expected: 'dismiss',
   },
   {
     name: 'kernel exemption suppresses a definite mass rebuild',
-    facts: { maxRebuildCount: 1000, isExemptKernelUpdate: true },
+    facts: {
+      maxRebuildCount: 1000,
+      onlyChangedFile: 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix',
+    },
     expected: 'dismiss',
   },
   {
     name: 'kernel exemption suppresses a NixOS test rebuild',
-    facts: { rebuildsAllTests: true, isExemptKernelUpdate: true },
+    facts: {
+      rebuildsAllTests: true,
+      onlyChangedFile: 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix',
+    },
     expected: 'dismiss',
   },
   {
     name: 'Home Assistant exemption suppresses a mass rebuild',
     facts: {
+      head: 'wip-home-assistant',
       maxRebuildCount: 1500,
-      isExemptHomeAssistantUpdate: true,
     },
     expected: 'dismiss',
   },
   {
+    name: 'does not exempt a Home Assistant update above 1500 rebuilds',
+    facts: { head: 'wip-home-assistant', maxRebuildCount: 1501 },
+    expected: 'mass-rebuild',
+  },
+  {
     name: 'Home Assistant exemption does not suppress a NixOS test rebuild',
     facts: {
+      head: 'wip-home-assistant',
       maxRebuildCount: 1500,
       rebuildsAllTests: true,
-      isExemptHomeAssistantUpdate: true,
     },
     expected: 'nixos-rebuild',
   },
@@ -198,6 +212,9 @@ const cases: Array<{
 
 for (const { name, facts, expected } of cases) {
   test(name, () => {
-    assert.equal(decideTargetBranchReview({ ...defaults, ...facts }), expected)
+    assert.equal(
+      evaluateTargetBranchPolicy({ ...defaults, ...facts }).decision,
+      expected,
+    )
   })
 }

--- a/ci/github-script/check-target-branch-policy.ts
+++ b/ci/github-script/check-target-branch-policy.ts
@@ -5,8 +5,7 @@ type TargetBranchPolicyFacts = {
   head: string
   maxRebuildCount: number
   rebuildsAllTests: boolean
-  isExemptKernelUpdate: boolean
-  isExemptHomeAssistantUpdate: boolean
+  onlyChangedFile: string | null
 }
 
 type TargetBranchReviewDecision =
@@ -15,6 +14,14 @@ type TargetBranchReviewDecision =
   | 'possible-mass-rebuild'
   | 'skip-development-merge'
   | 'dismiss'
+
+type TargetBranchPolicyResult = {
+  decision: TargetBranchReviewDecision
+  details: {
+    isExemptKernelUpdate: boolean
+    isExemptHomeAssistantUpdate: boolean
+  }
+}
 
 function getTargetBranchPolicy({ base, head }: { base: string; head: string }) {
   const baseClassification = classify(base)
@@ -35,31 +42,50 @@ function getTargetBranchPolicy({ base, head }: { base: string; head: string }) {
   }
 }
 
-function decideTargetBranchReview({
+function evaluateTargetBranchPolicy({
   base,
   head,
   maxRebuildCount,
   rebuildsAllTests,
-  isExemptKernelUpdate,
-  isExemptHomeAssistantUpdate,
-}: TargetBranchPolicyFacts): TargetBranchReviewDecision {
+  onlyChangedFile,
+}: TargetBranchPolicyFacts): TargetBranchPolicyResult {
   const {
     isStagingNixosBase,
     shouldSkipDevelopmentMerge,
     shouldCheckMassRebuild,
     shouldCheckNixosRebuild,
   } = getTargetBranchPolicy({ base, head })
+
+  // https://github.com/NixOS/nixpkgs/pull/521157
+  // These should go to master and release-xx.xx when backported
+  const isExemptKernelUpdate =
+    onlyChangedFile === 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix'
+
+  // https://github.com/NixOS/nixpkgs/pull/483194#issuecomment-3793393218
+  const isExemptHomeAssistantUpdate =
+    maxRebuildCount <= 1500 && head === 'wip-home-assistant'
+
+  const details = {
+    isExemptKernelUpdate,
+    isExemptHomeAssistantUpdate,
+  }
+
+  const result = (decision: TargetBranchReviewDecision) => ({
+    decision,
+    details,
+  })
+
   const isMassRebuild =
     maxRebuildCount >= 1000 &&
     !isExemptKernelUpdate &&
     !isExemptHomeAssistantUpdate
 
   if (shouldCheckMassRebuild && isMassRebuild) {
-    return 'mass-rebuild'
+    return result('mass-rebuild')
   }
 
   if (shouldCheckNixosRebuild && rebuildsAllTests && !isExemptKernelUpdate) {
-    return 'nixos-rebuild'
+    return result('nixos-rebuild')
   }
 
   const isPossibleMassRebuild =
@@ -72,10 +98,12 @@ function decideTargetBranchReview({
     isPossibleMassRebuild &&
     !(rebuildsAllTests && isStagingNixosBase)
   ) {
-    return 'possible-mass-rebuild'
+    return result('possible-mass-rebuild')
   }
 
-  return shouldSkipDevelopmentMerge ? 'skip-development-merge' : 'dismiss'
+  return result(
+    shouldSkipDevelopmentMerge ? 'skip-development-merge' : 'dismiss',
+  )
 }
 
-module.exports = { decideTargetBranchReview, getTargetBranchPolicy }
+module.exports = { evaluateTargetBranchPolicy, getTargetBranchPolicy }

--- a/ci/github-script/check-target-branch-policy.ts
+++ b/ci/github-script/check-target-branch-policy.ts
@@ -19,10 +19,14 @@ type TargetBranchReviewDecision =
 function getTargetBranchPolicy({ base, head }: { base: string; head: string }) {
   const baseClassification = classify(base)
   const headClassification = classify(head)
+  const isPrimaryBase = baseClassification.type.includes('primary')
+  const shouldSkipDevelopmentMerge =
+    headClassification.type.includes('development')
 
   return {
-    shouldSkipDevelopmentMerge: headClassification.type.includes('development'),
-    shouldCheckMassRebuild: baseClassification.type.includes('primary'),
+    shouldSkipDevelopmentMerge,
+    shouldCheckMassRebuild: !shouldSkipDevelopmentMerge && isPrimaryBase,
+    shouldCheckNixosRebuild: !shouldSkipDevelopmentMerge && isPrimaryBase,
   }
 }
 
@@ -34,34 +38,34 @@ function decideTargetBranchReview({
   isExemptKernelUpdate,
   isExemptHomeAssistantUpdate,
 }: TargetBranchPolicyFacts): TargetBranchReviewDecision {
-  const baseClassification = classify(base)
-  const headClassification = classify(head)
-
-  if (headClassification.type.includes('development')) {
-    return 'skip-development-merge'
-  }
-
-  if (!baseClassification.type.includes('primary')) {
-    return 'dismiss'
-  }
-
-  if (
+  const {
+    shouldSkipDevelopmentMerge,
+    shouldCheckMassRebuild,
+    shouldCheckNixosRebuild,
+  } = getTargetBranchPolicy({ base, head })
+  const isMassRebuild =
     maxRebuildCount >= 1000 &&
-    !isExemptHomeAssistantUpdate &&
-    !isExemptKernelUpdate
-  ) {
-    return 'mass-rebuild'
-  } else if (rebuildsAllTests && !isExemptKernelUpdate) {
-    return 'nixos-rebuild'
-  } else if (
-    maxRebuildCount >= 500 &&
     !isExemptKernelUpdate &&
     !isExemptHomeAssistantUpdate
-  ) {
-    return 'possible-mass-rebuild'
-  } else {
-    return 'dismiss'
+
+  if (shouldCheckMassRebuild && isMassRebuild) {
+    return 'mass-rebuild'
   }
+
+  if (shouldCheckNixosRebuild && rebuildsAllTests && !isExemptKernelUpdate) {
+    return 'nixos-rebuild'
+  }
+
+  const isPossibleMassRebuild =
+    maxRebuildCount >= 500 &&
+    !isMassRebuild &&
+    !isExemptKernelUpdate &&
+    !isExemptHomeAssistantUpdate
+  if (shouldCheckMassRebuild && isPossibleMassRebuild) {
+    return 'possible-mass-rebuild'
+  }
+
+  return shouldSkipDevelopmentMerge ? 'skip-development-merge' : 'dismiss'
 }
 
 module.exports = { decideTargetBranchReview, getTargetBranchPolicy }

--- a/ci/github-script/check-target-branch-policy.ts
+++ b/ci/github-script/check-target-branch-policy.ts
@@ -1,0 +1,67 @@
+const { classify } = require('../supportedBranches.js')
+
+type TargetBranchPolicyFacts = {
+  base: string
+  head: string
+  maxRebuildCount: number
+  rebuildsAllTests: boolean
+  isExemptKernelUpdate: boolean
+  isExemptHomeAssistantUpdate: boolean
+}
+
+type TargetBranchReviewDecision =
+  | 'mass-rebuild'
+  | 'nixos-rebuild'
+  | 'possible-mass-rebuild'
+  | 'skip-development-merge'
+  | 'dismiss'
+
+function getTargetBranchPolicy({ base, head }: { base: string; head: string }) {
+  const baseClassification = classify(base)
+  const headClassification = classify(head)
+
+  return {
+    shouldSkipDevelopmentMerge: headClassification.type.includes('development'),
+    shouldCheckMassRebuild: baseClassification.type.includes('primary'),
+  }
+}
+
+function decideTargetBranchReview({
+  base,
+  head,
+  maxRebuildCount,
+  rebuildsAllTests,
+  isExemptKernelUpdate,
+  isExemptHomeAssistantUpdate,
+}: TargetBranchPolicyFacts): TargetBranchReviewDecision {
+  const baseClassification = classify(base)
+  const headClassification = classify(head)
+
+  if (headClassification.type.includes('development')) {
+    return 'skip-development-merge'
+  }
+
+  if (!baseClassification.type.includes('primary')) {
+    return 'dismiss'
+  }
+
+  if (
+    maxRebuildCount >= 1000 &&
+    !isExemptHomeAssistantUpdate &&
+    !isExemptKernelUpdate
+  ) {
+    return 'mass-rebuild'
+  } else if (rebuildsAllTests && !isExemptKernelUpdate) {
+    return 'nixos-rebuild'
+  } else if (
+    maxRebuildCount >= 500 &&
+    !isExemptKernelUpdate &&
+    !isExemptHomeAssistantUpdate
+  ) {
+    return 'possible-mass-rebuild'
+  } else {
+    return 'dismiss'
+  }
+}
+
+module.exports = { decideTargetBranchReview, getTargetBranchPolicy }

--- a/ci/github-script/check-target-branch-policy.ts
+++ b/ci/github-script/check-target-branch-policy.ts
@@ -1,4 +1,4 @@
-const { classify } = require('../supportedBranches.js')
+const { classify, split } = require('../supportedBranches.js')
 
 type TargetBranchPolicyFacts = {
   base: string
@@ -20,12 +20,17 @@ function getTargetBranchPolicy({ base, head }: { base: string; head: string }) {
   const baseClassification = classify(base)
   const headClassification = classify(head)
   const isPrimaryBase = baseClassification.type.includes('primary')
+  const isPrimaryHead = headClassification.type.includes('primary')
+  const isStagingNixosBase = split(base).prefix === 'staging-nixos'
+  const isDevelopmentHead = headClassification.type.includes('development')
   const shouldSkipDevelopmentMerge =
-    headClassification.type.includes('development')
+    isDevelopmentHead && (!isStagingNixosBase || isPrimaryHead)
 
   return {
+    isStagingNixosBase,
     shouldSkipDevelopmentMerge,
-    shouldCheckMassRebuild: !shouldSkipDevelopmentMerge && isPrimaryBase,
+    shouldCheckMassRebuild:
+      !shouldSkipDevelopmentMerge && (isPrimaryBase || isStagingNixosBase),
     shouldCheckNixosRebuild: !shouldSkipDevelopmentMerge && isPrimaryBase,
   }
 }
@@ -39,6 +44,7 @@ function decideTargetBranchReview({
   isExemptHomeAssistantUpdate,
 }: TargetBranchPolicyFacts): TargetBranchReviewDecision {
   const {
+    isStagingNixosBase,
     shouldSkipDevelopmentMerge,
     shouldCheckMassRebuild,
     shouldCheckNixosRebuild,
@@ -61,7 +67,11 @@ function decideTargetBranchReview({
     !isMassRebuild &&
     !isExemptKernelUpdate &&
     !isExemptHomeAssistantUpdate
-  if (shouldCheckMassRebuild && isPossibleMassRebuild) {
+  if (
+    shouldCheckMassRebuild &&
+    isPossibleMassRebuild &&
+    !(rebuildsAllTests && isStagingNixosBase)
+  ) {
     return 'possible-mass-rebuild'
   }
 

--- a/ci/github-script/check-target-branch.ts
+++ b/ci/github-script/check-target-branch.ts
@@ -10,7 +10,7 @@ const { split } = require('../supportedBranches.js')
 const { readFile } = require('node:fs/promises')
 const { postReview, dismissReviews } = require('./reviews.js')
 const {
-  decideTargetBranchReview,
+  evaluateTargetBranchPolicy,
   getTargetBranchPolicy,
 } = require('./check-target-branch-policy.ts')
 
@@ -168,9 +168,7 @@ async function checkTargetBranch({
     changed.attrdiff.changed.includes('nixosTests.simple-container') ||
     changed.attrdiff.changed.includes('nixosTests.simple-vm')
 
-  // https://github.com/NixOS/nixpkgs/pull/521157
-  // These should go to master and release-xx.xx when backported
-  let isExemptKernelUpdate = false
+  let onlyChangedFile: string | null = null
   if (shouldCheckMassRebuild && prInfo.changed_files === 1) {
     const changedFiles = (
       await github.rest.pulls.listFiles({
@@ -178,22 +176,19 @@ async function checkTargetBranch({
         pull_number,
       })
     ).data
-    isExemptKernelUpdate =
-      changedFiles.length === 1 &&
-      changedFiles[0].filename ===
-        'pkgs/os-specific/linux/kernel/xanmod-kernels.nix'
+    onlyChangedFile =
+      changedFiles.length === 1 ? changedFiles[0].filename : null
   }
 
-  // https://github.com/NixOS/nixpkgs/pull/483194#issuecomment-3793393218
-  const isExemptHomeAssistantUpdate =
-    maxRebuildCount <= 1500 && head === 'wip-home-assistant'
-  const decision = decideTargetBranchReview({
+  const {
+    decision,
+    details: { isExemptKernelUpdate, isExemptHomeAssistantUpdate },
+  } = evaluateTargetBranchPolicy({
     base,
     head,
     maxRebuildCount,
     rebuildsAllTests,
-    isExemptKernelUpdate,
-    isExemptHomeAssistantUpdate,
+    onlyChangedFile,
   })
 
   core.info(

--- a/ci/github-script/check-target-branch.ts
+++ b/ci/github-script/check-target-branch.ts
@@ -53,10 +53,14 @@ type TargetBranchReviewFacts = {
   maxRebuildCount: number
 }
 
+function getStagingBranch(base: string) {
+  const version = split(base).version
+  return version ? `staging-${version}` : 'staging'
+}
+
 async function postMassRebuildReview(facts: TargetBranchReviewFacts) {
   const { github, context, core, dry, base, maxRebuildCount } = facts
-  const desiredBranch =
-    base === 'master' ? 'staging' : `staging-${split(base).version}`
+  const desiredBranch = getStagingBranch(base)
   const body = [
     `The PR's base branch is set to \`${base}\`, but this PR causes ${maxRebuildCount} rebuilds.`,
     'It is therefore considered a mass rebuild.',
@@ -107,8 +111,7 @@ async function postNixosRebuildReview(facts: TargetBranchReviewFacts) {
 
 async function postPossibleMassRebuildReview(facts: TargetBranchReviewFacts) {
   const { github, context, core, dry, base, maxRebuildCount } = facts
-  const stagingBranch =
-    base === 'master' ? 'staging' : `staging-${split(base).version}`
+  const stagingBranch = getStagingBranch(base)
   const body = [
     `The PR's base branch is set to \`${base}\`, and this PR causes ${maxRebuildCount} rebuilds.`,
     `Please consider whether this PR causes a mass rebuild according to [our conventions](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions).`,

--- a/ci/github-script/check-target-branch.ts
+++ b/ci/github-script/check-target-branch.ts
@@ -40,6 +40,89 @@ type ChangedPaths = {
   rebuildsByPlatform: Record<string, string[]>
 }
 
+type TargetBranchReviewFacts = {
+  github: InstanceType<typeof GitHub>
+  context: typeof actionsContext
+  core: typeof actionsCore
+  dry: boolean
+  base: string
+  maxRebuildCount: number
+}
+
+async function postMassRebuildReview(facts: TargetBranchReviewFacts) {
+  const { github, context, core, dry, base, maxRebuildCount } = facts
+  const desiredBranch =
+    base === 'master' ? 'staging' : `staging-${split(base).version}`
+  const body = [
+    `The PR's base branch is set to \`${base}\`, but this PR causes ${maxRebuildCount} rebuilds.`,
+    'It is therefore considered a mass rebuild.',
+    `Please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) (probably \`${desiredBranch}\`).`,
+  ].join('\n')
+
+  await postReview({
+    github,
+    context,
+    core,
+    dry,
+    body,
+    event: 'REQUEST_CHANGES',
+    reviewKey,
+  })
+}
+
+async function postNixosRebuildReview(facts: TargetBranchReviewFacts) {
+  const { github, context, core, dry, base, maxRebuildCount } = facts
+  let branchText: string
+  if (base === 'master' && maxRebuildCount >= 500) {
+    branchText = '(probably either `staging-nixos` or `staging`)'
+  } else if (base === 'master') {
+    branchText = '(probably `staging-nixos`)'
+  } else if (maxRebuildCount >= 500) {
+    branchText = `(probably either \`staging-nixos-${split(base).version}\` or \`staging-${split(base).version}\`)`
+  } else {
+    branchText = `(probably \`staging-nixos-${split(base).version}\`)`
+  }
+  const body = [
+    `The PR's base branch is set to \`${base}\`, but this PR rebuilds all NixOS tests.`,
+    base === 'master' && maxRebuildCount >= 500
+      ? `Since this PR also causes ${maxRebuildCount} rebuilds, it may also be considered a mass rebuild.`
+      : '',
+    `Please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) ${branchText}.`,
+  ].join('\n')
+
+  await postReview({
+    github,
+    context,
+    core,
+    dry,
+    body,
+    event: 'REQUEST_CHANGES',
+    reviewKey,
+  })
+}
+
+async function postPossibleMassRebuildReview(facts: TargetBranchReviewFacts) {
+  const { github, context, core, dry, base, maxRebuildCount } = facts
+  const stagingBranch =
+    base === 'master' ? 'staging' : `staging-${split(base).version}`
+  const body = [
+    `The PR's base branch is set to \`${base}\`, and this PR causes ${maxRebuildCount} rebuilds.`,
+    `Please consider whether this PR causes a mass rebuild according to [our conventions](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions).`,
+    `If it does cause a mass rebuild, please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) (probably \`${stagingBranch}\`).`,
+    `If it does not cause a mass rebuild, this message can be ignored.`,
+  ].join('\n')
+
+  await postReview({
+    github,
+    context,
+    core,
+    dry,
+    body,
+    event: 'REQUEST_CHANGES',
+    reviewKey,
+  })
+}
+
 async function checkTargetBranch({
   github,
   context,
@@ -142,79 +225,29 @@ async function checkTargetBranch({
     ].join('\n'),
   )
 
+  const reviewFacts: TargetBranchReviewFacts = {
+    github,
+    context,
+    core,
+    dry,
+    base,
+    maxRebuildCount,
+  }
+
   if (
     maxRebuildCount >= 1000 &&
     !isExemptHomeAssistantUpdate &&
     !isExemptKernelUpdate
   ) {
-    const desiredBranch =
-      base === 'master' ? 'staging' : `staging-${split(base).version}`
-    const body = [
-      `The PR's base branch is set to \`${base}\`, but this PR causes ${maxRebuildCount} rebuilds.`,
-      'It is therefore considered a mass rebuild.',
-      `Please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) (probably \`${desiredBranch}\`).`,
-    ].join('\n')
-
-    await postReview({
-      github,
-      context,
-      core,
-      dry,
-      body,
-      event: 'REQUEST_CHANGES',
-      reviewKey,
-    })
+    await postMassRebuildReview(reviewFacts)
   } else if (rebuildsAllTests && !isExemptKernelUpdate) {
-    let branchText: string
-    if (base === 'master' && maxRebuildCount >= 500) {
-      branchText = '(probably either `staging-nixos` or `staging`)'
-    } else if (base === 'master') {
-      branchText = '(probably `staging-nixos`)'
-    } else if (maxRebuildCount >= 500) {
-      branchText = `(probably either \`staging-nixos-${split(base).version}\` or \`staging-${split(base).version}\`)`
-    } else {
-      branchText = `(probably \`staging-nixos-${split(base).version}\`)`
-    }
-    const body = [
-      `The PR's base branch is set to \`${base}\`, but this PR rebuilds all NixOS tests.`,
-      base === 'master' && maxRebuildCount >= 500
-        ? `Since this PR also causes ${maxRebuildCount} rebuilds, it may also be considered a mass rebuild.`
-        : '',
-      `Please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) ${branchText}.`,
-    ].join('\n')
-
-    await postReview({
-      github,
-      context,
-      core,
-      dry,
-      body,
-      event: 'REQUEST_CHANGES',
-      reviewKey,
-    })
+    await postNixosRebuildReview(reviewFacts)
   } else if (
     maxRebuildCount >= 500 &&
     !isExemptKernelUpdate &&
     !isExemptHomeAssistantUpdate
   ) {
-    const stagingBranch =
-      base === 'master' ? 'staging' : `staging-${split(base).version}`
-    const body = [
-      `The PR's base branch is set to \`${base}\`, and this PR causes ${maxRebuildCount} rebuilds.`,
-      `Please consider whether this PR causes a mass rebuild according to [our conventions](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions).`,
-      `If it does cause a mass rebuild, please [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request) to [the right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) (probably \`${stagingBranch}\`).`,
-      `If it does not cause a mass rebuild, this message can be ignored.`,
-    ].join('\n')
-
-    await postReview({
-      github,
-      context,
-      core,
-      dry,
-      body,
-      event: 'REQUEST_CHANGES',
-      reviewKey,
-    })
+    await postPossibleMassRebuildReview(reviewFacts)
   } else {
     core.info('checkTargetBranch: this PR is against an appropriate branch.')
 

--- a/ci/github-script/check-target-branch.ts
+++ b/ci/github-script/check-target-branch.ts
@@ -6,9 +6,13 @@ import type { GitHub } from '@actions/github/lib/utils'
 // They do seem quite similar, but this needs to run after eval,
 // and prepare.js obviously doesn't.
 
-const { classify, split } = require('../supportedBranches.js')
+const { split } = require('../supportedBranches.js')
 const { readFile } = require('node:fs/promises')
 const { postReview, dismissReviews } = require('./reviews.js')
+const {
+  decideTargetBranchReview,
+  getTargetBranchPolicy,
+} = require('./check-target-branch-policy.ts')
 
 const reviewKey = 'check-target-branch'
 
@@ -152,11 +156,11 @@ async function checkTargetBranch({
   ).data
   const base = prInfo.base.ref
   const head = prInfo.head.ref
-  const baseClassification = classify(base)
-  const headClassification = classify(head)
+  const { shouldSkipDevelopmentMerge, shouldCheckMassRebuild } =
+    getTargetBranchPolicy({ base, head })
 
   // Don't run on, e.g., staging-nixos to master merges.
-  if (headClassification.type.includes('development')) {
+  if (shouldSkipDevelopmentMerge) {
     core.info(
       `Skipping checkTargetBranch: PR is from a development branch (${head})`,
     )
@@ -172,7 +176,7 @@ async function checkTargetBranch({
     return
   }
   // Don't run on PRs against staging branches, wip branches, haskell-updates, etc.
-  if (!baseClassification.type.includes('primary')) {
+  if (!shouldCheckMassRebuild) {
     core.info(
       `Skipping checkTargetBranch: PR is against a non-primary base branch (${base})`,
     )
@@ -214,6 +218,14 @@ async function checkTargetBranch({
   // https://github.com/NixOS/nixpkgs/pull/483194#issuecomment-3793393218
   const isExemptHomeAssistantUpdate =
     maxRebuildCount <= 1500 && head === 'wip-home-assistant'
+  const decision = decideTargetBranchReview({
+    base,
+    head,
+    maxRebuildCount,
+    rebuildsAllTests,
+    isExemptKernelUpdate,
+    isExemptHomeAssistantUpdate,
+  })
 
   core.info(
     [
@@ -234,19 +246,11 @@ async function checkTargetBranch({
     maxRebuildCount,
   }
 
-  if (
-    maxRebuildCount >= 1000 &&
-    !isExemptHomeAssistantUpdate &&
-    !isExemptKernelUpdate
-  ) {
+  if (decision === 'mass-rebuild') {
     await postMassRebuildReview(reviewFacts)
-  } else if (rebuildsAllTests && !isExemptKernelUpdate) {
+  } else if (decision === 'nixos-rebuild') {
     await postNixosRebuildReview(reviewFacts)
-  } else if (
-    maxRebuildCount >= 500 &&
-    !isExemptKernelUpdate &&
-    !isExemptHomeAssistantUpdate
-  ) {
+  } else if (decision === 'possible-mass-rebuild') {
     await postPossibleMassRebuildReview(reviewFacts)
   } else {
     core.info('checkTargetBranch: this PR is against an appropriate branch.')

--- a/ci/github-script/check-target-branch.ts
+++ b/ci/github-script/check-target-branch.ts
@@ -156,41 +156,7 @@ async function checkTargetBranch({
   ).data
   const base = prInfo.base.ref
   const head = prInfo.head.ref
-  const { shouldSkipDevelopmentMerge, shouldCheckMassRebuild } =
-    getTargetBranchPolicy({ base, head })
-
-  // Don't run on, e.g., staging-nixos to master merges.
-  if (shouldSkipDevelopmentMerge) {
-    core.info(
-      `Skipping checkTargetBranch: PR is from a development branch (${head})`,
-    )
-
-    await dismissReviews({
-      github,
-      context,
-      core,
-      dry,
-      reviewKey,
-    })
-
-    return
-  }
-  // Don't run on PRs against staging branches, wip branches, haskell-updates, etc.
-  if (!shouldCheckMassRebuild) {
-    core.info(
-      `Skipping checkTargetBranch: PR is against a non-primary base branch (${base})`,
-    )
-
-    await dismissReviews({
-      github,
-      context,
-      core,
-      dry,
-      reviewKey,
-    })
-
-    return
-  }
+  const { shouldCheckMassRebuild } = getTargetBranchPolicy({ base, head })
 
   const maxRebuildCount = Math.max(
     ...Object.values(changed.rebuildCountByKernel),
@@ -202,7 +168,7 @@ async function checkTargetBranch({
   // https://github.com/NixOS/nixpkgs/pull/521157
   // These should go to master and release-xx.xx when backported
   let isExemptKernelUpdate = false
-  if (prInfo.changed_files === 1) {
+  if (shouldCheckMassRebuild && prInfo.changed_files === 1) {
     const changedFiles = (
       await github.rest.pulls.listFiles({
         ...context.repo,
@@ -248,21 +214,34 @@ async function checkTargetBranch({
 
   if (decision === 'mass-rebuild') {
     await postMassRebuildReview(reviewFacts)
-  } else if (decision === 'nixos-rebuild') {
+    return
+  }
+
+  if (decision === 'nixos-rebuild') {
     await postNixosRebuildReview(reviewFacts)
-  } else if (decision === 'possible-mass-rebuild') {
+    return
+  }
+
+  if (decision === 'possible-mass-rebuild') {
     await postPossibleMassRebuildReview(reviewFacts)
+    return
+  }
+
+  if (decision === 'skip-development-merge') {
+    core.info(
+      `Skipping checkTargetBranch: PR merges the development branch ${head} into ${base}`,
+    )
   } else {
     core.info('checkTargetBranch: this PR is against an appropriate branch.')
-
-    await dismissReviews({
-      github,
-      context,
-      core,
-      dry,
-      reviewKey,
-    })
   }
+
+  await dismissReviews({
+    github,
+    context,
+    core,
+    dry,
+    reviewKey,
+  })
 }
 
 module.exports = checkTargetBranch

--- a/ci/github-script/package.json
+++ b/ci/github-script/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "typecheck": "tsc --build",
-    "test": "npm run typecheck"
+    "testsuite": "node --test",
+    "test": "npm run typecheck && npm run testsuite"
   },
   "//": [
     "Keep `@actions/core` and `@actions/github` in sync with",

--- a/ci/github-script/package.json
+++ b/ci/github-script/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "scripts": {
+    "typecheck": "tsc --build",
+    "test": "npm run typecheck"
+  },
   "//": [
     "Keep `@actions/core` and `@actions/github` in sync with",
     "https://github.com/actions/github-script/blob/main/package.json."


### PR DESCRIPTION
As we realized today, target branch bot was not flagging mass rebuilds on
staging-nixos. This series solves this policy gap.

The buggy code is a bit convoluted plus lacks tests, so this series first
prepares it by extracting policy decision as a pure function. Then it adds
tests that reflect the current policy (with all its bugs and quirks). Finally,
it adjusts the policy to flag mass rebuilds on staging-nixos.

The series also adds a new github-script step that runs the newly added tests for
`github-script` package.

Note: there are probably more policy issues. For example, the xanmod kernel
exempt seems too broad: I think it was added to avoid "probable" mass rebuilds
comments, but it applies to any mass rebuilds, so if it ever spills above the
hard 1000 limit, we would not flag it.

Regardless whether it's a bug or not, this series leaves the rest of the policy
as is, and only adds the staging-nixos mass rebuilds check.

Commits:
- **ci/github-script/check-target-branch: extract review helpers**
- **ci/github-script/check-target-branch: extract policy decision**
- **ci/github-script/check-target-branch: add policy tests**
- **ci/github-script/check-target-branch: simplify policy decisions**
- **.github: test github-script package in CI**
- **ci/github-script/check-target-branch: check staging-nixos mass rebuilds**
- **ci/github-script/check-target-branch: evaluate exemptions in policy**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
