### PR TITLE
gitpulsar: init at 1.3.1

### DIFF
--- a/pkgs/by-name/gi/gitpulsar/package.nix
+++ b/pkgs/by-name/gi/gitpulsar/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  pkg-config,
+  wrapGAppsHook4,
+  gtk4,
+  libadwaita,
+  glib,
+  cairo,
+  pango,
+  git,
+  openssl,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gitpulsar";
+  version = "1.3.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "ilshat-apps";
+    repo = "gitpulsar";
+    tag = "v${version}";
+    hash = "sha256-TjfCZ7u8OgPJcgwoizfEcojYD1RJXyLejHVvlkTHseE=";
+  };
+
+  cargoHash = "sha256-/+Ol4dsTEBgAUmGyE0rmkI56zjL6giSwoZ1VWFnDKrM=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    glib
+    cairo
+    pango
+    openssl
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    install -Dm644 data/io.gitlab.ilshat_apps.gitpulsar.desktop $out/share/applications/io.gitlab.ilshat_apps.gitpulsar.desktop
+    install -Dm644 data/io.gitlab.ilshat_apps.gitpulsar.metainfo.xml $out/share/metainfo/io.gitlab.ilshat_apps.gitpulsar.metainfo.xml
+    install -Dm644 data/icons/hicolor/scalable/apps/io.gitlab.ilshat_apps.gitpulsar.svg $out/share/icons/hicolor/scalable/apps/io.gitlab.ilshat_apps.gitpulsar.svg
+
+    for icon in data/icons/hicolor/scalable/actions/*.svg; do
+      install -Dm644 "$icon" "$out/share/icons/hicolor/scalable/actions/$(basename "$icon")"
+    done
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ git ]}"
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast, native Git client for GNOME";
+    homepage = "https://gitlab.com/ilshat-apps/gitpulsar";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "gitpulsar-gtk";
+  };
+}


### PR DESCRIPTION
[Gitpulsar](https://gitlab.com/ilshat-apps/gitpulsar) 

A lightweight, GNOME-native Git GUI built with Rust, GTK4, and libadwaita

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
