### PR TITLE
claude-code: 2.1.233 -> 2.1.234

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-IboTqMAH/w3x43M7WXXCVQx8eL1Bw7syG8On18GU/xc=";
+          hash = "sha256-8SakE2rooV1s7+vDSNFKGErsnGEpxFMuds2Zit1b9cw=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-k+CkNkRoM2EB/8i/WFyRVv8COmHvN2WO0WbWkpfGvLg=";
+          hash = "sha256-gGli7mBulBHvEzUMY8IpAAyFYoVCT/oCE7pzLONf1Yg=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-YV5ZGPmZ7ovL6u0rnufzyOGsbJrt9BbXENBRVB7GS3I=";
+          hash = "sha256-4exme1H0ax6kGs06ob2FdHowsMxCSMldn+niKeQHcIU=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.233";
+      version = "2.1.234";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,52 +1,51 @@
 {
-  "version": "2.1.233",
-  "commit": "f8d57569aaf350fe25dc4dfa10cad59db8ea4d45",
-  "buildDate": "2026-08-14T17:37:41Z",
+  "version": "2.1.234",
+  "commit": "7215ba60b06dff03b3e75825084c7038a013d0b0",
+  "buildDate": "2026-08-17T01:50:17Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "bc466b6cde63edafc773f471a1fb98787fabb31f52240c8616ce7e1f587b212d",
-      "size": 306981408
+      "checksum": "08d8700313697cbe730a25420c908a299ce52d56f0eb2cf4fac94cab5109bc57",
+      "size": 310740672
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "8b3ae18df411098ce55705c4bb151e9c97e34df55fe379c7b6b3122a69f0ea74",
-      "size": 315654448
+      "checksum": "1a7b2e8948609f1f732a6498cd17b805b5c5187d74a99adc61ebaa5a29efc34c",
+      "size": 319452208
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "42df1841f74e9b2ac13f2c1a2a820ef6b9ac5b2efb8646bb25c9a92b8bd69194",
-      "size": 321771752
+      "checksum": "24adda673591cd8345b03ec8245915bb151a259a1ebc3ef23649b57ba944aaa2",
+      "size": 325507304
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "55d281096f57d411ebbdd94dbf5e9ff3accb7c05713e37348c2c11d4b83bf9d9",
-      "size": 324598064
+      "checksum": "3473601ea695d5bf769c5b202844d4cb4fbf723ae995450fcb6973204775c84a",
+      "size": 328358192
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "1669931403b9fea920aea1c2db398f70eae08836ca78896f3e5e85b04e9a2d97",
-      "size": 314916456
+      "checksum": "3d458e3709a4373fb62f799c1d421e8fd2dd1cfcbf3d608157c15cddd11715fb",
+      "size": 318652008
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "55f95b1ed2f8c52b429a5334c7101dd6171a78368677e0f5b89905c570dc56de",
-      "size": 318721832
+      "checksum": "408a059131b70cf51e01e2d19fbc340eafcbcfe1c99b49a08e6f8bd375326e71",
+      "size": 322486056
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "8ae35d41252b02a7b747097ececf368b6872fab93ca104832b99a8ec5942fabd",
-      "size": 320400544
+      "checksum": "3f877e78543e2cb4daad61d18f06cc11028f9dffc1afd41ccf1f8f84cf02eb1b",
+      "size": 324028576
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "c3852bb4a2d8418493ba75531913b03d00373974753c6d4a018ae419a0a106a1",
-      "size": 308298912
+      "checksum": "ed6cc3d0218e4b27f3691e3832837d814a5274b02755c34aedeb74e3db65e8d4",
+      "size": 311927456
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.195",
       "0.3.196",
       "0.3.197",
       "0.3.198",


### PR DESCRIPTION
Update claude-code and vscode-extensions.anthropic.claude-code to 2.1.234.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

> [!NOTE]
> Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard `maintainers/scripts/update.nix` script; the change was built locally and validated across arches via `nixpkgs-review`, and reviewed by a human (@markus1189) before being marked ready.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
