### PR TITLE
 peppercarrot-fonts: make use of compound licenses instead of deprecated spdx licenses

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1284,6 +1284,11 @@ lib.mapAttrs mkLicense (
       fullName = "Open Data Commons Open Database License v1.0";
     };
 
+    ofl10 = {
+      spdxId = "OFL-1.0";
+      fullName = "SIL Open Font License 1.0";
+    };
+
     ofl = {
       spdxId = "OFL-1.1";
       fullName = "SIL Open Font License 1.1";

--- a/pkgs/by-name/pe/peppercarrot-fonts/package.nix
+++ b/pkgs/by-name/pe/peppercarrot-fonts/package.nix
@@ -57,30 +57,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.nim65s ];
     license =
       with lib.licenses;
-      let
-        gpl2font = {
-          deprecated = true;
-          free = true;
-          fullName = "GNU General Public License v2.0 w/Font exception";
-          redistributable = true;
-          shortName = "gpl2font";
-          spdxId = " GPL-2.0-with-font-exception";
-          url = "https://spdx.org/licenses/GPL-2.0-with-font-exception.html";
-        };
-        ofl10 = {
-          deprecated = false;
-          free = true;
-          fullName = "SIL Open Font License 1.0";
-          redistributable = true;
-          shortName = "ofl10";
-          spdxId = "OFL-1.0";
-          url = "https://spdx.org/licenses/OFL-1.0.html";
-        };
-      in
-      [
+      AND [
         asl20
         cc-by-30
-        gpl2font
+        (WITH gpl2 fontException)
+        (WITH gpl3 fontException)
         gpl3
         mplus
         ofl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
