### PR TITLE
openscreen: add etiennelescot as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8738,6 +8738,11 @@
     githubId = 965612;
     name = "York Wong";
   };
+  etiennelescot = {
+    github = "EtienneLescot";
+    githubId = 215859519;
+    name = "Etienne Lescot";
+  };
   Etjean = {
     email = "et.jean@outlook.fr";
     github = "Etjean";

--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -121,7 +121,6 @@ buildNpmPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       etiennelescot
-      Renna42
     ];
     mainProgram = "openscreen";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -120,6 +120,7 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://openscreen.vercel.app";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      etiennelescot
       Renna42
     ];
     mainProgram = "openscreen";


### PR DESCRIPTION
I maintain [getopenscreen/openscreen](https://github.com/getopenscreen/openscreen), the maintained continuation of this package's upstream, and I'd like to look after the nixpkgs package.

The current maintainer stepped down in #554708:

> Sorry but I don't have enough time to maintain this package.

This adds me to `maintainers/maintainer-list.nix` and to the package's `meta.maintainers`, and takes `Renna42` off it per that message. Happy to put them back if I have read it too broadly.

### What this deliberately does not change

`src`, `version`, `meta.homepage` and `meta.description` are untouched. The package still builds `siddharthvaddem/openscreen` at v1.4.0, which is archived, and its homepage returns 404. Fixing that means re-pointing `src` at the continuation, and that is not a version bump: since 1.4.0 the application grew per-platform native components and a build-time ffmpeg download, none of which survive `npmRebuildFlags = [ "--ignore-scripts" ]` or the build sandbox. A straight bump would produce a package that builds and launches without its export path. #554708 describes it in full.

I would rather sort out maintainership first and do that work properly as a separate PR than rush both together.

### Automation/AI disclosure

Per the [automation/AI policy], disclosed separately for the commits and for this summary:

- **Commits:** written with the assistance of Claude Code (primary model `claude-opus-5`). All three commits carry an `Assisted-by:` trailer.
- **This pull request summary:** also written with the assistance of Claude Code (`claude-opus-5`), reviewed and edited by me before submission.

I have read the complete diff — a five-line maintainer entry in `maintainers/maintainer-list.nix` and a one-line swap in the package's `meta.maintainers` — understand it, and am accountable for it. Sorry for not disclosing this up front; thanks to @Prince213 for the pointer to the policy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Nothing is checked in the build and test sections because this PR changes metadata only and triggers no rebuild: `nixpkgs-review` on a maintainer-list addition would build nothing relevant, and I have no NixOS or Darwin machine to build on. I have not attempted to verify the package's runtime behaviour here — as noted above, it is known to be stale, and fixing that is separate work.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
