### PR TITLE
 python314Packages.dlib: fix build after dlib 20.0.1 bump 

### DIFF
--- a/pkgs/by-name/dl/dlib/package.nix
+++ b/pkgs/by-name/dl/dlib/package.nix
@@ -17,6 +17,7 @@
   avxSupport ? stdenv.hostPlatform.avxSupport,
   cudaSupport ? config.cudaSupport,
   cudaPackages,
+  python3Packages,
 }@inputs:
 (if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv).mkDerivation rec {
   pname = "dlib";
@@ -81,6 +82,9 @@
   );
 
   passthru = {
+    tests = {
+      python-dlib = python3Packages.dlib;
+    };
     inherit
       cudaSupport
       cudaPackages

--- a/pkgs/development/python-modules/dlib/build-cores.patch
+++ b/pkgs/development/python-modules/dlib/build-cores.patch
@@ -1,8 +1,8 @@
 diff --git a/setup.py b/setup.py
-index 219583b..3ca5f88 100644
+index 59b65a62..363c9e56 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -170,23 +170,7 @@ class CMakeBuild(build_ext):
+@@ -217,23 +217,7 @@ def build_extension(self, ext):
          subprocess.check_call(cmake_build, cwd=build_folder)
  
  def num_available_cpu_cores(ram_per_build_process_in_gb):
@@ -13,9 +13,9 @@ index 219583b..3ca5f88 100644
 -    elif 'CMAKE_BUILD_PARALLEL_LEVEL' in os.environ and os.environ['CMAKE_BUILD_PARALLEL_LEVEL'].isnumeric():
 -        return int(os.environ['CMAKE_BUILD_PARALLEL_LEVEL'])
 -    try:
--        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')  
+-        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
 -        mem_gib = mem_bytes/(1024.**3)
--        num_cores = multiprocessing.cpu_count() 
+-        num_cores = multiprocessing.cpu_count()
 -        # make sure we have enough ram for each build process.
 -        mem_cores = int(floor(mem_gib/float(ram_per_build_process_in_gb)+0.5));
 -        # We are limited either by RAM or CPU cores.  So pick the limiting amount
@@ -26,4 +26,4 @@ index 219583b..3ca5f88 100644
 +    return os.getenv("NIX_BUILD_CORES", 1)
  
  
- from setuptools.command.test import test as TestCommand
+ def read_version_from_cmakelists(cmake_file):

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -1,8 +1,9 @@
 {
   buildPythonPackage,
+  cmake,
   dlib,
   pytestCheckHook,
-  more-itertools,
+  setuptools,
 }:
 
 buildPythonPackage.override { inherit (dlib) stdenv; } {
@@ -17,20 +18,13 @@ buildPythonPackage.override { inherit (dlib) stdenv; } {
     meta
     ;
 
-  format = "setuptools";
-
   patches = [ ./build-cores.patch ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-    more-itertools
+  pyproject = true;
+  build-system = [
+    cmake
+    setuptools
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "more-itertools<6.0.0" "more-itertools" \
-      --replace "pytest==3.8" "pytest"
-  '';
 
   # Pass CMake flags through to the build script
   preConfigure = ''
@@ -42,6 +36,10 @@ buildPythonPackage.override { inherit (dlib) stdenv; } {
   '';
 
   dontUseCmakeConfigure = true;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   doCheck =
     !(


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
