### PR TITLE
psitop, pkgtop: add ravi-arnan as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23893,6 +23893,11 @@
     githubId = 86608952;
     name = "RAVENz46";
   };
+  ravi-arnan = {
+    github = "ravi-arnan";
+    githubId = 74779667;
+    name = "Ravi Arnan Irianto";
+  };
   rawkode = {
     email = "david.andrew.mckay@gmail.com";
     github = "rawkode";

--- a/pkgs/by-name/pk/pkgtop/package.nix
+++ b/pkgs/by-name/pk/pkgtop/package.nix
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/orhun/pkgtop";
     changelog = "https://github.com/orhun/pkgtop/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ravi-arnan ];
     mainProgram = "pkgtop";
   };
 })

--- a/pkgs/by-name/ps/psitop/package.nix
+++ b/pkgs/by-name/ps/psitop/package.nix
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     description = "Top for /proc/pressure";
     homepage = "https://github.com/jamespwilliams/psitop";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ravi-arnan ];
     mainProgram = "psitop";
   };
 })


### PR DESCRIPTION
Adopting two unmaintained Go TUI monitors listed in the tracking issue #458096, both of which
currently have `maintainers = [ ]` after #455942: `psitop` and `pkgtop`.

I contribute to htop upstream, mostly around its Linux meters, which is the same `/proc/pressure`
and per-process accounting surface `psitop` presents, so these two sit squarely in an area I already
follow.

Metadata only, so there is no rebuild.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Details on the boxes above:

- `nix-build lib/tests/maintainers.nix` passes. I also checked it actually validates the new entry
  by temporarily setting `githubId` to a string, which fails with
  `A definition for option 'lib.maintainers.ravi-arnan.githubId' is not of type 'unsigned integer'`.
- No rebuild, checked rather than assumed: `nix-instantiate -A psitop` and `-A pkgtop` produce the
  same derivation paths at the base commit and at the tip of this branch
  (`dpa68qn1phqhhsnf52rpva895x570csw-psitop-1.1.3.drv`,
  `i0z44p01hwdak1yj8vy6296vwbrz5abl-pkgtop-2.5.1.drv`). I did not run `nixpkgs-review` itself, since
  the derivation comparison answers the same question for a metadata-only change.
- Both binaries run on x86_64-linux, not just build: `psitop` renders live CPU, memory and IO
  panels whose avg10/avg60/avg300 values match `/proc/pressure/*` on the same machine, and
  `pkgtop` starts and prints its full flag set.

**Automation disclosure**, separate from the commit trailers, as the policy requires: this pull
request's changes and this summary were prepared with Claude Code (claude-opus-5). I reviewed the
diff and reproduced the verification above myself before submitting, and I am the person
accountable for it.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
