### PR TITLE
curl-impersonate: fix dylib install name on darwin

### DIFF
--- a/pkgs/by-name/cu/curl-impersonate/package.nix
+++ b/pkgs/by-name/cu/curl-impersonate/package.nix
@@ -12,6 +12,7 @@
   automake,
   libtool,
   unzip,
+  fixDarwinDylibNames,
   nixosTests,
 }:
 stdenv.mkDerivation rec {
@@ -47,6 +48,14 @@ stdenv.mkDerivation rec {
     automake
     libtool
     unzip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Rewrite the dylib's install name to its absolute store path.
+    # Without this it keeps upstream's "@rpath/libcurl-impersonate.4.dylib",
+    # and every consumer linking it (e.g. python3Packages.curl-cffi's
+    # extension module, and through it yt-dlp) records an @rpath reference
+    # with no LC_RPATH set, failing at dlopen with "no LC_RPATH's found".
+    fixDarwinDylibNames
   ];
 
   # Upstream CMake build wants its own specific versions of

--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -52,11 +52,6 @@ buildPythonPackage rec {
     rich
   ];
 
-  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    install_name_tool -add_rpath "${curl-impersonate}/lib" \
-      $out/${python.sitePackages}/curl_cffi/_wrapper.abi3.so
-  '';
-
   pythonImportsCheck = [ "curl_cffi" ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
### Description

On darwin, `libcurl-impersonate.4.dylib` keeps upstream's `@rpath/...` install name (the package never ran `fixDarwinDylibNames`). Every consumer that links the library therefore records an `@rpath` reference without any `LC_RPATH` to resolve it, and fails at load time. Concretely, `python3Packages.curl-cffi` (a yt-dlp dependency since it moved to curl-impersonate) fails its `pythonImportsCheck` on aarch64-darwin:

```
ImportError: dlopen(.../curl_cffi/_wrapper.abi3.so, 0x0002):
  Library not loaded: @rpath/libcurl-impersonate.4.dylib
  Reason: no LC_RPATH's found
```

Adding the standard `fixDarwinDylibNames` hook rewrites the install name to the absolute store path, and consumers pick it up at link time with no changes on their side.

Verified on aarch64-darwin (macOS 27 beta):

- before: `otool -D lib/libcurl-impersonate.4.dylib` → `@rpath/libcurl-impersonate.4.dylib`
- after: → `/nix/store/...-curl-impersonate-2.1.0/lib/libcurl-impersonate.4.8.0.dylib`
- `python3Packages.curl-cffi` then passes its import check and proceeds into its test suite (remaining test failures there are the unrelated, already-skipped ones from #554405), and `yt-dlp` builds again.

**Automation/AI disclosure:** this change was prepared with the assistance of Claude Code (model: Claude Fable 5); the submitter reviewed the diff and the build evidence above. The commit carries the corresponding `Assisted-by:` trailer.

### Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test