### PR TITLE
hevi: switch from github to codeberg source

### DIFF
--- a/pkgs/by-name/he/hevi/package.nix
+++ b/pkgs/by-name/he/hevi/package.nix
@@ -1,6 +1,6 @@
 {
   callPackage,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   lib,
   stdenv,
   zig_0_13,
@@ -13,8 +13,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "hevi";
   version = "1.1.0";
 
-  src = fetchFromGitHub {
-    owner = "Arnau478";
+  src = fetchFromCodeberg {
+    owner = "arnauc";
     repo = "hevi";
     tag = "v${finalAttrs.version}";
     hash = "sha256-wnpuM2qlbeDIupDPQPKdWmjAKepCG0+u3uxcLDFB09w=";
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Hex viewer";
-    homepage = "https://github.com/Arnau478/hevi";
+    homepage = "https://codeberg.org/arnauc/hevi";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.jmbaur ];
     mainProgram = "hevi";


### PR DESCRIPTION
as per the readme of the github repo:

> This repo was migrated to codeberg. The github repo is not a mirror. It won't receive any new commits. Please use the new repo.

the github repo is also now archived.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no rebuilds)
  - [x] aarch64-linux (no rebuilds)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
