### PR TITLE
minesweeper-tui: init at 0.1.0

### DIFF
--- a/pkgs/by-name/mi/minesweeper-tui/package.nix
+++ b/pkgs/by-name/mi/minesweeper-tui/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ncurses,
+  pkg-config,
+}:
+
+stdenv.mkDerivation {
+  pname = "minesweeper-tui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ZhaolunYin";
+    repo = "minesweeper-tui";
+    rev = "a6075d3f54ab0e81c94b71e9b7f92b1030603668";
+    hash = "sha256-1cY1d3q6+/llsrLRN9UGodvNxXwbUDKuD2a5fxSCy20=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    ncurses
+  ];
+
+  installPhase = ''
+    install -Dm755 minesweeper $out/bin/minesweeper
+  '';
+
+  meta = {
+    description = "A TUI Minesweeper game written in C";
+    homepage = "https://github.com/ZhaolunYin/minesweeper-tui";
+    license = lib.licenses.mit;
+    mainProgram = "minesweeper";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/mi/minesweeper-tui/package.nix
+++ b/pkgs/by-name/mi/minesweeper-tui/package.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation {
     hash = "sha256-1cY1d3q6+/llsrLRN9UGodvNxXwbUDKuD2a5fxSCy20=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     pkg-config
   ];


### PR DESCRIPTION
<!--
Added minesweeper-tui, a ncurses based minesweeper game written in C.

github.com/ZhaolunYin/minesweeper-tui
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
