### PR TITLE
rsyslog: fix imjournal invalidation reopen busy-loop

### DIFF
--- a/pkgs/by-name/rs/rsyslog/package.nix
+++ b/pkgs/by-name/rs/rsyslog/package.nix
@@ -80,6 +80,16 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/rsyslog/rsyslog/commit/f7f774228273730ba1075f4cd457ae78303a8f08.patch";
       hash = "sha256-ww8Ade2eKrQygJduLMPFjxd/fmBnpQ4ePLEzHffPy90=";
     })
+
+    # Fix imjournal invalidation reopen busy-loop.
+    # Remove with rsyslog 8.2608.0 or newer.
+    # https://github.com/rsyslog/rsyslog/pull/7384
+    (fetchpatch {
+      name = "imjournal-invalidation-reopen-busy-loop.patch";
+      url = "https://github.com/rsyslog/rsyslog/commit/383f80f21f16c3c94e7d7a57b0a5af12cdac9d75.patch";
+      excludes = [ "ChangeLog" ];
+      hash = "sha256-RlhXoK+dAPBN2wu4V7GoFw/d+uWQzO7+nUkW5+z7QJY=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->


Fix rsyslog imjournal invalidation reopen busy-loop introduced in rsyslog version 8.2606.0 - current versions in 26.05 and unstable: https://github.com/rsyslog/rsyslog/pull/7384

Without this patch rsyslog will continuously use about 80% of one logical CPU (seen using the top command).

Patch tested on our own infrastructure ~ 200 NixOS hosts - runs well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

``` 
nixpkgs-review pr 553864
...
nix/store/qnq6880g3cyrw6gb9l435d3siycz1mnj-rsyslog-8.2606.0]$ bin/rsyslogd -h
usage: rsyslogd [options]
use "man rsyslogd" for details. To run rsyslog interactively, use "rsyslogd -n"
to run it in debug mode use "rsyslogd -dn"
For further information see https://www.rsyslog.com/doc/
```

