### PR TITLE
linuxPackages_latest.opensnitch-ebpf: patch to fix build

### DIFF
--- a/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
+++ b/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/evilsocket/opensnitch/commit/614537c92ec82f54f76a45fb406ad2fb6e6fa618.patch?full_index=1";
       hash = "sha256-FCJfDhgmnm1GXPDaxr+YpVWTRrwBvjVzvGdZSFB6SqQ=";
     })
+    ./define-fentry-in-tracing.patch
   ];
 
   sourceRoot = "${src.name}/ebpf_prog";

--- a/pkgs/os-specific/linux/opensnitch-ebpf/define-fentry-in-tracing.patch
+++ b/pkgs/os-specific/linux/opensnitch-ebpf/define-fentry-in-tracing.patch
@@ -1,0 +1,31 @@
+--- a/common_defs.h
++++ b/common_defs.h
+@@ -1,6 +1,8 @@
+ #ifndef OPENSNITCH_COMMON_DEFS_H
+ #define OPENSNITCH_COMMON_DEFS_H
+ 
++#define CC_USING_FENTRY
++
+ #include <linux/sched.h>
+ #include <linux/ptrace.h>
+ #include <linux/byteorder/generic.h>
+diff --git a/ebpf_prog/opensnitch-dns.c b/ebpf_prog/opensnitch-dns.c
+index 13bd9b66..becc30e3 100644
+--- a/opensnitch-dns.c
++++ b/opensnitch-dns.c
+@@ -20,6 +20,7 @@
+ 
+ #define KBUILD_MODNAME "opensnitch-dns"
+ 
++#include "common_defs.h"
+ #include <linux/in.h>
+ #include <linux/in6.h>
+ #include <linux/ptrace.h>
+@@ -27,7 +28,6 @@
+ #include <net/sock.h>
+ #include <uapi/linux/bpf.h>
+ #include <uapi/linux/tcp.h>
+-#include "common_defs.h"
+ #include "bpf_headers/bpf_helpers.h"
+ #include "bpf_headers/bpf_tracing.h"
+ 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/553951

cc @eclairevoyant 
Draft until i get around to upstreaming this, because i am not fully confident this is actually the correct fix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
