### PR TITLE
martin: 1.13.0 → 1.14.0

### DIFF
--- a/pkgs/by-name/ma/martin/package.nix
+++ b/pkgs/by-name/ma/martin/package.nix
@@ -47,18 +47,18 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "martin";
-  version = "1.13.0";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "maplibre";
     repo = "martin";
     tag = "martin-v${finalAttrs.version}";
-    hash = "sha256-rtlq6XdLvb3T82wKgrjr8m1HGDgqGLy4L/NMzTrJYi0=";
+    hash = "sha256-XvGBLs6jIvVWtfjiwu7GHpflnAW5D3j6FjzP+AIpsvQ=";
   };
 
   patches = [ ./dont-build-webui.patch ];
 
-  cargoHash = "sha256-8eGbmZx6mt8CKsa90gLnrSxEQnd19jQFSM+qED79+JY=";
+  cargoHash = "sha256-2xAdqSZmbsTpO9lfDuyk2v6mtTwxSgtwhx3R8VMQ3lA=";
 
   webui = buildNpmPackage {
     pname = "martin-ui";
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ln -sf ${finalAttrs.src}/demo/frontend/public/favicon.ico public/_/assets/favicon.ico
     '';
 
-    npmDepsHash = "sha256-CYJOL06jCpbZ5ewiuwkoBUj0umwQMgIFqFBlvazlj3c=";
+    npmDepsHash = "sha256-cK/glIbXuGsXuCbGSMqVGh8vkIOPNbm6BoDMTc/TSWg=";
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
https://github.com/maplibre/martin/releases#release-martin-v1.14.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
