### PR TITLE
openafs: 1.8.16 → 1.8.16.1, patch for Linux kernel 7.2

### DIFF
--- a/pkgs/by-name/op/openafs/module.nix
+++ b/pkgs/by-name/op/openafs/module.nix
@@ -28,6 +28,18 @@ stdenv.mkDerivation {
   inherit src;
 
   patches = [
+    # LINUX: Disable osi_dnlc
+    (fetchpatch {
+      url = "https://gerrit.openafs.org/changes/16927/revisions/a3bd427be8437a38c96ac34ef8216e58ab999945/patch";
+      hash = "sha256-q0AOGpWL1r2hMLQgowMBkfOcEvhXEhXVLe1A/tlawFo=";
+      decode = "base64 -d";
+    })
+    # linux: replace strncpy with strscpy
+    (fetchpatch {
+      url = "https://gerrit.openafs.org/changes/16928/revisions/5f04ae748a1ede14882174a81dfa38baa2e66a20/patch";
+      hash = "sha256-fwzRzS799Y68l29vlzIAmHLda57gToLippgNMKWfWaw=";
+      decode = "base64 -d";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openafs/module.nix
+++ b/pkgs/by-name/op/openafs/module.nix
@@ -28,16 +28,6 @@ stdenv.mkDerivation {
   inherit src;
 
   patches = [
-    # Linux: pagevec.h renamed to folio_batch.h
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/d47c438aec49e417066a7bef00bd82078014f5ea.patch";
-      hash = "sha256-LPURZovpl6KbigzP4mNjgHvPlXYKY5Pxh8sj9RT2W08=";
-    })
-    # Linux: Add comment for d_alias configure test
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/fd157926f08d10afe981d85654395bbf083ea7a3.patch";
-      hash = "sha256-gJ+ylIEZwJcpTWc5hmIXS/QcxtICqjaEzZsl2QegjhY=";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openafs/srcs.nix
+++ b/pkgs/by-name/op/openafs/srcs.nix
@@ -1,16 +1,16 @@
 { fetchurl }:
 rec {
-  version = "1.8.16";
+  version = "1.8.16.1";
   src = fetchurl {
     url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    hash = "sha256-7oEnaJdXy9lyOoU6EvrigcnenD6JSkvZAQf7b4UnBGk=";
+    hash = "sha256-z1kGdYmilUcePxD2RPDyFlETNHzIsK0Pu0EjJZoq8KI=";
   };
 
   srcs = [
     src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      hash = "sha256-F9fyLe5Ofs6Ri4MXlO63wOZmhZuY8FAh2P/aoAX5wiQ=";
+      hash = "sha256-kZhKpuF1VEZC4d2z10ROwibq57oTTTfAXfEPu4CNnjA=";
     })
   ];
 }


### PR DESCRIPTION
Upgrade OpenAFS from 1.8.16 to 1.8.16.1, drop merged upstream patches, and add upstream patches from Gerrit to fix building with Linux kernel 7.2.

- https://openafs.org/dl/openafs/1.8.16.1/RELNOTES-1.8.16.1
- https://github.com/openafs/openafs/compare/openafs-stable-1_8_16...openafs-stable-1_8_16_1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
