### PR TITLE
liborigin: init at 3.0.4

### DIFF
--- a/pkgs/by-name/li/liborigin/001-fix-pkg-config-file.patch
+++ b/pkgs/by-name/li/liborigin/001-fix-pkg-config-file.patch
@@ -1,0 +1,14 @@
+diff --git a/liborigin.pc.in b/liborigin.pc.in
+index 80cd898..69d6b8f 100644
+--- a/liborigin.pc.in
++++ b/liborigin.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: liborigin
+ Description: Library for reading OriginLab files

--- a/pkgs/by-name/li/liborigin/package.nix
+++ b/pkgs/by-name/li/liborigin/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  fetchurl,
+  cmake,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "liborigin";
+  version = "3.0.4";
+
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/liborigin/files/liborigin/3.0/liborigin-${finalAttrs.version}.tar.gz";
+    hash = "sha256-sb819y45iSrTUb7Uo+ckrubPpnMoHeoseMzrkEKnTlc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  patches = [
+    ./001-fix-pkg-config-file.patch
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Library for reading OriginLab OPJ project files";
+    homepage = "https://sourceforge.net/projects/liborigin";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      AhmedAmr
+    ];
+    teams = with lib.teams; [ ngi ];
+    platforms = lib.platforms.all;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the `laborigin` library (Library for reading OriginLab project files).

This package is a dependency of KDE Labplot and is being packaged as part of the work to bring Labplot into nixpkgs / NGI Forge.

Homepage: https://sourceforge.net/projects/liborigin

This work is done as part of Summer of Nix 2026.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
