### PR TITLE
cursor-origin-cli: init at `2026.08.18-07-32-40-5c3b379`

### DIFF
--- a/pkgs/by-name/cu/cursor-origin-cli/package.nix
+++ b/pkgs/by-name/cu/cursor-origin-cli/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  versionCheckHook,
+}:
+
+let
+  inherit (stdenv) hostPlatform;
+  sources = {
+    aarch64-darwin = fetchurl {
+      url = "https://downloads.cursor.com/co/2026.08.18-07-32-40-5c3b379/darwin-arm64/co.tar.gz";
+      hash = "sha256-hMK2v1Y0tp8V21RVk6ry9ihD+/02hiRn4gEMm5Whi8E=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://downloads.cursor.com/co/2026.08.18-07-32-40-5c3b379/linux-arm64/co.tar.gz";
+      hash = "sha256-MCxixYhhEU381gDIjDTseP6R7yKCGGOyVRnlRONHAr4=";
+    };
+    x86_64-linux = fetchurl {
+      url = "https://downloads.cursor.com/co/2026.08.18-07-32-40-5c3b379/linux-x64/co.tar.gz";
+      hash = "sha256-pL5U3XFUqfkHdsh0QMHPr0Jb24Yu35GXulbVfvXMj7U=";
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "cursor-origin-cli";
+  version = "2026.08.18-07-32-40-5c3b379";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = sources.${hostPlatform.system};
+
+  # The source tarball does not have a single top-level directory.
+  preUnpack = ''
+    mkdir source
+    cd source
+  '';
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optionals hostPlatform.isLinux [ autoPatchelfHook ];
+
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 origin $out/bin/origin
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    inherit sources;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "CLI for Cursor's Origin code hosting platform";
+    homepage = "https://cursor.com/docs/origin/cli";
+    downloadPage = "https://downloads.cursor.com/origin/install.sh";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ omarjatoi ];
+    mainProgram = "origin";
+    platforms = builtins.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/cu/cursor-origin-cli/update.sh
+++ b/pkgs/by-name/cu/cursor-origin-cli/update.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts nix
+
+set -euo pipefail
+
+installer=$(curl -fsSL https://downloads.cursor.com/origin/install.sh)
+latest_block=$(sed -n '/^latest)$/,/^  esac$/p' <<< "$installer")
+version=$(sed -n 's/^  version="\([^"]*\)"/\1/p' <<< "$latest_block")
+
+if [[ -z "$version" ]]; then
+  echo "Could not determine the latest Cursor Origin version" >&2
+  exit 1
+fi
+
+current_version=$(nix eval --raw -f . cursor-origin-cli.version)
+if [[ "$version" == "$current_version" ]]; then
+  echo "cursor-origin-cli is already up to date at $current_version"
+  exit 0
+fi
+
+declare -A upstream_platforms=(
+  [aarch64-darwin]="darwin-arm64"
+  [aarch64-linux]="linux-arm64"
+  [x86_64-linux]="linux-x64"
+)
+
+for platform in "${!upstream_platforms[@]}"; do
+  upstream_platform=${upstream_platforms[$platform]}
+  url=$(awk -v platform="$upstream_platform" '
+    $0 == "  " platform ")" { found = 1 }
+    found && /url=/ { sub(/^.*url="/, ""); sub(/"$/, ""); print; exit }
+  ' <<< "$latest_block")
+  sha256=$(awk -v platform="$upstream_platform" '
+    $0 == "  " platform ")" { found = 1 }
+    found && /sha=/ { sub(/^.*sha="/, ""); sub(/"$/, ""); print; exit }
+  ' <<< "$latest_block")
+
+  if [[ -z "$url" || -z "$sha256" ]]; then
+    echo "Could not determine the URL and hash for $upstream_platform" >&2
+    exit 1
+  fi
+
+  hash=$(nix hash convert --hash-algo sha256 --to sri "$sha256")
+  update-source-version cursor-origin-cli "$version" "$hash" "$url" \
+    --system="$platform" \
+    --source-key="sources.$platform" \
+    --ignore-same-version
+done


### PR DESCRIPTION
Add new package for the origin cli (see https://cursor.com/docs/origin/cli).

```
φ ./result/bin/origin --version
2026.08.18-07-32-40-5c3b379
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
