### PR TITLE
_4ti2: fix cross-compiles and parallel builds

### DIFF
--- a/pkgs/by-name/_4/_4ti2/package.nix
+++ b/pkgs/by-name/_4/_4ti2/package.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/{groebner/script.template.in,zsolve/{graver,hilbert}.template} \
       --replace-fail 'SCRIPT=$(realpath $(which "$0"))' \
                      'SCRIPT=$(realpath $(${lib.getExe which} "$0"))'
+  ''
+  + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # configure.ac tries to compile and execute a specific test file here
+    substituteInPlace configure.ac \
+      --replace-fail "CHECK_TRAPV" ""
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/_4/_4ti2/package.nix
+++ b/pkgs/by-name/_4/_4ti2/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+  enableParallelInstalling = false;
 
   installFlags = [ "install-exec" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I ran into this issue while working on #554108 and realized that #552454 may have broken the aarch64 builds ([see here](https://hydra.nixos.org/build/342283394)).  The actual build goes fine, but the `install-exec` target seems to break when parallelized.  The second commit fixes an issue I ran into when I was trying to test the aarch64 builds.

Waiting on nixpkgs-review-gha to finish.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
