### PR TITLE
python3Packages.ipykernel: 7.1.0 -> 7.3.0

### DIFF
--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -11,7 +11,7 @@
   jupyter-client,
   jupyter-core,
   matplotlib-inline,
-  nest-asyncio,
+  nest-asyncio2,
   packaging,
   psutil,
   pyzmq,
@@ -22,14 +22,15 @@
   sage,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ipykernel";
-  version = "7.1.0";
+  version = "7.3.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-WKP8iFM9WTDDVG3H6sZsbSiKzeT4AeIAHmXtxdyc8Ns=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-msqq+X0WNVFm5Aha/p0iW/vfK371IPnfO+jyskgnXgk=";
   };
 
   # debugpy is optional, see https://github.com/ipython/ipykernel/pull/767
@@ -43,7 +44,7 @@ buildPythonPackage rec {
     jupyter-client
     jupyter-core
     matplotlib-inline
-    nest-asyncio
+    nest-asyncio2
     packaging
     psutil
     pyzmq
@@ -63,8 +64,8 @@ buildPythonPackage rec {
   meta = {
     description = "IPython Kernel for Jupyter";
     homepage = "https://ipython.org/";
-    changelog = "https://github.com/ipython/ipykernel/releases/tag/v${version}";
+    changelog = "https://github.com/ipython/ipykernel/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.jupyter ];
   };
-}
+})

--- a/pkgs/development/python-modules/ipykernel/tests.nix
+++ b/pkgs/development/python-modules/ipykernel/tests.nix
@@ -6,9 +6,11 @@
   ipykernel,
   ipyparallel,
   pre-commit,
-  pytestCheckHook,
   pytest-asyncio,
+  pytestCheckHook,
+  pytest-cov-stub,
   pytest-timeout,
+  trio,
 }:
 
 buildPythonPackage {
@@ -24,27 +26,18 @@ buildPythonPackage {
     ipykernel
     ipyparallel
     pre-commit
-    pytestCheckHook
     pytest-asyncio
+    pytestCheckHook
+    pytest-cov-stub
     pytest-timeout
+    trio
   ];
 
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
 
-  disabledTests = [
-    # The following three tests fail for unclear reasons.
-    # pytest.PytestUnhandledThreadExceptionWarning: Exception in thread Thread-8
-    "test_asyncio_interrupt"
-
-    # DeprecationWarning: Passing unrecognized arguments to super(IPythonKernel)
-    "test_embed_kernel_func"
-
-    # traitlets.config.configurable.MultipleInstanceError: An incompatible siblin...
-    "test_install_kernelspec"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # see https://github.com/NixOS/nixpkgs/issues/76197
     "test_subprocess_print"
     "test_subprocess_error"

--- a/pkgs/development/python-modules/jupyter-client/default.nix
+++ b/pkgs/development/python-modules/jupyter-client/default.nix
@@ -8,17 +8,19 @@
   pyzmq,
   tornado,
   traitlets,
+  typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jupyter-client";
-  version = "8.8.0";
+  version = "8.9.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
     pname = "jupyter_client";
-    inherit version;
-    hash = "sha256-1VaBFBmk8tlshprzToVOPwWbfMLW0Bqc2chcJnaRvj4=";
+    inherit (finalAttrs) version;
+    hash = "sha256-pY9zDdnnKLoWuh1i68z3/+Hrvbzk6Vz66UG3Mhrh9Po=";
   };
 
   build-system = [ hatchling ];
@@ -29,6 +31,7 @@ buildPythonPackage rec {
     pyzmq
     tornado
     traitlets
+    typing-extensions
   ];
 
   pythonImportsCheck = [ "jupyter_client" ];
@@ -39,8 +42,8 @@ buildPythonPackage rec {
   meta = {
     description = "Jupyter protocol implementation and client libraries";
     homepage = "https://github.com/jupyter/jupyter_client";
-    changelog = "https://github.com/jupyter/jupyter_client/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/jupyter/jupyter_client/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.jupyter ];
   };
-}
+})

--- a/pkgs/development/python-modules/nest-asyncio2/default.nix
+++ b/pkgs/development/python-modules/nest-asyncio2/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "nest-asyncio2";
+  version = "1.7.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Chaoses-Ib";
+    repo = "nest-asyncio2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-T7jUa4odhJZ1lpJjVmPrqur8ro2Iqccwf4khEb4ArGs=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "nest_asyncio2" ];
+
+  meta = {
+    description = "Patch asyncio to allow nested event loops";
+    homepage = "https://github.com/Chaoses-Ib/nest-asyncio2";
+    changelog = "https://github.com/Chaoses-Ib/nest-asyncio2/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd2;
+    teams = [ lib.teams.jupyter ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11847,6 +11847,8 @@ self: super: with self; {
 
   nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
 
+  nest-asyncio2 = callPackage ../development/python-modules/nest-asyncio2 { };
+
   nested-lookup = callPackage ../development/python-modules/nested-lookup { };
 
   nested-multipart-parser = callPackage ../development/python-modules/nested-multipart-parser { };


### PR DESCRIPTION
Upstream changelog for *ipykernel*: https://github.com/ipython/ipykernel/blob/v7.3.0/CHANGELOG.md

Necessary dependencies:
* jupyter-client: 8.8.0 -> 8.9.1: https://github.com/jupyter/jupyter_client/blob/v8.9.1/CHANGELOG.md
* nest-asyncio2: fork of nest_asyncio, https://github.com/Chaoses-Ib/nest-asyncio2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`: Except *sage*.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
