### PR TITLE
fx-sh: init at 0.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -506,6 +506,12 @@
     githubId = 15805292;
     name = "Abdirahman Osman";
   };
+  abhi-kr-2100 = {
+    email = "abhi.kr.2100@gmail.com";
+    github = "abhi-kr-2100";
+    githubId = 66527624;
+    name = "Abhishek Kumar";
+  };
   abhi18av = {
     email = "abhi18av@gmail.com";
     github = "abhi18av";

--- a/pkgs/by-name/fx/fx-sh/package.nix
+++ b/pkgs/by-name/fx/fx-sh/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  zig_0_16,
+}:
+
+let
+  zig = zig_0_16;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fx-sh";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "vercel-labs";
+    repo = "fx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NeDAx55Ws3pZJeug8rYEFQaMI2Kf1Smz07nwhhiL+WM=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ zig.hook ];
+
+  zigBuildFlags = [ "-Doptimize=ReleaseSafe" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Unix like coding agent";
+    homepage = "https://github.com/vercel-labs/fx";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      abhi-kr-2100
+      amadejkastelic
+    ];
+    mainProgram = "fx";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
