### PR TITLE
babashka: install babashka.cli shell completions on supported versions

### DIFF
--- a/pkgs/by-name/ba/babashka-unwrapped/package.nix
+++ b/pkgs/by-name/ba/babashka-unwrapped/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGraalvmNativeImage,
   fetchurl,
   writeScript,
@@ -39,11 +40,22 @@ buildGraalvmNativeImage (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  postInstall = ''
-    installShellCompletion --cmd bb --bash ${./completions/bb.bash}
-    installShellCompletion --cmd bb --zsh ${./completions/bb.zsh}
-    installShellCompletion --cmd bb --fish ${./completions/bb.fish}
-  '';
+  postInstall =
+    if lib.versionAtLeast finalAttrs.version "1.13.219" then
+      # babashka.cli 0.12.85+ (bundled since bb 1.13.219) generates shell
+      # completions itself, see https://github.com/babashka/cli#completions
+      lib.optionalString (stdenv.hostPlatform.canExecute stdenv.buildPlatform) ''
+        installShellCompletion --cmd bb \
+          --bash <($out/bin/bb org.babashka.cli/completions snippet --shell bash --prog bb) \
+          --fish <($out/bin/bb org.babashka.cli/completions snippet --shell fish --prog bb) \
+          --zsh <($out/bin/bb org.babashka.cli/completions snippet --shell zsh --prog bb)
+      ''
+    else
+      ''
+        installShellCompletion --cmd bb --bash ${./completions/bb.bash}
+        installShellCompletion --cmd bb --zsh ${./completions/bb.zsh}
+        installShellCompletion --cmd bb --fish ${./completions/bb.fish}
+      '';
 
   passthru.updateScript = writeScript "update-babashka" ''
     #!/usr/bin/env nix-shell


### PR DESCRIPTION
Babashka ships with the babashka.cli library for building command line applications. Since 0.12.85 babashka.cli ships with support for more powerful [completions](https://github.com/babashka/cli#completions). This change installs those completion snippets instead of the old completion snippets that could only complete task names, if the babashka version is new enough (v1.13.219) to support it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
