### PR TITLE
gst_all_1.gst-rtsp-server: refactor package

### DIFF
--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -3,19 +3,23 @@
   lib,
   fetchurl,
   testers,
+  directoryListingUpdater,
+  apple-sdk_gstreamer,
   meson,
   ninja,
   pkg-config,
   python3,
   gettext,
-  gobject-introspection,
   gst-plugins-base,
   gst-plugins-bad,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   hotdoc,
-  directoryListingUpdater,
-  apple-sdk_gstreamer,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  buildPackages,
+  gobject-introspection,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -41,9 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     gettext
-    gobject-introspection
     pkg-config
     python3
+  ]
+  ++ lib.optionals withIntrospection [
+    gobject-introspection
   ]
   ++ lib.optionals enableDocumentation [
     hotdoc
@@ -62,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     examples = false; # requires many dependencies and probably not useful for our users
     doc = enableDocumentation;
     tests = finalAttrs.finalPackage.doCheck;
+    introspection = withIntrospection;
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  testers,
   meson,
   ninja,
   pkg-config,
@@ -73,6 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = directoryListingUpdater { odd-unstable = true; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
   };
 
   meta = {
@@ -81,6 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = ''
       A library on top of GStreamer for building an RTSP server.
     '';
+    pkgConfigModules = [ "gstreamer-rtsp-server-1.0" ];
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ bkchr ];

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -87,6 +87,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkgConfigModules = [ "gstreamer-rtsp-server-1.0" ];
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ bkchr ];
+    maintainers = with lib.maintainers; [
+      bkchr
+      tmarkus
+    ];
   };
 })

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -57,11 +57,12 @@ stdenv.mkDerivation (finalAttrs: {
     apple-sdk_gstreamer
   ];
 
-  mesonFlags = [
-    "-Dglib_debug=disabled" # cast checks should be disabled on stable releases
-    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-    (lib.mesonEnable "doc" enableDocumentation)
-  ];
+  mesonFlags = lib.mapAttrsToList lib.mesonEnable {
+    glib_debug = false; # cast checks should be disabled on stable releases
+    examples = false; # requires many dependencies and probably not useful for our users
+    doc = enableDocumentation;
+    tests = finalAttrs.finalPackage.doCheck;
+  };
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -9,7 +9,6 @@
   ninja,
   pkg-config,
   python3,
-  gettext,
   gst-plugins-base,
   gst-plugins-bad,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
@@ -44,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     meson
     ninja
-    gettext
     pkg-config
     python3
   ]


### PR DESCRIPTION
- refactor mesonFlags
- add proper `withIntrospection` flag
- specify and test `meta.pkgConfigModules`
- add myself as maintainer
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
