### PR TITLE
piper-tts: 1.4.2 -> 1.7.0

### DIFF
--- a/pkgs/by-name/pi/piper-tts/cmake-system-libs.patch
+++ b/pkgs/by-name/pi/piper-tts/cmake-system-libs.patch
@@ -28,7 +28,7 @@ index 04dd613..7374d25 100644
 -
 -ExternalProject_Add(espeak_ng_external
 -    GIT_REPOSITORY https://github.com/espeak-ng/espeak-ng.git
--    GIT_TAG 212928b394a96e8fd2096616bfd54e17845c48f6  # 2025-Mar-22
+-    GIT_TAG 724808c  # 2026-Apr-06
 -    PREFIX ${ESPEAKNG_BUILD_DIR}
 -    CMAKE_ARGS
 -        -DCMAKE_INSTALL_PREFIX=${ESPEAKNG_INSTALL_DIR}

--- a/pkgs/by-name/pi/piper-tts/package.nix
+++ b/pkgs/by-name/pi/piper-tts/package.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  # https://github.com/OHF-Voice/piper1-gpl/blob/v1.3.0/CMakeLists.txt#L33-L40
+  # https://github.com/OHF-Voice/piper1-gpl/blob/v1.7.0/CMakeLists.txt#L33-L40
   espeak-ng' = espeak-ng.override {
     asyncSupport = false;
     klattSupport = false;
@@ -29,14 +29,14 @@ in
 
 python3Packages.buildPythonApplication rec {
   pname = "piper-tts";
-  version = "1.4.2";
+  version = "1.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OHF-Voice";
     repo = "piper1-gpl";
     tag = "v${version}";
-    hash = "sha256-FHO+1d1iJimc6KweY/O6lEvWqGCyUwnDrslEfkxYR7A=";
+    hash = "sha256-oQhDFhB2GXlAdxW1K7BM7RJkzihAwyoB6QbOpaMUVHM=";
   };
 
   patches = [
@@ -92,6 +92,7 @@ python3Packages.buildPythonApplication rec {
         jsonargparse
         librosa
         lightning
+        onnx
         pysilero-vad
         tensorboard
         tensorboardx
@@ -104,6 +105,15 @@ python3Packages.buildPythonApplication rec {
     alignment = with python3Packages; [
       onnx
     ];
+    zh = with python3Packages; [
+      # g2pw # not packaged
+      transformers
+      sentence-stream
+      unicode-rbnf
+    ];
+    ja = [
+      # pyopenjtalk-plus # not packaged
+    ];
   };
 
   postInstall = ''
@@ -114,6 +124,14 @@ python3Packages.buildPythonApplication rec {
     rm -v src/piper/train/vits/monotonic_align/{Makefile,setup.py,core.c,core.pyx}
     cp -Rv src/piper/train/vits $train/
   '';
+
+  pythonImportsCheck = [
+    "piper"
+    "piper.tashkeel"
+    "piper.hebrew"
+    "piper.train"
+    "piper.train.vits"
+  ];
 
   meta = {
     changelog = "https://github.com/OHF-Voice/piper1-gpl/releases/tag/v${version}";


### PR DESCRIPTION
Diff: https://github.com/OHF-Voice/piper1-gpl/compare/v1.4.2...v1.7.0

Changelog: https://github.com/OHF-Voice/piper1-gpl/releases/tag/v1.5.0
Changelog: https://github.com/OHF-Voice/piper1-gpl/releases/tag/v1.6.0
Changelog: https://github.com/OHF-Voice/piper1-gpl/releases/tag/v1.6.1
Changelog: https://github.com/OHF-Voice/piper1-gpl/releases/tag/v1.7.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
