### PR TITLE
nixos/vlc: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -62,6 +62,8 @@
 
 - [Freescout](https://freescout.net/), a free, open source Helpdesk and shared mailbox. Available as [services.freescout](#opt-services.freescout.enable).
 
+- [VLC media player](https://www.videolan.org/), a free and open source cross-platform multimedia player. Available as programs.vlc.
+
 - [Lix TOML remote builders](https://docs.lix.systems/manual/lix/stable/advanced-topics/distributed-builds.html#using-a-toml-configuration), remote builder configuration using lix's TOML format. Available as [lix.buildMachines](#opt-lix.buildMachines). Note: incompatible with `nix.buildMachines`.
 
 - [Forgejo Runner](https://forgejo.org/docs/latest/admin/actions/), a daemon for Forgejo Actions. Available as [services.forgejo-runner](#opt-services.forgejo-runner.instances).

--- a/nixos/modules/programs/vlc.nix
+++ b/nixos/modules/programs/vlc.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.vlc;
+in
+{
+  options = {
+    programs.vlc = {
+      enable = lib.mkEnableOption "VideoLAN's VLC media player";
+      package = lib.mkPackageOption pkgs "vlc" { };
+
+      chromecast.openFirewall = lib.mkEnableOption "" // {
+        description = ''
+          Open the default port (8010) in the firewall for Chromecast to work.
+
+          Make sure to use the {package}`vlc` package with
+          `chromecastSupport = true`, which is the default.
+        '';
+      };
+
+      plugins = lib.mkOption {
+        default = [ ];
+        # TODO: List 2 plugins in the example once there are enough in nixpkgs
+        example = lib.literalExpression "[ pkgs.vlc-bittorrent ]";
+        type = with lib.types; listOf package;
+        description = ''
+          List of VLC plugins to use.
+        '';
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = (
+      [
+        cfg.package
+      ]
+      ++ cfg.plugins
+    );
+
+    environment.variables = lib.mkIf (cfg.plugins != [ ]) {
+      # VLC_PLUGIN_PATH expects a single folder containing the user-supplied
+      # plugins, not a list of directories separated by a color (:). So we
+      # symlink the plugins together.
+      VLC_PLUGIN_PATH = pkgs.symlinkJoin {
+        name = "custom-vlc-plugins";
+        paths = cfg.plugins;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.chromecast.openFirewall [
+      8010
+    ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ kintrix ];
+}


### PR DESCRIPTION
The following two things required extra config when installing VLC:

- allowing Chromecast (by opening a firewall port)
- adding plugins to VLC

This module is aimed at remedying it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
