### PR TITLE
systemd: fix some tests

### DIFF
--- a/nixos/tests/systemd-coredump.nix
+++ b/nixos/tests/systemd-coredump.nix
@@ -4,15 +4,6 @@ let
 
   crasher = pkgs.writeCBin "crasher" "int main;";
 
-  commonConfig = {
-    systemd.services.crasher.serviceConfig = {
-      ExecStart = "${crasher}/bin/crasher";
-      StateDirectory = "crasher";
-      WorkingDirectory = "%S/crasher";
-      Restart = "no";
-    };
-  };
-
 in
 
 {
@@ -21,40 +12,33 @@ in
     maintainers = [ ];
   };
 
-  nodes.machine1 =
-    { pkgs, lib, ... }:
-    {
-      imports = [ commonConfig ];
-      systemd.coredump.settings.Coredump = {
+  nodes.machine = {
+    systemd = {
+      services.crasher.serviceConfig = {
+        ExecStart = "${crasher}/bin/crasher";
+        StateDirectory = "crasher";
+        WorkingDirectory = "%S/crasher";
+        Restart = "no";
+      };
+
+      coredump.settings.Coredump = {
         Storage = "journal";
         ProcessSizeMax = "0";
       };
     };
-  nodes.machine2 =
-    { pkgs, lib, ... }:
-    {
-      imports = [ commonConfig ];
-      systemd.coredump.enable = false;
-      systemd.package = pkgs.systemd.override {
-        withCoredump = false;
-      };
-    };
+  };
 
   testScript = ''
     with subtest("systemd-coredump enabled"):
-      machine1.wait_for_unit("multi-user.target")
-      machine1.wait_for_unit("systemd-coredump.socket")
-      machine1.systemctl("start crasher");
-      machine1.wait_until_succeeds("coredumpctl list | grep crasher", timeout=10)
-      machine1.fail("stat /var/lib/crasher/core*")
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("systemd-coredump.socket")
+      machine.systemctl("start crasher");
+      machine.wait_until_succeeds("coredumpctl list | grep crasher", timeout=10)
+      machine.fail("stat /var/lib/crasher/core*")
 
     with subtest("settings.Coredump renders coredump.conf"):
-      machine1.succeed("grep -F '[Coredump]' /etc/systemd/coredump.conf")
-      machine1.succeed("grep -F 'Storage=journal' /etc/systemd/coredump.conf")
-      machine1.succeed("grep -F 'ProcessSizeMax=0' /etc/systemd/coredump.conf")
-
-    with subtest("systemd-coredump disabled"):
-      machine2.systemctl("start crasher");
-      machine2.wait_until_succeeds("stat /var/lib/crasher/core*", timeout=10)
+      machine.succeed("grep -F '[Coredump]' /etc/systemd/coredump.conf")
+      machine.succeed("grep -F 'Storage=journal' /etc/systemd/coredump.conf")
+      machine.succeed("grep -F 'ProcessSizeMax=0' /etc/systemd/coredump.conf")
   '';
 }

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -828,7 +828,6 @@ stdenv.mkDerivation (finalAttrs: {
           systemd-networkd-bridge
           systemd-networkd-dhcpserver
           systemd-networkd-dhcpserver-static-leases
-          systemd-networkd-ipv6-prefix-delegation
           systemd-networkd-vrf
           systemd-no-tainted
           systemd-nspawn


### PR DESCRIPTION
See the commit messages for more details

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
