### PR TITLE
postgresqlPackages.omnigres: unpin clang_18

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/omnigres.nix
+++ b/pkgs/servers/sql/postgresql/ext/omnigres.nix
@@ -1,6 +1,6 @@
 {
   brotli,
-  clang_18,
+  clang,
   cmake,
   fetchFromGitHub,
   flex,
@@ -58,7 +58,7 @@ postgresqlBuildExtension (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    clang_18
+    clang
     cmake
     flex
     netcat


### PR DESCRIPTION
we are having trouble ascertaining *why* this this was originally pinned at all, given that this was added in the init of omnigres and the init pr (#404027) does not seem to offer more clarity on why this is. given that it still builds with an unpinned clang, we simply unpin and let it use the default version of clang, which helps reduce compiler version proliferation and prepare for the drop of llvm 18 (hopefully in the 26.11 release cycle).

frankly, we are not entirely sure why this has a clang dependency at all, and it seems to build just fine without it. if this is supposed to be built with clang, it seems that it should be using `clangStdenv` or `llvmPackages_NN.stdenv` in some form, but that does not seem to be the case. however, without further domain expertise we're not inclined to just remove the dependency. we would be more than happy for someone more familiar/knowledgeable to tell us that this can simply be dropped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
