### PR TITLE
nixos/i2pd: fix config check for yggdrasil-only setups

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -398,8 +398,8 @@ in
           sections = (lib.mapAttrs (_: unwrapPrefixes) (removeNulls attrs));
         };
 
-      gen = attr: {
-        conf = genConfig "i2pd.conf" (credSubstituteRec attr cfg.settings);
+      gen = attr: settings: {
+        conf = genConfig "i2pd.conf" (credSubstituteRec attr settings);
         tunconf = genTunnels "i2pd-tunnels.conf" (
           lib.mapAttrs' (k: v: lib.nameValuePair "client-${k}" (v // { "type" = "client"; })) (
             credSubstituteRec attr cfg.clientTunnels
@@ -410,8 +410,21 @@ in
         );
       };
 
-      i2pdConfig = gen "id";
-      i2pdCheckedConfig = gen "placeholder";
+      i2pdConfig = gen "id" cfg.settings;
+      # i2pd has no parse-only mode and requires a transport during startup.
+      i2pdCheckedConfig = gen "placeholder" (
+        lib.recursiveUpdate cfg.settings (
+          {
+            # Disable connectivity, in case build sandbox is disabled
+            ipv4 = false;
+            ipv6 = false;
+          }
+          // lib.optionalAttrs (cfg.settings.meshnets.yggdrasil or false) {
+            # Yggdrasil is unavailable in the check environment, so provide a usable transport.
+            ntcp2.enabled = true;
+          }
+        )
+      );
 
       # List of all passed credentials: `[ { id = ...; path = ...; } ... ]`
       credentials = credCollectRec [
@@ -457,10 +470,6 @@ in
             conf="${i2pdCheckedConfig.conf}"
             tunconf="${i2pdCheckedConfig.tunconf}"
 
-            # Disable connectivity, in case build sandbox is disabled
-            echo "ipv4 = false" >>conf
-            echo "ipv6 = false" >>conf
-            grep -Pv "^(ipv4|ipv6)[\s=]" "$conf" >>conf
             opts="$("$i2pd" --help | grep -Eo "^  --\S*port(udp)? arg" | sed "s/ arg\$/=0/g")"
 
             echo Checking "$conf"

--- a/nixos/tests/i2pd.nix
+++ b/nixos/tests/i2pd.nix
@@ -136,6 +136,38 @@
           };
         };
       };
+
+    yggdrasilCheck = {
+      services = {
+        yggdrasil = {
+          enable = true;
+          settings.MulticastInterfaces = [ ];
+        };
+
+        i2pd = {
+          enable = true;
+          settings = {
+            loglevel = "info";
+            netid = 77;
+            reseed.urls = "";
+            reseed.yggurls = "";
+            httpproxy.enabled = false;
+            socksproxy.enabled = false;
+
+            ipv4 = false;
+            ipv6 = false;
+            ntcp2.enabled = false;
+            ssu2.enabled = false;
+            meshnets.yggdrasil = true;
+
+            shareddest.inbound.length = 0;
+            shareddest.outbound.length = 0;
+            exploratory.inbound.length = 0;
+            exploratory.outbound.length = 0;
+          };
+        };
+      };
+    };
   };
 
   testScript =
@@ -147,9 +179,12 @@
       server.wait_for_unit("i2pd.service")
       client.wait_for_unit("i2pd.service")
       router.wait_for_unit("i2pd.service")
+      yggdrasilCheck.wait_for_unit("yggdrasil.service")
+      yggdrasilCheck.wait_for_unit("i2pd.service")
       server.wait_for_file("/var/lib/i2pd/router.info")
       client.wait_for_file("/var/lib/i2pd/router.info")
       router.wait_for_file("/var/lib/i2pd/router.info")
+      yggdrasilCheck.wait_for_file("/var/lib/i2pd/router.info")
 
       with subtest("Exchange router info"):
           server.wait_until_succeeds(


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Made the config check basically ignore transport selection by overriding them with known working values to allow yggdrasil-only configurations which fail the check because yggdrasil is not available.
Added a config check test for the yggdrasil-only configuration.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
