### PR TITLE
neuralrack: fix crosscompilation

### DIFF
--- a/pkgs/by-name/ne/neuralrack/package.nix
+++ b/pkgs/by-name/ne/neuralrack/package.nix
@@ -10,6 +10,7 @@
   pkg-config,
   stdenv,
   xorgproto,
+  xxd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    xxd
   ];
 
   buildInputs = [
@@ -51,11 +53,19 @@ stdenv.mkDerivation (finalAttrs: {
     "VST3_INSTAL_DIR=$(out)/lib/vst3"
     "user=root"
     "STRIP=:"
+    "HAVE_XXD=1"
   ];
 
   postPatch = ''
     substituteInPlace NeuralRack/makefile \
-      --replace-fail "-flto=auto" ""
+      --replace-fail "-flto=auto" "" \
+      --replace-fail "pkg-config" '$(PKG_CONFIG)'
+
+    substituteInPlace libxputty/Build/Makefile \
+      --replace-fail "pkg-config" '$(PKG_CONFIG)'
+
+    substituteInPlace libxputty/Build/Makefile.base \
+      --replace-fail "pkg-config" '$(PKG_CONFIG)'
   '';
 
   meta = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] pkgsCross.aarch64-multiplatform
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
