### PR TITLE
[Backport release-26.05] sgdboop: 1.3.2 -> 1.4.3

### DIFF
--- a/pkgs/by-name/sg/sgdboop/package.nix
+++ b/pkgs/by-name/sg/sgdboop/package.nix
@@ -9,27 +9,28 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "sgdboop";
-  version = "1.3.2";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "SteamGridDB";
     repo = "SGDBoop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/pXZMq80fb7Z+619ACnu/ZYWpouh59PIiruWY7l2cnQ=";
+    hash = "sha256-17LfPmqvSrXvIcKfjTrpopAIzue62TXw/yXXmAQOeR0=";
   };
 
-  makeFlags = [
-    # The flatpak install just copies things to /app - otherwise wants to do things with XDG
-    "FLATPAK_ID=fake"
-  ];
+  installPhase = ''
+    runHook preInstall
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace-fail "/app/" "$out/"
-  '';
+    install -Dm755 SGDBoop \
+      $out/bin/SGDBoop
 
-  postInstall = ''
-    rm -r "$out/share/metainfo"
+    install -Dm644 res/linux/com.steamgriddb.SGDBoop.desktop \
+      $out/share/applications/com.steamgriddb.SGDBoop.desktop
+
+    install -Dm444 res/com.steamgriddb.SGDBoop.svg \
+      $out/share/icons/hicolor/scalable/apps/com.steamgriddb.SGDBoop.svg
+
+    runHook postInstall
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sg/sgdboop/package.nix
+++ b/pkgs/by-name/sg/sgdboop/package.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "sgdboop";
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "SteamGridDB";
     repo = "SGDBoop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-17LfPmqvSrXvIcKfjTrpopAIzue62TXw/yXXmAQOeR0=";
+    hash = "sha256-l4l5CWupL/V/qlnFZIgqUBagc5qg0DDv/zz2yc0mtng=";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

backporting sgdboop update to 1.4.3 manually, ryantm failed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
