### PR TITLE
python3Packages.hy: modernize

### DIFF
--- a/pkgs/development/python-modules/hy/default.nix
+++ b/pkgs/development/python-modules/hy/default.nix
@@ -4,14 +4,13 @@
   buildPythonPackage,
   fetchFromGitHub,
   funcparserlib,
-  hy,
   pytestCheckHook,
   python,
   setuptools,
-  testers,
+  versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hy";
   version = "1.3.1";
   pyproject = true;
@@ -19,18 +18,22 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "hylang";
     repo = "hy";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-qNgPuFG/j/q1osu/IJ8JbF+l/XiCphdhUYPOKbLEgTk=";
   };
 
   # https://github.com/hylang/hy/blob/1.0a4/get_version.py#L9-L10
-  env.HY_VERSION = version;
+  env.HY_VERSION = finalAttrs.version;
 
   build-system = [ setuptools ];
 
   dependencies = [ funcparserlib ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "-v";
 
   preCheck = ''
     # For test_bin_hy
@@ -40,29 +43,26 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "hy" ];
 
   passthru = {
-    tests.version = testers.testVersion {
-      package = hy;
-      command = "hy -v";
-    };
     # For backwards compatibility with removed pkgs/development/interpreters/hy
     # Example usage:
     #   hy.withPackages (ps: with ps; [ hyrule requests ])
     withPackages =
       python-packages:
       (python.withPackages (ps: (python-packages ps) ++ [ ps.hy ])).overrideAttrs (old: {
-        name = "${hy.name}-env";
-        meta = lib.mergeAttrs (removeAttrs hy.meta [ "license" ]) { mainProgram = "hy"; };
+        name = "${finalAttrs.finalPackage.name}-env";
+        meta = removeAttrs finalAttrs.finalPackage.meta [ "license" ];
       });
   };
 
   meta = {
     description = "LISP dialect embedded in Python";
     homepage = "https://hylang.org/";
-    changelog = "https://github.com/hylang/hy/releases/tag/${src.tag}";
+    changelog = "https://github.com/hylang/hy/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
+    mainProgram = "hy";
     maintainers = with lib.maintainers; [
       mazurel
       nixy
     ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
