### PR TITLE
vacask: set OpenVAF target CPU

### DIFF
--- a/pkgs/by-name/va/vacask/package.nix
+++ b/pkgs/by-name/va/vacask/package.nix
@@ -16,6 +16,35 @@
   boost188,
   suitesparse,
   tomlplusplus,
+
+  # VACASK's device models are compiled by OpenVAF, a Verilog-A compiler.
+  #
+  # By default, OpenVAF's `--target_cpu native` tells it to use every CPU
+  # instruction available on the machine doing the build (e.g. AVX-512, if the
+  # builder happens to have it). If the resulting binary is then run on a
+  # different, older CPU that doesn't support those instructions, it crashes
+  # with "illegal instruction" (SIGILL).
+  #
+  # To avoid this, we detect which instruction set the CPU we're building for
+  # actually supports and tell OpenVAF to target that instead, which keeps the
+  # compiled models runnable on other x86_64 machines as well.
+  #
+  # See:
+  #   - https://codeberg.org/arpadbuermen/VACASK/src/commit/bf59752fbfdfed18dc7fe2e3e11a9c02f8de28a0/README.md#installation-from-pre-built-packages
+  #   - https://github.com/NixOS/nixpkgs/blob/dc36b3c506df17272cdca29e85d0d0190b068981/lib/systems/architectures.nix
+  openvafTargetCpu ?
+    with stdenv.hostPlatform;
+    if isx86_64 then
+      if avx512Support then
+        "x86-64-v4"
+      else if avx2Support then
+        "x86-64-v3"
+      else if sse4_2Support then
+        "x86-64-v2"
+      else
+        "x86-64"
+    else
+      "generic",
 }:
 
 let
@@ -79,6 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "FLEX_INCLUDE_DIR" "${flex}/include")
     (lib.cmakeFeature "SuiteSparse_DIR" "${suitesparse-include}")
     (lib.cmakeFeature "TOMLPP_DIR" "${tomlplusplus}")
+    (lib.cmakeFeature "OPENVAF_OPTIONS" "--target_cpu ${openvafTargetCpu}")
   ];
 
   doCheck = true;


### PR DESCRIPTION
VACASK's device models are compiled by OpenVAF, a Verilog-A compiler.

By default, OpenVAF's `--target_cpu native` tells it to use every CPU instruction available on the machine doing the build (e.g. AVX-512, if the builder happens to have it). If the resulting binary is then run on a different, older CPU that doesn't support those instructions, it crashes with "illegal instruction" (SIGILL).

To avoid this, we detect which instruction set the CPU we're building for actually supports and tell OpenVAF to target that instead, which keeps the compiled models runnable on other x86_64 machines as well.

See:
  - https://codeberg.org/arpadbuermen/VACASK/src/commit/bf59752fbfdfed18dc7fe2e3e11a9c02f8de28a0/README.md#installation-from-pre-built-packages
  - https://github.com/NixOS/nixpkgs/blob/dc36b3c506df17272cdca29e85d0d0190b068981/lib/systems/architectures.nix

Assisted-by: DeepSeek V4 Flash Free


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
