### PR TITLE
nixos/fmd-server: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -108,6 +108,8 @@
 
 - [bulwark](https://github.com/bulwarkmail/webmail), a modern, self-hosted webmail client for Stalwart Mail Server. Available as [services.bulwark](#opt-services.bulwark.enable).
 
+- [FMD Server](https://fmd-foss.org/docs/fmd-server/overview), a companion for FMD Android to help you locate and remotely control your Android device. Available as [services.fmd-server](#opt-services.fmd-server.enable).
+
 - [Entropy](https://github.com/ergohaven/entropy), a configurator for programmable keyboards and input devices running Vial-QMK/RMK firmware. Available as [programs.entropy](#opt-programs.entropy.enable).
 
 - [Kvrocks](https://kvrocks.apache.org/), a distributed key value NoSQL database compatible with the Redis protocol. Available as [services.kvrocks](#opt-services.kvrocks.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1706,6 +1706,7 @@
   ./services/web-apps/firefly-iii.nix
   ./services/web-apps/flarum.nix
   ./services/web-apps/fluidd.nix
+  ./services/web-apps/fmd-server.nix
   ./services/web-apps/freescout.nix
   ./services/web-apps/freshrss.nix
   ./services/web-apps/froide-govplan.nix

--- a/nixos/modules/services/web-apps/fmd-server.nix
+++ b/nixos/modules/services/web-apps/fmd-server.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  format = pkgs.formats.yaml { };
+  cfg = config.services.fmd-server;
+  settingsFile = format.generate "fmd-server-config.yml" cfg.settings;
+in
+{
+  options.services.fmd-server = {
+    enable = lib.mkEnableOption "FMD server";
+    package = lib.mkPackageOption pkgs "fmd-server" { };
+    environmentFile = lib.mkOption {
+      description = ''
+        Path to a file containing environment variables.
+
+        Use this option to pass secrets.
+      '';
+      default = "";
+      type = lib.types.oneOf [
+        lib.types.path
+        lib.types.str
+      ];
+    };
+    settings = lib.mkOption {
+      description = ''
+        Configuration for the FMD server.
+
+        See [the documentation](https://fmd-foss.org/docs/fmd-server/installation/configuration)
+        for more information.
+
+        Use {option}`services.fmd-server.environmentFile` to specify secrets.
+      '';
+      default = { };
+      type = format.type;
+    };
+    databaseDir = lib.mkOption {
+      description = ''
+        Path to a directory where the database should be stored.
+      '';
+      default = "/var/lib/fmd-server/db/";
+      type = lib.types.str;
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.fmd-server = {
+      description = "FMD Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} serve --config ${settingsFile} --db-dir ${cfg.databaseDir}";
+        Restart = "always";
+        DynamicUser = true;
+        RuntimeDirectory = "fmd-server";
+        RuntimeDirectoryMode = "0770";
+        StateDirectory = "fmd-server";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != "") cfg.environmentFile;
+        # Hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    ungeskriptet
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -646,6 +646,7 @@ in
   fluent-bit = runTest ./fluent-bit.nix;
   fluentd = runTest ./fluentd.nix;
   fluidd = runTest ./fluidd.nix;
+  fmd-server = runTest ./web-apps/fmd-server.nix;
   fontconfig-bitmap-fonts = runTest ./fontconfig-bitmap-fonts.nix;
   fontconfig-default-fonts = runTest ./fontconfig-default-fonts.nix;
   forgejo = import ./forgejo.nix {

--- a/nixos/tests/web-apps/fmd-server.nix
+++ b/nixos/tests/web-apps/fmd-server.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+
+{
+  name = "fmd-server";
+
+  nodes = {
+    machine = {
+      services.fmd-server = {
+        enable = true;
+        settings = {
+          PortInsecure = 80;
+          MetricsAddrPort = "[::1]:9100";
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("fmd-server.service")
+
+    machine.wait_for_open_port(80)
+    machine.succeed("curl --fail http://localhost", timeout=10)
+
+    machine.wait_for_open_port(9100)
+    machine.succeed("curl --fail http://localhost:9100/metrics", timeout=10)
+  '';
+
+  meta.maintainers = with lib.maintainers; [ ungeskriptet ];
+}

--- a/pkgs/by-name/fm/fmd-server/package.nix
+++ b/pkgs/by-name/fm/fmd-server/package.nix
@@ -9,6 +9,7 @@
   pnpmConfigHook,
   stdenv,
   versionCheckHook,
+  nixosTests,
 }:
 buildGoModule (
   finalAttrs:
@@ -43,39 +44,43 @@ buildGoModule (
     versionCheckProgramArg = "version";
 
     doInstallCheck = true;
-    passthru.updateScript = nix-update-script { };
+    passthru = {
+      tests = { inherit (nixosTests) fmd-server; };
 
-    passthru.ui = stdenv.mkDerivation {
-      inherit (finalAttrs) version src pnpmDeps;
-      pname = "${finalAttrs.pname}-web-ui";
+      updateScript = nix-update-script { };
 
-      pnpmRoot = "web";
-      distRoot = "dist";
+      ui = stdenv.mkDerivation {
+        inherit (finalAttrs) version src pnpmDeps;
+        pname = "${finalAttrs.pname}-web-ui";
 
-      nativeBuildInputs = [
-        nodejs
-        pnpmConfigHook
-        pnpm_11
-      ];
+        pnpmRoot = "web";
+        distRoot = "dist";
 
-      buildPhase = ''
-        runHook preBuild
+        nativeBuildInputs = [
+          nodejs
+          pnpmConfigHook
+          pnpm_11
+        ];
 
-        pushd web
-        pnpm build
-        popd
+        buildPhase = ''
+          runHook preBuild
 
-        runHook postBuild
-      '';
+          pushd web
+          pnpm build
+          popd
 
-      installPhase = ''
-        runHook preInstall
+          runHook postBuild
+        '';
 
-        mkdir -p "$out"
-        cp -r '${ui.pnpmRoot}/${ui.distRoot}' "$out"
+        installPhase = ''
+          runHook preInstall
 
-        runHook postInstall
-      '';
+          mkdir -p "$out"
+          cp -r '${ui.pnpmRoot}/${ui.distRoot}' "$out"
+
+          runHook postInstall
+        '';
+      };
     };
 
     meta = {


### PR DESCRIPTION
Add a new module for [FMD Server](https://fmd-foss.org/docs/fmd-server/overview).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
