### PR TITLE
[26.05] mago: 1.29.0 -> 1.46.0

### DIFF
--- a/pkgs/by-name/ma/mago/package.nix
+++ b/pkgs/by-name/ma/mago/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  rustPlatform,
+  rustPackages_1_97,
   fetchFromGitHub,
   installShellFiles,
   pkg-config,
@@ -9,19 +9,19 @@
   versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+rustPackages_1_97.rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mago";
-  version = "1.29.0";
+  version = "1.43.0";
 
   src = fetchFromGitHub {
     owner = "carthage-software";
     repo = "mago";
     tag = finalAttrs.version;
-    hash = "sha256-e/LKOQ+GAtdDye/poJdbX/98gDWle3NWIZ2zHwkGkcQ=";
+    hash = "sha256-AWnPhylz41E6d1M7PxVpH4EbyYeO9T6jlWVlzBqiOhQ=";
     forceFetchGit = true; # Does not download all files otherwise
   };
 
-  cargoHash = "sha256-stjjP8VRHy5k9zMXWGikVNExXRFte0gVBEsbKmPY6U4=";
+  cargoHash = "sha256-f7HZTJ0ESx7QTKgBqd2FOH1nCeIzgODMM9Sb0tQpfdE=";
 
   env = {
     # Get openssl-sys to use pkg-config

--- a/pkgs/by-name/ma/mago/package.nix
+++ b/pkgs/by-name/ma/mago/package.nix
@@ -11,17 +11,17 @@
 
 rustPackages_1_97.rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mago";
-  version = "1.45.0";
+  version = "1.46.0";
 
   src = fetchFromGitHub {
     owner = "carthage-software";
     repo = "mago";
     tag = finalAttrs.version;
-    hash = "sha256-ue1jf2fdus6a6XHhNBL21cIaHtX46av2AQUBcRs0W44=";
+    hash = "sha256-yFmTUsTiNLmgZRbASWp0fm3pjmJgfx82YPGmzx6JcZY=";
     forceFetchGit = true; # Does not download all files otherwise
   };
 
-  cargoHash = "sha256-fViy3y1ipphSwh9NsFVR8hEUya/juQ1WCvqrzZpwsRU=";
+  cargoHash = "sha256-91tt31lKeeH0+PrsVTMSP+jKjt/1XFNJStqVtt0q8n0=";
 
   env = {
     # Get openssl-sys to use pkg-config

--- a/pkgs/by-name/ma/mago/package.nix
+++ b/pkgs/by-name/ma/mago/package.nix
@@ -11,17 +11,17 @@
 
 rustPackages_1_97.rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mago";
-  version = "1.43.0";
+  version = "1.45.0";
 
   src = fetchFromGitHub {
     owner = "carthage-software";
     repo = "mago";
     tag = finalAttrs.version;
-    hash = "sha256-AWnPhylz41E6d1M7PxVpH4EbyYeO9T6jlWVlzBqiOhQ=";
+    hash = "sha256-ue1jf2fdus6a6XHhNBL21cIaHtX46av2AQUBcRs0W44=";
     forceFetchGit = true; # Does not download all files otherwise
   };
 
-  cargoHash = "sha256-f7HZTJ0ESx7QTKgBqd2FOH1nCeIzgODMM9Sb0tQpfdE=";
+  cargoHash = "sha256-fViy3y1ipphSwh9NsFVR8hEUya/juQ1WCvqrzZpwsRU=";
 
   env = {
     # Get openssl-sys to use pkg-config
@@ -51,6 +51,7 @@ rustPackages_1_97.rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/carthage-software/mago";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      atomicptr
       hythera
       patka
     ];

--- a/pkgs/development/compilers/rust/1_97.nix
+++ b/pkgs/development/compilers/rust/1_97.nix
@@ -1,0 +1,104 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+
+# Note: The way this is structured is:
+# 1. Import default.nix, and apply arguments as needed for the file-defined function
+# 2. Implicitly, all arguments to this file are applied to the function that is imported.
+#    if you want to add an argument to default.nix's top-level function, but not the function
+#    it instantiates, add it to the `removeAttrs` call below.
+{
+  stdenv,
+  lib,
+  newScope,
+  callPackage,
+  pkgsBuildTarget,
+  pkgsBuildBuild,
+  pkgsBuildHost,
+  pkgsHostTarget,
+  pkgsTargetTarget,
+  makeRustPlatform,
+  wrapRustcWith,
+  llvmPackages,
+  llvm,
+  cargo-auditable,
+  wrapCCWith,
+  overrideCC,
+  fetchpatch,
+}@args:
+let
+  llvmSharedFor =
+    pkgSet:
+    pkgSet.llvmPackages.libllvm.override (
+      {
+        enableSharedLibraries = true;
+      }
+      // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
+        # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
+        stdenv = pkgSet.stdenv.override {
+          allowedRequisites = null;
+          cc = pkgSet.pkgsBuildHost.llvmPackages.clangUseLLVM;
+        };
+      }
+    );
+in
+import ./default.nix
+  {
+    rustcVersion = "1.97.1";
+    rustcSha256 = "sha256-YiwrQpxTy/3A3TpR0DVU6RzWPr7BkSwfVwlkDN/vGp0=";
+
+    llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
+    llvmSharedForHost = llvmSharedFor pkgsBuildHost;
+    llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
+
+    inherit llvmPackages cargo-auditable;
+
+    # For use at runtime
+    llvmShared = llvmSharedFor pkgsHostTarget;
+
+    # Note: the version MUST be the same version that we are building. Upstream
+    # ensures that each released compiler can compile itself:
+    # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
+    bootstrapVersion = "1.97.1";
+
+    # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+    bootstrapHashes = {
+      i686-unknown-linux-gnu = "914c2702deada0b9cf1d64bb3495d76e55cb3eba07d508472dde8b55a93e3759";
+      x86_64-unknown-linux-gnu = "b4cdbc7cc6b0ee0a2666b1872769fdb2ad8393b28b63952f6493b4b400e4832b";
+      x86_64-unknown-linux-musl = "40dbea28193cf2b488cf3e4a89274ccfb60efa50883f19917a382f84fd05bdc4";
+      arm-unknown-linux-gnueabihf = "ba62fe07ad85b507907705a14adc1e8bc258de5f6177ba41d77bbff9f469a4ce";
+      armv7-unknown-linux-gnueabihf = "e89c5e33aaddc6ef56857000c9117875c2997e9a1a500bd7b16277c9874b002f";
+      aarch64-unknown-linux-gnu = "2f2496c70bd336a66a4c8baf2d303ba161f3552f192444c3639ba903c7c1e2c5";
+      aarch64-unknown-linux-musl = "c5f45b5c6eb7f8fdb277c54c08402b7c931516740fbd4eccc26ba148f7cd5d57";
+      x86_64-apple-darwin = "5f4c84d2bcce7983468642855a45fc4978fba1324cfdd1ea0b182face3ab4ffa";
+      aarch64-apple-darwin = "cbd14c36f039f6f11f38148a6295d8234d18ddf20bea53031c86f119423a8b26";
+      powerpc64-unknown-linux-gnu = "2b507d5eb9b5c4c041b50e93e069db56d094f02e6df103dc74c016155141bfae";
+      powerpc64le-unknown-linux-gnu = "ff524eef5a59d801df09ccad5cdaf9ea1f0a07d75cbed2a7e9f013a9eb76a3c1";
+      powerpc64le-unknown-linux-musl = "15630f33fbea2dd9661f8482b6c612da271549aba40401444aaa53650e646b9b";
+      riscv64gc-unknown-linux-gnu = "59bec35d8febb2ab918fa41cffbaa5b07146a63bdc33f029ff756d70a3151ece";
+      s390x-unknown-linux-gnu = "808268af9e880d41b8cb32b242e38c9bd3ea7aba6409b02fbffa0fbc5370c538";
+      loongarch64-unknown-linux-gnu = "d5a925962854730ae7641420d8337af93988ea4ff47b503a856ec53776c87841";
+      loongarch64-unknown-linux-musl = "3fb653299d228e3e0726afb179b07dd10a51a2ecc3cdfcd740011b1d8420ca97";
+      x86_64-unknown-freebsd = "77866a4c449bcccb40e9d6712bf3eb899d29018ed8e841fd9d8d59370751f152";
+    };
+
+    selectRustPackage = pkgs: pkgs.rust_1_97;
+  }
+
+  (
+    removeAttrs args [
+      "llvmPackages"
+      "llvm"
+      "wrapCCWith"
+      "overrideCC"
+      "pkgsHostTarget"
+      "fetchpatch"
+      "cargo-auditable"
+    ]
+  )

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage.override
     pname = "cargo";
     inherit (rustc.unwrapped) version src;
 
-    patches = [
+    patches = lib.optionals (lib.versionOlder rustc.unwrapped.version "1.97.0") [
       (fetchpatch {
         name = "CVE-2026-5222.patch";
         url = "https://github.com/rust-lang/cargo/commit/c4d63a44234de22dc745231c416b80ed848d997f.patch";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4326,6 +4326,7 @@ with pkgs;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
   rust_1_95 = callPackage ../development/compilers/rust/1_95.nix { };
+  rust_1_97 = callPackage ../development/compilers/rust/1_97.nix { };
   rust = rust_1_95;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -4333,6 +4334,7 @@ with pkgs;
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
   rustPackages_1_95 = rust_1_95.packages.stable;
+  rustPackages_1_97 = rust_1_97.packages.stable;
   rustPackages = rustPackages_1_95;
 
   inherit (rustPackages)


### PR DESCRIPTION
I don't think the security issue is too critical but it's still good to have. Version `1.44+` requires at least rust `1.97` so that needs to be backported too. 

Backports #540226 (modified)
Backports #546355
Backports #549801

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
