### PR TITLE
undocker: fix upstream URL

### DIFF
--- a/pkgs/by-name/un/undocker/package.nix
+++ b/pkgs/by-name/un/undocker/package.nix
@@ -7,7 +7,7 @@
 let
   version = "1.2.3";
   src = fetchgit {
-    url = "https://git.jakstys.lt/motiejus/undocker.git";
+    url = "https://git.jakstys.lt/undocker.git";
     rev = "v${version}";
     hash = "sha256-hyP85pYtXxucAliilUt9Y2qnrfPeSjeGsYEFJndJWyA=";
   };
@@ -25,7 +25,7 @@ buildGoModule {
   vendorHash = null;
 
   meta = {
-    homepage = "https://git.jakstys.lt/motiejus/undocker";
+    homepage = "https://git.jakstys.lt/undocker";
     description = "CLI tool to convert a Docker image to a flattened rootfs tarball";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
I recently removed the "org" prefix from my git hosting suite and maintain an override.

Let's switch to the correct url.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
