### PR TITLE
shadps4: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/by-name/sh/shadps4-qtlauncher/package.nix
+++ b/pkgs/by-name/sh/shadps4-qtlauncher/package.nix
@@ -17,13 +17,13 @@
 }:
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "shadps4-qtlauncher";
-  version = "0-unstable-2026-08-08";
+  version = "0-unstable-2026-08-18";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadps4-qtlauncher";
-    rev = "a12b988ef35d98f2222a614c05498b27fef87121";
-    hash = "sha256-ux9iXNV5QiBCyLCyDYTN1WtO+DyMlXrr+8xWX/4TmD4=";
+    rev = "a30486c3e0a17460c44cf1caf15559c6f3331e57";
+    hash = "sha256-uVTy+0JvJUREY0qt+hkggSjyN1swGdG9aAYQvWNiNs4=";
 
     postCheckout = ''
       git -C "$out" rev-parse --short=8 HEAD > $out/COMMIT

--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -2,8 +2,7 @@
   lib,
   clangStdenv,
   fetchFromGitHub,
-  fetchpatch2,
-  makeWrapper,
+  makeBinaryWrapper,
 
   nixosTests,
   alsa-lib,
@@ -71,13 +70,13 @@ let
 in
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "shadps4";
-  version = "0.17.0";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadPS4";
     tag = "v.${finalAttrs.version}";
-    hash = "sha256-Z3UwxK+0D3RXKTM0ybYG4U42bInjF05KlMXzxN4UcNg=";
+    hash = "sha256-n2q4qmbknkT6kb6I5aeu6tU6EzSIfdrV+ptzQvhUJ/Q=";
 
     postCheckout = ''
       git -C "$out" rev-parse --short=8 HEAD > $out/COMMIT
@@ -105,15 +104,6 @@ clangStdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   __structuredAttrs = true;
 
-  patches = [
-    # https://github.com/shadps4-emu/shadPS4/pull/4786
-    (fetchpatch2 {
-      name = "use-system-zarchive.patch";
-      url = "https://github.com/shadps4-emu/shadPS4/commit/71c48b43570ac8df545d3d96261b0ec7fa37c808.patch?full_index=1";
-      hash = "sha256-MQiw+DGi/85nTSAVrNw2GmwhbBD7/Xy3lCIDMg1HxxU=";
-    })
-  ];
-
   postPatch = ''
     substituteInPlace src/common/scm_rev.cpp.in \
       --replace-fail @APP_VERSION@ ${finalAttrs.version} \
@@ -129,7 +119,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    makeWrapper
+    makeBinaryWrapper
   ];
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/releases/tag/v.0.18.0
Diff: https://github.com/shadps4-emu/shadPS4/compare/v.0.17.0...v.0.18.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
