### PR TITLE
curlMinimal: disable some optional dependencies

### DIFF
--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -115,6 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
       (curlMinimal.override {
         # TODO: remove this override on staging
         gssSupport = true;
+        scpSupport = !stdenv.hostPlatform.isSunOS;
       })
       expat
       libarchive

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -112,7 +112,10 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     lib.optionals useSharedLibraries [
       bzip2
-      curlMinimal
+      (curlMinimal.override {
+        # TODO: remove this override on staging
+        gssSupport = true;
+      })
       expat
       libarchive
       xz

--- a/pkgs/by-name/cu/curl/package.nix
+++ b/pkgs/by-name/cu/curl/package.nix
@@ -12,6 +12,7 @@ curlMinimal.override (
     http3Support = true;
     idnSupport = true;
     pslSupport = true;
+    scpSupport = !stdenv.hostPlatform.isSunOS && !stdenv.hostPlatform.isCygwin;
     zstdSupport = true;
 
     gssSupport = !(curlMinimal.override { gssSupport = true; }).meta.broken;

--- a/pkgs/by-name/cu/curl/package.nix
+++ b/pkgs/by-name/cu/curl/package.nix
@@ -3,6 +3,9 @@
   ...
 }@args:
 
+let
+  inherit (curlMinimal) stdenv;
+in
 curlMinimal.override (
   {
     brotliSupport = true;
@@ -10,6 +13,8 @@ curlMinimal.override (
     idnSupport = true;
     pslSupport = true;
     zstdSupport = true;
+
+    gssSupport = !(curlMinimal.override { gssSupport = true; }).meta.broken;
   }
   // removeAttrs args [ "curlMinimal" ]
 )

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -16,21 +16,7 @@
   gnutls,
   gsaslSupport ? false,
   gsasl,
-  gssSupport ?
-    with stdenv.hostPlatform;
-    (
-      # krb5 is broken on cygwin
-      !(isWindows || isCygwin)
-      &&
-        # disable gss because of: undefined reference to `k5_bcmp'
-        # a very sad story re static: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
-        !isStatic
-      &&
-        # the "mig" tool does not configure its compiler correctly. This could be
-        # fixed in mig, but losing gss support on cross compilation to darwin is
-        # not worth the effort.
-        !(isDarwin && (stdenv.buildPlatform != stdenv.hostPlatform))
-    ),
+  gssSupport ? false,
   libkrb5,
   http2Support ? true,
   nghttp2,
@@ -302,8 +288,23 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
-    # Fails to link against static gss
-    broken = stdenv.hostPlatform.isStatic && gssSupport;
+    broken =
+      with stdenv.hostPlatform;
+      gssSupport
+      && (
+        # krb5 is broken on cygwin
+        isWindows
+        || isCygwin
+        ||
+          # broken gss because of: undefined reference to `k5_bcmp'
+          # a very sad story re static: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
+          isStatic
+        ||
+          # the "mig" tool does not configure its compiler correctly. This could be
+          # fixed in mig, but losing gss support on cross compilation to darwin is
+          # not worth the effort.
+          (isDarwin && (stdenv.buildPlatform != stdenv.hostPlatform))
+      );
     pkgConfigModules = [ "libcurl" ];
     mainProgram = "curl";
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "haxx" finalAttrs.version;

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -34,7 +34,7 @@
   libpsl,
   rtmpSupport ? false,
   rtmpdump,
-  scpSupport ? zlibSupport && !stdenv.hostPlatform.isSunOS && !stdenv.hostPlatform.isCygwin,
+  scpSupport ? false,
   libssh2,
   rustlsSupport ? false,
   rustls-ffi,

--- a/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
       # Avoid messing with libnghttp2.
       curl_ = curlMinimal.override (prevArgs: {
         http2Support = false;
-        scpSupport = false;
       });
 
       unpackScript = writeText "bootstrap-tools-unpack.sh" ''

--- a/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
@@ -55,9 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
         singleBinary = false;
       });
 
-      # Avoid messing with libkrb5 and libnghttp2.
+      # Avoid messing with libnghttp2.
       curl_ = curlMinimal.override (prevArgs: {
-        gssSupport = false;
         http2Support = false;
         scpSupport = false;
       });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -610,7 +610,7 @@ with pkgs;
             if stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isWindows then
               false
             else
-              old.gssSupport or true; # `? true` is the default
+              old.gssSupport or true; # `? false` is the default
           libkrb5 = buildPackages.krb5.override {
             fetchurl = stdenv.fetchurlBoot;
             inherit pkg-config perl openssl;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -618,6 +618,7 @@ with pkgs;
             byacc = buildPackages.byacc.override { fetchurl = stdenv.fetchurlBoot; };
             keyutils = buildPackages.keyutils.override { fetchurl = stdenv.fetchurlBoot; };
           };
+          scpSupport = !stdenv.hostPlatform.isSunOS && !stdenv.hostPlatform.isCygwin;
           nghttp2 = buildPackages.nghttp2.override {
             fetchurl = stdenv.fetchurlBoot;
             inherit pkg-config;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Before:

```console
$ du -sh /nix/store/f4akw5gcass763kipij6h74803dmx6i9-curl-8.21.0 /nix/store/ic20csi1jd9n3mf6whh6n75ys37qzdhp-krb5-1.22.2-lib /nix/store/mphbzgnpnpxfssvazl8r8rgm022m87qw-libssh2-1.11.1 /nix/store/akk9gn6mq32zk7sm80yq05y1lzv5fxi0-nghttp2-1.69.0-lib
920K    /nix/store/f4akw5gcass763kipij6h74803dmx6i9-curl-8.21.0
2.6M    /nix/store/ic20csi1jd9n3mf6whh6n75ys37qzdhp-krb5-1.22.2-lib
296K    /nix/store/mphbzgnpnpxfssvazl8r8rgm022m87qw-libssh2-1.11.1
212K    /nix/store/akk9gn6mq32zk7sm80yq05y1lzv5fxi0-nghttp2-1.69.0-lib
```

After:

```console
$ du -sh /nix/store/z4acr98qr76kxm4222iq22dcpfz9f6lp-curl-8.21.0                                                   
824K    /nix/store/z4acr98qr76kxm4222iq22dcpfz9f6lp-curl-8.21.0
```

`zlibSupport` still defaults to `true` (and `opensslSupport` still defaults to `zlibSupport`) as a cURL with any support for HTTPS has really fewer practical applications, so I chose to interpret "minimal" as meaning "with some HTTPS support".
EDIT: I've reverted the disabling of `http2Support`, the above derivation size are outdated (but should still give a rough idea of how "minimal" we're talking about)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
