### PR TITLE
spotify: modernize and refactor

### DIFF
--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -112,6 +112,8 @@ let
     libxscrnsaver
     libxshmfence
     libxtst
+    nspr
+    openssl
     zlib
   ];
 in
@@ -160,14 +162,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preUnpack
     unsquashfs "$src" '/usr/share/spotify' '/usr/bin/spotify' '/meta/snap.yaml'
     cd squashfs-root
-    if ! grep -q 'grade: stable' meta/snap.yaml; then
-      # Unfortunately this check is not reliable: At the moment (2018-07-26) the
-      # latest version in the "edge" channel is also marked as stable.
-      echo "The snap package is marked as unstable:"
-      grep 'grade: ' meta/snap.yaml
-      echo "You probably chose the wrong revision."
-      exit 1
-    fi
     if ! grep -q '${finalAttrs.version}' meta/snap.yaml; then
       echo "Package version differs from version found in snap metadata:"
       grep 'version: ' meta/snap.yaml
@@ -181,41 +175,22 @@ stdenv.mkDerivation (finalAttrs: {
   # Prevent double wrapping
   dontWrapGApps = true;
 
-  env = rec {
-    libdir = "${placeholder "out"}/lib/spotify";
-    librarypath = "${lib.makeLibraryPath deps}:${libdir}";
-  };
-
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $libdir
+    mkdir $out
     mv ./usr/* $out/
-
-    # Work around Spotify referring to a specific minor version of
-    # OpenSSL.
-
-    ln -s ${lib.getLib openssl}/lib/libssl.so $libdir/libssl.so.1.0.0
-    ln -s ${lib.getLib openssl}/lib/libcrypto.so $libdir/libcrypto.so.1.0.0
-    ln -s ${nspr.out}/lib/libnspr4.so $libdir/libnspr4.so
-    ln -s ${nspr.out}/lib/libplc4.so $libdir/libplc4.so
-
-    ln -s ${ffmpeg_7-headless.lib}/lib/libavcodec.so* $libdir
-    ln -s ${ffmpeg_7-headless.lib}/lib/libavformat.so* $libdir
-
-    rpath="$out/share/spotify:$libdir"
 
     chmod +w "$out/share/spotify/spotify"
     patchelf \
       --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath $rpath $out/share/spotify/spotify
+      $out/share/spotify/spotify
 
     # fix Icon line in the desktop file (#48062)
     sed -i "s:^Icon=.*:Icon=spotify-client:" "$out/share/spotify/spotify.desktop"
 
     # Desktop file
-    mkdir -p "$out/share/applications/"
-    cp "$out/share/spotify/spotify.desktop" "$out/share/applications/"
+    install -Dm644 "$out/share/spotify/spotify.desktop" "$out/share/applications/spotify.desktop"
 
     # Icons
     for i in 16 22 24 32 48 64 128 256 512; do
@@ -238,7 +213,7 @@ stdenv.mkDerivation (finalAttrs: {
           --add-flags "--force-device-scale-factor=${toString deviceScaleFactor}" \
         ''
       } \
-      --prefix LD_LIBRARY_PATH : "$librarypath" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath deps}" \
       --prefix PATH : "${zenity}/bin" \
       --run 'if [[ "''${NIXOS_OZONE_WL:-default}" == "1" ]]; then unset DISPLAY; fi'
 

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -215,6 +215,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = meta // {
     maintainers = with lib.maintainers; [
+      letgamer
       ma27
     ];
   };

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -1,62 +1,53 @@
 {
   fetchurl,
   lib,
+  meta,
+  pname,
   stdenv,
-  squashfs-tools,
-  libxtst,
-  libxscrnsaver,
-  libxrender,
-  libxrandr,
-  libxi,
-  libxfixes,
-  libxext,
-  libxdamage,
-  libxcursor,
-  libxcomposite,
-  libx11,
-  libsm,
-  libice,
-  libxshmfence,
-  libxcb,
-  alsa-lib,
   makeShellWrapper,
+  squashfs-tools,
   wrapGAppsHook3,
-  openssl,
-  freetype,
-  glib,
-  pango,
-  cairo,
+
+  #Spotify
   atk,
+  ayatana-ido,
+  cairo,
+  ffmpeg_7-headless, # Requires libavcodec < 62
   gdk-pixbuf,
+  glib,
   gtk3,
-  cups,
-  nspr,
-  nss_latest,
-  libpng,
-  libnotify,
-  libgcrypt,
-  systemd,
-  fontconfig,
-  dbus,
-  expat,
-  ffmpeg_7-headless,
-  curlWithGnuTls,
+  harfbuzz,
+  libayatana-appindicator,
+  libayatana-indicator,
+  libdbusmenu,
+  libx11,
+  pango,
+  pulseaudio,
   zlib,
-  zenity,
+
+  # CEF
+  alsa-lib,
   at-spi2-atk,
   at-spi2-core,
-  libpulseaudio,
+  cups,
+  dbus,
+  expat,
   libdrm,
   libgbm,
-  libxkbcommon,
-  pname,
-  meta,
-  harfbuzz,
-  libayatana-indicator,
-  libayatana-appindicator,
-  ayatana-ido,
-  libdbusmenu,
   libGL,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxkbcommon,
+  libxrandr,
+  libxshmfence,
+  nspr,
+  nss_latest,
+  systemdLibs,
+  udev,
+
   # High-DPI support: Spotify's --force-device-scale-factor argument
   # not added if `null`, otherwise, should be a number.
   deviceScaleFactor ? null,
@@ -65,56 +56,57 @@
 
 let
   deps = [
-    alsa-lib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    curlWithGnuTls
-    dbus
-    expat
-    ffmpeg_7-headless # Requires libavcodec < 62
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    harfbuzz
-    libayatana-indicator
-    libayatana-appindicator
+    # Via lddtree:
     ayatana-ido
+    cairo
+    gdk-pixbuf
+    gtk3
+    libayatana-appindicator
+    libayatana-indicator
     libdbusmenu
-    libdrm
-    libgcrypt
-    libGL
-    libnotify
-    libpng
-    libpulseaudio
-    libxkbcommon
-    libgbm
-    nss_latest
     pango
     stdenv.cc.cc
-    systemd
-    libice
-    libsm
+
+    # Found via dlopen:
+    atk
+    ffmpeg_7-headless # Requires libavcodec < 62
+    glib
+    harfbuzz
     libx11
+    pulseaudio
+    zlib
+
+    # https://github.com/NixOS/nixpkgs/blob/b6c2725f1208c66437095d28c5b84e6a173d9e3c/pkgs/by-name/ce/cef-binary/package.nix#L45
+    # Copied CEF Dependencies with duplicates commented out:
+
+    #glib
+    # https://github.com/NixOS/nixpkgs/commit/699e707e90a89fb06a9880df6b83c22428fd8deb
+    nss_latest
+    nspr
+    #atk
+    at-spi2-atk
+    libdrm
+    expat
+    libxkbcommon
+    libgbm
+    #gtk3
+    #pango
+    #cairo
+    alsa-lib
+    dbus
+    at-spi2-core
+    cups
+    libGL
+    udev
+    systemdLibs
     libxcb
+    #libx11
     libxcomposite
-    libxcursor
     libxdamage
     libxext
     libxfixes
-    libxi
     libxrandr
-    libxrender
-    libxscrnsaver
     libxshmfence
-    libxtst
-    nspr
-    openssl
-    zlib
   ];
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -214,7 +206,6 @@ stdenv.mkDerivation (finalAttrs: {
         ''
       } \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath deps}" \
-      --prefix PATH : "${zenity}/bin" \
       --run 'if [[ "''${NIXOS_OZONE_WL:-default}" == "1" ]]; then unset DISPLAY; fi'
 
     runHook postFixup


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR refactors the Spotify package, with a focus on simplifying and clarifying dependency handling.

It reduces the closure size from 1497518808 = 1.39 GiB to 997399720 = 0.93 GiB !


1. In the first commit the dependency handling was improved by removing the `$libraryPath` as these fixes were not needed anymore and everything was switched to: `lib.makeLibraryPath`

2. In the second commit the dependencies themselves were improved.

They are now logically separated by spotify CEF dependencies and unnecessary Dependencies were removed:
- zenity, which doesnt show up in strace when adding a local folder or in strings
- curl, not used by spotify
- libgcrypt

3. In the third commit I added myself as a maintainer

## Things done

Tested Spotify extensively, including:

- Playback
- Local files
- Login
- Logout
- Notifications


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
