### PR TITLE
immich: use append-only reporter for pnpm output

### DIFF
--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -176,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     # If exiftool-vendored.pl isn't found, exiftool is searched for on the PATH
     rm node_modules/.pnpm/node_modules/exiftool-vendored.pl
 
-    pnpm --filter immich... --filter immich-web... --filter @immich/plugin-core... build
+    pnpm --reporter=append-only --filter immich... --filter immich-web... --filter @immich/plugin-core... build
 
     runHook postBuild
   '';
@@ -188,7 +188,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # install node_modules and built files in $out
     # upstream uses pnpm deploy to build their docker images
-    pnpm --filter immich deploy --prod --no-optional "$packageOut"
+    pnpm --reporter=append-only --filter immich deploy --prod --no-optional "$packageOut"
 
     # remove build artifacts that bloat the closure
     find "$packageOut/node_modules" \( \


### PR DESCRIPTION
Changes the pnpm build and deploy commands to use the append-only reporter. Without this the log is not captured properly and it is more difficult to debug.

Before, the output for the buildPhase looked like this:

```
immich> Running phase: buildPhase
immich> Scope: 5 of 12 workspace projects
immich> packages/sdk build$
immich> └─ Running...
immich> └─ Done in 170ms
immich> packages/plugin-sdk build$
immich> └─ Running...
immich> web build$
immich> └─ Running...
immich> └─ Done in 283ms
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> [1 lines collapsed]
immich> │
immich> └─ Running...
immich> [10 lines collapsed]
immich> [100 lines collapsed]
immich> └─ Done in 28.2s
immich> server build$
immich> └─ Running...
immich> packages/plugin-core build$
immich> └─ Running...
immich> │
immich> └─ Running...
immich> │
immich> └─ Running...
immich> └─ Done in 3.1s
immich> └─ Done in 22.3s
immich> buildPhase completed in 51 seconds
```

Now it prints the proper log:

```
immich> Running phase: buildPhase
immich> Scope: 5 of 12 workspace projects
immich> packages/sdk build$ tsc
immich> packages/sdk build: Done
immich> packages/plugin-sdk build$ node esbuild.js && tsc --emitDeclarationOnly && tsc-alias
immich> web build$ vite build
immich> packages/plugin-sdk build: Done
immich> web build: vite v8.1.5 building ssr environment for production...
immich> web build:
immich> web build: transforming...✓ 2729 modules transformed.
immich> web build: rendering chunks...
immich> web build: vite v8.1.5 building client environment for production...
immich> web build:
immich> web build: new URL('justified-layout-wasm_bg.wasm', import.meta.url) doesn't exist at build time, it will remain unchanged to be resolved at runtime. If this is intended, you can use the /* @vite-ignore */ comment to suppress this warning.
immich> web build: [PLUGIN_TIMINGS] Your build spent significant time in plugin `vite:asset`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.
immich> web build: transforming...✓ 3645 modules transformed.
immich> web build: rendering chunks...
immich> web build: computing gzip size...
immich> web build: .svelte-kit/output/client/_app/version.json                                                 0.01 kB │ gzip:   0.03 kB
...
```

Similar for the installPhase.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
