### PR TITLE
libsignal-jni: move env variables into env

### DIFF
--- a/pkgs/by-name/si/signal-cli/libsignal-jni.nix
+++ b/pkgs/by-name/si/signal-cli/libsignal-jni.nix
@@ -34,16 +34,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gitMinimal # needed by boring-sys build script
   ];
 
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  env = {
+    LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
-  # bindgen needs to find C headers (stdlib.h etc.)
-  # On Linux, libc headers are in a separate .dev output; on Darwin they
-  # come from the SDK and libclang already knows where to find them.
-  BINDGEN_EXTRA_CLANG_ARGS =
-    if stdenv.hostPlatform.isDarwin then
-      "-isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.versions.major llvmPackages.libclang.version}/include"
-    else
-      "-isystem ${stdenv.cc.libc.dev}/include -isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.versions.major llvmPackages.libclang.version}/include";
+    # bindgen needs to find C headers (stdlib.h etc.)
+    # On Linux, libc headers are in a separate .dev output; on Darwin they
+    # come from the SDK and libclang already knows where to find them.
+    BINDGEN_EXTRA_CLANG_ARGS =
+      if stdenv.hostPlatform.isDarwin then
+        "-isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.versions.major llvmPackages.libclang.version}/include"
+      else
+        "-isystem ${stdenv.cc.libc.dev}/include -isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.versions.major llvmPackages.libclang.version}/include";
+
+    RUSTFLAGS = "--cfg aes_armv8 --cfg tokio_unstable";
+    BORING_BSSL_SOURCE_EXTERNAL = "0";
+  };
 
   buildAndTestSubdir = "rust/bridge/jni";
 
@@ -51,12 +56,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "-p"
     "libsignal-jni"
   ];
-
-  RUSTFLAGS = "--cfg aes_armv8 --cfg tokio_unstable";
-
-  env = {
-    BORING_BSSL_SOURCE_EXTERNAL = "0";
-  };
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
This is not a top-level packages so I missed it for a long time, but I just noticed them...

Should cause zero rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
