### PR TITLE
luaPackages.lua-resty-core: 0.1.32 -> 0.1.34rc3 (fix nixosTests.nginx-lua)

### DIFF
--- a/pkgs/development/interpreters/luajit/openresty.nix
+++ b/pkgs/development/interpreters/luajit/openresty.nix
@@ -6,13 +6,13 @@
 }:
 
 callPackage ./default.nix rec {
-  version = "2.1-20251030";
+  version = "2.1-20260724";
 
   src = fetchFromGitHub {
     owner = "openresty";
     repo = "luajit2";
     rev = "v${version}";
-    hash = "sha256-SICmM+/dvp/36UAWAH0l7D938iFDimnoKBOjlOodrCY=";
+    hash = "sha256-cvy9FgHWFuacCFl7/conLwNuMgaol1LnIUiqcnXy9H8=";
   };
 
   extraMeta = {

--- a/pkgs/servers/http/nginx/modules/lua/package.nix
+++ b/pkgs/servers/http/nginx/modules/lua/package.nix
@@ -7,6 +7,8 @@
 
 mkNginxPlugin (finalAttrs: {
   pname = "lua";
+  # The version needs to fit to lua-resty-core.
+  # Adapt both.
   version = "0.10.31";
 
   src = fetchFromGitHub {

--- a/pkgs/servers/http/nginx/modules/lua/package.nix
+++ b/pkgs/servers/http/nginx/modules/lua/package.nix
@@ -3,6 +3,7 @@
   lib,
   luajit_openresty,
   mkNginxPlugin,
+  nixosTests,
 }:
 
 mkNginxPlugin (finalAttrs: {
@@ -26,6 +27,10 @@ mkNginxPlugin (finalAttrs: {
   '';
 
   allowMemoryWriteExecute = true;
+
+  passthru.tests = {
+    inherit (nixosTests) nginx-lua;
+  };
 
   meta = {
     description = "Embed the Power of Lua";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -165,6 +165,8 @@ rec {
     { fetchFromGitHub }:
     buildLuaPackage rec {
       pname = "lua-resty-core";
+      # The version needs to fit to nginxModules.lua
+      version = "0.1.34rc3";
 
       src = fetchFromGitHub {
         owner = "openresty";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -165,13 +165,12 @@ rec {
     { fetchFromGitHub }:
     buildLuaPackage rec {
       pname = "lua-resty-core";
-      version = "0.1.32";
 
       src = fetchFromGitHub {
         owner = "openresty";
         repo = "lua-resty-core";
         rev = "v${version}";
-        sha256 = "sha256-ba/ahIl8BDfyXIbaN6zVCh3UwY6JbAqqZEpXktOfeYo=";
+        sha256 = "sha256-+rtbaHEqKSvaba+zZwRUnUsdu3Jndi8OVGUtFC55Fts=";
       };
 
       propagatedBuildInputs = [ lua-resty-lrucache ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes `nixosTests.nginx-lua` which was broken by #548641.

Strictly [luaPackages.lua-resty-core: 0.1.32 -> 0.1.34rc3](https://github.com/NixOS/nixpkgs/commit/69a5f0cfd1f92578d7e3d9257724902cfe19e49e) is the only commit to actually fix the test

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
