### PR TITLE
mediawiki: fix postgres external database host address

### DIFF
--- a/nixos/modules/services/web-apps/mediawiki.nix
+++ b/nixos/modules/services/web-apps/mediawiki.nix
@@ -109,12 +109,12 @@ let
       '';
 
   dbAddr =
-    if cfg.database.socket == null then
+    if cfg.database.type == "postgres" then
+      (if cfg.database.socket == null then cfg.database.host else cfg.database.socket)
+    else if cfg.database.socket == null then
       "${cfg.database.host}:${toString cfg.database.port}"
     else if cfg.database.type == "mysql" then
       "${cfg.database.host}:${cfg.database.socket}"
-    else if cfg.database.type == "postgres" then
-      "${cfg.database.socket}"
     else
       throw "Unsupported database type: ${cfg.database.type} for socket: ${cfg.database.socket}";
 


### PR DESCRIPTION
Fixes #448766. 

When using Mediawiki service with Postgresql, [$wgDBport](https://www.mediawiki.org/wiki/Manual:$wgDBport) is used instead of appending it to [$wgDBserver](https://www.mediawiki.org/wiki/Manual:$wgDBserver). I fixed the logic.

## Things done

This patch is deployed on our Mediawiki instance.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
