### PR TITLE
python3Packages.pyinstaller: modernize

### DIFF
--- a/pkgs/development/python-modules/pyinstaller/default.nix
+++ b/pkgs/development/python-modules/pyinstaller/default.nix
@@ -19,17 +19,16 @@
   # tests
   binutils,
   glibc,
-  pyinstaller,
-  testers,
+  versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyinstaller";
   version = "6.22.2";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-ibZaOtB9ndWDIlPje8RfMYctENf51cn9D91giKg4Kd0=";
   };
 
@@ -56,14 +55,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "PyInstaller" ];
 
-  passthru.tests.version = testers.testVersion {
-    package = pyinstaller;
-  };
+  nativeCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Tool to bundle a python application with dependencies into a single package";
     homepage = "https://pyinstaller.org/";
-    changelog = "https://pyinstaller.org/en/v${version}/CHANGES.html";
+    changelog = "https://pyinstaller.org/en/v${finalAttrs.version}/CHANGES.html";
     downloadPage = "https://pypi.org/project/pyinstaller/";
     license = with lib.licenses; [
       mit
@@ -73,4 +70,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ h7x4 ];
     mainProgram = "pyinstaller";
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
