### PR TITLE
nixos/test-driver: keep streaming a container journal that is slow to appear

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -1809,15 +1809,16 @@ class NspawnMachine(BaseMachine):
 
         # 1. Wait for the directory to actually be created by the container
         self.log(f"Waiting for journal at {journal_path}...")
-        max_attempts = 10
+        warn_after = 10
         attempts = 0
-        while not journal_path.exists() and attempts < max_attempts:
+        while not journal_path.exists():
+            if proc.poll() is not None:
+                self.log(f"Error: Journal directory {journal_path} never appeared.")
+                return
             time.sleep(1)
             attempts += 1
-
-        if not journal_path.exists():
-            self.log(f"Error: Journal directory {journal_path} never appeared.")
-            return
+            if attempts == warn_after:
+                self.log(f"Still waiting for journal at {journal_path}...")
 
         # 2. Start the journalctl process
         # Using a loop here handles cases where journalctl might exit unexpectedly


### PR DESCRIPTION
Poll for nspawn containers' journal for as long as needed rather than giving up
after ten seconds, ensuring we can still get output on slower nodes.

Before this change, resource-constrained environments or node parallism could
make for a situation where it gave up before they loaded, preventing output
for the rest of the run.

Assisted-by: Claude:claude-opus-5

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] `nix-build -A nixos-test-driver` (`ty`, `ruff check` and `ruff format --check` all pass)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
