### PR TITLE
ocaml: default to version 5.5

### DIFF
--- a/pkgs/by-name/ab/abella/package.nix
+++ b/pkgs/by-name/ab/abella/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   rsync,
   ocamlPackages,
   dune,
@@ -15,6 +16,15 @@ stdenv.mkDerivation (finalAttrs: {
     url = "http://abella-prover.org/distributions/abella-${finalAttrs.version}.tar.gz";
     hash = "sha256-80b/RUpE3KRY0Qu8eeTxAbk6mwGG6jVTPOP0qFjyj2M=";
   };
+
+  patches = [
+    # Compatibility with OCaml 5.5
+    (fetchpatch {
+      url = "https://github.com/abella-prover/abella/commit/85dd329c03bf8866975ca0ea7278553d64f8d17f.patch";
+      includes = [ "src/*.ml" ];
+      hash = "sha256-adS2QGwqhLjiZo/Q4KUbpJVp8D/eNy/Ux17/nY3XMh4=";
+    })
+  ];
 
   strictDeps = true;
   __structuredAttrs = true;

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -50,7 +50,7 @@
   lz4,
   lzip,
   mono,
-  ocaml,
+  ocaml-ng,
   odt2txt,
   oggvideotools,
   openssh,
@@ -231,7 +231,7 @@ python.pkgs.buildPythonApplication rec {
         libcaca
         llvm
         mono
-        ocaml
+        ocaml-ng.ocamlPackages_5_4.ocaml
         odt2txt
         oggvideotools
         openssh

--- a/pkgs/by-name/ho/hol_light/package.nix
+++ b/pkgs/by-name/ho/hol_light/package.nix
@@ -4,13 +4,13 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   writeText,
-  ocamlPackages,
+  ocaml-ng,
   ledit,
   bash,
 }:
 
 let
-  inherit (ocamlPackages)
+  inherit (ocaml-ng.ocamlPackages_5_4)
     ocaml
     findlib
     zarith

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2422,7 +2422,7 @@ rec {
 
   ocamlPackages_latest = ocamlPackages_5_5;
 
-  ocamlPackages = ocamlPackages_5_4;
+  ocamlPackages = ocamlPackages_5_5;
 
   # We still have packages that rely on unsafe-string, which is deprecated in OCaml 4.06.0.
   # Below are aliases for porting them to the latest versions of the OCaml 4 series.


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
