### PR TITLE
bytecode-viewer: 2.12 -> 2.13.2

### DIFF
--- a/pkgs/by-name/by/bytecode-viewer/package.nix
+++ b/pkgs/by-name/by/bytecode-viewer/package.nix
@@ -11,13 +11,13 @@
 
 maven.buildMavenPackage rec {
   pname = "bytecode-viewer";
-  version = "2.12";
+  version = "2.13.2";
 
   src = fetchFromGitHub {
     owner = "Konloch";
     repo = "bytecode-viewer";
     rev = "v${version}";
-    hash = "sha256-opAUmkEcWPOrcxAL+I1rBQXwHmvzbu0+InTnsg9r+z8=";
+    hash = "sha256-PWL9fFBWksIfCZuVH/QV0j47stZ4CFY24SIunp+DuUI=";
   };
 
   desktopItems = [
@@ -37,7 +37,7 @@ maven.buildMavenPackage rec {
     ./make-deterministic.patch
   ];
 
-  mvnHash = "sha256-iAxzFq8nR9UiH8y3ZWmGuChZEMwQBAkN8wD+t9q/RWY=";
+  mvnHash = "sha256-NmSme8Jea2VGE0HvdqfhAs+CI1ZD+5jqD06pFSfSr1o=";
 
   mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
