### PR TITLE
native-sdk|native-cli: init at 0.9.5

### DIFF
--- a/pkgs/by-name/na/native-cli/package.nix
+++ b/pkgs/by-name/na/native-cli/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenvNoCC,
+  zig_0_16,
+  makeWrapper,
+  native-sdk,
+  lib,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "native-cli";
+  inherit (native-sdk) version;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = native-sdk;
+
+  nativeBuildInputs = [
+    makeWrapper
+    zig_0_16
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p $TMPDIR/zig-cache
+    zig build cli lib --global-cache-dir $TMPDIR/zig-cache
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec $out/bin $out/lib
+
+    cp zig-out/bin/native $out/libexec/native
+    makeWrapper $out/libexec/native $out/bin/native \
+        --set NATIVE_SDK_PATH ${native-sdk}
+
+    cp -r zig-out/lib/* $out/lib/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Toolkit for building native desktop apps";
+    homepage = "https://native-sdk.dev";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.ElSebas41 ];
+  };
+})

--- a/pkgs/by-name/na/native-sdk/package.nix
+++ b/pkgs/by-name/na/native-sdk/package.nix
@@ -1,0 +1,31 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "native-sdk";
+  version = "0.9.5";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vercel-labs";
+    repo = "native";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-N2HIkXvCtmju6ELTB/toiC0daMP5CS/YVrGRqQpBr4M=";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r $src/* $out/
+  '';
+
+  meta = {
+    description = "Toolkit for building native desktop apps";
+    homepage = "https://native-sdk.dev";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.ElSebas41 ];
+  };
+})


### PR DESCRIPTION
Native SDK is a toolkit for building native desktop apps for Linux, MacOS and Windows. Installing this via npm is very painfull in NixOS because the precompiled binaries downloaded by npm needs the standard linux FHS, so making a package which builds from source seems good to me.
To use the CLI, it is needed the native-sdk which is simply the source repo of the project so I created 2 packages, one for the SDK and one for the CLI which is a wrapper of the basic native CLI binary with the sdk environment variable pointing towards native-sdk.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
