### PR TITLE
insomnia: repackage using source instead of prepackaged

### DIFF
--- a/pkgs/by-name/in/insomnia/nan-v8-13.patch
+++ b/pkgs/by-name/in/insomnia/nan-v8-13.patch
@@ -1,0 +1,13 @@
+--- a/nan_callbacks_12_inl.h
++++ b/nan_callbacks_12_inl.h
+@@ -159,8 +159,8 @@
+ 
+   inline v8::Isolate* GetIsolate() const { return info_.GetIsolate(); }
+   inline v8::Local<v8::Value> Data() const { return data_; }
+-  inline v8::Local<v8::Object> This() const { return info_.This(); }
+-  inline v8::Local<v8::Object> Holder() const { return info_.Holder(); }
++  inline v8::Local<v8::Object> This() const { return info_.HolderV2(); }
++  inline v8::Local<v8::Object> Holder() const { return info_.HolderV2(); }
+   inline ReturnValue<T> GetReturnValue() const {
+     return ReturnValue<T>(info_.GetReturnValue());
+   }

--- a/pkgs/by-name/in/insomnia/package.nix
+++ b/pkgs/by-name/in/insomnia/package.nix
@@ -1,27 +1,142 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  appimageTools,
-  undmg,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  python3,
+  pkg-config,
+  curl,
+  electron_41,
+  copyDesktopItems,
+  makeDesktopItem,
 }:
+
 let
+  electron = electron_41;
+in
+buildNpmPackage rec {
   pname = "insomnia";
   version = "13.0.0";
 
-  src =
-    fetchurl
-      {
-        aarch64-darwin = {
-          url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
-          hash = "sha256-sPl7KXC8Z13LFZvxuKg02iDbtrCxn//Yrr8AOOf3VD4=";
-        };
-        x86_64-linux = {
-          url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.AppImage";
-          hash = "sha256-PlcKBQnkmgU/SsLRKX7ohrGHm7B4hK9FMkplwlbFolI=";
-        };
-      }
-      .${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+  src = fetchFromGitHub {
+    owner = "Kong";
+    repo = "insomnia";
+    rev = "core@${version}";
+    hash = "sha256-+eWLO8f9dqsssoqu1EGg2kNVckXVcRuWyfp8h6FYVbU=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  npmDepsHash = "sha256-zc3JLmriut7YTLDuORRCMJG+djs6WEnBRwF2Io5rnLI=";
+
+  postPatch = ''
+    ${python3}/bin/python3 ${./patch-package.py}
+
+    echo "DEBUG: package-lock.json status after patching:"
+    ls -lh package-lock.json
+    head -n 10 package-lock.json
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    python3
+    pkg-config
+    curl.dev
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    curl
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    npm_config_build_from_source = "true";
+    NODE_OPTIONS = "--max-old-space-size=8192";
+  };
+
+  makeCacheWritable = true;
+
+  npmBuildScript = "app-build";
+
+  preBuild = ''
+    echo "DEBUG: checking grpc-reflection-js in node_modules:"
+    ls -la node_modules/grpc-reflection-js || echo "grpc-reflection-js is MISSING!"
+  '';
+
+  postBuild = ''
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    patch -p1 -d node_modules/nan < ${./nan-v8-13.patch}
+
+    echo "DEBUG: forcing clean rebuild of node-libcurl against Electron ABI"
+    rm -rf node_modules/@getinsomnia/node-libcurl/lib/binding
+    HOME=$TMPDIR node_modules/.bin/node-pre-gyp rebuild \
+      --directory node_modules/@getinsomnia/node-libcurl \
+      --runtime=electron \
+      --target=${electron.version} \
+      --nodedir=${electron.headers} \
+      --build-from-source \
+      --verbose
+
+    pushd packages/insomnia
+    npm exec electron-builder -- \
+      --dir \
+      --config electron-builder.config.js \
+      -c.electronDist=../../electron-dist \
+      -c.electronVersion=${electron.version} \
+      -c.mac.identity=null
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications
+    cp -r packages/insomnia/dist/mac*/Insomnia.app $out/Applications
+    makeWrapper $out/Applications/Insomnia.app/Contents/MacOS/Insomnia $out/bin/insomnia
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    mkdir -p $out/share/insomnia
+    cp -r packages/insomnia/dist/linux*-unpacked/{locales,resources{,.pak}} $out/share/insomnia
+
+    # XDG Desktop Item and Icon
+    if [ -d packages/insomnia/build/icons ]; then
+      for icon in packages/insomnia/build/icons/*.png; do
+        size=$(basename "$icon" .png)
+        mkdir -p "$out/share/icons/hicolor/$size/apps"
+        cp "$icon" "$out/share/icons/hicolor/$size/apps/insomnia.png"
+      done
+    elif [ -f packages/insomnia/build/icon.png ]; then
+      mkdir -p "$out/share/icons/hicolor/512x512/apps"
+      cp packages/insomnia/build/icon.png "$out/share/icons/hicolor/512x512/apps/insomnia.png"
+    fi
+
+    makeWrapper ${lib.getExe electron} $out/bin/insomnia \
+      --add-flags $out/share/insomnia/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --inherit-argv0
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "insomnia";
+      exec = "insomnia %U";
+      icon = "insomnia";
+      desktopName = "Insomnia";
+      comment = meta.description;
+      categories = [ "Development" ];
+    })
+  ];
 
   meta = {
     homepage = "https://insomnia.rest";
@@ -39,47 +154,4 @@ let
       DataHearth
     ];
   };
-in
-if stdenv.hostPlatform.isDarwin then
-  stdenv.mkDerivation {
-    inherit
-      pname
-      version
-      src
-      meta
-      ;
-    sourceRoot = ".";
-
-    nativeBuildInputs = [ undmg ];
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p "$out/Applications"
-      mv Insomnia.app $out/Applications/
-      runHook postInstall
-    '';
-  }
-else
-  appimageTools.wrapType2 {
-    inherit
-      pname
-      version
-      src
-      meta
-      ;
-
-    extraInstallCommands =
-      let
-        appimageContents = appimageTools.extract {
-          inherit pname version src;
-        };
-      in
-      ''
-        # Install XDG Desktop file and its icon
-        install -Dm444 ${appimageContents}/insomnia.desktop -t $out/share/applications
-        install -Dm444 ${appimageContents}/insomnia.png -t $out/share/icons/
-        # Replace wrong exec statement in XDG Desktop file
-        substituteInPlace $out/share/applications/insomnia.desktop \
-            --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=insomnia'
-      '';
-  }
+}

--- a/pkgs/by-name/in/insomnia/patch-package.py
+++ b/pkgs/by-name/in/insomnia/patch-package.py
@@ -1,0 +1,148 @@
+import os
+import json
+
+# Find and modify all package.json files recursively
+for root, dirs, files in os.walk('.'):
+    for file in files:
+        if file == 'package.json':
+            filepath = os.path.join(root, file)
+            try:
+                with open(filepath, 'r') as f:
+                    data = json.load(f)
+                modified = False
+
+                # Exclude non-required workspaces from root package.json
+                if filepath == './package.json':
+                    if 'workspaces' in data:
+                        data['workspaces'] = [
+                            w for w in data['workspaces']
+                            if w not in ['packages/insomnia-smoke-test', 'packages/insomnia-inso']
+                        ]
+                        modified = True
+
+                # Convert git dependency to standard registry dependency and add lodash.set missing deps
+                if filepath == './packages/insomnia/package.json':
+                    if 'dependencies' in data:
+                        data['dependencies']['grpc-reflection-js'] = '^0.3.0'
+                        data['dependencies']['lodash.set'] = '^4.3.2'
+                        data['dependencies']['@types/lodash.set'] = '^4.3.9'
+                        data['dependencies']['@types/lodash'] = '^4.17.25'
+                        modified = True
+
+                for section in ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']:
+                    if section in data:
+                        if '@kong/insomnia-plugin-ai' in data[section]:
+                            data[section].pop('@kong/insomnia-plugin-ai')
+                            modified = True
+                        if '@kong/insomnia-plugin-external-vault' in data[section]:
+                            data[section].pop('@kong/insomnia-plugin-external-vault')
+                            modified = True
+                if modified:
+                    with open(filepath, 'w') as f:
+                        json.dump(data, f, indent=2)
+                    print(f"Patched {filepath}")
+            except Exception as e:
+                print(f"Failed to patch {filepath}: {e}")
+
+# Modify package-lock.json
+with open('package-lock.json', 'r') as f:
+    lock = json.load(f)
+if 'packages' in lock:
+    # Exclude from workspaces list of root package in lockfile
+    if "" in lock['packages'] and 'workspaces' in lock['packages'][""]:
+        lock['packages'][""]['workspaces'] = [
+            w for w in lock['packages'][""]['workspaces']
+            if w not in ['packages/insomnia-smoke-test', 'packages/insomnia-inso']
+        ]
+
+    # Update node_modules/grpc-reflection-js entry to use standard registry tgz with integrity hash
+    if 'node_modules/grpc-reflection-js' in lock['packages']:
+        pkg = lock['packages']['node_modules/grpc-reflection-js']
+        pkg['resolved'] = 'https://registry.npmjs.org/grpc-reflection-js/-/grpc-reflection-js-0.3.0.tgz'
+        pkg['integrity'] = 'sha512-3lhTlQluPxVgbowCXA3tAZC3RJW+GSOUkguLNYl1QffYRiutUB3RDfPkQFTcrCFJgNiIIxx+iJkr8s3uSp3zWA=='
+        pkg.pop('resolvedEnv', None)
+
+    # Inject lodash.set, @types/lodash.set, and @types/lodash entries
+    lock['packages']['node_modules/lodash.set'] = {
+        "version": "4.3.2",
+        "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+        "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
+        "license": "MIT"
+    }
+    lock['packages']['node_modules/@types/lodash.set'] = {
+        "version": "4.3.9",
+        "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.9.tgz",
+        "integrity": "sha512-KOxyNkZpbaggVmqbpr82N2tDVTx05/3/j0f50Es1prxrWB0XYf9p3QNxqcbWb7P1Q9wlvsUSlCFnwlPCIJ46PQ==",
+        "license": "MIT",
+        "dependencies": {
+            "@types/lodash": "*"
+        }
+    }
+    lock['packages']['node_modules/@types/lodash'] = {
+        "version": "4.17.25",
+        "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+        "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+        "license": "MIT"
+    }
+
+    # Inject into packages/insomnia dependencies in lockfile
+    if 'packages/insomnia' in lock['packages']:
+        insomnia_lock_pkg = lock['packages']['packages/insomnia']
+        if 'dependencies' not in insomnia_lock_pkg:
+            insomnia_lock_pkg['dependencies'] = {}
+        insomnia_lock_pkg['dependencies']['grpc-reflection-js'] = '^0.3.0'
+        insomnia_lock_pkg['dependencies']['lodash.set'] = '^4.3.2'
+        insomnia_lock_pkg['dependencies']['@types/lodash.set'] = '^4.3.9'
+        insomnia_lock_pkg['dependencies']['@types/lodash'] = '^4.17.25'
+
+    keys_to_delete = []
+    for k in lock['packages']:
+        if k in [
+            'node_modules/@kong/insomnia-plugin-ai',
+            'node_modules/@kong/insomnia-plugin-external-vault',
+            'node_modules/insomnia-inso',
+            'node_modules/insomnia-smoke-test'
+        ] or \
+           k.startswith('node_modules/@kong/insomnia-plugin-ai/') or \
+           k.startswith('node_modules/@kong/insomnia-plugin-external-vault/') or \
+           k.startswith('node_modules/insomnia-inso/') or \
+           k.startswith('node_modules/insomnia-smoke-test/') or \
+           k.startswith('packages/insomnia-smoke-test') or \
+           k.startswith('packages/insomnia-inso'):
+            keys_to_delete.append(k)
+    for k in keys_to_delete:
+        lock['packages'].pop(k)
+    for pkg_name, pkg in lock['packages'].items():
+        for section in ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']:
+            if section in pkg:
+                pkg[section].pop('@kong/insomnia-plugin-ai', None)
+                pkg[section].pop('@kong/insomnia-plugin-external-vault', None)
+
+    # Map of known missing resolutions and integrity hashes
+    integrity_map = {
+        "@testing-library/dom@10.4.1": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+        "@testing-library/react@16.3.0": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+        "aria-query@5.3.0": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+        "tailwind-merge@2.6.0": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="
+    }
+
+    # Synthesize missing resolved URLs for nested registry packages
+    for k, pkg in lock['packages'].items():
+        if k != "" and 'resolved' not in pkg:
+            parts = k.split('node_modules/')
+            if len(parts) > 1:
+                pkg_name = parts[-1]
+                version = pkg.get('version')
+                if version:
+                    map_key = f"{pkg_name}@{version}"
+                    if map_key in integrity_map:
+                        pkg['resolved'] = f"https://registry.npmjs.org/{pkg_name}/-/{pkg_name.split('/')[-1]}-{version}.tgz"
+                        pkg['integrity'] = integrity_map[map_key]
+
+    # Translate any remaining git+ssh to git+https
+    for k, pkg in lock['packages'].items():
+        if 'resolved' in pkg and pkg['resolved'].startswith('git+ssh://git@github.com/'):
+            pkg['resolved'] = pkg['resolved'].replace('git+ssh://git@github.com/', 'git+https://github.com/')
+
+with open('package-lock.json', 'w') as f:
+    json.dump(lock, f, indent=2)


### PR DESCRIPTION
This PR is a discussion, not a real PR to review. 
- 100% of the code there has been AI-written and not reviewed (so I won't ask someone else to review my slop).
- Insomnia builds and runs in the current state

Currently, packaging relies on the upstream AppImage, which creates a bloated closure containing redundant dependencies.
Rebuilding from source instead reduces the total closure size from 2.9 GiB to 1.9 GiB by utilizing a native Electron wrapper and avoiding the heavy FHS compatibility layer.

@DataHearth do you remember why you chose to use AppImage instead of trying to build it from scratch in : #307571

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@markus1189 @kashw2 @DataHearth