### PR TITLE
deluge: add option to add custom plugins

### DIFF
--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.deluge;
   cfg_web = config.services.deluge.web;
-  isDeluge1 = lib.versionOlder cfg.package.version "2.0.0";
+  isDeluge1 = lib.versionOlder package.version "2.0.0";
 
   openFilesLimit = 4096;
   listenPortsDefault = [
@@ -45,6 +45,10 @@ let
           rm ${declarativeLockFile}
         fi
       '';
+
+  package = cfg.package.override {
+    additionalPlugins = cfg.additionalPlugins;
+  };
 in
 {
   options = {
@@ -71,6 +75,7 @@ in
               allow_remote = true;
               daemon_port = 58846;
               listen_ports = [ ${toString listenPortsDefault} ];
+              enabled_plugins = [ "Label" "my_custom_plugin" ];
             }
           '';
           description = ''
@@ -80,6 +85,9 @@ in
             boolean values must not. See
             <https://git.deluge-torrent.org/deluge/tree/deluge/core/preferencesmanager.py#n41>
             for the available options.
+
+            To enable a built-in plugin, just give its name. To enable a custom plugin,
+            you also need to add it to (option)`services.deluge.additionalPlugins`.
           '';
         };
 
@@ -160,6 +168,16 @@ in
           '';
         };
 
+        additionalPlugins = lib.mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [ ];
+          description = ''
+            Additional plugins to be made available to Deluge. Each plugin can contain
+            one or multiple .egg files which will all be symlinked to into Deluge's
+            plugin folder.
+          '';
+        };
+
         package = lib.mkPackageOption pkgs "deluge-2_x" { };
       };
 
@@ -235,10 +253,10 @@ in
       after = [ "network.target" ];
       description = "Deluge BitTorrent Daemon";
       wantedBy = [ "multi-user.target" ];
-      path = [ cfg.package ] ++ cfg.extraPackages;
+      path = [ package ] ++ cfg.extraPackages;
       serviceConfig = {
         ExecStart = ''
-          ${cfg.package}/bin/deluged \
+          ${package}/bin/deluged \
             --do-not-daemonize \
             --config ${configDir}
         '';
@@ -261,10 +279,10 @@ in
       requires = [ "deluged.service" ];
       description = "Deluge BitTorrent WebUI";
       wantedBy = [ "multi-user.target" ];
-      path = [ cfg.package ];
+      path = [ package ];
       serviceConfig = {
         ExecStart = ''
-          ${cfg.package}/bin/deluge-web \
+          ${package}/bin/deluge-web \
             ${lib.optionalString (!isDeluge1) "--do-not-daemonize"} \
             --config ${configDir} \
             --port ${toString cfg.web.port}
@@ -284,7 +302,7 @@ in
       })
     ];
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ package ];
 
     users.users = lib.mkIf (cfg.user == "deluge") {
       deluge = {

--- a/nixos/tests/deluge.nix
+++ b/nixos/tests/deluge.nix
@@ -1,4 +1,31 @@
 { pkgs, ... }:
+let
+  pluginName = "DefaultTrackers";
+  plugin = (
+    pkgs.callPackage (
+      { python3, fetchFromGitHub }:
+      python3.pkgs.buildPythonPackage {
+        name = "deluge-default-trackers";
+        version = "v0.6";
+        src = fetchFromGitHub {
+          owner = "stefantalpalaru/";
+          repo = "deluge-default-trackers";
+          rev = "v0.6";
+          sha256 = "sha256-4dii8OLobczEDXhD+TFUD2yCXHf1B4Ns51cRQJsGIvI=";
+        };
+        doCheck = false;
+        format = "other";
+        nativeBuildInputs = [ python3.pkgs.setuptools ];
+        buildPhase = ''
+          mkdir "$out"
+          python3 setup.py bdist_egg
+          cp dist/* "$out"
+        '';
+        doInstallPhase = false;
+      }
+    ) { }
+  );
+in
 {
   name = "deluge";
   meta = with pkgs.lib.maintainers; {
@@ -31,6 +58,7 @@
             6881
             6889
           ];
+          enabled_plugins = [ pluginName ];
         };
         web = {
           enable = true;
@@ -41,12 +69,25 @@
           andrew:password:10
           user3:anotherpass:5
         '';
+        additionalPlugins = [
+          plugin
+        ];
       };
     };
 
   };
 
   testScript = ''
+    def deluge_console(node, cmd):
+        out = node.succeed(f"deluge-console 'connect 127.0.0.1:58846 andrew password; {cmd}'")
+        print(f"{cmd}:\n{out}")
+        return out
+
+    def parse_plugin(out):
+        return [p.strip() for p in out.splitlines()[1:]]
+
+    pluginName = "${pluginName}"
+
     start_all()
 
     simple.wait_for_unit("deluged")
@@ -59,9 +100,16 @@
     declarative.wait_for_unit("delugeweb")
     declarative.wait_until_succeeds("curl --fail http://declarative:3142")
 
-    # deluge-console always exits with 1. https://dev.deluge-torrent.org/ticket/3291
-    declarative.succeed(
-        "(deluge-console 'connect 127.0.0.1:58846 andrew password; help' || true) | grep -q 'rm.*Remove a torrent'"
-    )
+    deluge_console(declarative, "help")
+
+    with subtest("Additional plugin found in available plugins list"):
+        available_plugins = parse_plugin(deluge_console(declarative, "plugin --list"))
+        if pluginName not in available_plugins:
+           raise Exception(f"Expected {pluginName} to be in available plugins list: {", ".join(available_plugins)}")
+
+    with subtest("Additional plugin found in enabled plugins list"):
+        enabled_plugins = parse_plugin(deluge_console(declarative, "plugin --show"))
+        if pluginName not in enabled_plugins:
+           raise Exception(f"Expected {pluginName} to be in enabled plugins list: {", ".join(enabled_plugins)}")
   '';
 }

--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -11,6 +11,7 @@
   librsvg,
   wrapGAppsHook3,
   nixosTests,
+  additionalPlugins ? [ ],
 }:
 
 let
@@ -97,7 +98,11 @@ let
             rm -r $out/${python3Packages.python.sitePackages}/deluge/ui/gtk3
             rm -r $out/share/{icons,man/man1/deluge-gtk*,pixmaps}
           ''
-      );
+      )
+      + (lib.concatMapStringsSep "\n" (p: ''
+        find "${p}/" -type f -name "*.egg" -print0 | \
+          xargs -n1 -0 -I{} -- ln -s {} $out/${python3Packages.python.sitePackages}/deluge/plugins
+      '') additionalPlugins);
 
       postFixup = ''
         for f in $out/lib/systemd/system/*; do


### PR DESCRIPTION
Add a new `additionalPlugins` argument to link custom deluge plugins inside the deluge package directly.

Also adds a NixOS option `services.deluge.additionalPlugins` to more easily add those using NixOS module options. The option supports adding those plugins to a user-given `services.deluge.package`. Adds a check in the NixOS test to make sure this works.

And finally revamps a little bit the NixOS test with a function to run deluge-console commands.

One day we could have a registry of plugins like Nextcloud does.

Note: this PR needs https://github.com/NixOS/nixpkgs/pull/548035 to run the test. I applied the patch locally and ran the test that way.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
