### PR TITLE
hunk: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/by-name/hu/hunk/package.nix
+++ b/pkgs/by-name/hu/hunk/package.nix
@@ -10,13 +10,13 @@
 
 let
   pname = "hunk";
-  version = "0.18.0";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "modem-dev";
     repo = "hunk";
     tag = "v${version}";
-    hash = "sha256-IkARkW5haVmc+iZPYe22sUi5Ak+egImdrEugtr2O5A4=";
+    hash = "sha256-PWblqDS86PaSl5ToFawCNGTxmrWcmoBAfq8R5lMDbyk=";
   };
 
   node_modules = stdenv.mkDerivation {
@@ -56,7 +56,7 @@ let
 
     dontFixup = true;
 
-    outputHash = "sha256-ueZNCab0yDRgvftao1Wgy8yrcxh1mdnQl6zR237q8WI=";
+    outputHash = "sha256-Ixsv2wXb39kSRck9ZbjJjRlzn4KS2fkfl3v4MEeD7cE=";
     outputHashMode = "recursive";
   };
 in
@@ -76,9 +76,9 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace src/core/paths.ts \
       --replace-fail \
-        'join("node_modules", "hunkdiff", HUNK_REVIEW_SKILL_RELATIVE_PATH),' \
-        'join("node_modules", "hunkdiff", HUNK_REVIEW_SKILL_RELATIVE_PATH),
-    join("share", "skills", "hunk", "hunk-review", "SKILL.md"),'
+        'join("node_modules", "hunkdiff", skillRelativePath),' \
+        'join("node_modules", "hunkdiff", skillRelativePath),
+    join("share", "skills", "hunk", name, "SKILL.md"),'
   '';
 
   configurePhase = ''
@@ -110,8 +110,8 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm755 hunk $out/bin/hunk
-    mkdir -p $out/share/skills/hunk/hunk-review
-    cp skills/hunk-review/SKILL.md $out/share/skills/hunk/hunk-review/SKILL.md
+    mkdir -p $out/share/skills/hunk
+    cp -R skills/hunk-review skills/hunk-extensions $out/share/skills/hunk/
 
     runHook postInstall
   '';
@@ -131,6 +131,7 @@ stdenv.mkDerivation {
 
     $out/bin/hunk --version | grep -F ${version}
     test -f "$($out/bin/hunk skill path)"
+    test -f "$($out/bin/hunk skill path hunk-extensions)"
 
     runHook postInstallCheck
   '';


### PR DESCRIPTION
Release notes: https://github.com/modem-dev/hunk/releases/tag/v0.19.0

The automatic @r-ryantm update to 0.19.0 fails to build because upstream refactored bundled skill path resolution. `src/core/paths.ts` now assembles the relative path from a local `skillRelativePath` variable and a `name` parameter — 0.19.0 bundles a second skill, `hunk-extensions` — instead of the `HUNK_REVIEW_SKILL_RELATIVE_PATH` constant that the `postPatch` replacement matched on, so `--replace-fail` aborts:

```
ERROR: pattern join\("node_modules"\,\ "hunkdiff"\,\ HUNK_REVIEW_SKILL_RELATIVE_PATH\)\, doesn't match anything in file 'src/core/paths.ts'
```

<https://nixpkgs-update-logs.nix-community.org/hunk/2026-08-18.log>

This follows the new code, installs both bundled skills under `share/skills/hunk/`, and extends the install check to cover the added one, keeping the FHS layout introduced in #551371 (discussed in #547426).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs
- [x] Follows the automation/AI policy

### Testing notes

- Built on aarch64-darwin (sandboxing is off by default there) and exercised the result: `hunk --version`, `hunk skill path`, `hunk skill path hunk-extensions`, and an interactive review session including loading a third-party extension against the 0.19.0 extension API.
- `nixpkgs-review` was not run: no other package in Nixpkgs depends on `hunk`.

## Disclosure

Per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy), this change was prepared with Claude Code (claude-opus-5), disclosed in the commit's `Assisted-by:` trailer. Opening as a draft: I will review it in full myself before marking it ready for review.
