### PR TITLE
gitlab: 19.2.2 -> 19.2.4

### DIFF
--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "19.2.2";
+  version = "19.2.4";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,7 +21,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-S48IuJmL7Huo07ECTI953aFtjXdRJktrCWRoPHF0qjE=";
+      hash = "sha256-tUofUDi2cb31qh5PX6fx7BZ8eflvR7fUi7jnK1fH0q8=";
     };
 
     vendorHash = "sha256-4yB63q5a9GaCaasI40uObx6ZV/5FMIvkbkHt8fqD1gA=";

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitlab-pages";
-  version = "19.2.2";
+  version = "19.2.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lKLwhpHQcSfjLBumK6YcZ4TTj0sEZyJ7pmYeh1lLurY=";
+    hash = "sha256-GXhKAk6PVOK/y5FjRDWkKukqK4j2DTONsDMkbPZ/Iz4=";
   };
 
   vendorHash = "sha256-aTnRSas8PgxPLLcBExNb5GHYXV0eLc1gD4Ky+50/kfw=";

--- a/pkgs/by-name/gi/gitlab/data.json
+++ b/pkgs/by-name/gi/gitlab/data.json
@@ -1,17 +1,17 @@
 {
-  "version": "19.2.2",
-  "repo_hash": "sha256-3JyP5xRjYegkjD3y8dVjMQ7zwLi+46GNKVcMb5bZGG4=",
+  "version": "19.2.4",
+  "repo_hash": "sha256-AP2sWC0O5D8zPaIYm5/m8t/Z5aXq74AZsT4hH9B0Quk=",
   "yarn_hash": "sha256-UJS0ZX8d6iIRNa/LQLQTSNZDtjKNm9e35RKqvsXxv3c=",
   "frontend_islands_yarn_hash": "sha256-EvGQin+5DqqIgM36jlVkVI49WcJzVvceYnkSS9ybfcY=",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v19.2.2-ee",
+  "rev": "v19.2.4-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "19.2.2",
-    "GITLAB_KAS_VERSION": "19.2.2",
-    "GITLAB_PAGES_VERSION": "19.2.2",
+    "GITALY_SERVER_VERSION": "19.2.4",
+    "GITLAB_KAS_VERSION": "19.2.4",
+    "GITLAB_PAGES_VERSION": "19.2.4",
     "GITLAB_SHELL_VERSION": "14.56.1",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.14.7",
-    "GITLAB_WORKHORSE_VERSION": "19.2.2"
+    "GITLAB_WORKHORSE_VERSION": "19.2.4"
   }
 }

--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule (finalAttrs: {
   pname = "gitlab-workhorse";
 
-  version = "19.2.2";
+  version = "19.2.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {


### PR DESCRIPTION
https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.4-ee/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
