### PR TITLE
zennotes-desktop: 2.30.0 -> 2.31.0

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.30.0";
-  npmDepsHash = "sha256-+zcRyIVGz/TeMh9ERx+7lKI8X5kKoAC0ZzKAUBdM7wY=";
+  version = "2.31.0";
+  npmDepsHash = "sha256-3PvR/WcQj3Eu0qr4o+MNY+rH5SIAgLVhbHk14vzjX/Q=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-s7/tH/L+gQWuD+c8wv4sqUzq452SY1iv7oycYWX9H5A=";
+    hash = "sha256-iptW9Pplvh8hGZcEXGAm1oC1y/5NOefbjHlYrft443o=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update zennotes-desktop 2.30.0 -> 2.31.0. I'm the upstream author of ZenNotes.

2.31.0 makes ZenNotes Cloud stream large files (over 5 MB) directly from disk to object storage instead of inlining them into the sync request, and ships a four-fix community sweep (title-first buffer switcher, vim jump history through the Tasks and Tags views, an nvm-aware Raycast toolchain check on macOS, and a which-key card that fits short tiled-WM windows). Nothing changes in how the package builds or is wrapped; the bump is version plus the two hashes.

Hash provenance: `npmDepsHash` and the `src` hash are the values our repo's own Nix packaging CI computed and build-verified on a Nix runner for this release (the in-repo flake builds the same workspace from the same lockfile, and that build passed on v2.31.0): https://github.com/ZenNotes/zennotes/actions/runs/32312172084

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.31.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux (equivalent derivation with these hashes build-verified
        in upstream repo CI on x86_64-linux)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).