### PR TITLE
starc: use finalAttrs

### DIFF
--- a/pkgs/by-name/st/starc/package.nix
+++ b/pkgs/by-name/st/starc/package.nix
@@ -4,27 +4,24 @@
   appimageTools,
   makeWrapper,
 }:
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "starc";
   version = "0.8.2";
+
   src = fetchurl {
-    url = "https://github.com/story-apps/starc/releases/download/v${version}/starc-setup.AppImage";
+    url = "https://github.com/story-apps/starc/releases/download/v${finalAttrs.version}/starc-setup.AppImage";
     hash = "sha256-7uwc4gD+AlbYGMffaWj3v2Zt2x6P5edPXY3BsznBNdQ=";
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
   nativeBuildInputs = [ makeWrapper ];
   extraInstallCommands = ''
     # Fixup desktop item icons
-    install -D ${appimageContents}/starc.desktop -t $out/share/applications/
+    install -D ${finalAttrs.contents}/starc.desktop -t $out/share/applications/
     substituteInPlace $out/share/applications/starc.desktop \
       --replace-fail "Icon=starc" "${''
         Icon=dev.storyapps.starc
         StartupWMClass=Story Architect''}"
-    cp -r ${appimageContents}/share/* $out/share/
+    cp -r ${finalAttrs.contents}/share/* $out/share/
 
     wrapProgram $out/bin/starc \
       --unset QT_PLUGIN_PATH
@@ -38,4 +35,4 @@ appimageTools.wrapType2 {
     maintainers = with lib.maintainers; [ pancaek ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
