### PR TITLE
lark-cli: 1.0.58 -> 1.0.88

### DIFF
--- a/pkgs/by-name/la/lark-cli/package.nix
+++ b/pkgs/by-name/la/lark-cli/package.nix
@@ -26,7 +26,8 @@ buildGoModule (finalAttrs: {
   subPackages = [ "." ];
 
   metaData = fetchurl {
-    name = "meta_data.json";
+    pname = "meta_data.json";
+    inherit (finalAttrs) version;
     url = "https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
     hash = "sha256-ihPrq/VzFIBnlrKxE2762NpQZzBRk7ylM3Mvg0iJfCE=";
     postFetch = ''

--- a/pkgs/by-name/la/lark-cli/package.nix
+++ b/pkgs/by-name/la/lark-cli/package.nix
@@ -10,7 +10,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "lark-cli";
-  version = "1.0.58";
+  version = "1.0.88";
 
   __structuredAttrs = true;
 
@@ -18,10 +18,10 @@ buildGoModule (finalAttrs: {
     owner = "larksuite";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MqaxcmzX/79vM2EI8wD4ZAFsUfqWvPAovlpmuDP1IWU=";
+    hash = "sha256-MRaFOq+0+ieNPG23ncYot/kp5hyWER7bX95I+trLHbw=";
   };
 
-  vendorHash = "sha256-M0/Y62Y+M/P1B/YIDjX5bEyB/GKihCWQakTWVd7zvBg=";
+  vendorHash = "sha256-WClES7ilNmQ0018Qf13tNHouE/SIwh99MaewZ7VGQ2E=";
 
   subPackages = [ "." ];
 
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     pname = "meta_data.json";
     inherit (finalAttrs) version;
     url = "https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
-    hash = "sha256-ihPrq/VzFIBnlrKxE2762NpQZzBRk7ylM3Mvg0iJfCE=";
+    hash = "sha256-JEt2n3mcTNMuZf81c9VyoruABrgXVz5u6SxHg+lTWDI=";
     postFetch = ''
       ${lib.getExe jq} -S ".data" "$out" > normalized
       mv normalized "$out"


### PR DESCRIPTION
## Description of changes

Two commits:

1. **`lark-cli: version metaData fetch derivation name`** — The `metaData` `fetchurl` is a fixed-output derivation whose store path is keyed by `name` + `hash`. Previously its name was the constant `meta_data.json`, so a version bump alone (same stale hash) produced the same store path and Nix would silently reuse the previously fetched/cached `meta_data.json`, even if the content served for the new `client_version` had changed upstream. The derivation now inherits the package version, making the name e.g. `meta_data.json-1.0.88`. Consequently, every version bump forces a fresh fetch, and if `meta_data.json` changed while the pinned hash was not updated, the build fails the `fetchurl` hash check loudly instead of silently building against stale API metadata. This turned out to be immediately useful: the live endpoint's content has already drifted since the package was introduced.

2. **`lark-cli: 1.0.58 -> 1.0.88`** — Version bump with updated `src`/`vendorHash`, and a refreshed `metaData` hash because the content of the live `api_definition` endpoint changed since the package was added (today it is byte-identical for `v1.0.58` and `v1.0.88`, but different from what was pinned at init).

Release notes: https://github.com/larksuite/cli/releases

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (`passthru.tests.version`, passing: `lark-cli version v1.0.88`)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`lark-cli --version`, `lark-cli --help`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test