### PR TITLE
evtest-qt: 0.2.0-unstable-2023-09-13 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ev/evtest-qt/package.nix
+++ b/pkgs/by-name/ev/evtest-qt/package.nix
@@ -6,45 +6,44 @@
   fetchFromGitHub,
   fetchpatch,
   unstableGitUpdater,
+  pkg-config,
+  libevdev,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "evtest-qt";
-  version = "0.2.0-unstable-2023-09-13";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "Grumbel";
     repo = "evtest-qt";
-    rev = "fb087f4d3d51377790f1ff30681c48031bf23145";
-    hash = "sha256-gE47x1J13YZUVyB0b4VRyESIVCm3GbOXp2bX0TP97UU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ea0STAFjrP/0cx/+0kjolqvGdRnQxouA2w4JUhYueY8=";
     fetchSubmodules = true;
   };
 
-  patches = [
-    # Fix build against gcc-13:
-    #   https://github.com/Grumbel/evtest-qt/pull/14
-    (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/Grumbel/evtest-qt/commit/975dedcfd60853bd329f34d48ce4740add8866eb.patch";
-      hash = "sha256-gR/9oVhO4G9i7dn+CjvDAQN0KLXoX/fatpE0W3gXDc0=";
-    })
-  ];
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
     libsForQt5.wrapQtAppsHook
+    pkg-config
   ];
 
-  buildInputs = [ libsForQt5.qtbase ];
-
-  passthru.updateScript = unstableGitUpdater { };
+  buildInputs = [
+    libsForQt5.qtbase
+    libevdev
+  ];
 
   meta = {
     description = "Simple input device tester for linux with Qt GUI";
     mainProgram = "evtest-qt";
     homepage = "https://github.com/Grumbel/evtest-qt";
-    maintainers = with lib.maintainers; [ alexarice ];
+    maintainers = with lib.maintainers; [
+      alexarice
+      lukas-sgx
+    ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Plus;
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
