### PR TITLE
ib-async: init at 2.1.0, aeventkit: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/aeventkit/default.nix
+++ b/pkgs/development/python-modules/aeventkit/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  numpy,
+  poetry-core,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aeventkit";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ib-api-reloaded";
+    repo = "eventkit";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-0u7yeW2C27XqMPakcKZdXwg/F50vyLb6LX/JDLOkqHg=";
+  };
+
+  build-system = [ poetry-core ];
+  dependencies = [
+    numpy
+  ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Python sync/async framework for Interactive Brokers API";
+    maintainers = [ lib.maintainers.supermarin ];
+    homepage = "https://github.com/ib-api-reloaded/eventkit";
+    license = lib.licenses.bsd2;
+  };
+})

--- a/pkgs/development/python-modules/ib-async/default.nix
+++ b/pkgs/development/python-modules/ib-async/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  aeventkit,
+  nest-asyncio,
+  pandas,
+  poetry-core,
+  pytestCheckHook,
+  tzdata,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ib_async";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ib-api-reloaded";
+    repo = "ib_async";
+    rev = "ab629f34c1823ea4c1542f32f07377208a86bdfd";
+    sha256 = "sha256-B4XC122EWjs9+nc8dgk9VanQyN0L8jR/cV2Bp74yPE4=";
+  };
+
+  build-system = [ poetry-core ];
+  dependencies = [
+    aeventkit
+    nest-asyncio
+    tzdata
+  ];
+  pythonRelaxDeps = [ "tzdata" ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pandas
+  ];
+  meta = {
+    description = "Python sync/async framework for Interactive Brokers API";
+    homepage = "https://github.com/ib-api-reloaded/ib_async";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.supermarin ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -132,6 +132,8 @@ self: super: with self; {
 
   aetcd = callPackage ../development/python-modules/aetcd { };
 
+  aeventkit = callPackage ../development/python-modules/aeventkit { };
+
   afdko = callPackage ../development/python-modules/afdko { };
 
   affine = callPackage ../development/python-modules/affine { };
@@ -8133,6 +8135,8 @@ self: super: with self; {
   iapws = callPackage ../development/python-modules/iapws { };
 
   iaqualink = callPackage ../development/python-modules/iaqualink { };
+
+  ib_async = callPackage ../development/python-modules/ib-async { };
 
   ibeacon-ble = callPackage ../development/python-modules/ibeacon-ble { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Add ib_async Python 3 package.
It depends on aeventkit, so I had to add that one together as well.

NOTE: tzdata 2025.3 is temporarily in until [ib_async removes a hard pin on tzdata](https://github.com/ib-api-reloaded/ib_async/issues/209).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
