### PR TITLE
teamtype: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/by-name/te/teamtype/package.nix
+++ b/pkgs/by-name/te/teamtype/package.nix
@@ -1,12 +1,15 @@
 {
   fetchFromGitHub,
   lib,
+  stdenv,
   rustPlatform,
   versionCheckHook,
   installShellFiles,
   nix-update-script,
   pkg-config,
   libgit2,
+  neovim,
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -50,14 +53,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  # E2E Tests fail reporting:
-  # Before running e2e tests you must build /build/source/target/debug/teamtype
-  checkFlags = [
-    "--skip=nvim_processes_deltas_correctly"
-    "--skip=nvim_sends_correct_delta"
-    "--skip=nvim_sends_something_to_socket"
-    "--skip=plugin_loaded"
-    "--skip=teamtype_executable_from_nvim"
+  nativeCheckInputs = [
+    neovim
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    substituteInPlace .cargo/config.toml \
+      --replace-fail 'target/debug/teamtype' 'target/${stdenv.hostPlatform.rust.rustcTarget}/release/teamtype'
+  '';
+
+  # watcher tests use FSEvents which hangs in the macOS sandbox
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=watcher::"
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/te/teamtype/package.nix
+++ b/pkgs/by-name/te/teamtype/package.nix
@@ -11,18 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "teamtype";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "teamtype";
     repo = "teamtype";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-74MufpLTACkPevzOyaXw2Rr7S7VvaFEYHEyTQYwKVT8=";
+    hash = "sha256-FsT1ako/3EIPynWuBqCSiwaZtMnsd7ypJnrh+4EDRwM=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/daemon";
-
-  cargoHash = "sha256-OIOffnCC9PlT/SXPOuTnKx3feZnkHP+jzbQIJWX0tzk=";
+  cargoHash = "sha256-gphTpVKbmfYJSUasOCtNgyMKI9JU/if8KcH7Lu3Svjs=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -51,6 +49,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
+
+  # E2E Tests fail reporting:
+  # Before running e2e tests you must build /build/source/target/debug/teamtype
+  checkFlags = [
+    "--skip=nvim_processes_deltas_correctly"
+    "--skip=nvim_sends_correct_delta"
+    "--skip=nvim_sends_something_to_socket"
+    "--skip=plugin_loaded"
+    "--skip=teamtype_executable_from_nvim"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Includes work done by @ddogfoodd in https://github.com/NixOS/nixpkgs/pull/539655

replaces and closes https://github.com/NixOS/nixpkgs/pull/539655

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
