### PR TITLE
nixos/adguardhome: preserve HTTP settings

### DIFF
--- a/nixos/modules/services/networking/adguardhome.nix
+++ b/nixos/modules/services/networking/adguardhome.nix
@@ -29,7 +29,9 @@ let
           }
         else
           {
-            http.address = "${cfg.host}:${toString cfg.port}";
+            http = (cfg.settings.http or { }) // {
+              address = "${cfg.host}:${toString cfg.port}";
+            };
           }
       )
     else

--- a/nixos/tests/adguardhome.nix
+++ b/nixos/tests/adguardhome.nix
@@ -26,8 +26,13 @@
       services.adguardhome = {
         enable = true;
 
+        host = "127.0.0.1";
         mutableSettings = false;
-        settings.dns.bootstrap_dns = [ "127.0.0.1" ];
+        port = 43074;
+        settings = {
+          dns.bootstrap_dns = [ "127.0.0.1" ];
+          http.doh.insecure_enabled = true;
+        };
       };
     };
 
@@ -125,7 +130,13 @@
     with subtest("Declarative config test, DNS will be reachable"):
       declarativeConf.wait_for_unit("adguardhome.service")
       declarativeConf.wait_for_open_port(53)
-      declarativeConf.wait_for_open_port(3000)
+      declarativeConf.wait_for_open_port(43074)
+      declarativeConf.succeed(
+          "grep -qFx '  address: 127.0.0.1:43074' /var/lib/AdGuardHome/AdGuardHome.yaml"
+      )
+      declarativeConf.succeed(
+          "grep -qFx '    insecure_enabled: true' /var/lib/AdGuardHome/AdGuardHome.yaml"
+      )
 
     with subtest("Mixed config test, check whether merging works"):
       mixedConf.wait_for_unit("adguardhome.service")


### PR DESCRIPTION
## Description

`services.adguardhome` injects `http.address` into the generated
configuration using a shallow attribute-set merge.

This replaces the entire user-provided `settings.http` attribute set,
causing nested settings such as `http.doh.insecure_enabled` to be lost.

This change preserves the existing `http` attribute set while overriding
only `http.address`.

A regression test was added to verify that both `http.address` and
`http.doh.insecure_enabled` are present in the generated configuration.

## Testing

- `nix build .#nixosTests.adguardhome`
- Verified that the regression test fails without the fix and passes with it.

AI assistance: Codex (GPT-5) was used to help prepare the implementation and test. I reviewed and tested the changes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
