### PR TITLE
testing-farm: init at 0.0.38

### DIFF
--- a/pkgs/by-name/te/testing-farm/package.nix
+++ b/pkgs/by-name/te/testing-farm/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitLab,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "testing-farm";
+  version = "0.0.38";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "testing-farm";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-guoZfFkx9VNXiJy61Cg08G/H4HIcSZ66J+US69SsioM=";
+  };
+
+  build-system = [
+    python3Packages.poetry-core
+    python3Packages.poetry-dynamic-versioning
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    colorama
+    cryptography
+    dynaconf
+    keyring
+    pendulum
+    python-dotenv
+    requests
+    rich
+    ruamel-yaml
+    shellingham
+    typer
+  ];
+
+  pythonImportsCheck = [
+    "tft.cli"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Testing Farm's CLI tool";
+    homepage = "https://testing-farm.io/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ WOnder93 ];
+    mainProgram = "testing-farm";
+  };
+})


### PR DESCRIPTION
Add the CLI for Testing Farm - a testing service provided by Red Hat both for its own and open-source projects.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
