### PR TITLE
ocamlPackages.buildDunePackage: allow multiple dune packages

### DIFF
--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -59,6 +59,9 @@ Here is a simple package example.
 - The library will be installed using the `angstrom.install` file that dune
   generates.
 
+- It also accepts an optional `dunePackages` argument, if there is more than one
+  dune package that needs to be built (see `zipperposition`)
+
 ```nix
 {
   lib,

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -18,6 +18,7 @@ lib.extendMkDerivation {
     {
       pname,
       version,
+      dunePackages ? [ pname ],
       nativeBuildInputs ? [ ],
       enableParallelBuilding ? true,
       ...
@@ -58,14 +59,14 @@ lib.extendMkDerivation {
         buildPhase =
           args.buildPhase or ''
             runHook preBuild
-            dune build -p ${pname} ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+            dune build -p ${lib.concatStringsSep "," dunePackages} ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
             runHook postBuild
           '';
 
         installPhase =
           args.installPhase or ''
             runHook preInstall
-            dune install --prefix $out --libdir $OCAMLFIND_DESTDIR ${pname} \
+            dune install --prefix $out --libdir $OCAMLFIND_DESTDIR ${lib.concatStringsSep " " dunePackages} \
              ${
                if lib.versionAtLeast Dune.version "2.9" then
                  "--docdir $out/share/doc --mandir $out/share/man"
@@ -78,7 +79,7 @@ lib.extendMkDerivation {
         checkPhase =
           args.checkPhase or ''
             runHook preCheck
-            dune runtest -p ${pname} ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+            dune runtest -p ${lib.concatStringsSep "," dunePackages} ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
             runHook postCheck
           '';
 

--- a/pkgs/by-name/zi/zipperposition/package.nix
+++ b/pkgs/by-name/zi/zipperposition/package.nix
@@ -29,17 +29,12 @@ ocamlPackages.buildDunePackage {
     oseq
   ];
 
-  buildPhase = ''
-    runHook preBuild
-    dune build -p logtk,libzipperposition,zipperposition,zipperposition-tools ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR logtk libzipperposition zipperposition zipperposition-tools
-    runHook postInstall
-  '';
+  dunePackages = [
+    "logtk"
+    "libzipperposition"
+    "zipperposition"
+    "zipperposition-tools"
+  ];
 
   doCheck = true;
 
@@ -48,12 +43,6 @@ ocamlPackages.buildDunePackage {
     qcheck-core
     qcheck-alcotest
   ];
-
-  checkPhase = ''
-    runHook preCheck
-    dune runtest -p logtk,libzipperposition,zipperposition,zipperposition-tools ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
-    runHook postCheck
-  '';
 
   meta = {
     description = "Superposition prover for full first order logic";


### PR DESCRIPTION
A single `dune-project` file can contain multiple packages that dune can build. This is a problem, because the default dune build command we use doesn't search through `dune-project` for dependencies, it assumes that will have already been built and can be found with findlib. See zipperposition for an example of this.

Adds a new `dunePackages` argument to allow this, defaulting to `[ pname ]` for backwards compatibility. This is happening now because #553241 adds a bunch of packages that have multiple dune packages in one repo. 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
