### PR TITLE
packagekit: replace systemd dependency with systemdLibs

### DIFF
--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    (if enableSystemd then "-Dsystemd=true" else "-Dsystem=false")
+    (lib.mesonBool "systemd" enableSystemd)
     # often fails to build with nix updates
     # and remounts /nix/store as rw
     # https://github.com/NixOS/nixpkgs/issues/177946

--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -25,8 +25,8 @@
   enableCommandNotFound ? false,
   enableBashCompletion ? false,
   bash-completion ? null,
-  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
-  systemd,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemdLibs,
   nixosTests,
 }:
 
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     sqlite
     boost
   ]
-  ++ lib.optional enableSystemd systemd
+  ++ lib.optional enableSystemd systemdLibs
   ++ lib.optional enableBashCompletion bash-completion;
   nativeBuildInputs = [
     gobject-introspection


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[just](https://github.com/NixOS/nixpkgs/pull/554453) [some](https://github.com/NixOS/nixpkgs/pull/554457) [simple](https://github.com/NixOS/nixpkgs/pull/554458) [cleanup](https://github.com/NixOS/nixpkgs/pull/554459) [PRs](https://github.com/NixOS/nixpkgs/pull/554460) [for](https://github.com/NixOS/nixpkgs/pull/554463) [nixpkgs](https://github.com/NixOS/nixpkgs/pull/554456)




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
