### PR TITLE
qbs: 1.24.1 -> 3.3.1

### DIFF
--- a/pkgs/by-name/qb/qbs/package.nix
+++ b/pkgs/by-name/qb/qbs/package.nix
@@ -1,41 +1,38 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  libsForQt5,
+  fetchgit,
+  cmake,
+  qt6,
 }:
 
 stdenv.mkDerivation rec {
   pname = "qbs";
 
-  version = "1.24.1";
+  version = "3.3.1";
 
-  src = fetchFromGitHub {
-    owner = "qbs";
-    repo = "qbs";
-    rev = "v${version}";
-    sha256 = "sha256-nL7UZh29Oecu3RvXYg5xsin2IvPWpApleLH37sEdSAI=";
+  src = fetchgit {
+    url = "https://code.qt.io/qbs/qbs.git";
+    tag = "v${version}";
+    sha256 = "sha256-1W7+CZt1mtx8RdcZxhEhgi6+4/SPQAjic8yYXckBuJg=";
   };
-
-  nativeBuildInputs = [ libsForQt5.qmake ];
 
   dontWrapQtApps = true;
 
-  qmakeFlags = [
-    "QBS_INSTALL_PREFIX=$(out)"
-    "qbs.pro"
-  ];
+  nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qtscript
+    qt6.qtbase
+    qt6.qt5compat
   ];
 
   meta = {
     description = "Tool that helps simplify the build process for developing projects across multiple platforms";
     homepage = "https://wiki.qt.io/Qbs";
     license = lib.licenses.lgpl3;
-    maintainers = [ ];
-    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      robinheghan
+    ];
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Existing package was outdated, so I updated to latest official sources.

I believe this will make it possible to build the tiled map editor on the darwin platform

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
