### PR TITLE
python3Packages.webexpythonsdk: add pyprojectVersionPatchHook

### DIFF
--- a/pkgs/development/python-modules/webexpythonsdk/default.nix
+++ b/pkgs/development/python-modules/webexpythonsdk/default.nix
@@ -7,6 +7,7 @@
   requests-toolbelt,
   poetry-core,
   poetry-dynamic-versioning,
+  pyprojectVersionPatchHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -25,6 +26,8 @@ buildPythonPackage (finalAttrs: {
     poetry-core
     poetry-dynamic-versioning
   ];
+
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
   dependencies = [
     pyjwt

--- a/pkgs/development/python-modules/webexpythonsdk/default.nix
+++ b/pkgs/development/python-modules/webexpythonsdk/default.nix
@@ -3,24 +3,21 @@
   buildPythonPackage,
   fetchFromGitHub,
   pyjwt,
-  pythonOlder,
   requests,
   requests-toolbelt,
   poetry-core,
   poetry-dynamic-versioning,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "webexpythonsdk";
   version = "2.0.6";
   pyproject = true;
 
-  disabled = pythonOlder "3.12";
-
   src = fetchFromGitHub {
     owner = "WebexCommunity";
     repo = "WebexPythonSDK";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2yyGR5gCJVRsEnoPAr8tkMeG19vTfATl/ybuMydnplU=";
   };
 
@@ -43,8 +40,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python module for Webex Teams APIs";
     homepage = "https://github.com/WebexCommunity/WebexPythonSDK";
-    changelog = "https://github.com/WebexCommunity/WebexPythonSDK/releases/tag/${src.tag}";
+    changelog = "https://github.com/WebexCommunity/WebexPythonSDK/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
