### PR TITLE
lndinit: 0.1.22-beta -> 0.1.36-beta

### DIFF
--- a/pkgs/by-name/ln/lndinit/package.nix
+++ b/pkgs/by-name/ln/lndinit/package.nix
@@ -5,16 +5,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "lndinit";
-  version = "0.1.22-beta";
+  version = "0.1.36-beta";
 
   src = fetchFromGitHub {
     owner = "lightninglabs";
     repo = "lndinit";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-KXCObRUhXTEeb48hnQYrnb55g+nJomr52IIVpFDn+nY=";
+    hash = "sha256-2rFiDy1yVXqI0ag8fsifx9sCCu0BbwSj9U7bzU352dc=";
   };
 
-  vendorHash = "sha256-peyLhDEH9DKHAQfxVCvv92DErHjidA3DSjpN357Px6M=";
+  vendorHash = "sha256-vLatsVG4VUtSAJtOiZgy4zWdh9Qs4cwkz0CaUTRZ3oE=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
Updates lndinit to 0.1.36-beta.

Release notes: https://github.com/lightninglabs/lndinit/releases/tag/v0.1.36-beta

Verification on x86_64-linux:
- `nix-build -A lndinit --no-out-link`
- Go package checks passed
- startup banner reports version 0.1.36-beta