### PR TITLE
claude-code: 2.1.235 -> 2.1.237

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-tnYZJ2Lx6AerYLhm5+2bNEpkNWRauDynJiA7T4wvveU=";
+          hash = "sha256-OkUNFovJqm/F65O9p47lPgne0mjXqMKVPpjSbP2vsHo=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-VNZr3WXNqFA8MYdwFwTjN2QoyRZCgKlKtMso7oocWvE=";
+          hash = "sha256-oPEwnli4L0FB0G5aJFxqadfSfzfar5FAvR5B03PjQog=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-w9afYKBwYitjqu1ORRtEfwZri3FAg7sQ+0p3nTimHzM=";
+          hash = "sha256-WHZojtsjbDwo+VwCUhj6jJVmhT/WiPlE7WRr8DUq170=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.235";
+      version = "2.1.237";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.json
+++ b/pkgs/by-name/cl/claude-code/manifest.json
@@ -1,53 +1,51 @@
 {
-  "version": "2.1.235",
-  "commit": "ba01fa45e3d1d888c1c23caed775ddd06192448b",
-  "buildDate": "2026-08-18T01:48:25Z",
+  "version": "2.1.237",
+  "commit": "45590910f0b746ddad3fe7d8135c5c29b33ccf88",
+  "buildDate": "2026-08-19T22:55:17Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "83b8f806f6f2eea316cfe246628e6c23374711d868f1fd0409db551b877b7748",
-      "size": 313334608
+      "checksum": "338901351d4ff17495738c67fc3e12a32c1b506738ac5e012eb782d3d8b5be43",
+      "size": 317110288
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "325a2dbc166ba8361a913ce588dce4a236789502060239acea52072bb51a54f1",
-      "size": 321995248
+      "checksum": "9f00789754a7b95febc6d4e37a3b6523d4d9c4c2333a2ce4bd596ad82186224e",
+      "size": 325793008
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "cff9592faa292db0f6ac21874f151b8c3d44e23bf0ab9fd1bcca95edc3469549",
-      "size": 328063208
+      "checksum": "a701cfb6bb4703abc6f3ce47508c878ca8158ebdbeacd5c35c7d510c7bc70177",
+      "size": 331864296
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "bfcf0ae2dbf94b2b6a106074aabf3938b9a10889c3b678e4cb5a00c03274d5d5",
-      "size": 330946864
+      "checksum": "73975167f0108693cf6fd6614994781657ebb8456ebef5d247458734abfb3916",
+      "size": 334715184
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "c852a47a50db72560a779240a0a9b86ef38cc1453ab5268228f6519e0eb231de",
-      "size": 321208088
+      "checksum": "60d832e81dd5076333e9f91286f660f2aaacc630079863599555caa8fe134eba",
+      "size": 325009176
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "6aae801d8f9d31d372e2152cab17d582941d94be03cfcd63328bb4436f0e0385",
-      "size": 325074912
+      "checksum": "b2c81ba8f2b0086b2536a56bf074bbf643043c2bd1aeea6ac8905709ae296168",
+      "size": 328843232
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "6786fa5d75a64260de09a3b5f88cd4644dc4292e45a38a4df93dc7eb4d0df3fb",
-      "size": 326528672
+      "checksum": "406167231b3636e55a01d0ce93567256c61e7973489e645883302f14808ae668",
+      "size": 330167456
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "8709594f6daebfef9a03ab56401600cfd1d0a980c640daf30d6de6f7cf3f42fe",
-      "size": 314428576
+      "checksum": "35978113ca98721cbf14c3abac90482d467419b9669d849c89d91c5664a5f95d",
+      "size": 318066848
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.197",
-      "0.3.198",
       "0.3.199",
       "0.3.200",
       "0.3.201",


### PR DESCRIPTION
Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard maintainers/scripts/update.nix script.

Updates `claude-code` and the `anthropic.claude-code` VS Code extension from 2.1.235 to 2.1.237.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
