### PR TITLE
ginkgo: 2.28.1 -> 2.32.1

### DIFF
--- a/pkgs/by-name/gi/ginkgo/package.nix
+++ b/pkgs/by-name/gi/ginkgo/package.nix
@@ -2,31 +2,22 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  fetchpatch,
   testers,
   ginkgo,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "ginkgo";
-  version = "2.28.1";
+  version = "2.32.1";
 
   src = fetchFromGitHub {
     owner = "onsi";
     repo = "ginkgo";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-mevZN35RUpaPmAYw3lfmzvdT2H+yucD8g3/bX9Rl00s=";
+    sha256 = "sha256-mXfY+txLg8z+DxPfB8D0SqZMTXNJrDBhPcSVTirkgxg=";
   };
-  vendorHash = "sha256-I3n1FPINb/nhi4QUzRFEspn7REN1dQEPg8Bhb3PemQU=";
+  vendorHash = "sha256-lj8b9f5q9hbPML7uLca74lTCadNOCtGIDmvP+CUwJx4=";
 
-  patches = [
-    # Add ArtifactDir() to support Go 1.26 testing.TB interface
-    # https://github.com/onsi/ginkgo/pull/1648
-    (fetchpatch {
-      url = "https://github.com/onsi/ginkgo/pull/1648.patch";
-      hash = "sha256-O8YWPAvf0ukPWSTm6+YKnV/L+qSL0RCoBswmiQVXOKI=";
-    })
-  ];
   # integration tests expect more file changes
   # types tests are missing CodeLocation
   excludedPackages = [


### PR DESCRIPTION
Updates ginkgo 2.28.1 → 2.32.1.

Also drops the Go 1.26 `ArtifactDir()` compatibility patch: it backported [onsi/ginkgo#1648](https://github.com/onsi/ginkgo/pull/1648), which was merged upstream and ships in 2.28.2 onwards, so the patch no longer applies on top of the new source.

Changelog: https://github.com/onsi/ginkgo/blob/master/CHANGELOG.md

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-darwin
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
  - [x] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) (`passthru.tests.version`)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Automation/AI disclosure

This change was prepared with the assistance of Claude Code (model `claude-opus-4-8`): version bump, hash updates, and identifying the now-redundant patch. All edits were reviewed and verified by me (`nix build` + `nixpkgs-review rev HEAD`, both passing on aarch64-darwin).
