### PR TITLE
python3Packages.monty: 2025.3.3 -> 2026.7.16

### DIFF
--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -9,42 +9,47 @@
   setuptools-scm,
 
   # dependencies
-  msgpack,
+  numpy,
   ruamel-yaml,
 
   # optional-dependencies
-  coverage,
+  invoke,
+  ipython,
+  msgpack,
+  mypy,
+  myst-parser,
+  orjson,
+  pandas,
+  pint,
+  pydantic,
   pymongo,
   pytest,
   pytest-cov,
-  types-requests,
+  requests,
+  roman-numerals,
+  ruff,
   sphinx,
+  sphinx-markdown-builder,
   sphinx-rtd-theme,
-  orjson,
-  pandas,
-  pydantic,
-  pint,
   torch,
   tqdm,
-  invoke,
-  requests,
+  uv,
 
   # tests
-  ipython,
-  numpy,
   pytestCheckHook,
+  pytest-benchmark,
 }:
 
 buildPythonPackage rec {
   pname = "monty";
-  version = "2025.3.3";
+  version = "2026.7.16";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "materialsvirtuallab";
+    owner = "materialyzeai";
     repo = "monty";
     tag = "v${version}";
-    hash = "sha256-3UoACKJtPm2BrkJP8z7BFrh3baRyL/S3VwCG3K8AQn0=";
+    hash = "sha256-x5FNw7E3rtrgCWVhMsBpnO+uwu+mB3ELNFdd33+uFds=";
   };
 
   build-system = [
@@ -53,53 +58,47 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    msgpack
+    numpy
     ruamel-yaml
   ];
 
   optional-dependencies = rec {
     ci = [
-      coverage
-      pymongo
+      mypy
       pytest
       pytest-cov
-      types-requests
+      ruff
+      uv
     ]
     ++ optional;
     dev = [ ipython ];
     docs = [
       sphinx
       sphinx-rtd-theme
+      requests
+      invoke
+      myst-parser
+      sphinx-markdown-builder
+      roman-numerals
     ];
     json = [
       orjson
       pandas
+      pint
       pydantic
       pymongo
-    ]
-    ++ lib.optionals (pythonOlder "3.13") [
-      pint
       torch
     ];
     multiprocessing = [ tqdm ];
     optional = dev ++ json ++ multiprocessing ++ serialization;
     serialization = [ msgpack ];
-    task = [
-      invoke
-      requests
-    ];
   };
 
   nativeCheckInputs = [
-    ipython
-    numpy
-    pandas
-    pydantic
-    pymongo
     pytestCheckHook
-    torch
-    tqdm
-  ];
+    pytest-benchmark
+  ]
+  ++ optional-dependencies.optional;
 
   pythonImportsCheck = [ "monty" ];
 
@@ -110,8 +109,8 @@ buildPythonPackage rec {
       standard library. Examples include useful utilities like transparent support for zipped files, useful design
       patterns such as singleton and cached_class, and many more.
     ";
-    homepage = "https://github.com/materialsvirtuallab/monty";
-    changelog = "https://github.com/materialsvirtuallab/monty/releases/tag/${src.tag}";
+    homepage = "https://github.com/materialyzeai/monty";
+    changelog = "https://github.com/materialyzeai/monty/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ psyanticy ];
   };

--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -112,6 +112,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/materialyzeai/monty";
     changelog = "https://github.com/materialyzeai/monty/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ psyanticy ];
+    maintainers = with lib.maintainers; [
+      psyanticy
+      berquist
+    ];
   };
 }

--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -16,24 +16,19 @@
   invoke,
   ipython,
   msgpack,
-  mypy,
   myst-parser,
   orjson,
   pandas,
   pint,
   pydantic,
   pymongo,
-  pytest,
-  pytest-cov,
   requests,
   roman-numerals,
-  ruff,
   sphinx,
   sphinx-markdown-builder,
   sphinx-rtd-theme,
   torch,
   tqdm,
-  uv,
 
   # tests
   pytestCheckHook,
@@ -63,14 +58,6 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = rec {
-    ci = [
-      mypy
-      pytest
-      pytest-cov
-      ruff
-      uv
-    ]
-    ++ optional;
     dev = [ ipython ];
     docs = [
       sphinx

--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -35,15 +35,16 @@
   pytest-benchmark,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "monty";
   version = "2026.7.16";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "materialyzeai";
     repo = "monty";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-x5FNw7E3rtrgCWVhMsBpnO+uwu+mB3ELNFdd33+uFds=";
   };
 
@@ -85,7 +86,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-benchmark
   ]
-  ++ optional-dependencies.optional;
+  ++ finalAttrs.passthru.optional-dependencies.optional;
 
   pythonImportsCheck = [ "monty" ];
 
@@ -97,11 +98,11 @@ buildPythonPackage rec {
       patterns such as singleton and cached_class, and many more.
     ";
     homepage = "https://github.com/materialyzeai/monty";
-    changelog = "https://github.com/materialyzeai/monty/releases/tag/${src.tag}";
+    changelog = "https://github.com/materialyzeai/monty/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       psyanticy
       berquist
     ];
   };
-}
+})


### PR DESCRIPTION
I've kept the `ci` group even though that is replaced with `uv run ...` in their GHA CI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
