### PR TITLE
python3Packages.coinmetrics-api-client: 2026.2.9.18 -> 2026.8.13.18

### DIFF
--- a/pkgs/development/python-modules/coinmetrics-api-client/default.nix
+++ b/pkgs/development/python-modules/coinmetrics-api-client/default.nix
@@ -2,10 +2,13 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  openapi-spec-validator,
   orjson,
   pandas,
   poetry-core,
   polars,
+  prance,
+  pyarrow,
   pytest-mock,
   pytestCheckHook,
   python-dateutil,
@@ -18,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "coinmetrics-api-client";
-  version = "2026.2.9.18";
+  version = "2026.8.13.18";
   pyproject = true;
 
   __darwinAllowLocalNetworking = true;
@@ -26,20 +29,29 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit version;
     pname = "coinmetrics_api_client";
-    hash = "sha256-5R/Z/FItszcNAdwHkhzr/HWqQBbXsYf9Hub+HGdBEGo=";
+    hash = "sha256-pvT+teZY5G2zkpHU+tRxjv/HBYBrMnNeqVR4E1A4i9I=";
   };
 
-  pythonRelaxDeps = [ "typer" ];
+  pythonRelaxDeps = [
+    "typer"
+    "pandas"
+    "websocket-client"
+  ];
 
-  build-system = [ poetry-core ];
+  build-system = [
+    openapi-spec-validator
+    poetry-core
+    prance
+  ];
 
   dependencies = [
     orjson
+    pyarrow
     python-dateutil
     pyyaml
     requests
-    typer
     tqdm
+    typer
     websocket-client
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
