### PR TITLE
reflection: init at 0.4

### DIFF
--- a/pkgs/by-name/re/reflection/package.nix
+++ b/pkgs/by-name/re/reflection/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  wrapGAppsHook4,
+
+  rustPlatform,
+  pkg-config,
+  meson,
+  ninja,
+  cargo,
+  rustc,
+
+  cairo,
+  gdk-pixbuf,
+  gtk4,
+  gtksourceview5,
+  libadwaita,
+  pango,
+  sqlite,
+  glib,
+  openssl,
+  libspelling,
+  blueprint-compiler,
+  desktop-file-utils,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "reflection";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "p2panda";
+    repo = "reflection";
+    tag = finalAttrs.version;
+    hash = "sha256-VPfYbMAyKv+2lWJ/TcQ7Em6kbutnJQIgbBTEqOnEDcc=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-3RR/YfJsq0eaRhaVVnocV5R1fbQ6YKsQ3QVZ1dc5HsI=";
+  };
+
+  env = {
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    cargo
+    desktop-file-utils
+    glib
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    cairo
+    gdk-pixbuf
+    glib
+    gtk4
+    gtksourceview5
+    libadwaita
+    libspelling
+    openssl
+    pango
+    sqlite
+  ];
+
+  meta = {
+    description = "Collaborative, local-first GTK text editor";
+    homepage = "https://github.com/p2panda/reflection";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "reflection";
+    maintainers = with lib.maintainers; [ hougo ];
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
Upstreaming the package derivation from the repository's flake https://github.com/p2panda/reflection/pull/126

Based on the work by @hrenard, I've only made cosmetic changes.

I've also added @hrenard as a maintainer, please let me know if I should remove that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
