### PR TITLE
xrizer: add version.txt

### DIFF
--- a/pkgs/by-name/xr/xrizer/package.nix
+++ b/pkgs/by-name/xr/xrizer/package.nix
@@ -54,6 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     mkdir -p $out/lib/xrizer/$platformPath
     mv "$out/lib/libxrizer.so" "$out/lib/xrizer/$platformPath/vrclient.so"
+    touch $out/lib/xrizer/bin/version.txt
   '';
 
   platformPath = platformPaths."${stdenv.hostPlatform.system}";


### PR DESCRIPTION
Added version.txt to xrizer's output directory to prevent SteamVR from eventually overwriting `openvrpaths.vrpath` with it's own runtime. This file is included in the [official releases of xrizer](https://github.com/Supreeeme/xrizer/releases/tag/v0.5) for that reason but isn't included in the nixpkgs package. With this change, the package output will fully mirror the structure of official releases.

## Things done

Modified the `postInstall` script for the `xrizer` package to create an empty `version.txt` in the `bin` directory.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
