### PR TITLE
tea: 0.14.0 -> 0.15.1

### DIFF
--- a/pkgs/by-name/te/tea/package.nix
+++ b/pkgs/by-name/te/tea/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitea,
+  gitMinimal,
   installShellFiles,
   stdenv,
   writableTmpDirAsHomeHook,
@@ -9,34 +10,34 @@
 
 buildGoModule (finalAttrs: {
   pname = "tea";
-  version = "0.14.0";
+  version = "0.15.1";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
     repo = "tea";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-FLaOhU9oDZhpRJnWrXgIV3Cup6L9i5JHP5xWiu9aZkI=";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-b0Tzw9feSv/7lp67dzBoNV1l97t/AanUOo910Na6RQo=";
   };
 
-  vendorHash = "sha256-7FLDDJB5ms9miAaxQJ26MCBfRxQZN/RlXyMJweTk7SE=";
+  vendorHash = "sha256-tnA14lDGvEdUnOM1/f4d40PBYY7nXkUOTFzxzvzgJvY=";
 
   ldflags = [
     "-s"
     "-w"
-    "-X code.gitea.io/tea/modules/version.Version=${finalAttrs.version}"
-    "-X code.gitea.io/tea/modules/version.Tags=nixpkgs"
-    "-X code.gitea.io/tea/modules/version.SDK=0.23.2"
-  ];
-
-  checkFlags = [
-    # requires a git repository
-    "-skip=TestRepoFromPath_Worktree"
+    "-X gitea.dev/tea/modules/version.Version=${finalAttrs.version}"
+    "-X gitea.dev/tea/modules/version.Tags=nixpkgs"
+    "-X gitea.dev/tea/modules/version.SDK=1.2.0"
   ];
 
   nativeBuildInputs = [ installShellFiles ];
 
-  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tea \
@@ -53,6 +54,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Gitea official CLI client";
     homepage = "https://gitea.com/gitea/tea";
+    changelog = "https://gitea.com/gitea/tea/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       j4m3s


### PR DESCRIPTION
The module was renamed to gitea.dev/tea and switched to the new gitea.dev/sdk (v1.2.0), so I updated the ldflags to match.

During checkPhase, the new tests need git, so I added it to nativeCheckInputs.

Changelog in https://gitea.com/gitea/tea/releases

Closes #555438

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
