### PR TITLE
python3Packages.qasync: disable failing tests with pytest9

### DIFF
--- a/pkgs/development/python-modules/qasync/default.nix
+++ b/pkgs/development/python-modules/qasync/default.nix
@@ -40,6 +40,13 @@ buildPythonPackage rec {
     "tests/test_run.py"
   ];
 
+  # qasync fails these tests due to a compatibility issue with Pytest 9:
+  # https://github.com/CabbageDevelopment/qasync/issues/178
+  disabledTests = [
+    "test_no_stale_reference_as_argument"
+    "test_no_stale_reference_as_result"
+  ];
+
   meta = {
     description = "Allows coroutines to be used in PyQt/PySide applications by providing an implementation of the PEP 3156 event-loop";
     homepage = "https://github.com/CabbageDevelopment/qasync";


### PR DESCRIPTION


Added `test_no_stale_reference_as_argument` and `test_no_stale_reference_as_result` to disabledTests, which fail due to a [`Pytest 9` incompatibility.](https://github.com/CabbageDevelopment/qasync/issues/178)


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].