### PR TITLE
stillcolor: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21889,6 +21889,12 @@
     githubId = 4908217;
     name = "Paho Lurie-Gregg";
   };
+  paige = {
+    email = "paigely@tuta.io";
+    github = "ssalggnikool";
+    githubId = 235818692;
+    name = "paige";
+  };
   pakhfn = {
     email = "pakhfn@gmail.com";
     github = "pakhfn";

--- a/pkgs/by-name/st/stillcolor/package.nix
+++ b/pkgs/by-name/st/stillcolor/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchzip,
+  stdenvNoCC,
+  unzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pname = "stillcolor";
+  version = "1.1";
+
+  src = fetchzip {
+    url = "https://github.com/aiaf/Stillcolor/releases/download/v${finalAttrs.version}/Stillcolor-v${finalAttrs.version}.zip";
+    hash = "sha256-ojs5EvrH4FVWHV6VXOhQmpfH69Zmy0PGMZnEO751pi8=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/Stillcolor.app
+    cp -R . $out/Applications/Stillcolor.app/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Disable temporal dithering on your Mac with this lightweight menu bar app. Designed for Apple silicon Macs.";
+    downloadPage = "https://github.com/aiaf/Stillcolor/releases";
+    homepage = "https://github.com/aiaf/Stillcolor";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    mainProgram = "stillcolor";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ paige ];
+  };
+})


### PR DESCRIPTION
this PR adds the macOS app, [Stillcolor](https://github.com/aiaf/Stillcolor)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
