### PR TITLE
impactor: init at 2.6.0

### DIFF
--- a/pkgs/by-name/im/impactor/package.nix
+++ b/pkgs/by-name/im/impactor/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  pkg-config,
+  gtk3,
+  libayatana-appindicator,
+  libappindicator,
+  glib,
+  autoPatchelfHook,
+}:
+let
+  cargoFlags = [
+    "--bin"
+    "plumeimpactor"
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "impactor";
+  version = "2.6.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "claration";
+    repo = "Impactor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ahKJ3NRZvyLhhEYtH0fB2s7yF3HsD3WrTaA1O1knFsg=";
+  };
+
+  cargoHash = "sha256-W5AKdOjUOtggDnzKno4U40DXbComVUj0mFXRcQ8abqc=";
+  doCheck = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib
+    libappindicator
+    libayatana-appindicator
+    gtk3
+  ];
+
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
+    libappindicator
+    libayatana-appindicator
+  ];
+
+  cargoBuildFlags = cargoFlags;
+  cargoTestFlags = cargoFlags;
+
+  installPhase =
+    let
+      packageId = "dev.khcrysalis.PlumeImpactor";
+      targetDir = "target/${stdenv.hostPlatform.rust.rustcTarget}/${finalAttrs.cargoBuildType}/";
+    in
+    lib.concatStringsSep "\n" [
+      "runHook preInstall"
+      (lib.optionalString stdenv.hostPlatform.isDarwin ''
+        mkdir -p dist/Impactor.app/Contents/MacOS
+        cp -R package/macos/Impactor.app dist/Impactor.app
+
+        cp ${targetDir}/plumeimpactor dist/Impactor.app/Contents/MacOS/Impactor
+        chmod +x dist/Impactor.app/Contents/MacOS/Impactor
+        strip dist/Impactor.app/Contents/MacOS/Impactor
+
+        /usr/libexec/PlistBuddy dist/Impactor.app/Contents/Info.plist <<EOF
+        Set :CFBundleShortVersionString ${finalAttrs.version}
+        Set :CFBundleVersion ${finalAttrs.version}
+        Save
+        EOF
+
+        mkdir -p $out/Applications/Impactor.app
+        cp -R dist/Impactor.app $out/Applications/Impactor.app
+      '')
+      (lib.optionalString stdenv.hostPlatform.isLinux ''
+        install -Dm755 ${targetDir}/plumeimpactor $out/bin/plumeimpactor
+
+        install -Dm644 package/linux/${packageId}.desktop $out/share/applications/${packageId}.desktop
+        install -Dm644 package/linux/icons/hicolor/16x16/apps/${packageId}.png $out/share/icons/hicolor/16x16/apps/${packageId}.png
+        install -Dm644 package/linux/icons/hicolor/32x32/apps/${packageId}.png $out/share/icons/hicolor/32x32/apps/${packageId}.png
+        install -Dm644 package/linux/icons/hicolor/48x48/apps/${packageId}.png $out/share/icons/hicolor/48x48/apps/${packageId}.png
+        install -Dm644 package/linux/icons/hicolor/64x64/apps/${packageId}.png $out/share/icons/hicolor/64x64/apps/${packageId}.png
+        install -Dm644 package/linux/icons/hicolor/128x128/apps/${packageId}.png $out/share/icons/hicolor/128x128/apps/${packageId}.png
+        install -Dm644 package/linux/icons/hicolor/256x256/apps/${packageId}.png $out/share/icons/hicolor/256x256/apps/${packageId}.png
+        install -Dm644 package/linux/icons/hicolor/512x512/apps/${packageId}.png $out/share/icons/hicolor/512x512/apps/${packageId}.png
+      '')
+      "runHook postInstall"
+    ];
+
+  meta = {
+    description = "Cross-platform iOS/iPadOS/tvOS sideloading application";
+    homepage = "https://impactor.claration.dev/";
+    downloadPage = "https://impactor.claration.dev/download/";
+    donationPage = "https://github.com/sponsors/claration";
+    mainProgram = "impactor";
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [ paige ];
+    license = with lib.licenses; [
+      mit
+      bsd3
+    ];
+  };
+})


### PR DESCRIPTION
adds a package for [claration/Impactor](https://github.com/claration/Impactor) (formerly PlumeImpactor), a cross-platform iOS/iPadOS/tvOS sideloading app, builds from source and works on both linux and ~~macOS~~, packaged by me with some help from @blahai for getting it working on linux

---

draft because it does not currently work on macOS due to a cryptic error:

```
~/Projects/dots  (git)-[master]-% sudo darwin-rebuild switch --flake .#Abyssgard --show-trace
Password:
building the system configuration...
error: builder for '/nix/store/v4fdnvr4izik1h9bi5hsvbr18n82bibh-impactor-2.6.0.drv' failed to produce output path for output 'out' at "/nix/store/c964pw0yx17q1hsiscg6dbz67dqwqhal-impactor-2.6.0"
error: Cannot build '/nix/store/x7wm35xrdygpmi88i8c21va37gnf7ck3-system-applications.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/xlf0h029p0xbm2g5hgvlpkf2fviv2phh-system-applications
error: Cannot build '/nix/store/hh300ky3pdqx14zglsh60dxnlk9j6ka3-system-path.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/4bk1d6dsakcvk43cd78zp5ysgyq07sjg-system-path
error: Cannot build '/nix/store/qy2xfh05r29p481ykyxfi39m346jbkcj-darwin-system-26.11.4cff07d.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/sns8nj4v1gnl3hb2r1v0092az8adri4c-darwin-system-26.11.4cff07d
~/Projects/dots  (git)-[master]-%
```

call site is just me using it in `systemPackages`:

```nix
# configuration.nix
{pkgs, ...}: {
  environment.systemPackages = with pkgs; [
    (pkgs.callPackage ../../packages/impactor.nix {})
  ];
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
