### PR TITLE
python3Packages.pylitterbot: fix tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/pylitterbot/default.nix
+++ b/pkgs/development/python-modules/pylitterbot/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage (finalAttrs: {
   version = "2025.6.4";
   pyproject = true;
 
+  __darwinAllowLocalNetworking = true;
+
   src = fetchFromGitHub {
     owner = "natekspencer";
     repo = "pylitterbot";


### PR DESCRIPTION
Enable the standard Darwin sandbox opt-in for local networking during
`pylitterbot` checks.

This addresses the pre-existing failure documented in
https://github.com/NixOS/nixpkgs/pull/553746#issuecomment-5343990499.
The `pylitterbot` expressions at that PR's base and head are identical.

The `mock_aiointercept` fixture starts aiointercept's real aiohttp
`TestServer`, which binds a loopback socket. The Darwin Nix sandbox denies
that bind unless the derivation opts into local networking, causing 81 tests
to error during fixture setup while the remaining 588 pass.

This change does not disable tests, patch upstream, alter dependencies, or
change package outputs. External network access remains sandboxed.

Validation on aarch64-darwin:

- `nix-build --check --no-out-link -A python313Packages.pylitterbot -A python314Packages.pylitterbot`
  - Python 3.13: 669 passed
  - Python 3.14: 669 passed
- `nixpkgs-review rev HEAD -b master --no-shell --print-result -p python313Packages.pylitterbot -p python314Packages.pylitterbot -p tests.home-assistant-components.litterrobot`
  - built both `pylitterbot` variants successfully
  - the Home Assistant test is Linux-only and was therefore excluded on Darwin; Linux CI remains unchanged
- `nix-shell --run 'treefmt pkgs/development/python-modules/pylitterbot/default.nix'`
- `./ci/nixpkgs-vet.sh master`

The local daemon has `sandbox = false`, so the before/after local runs verify
that all tests remain enabled and passing; the linked Nixpkgs Darwin CI result
provides the sandboxed failure evidence.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
