### PR TITLE
nixos/avahi: fix on 32 bit host platforms

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -436,6 +436,15 @@ in
           "@system-service"
           "~@privileged"
           "@chown setgroups setresuid"
+        ]
+        ++ lib.optionals pkgs.stdenv.hostPlatform.is32bit [
+          # glibc's setresuid()/setgroups() invoke the kernel's 32-bit compat
+          # syscalls (setresuid32/setgroups32) on 32-bit architectures --
+          # distinct syscalls from the ones already allowlisted above, so
+          # without these 2, avahi-daemon is killed with SIGSYS as soon as it
+          # tries to drop privileges.
+          "setgroups32"
+          "setresuid32"
         ];
         UMask = "0077";
       };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Built for platform
  - [x] armv7l-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
- [x] Tested basic functionality of avahi service.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test