### PR TITLE
[WIP] python3Packages.typed-argparse: 0.3.1-unstable-2025-05-09 -> 0.3.1-unstable-2026-08-20

### DIFF
--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -8,6 +8,7 @@
   packaging,
   pathspec,
   pluggy,
+  tomlkit,
   trove-classifiers,
 
   # tests
@@ -19,12 +20,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "hatchling";
-  version = "1.31.0";
+  version = "1.32.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-a0itQGikgu1yObOoIVvFW0eq0zRdWN/JTlU8XS1GIRs=";
+    hash = "sha256-C9veSlKwbDfj7KOV+Fp2K/DvBv43T9iuQp3GvhAjD18=";
   };
 
   # listed in backend/pyproject.toml
@@ -33,6 +34,7 @@ buildPythonPackage (finalAttrs: {
     packaging
     pathspec
     pluggy
+    tomlkit
     trove-classifiers
   ];
 

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -14,7 +14,7 @@
   virtualenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "poetry-core";
   version = "2.4.1";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = "poetry-core";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Io2VpLxnJesO4QohsunD7ogr87NiNjGeTmEl9wFswkw=";
   };
 
@@ -57,10 +57,10 @@ buildPythonPackage rec {
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
 
   meta = {
-    changelog = "https://github.com/python-poetry/poetry-core/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/python-poetry/poetry-core/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Poetry PEP 517 Build Backend";
     homepage = "https://github.com/python-poetry/poetry-core/";
     license = lib.licenses.mit;
     teams = [ lib.teams.python ];
   };
-}
+})

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -26,6 +26,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-Io2VpLxnJesO4QohsunD7ogr87NiNjGeTmEl9wFswkw=";
   };
 
+  # Disable checks by default, as checks require gitMinimal, which eventually
+  # depends on hatchling, which depends on tomlkit, which depends on
+  # poetry-core, leading to infinite recursion.
+  doCheck = false;
+
   nativeCheckInputs = [
     build
     gitMinimal
@@ -55,6 +60,10 @@ buildPythonPackage (finalAttrs: {
   pythonNamespaces = [ "poetry" ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
+
+  # In passthru.tests, build with the check phase enabled, since that'll be
+  # outside the bootstrap dependency chain.
+  passthru.tests.withChecks = finalAttrs.finalPackage.overrideAttrs { doCheck = true; };
 
   meta = {
     changelog = "https://github.com/python-poetry/poetry-core/blob/${finalAttrs.src.tag}/CHANGELOG.md";

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -21,7 +21,12 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-fRqey6MIZjghGxOBTqeckN1U3RGZNWQ3bzqpInH1x6M=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ (poetry-core.overridePythonAttrs { doCheck = false; }) ];
+
+  # Disable checks by default, as checks require pytest, which eventually
+  # depends on hatchling, which depends on tomlkit, leading to infinite
+  # recursion.
+  doCheck = false;
 
   nativeCheckInputs = [
     pyyaml
@@ -29,6 +34,10 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "tomlkit" ];
+
+  # In passthru.tests, build with the check phase enabled, since that'll be
+  # outside the bootstrap dependency chain.
+  passthru.tests.withChecks = finalAttrs.finalPackage.overrideAttrs { doCheck = true; };
 
   meta = {
     homepage = "https://github.com/sdispater/tomlkit";

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -11,13 +11,13 @@
   pyyaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tomlkit";
   version = "0.15.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-fRqey6MIZjghGxOBTqeckN1U3RGZNWQ3bzqpInH1x6M=";
   };
 
@@ -32,9 +32,9 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://github.com/sdispater/tomlkit";
-    changelog = "https://github.com/sdispater/tomlkit/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/sdispater/tomlkit/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "Style-preserving TOML library for Python";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jakewaksbaum ];
   };
-}
+})

--- a/pkgs/development/python-modules/typed-argparse/default.nix
+++ b/pkgs/development/python-modules/typed-argparse/default.nix
@@ -2,26 +2,25 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
-  setuptools,
+  hatchling,
   typing-extensions,
   pytestCheckHook,
   pytest-cov-stub,
 }:
 buildPythonPackage {
   pname = "typed-argparse";
-  version = "0.3.1-unstable-2025-05-09";
+  version = "0.3.1-unstable-2026-08-20";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "typed-argparse";
     repo = "typed-argparse";
-    rev = "989887701c5b4e8c835fac60d6124a9efa557e6f";
-    hash = "sha256-RgOHIjODBacZdUMCrazZxhQerHtZrNO0BBXPkWPN47o=";
+    rev = "f0e6f8995dfe45a3c9b5484b2806e3194397a1bf";
+    hash = "sha256-uXL4NCgH2lnoH+cCJXmpeI/YiqZPiKo5Gx48mYtBz0A=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [ typing-extensions ];
 
@@ -29,28 +28,6 @@ buildPythonPackage {
     pytestCheckHook
     pytest-cov-stub
   ];
-
-  # The test suite checks for exact output in a way that seems fragile to
-  # cosmetic changes in Python's argparse output, and means some tests fail on
-  # more recent releases.  Disable the affected tests while we're waiting for
-  # upstream fixes.
-  #
-  # https://github.com/typed-argparse/typed-argparse/pull/82
-  # https://github.com/typed-argparse/typed-argparse/issues/84
-  disabledTests =
-    lib.optionals (pythonAtLeast "3.14") [
-      "test_nargs_with_choices__literal_illegal_default"
-      "test_nargs_with_choices__enum_illegal_default"
-      "test_bindings_check"
-      "test_check_reserved_names"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.13") [
-      "test_dynamic_choices"
-      "test_literal__basics"
-      "test_enum__basics[False]"
-      "test_enum__basics[True]"
-      "test_subparsers_common_args__subparser_after_positional"
-    ];
 
   pythonImportsCheck = [ "typed_argparse" ];
 


### PR DESCRIPTION
python3Packages.typed-argparse: 0.3.1-unstable-2025-05-09 -> 0.3.1-unstable-2026-08-20

Changelog: https://github.com/typed-argparse/typed-argparse/compare/989887701c5b4e8c835fac60d6124a9efa557e6f...f0e6f8995dfe45a3c9b5484b2806e3194397a1bf
  
Notably, this adds official support for Python 3.14, and means the Nixpkgs packaging can run the full test suite again.

This PR depends on #554653. I'm targeting master as, once that PR has made it into master, the changes here won't require significant rebuilds, but in the meantime I'm keeping the full set of commits to get a working build and marking the PR as draft/WIP.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test