### PR TITLE
python3Packages.hatchling: 1.31.0 -> 1.32.0

### DIFF
--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -8,6 +8,7 @@
   packaging,
   pathspec,
   pluggy,
+  tomlkit,
   trove-classifiers,
 
   # tests
@@ -19,12 +20,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "hatchling";
-  version = "1.31.0";
+  version = "1.32.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-a0itQGikgu1yObOoIVvFW0eq0zRdWN/JTlU8XS1GIRs=";
+    hash = "sha256-C9veSlKwbDfj7KOV+Fp2K/DvBv43T9iuQp3GvhAjD18=";
   };
 
   # listed in backend/pyproject.toml
@@ -33,6 +34,7 @@ buildPythonPackage (finalAttrs: {
     packaging
     pathspec
     pluggy
+    tomlkit
     trove-classifiers
   ];
 

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -12,6 +12,15 @@
   tomli-w,
   trove-classifiers,
   virtualenv,
+
+  # Disable checks by default, as checks require gitMinimal, which eventually
+  # depends on hatchling, which depends on tomlkit, which depends on
+  # poetry-core, leading to infinite recursion.
+  doCheck ? false,
+
+  # self-reference for tests, since finalAttrs.finalPackage exposes neither
+  # `override` nor `overridePythonAttrs`.
+  poetry-core,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -25,6 +34,8 @@ buildPythonPackage (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-Io2VpLxnJesO4QohsunD7ogr87NiNjGeTmEl9wFswkw=";
   };
+
+  inherit doCheck;
 
   nativeCheckInputs = [
     build
@@ -55,6 +66,10 @@ buildPythonPackage (finalAttrs: {
   pythonNamespaces = [ "poetry" ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
+
+  # In passthru.tests, build with the check phase enabled, since that'll be
+  # outside the bootstrap dependency chain.
+  passthru.tests.withChecks = poetry-core.override { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/python-poetry/poetry-core/blob/${finalAttrs.src.tag}/CHANGELOG.md";

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -14,7 +14,7 @@
   virtualenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "poetry-core";
   version = "2.4.1";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = "poetry-core";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Io2VpLxnJesO4QohsunD7ogr87NiNjGeTmEl9wFswkw=";
   };
 
@@ -57,10 +57,10 @@ buildPythonPackage rec {
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
 
   meta = {
-    changelog = "https://github.com/python-poetry/poetry-core/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/python-poetry/poetry-core/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Poetry PEP 517 Build Backend";
     homepage = "https://github.com/python-poetry/poetry-core/";
     license = lib.licenses.mit;
     teams = [ lib.teams.python ];
   };
-}
+})

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -11,13 +11,13 @@
   pyyaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tomlkit";
   version = "0.15.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-fRqey6MIZjghGxOBTqeckN1U3RGZNWQ3bzqpInH1x6M=";
   };
 
@@ -32,9 +32,9 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://github.com/sdispater/tomlkit";
-    changelog = "https://github.com/sdispater/tomlkit/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/sdispater/tomlkit/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "Style-preserving TOML library for Python";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jakewaksbaum ];
   };
-}
+})

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -9,6 +9,15 @@
   # tests
   pytestCheckHook,
   pyyaml,
+
+  # Disable checks by default, as checks require pytest, which eventually
+  # depends on hatchling, which depends on tomlkit, leading to infinite
+  # recursion.
+  doCheck ? false,
+
+  # self-reference for tests, since finalAttrs.finalPackage exposes neither
+  # `override` nor `overridePythonAttrs`.
+  tomlkit,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -23,12 +32,18 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ poetry-core ];
 
+  inherit doCheck;
+
   nativeCheckInputs = [
     pyyaml
     pytestCheckHook
   ];
 
   pythonImportsCheck = [ "tomlkit" ];
+
+  # In passthru.tests, build with the check phase enabled, since that'll be
+  # outside the bootstrap dependency chain.
+  passthru.tests.withChecks = tomlkit.override { doCheck = true; };
 
   meta = {
     homepage = "https://github.com/sdispater/tomlkit";


### PR DESCRIPTION
Changelog: https://github.com/pypa/hatch/releases/tag/hatchling-v1.32.0

This version changes adds tomlkit as a dependency for hatchling.  To avoid circular dependencies, this PR also changes the builds of tomlkit and poetry-core to skip their check phase, as their check phases currently indirectly require hatchling.  Add additional builds of both those packages in `passthru.tests`, so we still get the benefit of the tests but without them being part of the mainline dependency chain.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
