### PR TITLE
python3Packages.torchlensmaker: init at 0.0.14

### DIFF
--- a/pkgs/development/python-modules/indicio/default.nix
+++ b/pkgs/development/python-modules/indicio/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+
+  # build-system
+  uv-build,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "indicio";
+  version = "1.1.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "victorpoughon";
+    repo = "indicio";
+    tag = finalAttrs.version;
+    hash = "sha256-F2afc+Gi1EPxJYfvcIRdiCKpqTObxtU/ae6Y7qijw9Q=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.10.9,<0.11.0" "uv_build"
+  '';
+
+  build-system = [
+    uv-build
+  ];
+
+  pythonImportsCheck = [
+    "indicio"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python interface to refractiveindex.info";
+    longDescription = ''
+      Indicio is a python package that provides offline access to the
+      refractiveindex.info database of optical constants.
+    '';
+    homepage = "https://codeberg.org/victorpoughon/indicio";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/tlmviewer/default.nix
+++ b/pkgs/development/python-modules/tlmviewer/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  torchlensmaker,
+
+  # build-system
+  uv-build,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "tlmviewer";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  inherit (torchlensmaker)
+    version
+    src
+    ;
+
+  sourceRoot = "${finalAttrs.src.name}/tlmviewer-python";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.10.9,<0.11.0" "uv_build"
+  '';
+
+  build-system = [
+    uv-build
+  ];
+
+  pythonImportsCheck = [
+    "tlmviewer"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Require connection to tlmserver (http://127.0.0.1:8765/push)
+    # TODO: package tlmserver?
+    "test_push_raises_connection_refused_when_unreachable"
+    "test_allow_fail_silences_http_error"
+    "test_allow_fail_not_set_still_raises"
+  ];
+
+  meta = {
+    description = "3D optical scene viewer for torchlensmaker";
+
+    inherit (torchlensmaker.meta)
+      homepage
+      changelog
+      license
+      maintainers
+      teams
+      ;
+  };
+})

--- a/pkgs/development/python-modules/torchimplicit/default.nix
+++ b/pkgs/development/python-modules/torchimplicit/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  torchlensmaker,
+
+  # build-system
+  uv-build,
+
+  # dependencies
+  torch,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torchimplicit";
+  version = "0.1.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  inherit (torchlensmaker)
+    src
+    ;
+
+  sourceRoot = "${finalAttrs.src.name}/torchimplicit";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.10.9,<0.11.0" "uv_build"
+  '';
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    torch
+  ];
+
+  pythonImportsCheck = [
+    "torchimplicit"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Implicit 2D and 3D surfaces in PyTorch";
+
+    inherit (torchlensmaker.meta)
+      homepage
+      changelog
+      license
+      maintainers
+      teams
+      ;
+  };
+})

--- a/pkgs/development/python-modules/torchlensmaker/default.nix
+++ b/pkgs/development/python-modules/torchlensmaker/default.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  indicio,
+  ipython,
+  jaxtyping,
+  matplotlib,
+  tlmviewer,
+  torchimplicit,
+
+  # tests
+  onnxruntime,
+  onnxscript,
+  pytestCheckHook,
+
+  # passthru
+  callPackage,
+  python,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torchlensmaker";
+  version = "0.0.14";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "victorpoughon";
+    repo = "torchlensmaker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-B9gjBo8piV9wNIDhV0YWV3nBtCgZlcMZ22KJ92Wn3lc=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/torchlensmaker";
+
+  postPatch = ''
+    # Fix Jupyter widget: unpkg serves the UMD build for the bare URL,
+    # which has no ESM default export. Point at the ES module bundle and
+    # defend against a missing default export.
+    substituteInPlace src/torchlensmaker/viewer/script_template.js \
+      --replace-fail \
+        'https://unpkg.com/tlmviewer@''${version}' \
+        'https://unpkg.com/tlmviewer@''${version}/dist/tlmviewer-''${version}.es.js' \
+      --replace-fail \
+        'const tlmviewer = module.default;' \
+        'const tlmviewer = module.default ?? module;'
+  '';
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    indicio
+    ipython
+    jaxtyping
+    matplotlib
+    tlmviewer
+    torchimplicit
+  ];
+
+  pythonRelaxDeps = [
+    "matplotlib"
+  ];
+
+  pythonImportsCheck = [
+    "torchlensmaker"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    onnxruntime
+    onnxscript
+  ];
+
+  passthru = {
+    tests = callPackage ./tests { };
+
+    # nix-shell -A python3Packages.torchlensmaker.pyEnv
+    pyEnv = python.withPackages (
+      ps: with ps; [
+        ipython
+        jupyter
+        torchlensmaker
+      ]
+    );
+  };
+
+  meta = {
+    description = "Python library for modeling and designing optical systems";
+    longDescription = ''
+      Torch Lens Maker is an open-source Python library for differentiable
+      geometric optics based on [PyTorch](https://pytorch.org/).
+
+      The goal of the project is to be able to design complex real-world
+      optical systems (lenses, mirrors, etc.) using modern computer code and
+      state-of-the art numerical optimization.
+    '';
+    homepage = "https://github.com/victorpoughon/torchlensmaker";
+    changelog = "https://github.com/victorpoughon/torchlensmaker/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/torchlensmaker/tests/default.nix
+++ b/pkgs/development/python-modules/torchlensmaker/tests/default.nix
@@ -1,0 +1,15 @@
+{
+  runCommand,
+  torchlensmaker,
+}:
+
+runCommand "test-torchlensmaker"
+  {
+    nativeBuildInputs = [
+      torchlensmaker.pyEnv
+    ];
+  }
+  ''
+    python ${./landscape.py}
+    mv landscape.json $out
+  ''

--- a/pkgs/development/python-modules/torchlensmaker/tests/landscape.py
+++ b/pkgs/development/python-modules/torchlensmaker/tests/landscape.py
@@ -1,0 +1,21 @@
+import torchlensmaker as tlm
+
+optics = tlm.Sequential(
+    tlm.ObjectAtInfinity(beam_diameter=10, angular_size=20),
+    tlm.Gap(15),
+    tlm.RefractiveSurface(
+        tlm.SphereByCurvature(diameter=25, C=1 / -45.0), materials=("air", "BK7")
+    ),
+    tlm.Gap(3),
+    tlm.RefractiveSurface(
+        tlm.SphereByCurvature(diameter=25, C=tlm.parameter(1 / -20)),
+        materials=("BK7", "air"),
+    ),
+    tlm.Gap(100),
+    tlm.ImagePlane(50),
+)
+
+tlm.simple_optimize(optics, tlm.optim.Adam(optics.parameters(), lr=5e-4), 100)
+
+tlm.show2d(optics, title="Landscape Lens")
+tlm.export_json(optics, "landscape.json", dim=2, title="Landscape Lens")

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20868,6 +20868,8 @@ self: super: with self; {
 
   torchio = callPackage ../development/python-modules/torchio { };
 
+  torchlensmaker = callPackage ../development/python-modules/torchlensmaker { };
+
   torchlibrosa = callPackage ../development/python-modules/torchlibrosa { };
 
   torchmd-net = callPackage ../development/python-modules/torchmd-net { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20733,6 +20733,8 @@ self: super: with self; {
 
   tlds = callPackage ../development/python-modules/tlds { };
 
+  tlmviewer = callPackage ../development/python-modules/tlmviewer { };
+
   tlparse = callPackage ../development/python-modules/tlparse { };
 
   tls-client = callPackage ../development/python-modules/tls-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8286,6 +8286,8 @@ self: super: with self; {
 
   indexed-zstd = callPackage ../development/python-modules/indexed-zstd { inherit (pkgs) zstd; };
 
+  indicio = callPackage ../development/python-modules/indicio { };
+
   inequality = callPackage ../development/python-modules/inequality { };
 
   inference-gym = callPackage ../development/python-modules/inference-gym { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20866,6 +20866,8 @@ self: super: with self; {
 
   torcheval = callPackage ../development/python-modules/torcheval { };
 
+  torchimplicit = callPackage ../development/python-modules/torchimplicit { };
+
   torchinfo = callPackage ../development/python-modules/torchinfo { };
 
   torchio = callPackage ../development/python-modules/torchio { };


### PR DESCRIPTION
[Torch Lens Maker](https://github.com/victorpoughon/torchlensmaker) is a Python library for modeling and designing optical systems.

Closes https://github.com/ngi-nix/projects/issues/2227

> [!NOTE]
>  Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi) packaging effort.

Assisted-by: `nix-init`
Assisted-by: `DeepSeek V4 Flash Free` in fixing the Jupyter widget

<img width="1086" height="835" alt="image" src="https://github.com/user-attachments/assets/b47548a3-c179-481c-b9f5-099d9fa92800" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
