### PR TITLE
linkding: 1.46.1 -> 1.46.2

### DIFF
--- a/pkgs/by-name/li/linkding/package.nix
+++ b/pkgs/by-name/li/linkding/package.nix
@@ -14,7 +14,7 @@
   uwsgi,
 }:
 let
-  version = "1.46.1";
+  version = "1.46.2";
 
   python = python3.override {
     self = python;
@@ -77,7 +77,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     owner = "sissbruecker";
     repo = "linkding";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1tXWbcG4lKquI02nYw+CVKJWyCWbD3m5/ieRgbhtQnE=";
+    hash = "sha256-d/APoPxlrsvBqWGOSYLzLPfCgZd4PRPNh/zxcFnvCRA=";
   };
 
   __structuredAttrs = true;


### PR DESCRIPTION
Changelog: https://github.com/sissbruecker/linkding/releases/tag/v1.46.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
