### PR TITLE
mesa: Fix AV1 decoding artifacts with new amdgpu firmware

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -7,6 +7,7 @@
   expat,
   fetchCrate,
   fetchFromGitLab,
+  fetchpatch,
   file,
   flex,
   glslang,
@@ -153,6 +154,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./opencl.patch
+    # radv/video: Fix AV1 decode qmatrix params
+    # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/43787 (merged)
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/d298e30ad819e92680c3b098c261e9642a4b1602.patch";
+      hash = "sha256-rBm4L34zNhlmq2V6qUSDaE+ZjDed3MzK7picuWBHcTA=";
+    })
+    # radeonsi/mm: Fix AV1 decode qmatrix params
+    # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/43787 (merged)
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/3c4d3e46d19f2f4e951f3ae059543b03592f7944.patch";
+      hash = "sha256-TmAHV+9URKd4QRVBi/PoZSoinMNlYvzKhIYHAUtgXV4=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
This patch series fixes a quantization matrix corruption issue with hardware AV1 decoding, exposed by the linux-firmware 20260810 upgrade. Upstream merged it to main, staging/26.2, and staging/26.1.

https://gitlab.freedesktop.org/drm/amd/-/work_items/5615
https://gitlab.freedesktop.org/mesa/mesa/-/work_items/16090
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/43787

- Fixes #553701.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
