### PR TITLE
lnd: 0.21.1-beta -> 0.21.2-beta

### DIFF
--- a/pkgs/by-name/ln/lnd/package.nix
+++ b/pkgs/by-name/ln/lnd/package.nix
@@ -23,16 +23,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "lnd";
-  version = "0.21.1-beta";
+  version = "0.21.2-beta";
 
   src = fetchFromGitHub {
     owner = "lightningnetwork";
     repo = "lnd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LOP5vyffwxzXRI16Jgfjb+JykHcNWrGApM27frYUoPw=";
+    hash = "sha256-8HSKntW0cLkJi4You8gJgXaUoQoevl2zY+mji3fprJI=";
   };
 
-  vendorHash = "sha256-7fssqutcagEv6JKxwaAp9g3TtxHnQ34Kyln4DIhxjSQ=";
+  vendorHash = "sha256-YdrgmzTbxrsW/smmxFBiHQ1jB+cxNgNxPAsrPPS61AU=";
 
   subPackages = [
     "cmd/lncli"


### PR DESCRIPTION
Updates LND to the latest stable release.

Release notes: https://github.com/lightningnetwork/lnd/releases/tag/v0.21.2-beta

The release contains no new database migrations and fixes two existing
migration paths, along with channel graph memory bounds and other bug fixes.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Built `lnd` and `lncli`
- [x] Ran the package check phase
- [x] Verified both binaries report `0.21.2-beta`
