### PR TITLE
vercel-fx: init at 0.0.4

### DIFF
--- a/pkgs/by-name/ve/vercel-fx/package.nix
+++ b/pkgs/by-name/ve/vercel-fx/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig_0_16,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vercel-fx";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "vercel-labs";
+    repo = "fx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NeDAx55Ws3pZJeug8rYEFQaMI2Kf1Smz07nwhhiL+WM=";
+  };
+
+  nativeBuildInputs = [ zig_0_16.hook ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Coding agent harness and CLI";
+    homepage = "https://github.com/vercel-labs/fx";
+    changelog = "https://github.com/vercel-labs/fx/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "fx";
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+})


### PR DESCRIPTION
Adds https://fx.sh/, which is a coding agent by Vercel written in zig.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
