### PR TITLE
bulwark-webmail: init at 1.8.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -100,6 +100,8 @@
 
 - [kvrocks_exporter](https://github.com/RocksLabs/kvrocks_exporter), a Prometheus exporter for Kvrocks metrics. Available as [services.prometheus.exporters.kvrocks](#opt-services.prometheus.exporters.kvrocks.enable).
 
+- [Bulwark Webmail](https://bulwarkmail.org/), a JMAP webmail client for the Stalwart mail server. Available as [services.bulwark-webmail](#opt-services.bulwark-webmail.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1659,6 +1659,7 @@
   ./services/web-apps/bluemap.nix
   ./services/web-apps/bluesky-pds.nix
   ./services/web-apps/bookstack.nix
+  ./services/web-apps/bulwark-webmail.nix
   ./services/web-apps/c2fmzq-server.nix
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/castopod.nix

--- a/nixos/modules/services/web-apps/bulwark-webmail.nix
+++ b/nixos/modules/services/web-apps/bulwark-webmail.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.bulwark-webmail;
+  dataDir = "/var/lib/bulwark-webmail";
+in
+{
+  options.services.bulwark-webmail = {
+    enable = lib.mkEnableOption "Bulwark Webmail";
+    package = lib.mkPackageOption pkgs "bulwark-webmail" { };
+    environmentFile = lib.mkOption {
+      description = ''
+        Path to a file containing environment variables.
+
+        Use this option to pass secrets.
+      '';
+      default = "";
+      type = lib.types.oneOf [
+        lib.types.path
+        lib.types.str
+      ];
+    };
+    environment = lib.mkOption {
+      description = ''
+        Configuration for Bulwark Webmail.
+
+        See [the envfile example](https://github.com/bulwarkmail/webmail/blob/main/.env.example)
+        for possible variables.
+
+        Use {option}`services.bulwark-webmail.environmentFile` to specify secrets.
+      '';
+      default = { };
+      type = lib.types.attrsOf lib.types.str;
+    };
+    dataDir = lib.mkOption {
+      description = ''
+        Path to the directory where the data should be stored.
+      '';
+      default = dataDir;
+      type = lib.types.str;
+    };
+
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.bulwark-webmail = {
+      description = "Bulwark Webmail";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        NODE_ENV = "production";
+        BULWARK_TELEMETRY = "off";
+        BULWARK_UPDATE_CHECK = "off";
+        ADMIN_CONFIG_DIR = "${cfg.dataDir}/admin";
+        ADMIN_STATE_DIR = "${cfg.dataDir}/admin-state";
+        SETTINGS_DATA_DIR = "${cfg.dataDir}/settings";
+        TELEMETRY_DATA_DIR = "${cfg.dataDir}/telemetry";
+        VERSION_CHECK_DATA_DIR = "${cfg.dataDir}/version-check";
+      }
+      // cfg.environment;
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "always";
+        DynamicUser = true;
+        StateDirectory = lib.mkIf (cfg.dataDir == dataDir) "bulwark-webmail";
+        WorkingDirectory = lib.mkIf (cfg.dataDir == dataDir) "%S/bulwark-webmail";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != "") cfg.environmentFile;
+        # Hardening
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        CapabilityBoundingSet = "";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@privileged"
+          "~@raw-io"
+          "~@reboot"
+          "~@resources"
+          "~@swap"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    ungeskriptet
+  ];
+}

--- a/pkgs/by-name/bu/bulwark-webmail/font-lookup.patch
+++ b/pkgs/by-name/bu/bulwark-webmail/font-lookup.patch
@@ -1,0 +1,31 @@
+diff --git a/app/(main)/layout.tsx b/app/(main)/layout.tsx
+index efa470c4..4320f983 100644
+--- a/app/(main)/layout.tsx
++++ b/app/(main)/layout.tsx
+@@ -1,6 +1,6 @@
+ import type { Metadata, Viewport } from "next";
+ import { getLocaleDirection } from "@/i18n/direction";
+-import { Geist, Geist_Mono } from "next/font/google";
++import localFont from "next/font/local";
+ import { headers } from "next/headers";
+ import { getLocale, getTranslations } from "next-intl/server";
+ import { ServiceWorkerRegistration } from "@/components/service-worker-registration";
+@@ -29,14 +29,14 @@ async function resolveRequestLocale(): Promise<string> {
+   return seg ?? (await getLocale());
+ }
+ 
+-const geistSans = Geist({
++const geistSans = localFont({
++  src: '../../Geist-Regular.otf',
+   variable: "--font-geist-sans",
+-  subsets: ["latin"],
+ });
+ 
+-const geistMono = Geist_Mono({
++const geistMono = localFont({
++  src: '../../GeistMono-Regular.otf',
+   variable: "--font-geist-mono",
+-  subsets: ["latin"],
+ });
+ 
+ // Resolve a branding value for the requesting host: per-domain override first,

--- a/pkgs/by-name/bu/bulwark-webmail/package.nix
+++ b/pkgs/by-name/bu/bulwark-webmail/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  geist-font,
+  nodejs-slim,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "bulwark-webmail";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "bulwarkmail";
+    repo = "webmail";
+    tag = finalAttrs.version;
+    hash = "sha256-u4m3S33zH+1TUlexQk3HSM4lMhNbXRdax7LZPx9DCww=";
+  };
+
+  npmDepsHash = "sha256-q80VsVyGj/a5Fzf2DqNWMPXQdhFafiGJeJJ23gWduMU=";
+
+  patches = [ ./font-lookup.patch ];
+
+  postPatch = ''
+    cp ${geist-font}/share/fonts/opentype/Geist{,Mono}-Regular.otf .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/bulwark-webmail $out/bin
+    cp -r .next/standalone/. $out/share/bulwark-webmail
+    cp -r .next/static $out/share/bulwark-webmail/.next/static
+    cp -r public $out/share/bulwark-webmail/public
+
+    makeWrapper "${lib.getExe nodejs-slim}" "$out/bin/bulwark-webmail" \
+      --add-flags "$out/share/bulwark-webmail/server.js" \
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    mainProgram = "bulwark-webmail";
+    description = "Self-hosted JMAP webmail for Stalwart Mail Server.";
+    homepage = "https://bulwarkmail.org/";
+    changelog = "https://github.com/bulwarkmail/webmail/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})


### PR DESCRIPTION
Add a package and module for [Bulwark Webmail](https://bulwarkmail.org/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
