### PR TITLE
python3Packages.oci-lexer-parser: 0.1.2-unstable-2026-08-03 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/oci-lexer-parser/default.nix
+++ b/pkgs/development/python-modules/oci-lexer-parser/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "oci-lexer-parser";
-  version = "0.1.2-unstable-2026-08-03";
+  version = "0.5.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -18,9 +18,8 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "NetSPI";
     repo = "oci-lexer-parser";
-    # https://github.com/NetSPI/oci-lexer-parser/issues/15
-    rev = "bc3c90c411009cf12ad44690d4ad2a0b172f9f1b";
-    hash = "sha256-AAOPMR94zH57pW5S8NAjzakXR3CyI5kLFXwfvOoOn4c=";
+    tag = finalAttrs.version;
+    hash = "sha256-h1eZgw2k5QOsU6KyYIDuuWu+wRRcZc30u0mJ2g3TL1w=";
   };
 
   build-system = [ setuptools ];
@@ -36,6 +35,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Utility to convert OCI IAM Policy Statements and Dynamic Group Matching Rules to serialized JSON output";
     homepage = "https://github.com/NetSPI/oci-lexer-parser";
+    changelog = "https://github.com/NetSPI/oci-lexer-parser/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
Diff: https://github.com/NetSPI/oci-lexer-parser/compare/0.1.2-unstable-2026-08-03...0.5.0

Changelog: https://github.com/NetSPI/oci-lexer-parser/releases/tag/0.5.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
