### PR TITLE
nixos/garm: init

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -2925,5 +2925,20 @@
   ],
   "sec-release-13.10": [
     "release-notes.html#sec-release-13.10"
+  ],
+  "module-garm": [
+    "index.html#module-garm"
+  ],
+  "module-garm-secrets": [
+    "index.html#module-garm-secrets"
+  ],
+  "module-garm-providers": [
+    "index.html#module-garm-providers"
+  ],
+  "module-garm-reachability": [
+    "index.html#module-garm-reachability"
+  ],
+  "module-garm-setup": [
+    "index.html#module-garm-setup"
   ]
 }

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -76,6 +76,8 @@
 
 - [gocron](https://github.com/flohoss/gocron), a task scheduler with web interface. Available as [services.gocron](#opt-services.gocron.enable).
 
+- [GARM](https://github.com/cloudbase/garm), a self-hosted, multi-provider runner manager for GitHub Actions and Gitea Actions. Available as [services.garm](#opt-services.garm.enable).
+
 - [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
 
 - [ioquake3](https://ioquake3.org), a open-source port of the 3D action shooter Quake 3 Arena. Available as [programs.ioquake3](#opt-programs.ioquake3.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -524,6 +524,7 @@
   ./services/continuous-integration/buildbot/worker.nix
   ./services/continuous-integration/buildkite-agents.nix
   ./services/continuous-integration/forgejo-runner.nix
+  ./services/continuous-integration/garm.nix
   ./services/continuous-integration/gitea-actions-runner.nix
   ./services/continuous-integration/github-runners.nix
   ./services/continuous-integration/gitlab-runner/runner.nix

--- a/nixos/modules/services/continuous-integration/garm.md
+++ b/nixos/modules/services/continuous-integration/garm.md
@@ -1,0 +1,130 @@
+# GARM {#module-garm}
+
+[GARM](https://github.com/cloudbase/garm) manages pools of self-hosted runners
+for GitHub Actions and Gitea Actions. Runners are created on demand through
+pluggable providers, for example [garm-provider-incus](https://github.com/cloudbase/garm-provider-incus),
+which runs them as Incus containers or virtual machines.
+
+This module configures the GARM daemon. Everything GARM manages (forge
+credentials, repositories and runner pools) lives in its database, and for now
+has to be set up imperatively with `garm-cli` once the service runs, see
+[first steps](https://github.com/cloudbase/garm/blob/main/doc/first-steps.md)
+upstream.
+
+## Secrets {#module-garm-secrets}
+
+GARM requires `jwt_auth.secret` and `database.passphrase` to be set, and
+validates both: the passphrase must be exactly 32 characters, the secret has no
+length requirement, and both values have to pass a password strength check. The
+commands below generate a 48 character secret and a 32 character passphrase.
+
+```ShellSession
+# install -d -m 0700 /var/lib/secrets
+# tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 48 > /var/lib/secrets/garm-jwt-secret
+# tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32 > /var/lib/secrets/garm-db-passphrase
+# chmod 0400 /var/lib/secrets/garm-*
+```
+
+::: {.warning}
+Changing `database.passphrase` invalidates all secrets already encrypted in the
+database, changing `jwt_auth.secret` invalidates all tokens issued to runners.
+Keep both stable and back them up together with the database.
+:::
+
+GARM reads its configuration from a single file and cannot pick up secrets from
+the environment. Settings that hold secret data are therefore given as an
+attribute set `{ _secret = "/path/to/file"; }`, and the module substitutes the
+file contents on startup. The files are read through systemd credentials, so
+they only need to be readable by root:
+
+```nix
+{
+  services.garm = {
+    enable = true;
+    settings = {
+      jwt_auth.secret._secret = "/var/lib/secrets/garm-jwt-secret";
+      database.passphrase._secret = "/var/lib/secrets/garm-db-passphrase";
+    };
+  };
+}
+```
+
+## Providers {#module-garm-providers}
+
+Providers are external executables that GARM calls to create and delete
+runners. They are declared in `settings.provider` and take their own
+configuration file:
+
+```nix
+{
+  services.garm.settings.provider = [
+    {
+      name = "incus";
+      description = "Incus external provider";
+      provider_type = "external";
+      external = {
+        provider_executable = lib.getExe pkgs.garm-provider-incus;
+        config_file = pkgs.writers.writeTOML "garm-provider-incus.toml" {
+          unix_socket_path = "/var/lib/incus/unix.socket";
+          instance_type = "container";
+          project_name = "default";
+          include_default_profile = false;
+          image_remotes.images = {
+            addr = "https://images.linuxcontainers.org";
+            public = true;
+            protocol = "simplestreams";
+          };
+        };
+      };
+    }
+  ];
+}
+```
+
+The service runs as a dynamic user in a restricted environment, so it needs to
+be granted access to whatever the provider talks to. For Incus:
+
+```nix
+{
+  systemd.services.garm.serviceConfig.SupplementaryGroups = [ "incus-admin" ];
+}
+```
+
+A provider that needs more than a socket, for example a device or a writable
+path, needs the corresponding systemd sandboxing option relaxed in
+`systemd.services.garm.serviceConfig` as well.
+
+Images must have `cloud-init` installed, as that is how GARM bootstraps the
+runner. The images of the remote above come in variants, of which only the ones
+suffixed `/cloud` include `cloud-init`.
+
+## Reachability {#module-garm-reachability}
+
+Runners fetch their configuration from GARM and report back to it, so the
+address GARM is initialized with must be reachable from the runners.
+With runners on an Incus bridge, bind GARM to all interfaces
+and keep the port closed on the public ones:
+
+```nix
+{
+  services.garm.settings.apiserver.bind = "0.0.0.0";
+  networking.firewall.trustedInterfaces = [ "incusbr0" ];
+}
+```
+
+::: {.note}
+GARM serves its API, the runner metadata endpoints and, if enabled with
+`settings.apiserver.webui.enable`, a web UI on the same port. Do not open that
+port to untrusted networks without putting a reverse proxy in front of it.
+:::
+
+## Initial setup {#module-garm-setup}
+
+Once the service runs, initialize the controller and add credentials, an entity
+and a pool as described in the [upstream
+documentation](https://github.com/cloudbase/garm/blob/main/doc/first-steps.md).
+Pass `garm-cli init` the address the runners use, not `localhost`:
+
+```ShellSession
+$ garm-cli init --name garm --url http://10.0.10.1:9997
+```

--- a/nixos/modules/services/continuous-integration/garm.nix
+++ b/nixos/modules/services/continuous-integration/garm.nix
@@ -1,0 +1,212 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.garm;
+
+  format = pkgs.formats.toml { };
+
+  # garm can't read secrets from files or the environment. Settings declared
+  # as { _secret = "/path/to/file"; } are rendered into the config as a
+  # placeholder, which is substituted with the file's content on startup.
+  isSecret = v: lib.isAttrs v && v ? _secret && lib.isString v._secret;
+
+  redactSecrets =
+    v:
+    if isSecret v then
+      lib.hashString "sha256" v._secret
+    else if lib.isDerivation v then
+      v
+    else if lib.isAttrs v then
+      lib.mapAttrs (_: redactSecrets) v
+    else if lib.isList v then
+      map redactSecrets v
+    else
+      v;
+
+  collectSecrets =
+    v:
+    if isSecret v then
+      [ v._secret ]
+    else if lib.isDerivation v then
+      [ ]
+    else if lib.isAttrs v then
+      lib.concatMap collectSecrets (lib.attrValues v)
+    else if lib.isList v then
+      lib.concatMap collectSecrets v
+    else
+      [ ];
+
+  secretPaths = lib.unique (collectSecrets cfg.settings);
+
+  configFile = format.generate "garm-config.toml" (redactSecrets cfg.settings);
+
+  defaultPort = 9997;
+
+  # Binding the API to a privileged port needs additional capability.
+  capabilities = lib.optional (cfg.settings.apiserver.port < 1024) "CAP_NET_BIND_SERVICE";
+in
+
+{
+  options.services.garm = {
+    enable = lib.mkEnableOption "GARM, a self-hosted runner manager for GitHub Actions and Gitea Actions";
+
+    package = lib.mkPackageOption pkgs "garm" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          apiserver.bind = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1";
+            description = ''
+              Address the API server binds to. Runner instances fetch their
+              metadata from it and report back to it, so it has to be reachable
+              from wherever the provider creates them.
+            '';
+          };
+          apiserver.port = lib.mkOption {
+            type = lib.types.port;
+            default = defaultPort;
+            description = "Port the API server listens on.";
+          };
+          database.backend = lib.mkOption {
+            type = lib.types.str;
+            default = "sqlite3";
+            description = "Database backend to use.";
+          };
+          database.sqlite3.db_file = lib.mkOption {
+            type = lib.types.str;
+            default = "/var/lib/garm/garm.db";
+            description = "Location of the SQLite database.";
+          };
+          jwt_auth.time_to_live = lib.mkOption {
+            type = lib.types.str;
+            default = "8760h";
+            description = "Lifetime of the tokens issued to runner instances.";
+          };
+        };
+      };
+      default = { };
+      example = lib.literalExpression ''
+        {
+          apiserver.bind = "0.0.0.0";
+          jwt_auth.secret._secret = "/run/keys/garm-jwt-secret";
+          database.passphrase._secret = "/run/keys/garm-db-passphrase";
+          provider = [
+            {
+              name = "incus";
+              description = "Incus external provider";
+              provider_type = "external";
+              external = {
+                provider_executable = lib.getExe pkgs.garm-provider-incus;
+                config_file = "/etc/garm/incus-provider.toml";
+              };
+            }
+          ];
+        }
+      '';
+      description = ''
+        Configuration for GARM, rendered to {file}`config.toml`. See
+        <https://github.com/cloudbase/garm/blob/main/doc/configuration.md>
+        for available settings. At least `jwt_auth.secret` and
+        `database.passphrase` must be set.
+
+        Settings containing secret data should be set to an attribute set
+        containing the attribute `_secret = "/path/to/secret"`, where that
+        file contains the actual value. Secret files are loaded through
+        systemd credentials, so they only need to be readable by root.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.settings.jwt_auth ? secret;
+        message = "services.garm.settings.jwt_auth.secret must be set.";
+      }
+      {
+        assertion = cfg.settings.database ? passphrase;
+        message = "services.garm.settings.database.passphrase must be set.";
+      }
+    ];
+
+    # Contains garm-cli, needed to manage the deployment.
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.garm = {
+      description = "GitHub Actions Runner Manager (garm)";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      preStart = ''
+        install -m 0600 ${configFile} "$RUNTIME_DIRECTORY/config.toml"
+      ''
+      # Substitute the quoted placeholder with the secret encoded as a TOML
+      # basic string, so that characters like " or \ in it can't break the
+      # config. JSON string escaping emits a valid TOML string, quotes included.
+      + lib.concatMapStrings (
+        path:
+        let
+          plHolder = lib.hashString "sha256" path;
+        in
+        ''
+          ${lib.getExe pkgs.jq} --raw-input --slurp 'rtrimstr("\n")' \
+            < "$CREDENTIALS_DIRECTORY/${plHolder}" > "$RUNTIME_DIRECTORY/secret"
+          ${lib.getExe pkgs.replace-secret} '"${plHolder}"' \
+            "$RUNTIME_DIRECTORY/secret" "$RUNTIME_DIRECTORY/config.toml"
+          rm "$RUNTIME_DIRECTORY/secret"
+        ''
+      ) secretPaths;
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} -config %t/garm/config.toml";
+        DynamicUser = true;
+        StateDirectory = "garm";
+        RuntimeDirectory = "garm";
+        RuntimeDirectoryMode = "0700";
+        LoadCredential = map (path: "${lib.hashString "sha256" path}:${path}") secretPaths;
+        Restart = "on-failure";
+
+        # Hardening.
+        AmbientCapabilities = capabilities;
+        CapabilityBoundingSet = capabilities;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta = {
+    doc = ./garm.md;
+    maintainers = with lib.maintainers; [ katexochen ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -680,6 +680,7 @@ in
     inherit runTest;
     package = pkgs.garage_2;
   };
+  garm-incus = runTestOn [ "x86_64-linux" ] ./garm-incus.nix;
   gatus = runTest ./gatus.nix;
   gemstash = import ./gemstash.nix { inherit pkgs runTest; };
   geoclue2 = runTest ./geoclue2.nix;

--- a/nixos/tests/garm-incus.nix
+++ b/nixos/tests/garm-incus.nix
@@ -1,0 +1,348 @@
+# End-to-end test of GARM with the external incus provider and a local Gitea
+# as the forge. GARM creates a runner instance from a locally imported NixOS
+# container image, the runner registers with Gitea and executes a workflow.
+# Everything runs offline: instead of fetching the runner release info and
+# binary from gitea.com, a stub serves the gitea-actions-runner package.
+
+{ lib, pkgs, ... }:
+
+let
+  releases = import ../release.nix {
+    configuration =
+      { pkgs, ... }:
+      {
+        # Strip documentation from the runner image.
+        documentation.enable = lib.mkForce false;
+        documentation.nixos.enable = lib.mkForce false;
+        # Including a channel forces the image to be rebuilt on any change.
+        system.installer.channel.enable = lib.mkForce false;
+        environment.etc."nix/registry.json".text = lib.mkForce "{}";
+
+        # GARM passes the runner install script via cloud-init user data.
+        services.cloud-init.enable = true;
+        services.cloud-init.settings.datasource_list = [ "LXD" ];
+
+        systemd.tmpfiles.rules = [
+          # cloud-init's LXD datasource only probes /dev/lxd/sock, while incus
+          # mounts its (API-compatible) guest socket at /dev/incus.
+          "L /dev/lxd - - - - /dev/incus"
+          # Install script has a /bin/bash shebang.
+          "L+ /bin/bash - - - - ${lib.getExe pkgs.bash}"
+        ];
+
+        # The install script expects the runner user to exist and to have
+        # passwordless sudo. Normally both are set up by cloud-init, but the
+        # sudoers.d drop-in cloud-init writes is not included by the sudoers
+        # file on NixOS.
+        users.groups.runner = { };
+        users.users.runner = {
+          isNormalUser = true;
+          group = "runner";
+          extraGroups = [ "wheel" ];
+          shell = pkgs.bash;
+        };
+        security.sudo.wheelNeedsPassword = false;
+
+        # The runner unit is installed at runtime by the install script.
+        # NixOS expects units to set their PATH explicitly, leaving
+        # the runner's unit without a shell.
+        systemd.settings.Manager.DefaultEnvironment = "PATH=/run/current-system/sw/bin";
+
+        environment.systemPackages = [
+          # Runner binary served by the stub release feed is dynamically linked.
+          # Include the package so it's runtime closure is present in the image.
+          pkgs.gitea-actions-runner
+          # Used by the install script.
+          pkgs.curl
+        ];
+      };
+  };
+  incusImageMeta =
+    releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system}
+    + "/tarball/nixos-image-lxc-*-${pkgs.stdenv.hostPlatform.system}.tar.xz";
+  incusImageRoot =
+    releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system}
+    + "/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
+
+  # The host as seen from the runner containers.
+  hostIP = "10.0.10.1";
+
+  # /etc/systemd/system is a symlink into the store, so the stock install script
+  # can't drop the runner unit there. Install the unit into /run/systemd/system
+  # instead and start it without enabling (which would also write to /etc).
+  # Persistence across reboots doesn't matter for ephemeral runners.
+  runnerInstallTemplate =
+    pkgs.runCommand "gitea-runner-install-nixos.tmpl" { inherit (pkgs.garm) src; }
+      ''
+        sed -e 's|/etc/systemd/system|/run/systemd/system|g' \
+            -e 's|systemctl enable --now|systemctl start|g' \
+            $src/internal/templates/userdata/gitea_linux_userdata.tmpl > $out
+        grep -q /run/systemd/system $out
+        ! grep -q 'enable --now' $out
+      '';
+in
+
+{
+  name = "garm-incus";
+  meta.maintainers = with lib.maintainers; [ katexochen ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      virtualisation = {
+        cores = 2;
+        memorySize = 4096;
+        diskSize = 8192;
+        incus = {
+          enable = true;
+          preseed = {
+            networks = [
+              {
+                name = "incusbr0";
+                type = "bridge";
+                config = {
+                  "ipv4.address" = "${hostIP}/24";
+                  "ipv4.nat" = "true";
+                };
+              }
+            ];
+            profiles = [
+              {
+                name = "default";
+                devices = {
+                  eth0 = {
+                    name = "eth0";
+                    network = "incusbr0";
+                    type = "nic";
+                  };
+                  root = {
+                    path = "/";
+                    pool = "default";
+                    type = "disk";
+                  };
+                };
+              }
+            ];
+            storage_pools = [
+              {
+                name = "default";
+                driver = "dir";
+              }
+            ];
+          };
+        };
+      };
+      networking.nftables.enable = true;
+      networking.firewall.trustedInterfaces = [ "incusbr0" ];
+
+      services.gitea = {
+        enable = true;
+        settings.server = {
+          HTTP_ADDR = "0.0.0.0";
+          ROOT_URL = "http://${hostIP}:3000/";
+        };
+        settings.service.DISABLE_REGISTRATION = true;
+        settings.actions.ENABLED = true;
+      };
+
+      # Stub for the gitea runner release feed and download server, replacing gitea.com.
+      services.nginx = {
+        enable = true;
+        virtualHosts.tools = {
+          listen = [
+            {
+              addr = "0.0.0.0";
+              port = 8080;
+            }
+          ];
+          root = pkgs.runCommand "garm-tools-stub" { } ''
+            mkdir $out
+            ln -s ${lib.getExe pkgs.gitea-actions-runner} $out/gitea-runner
+            ln -s ${
+              pkgs.writers.writeJSON "releases.json" [
+                {
+                  tag_name = "v${pkgs.gitea-actions-runner.version}";
+                  name = "v${pkgs.gitea-actions-runner.version}";
+                  assets = [
+                    {
+                      name = "gitea-runner-v${pkgs.gitea-actions-runner.version}-linux-amd64";
+                      browser_download_url = "http://${hostIP}:8080/gitea-runner";
+                    }
+                  ];
+                }
+              ]
+            } $out/releases.json
+          '';
+        };
+      };
+
+      services.garm = {
+        enable = true;
+        settings = {
+          # Instances need to reach the API server for metadata and callbacks.
+          apiserver.bind = "0.0.0.0";
+          apiserver.webui.enable = true;
+          jwt_auth.secret._secret = "/etc/garm-jwt-secret";
+          database.passphrase._secret = "/etc/garm-db-passphrase";
+          provider = [
+            {
+              name = "incus";
+              description = "Incus external provider";
+              provider_type = "external";
+              external = {
+                provider_executable = lib.getExe pkgs.garm-provider-incus;
+                config_file = pkgs.writers.writeTOML "incus-provider.toml" {
+                  unix_socket_path = "/var/lib/incus/unix.socket";
+                  project_name = "default";
+                  instance_type = "container";
+                  include_default_profile = false;
+                  # Never contacted, but required. Fixed in https://github.com/cloudbase/garm-provider-incus/pull/28
+                  image_remotes.images = {
+                    addr = "https://127.0.0.1";
+                    public = true;
+                    protocol = "simplestreams";
+                  };
+                };
+              };
+            }
+          ];
+        };
+      };
+      systemd.services.garm.serviceConfig.SupplementaryGroups = [ "incus-admin" ];
+
+      environment.etc."garm-jwt-secret".text = "uhAVE3d5hiA4f93yPJcVo5xRbvUSbvVUSLGC8tG8WTzxtqtS";
+      environment.etc."garm-db-passphrase".text = "6ahIZPHobW5SvKR92a8nrahCLsZvWBnD"; # must be exactly 32 chars
+
+      environment.systemPackages = [
+        pkgs.gitea
+        pkgs.jq
+      ];
+    };
+
+  testScript = ''
+    import base64
+    import json
+    from datetime import timedelta
+
+    workflow = base64.b64encode("""
+    name: test
+    on: [push]
+    jobs:
+      test:
+        runs-on: nixos-test
+        steps:
+          - run: echo it works
+    """.encode()).decode()
+
+    machine.wait_for_unit("incus-preseed.service")
+    machine.succeed("incus image import ${incusImageMeta} ${incusImageRoot} --alias nixos")
+
+    machine.wait_for_unit("gitea.service")
+    machine.wait_for_open_port(3000)
+    machine.succeed(
+        "su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea admin user create"
+        " --username test --password totallysafe --email test@localhost'"
+    )
+    token = machine.succeed(
+        "curl --fail --silent --show-error -X POST http://test:totallysafe@localhost:3000/api/v1/users/test/tokens"
+        " -H 'Content-Type: application/json'"
+        " -d '{\"name\": \"garm\", \"scopes\": [\"all\"]}'"
+        " | jq -r .sha1"
+    ).strip()
+    machine.succeed(
+        "curl --fail --silent --show-error -X POST http://localhost:3000/api/v1/user/repos"
+        f" -H 'Authorization: token {token}'"
+        " -H 'Content-Type: application/json'"
+        " -d '{\"name\": \"test\", \"auto_init\": true}'"
+    )
+
+    machine.wait_for_unit("garm.service")
+    machine.wait_for_open_port(9997)
+
+    webui = machine.succeed("curl -fsS http://127.0.0.1:9997/ui/")
+    assert "_app/immutable" in webui, f"expected web UI, got: {webui}"
+
+    machine.succeed(
+        "garm-cli init --name garm --url http://${hostIP}:9997"
+        " --username admin --email admin@example.com"
+        " --password CbIhvLQTXCCfVROvLcJ2B7A85BGWbasV"
+    )
+    machine.succeed(
+        "garm-cli gitea endpoint create --name local"
+        " --base-url http://${hostIP}:3000 --api-base-url http://${hostIP}:3000"
+        " --tools-metadata-url http://${hostIP}:8080/releases.json"
+    )
+    machine.succeed(
+        "garm-cli gitea credentials add --name test --endpoint local"
+        f" --auth-type pat --pat-oauth-token {token} --description test"
+    )
+    machine.succeed(
+        "garm-cli template create --name nixos --forge-type gitea --os-type linux"
+        " --path ${runnerInstallTemplate}"
+    )
+    repo_id = machine.succeed(
+        "garm-cli repo add --forge-type gitea --credentials test"
+        " --owner test --name test --random-webhook-secret"
+        " --format json | jq -r .id"
+    ).strip()
+    machine.succeed(
+        f"garm-cli pool add --repo {repo_id} --enabled"
+        " --provider-name incus --image nixos --flavor default"
+        " --runner-install-template nixos"
+        " --min-idle-runners 1 --max-runners 1 --tags nixos-test"
+        " --os-type linux --os-arch amd64"
+    )
+
+    # The instance boots, downloads the runner from the stub server, registers
+    # with Gitea through a GARM-provided registration token and reports back to GARM.
+
+    def runner_idle(_):
+        runners = json.loads(machine.succeed("garm-cli runner list --format json"))
+        if not runners:
+            return False
+        assert runners[0]["runner_status"] != "failed", f"runner failed: {runners}"
+        return runners[0]["runner_status"] == "idle"
+
+    def dump_diagnostics():
+        machine.log(machine.execute(
+            "curl -sS http://localhost:3000/api/v1/repos/test/test/actions/tasks"
+            f" -H 'Authorization: token {token}' 2>&1"
+        )[1])
+        machine.log(machine.execute(
+            'incus exec "$(incus list -c n --format csv)" --force-noninteractive'
+            " -- journalctl --no-pager -n 200 </dev/null 2>&1"
+        )[1])
+
+    def wait_with_diagnostics(description, condition):
+        try:
+            with machine.nested(description):
+                retry(condition, timeout=timedelta(minutes=5))
+        except Exception:
+            dump_diagnostics()
+            raise
+
+    wait_with_diagnostics("waiting for the runner to register", runner_idle)
+
+    instances = json.loads(machine.succeed("incus list --format json"))
+    assert len(instances) == 1, f"expected one incus instance, got: {instances}"
+    assert instances[0]["status"] == "Running", f"expected a running instance, got: {instances}"
+
+    # Pushing a workflow triggers a run on the new runner.
+    machine.succeed(
+        "curl --fail --silent --show-error -X POST"
+        " http://localhost:3000/api/v1/repos/test/test/contents/.gitea/workflows/test.yaml"
+        f" -H 'Authorization: token {token}'"
+        " -H 'Content-Type: application/json'"
+        f' -d \'{{"content": "{workflow}", "message": "add workflow"}}\'''
+    )
+
+    def workflow_succeeded(_):
+        tasks = json.loads(machine.succeed(
+            "curl --fail --silent --show-error http://localhost:3000/api/v1/repos/test/test/actions/tasks"
+            f" -H 'Authorization: token {token}'"
+        ))
+        return any(run["status"] == "success" for run in tasks["workflow_runs"])
+
+    wait_with_diagnostics("waiting for the workflow run to succeed", workflow_succeeded)
+  '';
+}

--- a/pkgs/by-name/ga/garm-provider-incus/package.nix
+++ b/pkgs/by-name/ga/garm-provider-incus/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "garm-provider-incus";
+  version = "0.1.5";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cloudbase";
+    repo = "garm-provider-incus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0xBNhuULfUYzy6mou80gr/kW6mooIe8h1OCkVO3RdmI=";
+  };
+
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-X github.com/cloudbase/garm-provider-incus/provider.Version=v${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Incus external provider for GARM";
+    homepage = "https://github.com/cloudbase/garm-provider-incus";
+    changelog = "https://github.com/cloudbase/garm-provider-incus/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ katexochen ];
+    mainProgram = "garm-provider-incus";
+  };
+})

--- a/pkgs/by-name/ga/garm-provider-incus/package.nix
+++ b/pkgs/by-name/ga/garm-provider-incus/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -24,7 +25,12 @@ buildGoModule (finalAttrs: {
     "-X github.com/cloudbase/garm-provider-incus/provider.Version=v${finalAttrs.version}"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) garm-incus;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Incus external provider for GARM";

--- a/pkgs/by-name/ga/garm/package.nix
+++ b/pkgs/by-name/ga/garm/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  npm-lockfile-fix,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "garm";
+  version = "0.2.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cloudbase";
+    repo = "garm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UAyS01NrvmTHWo603ICbsyxHpqWyLqPf8kppVrtwQPI=";
+    # Add missing hashes to the lockfile, required by fetchNpmDeps.
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/webapp/package-lock.json
+    '';
+  };
+
+  vendorHash = null;
+
+  subPackages = [
+    "cmd/garm"
+    "cmd/garm-cli"
+  ];
+
+  postPatch = ''
+    cp -r ${finalAttrs.passthru.webapp}/. webapp/assets/
+  '';
+
+  ldflags = [
+    "-s"
+    "-X github.com/cloudbase/garm/util/appdefaults.Version=v${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    export HOME=$(mktemp -d)
+    for shell in bash fish zsh; do
+      $out/bin/garm-cli completion $shell > "garm-cli.$shell"
+    done
+    installShellCompletion --cmd garm-cli garm-cli.{bash,fish,zsh}
+  '';
+
+  passthru = {
+    webapp = buildNpmPackage {
+      pname = "garm-webapp";
+      inherit (finalAttrs) version;
+      src = "${finalAttrs.src}/webapp";
+      npmDepsHash = "sha256-tWMkfK4k+kOv0OEyxNkxNln08fXEyQdNmpetKm55wFE=";
+      installPhase = ''
+        runHook preInstall
+        cp -r build $out
+        runHook postInstall
+      '';
+    };
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "webapp"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Multi-cloud, auto-scaling manager for GitHub Actions & Gitea self-hosted runners with pluggable providers";
+    homepage = "https://github.com/cloudbase/garm";
+    changelog = "https://github.com/cloudbase/garm/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ katexochen ];
+    mainProgram = "garm";
+  };
+})

--- a/pkgs/by-name/ga/garm/package.nix
+++ b/pkgs/by-name/ga/garm/package.nix
@@ -7,6 +7,7 @@
   nix-update-script,
   npm-lockfile-fix,
   stdenv,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -69,6 +70,10 @@ buildGoModule (finalAttrs: {
         "--subpackage"
         "webapp"
       ];
+    };
+
+    tests = {
+      inherit (nixosTests) garm-incus;
     };
   };
 


### PR DESCRIPTION
This adds a nixos module for garm, a dynamic scheduler for Github/Gitea action runners, together with the garm-incus-provider. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
