### PR TITLE
zennotes-desktop: 2.29.0 -> 2.30.0

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.29.0";
-  npmDepsHash = "sha256-Hml6oEZxNY6jK+dEDeA6KxfWa7k3/iqkUtlGRwHkO7U=";
+  version = "2.30.0";
+  npmDepsHash = "sha256-+zcRyIVGz/TeMh9ERx+7lKI8X5kKoAC0ZzKAUBdM7wY=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-naLrqLe5ED5c9OWBAlyP+1ar8wrcAxCEVaAsRDnQpgs=";
+    hash = "sha256-s7/tH/L+gQWuD+c8wv4sqUzq452SY1iv7oycYWX9H5A=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update zennotes-desktop 2.29.0 -> 2.30.0. I'm the upstream author of ZenNotes.

2.30.0 is the Atlas release: the whole vault drawn as a stable, deterministic map of notes and links (2D and 3D, fully keyboard-driven, themeable), alongside a cross-view Tasks filter and a sweep of eight fixes and small features (rebindable new-note shortcut, live-preview and markdown-link rendering fixes, workflows on remote vaults, counts for buffer motions, a math size slider). Nothing changes in how the package builds or is wrapped; the bump is version plus the two hashes.

Hash provenance: `npmDepsHash` and the `src` hash are the values our repo's own Nix packaging CI computed and build-verified on a Nix runner for this release (the in-repo flake builds the same workspace from the same lockfile, and that build passed on v2.30.0): https://github.com/ZenNotes/zennotes/actions/runs/32199717262

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.30.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux (equivalent derivation with these hashes build-verified
        in upstream repo CI on x86_64-linux)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
