### PR TITLE
rocqPackages: a few more use of mkRocqDerivation

### DIFF
--- a/pkgs/development/rocq-modules/coqeal/default.nix
+++ b/pkgs/development/rocq-modules/coqeal/default.nix
@@ -1,6 +1,6 @@
 {
   coq,
-  mkCoqDerivation,
+  mkRocqDerivation,
   mathcomp,
   bignums,
   paramcoq,
@@ -11,7 +11,7 @@
 }:
 
 let
-  derivation = mkCoqDerivation {
+  derivation = mkRocqDerivation {
 
     pname = "CoqEAL";
 
@@ -58,6 +58,8 @@ let
     release."1.0.5".hash = "sha256:0cmvky8glb5z2dy3q62aln6qbav4lrf2q1589f6h1gn5bgjrbzkm";
     release."1.0.4".hash = "sha256:1g5m26lr2lwxh6ld2gykailhay4d0ayql4bfh0aiwqpmmczmxipk";
     release."1.0.3".hash = "sha256:0hc63ny7phzbihy8l7wxjvn3haxx8jfnhi91iw8hkq8n29i23v24";
+
+    useCoqifVersion = v: v != null && v != "dev" && lib.versions.isLe "2.1.2" v;
 
     propagatedBuildInputs = [
       mathcomp.algebra

--- a/pkgs/development/rocq-modules/fourcolor/default.nix
+++ b/pkgs/development/rocq-modules/fourcolor/default.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  mkCoqDerivation,
+  mkRocqDerivation,
   coq,
   mathcomp,
   version ? null,
 }:
 
-mkCoqDerivation {
+mkRocqDerivation {
   pname = "fourcolor";
   owner = "math-comp";
 
@@ -37,15 +37,17 @@ mkCoqDerivation {
     lib.switch
       [ coq.coq-version mathcomp.version ]
       [
-        (case (isGe "8.20") (isGe "2.5") "1.4.3")
-        (case (isGe "8.20") (range "2.4" "2.5") "1.4.2")
-        (case (isGe "8.16") (range "2.0" "2.4") "1.4.1")
-        (case (isGe "8.16") "2.0.0" "1.3.0")
-        (case (isGe "8.11") (range "1.12" "1.19") "1.2.5")
-        (case (isGe "8.11") (range "1.11" "1.14") "1.2.4")
-        (case (isLe "8.13") (lib.pred.inter (isGe "1.11.0") (isLt "1.13")) "1.2.3")
+        (case (range "8.20" "9.3") (isGe "2.5") "1.4.3")
+        (case (range "8.20" "9.1") (range "2.4" "2.5") "1.4.2")
+        (case (range "8.16" "9.0") (range "2.0" "2.4") "1.4.1")
+        (case (range "8.16" "8.17") "2.0.0" "1.3.0")
+        (case (range "8.11" "8.16") (range "1.12" "1.19") "1.2.5")
+        (case (range "8.11" "8.15") (range "1.11" "1.14") "1.2.4")
+        (case (range "8.10" "8.13") (lib.pred.inter (isGe "1.11.0") (isLt "1.13")) "1.2.3")
       ]
       null;
+
+  useCoqifVersion = v: v != null && v != "dev" && lib.versions.isLe "1.4.3" v;
 
   propagatedBuildInputs = [
     mathcomp.boot

--- a/pkgs/development/rocq-modules/multinomials/default.nix
+++ b/pkgs/development/rocq-modules/multinomials/default.nix
@@ -1,6 +1,6 @@
 {
   coq,
-  mkCoqDerivation,
+  mkRocqDerivation,
   mathcomp,
   mathcomp-finmap,
   mathcomp-bigenough,
@@ -8,10 +8,10 @@
   version ? null,
   useDune ? false,
 }@args:
-mkCoqDerivation {
+mkRocqDerivation {
 
   namePrefix = [
-    "coq"
+    "rocq"
     "mathcomp"
   ];
   pname = "multinomials";
@@ -71,6 +71,8 @@ mkCoqDerivation {
     "1.1".hash = "sha256:1q8alsm89wkc0lhcvxlyn0pd8rbl2nnxg81zyrabpz610qqjqc3s";
     "1.0".hash = "sha256:1qmbxp1h81cy3imh627pznmng0kvv37k4hrwi2faa101s6bcx55m";
   };
+
+  useCoqifVersion = v: v != null && v != "dev" && lib.versions.isLe "2.4.0" v;
 
   useDuneifVersion = lib.versions.range "1.5.3" "2.2.0";
 

--- a/pkgs/development/rocq-modules/odd-order/default.nix
+++ b/pkgs/development/rocq-modules/odd-order/default.nix
@@ -1,12 +1,12 @@
 {
   lib,
   coq,
-  mkCoqDerivation,
+  mkRocqDerivation,
   mathcomp-group-representation,
   version ? null,
 }:
 
-mkCoqDerivation {
+mkRocqDerivation {
   pname = "odd-order";
   owner = "math-comp";
 
@@ -43,6 +43,8 @@ mkCoqDerivation {
         (case (range "8.10" "8.14") (range "1.10.0" "1.12.0") "1.12.0")
       ]
       null;
+
+  useCoqifVersion = v: v != null && v != "dev" && lib.versions.isLe "2.4.0" v;
 
   propagatedBuildInputs = [
     mathcomp-group-representation


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
