### PR TITLE
supercell-wx: fix build

### DIFF
--- a/pkgs/by-name/su/supercell-wx/package.nix
+++ b/pkgs/by-name/su/supercell-wx/package.nix
@@ -92,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/explicit-link-aws-crt.patch # fix missing symbols from aws-crt-cpp
     # }}}
     ./patches/boost-1.89-compat.patch
+    ./patches/memcpy-cstring.patch
   ];
 
   # This also may be submitted upstream to maplibre-native-qt, which is currently vendored

--- a/pkgs/by-name/su/supercell-wx/patches/memcpy-cstring.patch
+++ b/pkgs/by-name/su/supercell-wx/patches/memcpy-cstring.patch
@@ -1,0 +1,12 @@
+diff --git a/wxdata/source/scwx/zip/zip_stream_writer.cpp b/wxdata/source/scwx/zip/zip_stream_writer.cpp
+index 3822ea20..a455f63b 100644
+--- a/wxdata/source/scwx/zip/zip_stream_writer.cpp
++++ b/wxdata/source/scwx/zip/zip_stream_writer.cpp
+@@ -2,6 +2,7 @@
+ #include <scwx/util/logger.hpp>
+ 
+ #include <cstdlib>
++#include <cstring>
+ #include <fstream>
+ 
+ #include <zip.h>


### PR DESCRIPTION
Upstream dependency changed breaking transitive include resulting in a build failure. This change patches zip_stream_writer.cpp to explicitly include `<cstring>` so std::memcpy is properly resolved.

Resolves #554042.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
