### PR TITLE
qt6.qtdeclarative: backport QTBUG-147153 InternalClass crash fix

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -57,6 +57,15 @@ qtModule {
       url = "https://github.com/qt/qtdeclarative/commit/9d4d376726a6ce15c429128dc65b927e411e40da.diff";
       hash = "sha256-XhfliF5wZuN4/E55f8hfipIRjxBe9V7vL1cgn5p4xqA=";
     })
+
+    # backport fix for a QV4 heap corruption crash on JS objects with
+    # add/delete/re-add property churn (QTBUG-147153); crashes e.g.
+    # quickshell-based shells like noctalia-shell
+    # https://bugreports.qt.io/browse/QTBUG-147153
+    (fetchpatch {
+      url = "https://github.com/qt/qtdeclarative/commit/624e90bb5e89837d4b759b43e2120b059d98a41e.diff";
+      hash = "sha256-7duTYpHZusVNDMlkm19dCppEWBejjTbc0sy3QvJG65s=";
+    })
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
Backports the upstream fix for [QTBUG-147153](https://bugreports.qt.io/browse/QTBUG-147153) ("InternalClass: Fix index invalidation when cleaning up transitions", [qt/qtdeclarative@624e90bb5e](https://github.com/qt/qtdeclarative/commit/624e90bb5e89837d4b759b43e2120b059d98a41e)) to qtdeclarative 6.11.1.

**The bug:** QV4's `InternalClass::changeMember` returns a stale property index when `cleanInternalClass` rebuilds the transition hierarchy. The rebuild triggers after 255 redundant transitions accumulated by add/delete/re-add property churn on a plain JS object. The rebuilt object may hold all surviving members inline with no out-of-line `memberData`, so the subsequent store through the stale index dereferences null: SIGSEGV in `QV4::Object::insertMember`. Any long-running QML application that repeatedly adds/deletes/re-adds keys on a JS object eventually hits it.

**Real-world impact:** recurring crashes in quickshell-based desktop shells; root cause analysis, coredump evidence, and a deterministic 22-line QML reproducer in [noctalia-dev/noctalia#3992](https://github.com/noctalia-dev/noctalia/issues/3992).

**Fix status upstream:** merged to qtdeclarative dev, `Pick-to: 6.12 6.11 6.8`, but absent from every released Qt including 6.11.1 (verified: the 6.11 cherry-pick `d9d1fa1c51` is not reachable from the `v6.11.1` tag). This backport can be dropped at the next qt6 point release bump that contains it.

The patch (`.diff` of the upstream commit) applies to 6.11.1 with line offsets only; it touches `src/qml/jsruntime/qv4internalclass.cpp` plus one regression test in `tests/auto/qml/qjsengine`.

Targets `staging` (qt6.qtdeclarative mass rebuild).

**Verification done:**
- The identical patch built into qtdeclarative 6.11.0 on x86_64-linux (NixOS): the deterministic reproducer from the upstream regression test segfaults the unpatched build 100% of the time and passes on the patched build (`survived: 42 254 255`).
- Patch dry-run applies cleanly on pristine 6.11.1 sources (both hunks).
- `nixfmt` clean; expression instantiates.

**Automation/AI disclosure** (per the [automation/AI policy]): the root cause analysis, patch selection, and this PR were prepared with LLM assistance (Claude); the change was reviewed and is submitted under my responsibility.

## Things done

- Built on platform:
  - [ ] x86_64-linux (same patch built and runtime-verified against qtdeclarative 6.11.0; 6.11.1 staging build left to CI)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Deterministic reproducer for the crash passes on a patched build, segfaults on unpatched.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
