### PR TITLE
lark-cli: 1.0.58 -> 1.0.88, build API registry from the official release binary

### DIFF
--- a/pkgs/by-name/la/lark-cli/extract-meta.py
+++ b/pkgs/by-name/la/lark-cli/extract-meta.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Extract the API registry embedded in an official lark-cli release binary.
+
+lark-cli embeds its registry of Lark Open Platform APIs
+(internal/registry/meta_data.json) into the binary at build time:
+build.sh runs scripts/fetch_meta.py and internal/registry/loader_embedded.go
+pulls the file in via go:embed. scripts/fetch_meta.py stores the document
+with json.dump(..., indent=2), so the registry exists verbatim in the
+binary's read-only data section as a pretty-printed JSON object.
+
+This script locates that object without anchoring on any particular key
+order: the key order of the embedded registry is whatever the API endpoint
+used on the day upstream built the release (releases 1.0.58 and 1.0.88
+already differ), so it enumerates every pretty-printed top-level object in
+the binary and keeps the only one that parses as JSON with a non-empty
+"services" list. Extraction uses a brace-matching scan that is string- and
+escape-aware. The binary is never executed, so the linux-amd64 release
+artifact works as the source on every platform.
+
+If upstream changes how the registry is embedded, extraction fails loudly
+instead of silently producing stale data.
+"""
+
+import json
+import sys
+
+
+def candidates(data: bytes):
+    # json.dump(..., indent=2) indents nested objects deeper, so a newline
+    # followed by exactly two spaces can only occur at the top level of a
+    # pretty-printed document: every such '{' is a candidate, and inner
+    # objects of the registry itself never match. Raw newlines cannot occur
+    # inside JSON strings, so string literals produce no false candidates
+    # either. The registry's own key order is whatever the endpoint used
+    # when upstream built the release; do not anchor on any specific key.
+    marker = b'{\n  "'
+    start = 0
+    while True:
+        offset = data.find(marker, start)
+        if offset < 0:
+            return
+        start = offset + 1
+        yield offset
+
+
+def extract_object(data: bytes, start: int) -> bytes | None:
+    # Returns the bytes of the JSON object starting at `start`, or None when
+    # the bytes do not form one. Bails out on NUL bytes and unbalanced
+    # closes, which end non-JSON regions of the binary quickly.
+    depth = 0
+    in_string = False
+    escaped = False
+    for offset in range(start, len(data)):
+        byte = data[offset]
+        if byte == 0:
+            return None
+        if in_string:
+            if escaped:
+                escaped = False
+            elif byte == 0x5C:  # backslash
+                escaped = True
+            elif byte == 0x22:  # double quote
+                in_string = False
+        elif byte == 0x22:
+            in_string = True
+        elif byte == 0x7B:  # '{'
+            depth += 1
+        elif byte == 0x7D:  # '}'
+            depth -= 1
+            if depth < 0:
+                return None
+            if depth == 0:
+                return data[start : offset + 1]
+    return None
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} LARK_CLI_BINARY OUTPUT_JSON")
+
+    binary_path, output_path = sys.argv[1], sys.argv[2]
+    with open(binary_path, "rb") as fp:
+        data = fp.read()
+
+    registry = None
+    for start in candidates(data):
+        blob = extract_object(data, start)
+        if blob is None:
+            continue
+        try:
+            document = json.loads(blob)
+        except ValueError:
+            continue
+        # The real registry is the only candidate with a non-empty service
+        # list; embedded fallbacks look like {"version":"0.0.0","services":[]}.
+        if isinstance(document.get("services"), list) and document["services"]:
+            if registry is None or len(blob) > len(registry):
+                registry = blob
+
+    if registry is None:
+        sys.exit("no embedded API registry found in binary")
+
+    with open(output_path, "wb") as fp:
+        fp.write(registry)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/la/lark-cli/package.nix
+++ b/pkgs/by-name/la/lark-cli/package.nix
@@ -3,7 +3,8 @@
   buildGoModule,
   fetchFromGitHub,
   fetchurl,
-  jq,
+  python3,
+  runCommand,
   testers,
   nix-update-script,
 }:
@@ -25,16 +26,42 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "." ];
 
-  metaData = fetchurl {
-    pname = "meta_data.json";
-    inherit (finalAttrs) version;
-    url = "https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
-    hash = "sha256-JEt2n3mcTNMuZf81c9VyoruABrgXVz5u6SxHg+lTWDI=";
-    postFetch = ''
-      ${lib.getExe jq} -S ".data" "$out" > normalized
-      mv normalized "$out"
-    '';
+  # The registry of Open Platform APIs that lark-cli embeds at build time
+  # (internal/registry/meta_data.json). Upstream regenerates this file on
+  # every build from a live endpoint (scripts/fetch_meta.py,
+  # https://open.feishu.cn/api/tools/open/api_definition?protocol=meta).
+  # That endpoint serves a continuously updated document with no way to pin
+  # a version: the "data_version" parameter is only an exact-match
+  # conditional against a constant "1.0.0" that is never bumped,
+  # "client_version" is ignored, and there is no ETag, Last-Modified or
+  # historical access. Hash-pinning such a URL breaks as soon as the content
+  # drifts, and old revisions of this package become unbuildable because the
+  # bytes behind the URL are gone forever; this already happened to 1.0.58.
+  #
+  # The official release binaries embed the exact registry that upstream
+  # built the corresponding version with (build.sh runs fetch_meta.py before
+  # go build, and loader_embedded.go go:embeds the file). Release artifacts
+  # are immutable per version and checksummed upstream, so we extract the
+  # registry from the binary for this exact version instead: byte-exact,
+  # version-faithful (building 1.0.x yields the registry the official 1.0.x
+  # binary ships with) and reproducible for old revisions. Extraction is a
+  # pure byte scan, so the linux-amd64 tarball works on every platform.
+  # Hash recorded in the release checksums.txt.
+  metaDataRelease = fetchurl {
+    name = "lark-cli-${finalAttrs.version}-linux-amd64.tar.gz";
+    url = "https://github.com/larksuite/cli/releases/download/v${finalAttrs.version}/lark-cli-${finalAttrs.version}-linux-amd64.tar.gz";
+    hash = "sha256-SX3iCTms3SquTImP6noMpx1aRZ7VQyAudiqLyzIo7/4=";
   };
+
+  metaData =
+    runCommand "meta_data.json-${finalAttrs.version}"
+      {
+        nativeBuildInputs = [ python3 ];
+      }
+      ''
+        tar xf ${finalAttrs.metaDataRelease} lark-cli
+        python3 ${./extract-meta.py} lark-cli $out
+      '';
 
   postPatch = ''
     cp ${finalAttrs.metaData} internal/registry/meta_data.json
@@ -56,7 +83,7 @@ buildGoModule (finalAttrs: {
     updateScript = nix-update-script {
       extraArgs = [
         "--custom-dep"
-        "metaData"
+        "metaDataRelease"
       ];
     };
   };

--- a/pkgs/by-name/la/lark-cli/package.nix
+++ b/pkgs/by-name/la/lark-cli/package.nix
@@ -26,7 +26,8 @@ buildGoModule (finalAttrs: {
   subPackages = [ "." ];
 
   metaData = fetchurl {
-    name = "meta_data.json";
+    pname = "meta_data.json";
+    inherit (finalAttrs) version;
     url = "https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
     hash = "sha256-ihPrq/VzFIBnlrKxE2762NpQZzBRk7ylM3Mvg0iJfCE=";
     postFetch = ''

--- a/pkgs/by-name/la/lark-cli/package.nix
+++ b/pkgs/by-name/la/lark-cli/package.nix
@@ -10,7 +10,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "lark-cli";
-  version = "1.0.58";
+  version = "1.0.88";
 
   __structuredAttrs = true;
 
@@ -18,10 +18,10 @@ buildGoModule (finalAttrs: {
     owner = "larksuite";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MqaxcmzX/79vM2EI8wD4ZAFsUfqWvPAovlpmuDP1IWU=";
+    hash = "sha256-MRaFOq+0+ieNPG23ncYot/kp5hyWER7bX95I+trLHbw=";
   };
 
-  vendorHash = "sha256-M0/Y62Y+M/P1B/YIDjX5bEyB/GKihCWQakTWVd7zvBg=";
+  vendorHash = "sha256-WClES7ilNmQ0018Qf13tNHouE/SIwh99MaewZ7VGQ2E=";
 
   subPackages = [ "." ];
 
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     pname = "meta_data.json";
     inherit (finalAttrs) version;
     url = "https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
-    hash = "sha256-ihPrq/VzFIBnlrKxE2762NpQZzBRk7ylM3Mvg0iJfCE=";
+    hash = "sha256-JEt2n3mcTNMuZf81c9VyoruABrgXVz5u6SxHg+lTWDI=";
     postFetch = ''
       ${lib.getExe jq} -S ".data" "$out" > normalized
       mv normalized "$out"


### PR DESCRIPTION
## Description of changes

Supersedes #553983 (same version bump, plus a reproducible source for the API registry).

### 1. `lark-cli: 1.0.58 -> 1.0.88`

Version bump with refreshed `src`/`vendorHash`.

### 2. `lark-cli: extract API registry from official release binary`

`lark-cli` embeds a registry of Open Platform APIs (`internal/registry/meta_data.json`) at build time. Upstream generates it on every build from a live endpoint (`scripts/fetch_meta.py`, `https://open.feishu.cn/api/tools/open/api_definition?protocol=meta`), and this package previously did the same via `fetchurl`.

That endpoint cannot serve reproducible builds (all verified against the live endpoint):

- it returns a continuously updated document: at least five distinct versions since June (via Wayback Machine snapshots of 2026-06-26, 2026-07-01, 2026-08-11 and today: 14/77/237 -> 15/81/247 services/resources/methods);
- the `data_version` parameter is only an exact-match conditional against a constant `\"1.0.0\"` that is never bumped: passing `data_version=1.0.0` returns an empty \"not modified\" body, any other value returns the current full document;
- `client_version` is ignored (`v1.0.58` and `v1.0.88` URLs return byte-identical data);
- there is no ETag, Last-Modified, or historical access.

Consequences:

- rebuilding the same git tag at a different date embeds different data — official upstream builds are themselves not reproducible this way;
- hash-pinning the URL breaks as soon as the endpoint drifts, and past nixpkgs revisions become unbuildable because the bytes behind the URL are gone forever. This already happened: the hash pinned when the package was added (1.0.58) can no longer be fetched from the endpoint or from `cache.nixos.org`, so current master cannot build `lark-cli.metaData` from source.

Instead, this PR extracts the registry from the official release binary of the exact packaged version. Upstream embeds the registry each release was built with into the binary (`build.sh` runs `fetch_meta.py` before `go build`; `internal/registry/loader_embedded.go` `go:embed`s the file), and release artifacts are immutable per version and checksummed upstream (`checksums.txt`, npm `dist.integrity`). This is byte-exact, version-faithful (building 1.0.x yields the registry the official 1.0.x binary ships with), and reproducible for old revisions.

`extract-meta.py` locates the embedded document without depending on its key order (1.0.58 and 1.0.88 already differ): `json.dump(..., indent=2)` indents nested objects deeper, so every top-level pretty-printed `{` in the binary is a candidate, and the only one that parses as JSON with a non-empty `services` list is the registry. The binary is never executed, so the linux-amd64 tarball works as the source on every platform. Extraction was verified byte-identical against the registry embedded in the official 1.0.88 and 1.0.58 binaries, and against a synthetic binary with a shuffled key order; if upstream changes how the registry is embedded, extraction fails loudly instead of producing stale data.

An upstream issue asking for a versioned distribution channel for this data (bump `data.version` and/or ship `meta_data.json` in releases) is being filed separately.

### AI assistance disclosure

Per the [automation/AI policy]: the investigation that located the problem (probing the `api_definition` endpoint's versioning behavior, comparing archived snapshots, and discovering that the registry is recoverable from the release binaries) as well as the initial implementation of `extract-meta.py` were carried out with AI assistance. All findings were independently re-verified, and the resulting package was built and tested locally as described below.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (`passthru.tests.version`, passing: `lark-cli version v1.0.88`)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and \"core\" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`lark-cli --version`, `lark-cli --help`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
