### PR TITLE
frizbee: init at 0.1.11

### DIFF
--- a/pkgs/by-name/fr/frizbee/package.nix
+++ b/pkgs/by-name/fr/frizbee/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+
+  installShellFiles,
+
+  buildPackages,
+
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "frizbee";
+  version = "0.1.11";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "stacklok";
+    repo = "frizbee";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QmPzM7xdOuDt1d4jzqrDcHr3oqh8BbmFKBBbovVE/TA=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      # 0000-00-00T00:00:00Z
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-MdRSl4eCFCFzkT1A7AWULUDveWC9hj2kP1JqTUraYe4=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.Version=${finalAttrs.version}"
+    "-X=main.TreeState=clean"
+    "-X=github.com/stacklok/frizbee/internal/cli.CLIVersion=${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    ldflags+=" -X main.Commit=$(cat COMMIT)"
+    ldflags+=" -X main.CommitDate=$(cat SOURCE_DATE_EPOCH)"
+  '';
+
+  # almost all functionality requires the internet
+  doCheck = false;
+
+  postInstall =
+    let
+      cmd = finalAttrs.meta.mainProgram;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/${cmd}"
+        else
+          lib.getExe buildPackages.frizbee;
+    in
+    ''
+      installShellCompletion --cmd ${cmd} \
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Throw a tag at it and it comes back with a checksum";
+    homepage = "https://github.com/stacklok/frizbee";
+    changelog = "https://github.com/stacklok/frizbee/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    mainProgram = "frizbee";
+  };
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
