### PR TITLE
liquibase: fix license, rework update script

### DIFF
--- a/pkgs/by-name/li/liquibase/package.nix
+++ b/pkgs/by-name/li/liquibase/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  gitUpdater,
+  nix-update-script,
   jre,
   makeWrapper,
   mysqlSupport ? true,
@@ -77,14 +77,9 @@ stdenv.mkDerivation (finalAttrs: {
       chmod +x $out/bin/liquibase
     '';
 
-  passthru.updateScript = gitUpdater {
-    url = "https://github.com/liquibase/liquibase";
-    rev-prefix = "v";
-    # The latest versions are in the 4.xx series.  I am not sure where
-    # 10.10.10 and 5.0.0 came from, though it appears like they are
-    # for the commercial product.
-    ignoredVersions = "10.10.10|5.0.0|.*-beta.*";
-  };
+  # Upstream tags things it never releases -- v5.0.4 exists right now with no
+  # release behind it -- so ask the release endpoint rather than the tags.
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
 
   meta = {
     description = "Version Control for your database";

--- a/pkgs/by-name/li/liquibase/package.nix
+++ b/pkgs/by-name/li/liquibase/package.nix
@@ -96,7 +96,10 @@ stdenv.mkDerivation (finalAttrs: {
     # forbids competing products, so it is unfree by our definition; each
     # release additionally becomes Apache-2.0 two years after publication.
     license = lib.licenses.fsl11Asl20;
-    maintainers = with lib.maintainers; [ jsoo1 ];
+    maintainers = with lib.maintainers; [
+      agilesteel
+      jsoo1
+    ];
     platforms = with lib.platforms; unix;
   };
 })

--- a/pkgs/by-name/li/liquibase/package.nix
+++ b/pkgs/by-name/li/liquibase/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   nix-update-script,
+  testers,
   jre,
   makeWrapper,
   mysqlSupport ? true,
@@ -80,6 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
   # Upstream tags things it never releases -- v5.0.4 exists right now with no
   # release behind it -- so ask the release endpoint rather than the tags.
   passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
     description = "Version Control for your database";

--- a/pkgs/by-name/li/liquibase/package.nix
+++ b/pkgs/by-name/li/liquibase/package.nix
@@ -92,7 +92,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.liquibase.org/";
     changelog = "https://raw.githubusercontent.com/liquibase/liquibase/v${finalAttrs.version}/changelog.txt";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    license = lib.licenses.asl20;
+    # Relicensed at 5.0.0. The FSL permits internal and commercial use but
+    # forbids competing products, so it is unfree by our definition; each
+    # release additionally becomes Apache-2.0 two years after publication.
+    license = lib.licenses.fsl11Asl20;
     maintainers = with lib.maintainers; [ jsoo1 ];
     platforms = with lib.platforms; unix;
   };


### PR DESCRIPTION
Liquibase relicensed at 5.0.0 and we followed it across that boundary without anyone noticing, so nixpkgs has been advertising Apache-2.0 for a source-available product since 2025-10:

| tag | `LICENSE.txt` |
|---|---|
| v4.33.0 | Apache License 2.0 |
| v5.0.0 | SOFTWARE LICENSE SUBSCRIPTION AND SUPPORT AGREEMENT |
| v5.0.3 (what we package) | Functional Source License 1.1, ALv2 Future License |

The 5.x line arrived in #448899. GitHub reports the repository as `NOASSERTION`, and the tarball we install ships the FSL as its own `LICENSE.txt`.

### What this means for users

The FSL is permissive about *use* — internal use, commercial use, and professional services you provide to a licensee are all named permitted purposes — and forbids only "Competing Use", i.e. offering substantially similar functionality to others in a commercial product or service. Each release also carries an irrevocable grant to Apache-2.0 on its second anniversary, so 5.0.3 becomes ALv2 in May 2028.

But a field-of-use restriction is not free by our definition, hence `fsl11Asl20` rather than `asl20`. **liquibase therefore becomes unfree and needs `allowUnfree`.** It remains `redistributable`, so binaries can still be substituted, and nothing in `pkgs/` or `nixos/` depends on liquibase, so no other package or test is affected.

### Also in this PR

The `gitUpdater` is replaced with `nix-update-script { extraArgs = [ "--use-github-releases" ]; }`. Liquibase's tags cannot be walked reliably: there is a bogus `10.10.10`, release candidates that the `-beta` ignore pattern never matched, and right now a `v5.0.4` tag with no release behind it — which the old updater would have bumped to, breaking the fetch on a tarball that does not exist. The release listing has none of those problems; `github-copilot-cli` and `powertop-macos` fetch their release tarballs the same way.

The `ignoredVersions` entry for 5.0.0 disappears along with the `gitUpdater`, but the concern it encoded does not: keeping us on the Apache-2.0 line is what the licence commit now expresses properly, rather than as a version blacklist.

Plus a `passthru.tests.version`, and myself added as a maintainer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: this change was prepared with assistance from Claude Code. The commits carry `Assisted-by:` trailers naming the model used for each (Claude Fable 5 and Claude Opus 5), and this summary was drafted with Claude Opus 5. All changes were reviewed, built and manually tested by me.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
