### PR TITLE
coq: fix compilation following https://github.com/rocq-prover/rocq/pull/22327

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -307,7 +307,10 @@ let
       + ''
         ln -s $out/lib/coq${suffix} $OCAMLFIND_DESTDIR/coq${suffix}
       ''
-      + lib.optionalString (coqAtLeast "8.14") ''
+      + lib.optionalString (coqAtLeast "9.4") ''
+        ln -s $out/lib/rocqide-server $OCAMLFIND_DESTDIR/rocqide-server
+      ''
+      + lib.optionalString (coqAtLeast "8.14" && !coqAtLeast "9.4") ''
         ln -s $out/lib/coqide-server $OCAMLFIND_DESTDIR/coqide-server
       ''
       + lib.optionalString buildIde ''
@@ -340,6 +343,7 @@ let
     strictDeps = true;
     __structuredAttrs = true;
   };
+  coqrocqide-server = if coqAtLeast "9.4" then "rocqide-server" else "coqide-server";
 in
 if coqAtLeast "8.21" then
   self.overrideAttrs (o: {
@@ -352,12 +356,12 @@ if coqAtLeast "8.21" then
     ];
     buildPhase = ''
       runHook preBuild
-      dune build -p coq-core,coqide-server${lib.optionalString buildIde ",rocqide"} -j $NIX_BUILD_CORES
+      dune build -p coq-core,${coqrocqide-server}${lib.optionalString buildIde ",rocqide"} -j $NIX_BUILD_CORES
       runHook postBuild
     '';
     installPhase = ''
       runHook preInstall
-      dune install --prefix $out coq-core coqide-server${lib.optionalString buildIde " rocqide"}
+      dune install --prefix $out coq-core ${coqrocqide-server}${lib.optionalString buildIde " rocqide"}
       # coq and rocq are now in different directories, which sometimes confuses coq_makefile
       # which expects both in the same /nix/store/.../bin/ directory
       # adding symlinks to content it


### PR DESCRIPTION
coq: fix compilation following https://github.com/rocq-prover/rocq/pull/22327

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
