### PR TITLE
scx.rustscheds: 1.1.2 -> 1.1.3

### DIFF
--- a/nixos/tests/scx/default.nix
+++ b/nixos/tests/scx/default.nix
@@ -20,6 +20,7 @@
       flow.configuration.services.scx.scheduler = "scx_flow";
       forge.configuration.services.scx.scheduler = "scx_forge";
       lavd.configuration.services.scx.scheduler = "scx_lavd";
+      mlfq.configuration.services.scx.scheduler = "scx_mlfq";
       p2dq.configuration.services.scx.scheduler = "scx_p2dq";
       pandemonium.configuration.services.scx.scheduler = "scx_pandemonium";
       rlfifo.configuration.services.scx.scheduler = "scx_rlfifo";
@@ -40,6 +41,7 @@
       "flow",
       "forge",
       "lavd",
+      "mlfq",
       "p2dq",
       "pandemonium",
       "rlfifo",

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -15,16 +15,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scx_rustscheds";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "sched-ext";
     repo = "scx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-igrmrfimVOEJnFxMr9ghN6lAHwEBSFLLVrB2MQ72PXI=";
+    hash = "sha256-LK0go5blWgCtDpS5xm9BQc7C2NvbfrW+Jp66ImIThxA=";
   };
 
-  cargoHash = "sha256-CTEVdvw6aG/fFas2Fk3x9o4Sp2k3lHO/OLwUM8t9UjE=";
+  cargoHash = "sha256-vEsbpor52DEUpYO5OubFPMzRltO5kUXjqAoO/9hsKXc=";
 
   nativeBuildInputs = [
     pkg-config
@@ -95,6 +95,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "scx_lavd"
     "scx_layered"
     "scx_mitosis"
+    "scx_mlfq"
     "scx_p2dq"
     "scx_pandemonium"
     "scx_rlfifo"


### PR DESCRIPTION
Changelog: https://github.com/sched-ext/scx/releases/tag/v1.1.3
Diff: https://github.com/sched-ext/scx/compare/v1.1.2...v1.1.3
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
