### PR TITLE
prs: add macos patch for 0.5.7

### DIFF
--- a/pkgs/by-name/pr/prs/0001-fix-macos-compilation-error.patch
+++ b/pkgs/by-name/pr/prs/0001-fix-macos-compilation-error.patch
@@ -1,0 +1,23 @@
+From dd29c60992714a160e88c32f6ec8848e7ccbee12 Mon Sep 17 00:00:00 2001
+From: Daeho Ro <40587651+daeho-ro@users.noreply.github.com>
+Date: Thu, 22 Jan 2026 21:10:43 +0900
+Subject: [PATCH] Fix macos compilation error
+
+---
+ cli/src/util/clipboard.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cli/src/util/clipboard.rs b/cli/src/util/clipboard.rs
+index e3669c1..9b38359 100644
+--- a/cli/src/util/clipboard.rs
++++ b/cli/src/util/clipboard.rs
+@@ -662,7 +662,7 @@ pub(crate) struct NotifyHandle(
+ impl NotifyHandle {
+     /// Explicitly close the notification
+     fn close(self) {
+-        #[cfg(all(feature = "notify", not(target_env = "musl")))]
++        #[cfg(all(feature = "notify", not(target_env = "musl"), not(target_os = "macos")))]
+         self.0.close();
+     }
+ }
+

--- a/pkgs/by-name/pr/prs/package.nix
+++ b/pkgs/by-name/pr/prs/package.nix
@@ -25,6 +25,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-U0qaFrRp2KTKejPivd62tWM7qsGiBmGsWrEpTnCroyY=";
   };
 
+  patches = [ ./0001-fix-macos-compilation-error.patch ];
+
   cargoHash = "sha256-xPF3HeDU6AXQ0M4utko3SCuLVBjj/qMjTCeSUT6kGmo=";
 
   nativeBuildInputs = [


### PR DESCRIPTION
I asked for a new release that would include the patch: https://github.com/timvisee/prs/issues/58

here's the patch: https://github.com/timvisee/prs/commit/dd29c60992714a160e88c32f6ec8848e7ccbee12

confirmed fixes aarch64-linux darwin build of `prs`.

Fixes: #554107

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
