### PR TITLE
nixos/atuin: fix documentation link

### DIFF
--- a/nixos/modules/programs/atuin.nix
+++ b/nixos/modules/programs/atuin.nix
@@ -60,7 +60,7 @@ in
       description = ''
         Configuration written to {file}`/etc/atuin/config.toml`.
 
-        See <https://docs.atuin.sh/configuration/config/> for the full list
+        See <https://docs.atuin.sh/latest/configuration/config/> for the full list
         of options.
       '';
     };
@@ -99,7 +99,7 @@ in
         {file}`/etc/atuin/themes/theme-name.toml`
         where the name of each attribute is the theme-name
 
-        See <https://docs.atuin.sh/guide/theming/> for the full list
+        See <https://docs.atuin.sh/latest/guide/theming/> for the full list
         of options.
       '';
       default = { };

--- a/nixos/modules/services/misc/atuin.nix
+++ b/nixos/modules/services/misc/atuin.nix
@@ -74,7 +74,7 @@ in
         default = null;
         description = ''
           Environment file, used to set any secret ATUIN_* environment variables, such as ATUIN_DB_URI containing a password.
-          See https://docs.atuin.sh/cli/self-hosting/server-setup/#configuration for available environment variables.
+          See <https://docs.atuin.sh/latest/self-hosting/server-setup/#configuration> for available environment variables.
         '';
       };
     };


### PR DESCRIPTION
The atuin docs now require the version in the URL else it will redirect to its 404 page. Pinned the version tied to actual package version or "latest" to show the correct version of the docs 

Since dynamically importing over the version from pkgs.atuin.version is not possible for NixOS manual (build fails) I have just hardcoded to use the latest version of the docs. It aligns for now in unstable, but will of course no longer be aligned with current atuin nixpkg once upstream updates. But the atuin nixpkg does regularly get updated so it should be fine.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
