### PR TITLE
multiple-outputs.sh: Fix propagatedBuildOutputs and structuredAttrs

### DIFF
--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -192,23 +192,25 @@ _multioutPropagateDev() {
         propagaterOutput="$outputFirst"
     fi
 
-    # Default value: propagate binaries, includes and libraries
-    if [ -z "${propagatedBuildOutputs+1}" ]; then
+    local outputsToPropagate=()
+    if declare -p propagatedBuildOutputs &>/dev/null; then
+        concatTo outputsToPropagate propagatedBuildOutputs
+    else
         local po_dirty="$outputBin $outputInclude $outputLib"
         set +o pipefail
-        propagatedBuildOutputs=`echo "$po_dirty" \
+        readarray -t outputsToPropagate < <(echo "$po_dirty" \
             | tr -s ' ' '\n' | grep -v -F "$propagaterOutput" \
-            | sort -u | tr '\n' ' ' `
+            | sort -u )
         set -o pipefail
     fi
 
-    # The variable was explicitly set to empty or we resolved it so
-    if [ -z "$propagatedBuildOutputs" ]; then
+    # Check whether we actually have any outputs to propagate
+    if [[ "${#outputsToPropagate[@]}" -eq 0 ]]; then
         return
     fi
 
     mkdir -p "${!propagaterOutput}"/nix-support
-    for output in $propagatedBuildOutputs; do
+    for output in "${outputsToPropagate[@]}"; do
         echo -n " ${!output}" >> "${!propagaterOutput}"/nix-support/propagated-build-inputs
     done
 }

--- a/pkgs/by-name/gn/gnucobol/package.nix
+++ b/pkgs/by-name/gn/gnucobol/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gnucobol";
   version = "3.2";
 
+  __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchurl {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes the propagated build inputs variable so that it will be properly read and used regardless of whether `__structuredAttrs` is set. Also sets it on `gnucobol` so that it can be tested. I intend to test it by building `gnucobol`.

Closes: #323126

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
