### PR TITLE
cargo-lambda: zig_0_13 -> zig

### DIFF
--- a/pkgs/by-name/ca/cargo-lambda/package.nix
+++ b/pkgs/by-name/ca/cargo-lambda/package.nix
@@ -8,7 +8,7 @@
   pkg-config,
   openssl,
   stdenv,
-  zig_0_13,
+  zig,
   nix-update-script,
 }:
 
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postInstall = ''
-    wrapProgram $out/bin/cargo-lambda --prefix PATH : ${lib.makeBinPath [ zig_0_13 ]}
+    wrapProgram $out/bin/cargo-lambda --prefix PATH : ${lib.makeBinPath [ zig ]}
   '';
 
   env.CARGO_LAMBDA_BUILD_INFO = "(nixpkgs)";


### PR DESCRIPTION
cargo-lambda, as far as we can tell, only uses zig to call into cargo-zigbuild. cargo-zigbuild supports the latest versions of zig, and the main `cargo-zigbuild` derivation seems to have had a fine time with an unpinned zig. since we aim to drop zig 0.13 soon as it depends on the long-eol llvm 18, we unpin this to work towards that.

we do not use aws lambda, and thus cannot entirely test this, but initing a simple test project with `cargo lambda new` and building a project with `cargo lambda build` (which should default to using `cargo-zigbuild` interally) appears to work fine.

this pin was originally added in https://github.com/NixOS/nixpkgs/pull/387154, but we're not entirely sure why that is. at a glance, it looks like it was building just fine even before.

alternatively, we could pin a specific newer known-good version.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
