### PR TITLE
github-copilot-app: init at 1.1.11

### DIFF
--- a/pkgs/by-name/gi/github-copilot-app/package.nix
+++ b/pkgs/by-name/gi/github-copilot-app/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  undmg,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  alsa-lib,
+  gtk3,
+  pango,
+  harfbuzz,
+  gdk-pixbuf,
+  cairo,
+  glib,
+  dbus,
+  webkitgtk_4_1,
+  atk,
+  libsoup_3,
+  openssl_3,
+  libayatana-appindicator,
+}:
+
+let
+  pname = "github-copilot-app";
+  version = "1.1.11";
+
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-linux-x64.deb";
+      hash = "sha256-BmHuJg4fIsPp52LZ9F+9esvSNsAd9bjF4GEtfzgG7Dg=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-linux-arm64.deb";
+      hash = "sha256-AHUvg7aur4/eCo1Ewne7QWpEFsoZG7FcHPcxtbcOnyY=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-darwin-arm64.dmg";
+      hash = "sha256-gXJp65Kf/D4m+G3BSUDJwPkdM1dx8C+vTveCUtWkUX8=";
+    };
+  };
+
+  src =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      dpkg
+      autoPatchelfHook
+      wrapGAppsHook3
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      undmg
+    ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    gtk3
+    pango
+    harfbuzz
+    gdk-pixbuf
+    cairo
+    glib
+    dbus
+    webkitgtk_4_1
+    atk
+    libsoup_3
+    openssl_3
+    libayatana-appindicator
+    stdenv.cc.cc.lib
+  ];
+
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
+    libayatana-appindicator
+  ];
+
+  dontStrip = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  unpackCmd = if stdenv.hostPlatform.isDarwin then "undmg $curSrc" else "dpkg-deb -x $curSrc .";
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + (
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        mkdir -p $out/Applications
+        cp -r *.app $out/Applications/
+
+        mkdir -p $out/bin
+        ln -s "$out/Applications/"*.app/Contents/MacOS/* $out/bin/github-copilot-app
+      ''
+    else
+      ''
+        mkdir -p $out/bin $out/share $out/lib
+
+        cp -r usr/share/* $out/share/
+        cp -r usr/lib/* $out/lib/
+
+        # Rename the main executable from github to github-copilot-app to avoid conflicts
+        mv usr/bin/github $out/bin/github-copilot-app
+        cp usr/bin/git-credential-copilot $out/bin/
+
+        # Update desktop file to use the new executable name
+        substituteInPlace $out/share/applications/*.desktop \
+          --replace-fail "Exec=github" "Exec=github-copilot-app"
+      ''
+  )
+  + ''
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit sources;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Agent-native desktop experience for GitHub repositories";
+    homepage = "https://github.com/github/app";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "github-copilot-app";
+    platforms = lib.attrNames sources;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/gi/github-copilot-app/update.sh
+++ b/pkgs/by-name/gi/github-copilot-app/update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq perl nix
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+PACKAGE_NIX="$ROOT/package.nix"
+
+latest_tag=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/github/app/releases/latest" | jq -r .tag_name)
+latest_version=${latest_tag#v}
+
+current_version=$(grep -oP 'version = "\K[^"]+' "$PACKAGE_NIX")
+
+if [[ "$current_version" == "$latest_version" ]]; then
+    echo "Already up-to-date: $latest_version"
+    exit 0
+fi
+
+sed -i "s/version = \"$current_version\"/version = \"$latest_version\"/" "$PACKAGE_NIX"
+
+for arch in x86_64-linux aarch64-linux aarch64-darwin; do
+  case $arch in
+    x86_64-linux)
+      url="https://github.com/github/app/releases/download/v${latest_version}/GitHub-Copilot-linux-x64.deb"
+      ;;
+    aarch64-linux)
+      url="https://github.com/github/app/releases/download/v${latest_version}/GitHub-Copilot-linux-arm64.deb"
+      ;;
+    aarch64-darwin)
+      url="https://github.com/github/app/releases/download/v${latest_version}/GitHub-Copilot-darwin-arm64.dmg"
+      ;;
+  esac
+
+  raw_hash=$(nix-prefetch-url "$url")
+  new_hash=$(nix-hash --to-sri --type sha256 "$raw_hash")
+  perl -0777 -pi -e "s|($arch = fetchurl \\{\\s*url = \"[^\"]+\";\\s*hash = \")[^\"]+(\";)|\${1}${new_hash}\${2}|g" "$PACKAGE_NIX"
+done


### PR DESCRIPTION
This PR introduces [GitHub Copilot app](https://christitus.com/github-copilot-on-linux/) an agent-native desktop experience for finding, running, steering, and landing software work across your GitHub repositories.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
