### PR TITLE
linuxPackages.ena: fix build against Linux 7.2

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   gitUpdater,
   kernel,
   kernelModuleMakeFlags,
@@ -22,6 +23,15 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   hardeningDisable = [ "pic" ];
+
+  patches = [
+    # Linux 7.2 signature change
+    # https://github.com/amzn/amzn-drivers/pull/384
+    (fetchpatch2 {
+      url = "https://github.com/amzn/amzn-drivers/commit/907a1686e35458b8e3bc5b406609473bee7da39a.patch";
+      hash = "sha256-KG85r4m868mc6+QlBdoE06FQcSG2JiDPFHjfRgxfkHY=";
+    })
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
   makeFlags = kernelModuleMakeFlags;


### PR DESCRIPTION
The latest out-of-tree `ena` (Elastic Network Adapter) driver (v2.17.2) failed to build against kernel >= 7.2, due to a kernel API change.


<details>
<summary>Compiler error log</summary>

```
make -C /nix/store/azf5l25z6shjav7w7d3mkdba4wzgknl2-linux-7.2-dev/lib/modules/7.2.0/build M=/build/source/kernel/linux/ena modules
make[1]: Entering directory '/nix/store/azf5l25z6shjav7w7d3mkdba4wzgknl2-linux-7.2-dev/lib/modules/7.2.0/build'
make[2]: Entering directory '/build/source/kernel/linux/ena'
  CC [M]  ena_netdev.o
  CC [M]  ena_ethtool.o
ena_ethtool.c: In function 'ena_fetch_page_pool_stats':
ena_ethtool.c:386:30: error: invalid use of void expression
  386 |                 if (!pool || !page_pool_get_stats(pool, &stats))
      |                              ^
compilation terminated due to -Wfatal-errors.
make[4]: *** [/nix/store/azf5l25z6shjav7w7d3mkdba4wzgknl2-linux-7.2-dev/lib/modules/7.2.0/source/scripts/Makefile.build:289: ena_ethtool.o] Error 1
make[3]: *** [/nix/store/azf5l25z6shjav7w7d3mkdba4wzgknl2-linux-7.2-dev/lib/modules/7.2.0/source/Makefile:2187: .] Error 2
make[2]: *** [/nix/store/azf5l25z6shjav7w7d3mkdba4wzgknl2-linux-7.2-dev/lib/modules/7.2.0/source/Makefile:248: __sub-make] Error 2
make[2]: Leaving directory '/build/source/kernel/linux/ena'
make[1]: *** [/nix/store/azf5l25z6shjav7w7d3mkdba4wzgknl2-linux-7.2-dev/lib/modules/7.2.0/source/Makefile:248: __sub-make] Error 2
make[1]: Leaving directory '/nix/store/azf5l25z6shjav7w7d3mkdba4wzgknl2-linux-7.2-dev/lib/modules/7.2.0/build'
make: *** [Makefile:92: ena.ko] Error 2
```
</details>


`ena` has already been upstreamed to the kernel and is built as module by default on NixOS (`CONFIG_ENA_ETHERNET=m`).
Switching to the in-tree module fixes the compilation.

I tested it on a Lightsail instance.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
