### PR TITLE
haskellPackages.nixfmt: drop

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -720,8 +720,12 @@ with haskellLib;
   }) super.shell-conduit;
 
   # No maintenance planned until eventual removal
+  # Throw added 2026-08-19
   # https://github.com/NixOS/nixfmt/issues/340#issuecomment-3315920564
-  nixfmt = doJailbreak super.nixfmt;
+  nixfmt =
+    lib.throwIf pkgs.config.allowAliases
+      "haskell.packages.*.nixfmt has been removed as it is deprecated and unmaintained. Consider using top-level nixfmt instead."
+      (doJailbreak super.nixfmt);
 
   # Too strict upper bounds on turtle and text
   # https://github.com/awakesecurity/nix-deploy/issues/35

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -856,6 +856,12 @@ dont-distribute-packages:
   # Depends on shine, which is a ghcjs project.
   - shine-varying
 
+  # these packages are deprecated or unmaintained upstream
+  # TODO: fully exclude. See:
+  # - https://github.com/NixOS/cabal2nix/pull/667
+  # - https://github.com/NixOS/nixpkgs/pull/441204
+  - nixfmt # 2026-08-18 maintained versions are not released on hackage
+
   # these packages depend on software with an unfree license
   - accelerate-bignum
   - accelerate-blas

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -496548,6 +496548,7 @@ self: {
       ];
       description = "An opinionated formatter for Nix";
       license = lib.licenses.mpl20;
+      hydraPlatforms = lib.platforms.none;
       mainProgram = "nixfmt";
     }
   ) { };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1784,7 +1784,7 @@ mapAliases {
   nix-plugin-pijul = throw "nix-plugin-pijul has been removed due to being discontinued"; # Added 2025-05-18
   nix_2_3 = throw "'nix_2_3' has been removed, because it was unmaintained and insecure."; # Converted to throw 2025-07-24
   nixbang = throw "'nixbang' has been removed because it was unmaintained upstream. Use nix-shell shebang instead'"; # Added 2026-07-02
-  nixfmt-classic = throw "nixfmt-classic has been removed as it is deprecated and unmaintained." haskellPackages.nixfmt.bin; # Converted to throw 2026-07-01
+  nixfmt-classic = throw "nixfmt-classic has been removed as it is deprecated and unmaintained."; # Converted to throw 2026-07-01
   nixfmt-rfc-style = warnAlias "nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead." nixfmt; # Added 2025-07-14
   nixForLinking = throw "nixForLinking has been removed, use `nixVersions.nixComponents_<version>` instead"; # Added 2025-08-14
   nixnote2 = throw "'nixnote2' has been removed as upstream has been unmaintained since 2017"; # Added 2026-04-26


### PR DESCRIPTION
We've already dropped its top-level alias `nixfmt-classic`, however the underlying `haskellPackages` package is harder to drop because it is generated from hackage. See tracking issue: https://github.com/NixOS/nixfmt/issues/340

In this PR I've added a `throw` when `config.allowAliases` is true, and I've _attempted_ to drop the generated package. So far, I've only been able to get `regenerate-hackage-packages.sh` to set `hydraPlatforms = lib.platforms.none`, I've not been able to convince it to fully drop the package.

It'd be great if any haskell core maintainers could steer me in the right direction for how they want a generated-from-hackage package to be dropped. /cc @sternenseemann

~~I also fixed an issue with `regenerate-hackage-packages.sh` running `nixfmt` from PATH, instead of `treefmt` from the Nixpkgs shell. Otherwise, I was unable to run `regenerate-hackage-packages.sh`.~~ _EDIT: dropped for now; proved too controversial for this PR._

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
