### PR TITLE
pandora-box: init at 0.23.0

### DIFF
--- a/pkgs/by-name/pa/pandora-box/package.nix
+++ b/pkgs/by-name/pa/pandora-box/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pandora-box";
+  version = "0.23.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    pname = "pandora_box";
+    inherit version;
+    hash = "sha256-obmo4+7yzWoCquViTnuOYxP0GDjGFwDquUYcR8Oy0uQ=";
+  };
+
+  cargoHash = "sha256-zH/5pqVOFBs2qAMwDQg0SM4tACWV+eP/4C9FJLZbJ5Y=";
+
+  # Tests are integration tests that exercise the sydbox sandbox and require
+  # a real system environment; they cannot run inside the Nix build sandbox.
+  doCheck = false;
+
+  meta = {
+    description = "Syd's log inspector & profile writer";
+    homepage = "https://man.exherbo.org";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      mio
+    ];
+    mainProgram = "pandora";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

as we already have sydbox by @illdefined @getchoo . this is a tool for sydbox

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
