### PR TITLE
v2raya: 2.2.7.5 -> 2.4.15

### DIFF
--- a/nixos/modules/services/networking/v2raya.nix
+++ b/nixos/modules/services/networking/v2raya.nix
@@ -12,20 +12,22 @@ let
 in
 
 {
+  imports = [
+    (mkRemovedOptionModule [ "services" "v2raya" "cliPackage" ] ''
+      v2rayA now exclusively uses its bundled v2raya_core binary.
+    '')
+  ];
+
   options = {
     services.v2raya = {
       enable = options.mkEnableOption "the v2rayA service";
 
       package = options.mkPackageOption pkgs "v2raya" { };
-      cliPackage = options.mkPackageOption pkgs "v2ray" {
-        example = "pkgs.xray";
-        extraDescription = "This is the package used for overriding the value of the `v2ray` attribute in the package set by `services.v2raya.package`.";
-      };
     };
   };
 
   config = mkIf config.services.v2raya.enable {
-    environment.systemPackages = [ (cfg.package.override { v2ray = cfg.cliPackage; }) ];
+    environment.systemPackages = [ cfg.package ];
 
     systemd.services.v2raya =
       let
@@ -50,7 +52,7 @@ in
 
         serviceConfig = {
           User = "root";
-          ExecStart = "${getExe (cfg.package.override { v2ray = cfg.cliPackage; })} --log-disable-timestamp";
+          ExecStart = "${getExe cfg.package} --log-disable-timestamp";
           Environment = [ "V2RAYA_LOG_FILE=/var/log/v2raya/v2raya.log" ];
           LimitNPROC = 500;
           LimitNOFILE = 1000000;

--- a/pkgs/by-name/v2/v2raya/package.nix
+++ b/pkgs/by-name/v2/v2raya/package.nix
@@ -18,13 +18,14 @@
 }:
 let
   pname = "v2raya";
-  version = "2.2.7.5";
+  version = "2.4.15";
 
   src = fetchFromGitHub {
     owner = "v2rayA";
     repo = "v2rayA";
     tag = "v${version}";
-    hash = "sha256-aa/Eb+fZQ1hwm6H7wb7mr0b4tCu12Mhy14OXNjZUJ0Y=";
+    fetchSubmodules = true;
+    hash = "sha256-JJQFH1HEsXes59bEpa6R6Ukuv1E/iOHGPlkUH2PFaso=";
     postFetch = "sed -i -e 's/npmmirror/yarnpkg/g' $out/gui/yarn.lock";
   };
 
@@ -35,7 +36,7 @@ let
 
     offlineCache = fetchYarnDeps {
       yarnLock = "${src}/gui/yarn.lock";
-      hash = "sha256-g+hI9n+nfXAcuEpjvDDaHg/DfjtNusOaw3S6kC1QDn4=";
+      hash = "sha256-yrUyE0cgwstZ5SEbHwo9z4NSHLHsgjraUjhnEW8xReI=";
     };
 
     env.OUTPUT_DIR = placeholder "out";
@@ -55,13 +56,34 @@ let
     ];
   };
 
+  core = buildGoModule {
+    pname = "v2raya-core";
+    inherit version src;
+
+    sourceRoot = "${src.name}/core";
+
+    vendorHash = "sha256-nfIfJsMzf7BUpzbWPujVO02o6qSmcTcOeXF89z4prB4=";
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X main.Version=${version}"
+    ];
+
+    subPackages = [ "./main" ];
+
+    postInstall = ''
+      mv $out/bin/main $out/bin/v2raya_core
+    '';
+  };
+
 in
 buildGoModule {
   inherit pname version src;
 
   sourceRoot = "${src.name}/service";
 
-  vendorHash = "sha256-uiURsB1V4IB77YKLu5gdaqw9Fuja6fC5adWYDE3OE+Q=";
+  vendorHash = "sha256-dDtBV6Tv87CiDW/8/ZuhoEtfZWXZMKNsusSWm1wKn3U=";
 
   ldflags = [
     "-s"
@@ -84,12 +106,17 @@ buildGoModule {
       --replace-fail 'Icon=/usr/share/icons/hicolor/512x512/apps/v2raya.png' 'Icon=v2raya'
 
     wrapProgram $out/bin/v2rayA \
-      --prefix PATH ":" "${lib.makeBinPath [ v2ray ]}" \
+      --prefix PATH ":" "${
+        lib.makeBinPath [
+          core
+          v2ray
+        ]
+      }" \
       --prefix XDG_DATA_DIRS ":" ${assetsDir}/share
   '';
 
   passthru = {
-    inherit web;
+    inherit core web;
     updateScript = nix-update-script {
       extraArgs = [
         "--subpackage"

--- a/pkgs/by-name/v2/v2raya/package.nix
+++ b/pkgs/by-name/v2/v2raya/package.nix
@@ -18,13 +18,14 @@
 }:
 let
   pname = "v2raya";
-  version = "2.2.7.5";
+  version = "2.4.11";
 
   src = fetchFromGitHub {
     owner = "v2rayA";
     repo = "v2rayA";
     tag = "v${version}";
-    hash = "sha256-aa/Eb+fZQ1hwm6H7wb7mr0b4tCu12Mhy14OXNjZUJ0Y=";
+    fetchSubmodules = true;
+    hash = "sha256-dDKQpWjxXrAQGzg0EB/K5Lir34fEh2X+C7iTQYMTIq8=";
     postFetch = "sed -i -e 's/npmmirror/yarnpkg/g' $out/gui/yarn.lock";
   };
 
@@ -35,7 +36,7 @@ let
 
     offlineCache = fetchYarnDeps {
       yarnLock = "${src}/gui/yarn.lock";
-      hash = "sha256-g+hI9n+nfXAcuEpjvDDaHg/DfjtNusOaw3S6kC1QDn4=";
+      hash = "sha256-yrUyE0cgwstZ5SEbHwo9z4NSHLHsgjraUjhnEW8xReI=";
     };
 
     env.OUTPUT_DIR = placeholder "out";
@@ -55,13 +56,34 @@ let
     ];
   };
 
+  core = buildGoModule {
+    pname = "v2raya-core";
+    inherit version src;
+
+    sourceRoot = "${src.name}/core";
+
+    vendorHash = "sha256-nfIfJsMzf7BUpzbWPujVO02o6qSmcTcOeXF89z4prB4=";
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X main.Version=${version}"
+    ];
+
+    subPackages = [ "./main" ];
+
+    postInstall = ''
+      mv $out/bin/main $out/bin/v2raya_core
+    '';
+  };
+
 in
 buildGoModule {
   inherit pname version src;
 
   sourceRoot = "${src.name}/service";
 
-  vendorHash = "sha256-uiURsB1V4IB77YKLu5gdaqw9Fuja6fC5adWYDE3OE+Q=";
+  vendorHash = "sha256-dDtBV6Tv87CiDW/8/ZuhoEtfZWXZMKNsusSWm1wKn3U=";
 
   ldflags = [
     "-s"
@@ -84,12 +106,17 @@ buildGoModule {
       --replace-fail 'Icon=/usr/share/icons/hicolor/512x512/apps/v2raya.png' 'Icon=v2raya'
 
     wrapProgram $out/bin/v2rayA \
-      --prefix PATH ":" "${lib.makeBinPath [ v2ray ]}" \
+      --prefix PATH ":" "${
+        lib.makeBinPath [
+          core
+          v2ray
+        ]
+      }" \
       --prefix XDG_DATA_DIRS ":" ${assetsDir}/share
   '';
 
   passthru = {
-    inherit web;
+    inherit core web;
     updateScript = nix-update-script {
       extraArgs = [
         "--subpackage"

--- a/pkgs/by-name/v2/v2raya/package.nix
+++ b/pkgs/by-name/v2/v2raya/package.nix
@@ -11,7 +11,6 @@
   nodejs,
 
   makeWrapper,
-  v2ray,
   v2ray-geoip,
   v2ray-domain-list-community,
   nix-update-script,
@@ -106,12 +105,7 @@ buildGoModule {
       --replace-fail 'Icon=/usr/share/icons/hicolor/512x512/apps/v2raya.png' 'Icon=v2raya'
 
     wrapProgram $out/bin/v2rayA \
-      --prefix PATH ":" "${
-        lib.makeBinPath [
-          core
-          v2ray
-        ]
-      }" \
+      --prefix PATH ":" "${lib.makeBinPath [ core ]}" \
       --prefix XDG_DATA_DIRS ":" ${assetsDir}/share
   '';
 


### PR DESCRIPTION
Updates v2rayA from 2.2.7.5 to 2.4.15.

Starting with v2rayA 2.4, upstream exclusively uses a matching
`v2raya_core` binary instead of external V2Ray or Xray cores. This change:

- fetches the Xray submodule and builds `v2raya_core` from the same source and version as v2rayA;
- adds `v2raya_core` to the v2rayA runtime environment;
- removes the obsolete `v2ray` package dependency;
- removes `services.v2raya.cliPackage` with a migration error explaining the upstream change.

Changelog:
- https://github.com/v2rayA/v2rayA/releases/tag/v2.4.0
- https://github.com/v2rayA/v2rayA/releases/tag/v2.4.15
- https://github.com/v2rayA/v2rayA/compare/v2.2.7.5...v2.4.15

Tested the v2rayA service on x86_64-linux hardware.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

PR preparation assisted by OpenCode using OpenAI GPT-5.6-sol-fast.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/tree/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test
