### PR TITLE
papis: 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
 
   # build-system
   hatchling,
@@ -16,11 +15,11 @@
   dominate,
   filetype,
   habanero,
+  lark,
   lxml,
   platformdirs,
   prompt-toolkit,
   pygments,
-  pyparsing,
   python-doi,
   python-slugify,
   pyyaml,
@@ -48,14 +47,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "papis";
-  version = "0.15.0";
+  version = "0.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "papis";
     repo = "papis";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-G+ryUMBUEbGxUG+u2YwZbT04IAzOmajtIPXP12MaXsY=";
+    hash = "sha256-ZDGcuOCmddPaX6CldPf7YGHyIZfrG62ZQ6NXzFPDVAM=";
   };
 
   build-system = [ hatchling ];
@@ -69,11 +68,11 @@ buildPythonPackage (finalAttrs: {
     dominate
     filetype
     habanero
+    lark
     lxml
     platformdirs
     prompt-toolkit
     pygments
-    pyparsing
     python-doi
     python-slugify
     pyyaml
@@ -120,25 +119,6 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals withOptDeps [
     # Require network access
     "test_csl_style_download"
-  ];
-
-  # Until a release >0.15.0 (that would already contain these commits)
-  patches = [
-    # Commit 44c6463: chore: move isbnlib to optional dependencies
-    (fetchpatch2 {
-      url = "https://github.com/papis/papis/commit/44c6463f79cbc3a09adb541ae7df4e00a194b86b.patch?full_index=1";
-      hash = "sha256-3E18cyzkiZsNvgH/X8dZu+3tGGpbBsaQ3nIoDuIYFqw=";
-    })
-    # Commit 7518e53: chore: remove isbn dependency
-    (fetchpatch2 {
-      url = "https://github.com/papis/papis/commit/7518e53e5d485e3cec1e202af6cb4921b9976b5b.patch?full_index=1";
-      hash = "sha256-iBqlvHfH+6fyhi2C7lpwI1O59DKrKp7p45x29kzPRR0=";
-    })
-    # Commit 15cae59: test: skip tests if missing isbnlib
-    (fetchpatch2 {
-      url = "https://github.com/papis/papis/commit/15cae5986ae9dec75c7d103757adbd73c39feb89.patch?full_index=1";
-      hash = "sha256-kuVZdOd+H99TinM7yAs7NJrfw7rOPyxDlSaT0P2NeC4=";
-    })
   ];
 
   meta = {


### PR DESCRIPTION
Bump `papis` version to `0.16`

Remove patches that were targeting previous release, and already included in the new one.

Supersedes #548778.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] ~[NixOS tests] in [nixos/tests].~
  - [x] ~[Package tests] at `passthru.tests`.~
  - [x] ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - [x] ~Module addition: when adding a new NixOS module.~
  - [x] ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
