### PR TITLE
maintainers: add stefanboca; topcoat-cli: init at 0.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27393,6 +27393,12 @@
     githubId = 1699155;
     name = "Steve Elliott";
   };
+  stefanboca = {
+    email = "stefan.r.boca@gmail.com";
+    github = "stefanboca";
+    githubId = 45266795;
+    name = "Stefan Boca";
+  };
   stefanfehrenbach = {
     email = "stefan.fehrenbach@gmail.com";
     github = "fehrenbach";

--- a/pkgs/by-name/to/topcoat-cli/package.nix
+++ b/pkgs/by-name/to/topcoat-cli/package.nix
@@ -1,0 +1,38 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "topcoat-cli";
+  version = "0.6.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tokio-rs";
+    repo = "topcoat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gslnny08zjnKN+2DDXoXWYqihwrgUvV9wRaZrAUF5l4=";
+  };
+
+  cargoHash = "sha256-g11IsGMUcIzF+CC5sjIbX1pRpjmZCLynblaPWNvlelM=";
+
+  cargoBuildFlags = [
+    "-p"
+    "topcoat-cli"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "topcoat-cli"
+  ];
+
+  meta = {
+    description = "CLI for Topcoat, a modular, batteries-included Rust web framework for server-rendered apps";
+    homepage = "https://github.com/tokio-rs/topcoat";
+    changelog = "https://github.com/tokio-rs/topcoat/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "topcoat";
+    maintainers = with lib.maintainers; [ stefanboca ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
