### PR TITLE
creduce: llvmPackages_18 -> llvmPackages_21

### DIFF
--- a/pkgs/by-name/cr/creduce/package.nix
+++ b/pkgs/by-name/cr/creduce/package.nix
@@ -2,16 +2,17 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   makeWrapper,
-  llvmPackages_18,
+  llvmPackages_21,
   flex,
   zlib,
   perlPackages,
   util-linux,
 }:
 let
-  llvmPackages = llvmPackages_18;
+  llvmPackages = llvmPackages_21;
 in
 
 stdenv.mkDerivation {
@@ -28,6 +29,25 @@ stdenv.mkDerivation {
   patches = [
     # https://github.com/csmith-project/creduce/pull/290
     ./fix-gcc15.patch
+
+    # support for recent llvm versions, fetched from debian which applies fixes to
+    # several open PRs.
+    # https://salsa.debian.org/toolchain-team/creduce/-/commit/86e45dd83b7e8e88d9e5398ff8556883c1679629
+    (fetchpatch {
+      name = "llvm-19-support.patch";
+      url = "https://salsa.debian.org/toolchain-team/creduce/-/raw/86e45dd83b7e8e88d9e5398ff8556883c1679629/debian/patches/llvm-19-fixes.diff";
+      hash = "sha256-uYjZfCJ4csnq20OHVYB7m+qboaeJkLmZm4LlsX5+hvA=";
+    })
+    (fetchpatch {
+      name = "llvm-20-support.patch";
+      url = "https://salsa.debian.org/toolchain-team/creduce/-/raw/86e45dd83b7e8e88d9e5398ff8556883c1679629/debian/patches/287.diff";
+      hash = "sha256-xl9hTCgp37fRqhiYC7T/XuZkpZ3C55IZ6dSPmM81UCg=";
+    })
+    (fetchpatch {
+      name = "llvm-21-support.patch";
+      url = "https://salsa.debian.org/toolchain-team/creduce/-/raw/86e45dd83b7e8e88d9e5398ff8556883c1679629/debian/patches/289.diff";
+      hash = "sha256-DSnAAxGreVGZohrWalY0/1JMo7CL8+QrMfm2tXHn2oE=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
llvm 18 is quite old, and as we understand it, possibly slated for removal in the 26.11 cycle. creduce only supports a maximum of llvm 18 upstream, but with some open prs (which debian has fixed up a bit), adding llvm 21 support is relatively straightforward. accordingly, we fetch the relevant patches from debian to be able to upgrade to a modern llvm version.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (with some of the examples from https://web.archive.org/web/20201204141133/https://embed.cs.utah.edu/creduce/using/, where the behavior matches what is expected)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
