### PR TITLE
beamPackages: splice the package set

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -34,16 +34,20 @@ Inside each package set are:
 - builders: mixRelease, buildRebar3, etc
 - hooks: for composing builders and packages
 
-To use a non-default Elixir it's important to keep the rest of the package set consistent, so it's recommended to use `.extend`. This ensures that builders like `mixRelease`, `fetchMixDeps`, and `buildMix` all pick up the overridden Elixir:
+The package set is the only place Erlang and Elixir versions are chosen. Builders such as `mixRelease`, `fetchMixDeps` and `buildMix` take them from the set they are called from, and do not accept `erlang`, `elixir` or `hex` arguments.
+
+To use a non-default Elixir, derive a new set with `overrideScope`. This keeps the rest of the set consistent, so every builder picks up the overridden Elixir:
 
 ```nix
 let
-  beamPackages = beam27Packages.extend (self: super: { elixir = self.elixir_1_18; });
+  beamPackages = beam27Packages.overrideScope (final: prev: { elixir = final.elixir_1_18; });
 in
 beamPackages.mixRelease {
   # ...
 }
 ```
+
+`erlang` can be replaced the same way, which is useful for a patched OTP. Every member of the set is built from the set's own `erlang`, so overriding it rebuilds Elixir, Rebar3 and the rest against it.
 
 ## Build Tools {#beam-build-tools}
 
@@ -332,8 +336,8 @@ Usually, we need to create a `shell.nix` file and do our development inside the 
 
 with pkgs;
 let
-  # pin OTP via beam27Packages/beam28Packages/... and Elixir via .extend
-  beamPackages = beam27Packages.extend (self: super: { elixir = self.elixir_1_18; });
+  # pin OTP via beam27Packages/beam28Packages/... and Elixir via overrideScope
+  beamPackages = beam27Packages.overrideScope (final: prev: { elixir = final.elixir_1_18; });
 in
 mkShell { buildInputs = [ beamPackages.elixir ]; }
 ```
@@ -368,8 +372,8 @@ Here is an example `shell.nix`.
 with import <nixpkgs> { };
 
 let
-  # pin OTP via beam27Packages/beam28Packages/... and Elixir via .extend
-  beamPackages = beam27Packages.extend (self: super: { elixir = self.elixir_1_18; });
+  # pin OTP via beam27Packages/beam28Packages/... and Elixir via overrideScope
+  beamPackages = beam27Packages.overrideScope (final: prev: { elixir = final.elixir_1_18; });
 
   # define packages to install
   basePackages = [

--- a/pkgs/by-name/ak/akkoma/package.nix
+++ b/pkgs/by-name/ak/akkoma/package.nix
@@ -9,11 +9,11 @@
 }:
 
 let
-  beamPackages = beam_minimal.packages.erlang_27.extend (
-    self: super: {
-      elixir = self.elixir_1_17;
-      rebar3 = self.rebar3WithPlugins {
-        plugins = with self; [ pc ];
+  beamPackages = beam_minimal.packages.erlang_27.overrideScope (
+    final: prev: {
+      elixir = final.elixir_1_17;
+      rebar3 = final.rebar3WithPlugins {
+        plugins = with final; [ pc ];
       };
     }
   );

--- a/pkgs/by-name/mo/mobilizon/package.nix
+++ b/pkgs/by-name/mo/mobilizon/package.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  beamPackages = beam.packages.erlang_27.extend (self: super: { elixir = self.elixir_1_18; });
+  beamPackages = beam.packages.erlang_27.overrideScope (final: prev: { elixir = final.elixir_1_18; });
 
   common = callPackage ./common.nix { };
 in

--- a/pkgs/by-name/pl/plausible/package.nix
+++ b/pkgs/by-name/pl/plausible/package.nix
@@ -129,7 +129,7 @@ let
           $out/lazy_html/_build/c/third_party/lexbor/${lexborCommit}
       '';
 
-  beamPackages = beam27Packages.extend (self: super: { elixir = self.elixir_1_18; });
+  beamPackages = beam27Packages.overrideScope (final: prev: { elixir = final.elixir_1_18; });
 
 in
 beamPackages.mixRelease rec {

--- a/pkgs/by-name/pl/pleroma/package.nix
+++ b/pkgs/by-name/pl/pleroma/package.nix
@@ -15,7 +15,7 @@
 }:
 
 let
-  beamPackages = beam.packages.erlang_27.extend (self: super: { elixir = self.elixir_1_18; });
+  beamPackages = beam.packages.erlang_27.overrideScope (final: prev: { elixir = final.elixir_1_18; });
 in
 beamPackages.mixRelease rec {
   pname = "pleroma";

--- a/pkgs/by-name/ra/rabbitmq-server/package.nix
+++ b/pkgs/by-name/ra/rabbitmq-server/package.nix
@@ -40,7 +40,7 @@ let
     ]
   );
 
-  beamPackages = beam27Packages.extend (self: super: { elixir = self.elixir_1_18; });
+  beamPackages = beam27Packages.overrideScope (final: prev: { elixir = final.elixir_1_18; });
 in
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -3,29 +3,24 @@
   lib,
   pkgs,
   erlang,
+  generateSplicesForMkScope,
+  makeScopeWithSplicing',
+  # Where this package set lives in `pkgs`, so that cross compilation can find
+  # its build platform counterpart.
+  splicePath,
 }:
 
-let
-  inherit (lib) makeExtensible;
-
-  # FIXME: add support for overrideScope
-  callPackageWithScope =
-    scope: drv: args:
-    lib.callPackageWith scope drv args;
-  callPackagesWithScope =
-    scope: drv: args:
-    lib.callPackagesWith scope drv args;
-  mkScope = scope: pkgs // scope;
-
-  packages =
+makeScopeWithSplicing' {
+  otherSplices = generateSplicesForMkScope splicePath;
+  # This is the set itself, splicing it would recurse.
+  keep = self: { inherit (self) beamPackages; };
+  f =
     self:
     let
-      defaultScope = mkScope self;
-      callPackage = drv: args: callPackageWithScope defaultScope drv args;
-      callPackages = drv: args: callPackagesWithScope defaultScope drv args;
+      inherit (self) callPackage;
     in
-    rec {
-      inherit callPackage erlang;
+    {
+      inherit erlang;
       beamPackages = self;
 
       inherit (callPackage ../tools/build-managers/rebar3 { }) rebar3 rebar3WithPlugins;
@@ -50,47 +45,41 @@ let
       elvis-erlang = callPackage ./elvis-erlang { };
 
       # BEAM-based languages.
-      elixir = elixir_1_18;
+      elixir = self.elixir_1_18;
 
       elixir_1_20 = callPackage ../interpreters/elixir/1.20.nix {
-        inherit erlang;
         debugInfo = true;
       };
 
       elixir_1_19 = callPackage ../interpreters/elixir/1.19.nix {
-        inherit erlang;
         debugInfo = true;
       };
 
       elixir_1_18 = callPackage ../interpreters/elixir/1.18.nix {
-        inherit erlang;
         debugInfo = true;
       };
 
       elixir_1_17 = callPackage ../interpreters/elixir/1.17.nix {
-        inherit erlang;
         debugInfo = true;
       };
 
       # Remove old versions of elixir, when the supports fades out:
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 
-      ex_doc = callPackage ./ex_doc {
-        inherit fetchMixDeps mixRelease;
-      };
+      ex_doc = callPackage ./ex_doc { };
 
-      elixir-ls = callPackage ./elixir-ls { inherit elixir; };
+      elixir-ls = callPackage ./elixir-ls { };
       expert = callPackage ./expert { };
 
-      lfe = callPackage ../interpreters/lfe { inherit erlang buildRebar3 fetchHex; };
+      lfe = callPackage ../interpreters/lfe { };
 
-      livebook = callPackage ./livebook { inherit beamPackages; };
+      livebook = callPackage ./livebook { };
 
       # Non hex packages. Examples how to build Rebar/Mix packages with and
       # without helper functions buildRebar3 and buildMix.
       hex = callPackage ./hex { };
 
-      inherit (callPackages ./hooks { })
+      inherit (pkgs.callPackages ./hooks { })
         beamCopySourceHook
         beamModuleInstallHook
         mixBuildDirHook
@@ -104,5 +93,5 @@ let
     // lib.optionalAttrs config.allowAliases {
       webdriver = throw "'beamPackages.webdriver' has been removed."; # added 2026-07-29
     };
-in
-makeExtensible packages
+
+}

--- a/pkgs/development/beam-modules/ex_doc/default.nix
+++ b/pkgs/development/beam-modules/ex_doc/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  elixir,
   fetchFromGitHub,
   fetchMixDeps,
   mixRelease,
@@ -27,7 +26,6 @@ mixRelease {
     pname
     version
     src
-    elixir
     ;
 
   escriptBinName = "ex_doc";
@@ -36,7 +34,7 @@ mixRelease {
 
   mixFodDeps = fetchMixDeps {
     pname = "mix-deps-${pname}";
-    inherit src version elixir;
+    inherit src version;
     hash = "sha256-FSLAQhFk7NCUXRMfNr6E9XvndrviapjcKZDisHbB87Y=";
   };
 

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -20,10 +20,11 @@
   debug ? false,
   meta ? { },
   patches ? [ ],
-  elixir ? inputs.elixir,
-  hex ? inputs.hex.override { inherit elixir; },
   ...
 }@attrs:
+
+assert lib.assertMsg (!(attrs ? elixir || attrs ? hex))
+  "fetchMixDeps no longer takes `elixir` or `hex`. Build with the package set that has the versions you need, e.g. `beam27Packages.fetchMixDeps`, or derive one with `beamPackages.overrideScope (final: prev: { elixir = prev.elixir_1_18; })`.";
 
 let
   hash_ =

--- a/pkgs/development/beam-modules/livebook/default.nix
+++ b/pkgs/development/beam-modules/livebook/default.nix
@@ -17,8 +17,6 @@ beamPackages.mixRelease rec {
   pname = "livebook";
   version = "0.19.9";
 
-  inherit (beamPackages) elixir;
-
   buildInputs = [ beamPackages.erlang ];
 
   nativeBuildInputs = [

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -68,10 +68,6 @@ lib.extendMkDerivation {
       # This is how Mix finds dependencies.
       mixNixDeps ? { },
 
-      elixir ? inputs.elixir,
-      erlang ? inputs.erlang,
-      hex ? inputs.hex.override { inherit elixir; },
-
       # Remove releases/COOKIE
       #
       # People have different views on the nature of cookies. Some believe that they are
@@ -95,6 +91,8 @@ lib.extendMkDerivation {
 
       ...
     }@attrs:
+    assert lib.assertMsg (!(attrs ? elixir || attrs ? erlang || attrs ? hex))
+      "mixRelease no longer takes `elixir`, `erlang` or `hex`. Build with the package set that has the versions you need, e.g. `beam27Packages.mixRelease`, or derive one with `beamPackages.overrideScope (final: prev: { elixir = prev.elixir_1_18; })`.";
     assert mixNixDeps != { } -> mixFodDeps == null;
     assert stripDebug -> !enableDebugInfo;
     assert escriptBinName != null -> mixReleaseName == "";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4320,9 +4320,10 @@ with pkgs;
 
   dhallPackages = recurseIntoAttrs (callPackage ./dhall-packages.nix { });
 
-  beam = callPackage ./beam-packages.nix { };
+  beam = callPackage ./beam-packages.nix { scopeName = "beam"; };
   beam_minimal = callPackage ./beam-packages.nix {
     beam = beam_minimal;
+    scopeName = "beam_minimal";
     systemdSupport = false;
     wxSupport = false;
   };

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -8,6 +8,8 @@
   systemd,
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   __splicedPackages,
+  # Name of this set in `pkgs`, needed to splice the package sets it builds.
+  scopeName,
 }:
 
 let
@@ -21,6 +23,17 @@ let
         versionArgs: import ../development/interpreters/erlang/generic-builder.nix (versionArgs // args);
     in
     pkgs.callPackage (import drv genericBuilder) { };
+
+  packagesFor =
+    name: erlang:
+    callPackage ../development/beam-modules {
+      inherit erlang;
+      splicePath = [
+        scopeName
+        "packages"
+        name
+      ];
+    };
 in
 
 {
@@ -62,16 +75,13 @@ in
 
   };
 
-  # Helper function to generate package set with a specific Erlang version.
-  packagesWith = erlang: callPackage ../development/beam-modules { inherit erlang; };
-
   # Each field in this tuple represents all Beam packages in nixpkgs built with
   # appropriate Erlang/OTP version.
   packages = {
     erlang = self.packages.${self.latestVersion};
-    erlang_29 = self.packagesWith self.interpreters.erlang_29;
-    erlang_28 = self.packagesWith self.interpreters.erlang_28;
-    erlang_27 = self.packagesWith self.interpreters.erlang_27;
+    erlang_29 = packagesFor "erlang_29" self.interpreters.erlang_29;
+    erlang_28 = packagesFor "erlang_28" self.interpreters.erlang_28;
+    erlang_27 = packagesFor "erlang_27" self.interpreters.erlang_27;
   }
   // lib.optionalAttrs config.allowAliases {
     erlang_26 = throw "'erlang_26' has been removed, as it is EOL"; # added 2026-04-01
@@ -82,4 +92,6 @@ in
 
   elixir_1_16 = throw "'elixir_1_16' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
   elixir_1_15 = throw "'elixir_1_15' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
+
+  packagesWith = throw "'beam.packagesWith' has been removed, as such sets cannot be cross compiled. Use an OTP specific set, e.g. 'beam27Packages', and 'overrideScope' to change any of its members."; # added 2026-08-18
 }


### PR DESCRIPTION
Converts to a spliced package set. I don't accept this (external consumer) breaking change lightly, but when digging in to finally enabling proper cross compilation I realized it was the best path.

All local consumers have been updated, and a few rebuilds necessary.

Assisted-by: Claude Code (Claude Opus 5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
