### PR TITLE
extism-js: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/by-name/ex/extism-js-core/package.nix
+++ b/pkgs/by-name/ex/extism-js-core/package.nix
@@ -6,23 +6,22 @@
   lld,
   nodejs,
   npmHooks,
-  runCommand,
   rustPlatform,
   stdenv,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "extism-js-core";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "extism";
     repo = "js-pdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CLyH0gDtw988cTcw4B86/kejfbYWMXEVG9Y6PKAZazE=";
+    hash = "sha256-U2C82By8JXUrtaAceZ5xr5Fb9Ltipyvd/sXG+Dsi8F8=";
   };
 
-  cargoHash = "sha256-9lFX+Q4318ClVIRT4/uCesyNYwU9H2vV+fD3553M2Dc=";
+  cargoHash = "sha256-BBhHTzG0FU4AOuUz7yjp4bpELr1vEVdwT+vyyuITagE=";
 
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
@@ -35,7 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # https://github.com/extism/js-pdk/pull/154
   postPatch = ''
     substituteInPlace Cargo.toml \
-      --replace-fail '1.5.1' '${finalAttrs.version}'
+      --replace-fail '1.6.1' '${finalAttrs.version}'
   '';
 
   preBuild = ''
@@ -57,22 +56,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rustPlatform.bindgenHook
   ];
 
-  # io-extras v0.18.4 uses #![feature]
-  env.RUSTC_BOOTSTRAP = 1;
-
   env.RUSTFLAGS = "-C linker=wasm-ld";
 
-  # rquickjs-sys expects the dir structure from wasi-sdk
-  # https://github.com/DelSkayn/rquickjs/blob/v0.11.0/sys/build.rs#L216-L230
-  # TODO: revisit when https://github.com/DelSkayn/rquickjs/pull/648 is released and extism updated
-  env.WASI_SDK = runCommand "wasi-sdk" { } ''
-    mkdir -p $out/bin
-    ln -s ${lib.getExe' stdenv.cc "wasm32-unknown-wasip1-clang"} $out/bin/clang
-    ln -s ${lib.getExe' stdenv.cc "wasm32-unknown-wasip1-ar"} $out/bin/ar
-    ln -s ${stdenv.cc}/nix-support $out/nix-support
-    mkdir -p $out/share
-    ln -s ${stdenv.cc.libc} $out/share/wasi-sysroot
-  '';
+  # stdenv handles setting up the appropriate env variables
+  env.RQUICKJS_SYS_NO_WASI_SDK = 1;
 
   cargoBuildFlags = [ "--package=js-pdk-core" ];
 

--- a/pkgs/by-name/ex/extism-js/package.nix
+++ b/pkgs/by-name/ex/extism-js/package.nix
@@ -33,9 +33,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zstd
   ];
 
-  # fs-set-times v0.20.3 uses #![feature]
-  env.RUSTC_BOOTSTRAP = 1;
-
   env.EXTISM_ENGINE_PATH = "${pkgsCross.wasm32-wasip1.extism-js-core}/bin/js_pdk_core.wasm";
   env.ZSTD_SYS_USE_PKG_CONFIG = true;
 


### PR DESCRIPTION
https://github.com/extism/js-pdk/releases/tag/v1.7.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
