### PR TITLE
dt: 1.3.1-unstable-2024-07-16 -> 1.3.1-unstable-2025-06-20, zig_0_13 -> zig_0_14

### DIFF
--- a/pkgs/by-name/dt/dt/package.nix
+++ b/pkgs/by-name/dt/dt/package.nix
@@ -2,24 +2,21 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  testers,
-  zig_0_13,
+  zig_0_14,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dt";
-  version = "1.3.1-unstable-2024-07-16";
+  version = "1.3.1-unstable-2025-06-20";
 
   src = fetchFromGitHub {
     owner = "so-dang-cool";
     repo = "dt";
-    rev = "0d16ca2867131e99a93a412231465cf68f2e594f";
-    hash = "sha256-pfTlOMJpOPbXZaJJvOKDUyCZxFHNLRRUteJFWT9IKOU=";
+    rev = "7b87e3e012439179772617814cb7d001928d6868";
+    hash = "sha256-m3tpnPzgkZw7PR9+bnjbKWcvyfO91F0pucSLRJgiHhw=";
   };
 
-  nativeBuildInputs = [ zig_0_13 ];
-
-  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+  nativeBuildInputs = [ zig_0_14 ];
 
   meta = {
     homepage = "https://dt.plumbing";


### PR DESCRIPTION
diff: https://github.com/so-dang-cool/dt/compare/0d16ca2867131e99a93a412231465cf68f2e594f...7b87e3e012439179772617814cb7d001928d6868

zig 0.13 will soon be removed from nixpkgs as it depends on llvm 18. dt needs to be updated to a newer zig version, and this has been done upstream, but a release has not yet been cut. accordingly, we update to the latest upstream commit in order to get support for zig 0.14.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested some examples from the docs)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
