### PR TITLE
cherry-studio: 1.9.11 -> 2.0.8

### DIFF
--- a/pkgs/by-name/ch/cherry-studio/package.nix
+++ b/pkgs/by-name/ch/cherry-studio/package.nix
@@ -3,9 +3,9 @@
   stdenv,
   fetchFromGitHub,
   fetchPnpmDeps,
-  electron_40,
+  electron_41,
   nodejs-slim,
-  pnpm_10_29_2,
+  pnpm_11,
   pnpmConfigHook,
   makeWrapper,
   writableTmpDirAsHomeHook,
@@ -15,6 +15,10 @@
   pkg-config,
   makeDesktopItem,
   nix-update-script,
+  bun,
+  mise,
+  ripgrep,
+  uv,
   alsa-lib,
   libevdev,
   libx11,
@@ -26,35 +30,40 @@
 }:
 
 let
-  electron = electron_40;
-  pnpm = pnpm_10_29_2;
+  electron = electron_41;
+  pnpm = pnpm_11;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cherry-studio";
-  version = "1.9.11";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "CherryHQ";
     repo = "cherry-studio";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NbjFPHMh8LSqUv3wpXI/hBU9aJFe76l5UyoZ2XqX0hg=";
+    hash = "sha256-K49Y03OF2RyhUUhhKo4YCR4ObgnsBbBfhl2wqe1+xvs=";
   };
 
+  patches = [
+    # Upstream's packaging hooks download prebuilt binaries (mise, bun, uv,
+    # ripgrep, and a GLIBC-compatible better-sqlite3 addon) from GitHub during
+    # electron-builder packaging. That needs network access, which the build
+    # sandbox doesn't have. The tools are resolved from PATH at runtime
+    # instead (see the wrapper below), and better-sqlite3 is rebuilt from
+    # source against electron by electron-builder.
+    ./skip-binary-download.patch
+  ];
+
   postPatch = ''
-    substituteInPlace src/main/services/ConfigManager.ts \
-      --replace-fail "ConfigKeys.AutoUpdate, true" "ConfigKeys.AutoUpdate, false" \
-      --replace-fail "ConfigKeys.AutoUpdate, value" "ConfigKeys.AutoUpdate, false"
-    substituteInPlace src/main/services/AppUpdater.ts \
-      --replace-fail " = isActive" " = false"
-    substituteInPlace src/renderer/src/hooks/useSettings.ts \
-      --replace-fail "isAutoUpdate)" "false)"
+    substituteInPlace src/shared/data/preference/preferenceSchemas.ts \
+      --replace-fail "'app.dist.auto_update.enabled': true" "'app.dist.auto_update.enabled': false"
   '';
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-9Vx4WzQjwNxPAkz+FjjqnMQxJviP4e0EhkQBN9Y+ujo=";
+    fetcherVersion = 4;
+    hash = "sha256-bwfDr6z1/uBO1D0lTpO061nnrDunRjN9InxiT1MABAY=";
   };
 
   nativeBuildInputs = [
@@ -142,6 +151,14 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 build/icon.png $out/share/icons/cherry-studio.png
     makeWrapper ${lib.getExe electron} $out/bin/cherry-studio \
       --inherit-argv0 \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bun
+          mise
+          ripgrep
+          uv
+        ]
+      } \
       --add-flags $out/opt/cherry-studio/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}

--- a/pkgs/by-name/ch/cherry-studio/skip-binary-download.patch
+++ b/pkgs/by-name/ch/cherry-studio/skip-binary-download.patch
@@ -1,0 +1,55 @@
+diff -ruN a/scripts/after-pack.js b/scripts/after-pack.js
+--- a/scripts/after-pack.js
++++ b/scripts/after-pack.js
+@@ -10,19 +10,8 @@
+     fs.rmSync(path.join(context.appOutDir, 'LICENSE.electron.txt'), { force: true })
+     fs.rmSync(path.join(context.appOutDir, 'LICENSES.chromium.html'), { force: true })
+   } else if (platform === 'linux') {
+-    const arch = context.arch === Arch.arm64 ? 'arm64' : context.arch === Arch.x64 ? 'x64' : null
+-    if (!arch) throw new Error(`Unsupported Linux packaging architecture: ${context.arch}`)
+-
+-    const projectRoot = path.join(__dirname, '..')
+-    const { destination, manifest } = replacePackagedBetterSqlite3({
+-      projectRoot,
+-      appOutDir: context.appOutDir,
+-      arch,
+-      metadata: readProjectBuildMetadata(projectRoot)
+-    })
+-    process.stdout.write(
+-      `Installed GLIBC-compatible better-sqlite3 for linux-${arch} at ${destination} ` +
+-        `(ABI ${manifest.electronAbi}, ${JSON.stringify(manifest.requirements)})\n`
+-    )
++    // nixpkgs: keep the better-sqlite3 addon that electron-builder rebuilt
++    // from source against electron; skip installing upstream's prebuilt
++    // GLIBC-compatible artifact (it requires network access).
+   }
+ }
+diff -ruN a/scripts/before-pack.js b/scripts/before-pack.js
+--- a/scripts/before-pack.js
++++ b/scripts/before-pack.js
+@@ -183,21 +183,10 @@
+   ]
+   process.stdout.write(`Unpacking ${dshAsarUnpack.length / 2} DSH runtime dependency packages\n`)
+ 
+-  if (platform === 'linux') {
+-    const linuxArch = context.arch === Arch.arm64 ? 'arm64' : context.arch === Arch.x64 ? 'x64' : null
+-    if (!linuxArch) throw new Error(`Unsupported Linux packaging architecture: ${context.arch}`)
+-
+-    const artifact = ensureLinuxNativeArtifact({ projectRoot, arch: linuxArch })
+-    process.stdout.write(
+-      `${artifact.cached ? 'Verified cached' : 'Downloaded'} GLIBC-compatible better-sqlite3 for ` +
+-        `linux-${linuxArch} (${artifact.inspection.sha256})\n`
+-    )
+-  }
+-
+-  console.log(`Downloading bundled binaries for ${platform}-${arch}...`)
+-  execSync(`node "${path.join(__dirname, 'download-binaries.js')}" ${platform} ${arch}`, { stdio: 'inherit' })
+-  // Fail the build rather than ship a half-empty resources/binaries/<platform>.
+-  require('./download-binaries').verifyBundledBinaries(platform, arch)
++  // nixpkgs: mise/bun/uv/rg are provided via PATH by the wrapper at runtime
++  // instead of being bundled, and better-sqlite3 is rebuilt from source
++  // against electron by electron-builder. Skip downloading upstream's
++  // prebuilt artifacts (the build sandbox has no network access anyway).
+ 
+   const excludePackages = async (packagesToExclude) => {
+     // 从项目根目录的 electron-builder.yml 读取 files 配置，避免多次覆盖配置导致出错


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
