### PR TITLE
bootcheck: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21000,6 +21000,11 @@
     githubId = 2946283;
     name = "Brian Cohen";
   };
+  notzorua = {
+    github = "notzorua";
+    githubId = 248946345;
+    name = "rem";
+  };
   nouritsu = {
     name = "Aneesh Bhave";
     email = "aneesh1701@gmail.com";

--- a/pkgs/by-name/bo/bootcheck/package.nix
+++ b/pkgs/by-name/bo/bootcheck/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "bootcheck";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "notzorua";
+    repo = "bootcheck";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-avBjw3qGdiD9lVFXp2sJayHTplDtLDdalmsHqSC6d0E=";
+  };
+
+  vendorHash = null;
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Check whether a NixOS machine will boot before rebooting it";
+    longDescription = ''
+      Verifies that the kernels referenced by the GRUB menu exist on the EFI
+      system partition, that the bootloader entry is still present and first in
+      the UEFI boot order, that the menu boots the system that was actually
+      built, that the partition has room left, and that no files are left behind
+      by bootloaders no longer in use.
+    '';
+    homepage = "https://github.com/notzorua/bootcheck";
+    changelog = "https://github.com/notzorua/bootcheck/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ notzorua ];
+    mainProgram = "bootcheck";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds bootcheck, a tool that verifies a NixOS machine will boot before you reboot it.

It checks that kernels referenced by the GRUB menu exist on the ESP, that the UEFI boot entry is present and first in BootOrder, that the menu boots the system that was actually built, that there is free space left, and that no files remain from bootloaders no longer in use.

The generations check catches a failure mode that is otherwise invisible: a rebuild succeeds while installing the bootloader quietly does not, leaving a machine that looks healthy and boots into the previous system.

Upstream: https://github.com/notzorua/bootcheck

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test