### PR TITLE
github-runner: fix build reproducibility

### DIFF
--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -39,10 +39,10 @@ buildDotnetModule (finalAttrs: {
     owner = "actions";
     repo = "runner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wzPGtNdKszDT8VMgL13xUUp+IhP8UzpXVHkR0T2Ns1A=";
+    hash = "sha256-QbenIEfOvISgXXlsalZa51y0m8ZG5uc/MpLnddpxXLo=";
     leaveDotGit = true;
     postFetch = ''
-      git -C $out rev-parse --short HEAD > $out/.git-revision
+      git -C $out rev-parse HEAD > $out/.git-revision
       rm -rf $out/.git
     '';
   };
@@ -65,8 +65,8 @@ buildDotnetModule (finalAttrs: {
     mkdir -p $TMPDIR/bin
     cat > $TMPDIR/bin/git <<EOF
     #!${runtimeShell}
-    if [ \$# -eq 1 ] && [ "\$1" = "rev-parse" ]; then
-      echo $(cat $TMPDIR/src/.git-revision)
+    if [ \$# -eq 2 ] && [ "\$1" = "rev-parse" ] && [ "\$2" = "HEAD" ]; then
+      cat $TMPDIR/src/.git-revision
       exit 0
     fi
     exec ${buildPackages.git}/bin/git "\$@"
@@ -109,6 +109,9 @@ buildDotnetModule (finalAttrs: {
   };
 
   postConfigure = ''
+    # Avoid deriving assembly metadata from the nondeterministic temporary Git commit.
+    export SourceRevisionId="$(cat .git-revision)"
+
     # Generate src/Runner.Sdk/BuildConstants.cs
     dotnet msbuild \
       -t:GenerateConstant \
@@ -343,7 +346,7 @@ buildDotnetModule (finalAttrs: {
     fi
 
     commit=$($out/bin/Runner.Listener --commit)
-    if [[ "$commit" != "$(git rev-parse HEAD)" ]]; then
+    if [[ "$commit" != "$(cat .git-revision)" ]]; then
       printf 'Unexpected commit %s' "$commit"
       exit 1
     fi


### PR DESCRIPTION
Fixes #358808.
 
The package creates a temporary git repository for tests. Its commit changes between builds, and both `BuildConstants.cs` and the .NET SDK used that commit in the output.
 
Record the full upstream revision and use it for `git rev-parse HEAD` and MSBuild's `SourceRevisionId`. The temporary repository remains available to the tests without affecting the built files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
