### PR TITLE
python3Packages.curl-cffi: 0.15.0 -> 0.16.0; yt-dlp 2026.07.04 -> 2026.07.04-unstable-2026-08-19

### DIFF
--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -32,14 +32,14 @@ python3Packages.buildPythonApplication rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2026.07.04";
+  version = "2026.07.04-unstable-2026-08-19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "yt-dlp";
     repo = "yt-dlp";
-    tag = version;
-    hash = "sha256-+oHcVylLXFJTRR6jXF6IXvgntXJz0tRdtnwTruRPkoc=";
+    rev = "0d1e029d14058ddfb986fdafb07c00869c89105a";
+    hash = "sha256-ZCRvcs+XnA8GyEZCrd3ZLB5UTmVNPlGaMtsjuwHKsqk=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -25,14 +25,14 @@
 }:
 buildPythonPackage rec {
   pname = "curl-cffi";
-  version = "0.15.0";
+  version = "0.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lexiforest";
     repo = "curl_cffi";
     tag = "v${version}";
-    hash = "sha256-I8rQj28IvLD7HWuog46E0dLFgnWSA6oE4Jyn9Flr7mQ=";
+    hash = "sha256-VqfJS6vztIBIkOW+ZrY7JSiuJsxBBqxRbqeQyWR7bTo=";
   };
 
   patches = [ ./use-system-libs.patch ];

--- a/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
+++ b/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
@@ -1,6 +1,6 @@
 --- a/scripts/build.py
 +++ b/scripts/build.py
-@@ -122,27 +122,8 @@ def get_curl_libraries():
+@@ -182,32 +182,9 @@ def get_curl_libraries():
  ffibuilder = FFI()
  system = platform.system()
  root_dir = Path(__file__).parent.parent
@@ -15,24 +15,31 @@
 -            f"-Wl,-force_load,{static_libs[0]}",
 -            "-lc++",
 -        ]
--    elif system in ("Linux", "Android"):
--        cxx_lib = "-lc++" if is_android else "-lstdc++"
+-    elif is_android:
 -        extra_link_args = [
 -            "-Wl,--whole-archive",
 -            static_libs[0],
 -            "-Wl,--no-whole-archive",
--            cxx_lib,
+-            "-lc++",
 -        ]
--
+-    elif system == "Linux":
+-        extra_link_args = [
+-            "-Wl,--whole-archive",
+-            static_libs[0],
+-            "-Wl,--no-whole-archive",
+-        ]
+ 
 -libraries = get_curl_libraries()
 +libraries = ["curl-impersonate"]
  
  ffibuilder.set_source(
      "curl_cffi._wrapper",
-@@ -160,7 +132,7 @@ ffibuilder.set_source(
-     """,
-     library_dirs=[str(libdir)],
+@@ -218,7 +195,7 @@ ffibuilder.set_source(
+     runtime_library_dirs=(
+         [str(libdir)] if is_dynamic and arch["system"] != "Windows" else []
+     ),
 -    libraries=get_curl_libraries(),
 +    libraries=libraries,
      extra_objects=[],  # linked via extra_link_args
      source_extension=".c",
+     include_dirs=[


### PR DESCRIPTION
changelog: https://github.com/lexiforest/curl_cffi/releases/tag/v0.16.0

Updated yt-dlp to the HEAD of master as of now-ish to prevent breakage by curl_cffi which has support in master but not in a released version yet.

follow-up to #554405 which just skips the failing tests

Because there are a lot of rebuilds in linux, I rebased this off of staging and targeted the build there.


Broken currently in master, tests fail, updating package succeeded. That was as far as I investigated.

```
...snip
       >   /nix/store/rcdaipv92nqwipc0k7bv5sr3wki3y5wn-python3.14-curl-cffi-0.15.0/lib/python3.14/site-packages/curl_cffi/requests/session.py:631: CurlCffiWarning: Creating fresh curl handle in different thread.
       >     c = self.curl
       >
       > tests/unittest/test_requests.py::test_verify_false_skips_cainfo
       >   /nix/store/rcdaipv92nqwipc0k7bv5sr3wki3y5wn-python3.14-curl-cffi-0.15.0/lib/python3.14/site-packages/curl_cffi/requests/session.py:515: CurlCffiWarning: Creating fresh curl handle in different thread.
       >     self.curl.close()
       >
       > -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
       > =========================== short test summary info ============================
       > FAILED tests/unittest/test_async_session.py::test_verify - AssertionError: Regex pattern did not match.
       >   Expected regex: 'SSL certificate problem'
       >   Actual message: "Failed to perform, curl: (60) SSL: no alternative certificate subject name matches target ipv4 address '127.0.0.1'. See https://curl.se/libcurl/c/libcurl-errors.html first for more details."
       > FAILED tests/unittest/test_curl.py::test_verify - AssertionError: Regex pattern did not match.
       >   Expected regex: 'SSL certificate problem'
       >   Actual message: "Failed to perform, curl: (60) SSL: no alternative certificate subject name matches target ipv4 address '127.0.0.1'. See https://curl.se/libcurl/c/libcurl-errors.html first for more details."
       > FAILED tests/unittest/test_requests.py::test_verify - AssertionError: Regex pattern did not match.
       >   Expected regex: 'SSL certificate problem'
       >   Actual message: "Failed to perform, curl: (60) SSL: no alternative certificate subject name matches target ipv4 address '127.0.0.1'. See https://curl.se/libcurl/c/libcurl-errors.html first for more details."
       > FAILED tests/unittest/test_requests.py::test_delete_cookies - AssertionError: assert not 'bar'
       >  +  where 'bar' = get('foo')
       >  +    where get = <Cookies[<Cookie foo=bar for 127.0.0.1 />]>.get
       >  +      where <Cookies[<Cookie foo=bar for 127.0.0.1 />]> = <curl_cffi.requests.session.Session object at 0x7ffff0d6c910>.cookies
       > ==== 4 failed, 367 passed, 22 skipped, 24 deselected, 2 warnings in 25.65s =====
       > INFO - 2026-08-19 17:53:14,614 - websockets.server - server - server closed
       > Hello, world!Hello, world!Hello, world!Hello, world!Redirecting...Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!
       For full logs, run:
         nix log /nix/store/n3p7k9k0d8dpqry7zjjvhqd9k52xxfq9-python3.14-curl-cffi-0.15.0.drv
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
