### PR TITLE
heroku: 11.0.0 -> 11.10.0

### DIFF
--- a/pkgs/by-name/he/heroku/package.nix
+++ b/pkgs/by-name/he/heroku/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation {
   pname = "heroku";
-  version = "11.0.0";
+  version = "11.10.0";
 
   src = fetchzip {
-    url = "https://cli-assets.heroku.com/versions/11.0.0/a6e2188/heroku-v11.0.0-a6e2188-linux-x64.tar.xz";
-    hash = "sha256-kmshQ3QUcY4CLRFXHaOa7Y+wu8O5POL5+cGr7TyG5qg=";
+    url = "https://cli-assets.heroku.com/versions/11.10.0/bd9a3ab/heroku-v11.10.0-bd9a3ab-linux-x64.tar.xz";
+    hash = "sha256-IOFREL/C5afYBt+TUjVXZ97icEG+0IZ63M5cgsfMfN0=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -23,9 +23,9 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/share/heroku $out/bin
     cp -pr * $out/share/heroku
-    substituteInPlace $out/share/heroku/bin/run \
-      --replace "/usr/bin/env node" "${nodejs}/bin/node"
-    makeWrapper $out/share/heroku/bin/run $out/bin/heroku \
+    substituteInPlace $out/share/heroku/bin/run.js \
+      --replace "/usr/bin/env -S node" "${nodejs}/bin/node"
+    makeWrapper $out/share/heroku/bin/run.js $out/bin/heroku \
       --set HEROKU_DISABLE_AUTOUPDATE 1
   '';
 


### PR DESCRIPTION
The current version (11.0.0) contain [a bug that prevent using the subcommands `data:maintenances:*`](https://github.com/heroku/cli/issues/3608)

- Since [11.0.1](https://github.com/heroku/cli/releases/tag/v11.0.1): The shebang of `run` was changed to use `env -S node ...`
- Since [11.0.2](https://github.com/heroku/cli/releases/tag/v11.0.2): `run` exec was renamed to `run.js`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
