### PR TITLE
extBuilder bootSize param

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -8,6 +8,7 @@
 
 let
   inherit (lib)
+    max
     mkOption
     optionalString
     types
@@ -46,6 +47,16 @@ in
   ];
 
   options.amazonImage = {
+    bootSize = mkOption {
+      type = types.int;
+      default = 256;
+      example = 1024;
+      description = ''
+        Size of the boot partition in MB. With `ec2.zfs.enable` the boot
+        min value is 1000 MB.
+      '';
+    };
+
     contents = mkOption {
       example = literalExpression ''
         [ { source = pkgs.memtest86 + "/memtest.bin";
@@ -107,7 +118,7 @@ in
 
         includeChannel = true;
 
-        bootSize = 1000; # 1G is the minimum EBS volume
+        bootSize = max 1000 cfg.bootSize; # 1G is the minimum EBS volume
 
         rootSize = config.virtualisation.diskSize;
         rootPoolProperties = {
@@ -163,6 +174,7 @@ in
 
         fsType = "ext4";
         partitionTableType = if config.ec2.efi then "efi" else "legacy+gpt";
+        bootSize = "${toString cfg.bootSize}M";
 
         inherit (config.virtualisation) diskSize;
 

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -25,6 +25,7 @@ let
         ../modules/profiles/qemu-guest.nix
         {
           amazonImage.format = "qcow2";
+          amazonImage.bootSize = 512;
 
           # In a NixOS test the serial console is occupied by the "backdoor"
           # (see testing/test-instrumentation.nix) and is incompatible with
@@ -296,6 +297,14 @@ in
 
           with subtest("Basic EC2 functionality"):
               machine.succeed("findmnt / -o SIZE -n | grep -E '[0-9]+G'")
+
+          with subtest("Boot partition honors amazonImage.bootSize"):
+              if ${if imageCfg.ec2.efi then "True" else "False"}:
+                  esp_bytes = int(machine.succeed("blockdev --getsize64 /dev/vda1").strip())
+                  mib = 1024 * 1024
+                  # parted may round the end upto the next alignment boundary,
+                  # so allow a small margin of error.
+                  assert (512 - 8) * mib <= esp_bytes <= 513 * mib, f"unexpected ESP size: {esp_bytes}"
 
           with subtest("Decompression of gzip-compressed user-data"):
               import gzip as gzip_mod

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -20,12 +20,12 @@ let
         {
           # Hack to make the partition resizing work in QEMU.
           boot.initrd.services.udev.rules = ''
-            KERNEL==vda, SYMLINK+=xvda
-            KERNEL==vda1, SYMLINK+=xvda1
+            KERNEL=="vda", SYMLINK+="xvda"
+            KERNEL=="vda1", SYMLINK+="xvda1"
           '';
           services.udev.extraRules = ''
-            KERNEL==vda, SYMLINK+=xvda
-            KERNEL==vda1, SYMLINK+=xvda1
+            KERNEL=="vda", SYMLINK+="xvda"
+            KERNEL=="vda1", SYMLINK+="xvda1"
           '';
 
           amazonImage.format = "qcow2";


### PR DESCRIPTION
The non-ZFS Amazon image hardcodes 256M default for the boot partition. On EFI images the ESP holds kernels and initrds, so a few NixOS generations spanning distinct kernels overflow 256M, after which bootloader installation fails on long-lived instances.

This PR adds `amazonImage.bootSize` (int, MB, default 256 — the resulting image is unchanged unless the option is set), mirroring the existing `virtualisation.azureImage.bootSize`. The ZFS variant keeps its 1000 MB floor.

Also included:
- `nixos/tests/ec2`: quote udev rule values.  `udevadm verify` rejects the unquoted pairs, failing the image build for both ec2 tests (separate commit, standalone fix).
- `nixos/tests/ec2-image`: build the test image with a non-default `bootSize = 512` and assert the resulting ESP size.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
