### PR TITLE
nautilus: fix broken audio/video properties

### DIFF
--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -85,6 +85,10 @@ stdenv.mkDerivation (finalAttrs: {
     gsettings-desktop-schemas
     gnome-user-share
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
     gtk4
     libadwaita
     libportal-gtk4


### PR DESCRIPTION
This PR fixes an issue. The Nautilus Properties dialog did not show audio and video file properties. It showed the error message "Your GStreamer installation is missing a plug-in".

<img width="530" height="746" alt="Screenshot From 2026-08-18 17-43-28" src="https://github.com/user-attachments/assets/e70192a8-ebb1-4cd0-90b9-7bd40b9eca9a" />

Nautilus uses the `totem-properties-page` extension. This extension uses the `pbutils` library of GStreamer to discover the properties of media files, so this PR adds missing `gst-plugins-good`, `gst-plugins-bad`, `gst-plugins-ugly`, and `gst-libav` to `buildInputs`. The `wrapGAppsHook4` tool populates `GST_PLUGIN_SYSTEM_PATH_1_0` in the Nautilus wrapper. This configuration lets the extension load the plugins and read the metadata correctly.

<img width="530" height="746" alt="Screenshot From 2026-08-18 17-41-09" src="https://github.com/user-attachments/assets/e30dabfc-6625-4eba-85a2-77574b9337ad" />

This PR closes #53631.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
