### PR TITLE
poop: 0.5.0 -> 0.5.0-unstable-2026-05-04, zig_0_13 -> zig_0_16

### DIFF
--- a/pkgs/by-name/po/poop/package.nix
+++ b/pkgs/by-name/po/poop/package.nix
@@ -2,22 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  zig_0_13,
+  zig_0_16,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "poop";
-  version = "0.5.0";
+  version = "0.5.0-unstable-2026-05-04";
 
   src = fetchFromGitHub {
     owner = "andrewrk";
     repo = "poop";
-    tag = finalAttrs.version;
-    hash = "sha256-zrqR/TTELhsBIX42PysFsHPRs8Lx/zHcmi+VMDw1SdQ=";
+    rev = "e1a802d19a4b8267e2fa79c3ede15c09357b31c9";
+    hash = "sha256-cT9ueK4VrPR9qv4qS9suvm8P2bAywDYlxnDU183aBrA=";
   };
 
   nativeBuildInputs = [
-    zig_0_13
+    zig_0_16
   ];
 
   meta = {


### PR DESCRIPTION
diff: https://github.com/andrewrk/poop/compare/0.5.0...e1a802d19a4b8267e2fa79c3ede15c09357b31c9

zig 0.13 will soon be removed from nixpkgs as it depends on llvm 18. poop needs to be updated to a newer zig version, and this has been done upstream, but a release has not yet been cut. accordingly, we update to the latest upstream commit in order to get support for zig 0.16.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
