### PR TITLE
firefox: select ffmpeg by the libavcodec each browser prefers

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -11,8 +11,8 @@
   writeText,
 
   ## various stuff that can be plugged in
-  ffmpeg_7,
   ffmpeg_8,
+  ffmpeg_9,
   libxxf86vm,
   libxxf86dga,
   libxt,
@@ -91,9 +91,10 @@ let
       ffmpegSupport = browser.ffmpegSupport or false;
       # Firefox dlopens libavcodec by hardcoded soname, so each ffmpeg major needs
       # explicit browser support; keep versioned pins here (never the ffmpeg alias)
-      # and add a tier when a release gains the next ABI. 146 added libavcodec 62
-      # (https://bugzilla.mozilla.org/show_bug.cgi?id=1962139), not uplifted to ESR 140.
-      ffmpegPackage = if lib.versionAtLeast browser.version "146" then ffmpeg_8 else ffmpeg_7;
+      # and add a tier when a release gains the next ABI.
+      # libavcodec 62: 146 (bug 1962139), uplifted to ESR 140.10.2 (bug 2036244).
+      # libavcodec 63: 154 (bug 2057577), uplifted to ESR 153.1 (bug 2057577).
+      ffmpegPackage = if lib.versionAtLeast browser.version "153.1" then ffmpeg_9 else ffmpeg_8;
       gssSupport = browser.gssSupport or false;
       alsaSupport = browser.alsaSupport or false;
       pipewireSupport = browser.pipewireSupport or false;


### PR DESCRIPTION
Assisted-by: Claude Code (Claude Opus 5)


Follow-up to #548879. Browsers at Gecko 153.1 and later get `ffmpeg_9`. No wrapped browser is below libavcodec 62, so the `ffmpeg_7` tier is removed and `ffmpeg_8` becomes the floor. The previous comment said libavcodec 62 wasn't uplifted to ESR 140, which was wrong; this replaces it.

Evidence, checked against `mozilla-firefox/firefox` tags:

- libavcodec 63: 154 and later, ESR 153.1 and later ([bug 2057577](https://bugzilla.mozilla.org/show_bug.cgi?id=2057577))
- libavcodec 62: 146 and later, ESR 140.10.2 and later ([bug 1962139](https://bugzilla.mozilla.org/show_bug.cgi?id=1962139), [bug 2036244](https://bugzilla.mozilla.org/show_bug.cgi?id=2036244))

Resolved ffmpeg per `wrapFirefox` consumer:

| package | version | before | after |
| --- | --- | --- | --- |
| firefox, firefox-bin, firefox-mobile | 154.0 | 8 | 9 |
| firefox-beta, firefox-devedition | 154.0b10 | 8 | 9 |
| firefox-esr-153 | 153.1.0esr | 8 | 9 |
| librewolf | 154.0-2 | 8 | 9 |
| librewolf-bin | 153.0.4-1 | 8 | 8 |
| thunderbird | 153.0.3 | 8 | 8 |
| firefox-esr-140 | 140.14.0esr | 7 | 8 |
| thunderbird-esr | 140.13.0esr | 7 | 8 |
| firefoxpwa | 2.18.4 | 7 | 8 |
| floorp-bin | 12.16.4 | 7 | 8 |

`floorp-bin` and `firefoxpwa` report their own release number instead of the Gecko version they run, so `lib.versionAtLeast` puts them on the floor, which every in-tree Gecko supports.  This is preexisting and if addressed should be in separate PRs.

`vimb` also goes through `wrapFirefox`, but doesn't set `ffmpegSupport`, so it pulls no ffmpeg at all.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

