### PR TITLE
nixos/testing: skip `systemd-machine-id-commit` on nspawn containers

### DIFF
--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -112,6 +112,11 @@ let
         # is a cleaner fix than explicitly adding 'gzip' to systemPackages.
         documentation.info.enable = lib.mkDefault false;
 
+        systemd.suppressedSystemUnits = [
+          # containers are discarded afterwards, so they need no persistent id
+          "systemd-machine-id-commit.service"
+        ];
+
         # Gross, insecure hack to make login work. See above.
         security.pam.services.login = {
           text = ''


### PR DESCRIPTION
Disable test nspawn containers' `systemd-machine-id-commit.service`, which turns a transient machine id into a persistent one, and is run on container boot and on `nixos-rebuild switch`. Nspawn test containers are deleted when the build ends, so the result is never read.

## Why it can be slow: an unnamespaced `sync`

[`machine_id_commit`](https://github.com/systemd/systemd/blob/v261.1/src/shared/machine-id-setup.c#L298) adds an overhead proportionate to load on the _host_ system, so gets much worse on CI nodes running many such jobs. This is because it runs `sync()`, which writes back the *build host's* page cache. A container shares the host's kernel, and `sync()` is not namespaced. Measured directly, running `sync` inside `unshare --mount --uts --ipc --pid --user` on a host holding dirty pages:

| arm | elapsed | host `Dirty` before -> after |
|---|---|---|
| namespaced `sync` | 0.61 s, 0.89 s, 1.42 s, 3.60 s | 50-725 MB -> 1-22 MB |
| same namespaces, `true` (control) | 0.01-0.07 s | unchanged |

## What was measured

A/B on the same tree, `testers.runNixOSTest` with two plain containers on `x86_64-linux`. The only difference is that the `before` arm puts the unit back with `containerDefaults.systemd.suppressedSystemUnits = lib.mkForce [ ]`; the two arms evaluate to `[ ]` and `[ "systemd-machine-id-commit.service" ]` respectively, and in the `after` arm the container reports `LoadState=not-found`.

On an idle host there is no saving: Five interleaved `before`/`after` reps on the CI host itself (96 cores, 220 GB), while it happened to be quiet -- load average 1.4-2.2, under 1 MB of dirty pages throughout:

| | `before` | `after` |
|---|---|---|
| build wall time | 24.59-25.15 s (mean 24.86) | 24.40-25.03 s (mean 24.72) |
| boot to `multi-user.target` | 3.66-4.17 s (mean 4.07) | 3.67-4.17 s (mean 4.02) |
| `Startup finished` | 2.989-3.076 s (mean 3.044) | 2.985-3.089 s (mean 3.040) |
| `systemd-machine-id-commit` | 69-109 ms, never the top blame entry | absent |

**On a host under write load, the unit becomes the slowest job in the container's boot.** One completed pair on the 14 GB workstation with three continuous writers, two containers per arm:

| | `before` | `after` |
|---|---|---|
| top `systemd-analyze blame` entry | **3.952 s / 6.534 s** `systemd-machine-id-commit` | 1.858 s / 1.610 s `systemd-logind` |
| `Startup finished` | 4.914 s / 7.832 s | 5.380 s / 4.359 s |
| boot to `multi-user.target` | 6.17 s / 9.23 s | 6.66 s / 5.15 s |

**On a real CI host the tail is much worse.** These are the container boots I still have job logs for, timed from each container's own monotonic clock:

| job log | node | outcome | unit duration |
|---|---|---|---|
| `octodns` (main) | node / deployer | timed out | 90.06 / 90.08 s to `SIGTERM`; **155.01 / 176.47 s** total |
| `octodns` (main, later) | node / deployer | timed out, survived `SIGKILL` | 90.11 / 90.23 s to `SIGTERM`; **294.16 / 277.03 s** total |
| `octodns` (main, earlier) | node / deployer | completed | 4.52 / 1.77 s |
| `octodns` (PR) | node / deployer | completed | 19.04 / 14.79 s |
| `octodns` (PR) | node / deployer | completed | 7.11 / 4.70 s |
| terraform/incus | `incushost` (**VM**) | completed | **0.09 s** |

The first `wait_for_unit("multi-user.target")` in those same runs took 103.72, 118.21, 145.23, 479.33 and 627.88 s. That covers the entire boot, not just this unit, so I am not claiming all of it: what this change is answerable for is the unit's own duration in the table above, plus the `--notify-ready=yes` ordering that puts it ahead of the driver's first command rather than beside it.

Assisted-by: Claude:claude-opus-5

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] `nixosTests.nixos-test-driver.containers` evaluates; a two-container `runNixOSTest` boots with the unit inactive and `multi-user.target` reached as before (that test itself needs the `devnet` feature, which my workstation lacks).
  - [x] The A/B above, on two hosts.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
