### PR TITLE
nixos/doc/running-nixos-tests: Fix System Reqs

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests.section.md
@@ -59,6 +59,6 @@ To make this path available, set the following option:
 
 ```nix
 {
-  nix.settings.sandbox-paths = [ "/dev/net" ];
+  nix.settings.extra-sandbox-paths = [ "/dev/net" ];
 }
 ```


### PR DESCRIPTION
As stated in the Nix Reference Manual[^1]:

    “A configuration setting usually overrides any previous value.
    However, for settings that take a list of items, you can prefix the
    name of the setting by extra- to append to the previous value.”

On Linux at least, Nix ships a `busybox` shell[^2] as the default value for `nix.settings.sandbox-paths`.

Use thus `nix.settings.extra-sandbox-paths` as to not override the implicit default value of `nix.settings.sandbox-paths`, since not having `busybox` there causes issues with `nixos-rebuild` at least.

This choice is consistent with other parts of the documentation:
- https://github.com/NixOS/nixpkgs/blob/1ff04dd8c1544c0c64b7a7e03e879158d2175a8d/nixos/modules/config/nix.nix#L277-L288
- https://github.com/NixOS/nixpkgs/blob/1ff04dd8c1544c0c64b7a7e03e879158d2175a8d/nixos/lib/testing/run.nix#L43
- https://github.com/NixOS/nixpkgs/blob/1ff04dd8c1544c0c64b7a7e03e879158d2175a8d/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py#L94-L97

Ref: https://github.com/ngi-nix/projects/issues/73

This work is done as part of Summer of Nix 2026.

[^1]: https://nix.dev/manual/nix/2.34/command-ref/conf-file.html?highlight=extra-#file-format
[^2]: with `nix.settings.sandbox-paths` unset, run: `nix config show sandbox-paths`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
