### PR TITLE
lightning-pool: 0.6.4-beta -> 0.7.0-beta

### DIFF
--- a/pkgs/by-name/li/lightning-pool/package.nix
+++ b/pkgs/by-name/li/lightning-pool/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "lightning-pool";
-  version = "0.6.4-beta";
+  version = "0.7.0-beta";
 
   src = fetchFromGitHub {
     owner = "lightninglabs";
     repo = "pool";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lSc/zOZ5VpmaZ7jrlGvSaczrgOtAMS9tDUxcMoFdBmQ=";
+    hash = "sha256-jhHshr8THkact/xTVPoD5GyDxj+Cot7fFU8riPMSsYg=";
   };
 
-  vendorHash = "sha256-DD27zUW524qe9yLaVPEzw/c4sSzlH89HMw0PdtNYEhg=";
+  vendorHash = "sha256-zl6KwVWwk6uFPqMEd7e0pw3TbtP8IEwTaVJZd59dHTA=";
 
   subPackages = [
     "cmd/pool"


### PR DESCRIPTION
Updates Lightning Pool to the latest stable release.

Release notes: https://github.com/lightninglabs/pool/releases/tag/v0.7.0-beta

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Built `pool` and `poold`
- [x] Ran the package check phase
- [x] Verified both binaries report `0.7.0-beta`
