### PR TITLE
percona-toolkit 3.7.0 -> 3.7.1

### DIFF
--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -12,13 +12,13 @@
 }:
 
 let
-  version = "3.7.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "percona";
     repo = "percona-toolkit";
     rev = "v${version}";
-    sha256 = "sha256-NpLUHIdGnuNJmSYBYErU7yzFkxKRFQVWJHJqJ2q4U5E=";
+    sha256 = "sha256-bdEc+vaWxEN5jzd1bcScBj1QV7Oz7Xn3XWeW6TvkE/E=";
 
     # needed for build script
     leaveDotGit = true;
@@ -29,7 +29,7 @@ let
       pname = "Percona-Toolkit go-bindings";
       inherit src version;
 
-      vendorHash = "sha256-HAaoVYK6av085zSG0ZRpbmUgEA2UEt7CGWF/834e+z4=";
+      vendorHash = "sha256-+MToOAyY8UiNKWSMR4Mhw5foJPBoturoxWhX84tjfro=";
     }).goModules;
 in
 buildPerlPackage {


### PR DESCRIPTION
Percona Toolkit 3.7.0 has a Perl operator precedence bug which is no longer warning, but fatal.
```
$ pt-online-schema-change --version

Possible precedence problem between ! and string eq at /nix/store/2jkjhqyg3mgkrdgyisymc1mmzknskrz0-perl5.42.0-Percona-Toolkit-3.7.0/bin/pt-online-schema-change line 10616.
```

This is fixed in Percona Toolkit 3.7.1

## Things done

Tested basic functionality of the binary:
```
✗ ./result/bin/pt-query-digest --version
pt-query-digest 3.7.1
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
