### PR TITLE
ocamlPackages.ocaml-solo5: init at 1.3.3

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-solo5/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-solo5/default.nix
@@ -1,0 +1,154 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildDunePackage,
+  ocaml,
+  findlib,
+  fmt,
+  opam,
+  solo5,
+  target ?
+    if stdenv.targetPlatform.isx86_64 then
+      "x86_64-solo5-none-static"
+    else if stdenv.targetPlatform.isAarch64 then
+      "aarch64-solo5-none-static"
+    else
+      throw "ocaml-solo5 does not support ${stdenv.targetPlatform.system}",
+}:
+
+assert lib.asserts.assertOneOf "ocaml-solo5's ocaml version" ocaml.version [
+  "5.4.1"
+  "5.5.0"
+];
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ocaml-solo5";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-solo5";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/xUF98MPhjv9yRWoRDx2uIkCr2Furz1qUJexIxnHhI4=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    findlib
+    ocaml
+    opam
+    solo5
+  ];
+
+  propagatedBuildInputs = [ solo5 ];
+
+  setupHook = ./setup-hook.sh;
+
+  # upstream uses `ocamlfind query ocaml-src` and patch with opatch
+  # override with `ocaml.src` and apply patches
+  postPatch = ''
+    mkdir ocaml
+    tar xf ${ocaml.src} -C ocaml --strip-components=1
+    version=$(head -n1 ocaml/VERSION)
+    if test -d "patches/$version"; then
+      for p in "patches/$version"/*; do
+        patch -d ocaml -p1 < "$p"
+      done
+    fi
+  '';
+
+  # stdenv exports these environment variables
+  # ocaml configure script allow env vars to override target tool detection
+  # which would produce incorrect cross compiler setup
+  # see install check below
+  preConfigure = ''
+    unset CC CXX LD AR AS NM OBJCOPY OBJDUMP RANLIB READELF SIZE STRINGS STRIP
+  '';
+
+  configureScript = "./configure.sh";
+  configureFlags = [ "--target=${target}" ];
+  # only have --prefix, --sysroot, --target, --othertoolprefix, --ocaml-configure-option
+  # don't allow stdenv configurePhase append autotools flags
+  dontAddDisableDepTrack = true;
+  dontAddStaticConfigureFlags = true;
+  configurePlatforms = [ ];
+
+  dontStrip = true;
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  checkTarget = "test";
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/lib/ocaml-solo5/bin/ocamlopt.opt -config | grep "^c_compiler: .*-solo5-ocaml-"
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit target;
+
+    tests =
+      let
+        example =
+          mode: attrs:
+          buildDunePackage (
+            {
+              pname = "ocaml-solo5-example-${mode}";
+              inherit (finalAttrs) version src;
+              sourceRoot = "${finalAttrs.src.name}/example";
+
+              __structuredAttrs = true;
+
+              nativeBuildInputs = [ finalAttrs.finalPackage ];
+
+              buildInputs = [ fmt ];
+
+              env.MODE = mode;
+
+              buildPhase = ''
+                runHook preBuild
+                dune build @default
+                runHook postBuild
+              '';
+
+              doCheck = true;
+              checkPhase = ''
+                runHook preCheck
+                dune build @runtest --display short
+                runHook postCheck
+              '';
+
+              installPhase = ''
+                runHook preInstall
+                install -D _build/solo5/hello.exe $out/hello.${mode}
+                runHook postInstall
+              '';
+            }
+            // attrs
+          );
+      in
+      {
+        example-spt = example "spt" { };
+        example-hvt = example "hvt" { requiredSystemFeatures = [ "kvm" ]; };
+      };
+  };
+
+  meta = {
+    description = "OCaml cross-compiler to the freestanding Solo5 backend";
+    homepage = "https://github.com/mirage/ocaml-solo5";
+    changelog = "https://raw.githubusercontent.com/mirage/ocaml-solo5/v${finalAttrs.version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stepbrobd ];
+    teams = [ lib.teams.ngi ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+})

--- a/pkgs/development/ocaml-modules/ocaml-solo5/setup-hook.sh
+++ b/pkgs/development/ocaml-modules/ocaml-solo5/setup-hook.sh
@@ -1,0 +1,25 @@
+# Expose solo5 findlib config for
+# `ocamlfind -toolchain solo5`
+# dune setup with solo5 toolchain
+# etc.
+
+exportSolo5FindlibConf() {
+    command -v ocamlfind >/dev/null || return 0
+
+    local confdir baseconf
+    baseconf="${OCAMLFIND_CONF:-$(ocamlfind printconf conf 2>/dev/null)}"
+    [ -e "$baseconf" ] || return 0
+
+    confdir="$(mktemp -d)"
+    mkdir -p "$confdir/findlib.conf.d"
+    cat "$baseconf" > "$confdir/findlib.conf"
+    cp "${baseconf%/*}/findlib.conf.d/"*.conf "$confdir/findlib.conf.d/" 2>/dev/null || true
+
+    sed -e "s|^path(solo5) = \"\(.*\)\"|path(solo5) = \"\1${OCAMLPATH:+:${OCAMLPATH%:}}\"|" \
+        "@out@/lib/findlib.conf.d/solo5.conf" \
+        > "$confdir/findlib.conf.d/solo5.conf"
+
+    export OCAMLFIND_CONF="$confdir/findlib.conf"
+}
+
+postHooks+=(exportSolo5FindlibConf)

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1513,6 +1513,10 @@ let
 
         ocaml-sat-solvers = callPackage ../development/ocaml-modules/ocaml-sat-solvers { };
 
+        ocaml-solo5 = callPackage ../development/ocaml-modules/ocaml-solo5 {
+          inherit (pkgs) opam solo5;
+        };
+
         ocaml-syntax-shims = callPackage ../development/ocaml-modules/ocaml-syntax-shims { };
 
         ocaml-version = callPackage ../development/ocaml-modules/ocaml-version { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

tracking https://github.com/ngi-nix/projects/issues/148

solo5 backend is ready!

```console
$ nom build .#ocamlPackages.ocaml-solo5.tests.example
$ nix shell .#solo5 -c solo5-spt ./result/hello.spt
            |      ___|
  __|  _ \  |  _ \ __ \
\__ \ (   | | (   |  ) |
____/\___/ _|\___/____/
Solo5: Bindings version v0.10.1
Solo5: Memory map: 512 MB addressable:
Solo5:   reserved @ (0x0 - 0xfffff)
Solo5:       text @ (0x100000 - 0x1aefff)
Solo5:     rodata @ (0x1af000 - 0x1dafff)
Solo5:       data @ (0x1db000 - 0x229fff)
Solo5:       heap >= 0x22a000 < stack < 0x20000000
Hello from OCaml on Solo5!
Solo5: solo5_exit(0) called
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
