### PR TITLE
nixos/syncthing: use requires instead of requisite for syncthing-init

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -1049,7 +1049,7 @@ in
       };
       syncthing-init = lib.mkIf (cleanedConfig != { }) {
         description = "Syncthing configuration updater";
-        requisite = [ "syncthing.service" ];
+        requires = [ "syncthing.service" ];
         after = [ "syncthing.service" ];
         wantedBy = [ "multi-user.target" ];
 


### PR DESCRIPTION
---

`Requisite=` races during `nixos-rebuild switch`.
When syncthing.service is stopped and started again during activation (instead of restarted), switch-to-configuration starts units in separate transactions, in sorted order.
`syncthing-init.service` sorts before `syncthing.service`, so it's started before syncthing.service is.
Its `Requisite=` verify job runs immediately, sees syncthing.service inactive, and fails the whole job with result 'dependency'.

```
01:14:04  syncthing.service: Deactivated successfully
01:14:23  Dependency failed for Syncthing configuration updater.
01:14:23  syncthing-init.service: Job syncthing-init.service/start failed with result 'dependency'
01:14:24  syncthing v2.1.3 starting
01:14:32  Failed to start NixOS Upgrade.
```

Using `Requires` pulls `syncthing.service` into the same transaction.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]: `nixosTests.syncthing-init`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
