### PR TITLE
prs: fix darwin build

### DIFF
--- a/pkgs/by-name/pr/prs/package.nix
+++ b/pkgs/by-name/pr/prs/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitLab,
+  fetchpatch,
   installShellFiles,
   pkg-config,
   python3,
@@ -24,6 +25,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-U0qaFrRp2KTKejPivd62tWM7qsGiBmGsWrEpTnCroyY=";
   };
+
+  patches = [
+    # Fix macos compilation error
+    # https://gitlab.com/timvisee/prs/-/commit/dd29c60992714a160e88c32f6ec8848e7ccbee12
+    (fetchpatch {
+      url = "https://gitlab.com/timvisee/prs/-/commit/dd29c60992714a160e88c32f6ec8848e7ccbee12.patch";
+      hash = "sha256-P3hC+drh6gWsWVgICfEVxr3ghB4E45ZM2cZaCdFDELE=";
+    })
+  ];
 
   cargoHash = "sha256-xPF3HeDU6AXQ0M4utko3SCuLVBjj/qMjTCeSUT6kGmo=";
 


### PR DESCRIPTION
Closes #554107.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
