### PR TITLE
openobserve: add support for enterprise edition

### DIFF
--- a/pkgs/by-name/op/openobserve/package.nix
+++ b/pkgs/by-name/op/openobserve/package.nix
@@ -31,6 +31,7 @@ let
     mainProgram = "openobserve";
     maintainers = with lib.maintainers; [
       happysalada
+      kashw2
     ];
   };
 in

--- a/pkgs/by-name/op/openobserve/package.nix
+++ b/pkgs/by-name/op/openobserve/package.nix
@@ -15,155 +15,211 @@
   versionCheckHook,
   buildNpmPackage,
   gitUpdater,
+  installShellFiles,
+  # Enterprise Edition ships only as a prebuilt binary
+  enableEnterprise ? false,
 }:
 
-rustPlatform.buildRustPackage (
-  finalAttrs:
-  let
-    web = buildNpmPackage {
-      inherit (finalAttrs) src version;
-      pname = "openobserve-ui";
-
-      sourceRoot = "${finalAttrs.src.name}/web";
-
-      npmDepsHash = "sha256-te8uABzndzLRb6GQVSn33aaleQau2U/xo8LnMynTtx0=";
-
-      preBuild = ''
-        # Patch vite config to not open the browser to visualize plugin composition
-        substituteInPlace vite.config.ts \
-          --replace "open: true" "open: false";
-      '';
-
-      env = {
-        NODE_OPTIONS = "--max-old-space-size=8192";
-        # cypress tries to download binaries otherwise
-        CYPRESS_INSTALL_BINARY = 0;
-      };
-
-      installPhase = ''
-        runHook preInstall
-        mkdir -p $out/share
-        mv dist $out/share/openobserve-ui
-        runHook postInstall
-      '';
-    };
-  in
-  {
-    pname = "openobserve";
-    version = "0.91.5";
-
-    src = fetchFromGitHub {
-      owner = "openobserve";
-      repo = "openobserve";
-      tag = "v${finalAttrs.version}";
-      hash = "sha256-3K6xaXFmhWY0ElqiFgR8mEi0XUVBF/cRNwONqLhniPc=";
-    };
-
-    patches = [
-      # prevent using git to determine version info during build time
-      ./build.rs.patch
+let
+  version = "0.91.5";
+  updateScript = gitUpdater {
+    rev-prefix = "v";
+    ignoredVersions = "rc";
+  };
+  commonMeta = {
+    description = "Cloud-native observability platform built specifically for logs, metrics, traces, analytics & realtime user-monitoring";
+    mainProgram = "openobserve";
+    maintainers = with lib.maintainers; [
+      happysalada
     ];
+  };
+in
 
-    preBuild = ''
-      cp -r ${web}/share/openobserve-ui web/dist
+if enableEnterprise then
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "openobserve-ee";
+    inherit version;
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    src = fetchurl {
+      url = "https://downloads.openobserve.ai/releases/o2-enterprise/v${finalAttrs.version}/openobserve-ee-v${finalAttrs.version}-linux-amd64-musl.tar.gz";
+      hash = "sha256-DFhK180XeoSDC644kBqBUD35FtdSmQya2VbzxEh4iSM=";
+    };
+
+    # The tarball is a single flat `openobserve` binary.
+    sourceRoot = ".";
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [ installShellFiles ];
+
+    installPhase = ''
+      runHook preInstall
+      installBin openobserve
+      runHook postInstall
     '';
-
-    cargoHash = "sha256-PIhHHEP9kJmliOGtom1gDf7wt5C4RicWKgQe0hkW+4M=";
-
-    nativeBuildInputs = [
-      pkg-config
-      protobuf
-    ];
-
-    buildInputs = [
-      bzip2
-      oniguruma
-      sqlite
-      xz
-      zlib
-      zstd
-    ];
-
-    env = {
-      RUSTONIG_SYSTEM_LIBONIG = true;
-      ZSTD_SYS_USE_PKG_CONFIG = true;
-
-      RUSTC_BOOTSTRAP = 1; # uses experimental features
-
-      # the patched build.rs file sets these variables
-      GIT_VERSION = finalAttrs.src.tag;
-      GIT_COMMIT_HASH = "builtByNix";
-      GIT_BUILD_DATE = "1970-01-01T00:00:00Z";
-
-      RUSTFLAGS = "-C target-feature=+aes,+sse2";
-
-      SWAGGER_UI_DOWNLOAD_URL =
-        # When updating:
-        # - Look for the version of `utoipa-swagger-ui` at:
-        #   https://github.com/StractOrg/stract/blob/<STRACT-REV>/Cargo.toml#L183
-        # - Look at the corresponding version of `swagger-ui` at:
-        #   https://github.com/juhaku/utoipa/blob/utoipa-swagger-ui-<UTOPIA-SWAGGER-UI-VERSION>/utoipa-swagger-ui/build.rs#L21-L22
-        let
-          swaggerUiVersion = "5.17.14";
-          swaggerUi = fetchurl {
-            url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v${swaggerUiVersion}.zip";
-            hash = "sha256-SBJE0IEgl7Efuu73n3HZQrFxYX+cn5UU5jrL4T5xzNw=";
-          };
-        in
-        "file://${swaggerUi}";
-    };
-
-    # swagger-ui will once more be copied in the target directory during the check phase
-    # Not deleting the existing unpacked archive leads to a `PermissionDenied` error
-    preCheck = ''
-      rm -rf target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/build/
-    '';
-
-    # Skip doctests: upstream release build for v0.50.3 runs cargo build only,
-    # and the doctest examples currently fail due to async context.
-    cargoTestFlags = [
-      "--lib"
-      "--bins"
-      "--tests"
-      "--examples"
-    ];
-
-    # requires network access or filesystem mutations
-    checkFlags = [
-      "--skip=cli::basic::http::tests::test_node_operations_network_failure"
-      "--skip=cli::basic::http::tests::test_query_valid_time_range"
-      "--skip=common::meta::telemetry::test_telemetry::test_telemetry_send_track_event_without_base_info_or_zo_data"
-      "--skip=handler::http::router::tests::test_get_proxy_routes"
-      "--skip=tests::e2e_test"
-      "--skip=tests::test_setup_logs"
-      "--skip=handler::http::router::middlewares::compress::Compress"
-      "--skip=service::alerts::destinations::tests::test_alert_destination_requires_template"
-      "--skip=service::enrichment_table::url_processor"
-      "--skip=service::github"
-      "--skip=service::sourcemaps"
-      # Tests are not threadsafe. Most likely can only run one test at a time,
-      # due to altering shared database state.
-      # This option already in upstream code: https://github.com/openobserve/openobserve/pull/7084
-      # Also see: https://github.com/NixOS/nixpkgs/pull/457421
-      "--test-threads=1"
-    ];
 
     doInstallCheck = true;
     nativeInstallCheckInputs = [ versionCheckHook ];
 
-    passthru.updateScript = gitUpdater {
-      rev-prefix = "v";
-      ignoredVersions = "rc";
-    };
+    passthru.updateScript = updateScript;
 
-    meta = {
-      description = "Cloud-native observability platform built specifically for logs, metrics, traces, analytics & realtime user-monitoring";
-      homepage = "https://github.com/openobserve/openobserve";
-      changelog = "https://github.com/openobserve/openobserve/releases/tag/v${finalAttrs.version}";
-      license = lib.licenses.asl20;
-      maintainers = with lib.maintainers; [ happysalada ];
-      mainProgram = "openobserve";
-      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    meta = commonMeta // {
+      homepage = "https://openobserve.ai/";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      license = {
+        fullName = "OpenObserve Enterprise Edition License Agreement";
+        url = "https://openobserve.ai/legal/enterprise-license/";
+        free = false;
+        redistributable = false;
+      };
+      platforms = lib.intersectLists lib.platforms.x86_64 lib.platforms.linux;
     };
-  }
-)
+  })
+else
+  rustPlatform.buildRustPackage (
+    finalAttrs:
+    let
+      web = buildNpmPackage {
+        inherit (finalAttrs) src version;
+        pname = "openobserve-ui";
+
+        sourceRoot = "${finalAttrs.src.name}/web";
+
+        npmDepsHash = "sha256-te8uABzndzLRb6GQVSn33aaleQau2U/xo8LnMynTtx0=";
+
+        preBuild = ''
+          # Patch vite config to not open the browser to visualize plugin composition
+          substituteInPlace vite.config.ts \
+            --replace "open: true" "open: false";
+        '';
+
+        env = {
+          NODE_OPTIONS = "--max-old-space-size=8192";
+          # cypress tries to download binaries otherwise
+          CYPRESS_INSTALL_BINARY = 0;
+        };
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/share
+          mv dist $out/share/openobserve-ui
+          runHook postInstall
+        '';
+      };
+    in
+    {
+      pname = "openobserve";
+      inherit version;
+
+      src = fetchFromGitHub {
+        owner = "openobserve";
+        repo = "openobserve";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-3K6xaXFmhWY0ElqiFgR8mEi0XUVBF/cRNwONqLhniPc=";
+      };
+
+      patches = [
+        # prevent using git to determine version info during build time
+        ./build.rs.patch
+      ];
+
+      preBuild = ''
+        cp -r ${web}/share/openobserve-ui web/dist
+      '';
+
+      cargoHash = "sha256-PIhHHEP9kJmliOGtom1gDf7wt5C4RicWKgQe0hkW+4M=";
+
+      nativeBuildInputs = [
+        pkg-config
+        protobuf
+      ];
+
+      buildInputs = [
+        bzip2
+        oniguruma
+        sqlite
+        xz
+        zlib
+        zstd
+      ];
+
+      env = {
+        RUSTONIG_SYSTEM_LIBONIG = true;
+        ZSTD_SYS_USE_PKG_CONFIG = true;
+
+        RUSTC_BOOTSTRAP = 1; # uses experimental features
+
+        # the patched build.rs file sets these variables
+        GIT_VERSION = finalAttrs.src.tag;
+        GIT_COMMIT_HASH = "builtByNix";
+        GIT_BUILD_DATE = "1970-01-01T00:00:00Z";
+
+        RUSTFLAGS = "-C target-feature=+aes,+sse2";
+
+        SWAGGER_UI_DOWNLOAD_URL =
+          # When updating:
+          # - Look for the version of `utoipa-swagger-ui` at:
+          #   https://github.com/StractOrg/stract/blob/<STRACT-REV>/Cargo.toml#L183
+          # - Look at the corresponding version of `swagger-ui` at:
+          #   https://github.com/juhaku/utoipa/blob/utoipa-swagger-ui-<UTOPIA-SWAGGER-UI-VERSION>/utoipa-swagger-ui/build.rs#L21-L22
+          let
+            swaggerUiVersion = "5.17.14";
+            swaggerUi = fetchurl {
+              url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v${swaggerUiVersion}.zip";
+              hash = "sha256-SBJE0IEgl7Efuu73n3HZQrFxYX+cn5UU5jrL4T5xzNw=";
+            };
+          in
+          "file://${swaggerUi}";
+      };
+
+      # swagger-ui will once more be copied in the target directory during the check phase
+      # Not deleting the existing unpacked archive leads to a `PermissionDenied` error
+      preCheck = ''
+        rm -rf target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/build/
+      '';
+
+      # Skip doctests: upstream release build for v0.50.3 runs cargo build only,
+      # and the doctest examples currently fail due to async context.
+      cargoTestFlags = [
+        "--lib"
+        "--bins"
+        "--tests"
+        "--examples"
+      ];
+
+      # requires network access or filesystem mutations
+      checkFlags = [
+        "--skip=cli::basic::http::tests::test_node_operations_network_failure"
+        "--skip=cli::basic::http::tests::test_query_valid_time_range"
+        "--skip=common::meta::telemetry::test_telemetry::test_telemetry_send_track_event_without_base_info_or_zo_data"
+        "--skip=handler::http::router::tests::test_get_proxy_routes"
+        "--skip=tests::e2e_test"
+        "--skip=tests::test_setup_logs"
+        "--skip=handler::http::router::middlewares::compress::Compress"
+        "--skip=service::alerts::destinations::tests::test_alert_destination_requires_template"
+        "--skip=service::enrichment_table::url_processor"
+        "--skip=service::github"
+        "--skip=service::sourcemaps"
+        # Tests are not threadsafe. Most likely can only run one test at a time,
+        # due to altering shared database state.
+        # This option already in upstream code: https://github.com/openobserve/openobserve/pull/7084
+        # Also see: https://github.com/NixOS/nixpkgs/pull/457421
+        "--test-threads=1"
+      ];
+
+      doInstallCheck = true;
+      nativeInstallCheckInputs = [ versionCheckHook ];
+
+      passthru.updateScript = updateScript;
+
+      meta = commonMeta // {
+        homepage = "https://github.com/openobserve/openobserve";
+        changelog = "https://github.com/openobserve/openobserve/releases/tag/v${finalAttrs.version}";
+        license = lib.licenses.asl20;
+        platforms = lib.platforms.linux ++ lib.platforms.darwin;
+      };
+    }
+  )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2587,6 +2587,10 @@ with pkgs;
     privsepPath = "/var/empty";
   };
 
+  openobserve-ee = callPackage ../by-name/op/openobserve/package.nix {
+    enableEnterprise = true;
+  };
+
   openrgb-with-all-plugins = openrgb.withPlugins [
     openrgb-plugin-effects
     openrgb-plugin-hardwaresync


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds support for the enterprise edition of OpenObserve.

The OpenObserve team have explicitly granted a limited exception to the modification clause of their Enterprise Edition license found [here](https://openobserve.ai/legal/enterprise-license/) for the purposes of packaging in Nix with the current expectation being that the binary is not redistributed via a binary cache.

[this](https://openobserve-community.slack.com/archives/C0A7FPG5ENR/p1787029938390549) Slack thread can verify.

<img width="1413" height="107" alt="image" src="https://github.com/user-attachments/assets/d1617169-7ec2-4947-be83-0d1fdee70ad8" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
