### PR TITLE
maintainers/scripts: format with treefmt config

### DIFF
--- a/maintainers/scripts/haskell/regenerate-hackage-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-hackage-packages.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils haskellPackages.cabal2nix-unstable.bin git -I nixpkgs=.
+#! nix-shell -i bash -E 'with import ../../.. {}; mkShell { packages = [ bash coreutils haskellPackages.cabal2nix-unstable.bin git (import ../../../ci {}).fmt.pkg ]; }'
 
 set -euo pipefail
 
@@ -102,7 +102,7 @@ run_hackage2nix
 
 fi
 
-nixfmt pkgs/development/haskell-modules/hackage-packages.nix
+treefmt --no-cache pkgs/development/haskell-modules/hackage-packages.nix
 
 if [[ "$DO_COMMIT" -eq 1 ]]; then
 git add pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml

--- a/maintainers/scripts/haskell/update-cabal2nix-unstable.sh
+++ b/maintainers/scripts/haskell/update-cabal2nix-unstable.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils curl jq gnused haskellPackages.cabal2nix-unstable.bin nix-prefetch-scripts -I nixpkgs=.
+#! nix-shell -i bash -E 'with import ../../.. {}; mkShell { packages = [ bash coreutils curl jq gnused haskellPackages.cabal2nix-unstable.bin nix-prefetch-scripts (import ../../../ci {}).fmt.pkg ]; }'
 
 # Updates cabal2nix-unstable to the latest master of the nixos/cabal2nix repository.
 # See regenerate-hackage-packages.sh for details on the purpose of this script.
@@ -18,7 +18,7 @@ function mkPackage() {
   output=pkgs/development/haskell-modules/cabal2nix-unstable/$1.nix
   echo "# This file defines $1-unstable, used by maintainers/scripts/haskell/regenerate-hackage-packages.sh." > "$output"
   cabal2nix --subpath "$1" "https://github.com/NixOS/cabal2nix/archive/$commit.tar.gz" | sed -Ee 's/version = "(.*)"/version = "\1-unstable-'"$date"'"/' >> "$output"
-  nixfmt "$output"
+  treefmt --no-cache "$output"
 }
 
 mkPackage "cabal2nix"

--- a/maintainers/scripts/update-ruby-packages
+++ b/maintainers/scripts/update-ruby-packages
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bundler bundix nixfmt
+#!nix-shell -i bash -E 'with import ../.. {}; mkShell { packages = [ bash bundler bundix (import ../../ci {}).fmt.pkg ]; }'
 # shellcheck shell=bash
 
 set -euf -o pipefail
@@ -20,7 +20,7 @@ rm -f gemset.nix Gemfile.lock
 # platform from where it was executed.
 BUNDLE_FORCE_RUBY_PLATFORM=1 bundle lock
 bundix
-nixfmt gemset.nix
+treefmt --no-cache gemset.nix
 
 # Run checks against the update.
 if ! \


### PR DESCRIPTION
Followup to https://github.com/NixOS/nixpkgs/pull/554040#discussion_r3811745091 \
Prior art: 37aac0fb06e2ca890d463b35af6d45bad44a9f91

Scripts should avoid running formatters directly. If possible, we should always use `treefmt` as configured by CI.
1. The `nixfmt` used may be a different version to the one pinned by CI
2. Nixpkgs' treefmt applies _multiple_ formatting tools on `*.nix` files
3. Nixpkgs' treefmt applies non-default config to some formatting tools

One way to handle this would be to have multiple chained `nix-shell` shebangs, however that's a little messy and also makes enabling `--pure` a bit awkward.
A more robust approach, recommended by https://github.com/NixOS/nixpkgs/issues/425551, is to use an explicit `mkShell` expression via `nix-shell`'s `-E` flag.
In addition to allowing arbitrary expressions like `(import ../../ci {}).fmt.pkg`, another major advantage of `-E 'import ../.. {}` over `-I nixpkgs=.` is that paths resolve consistently regardless of where the script is run from; `-I` resolves relative to the CWD, while `-E` resolves relative to the script file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - [x] Ran the affected scripts
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
