### PR TITLE
devolo-cockpit: init at 5.2.0.185

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -56,6 +56,8 @@
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
+- [devolo Cockpit](https://www.devolo.global/support/downloads/download/devolo-cockpit), a configuration utility and background network service daemon for devolo dLAN/Magic powerline devices. Available as [services.devolo-cockpit](#opt-services.devolo-cockpit.enable).
+
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).
 
 - [P2Pool](https://github.com/SChernykh/p2pool), a decentralized mining pool for Monero. Available as [services.p2pool](#opt-services.p2pool.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1203,6 +1203,7 @@
   ./services/networking/ddclient.nix
   ./services/networking/ddns-updater.nix
   ./services/networking/deconz.nix
+  ./services/networking/devolo-cockpit.nix
   ./services/networking/dhcpcd.nix
   ./services/networking/dnscache.nix
   ./services/networking/dnscrypt-proxy.nix

--- a/nixos/modules/services/networking/devolo-cockpit.nix
+++ b/nixos/modules/services/networking/devolo-cockpit.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.devolo-cockpit;
+in
+{
+  options.services.devolo-cockpit = {
+    enable = lib.mkEnableOption "devolo network service daemon for dLAN/Magic powerline adapters";
+
+    package = lib.mkPackageOption pkgs "devolo-cockpit" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.devolonetsvc = {
+      description = "devolo network service daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = lib.getExe' cfg.package "devolonetsvc";
+        Restart = "on-failure";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ malix ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -480,6 +480,7 @@ in
   dendrite = runTest ./matrix/dendrite.nix;
   dep-scan = runTest ./dep-scan.nix;
   dependency-track = runTest ./dependency-track.nix;
+  devolo-cockpit = runTest ./devolo-cockpit.nix;
   devpi-server = runTest ./devpi-server.nix;
   dex-oidc = runTest ./dex-oidc.nix;
   dictd = runTest ./dictd.nix;

--- a/nixos/tests/devolo-cockpit.nix
+++ b/nixos/tests/devolo-cockpit.nix
@@ -15,13 +15,12 @@
       services.xserver.enable = true;
       test-support.displayManager.auto.user = "alice";
 
-      environment.systemPackages = [
-        pkgs.devolo-cockpit
-      ];
+      services.devolo-cockpit.enable = true;
     };
 
   testScript = ''
     start_all()
+    machine.wait_for_unit("devolonetsvc.service")
     machine.wait_for_x()
 
     # Test that devolo-cockpit starts in the user desktop session

--- a/nixos/tests/devolo-cockpit.nix
+++ b/nixos/tests/devolo-cockpit.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+
+{
+  name = "devolo-cockpit";
+  meta.maintainers = with pkgs.lib.maintainers; [ malix ];
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [
+        ./common/user-account.nix
+        ./common/x11.nix
+      ];
+
+      services.xserver.enable = true;
+      test-support.displayManager.auto.user = "alice";
+
+      environment.systemPackages = [
+        pkgs.devolo-cockpit
+      ];
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_x()
+
+    # Test that devolo-cockpit starts in the user desktop session
+    machine.succeed("su - alice -c 'devolo-cockpit' >&2 &")
+    machine.wait_until_succeeds("pgrep dlancockpit")
+  '';
+}

--- a/pkgs/by-name/de/devolo-cockpit/package.nix
+++ b/pkgs/by-name/de/devolo-cockpit/package.nix
@@ -1,0 +1,155 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  buildFHSEnv,
+  appimageTools,
+  dpkg,
+  unzip,
+  undmg,
+  makeBinaryWrapper,
+  writeShellScript,
+  nixosTests,
+}:
+
+let
+  pname = "devolo-cockpit";
+  sources = import ./sources.nix;
+  inherit (sources) version;
+
+  src = fetchurl (if stdenvNoCC.hostPlatform.isDarwin then sources.darwin else sources.linux);
+
+  meta = {
+    description = "Display and configure settings of your devolo dLAN/Magic devices";
+    homepage = "https://www.devolo.global/support/downloads/download/devolo-cockpit";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ malix ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = pname;
+  };
+
+  passthru = {
+    updateScript = ./update.sh;
+    tests = lib.optionalAttrs stdenvNoCC.hostPlatform.isLinux {
+      nixos = nixosTests.devolo-cockpit;
+    };
+  };
+
+  darwin = stdenvNoCC.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      passthru
+      ;
+
+    nativeBuildInputs = [
+      undmg
+      makeBinaryWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/Applications $out/bin
+      tar -zxf "devolo Cockpit Installation.app/Contents/Resources/dlancockpit_osx.tgz" -C $out/
+      makeWrapper "$out/Applications/devolo/devolo Cockpit.app/Contents/MacOS/dLAN Cockpit" "$out/bin/devolo-cockpit"
+      runHook postInstall
+    '';
+  };
+
+  linux =
+    let
+      arch = if stdenvNoCC.hostPlatform.isx86_64 then "amd64" else "i386";
+
+      unwrapped = stdenvNoCC.mkDerivation {
+        pname = "${pname}-unwrapped";
+        inherit version src;
+
+        nativeBuildInputs = [
+          unzip
+          dpkg
+        ];
+
+        dontUnpack = true;
+
+        installPhase = ''
+          runHook preInstall
+          unzip $src
+          tail -n +$(( $(grep -a -m1 -n "HERE_BE_DRAG[O]NS" devolo-cockpit-v*.run | cut -d: -f1) + 1 )) devolo-cockpit-v*.run | tar -x
+          for deb in *_${arch}.deb; do dpkg -x "$deb" $out; done
+          cp -r $out/usr/* $out/
+          rm -rf $out/etc $out/usr $out/var
+          substituteInPlace $out/opt/devolo/dlancockpit/bin/dlancockpit-run.sh \
+            --replace-fail '.appdata/' '$HOME/.appdata/' \
+            --replace-fail '/opt/devolo/dlancockpit/bin/dlancockpit' 'setarch i686 /opt/devolo/dlancockpit/bin/dlancockpit'
+          substituteInPlace $out/share/applications/devolo-dlan-cockpit.desktop \
+            --replace-fail '/opt/devolo/dlancockpit/bin/dlancockpit-run.sh' 'devolo-cockpit'
+          runHook postInstall
+        '';
+      };
+      libxml2-compat =
+        p:
+        p.runCommandCC "libxml2-compat" { } ''
+          mkdir -p $out/lib
+          $CC -shared -fPIC -o $out/lib/libxml2.so.2 -x c - -Wl,--no-as-needed -L${p.libxml2.out}/lib -lxml2 << 'EOF'
+          int xmlLoadExtDtdDefaultValue = 0;
+          EOF
+        '';
+    in
+    buildFHSEnv {
+      inherit pname version meta;
+
+      multiArch = true;
+
+      nativeBuildInputs = [ makeBinaryWrapper ];
+
+      targetPkgs = pkgs: [
+        unwrapped
+        pkgs.dpkg
+      ];
+
+      profile = ''
+        export LD_LIBRARY_PATH=/lib32:/usr/lib32:$LD_LIBRARY_PATH
+      '';
+
+      multiPkgs =
+        pkgs:
+        with pkgs;
+        [
+          gtk2
+          gnome-themes-extra
+          libxslt
+          libxml2
+          (libxml2-compat pkgs)
+        ]
+        ++ appimageTools.defaultFhsEnvArgs.multiPkgs pkgs;
+
+      extraInstallCommands = ''
+        ln -s ${unwrapped}/share $out/share
+        rm -f $out/bin/devolonetsvc
+        makeWrapper $out/bin/devolo-cockpit $out/bin/devolonetsvc \
+          --add-flags "--daemon"
+      '';
+
+      runScript = writeShellScript "devolo-cockpit-launcher" ''
+        if [ "''${1:-}" = "--daemon" ] || [ "''${1:-}" = "devolonetsvc" ]; then
+          shift
+          exec devolonetsvc "$@"
+        else
+          exec /opt/devolo/dlancockpit/bin/dlancockpit-run.sh "$@"
+        fi
+      '';
+
+      passthru = passthru // {
+        inherit unwrapped;
+      };
+    };
+in
+if stdenvNoCC.hostPlatform.isDarwin then darwin else linux

--- a/pkgs/by-name/de/devolo-cockpit/sources.nix
+++ b/pkgs/by-name/de/devolo-cockpit/sources.nix
@@ -1,0 +1,11 @@
+{
+  version = "5.2.0.185";
+  darwin = {
+    url = "https://www.devolo.de/media/a2/c6/4d/1758704955/devolo-cockpit-v5-2-0-185.dmg";
+    hash = "sha256-dJIedSNjzX25mFTDmJWBP33o3MEz7/Sz9bsTvAeheU8=";
+  };
+  linux = {
+    url = "https://www.devolo.de/media/0a/fd/c7/1762522595/devolo-cockpit-v5-2-0-185-linux.zip";
+    hash = "sha256-BjNvH+cuh0Uf+Fq5upbSqQ4xXAjF4G8/iunl9NEcPHY=";
+  };
+}

--- a/pkgs/by-name/de/devolo-cockpit/update.sh
+++ b/pkgs/by-name/de/devolo-cockpit/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix
+
+set -euo pipefail
+
+PACKAGE_DIR="$(realpath "$(dirname "$0")")"
+HTML="$(curl -sS https://www.devolo.com/en/software-downloads/cockpit)"
+
+LINUX_URL="$(echo "$HTML" | grep -o 'https://[^"]*devolo-cockpit[^"]*\.zip' | head -n1 | sed -E 's|https://[^/]+|https://www.devolo.de|; s|\?.*||')"
+DARWIN_URL="$(echo "$HTML" | grep -o 'https://[^"]*devolo-cockpit[^"]*\.dmg' | head -n1 | sed -E 's|https://[^/]+|https://www.devolo.de|; s|\?.*||')"
+
+LATEST_VERSION="$(echo "$LINUX_URL" | sed -E 's/.*devolo-cockpit-v([0-9-]+?)(-linux)?\.zip/\1/' | tr '-' '.')"
+CURRENT_VERSION="$(nix eval -f "$PACKAGE_DIR/sources.nix" --raw version || :)"
+
+if [[ "$CURRENT_VERSION" != "$LATEST_VERSION" ]] || [[ "${1:-}" == "--force" ]]; then
+  LINUX_HASH="$(nix store prefetch-file --json "$LINUX_URL" | jq -r .hash)"
+  DARWIN_HASH="$(nix store prefetch-file --json "$DARWIN_URL" | jq -r .hash)"
+
+  cat <<EOF > "$PACKAGE_DIR/sources.nix"
+{
+  version = "${LATEST_VERSION}";
+  darwin = {
+    url = "${DARWIN_URL}";
+    hash = "${DARWIN_HASH}";
+  };
+  linux = {
+    url = "${LINUX_URL}";
+    hash = "${LINUX_HASH}";
+  };
+}
+EOF
+fi


### PR DESCRIPTION
https://www.devolo.global/support/downloads/download/devolo-cockpit

A configuration and monitoring utility for devolo dLAN / Magic Powerline devices

Includes a new NixOS module `services.devolonetsvc` for the background powerline discovery network service daemon and tests

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in `nixos/tests`
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`
  - [ ] Tests in `lib/tests` or `pkgs/test` for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy). assisted by Gemini 3.7 Flash through Antigravity-CLI