### PR TITLE
nixos/systemd/nspawn: allow unit settings added since systemd 250

### DIFF
--- a/nixos/modules/system/boot/systemd/nspawn.nix
+++ b/nixos/modules/system/boot/systemd/nspawn.nix
@@ -55,10 +55,14 @@ let
       "LinkJournal"
       "Ephemeral"
       "AmbientCapability"
+      "SuppressSync"
+      "PrivateUsersDelegate"
+      "RestrictAddressFamilies"
     ])
     (assertValueOneOf "Boot" boolValues)
     (assertValueOneOf "ProcessTwo" boolValues)
     (assertValueOneOf "NotifyReady" boolValues)
+    (assertValueOneOf "SuppressSync" boolValues)
   ];
 
   checkFiles = checkUnitConfig "Files" [
@@ -74,6 +78,7 @@ let
       "BindUser"
       "Inaccessible"
       "PrivateUsersOwnership"
+      "BindUserShell"
     ])
     (assertValueOneOf "ReadOnly" boolValues)
     (assertValueOneOf "Volatile" (boolValues ++ [ "state" ]))
@@ -97,6 +102,7 @@ let
       "Bridge"
       "Zone"
       "Port"
+      "NamespacePath"
     ])
     (assertValueOneOf "Private" boolValues)
     (assertValueOneOf "VirtualEthernet" boolValues)


### PR DESCRIPTION
The `systemd.nspawn.<name>.execConfig`, `filesConfig` and `networkConfig` options generate a `.nspawn` unit file, and validate their keys against hand-maintained allowlists in `nixos/modules/system/boot/systemd/nspawn.nix`. Those lists have fallen behind systemd, so five settings that systemd's `.nspawn` parser accepts are rejected at evaluation time with `is not of type 'attribute set of (systemd option)'`. This adds them.

Against `src/nspawn/nspawn-gperf.gperf` at `v261.1`, the version nixpkgs currently builds:

- `[Exec]`: `SuppressSync` (systemd 250), `PrivateUsersDelegate` (260), `RestrictAddressFamilies` (261)
- `[Files]`: `BindUserShell` (258)
- `[Network]`: `NamespacePath` (259)

`SuppressSync` is the one with a concrete caller. It installs a seccomp filter that turns the `@sync` system calls into successful no-ops, which is systemd's own answer to a container's `sync()` reaching the host page cache rather than the container's own filesystems, since `sync()` is not namespaced. systemd has accepted the setting in a `.nspawn` file since v250; only the NixOS option could not reach it.

`SuppressSync` takes a boolean and gets an `assertValueOneOf` like the other boolean keys in the same section. The remaining four take a number, a list or a path, so they get no value assertion.

The diff was also run in the other direction: every key currently in the three lists is still accepted by systemd 261.1, so nothing needs removing.

Verified by setting each key through `nixos/lib/eval-config.nix`: all five are rejected before the change and accepted after, and the generated `.nspawn` file contains the expected `Key=Value` lines. An unknown key and an out-of-range `SuppressSync` are still rejected.

Assisted-by: Claude:claude-opus-5
