### PR TITLE
zigimports: 0.1.0 -> 0.1.0-unstable-2026-07-25, zig_0_13 -> zig_0_16

### DIFF
--- a/pkgs/by-name/zi/zigimports/package.nix
+++ b/pkgs/by-name/zi/zigimports/package.nix
@@ -2,23 +2,23 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  zig_0_13,
+  zig_0_16,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zigimports";
-  version = "0.1.0";
+  version = "0.1.0-unstable-2026-07-25";
 
   src = fetchFromGitHub {
     owner = "tusharsadhwani";
     repo = "zigimports";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-2cri+5mhhTQqlkv9db/3CQ3rCMq4yW4drMoRTZBhndE=";
+    rev = "bcfbb03a85553638f8a80e6596bdfaa93a0cc266";
+    hash = "sha256-ARM+pmk0elu+uYnrEdIixq6AS0eyUeqobOAPteER76w=";
   };
 
   nativeBuildInputs = [
-    zig_0_13
+    zig_0_16
   ];
 
   # Remove the system suffix on the program name.
@@ -34,6 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.jmbaur ];
     mainProgram = "zigimports";
-    inherit (zig_0_13.meta) platforms;
+    inherit (zig_0_16.meta) platforms;
   };
 })


### PR DESCRIPTION
diff: https://github.com/tusharsadhwani/zigimports/compare/v0.1.0...bcfbb03a85553638f8a80e6596bdfaa93a0cc266

zig 0.13 will soon be removed from nixpkgs as it depends on llvm 18. zigimports needs to be updated to a newer zig version, and this has been done upstream, but a release has not yet been cut. accordingly, we update to the latest upstream commit in order to get support for zig 0.16.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested on an extremely basic zig hello world with unused imports)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
