### PR TITLE
eitype: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11714,6 +11714,12 @@
     name = "Iago Manoel Brito";
     keys = [ { fingerprint = "DF90 9D58 BEE4 E73A 1B8C  5AF3 35D3 9F9A 9A1B C8DA"; } ];
   };
+  iainlane = {
+    email = "iain@orangesquash.org.uk";
+    github = "iainlane";
+    githubId = 321014;
+    name = "Iain Lane";
+  };
   iamanaws = {
     email = "iamanaws@httpd.dev";
     github = "iamanaws";

--- a/pkgs/by-name/ei/eitype/package.nix
+++ b/pkgs/by-name/ei/eitype/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libxkbcommon,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "eitype";
+  version = "0.2.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Adam-D-Lewis";
+    repo = "eitype";
+    tag = finalAttrs.version;
+    hash = "sha256-s5g6METDi8/jPEwZursorYWN8X96VlyVPtd8dCCVIlw=";
+  };
+
+  cargoHash = "sha256-k0JU3Y83aPHgQpyiG6DXxBzdYSMOmH42kPCxXWtNtkQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libxkbcommon ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Type text through the Emulated Input protocol on Wayland";
+    homepage = "https://github.com/Adam-D-Lewis/eitype";
+    changelog = "https://github.com/Adam-D-Lewis/eitype/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ iainlane ];
+    mainProgram = "eitype";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds eitype 0.2.2, a CLI and Rust library for typing text through the Emulated Input protocol on Wayland. The package builds from the upstream release tag and uses libxkbcommon for keyboard mapping.

This also adds me to the maintainer list.

Verification completed:

- `nix-build -A eitype --argstr system x86_64-linux`
- 42 unit tests and one doctest
- Installed `eitype --version` check
- `nixpkgs-vet`
- `nixfmt --check`
- `nix-build lib/tests/maintainers.nix`

The upstream `wayland-integration-tests` feature requires an interactive Wayland session, portal authorisation and a focused application. It is not enabled in the sandboxed package test run.

Automation disclosure: Codex (GPT-5) assisted with the package implementation, upstream research and verification.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
