### PR TITLE
electron_{41,42,43}: updates

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -21,13 +21,13 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "8961cdb57c95c073ff4770bc9309953832f447575f1a91127010f7b4870884b3",
-            "aarch64-linux": "1c18f4e9a67a6b5affb33596d8c886f35063e0439cbef79a6fc7037d147d1bbb",
-            "armv7l-linux": "1f1d6a5aab2f23be9485a90b4ad11d9a22d251fc1c913897d7d0f8359c918123",
-            "headers": "1y047hd1yhm4iv8rng1q89fd3x4ry07lfljcbdd5vjfzcnqmgmmr",
-            "x86_64-linux": "333c08c551387056966838a9f55cb10cf8203e68ca99e83982ce53ddd40383e9"
+            "aarch64-darwin": "659ba4253ca14f0bd8e74d5a2da2d6da3e73e44c0209d2c3b5e6ca65ac40558a",
+            "aarch64-linux": "9dbb040d575c33f8b2d2ab944e429979b01b5261c0240cff4749892be1bc56ea",
+            "armv7l-linux": "c96c2107073136a1fe7619e09dab07a14d7f4acde9a28d04993e67e69a156d15",
+            "headers": "1nvq3xvz38xr64r1z7xa6wdmf6zykdsbl7angmy7bvr5rw4pi897",
+            "x86_64-linux": "a27291d502b16170fe49d14beab68c4d9a1040192500e1643a9ab0b11274f075"
         },
-        "version": "41.10.3"
+        "version": "41.10.6"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -41,12 +41,12 @@
     },
     "43": {
         "hashes": {
-            "aarch64-darwin": "ad4a0ae3c37ee05aa06c7e2ed0627608389790f0505a2b0d20319efbe33ffe28",
-            "aarch64-linux": "50e1cdefbf8590e0d89b0276314a99c7b98e8eed732204c6f1a1c2a38376ed87",
-            "armv7l-linux": "e5cf445bda3ef071bbe9f16dfbabbca61b24b528f2dcbdff227e98fb349c99e8",
-            "headers": "0jxrbsi1ipzkq3ah7vbqd3glzd423603ii1d1i7kabirxmxra5kk",
-            "x86_64-linux": "f77ca6ed67bbc68702b69b56ad499bca6ae090705ade7d04f0ac545e409dec68"
+            "aarch64-darwin": "fe3cac8cbfd9ba1739fac6c69166cf30848741f93cbe251d800ae6ef7cebb64b",
+            "aarch64-linux": "9e2b5cfbd387e138f06c7bb19b399bb3ee487dbb4110215df097d94e80431892",
+            "armv7l-linux": "2875860d6b7cb2e8a0142fb87f9f7be50a382a87a24bf15a0861f20ba53dc400",
+            "headers": "0q7l48q2l4srmkw67l1bhk3qbybnqamcr5z8yrsnbxk8aazqjshv",
+            "x86_64-linux": "79d4efd69f0ccf1fc11891ea5075329c7b3faddad79a08d9fb395bbd63169acf"
         },
-        "version": "43.2.0"
+        "version": "43.4.1"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -31,13 +31,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "13b7c3782ac73ba64410542410a2d06f022c515730e97c5149aff2190a6c8e80",
-            "aarch64-linux": "ba1f8055a6b601e9cd771a7c750ed37b912c486a51f51e58654ed9414bc898ba",
-            "armv7l-linux": "32d446a7a8f1f430c2030a1b2cd4220e52f95d24a607db28539b00ac6141c1d5",
-            "headers": "1aidb6q7hfz0569qm8ah77dgw2zzp157ls1kbs0ylsifgvxc0zkd",
-            "x86_64-linux": "e85b28245deaa75c3c4f2cf5da084f4c7fbedd5af1630c59a827c41ac1f5e1af"
+            "aarch64-darwin": "ea14213b15708bf571f4685772fb562a6469bcb9c49f4148077727d681e82e57",
+            "aarch64-linux": "1064e5cc5aa6490bb094b5e665cad4c8d520dcd4d52581ad68877793199fb903",
+            "armv7l-linux": "41439e99891463e9bca4799e13ad636d8ecc81afc05bb6ac616b12747ab01bb7",
+            "headers": "1hjq26ssigp2dnfgg0wspsabvgpgm0cb63m5xkji9gsm2vf35rg1",
+            "x86_64-linux": "46fc1cd5d70de57c372fbc0f36870c4c4d80b127a0d452d80bd577c5a7d39b7d"
         },
-        "version": "42.7.1"
+        "version": "42.9.3"
     },
     "43": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -21,13 +21,13 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "b15b61d91c8d02a9f6a8ba8ec943736103aa0158f61220cda3d51867e72de9ea",
-            "aarch64-linux": "210abfcb3e3c4ab1ebd2eeae6312ecd5fb04c91563df9aa35ab8e2110ea9e6cb",
-            "armv7l-linux": "f5e1aeeb9bbdfa698efc60b44c4e4e0fd0addb52746416789f079889f3da3295",
-            "headers": "1y047hd1yhm4iv8rng1q89fd3x4ry07lfljcbdd5vjfzcnqmgmmr",
-            "x86_64-linux": "ffd42b9ed6809e993e82ea967817b02257c8ca5ff522d6da7c87744aa243658c"
+            "aarch64-darwin": "1b61cc5f26ca9d329f1502697dc3e1f00fd92b593f6b1688acebd33279854d1b",
+            "aarch64-linux": "8676949b061c58d5e4454f392d5f91206f807f556d993c5ac2c58ab0dc53f372",
+            "armv7l-linux": "e7191ce892fad4cca3c302faa389e1e469402765b58ce5508969f8a5ee813b48",
+            "headers": "1nvq3xvz38xr64r1z7xa6wdmf6zykdsbl7angmy7bvr5rw4pi897",
+            "x86_64-linux": "652465ce0057fb670c5e7d4ee126fb5d6043d1c1bf9152901ac85231a5ffdbbb"
         },
-        "version": "41.10.3"
+        "version": "41.10.6"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -41,12 +41,12 @@
     },
     "43": {
         "hashes": {
-            "aarch64-darwin": "a171d9b03328faf922a1046d822a7a318e8c5409932f16784e4df50c561ed867",
-            "aarch64-linux": "e065867528f16c723ba0eeedefb8b5bdacf3c18f083424bb9dbb2efb443807d6",
-            "armv7l-linux": "5c77f04d36705f8cc554aa83faa0187c6e181471e62d28713576dafb08b7742a",
-            "headers": "0jxrbsi1ipzkq3ah7vbqd3glzd423603ii1d1i7kabirxmxra5kk",
-            "x86_64-linux": "a7b40eb8e0dfcc98f0e9e08a62b769fe8a191990e263929b98e1b565ba44f06e"
+            "aarch64-darwin": "5facb44cd08b2d84054ec42ce9ef2d9ea9763bd081e93e04b835c82c6ea8ab49",
+            "aarch64-linux": "c9f666e0a2736378273545277e3fe00decfa856ff4701928c51adfeacd81b5a4",
+            "armv7l-linux": "2aaefcc5bd00d2ce61378c9f064e83f03177848526a057922dfef0cddbb0d49c",
+            "headers": "0q7l48q2l4srmkw67l1bhk3qbybnqamcr5z8yrsnbxk8aazqjshv",
+            "x86_64-linux": "7d66ef37dd8ac3dd9a80baf28193e686d97abddcd7229a47f021ec824259679e"
         },
-        "version": "43.2.0"
+        "version": "43.4.1"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -31,13 +31,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "86a51e959895606faea4d49e206cb343d61542f40a5814d636221176948e1054",
-            "aarch64-linux": "46f9a12160a0ddba75746a5d8e4d508a98a1ba757cd89dfa65a618805d5abc91",
-            "armv7l-linux": "ecdbdf8fa23e71c060e9bb0acab16e7887299b9a9534e43e1ffbfc7c308f0a9a",
-            "headers": "1aidb6q7hfz0569qm8ah77dgw2zzp157ls1kbs0ylsifgvxc0zkd",
-            "x86_64-linux": "3135cb825075c02456e05d45bf463284f79065002770ad00d2046c431fda1e77"
+            "aarch64-darwin": "68923728c4a777c64a7f4ea90f950c9859d981be341de75e8ee67265ebba28c9",
+            "aarch64-linux": "fdd4e11784b695bd0152b0aefb1262539ac763ec684cf8a3c50bb20ebcd2b084",
+            "armv7l-linux": "3cba937b4ccbe6d0409ed3064c1e126043e96160ac81183140eddfbb69366a07",
+            "headers": "1hjq26ssigp2dnfgg0wspsabvgpgm0cb63m5xkji9gsm2vf35rg1",
+            "x86_64-linux": "9abaadfe6c446613d3623ffb5de743aefba1afe4f8cb5928f293b330b0a7f2e6"
         },
-        "version": "42.7.1"
+        "version": "42.9.3"
     },
     "43": {
         "hashes": {

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1462,10 +1462,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-1EUoEiND6qF+Lj+SEXvJe5zP5uLnvGEU7GRATk4h1J4=",
+                    "hash": "sha256-RGgR1Gi8EtRfuNQ86Q3y0a+ys0Um3ilmuykKtq6BHVI=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v42.7.1"
+                    "tag": "v42.9.3"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1815,10 +1815,10 @@
             },
             "src/third_party/electron_node": {
                 "args": {
-                    "hash": "sha256-jlyRCBNU4YV5NKwsibJFcp7dRerfDlNFoCjWU1H1aqE=",
+                    "hash": "sha256-Pecc7wFTAcQmeCsXN6RGTuO1Wqyei+ChbpsJ7yBRHJI=",
                     "owner": "nodejs",
                     "repo": "node",
-                    "tag": "v24.18.0"
+                    "tag": "v24.18.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2816,8 +2816,8 @@
             }
         },
         "modules": "146",
-        "node": "24.18.0",
-        "version": "42.7.1"
+        "node": "24.18.1",
+        "version": "42.9.3"
     },
     "43": {
         "chrome": "150.0.7871.129",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2820,7 +2820,7 @@
         "version": "42.9.3"
     },
     "43": {
-        "chrome": "150.0.7871.129",
+        "chrome": "150.0.7871.224",
         "chromium": {
             "deps": {
                 "gn": {
@@ -2829,15 +2829,15 @@
                     "version": "0-unstable-2026-05-27"
                 }
             },
-            "version": "150.0.7871.129"
+            "version": "150.0.7871.224"
         },
         "chromium_npm_hash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-vO2/UI0MPa8Kpkr+hv4nABmzSwSkQO+Tq+eWPFCzd88=",
+                    "hash": "sha256-xlUNimJaRCiZKGaj3YtbVp2v8/jxbPiQHeSwX7o9ILQ=",
                     "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "150.0.7871.129",
+                    "tag": "150.0.7871.224",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -2884,10 +2884,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-Cv3XspF5/A4HCeSB+r3yilO9fMBtf5TBekG1ZM7eej8=",
+                    "hash": "sha256-sZMQ9KBxmW9xv5CiBgy0YBrxV2xlwrOWXR+f3YEp0H0=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v43.2.0"
+                    "tag": "v43.4.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2917,8 +2917,8 @@
             },
             "src/third_party/angle": {
                 "args": {
-                    "hash": "sha256-fbjREn3D+quRRADGwR7V65BZt5b+1DgnsG4ZMhwGq6o=",
-                    "rev": "13e691adf3d4d3ebee2f7239731a07d3b9704956",
+                    "hash": "sha256-JzxdmLqaXc5vmaiXjVnatgXzKF1MmT1gBoQ/iTjjggU=",
+                    "rev": "674c1eb24c1250ddf5911ac46b5373cd084d4e78",
                     "url": "https://chromium.googlesource.com/angle/angle.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3117,8 +3117,8 @@
             },
             "src/third_party/dawn": {
                 "args": {
-                    "hash": "sha256-tzomo+GTec2zixxk61gtlma/sjcBImgbLMwA+mIp1LM=",
-                    "rev": "01249a97332468dbdd6cf5edb8dd7bae77875de5",
+                    "hash": "sha256-ZcfSMBvdAdEJQv+qfwAe8EFHPAfPtuKLTIR5lDRKP3Q=",
+                    "rev": "d089fc91e7e4881362463faf8efe9ae435e34660",
                     "url": "https://dawn.googlesource.com/dawn.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3229,10 +3229,10 @@
             },
             "src/third_party/electron_node": {
                 "args": {
-                    "hash": "sha256-jlyRCBNU4YV5NKwsibJFcp7dRerfDlNFoCjWU1H1aqE=",
+                    "hash": "sha256-Pecc7wFTAcQmeCsXN6RGTuO1Wqyei+ChbpsJ7yBRHJI=",
                     "owner": "nodejs",
                     "repo": "node",
-                    "tag": "v24.18.0"
+                    "tag": "v24.18.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -3728,8 +3728,8 @@
             },
             "src/third_party/openh264/src": {
                 "args": {
-                    "hash": "sha256-tf0lnxATCkoq+xRti6gK6J47HwioAYWnpEsLGSA5Xdg=",
-                    "rev": "652bdb7719f30b52b08e506645a7322ff1b2cc6f",
+                    "hash": "sha256-KMn8T8jCs4tdsmrU/fEBd0IWnBdD702x9JdJ0p98ZGk=",
+                    "rev": "fca40fc19f5fb854609d297ae4bde71df72787c9",
                     "url": "https://chromium.googlesource.com/external/github.com/cisco/openh264"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3872,8 +3872,8 @@
             },
             "src/third_party/skia": {
                 "args": {
-                    "hash": "sha256-SWmoX+sNaw4KnlTBPt63uBSYfQavJejB3+Vlw/gtWX8=",
-                    "rev": "bee4c917220040e147f14964635ff92ce6c5a3f6",
+                    "hash": "sha256-Aux2Gp3Fgu5me3jZbwRAouGpEPIMzo/dQGkQLZJNf2Y=",
+                    "rev": "a81173f17b197686dc1e6c78515de86e92ddc861",
                     "url": "https://skia.googlesource.com/skia.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4195,8 +4195,8 @@
             },
             "src/v8": {
                 "args": {
-                    "hash": "sha256-bqzCZSpKdXgKv3O1I7ck1PEXCa/2jBT7hpBEKW0LgTA=",
-                    "rev": "2b2f69158528fdd9d86b778cfcc2d0a1c4f8c59f",
+                    "hash": "sha256-KCZnCIH6a9oAqMXZDsTuRQZv/JmdhasjlrQ5aYk/el4=",
+                    "rev": "17700469f857c3aaf7e2803a9b77b7b25ced9399",
                     "url": "https://chromium.googlesource.com/v8/v8.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4246,7 +4246,7 @@
             }
         },
         "modules": "148",
-        "node": "24.18.0",
-        "version": "43.2.0"
+        "node": "24.18.1",
+        "version": "43.4.1"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -56,10 +56,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-5dxL/+24XgRtShYUYDPEiTEWWSs4fRAZGs9KbwHepYw=",
+                    "hash": "sha256-cl0QDTNyO+hXh/B3uTUTK3UgwszIKd96+H64hn8RKuM=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v41.10.3"
+                    "tag": "v41.10.6"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1403,7 +1403,7 @@
         },
         "modules": "145",
         "node": "24.18.0",
-        "version": "41.10.3"
+        "version": "41.10.6"
     },
     "42": {
         "chrome": "148.0.7778.280",


### PR DESCRIPTION
New round of Electron updates!

### Electron 41

- Changelog: https://github.com/electron/electron/releases/tag/v41.10.6
- Diff: https://github.com/electron/electron/compare/refs/tags/v41.10.3...v41.10.6

### Electron 42

- Changelog: https://github.com/electron/electron/releases/tag/v42.9.3
- Diff: https://github.com/electron/electron/compare/refs/tags/v42.7.1...v42.9.3

### Electron 43

- Changelog: https://github.com/electron/electron/releases/tag/v43.4.1
- Diff: https://github.com/electron/electron/compare/refs/tags/v43.2.0...v43.4.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
