### PR TITLE
censor: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/by-name/ce/censor/package.nix
+++ b/pkgs/by-name/ce/censor/package.nix
@@ -9,27 +9,33 @@
   ninja,
   pkg-config,
   desktop-file-utils,
+  libxml2,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "censor";
-  version = "0.10.0";
+  version = "0.10.1";
   pyproject = false;
 
   src = fetchFromCodeberg {
     owner = "censor";
     repo = "Censor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F6ODQyI1hELVpHENmOfEDg0uenniqaICQVPvdDKKLzE=";
+    hash = "sha256-cNUokMWbvwPIq6gdnwkPwMWBlqo3HjqLeSyPyEDYrts=";
   };
 
+  postPatch = ''
+    patchShebangs po/build.sh
+  '';
+
   nativeBuildInputs = [
+    desktop-file-utils
+    gobject-introspection
+    libxml2 # xmllint
     meson
     ninja
     pkg-config
-    gobject-introspection
     wrapGAppsHook4
-    desktop-file-utils
   ];
 
   buildInputs = [


### PR DESCRIPTION
Changelog https://codeberg.org/censor/Censor/releases/tag/v0.10.1

Fixes https://github.com/NixOS/nixpkgs/issues/553973

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
