### PR TITLE
pgschema: init at 1.12.3

### DIFF
--- a/pkgs/by-name/pg/pgschema/package.nix
+++ b/pkgs/by-name/pg/pgschema/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  postgresql,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pgschema";
+  version = "1.12.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pgplex";
+    repo = "pgschema";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zfG87Uc5bx14zhYnuT3CF+sW5EEQLBRRMyBe57FBHJ4=";
+  };
+
+  # Adapted from $src/nix/pgschema.nix
+  proxyVendor = true;
+  vendorHash = "sha256-3nV7AEsWyEvIbxHetoEsA8PPXJ6ENvU/sz7Wn5aysss=";
+
+  env.CGO_ENABLED = "0";
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "github.com/pgplex/pgschema/cmd.GitCommit=${finalAttrs.src.rev}"
+    # "-X"
+    # "github.com/pgplex/pgschema/cmd.BuildDate=${buildDate}"
+    "-X"
+    "github.com/pgplex/pgschema/internal/postgres.binariesPath=${postgresql}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--help"; # there is no -v/--version
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terraform-style, declarative Postgres schema migration";
+    homepage = "https://github.com/pgplex/pgschema";
+    changelog = "https://github.com/pgplex/pgschema/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.bengsparks ];
+    mainProgram = "pgschema";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/pg/pgschema/package.nix
+++ b/pkgs/by-name/pg/pgschema/package.nix
@@ -29,8 +29,6 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X"
     "github.com/pgplex/pgschema/cmd.GitCommit=${finalAttrs.src.rev}"
-    # "-X"
-    # "github.com/pgplex/pgschema/cmd.BuildDate=${buildDate}"
     "-X"
     "github.com/pgplex/pgschema/internal/postgres.binariesPath=${postgresql}"
   ];


### PR DESCRIPTION
`pgschema dump` and `pgschema plan` tested against existing DB, looks fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
