### PR TITLE
ocamlPackages.cmdliner-stdlib: init at 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner-stdlib/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner-stdlib/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  cmdliner,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "cmdliner-stdlib";
+  version = "1.0.1";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/cmdliner-stdlib/releases/download/${finalAttrs.version}/cmdliner-stdlib-${finalAttrs.version}.tbz";
+    hash = "sha256-GbW5Y8Ibb+mNL2LkBOU2EcO8x7r1OO/QH1mO+Sgleq4=";
+  };
+
+  propagatedBuildInputs = [ cmdliner ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Collection of cmdliner terms to control OCaml runtime parameters";
+    homepage = "https://github.com/mirage/cmdliner-stdlib";
+    changelog = "https://raw.githubusercontent.com/mirage/cmdliner-stdlib/${finalAttrs.version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.stepbrobd ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -271,6 +271,8 @@ let
 
         cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
 
+        cmdliner-stdlib = callPackage ../development/ocaml-modules/cmdliner-stdlib { };
+
         cmdliner_1_0 = cmdliner.override { version = "1.0.4"; };
 
         cmdliner_1 = cmdliner.override { version = "1.3.0"; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

tracking https://github.com/ngi-nix/projects/issues/148

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
