### PR TITLE
rmw: 0.9.5 -> 0.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -81,6 +81,11 @@
     githubId = 54892055;
     name = "David mp";
   };
+  _0k4r1m = {
+    name = "0k4r1m";
+    github = "0k4r1m";
+    githubId = 318737393;
+  };
   _0nyr = {
     email = "onyr.maintainer@gmail.com";
     github = "0nyr";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -82,6 +82,7 @@
     name = "David mp";
   };
   _0k4r1m = {
+    matrix = "@darkdesync:matrix.org";
     name = "0k4r1m";
     github = "0k4r1m";
     githubId = 318737393;

--- a/pkgs/by-name/rm/rmw/package.nix
+++ b/pkgs/by-name/rm/rmw/package.nix
@@ -8,17 +8,22 @@
   canfigger,
   ncurses,
   gettext,
+  glib,
+  linuxHeaders,
 }:
 
+let
+  version = "0.10.0";
+in
 stdenv.mkDerivation (finalAttrs: {
+  inherit version;
   pname = "rmw";
-  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "theimpossibleastronaut";
     repo = "rmw";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-JWNLSilZjmcAKfNe4ydVjYkcxKxf6Wby0GTV7lvFnW4=";
+    tag = "v${version}";
+    hash = "sha256-NT6P0/pPYyAlno+w0DZoZUepm8cbwlc3+Ety15CKV+g=";
     fetchSubmodules = true;
   };
 
@@ -26,20 +31,24 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     meson
     ninja
-  ];
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux linuxHeaders;
 
   buildInputs = [
     canfigger
     ncurses
+    glib
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin gettext;
 
   meta = {
-    description = "Trashcan/ recycle bin utility for the command line";
+    description = "trashcan/recycle bin utility for the command line";
     homepage = "https://github.com/theimpossibleastronaut/rmw";
-    changelog = "https://github.com/theimpossibleastronaut/rmw/blob/${finalAttrs.src.rev}/ChangeLog";
+    changelog = "https://github.com/theimpossibleastronaut/rmw/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      _0k4r1m
+    ];
     mainProgram = "rmw";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/theimpossibleastronaut/rmw/releases/tag/v0.10.0

Tested with nixpkgs-review on x86_64-linux.

1 package built successfully:
- rmw 0.9.5 → 0.10.0

No build failures.

Also add myself to the maintainers list

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
