### PR TITLE
python3Packages.smmap: 6.0.0 -> 5.0.3

### DIFF
--- a/pkgs/development/python-modules/smmap/default.nix
+++ b/pkgs/development/python-modules/smmap/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "smmap";
-  version = "6.0.0";
+  version = "5.0.3";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jXkCjqbMEx2l6rCZpdlamY1DxneZVv/+O0VQQJEQdto=";
+    hash = "sha256-TZ3ruLmQB65HFlq8CGcL10y3S1In3af2Q+zMTp61ZCw=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Though it looks like donwgrading the upstream development is continued on 5.x branch with latest release 5.0.3 this year while the 6.0.0 was released in 2023. The 6.0.0 is marked as yanked on PyPi and replaced by non-breaking 5.0.1.
https://pypi.org/project/smmap/#history
https://pypi.org/project/smmap/6.0.0/
I noticed it while checking overrides in the Apache Airflow in #545537

@mweinelt can you take a look?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
