### PR TITLE
nixos/test-driver: bound a single retry attempt separately from the total budget

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -114,7 +114,15 @@ def retry(
     """Call the given function repeatedly, with a one second interval between
     retries, until it returns True or a timeout is reached.
 
-    Note that the timeout shown will include the time of the last attempted run.
+    ``timeout`` is a *total budget*: no further attempt is started once it has
+    elapsed. It is not a bound on a single attempt. ``retry`` calls ``fn`` and
+    cannot interrupt it, so a probe that can block has to bound itself -- see
+    ``_AttemptBudget``, which is how the ``wait_for_*`` helpers do it.
+
+    One final attempt runs after the budget is spent, called with ``True`` so
+    that it can report what it last saw. Its duration is therefore on top of
+    ``timeout``, which is why the timeout reported on failure covers the last
+    attempted run as well.
 
     Has a default timeout of 15 minutes which can be modified.
     The ``timeout_seconds`` argument is deprecated. Use ``timeout`` instead.
@@ -147,6 +155,38 @@ def retry(
             f"action timed out after {elapsed().total_seconds():.2f} seconds "
             f"(timeout={timeout.total_seconds()})"
         )
+
+
+class _AttemptBudget:
+    """Derives the bound for a single `retry` attempt from a total budget.
+
+    The `wait_for_*` helpers take two distinct quantities:
+
+    -   `timeout`, the total budget handed to `retry`, and
+    -   `attempt_timeout`, how long any one probe may block before it is
+        abandoned and retried.
+
+    `retry` only enforces the first, so the probe has to enforce the second on
+    itself. This does that bookkeeping: `next_attempt` returns the bound for the
+    attempt that is about to start, which is the per-attempt allowance clamped
+    to what is left of the budget.
+
+    Once the budget is spent -- which is when `retry` runs its one final
+    attempt -- the full allowance is handed out again rather than nothing, so
+    that final attempt still gets a fair chance to succeed and to report what it
+    saw.
+    """
+
+    def __init__(self, total: Duration, attempt: Duration | None = None) -> None:
+        budget = as_timedelta(total)
+        self.attempt = budget if attempt is None else as_timedelta(attempt)
+        self.deadline = time.monotonic() + budget.total_seconds()
+
+    def next_attempt(self) -> dt.timedelta:
+        remaining = dt.timedelta(seconds=self.deadline - time.monotonic())
+        if remaining <= dt.timedelta(0):
+            return self.attempt
+        return min(self.attempt, remaining)
 
 
 class QemuStartCommand:
@@ -346,7 +386,12 @@ class BaseMachine(ABC):
         """Shutdown the machine gracefully, waiting for it to exit."""
         ...
 
-    def systemctl(self, q: str, user: str | None = None) -> tuple[int, str]:
+    def systemctl(
+        self,
+        q: str,
+        user: str | None = None,
+        timeout: Duration | None = dt.timedelta(minutes=15),
+    ) -> tuple[int, str]:
         """
         Runs `systemctl` commands with optional support for
         `systemctl --user`
@@ -359,38 +404,51 @@ class BaseMachine(ABC):
         # `systemctl --user list-jobs --no-pager`
         machine.systemctl("list-jobs --no-pager", "any-user")
         ```
+
+        See `execute` for details on `timeout`.
         """
         if user is not None:
             q = q.replace("'", "\\'")
             return self.execute(
                 f"su -l {user} --shell /bin/sh -c "
                 "$'XDG_RUNTIME_DIR=/run/user/`id -u` "
-                f"systemctl --user {q}'"
+                f"systemctl --user {q}'",
+                timeout=timeout,
             )
-        return self.execute(f"systemctl {q}")
+        return self.execute(f"systemctl {q}", timeout=timeout)
 
     def wait_for_unit(
         self,
         unit: str,
         user: str | None = None,
         timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """
         Wait for a systemd unit to get into "active" state.
         Throws exceptions on "failed" and "inactive" states as well as after
         timing out.
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single `systemctl` call, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_for_unit")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_unit")
+        budget = _AttemptBudget(timeout, attempt_timeout)
 
         def check_active(_last_try: bool) -> bool:
-            state = self.get_unit_property(unit, "ActiveState", user)
+            state = self.get_unit_property(
+                unit, "ActiveState", user, timeout=budget.next_attempt()
+            )
             if state == "failed":
                 raise RequestedAssertionFailed(f'unit "{unit}" reached state "{state}"')
 
             if state == "inactive":
-                status, jobs = self.systemctl("list-jobs --full 2>&1", user)
+                status, jobs = self.systemctl(
+                    "list-jobs --full 2>&1", user, timeout=budget.next_attempt()
+                )
                 if "No jobs" in jobs:
-                    info = self.get_unit_info(unit, user)
+                    info = self.get_unit_info(unit, user, timeout=budget.next_attempt())
                     if info["ActiveState"] == state:
                         raise RequestedAssertionFailed(
                             f'unit "{unit}" is inactive and there are no pending jobs'
@@ -404,11 +462,18 @@ class BaseMachine(ABC):
         ):
             retry(check_active, as_timedelta(timeout))
 
-    def get_unit_info(self, unit: str, user: str | None = None) -> dict[str, str]:
+    def get_unit_info(
+        self,
+        unit: str,
+        user: str | None = None,
+        timeout: Duration | None = dt.timedelta(minutes=15),
+    ) -> dict[str, str]:
         """
         Get a dictionary of systemd unit properties, as obtained via `systemctl show`.
+
+        See `execute` for details on `timeout`.
         """
-        status, lines = self.systemctl(f'--no-pager show "{unit}"', user)
+        status, lines = self.systemctl(f'--no-pager show "{unit}"', user, timeout)
         if status != 0:
             raise RequestedAssertionFailed(
                 f'retrieving systemctl info for unit "{unit}"'
@@ -434,13 +499,17 @@ class BaseMachine(ABC):
         unit: str,
         property: str,
         user: str | None = None,
+        timeout: Duration | None = dt.timedelta(minutes=15),
     ) -> str:
         """
         Get the string value of a single systemd unit property
+
+        See `execute` for details on `timeout`.
         """
         status, lines = self.systemctl(
             f'--no-pager show "{unit}" --property="{property}"',
             user,
+            timeout,
         )
         if status != 0:
             raise RequestedAssertionFailed(
@@ -514,7 +583,10 @@ class BaseMachine(ABC):
         return output
 
     def wait_until_succeeds(
-        self, command: str, timeout: Duration = dt.timedelta(minutes=15)
+        self,
+        command: str,
+        timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> str:
         """
         Repeat a shell command on 1-second intervals until it succeeds.
@@ -528,13 +600,28 @@ class BaseMachine(ABC):
         A bare number is still accepted and interpreted as a number of seconds.
         See `execute` for details on command execution.
         Throws an exception on timeout.
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single run of `command`, and defaults to the whole of `timeout` -- so by
+        default one run that blocks consumes the budget on its own and the
+        command is effectively tried once. Pass `attempt_timeout` for a command
+        that can hang:
+            ```py
+            wait_until_succeeds(
+                cmd,
+                timeout=dt.timedelta(minutes=2),
+                attempt_timeout=dt.timedelta(seconds=5),
+            )
+            ```
         """
         _warn_if_numeric_duration(timeout, "wait_until_succeeds")
+        _warn_if_numeric_duration(attempt_timeout, "wait_until_succeeds")
+        budget = _AttemptBudget(timeout, attempt_timeout)
         output = ""
 
         def check_success(_last_try: bool) -> bool:
             nonlocal output
-            status, output = self.execute(command, timeout=timeout)
+            status, output = self.execute(command, timeout=budget.next_attempt())
             return status == 0
 
         with self.nested(f"waiting for success: {command}"):
@@ -542,17 +629,22 @@ class BaseMachine(ABC):
             return output
 
     def wait_until_fails(
-        self, command: str, timeout: Duration = dt.timedelta(minutes=15)
+        self,
+        command: str,
+        timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> str:
         """
         Like `wait_until_succeeds`, but repeating the command until it fails.
         """
         _warn_if_numeric_duration(timeout, "wait_until_fails")
+        _warn_if_numeric_duration(attempt_timeout, "wait_until_fails")
+        budget = _AttemptBudget(timeout, attempt_timeout)
         output = ""
 
         def check_failure(_last_try: bool) -> bool:
             nonlocal output
-            status, output = self.execute(command, timeout=timeout)
+            status, output = self.execute(command, timeout=budget.next_attempt())
             return status != 0
 
         with self.nested(f"waiting for failure: {command}"):
@@ -582,15 +674,25 @@ class BaseMachine(ABC):
         self.succeed(f"sleep {as_seconds(duration)}")
 
     def wait_for_file(
-        self, filename: str, timeout: Duration = dt.timedelta(minutes=15)
+        self,
+        filename: str,
+        timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """
         Waits until the file exists in the machine's file system.
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single check, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_for_file")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_file")
+        budget = _AttemptBudget(timeout, attempt_timeout)
 
         def check_file(_last_try: bool) -> bool:
-            status, _ = self.execute(f"test -e {filename}")
+            status, _ = self.execute(
+                f"test -e {filename}", timeout=budget.next_attempt()
+            )
             return status == 0
 
         with self.nested(f"waiting for file '{filename}'"):
@@ -601,15 +703,25 @@ class BaseMachine(ABC):
         port: int,
         addr: str = "localhost",
         timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """
         Wait until a process is listening on the given TCP port and IP address
         (default `localhost`).
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single probe, and defaults to the whole of `timeout`. A probe against an
+        address that silently drops packets blocks until the kernel gives up on
+        the connection, so a short `attempt_timeout` is worth setting there.
         """
         _warn_if_numeric_duration(timeout, "wait_for_open_port")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_open_port")
+        budget = _AttemptBudget(timeout, attempt_timeout)
 
         def port_is_open(_last_try: bool) -> bool:
-            status, _ = self.execute(f"nc -z {addr} {port}")
+            status, _ = self.execute(
+                f"nc -z {addr} {port}", timeout=budget.next_attempt()
+            )
             return status == 0
 
         with self.nested(f"waiting for TCP port {port} on {addr}"):
@@ -620,12 +732,18 @@ class BaseMachine(ABC):
         addr: str,
         is_datagram: bool = False,
         timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """
         Wait until a process is listening on the given UNIX-domain socket
         (default to a UNIX-domain stream socket).
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single probe, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_for_open_unix_socket")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_open_unix_socket")
+        budget = _AttemptBudget(timeout, attempt_timeout)
 
         nc_flags = [
             "-z",
@@ -633,7 +751,9 @@ class BaseMachine(ABC):
         ]
 
         def socket_is_open(_last_try: bool) -> bool:
-            status, _ = self.execute(f"nc {' '.join(nc_flags)} {addr}")
+            status, _ = self.execute(
+                f"nc {' '.join(nc_flags)} {addr}", timeout=budget.next_attempt()
+            )
             return status == 0
 
         with self.nested(
@@ -646,15 +766,23 @@ class BaseMachine(ABC):
         port: int,
         addr: str = "localhost",
         timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """
         Wait until nobody is listening on the given TCP port and IP address
         (default `localhost`).
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single probe, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_for_closed_port")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_closed_port")
+        budget = _AttemptBudget(timeout, attempt_timeout)
 
         def port_is_closed(_last_try: bool) -> bool:
-            status, _ = self.execute(f"nc -z {addr} {port}")
+            status, _ = self.execute(
+                f"nc -z {addr} {port}", timeout=budget.next_attempt()
+            )
             return status != 0
 
         with self.nested(f"waiting for TCP port {port} on {addr} to be closed"):
@@ -939,26 +1067,40 @@ class QemuMachine(BaseMachine):
                 break
         return "".join(output_buffer)
 
-    def get_tty_text(self, tty: str) -> str:
+    def get_tty_text(
+        self, tty: str, timeout: Duration | None = dt.timedelta(minutes=15)
+    ) -> str:
         """
         Get the output printed to a given TTY.
+
+        See `execute` for details on `timeout`.
         """
         status, output = self.execute(
-            f"fold -w$(stty -F /dev/tty{tty} size | awk '{{print $2}}') /dev/vcs{tty}"
+            f"fold -w$(stty -F /dev/tty{tty} size | awk '{{print $2}}') /dev/vcs{tty}",
+            timeout=timeout,
         )
         return output
 
     def wait_until_tty_matches(
-        self, tty: str, regexp: str, timeout: Duration = dt.timedelta(minutes=15)
+        self,
+        tty: str,
+        regexp: str,
+        timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """Wait until the visible output on the chosen TTY matches regular
         expression. Throws an exception on timeout.
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single read of the TTY, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_until_tty_matches")
+        _warn_if_numeric_duration(attempt_timeout, "wait_until_tty_matches")
+        budget = _AttemptBudget(timeout, attempt_timeout)
         matcher = re.compile(regexp)
 
         def tty_matches(last_try: bool) -> bool:
-            text = self.get_tty_text(tty)
+            text = self.get_tty_text(tty, timeout=budget.next_attempt())
             if last_try:
                 self.log(
                     f"Last chance to match /{regexp}/ on TTY{tty}, "
@@ -1122,15 +1264,25 @@ class QemuMachine(BaseMachine):
                 self.send_key(char, delay, log=False)
 
     def wait_for_file(
-        self, filename: str, timeout: Duration = dt.timedelta(minutes=15)
+        self,
+        filename: str,
+        timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """
         Waits until the file exists in the machine's file system.
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single check, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_for_file")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_file")
+        budget = _AttemptBudget(timeout, attempt_timeout)
 
         def check_file(_last_try: bool) -> bool:
-            status, _ = self.execute(f"test -e {filename}")
+            status, _ = self.execute(
+                f"test -e {filename}", timeout=budget.next_attempt()
+            )
             return status == 0
 
         with self.nested(f"waiting for file '{filename}'"):
@@ -1465,43 +1617,63 @@ class QemuMachine(BaseMachine):
         self.send_key("ctrl-alt-delete")
         self.connected = False
 
-    def wait_for_x(self, timeout: Duration = dt.timedelta(minutes=15)) -> None:
+    def wait_for_x(
+        self,
+        timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
+    ) -> None:
         """
         Wait until it is possible to connect to the X server.
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single check, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_for_x")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_x")
+        budget = _AttemptBudget(timeout, attempt_timeout)
 
         def check_x(_last_try: bool) -> bool:
             cmd = (
                 "journalctl -b SYSLOG_IDENTIFIER=systemd | "
                 + 'grep "Reached target Current graphical"'
             )
-            status, _ = self.execute(cmd)
+            status, _ = self.execute(cmd, timeout=budget.next_attempt())
             if status != 0:
                 return False
-            status, _ = self.execute("[ -e /tmp/.X11-unix/X0 ]")
+            status, _ = self.execute(
+                "[ -e /tmp/.X11-unix/X0 ]", timeout=budget.next_attempt()
+            )
             return status == 0
 
         with self.nested("waiting for the X11 server"):
             retry(check_x, as_timedelta(timeout))
 
-    def get_window_names(self) -> list[str]:
+    def get_window_names(self, timeout: Duration | None = None) -> list[str]:
         return self.succeed(
-            r"xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'"
+            r"xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'",
+            timeout=timeout,
         ).splitlines()
 
     def wait_for_window(
-        self, regexp: str, timeout: Duration = dt.timedelta(minutes=15)
+        self,
+        regexp: str,
+        timeout: Duration = dt.timedelta(minutes=15),
+        attempt_timeout: Duration | None = None,
     ) -> None:
         """
         Wait until an X11 window has appeared whose name matches the given
         regular expression, e.g., `wait_for_window("Terminal")`.
+
+        `timeout` is the total budget for the wait. `attempt_timeout` bounds a
+        single attempt, and defaults to the whole of `timeout`.
         """
         _warn_if_numeric_duration(timeout, "wait_for_window")
+        _warn_if_numeric_duration(attempt_timeout, "wait_for_window")
+        budget = _AttemptBudget(timeout, attempt_timeout)
         pattern = re.compile(regexp)
 
         def window_is_visible(last_try: bool) -> bool:
-            names = self.get_window_names()
+            names = self.get_window_names(timeout=budget.next_attempt())
             if last_try:
                 self.log(
                     f"Last chance to match {regexp} on the window list,"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -156,6 +156,7 @@ in
     multi-arch-test = runTest ./nixos-test-driver/multi-arch-test.nix;
     skip-typecheck = runTest ./nixos-test-driver/skip-typecheck.nix;
     console-timeout = runTest ./nixos-test-driver/console-timeout.nix;
+    attempt-timeout = runTest ./nixos-test-driver/attempt-timeout.nix;
     options-doc-regression = import ./nixos-test-driver/options-doc-regression.nix { inherit pkgs; };
     driver-timeout =
       pkgs.runCommand "ensure-timeout-induced-failure"

--- a/nixos/tests/nixos-test-driver/attempt-timeout.nix
+++ b/nixos/tests/nixos-test-driver/attempt-timeout.nix
@@ -1,0 +1,60 @@
+# The test driver's polling helpers take two distinct quantities:
+#
+#   - a total budget, how long to keep retrying before giving up, and
+#   - a per-attempt bound, how long one probe may block before it is abandoned
+#     and retried.
+#
+# `timeout` is the total budget and `attempt_timeout` is the per-attempt bound.
+# Both are only observable when a probe blocks, which is the case these helpers
+# exist to survive, so this test makes one block on purpose.
+{ pkgs, ... }:
+{
+  name = "test-driver-attempt-timeout";
+
+  nodes.machine.environment.systemPackages = [ pkgs.iptables ];
+
+  testScript = ''
+    import datetime as dt
+    import time
+
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("a blocking command is retried within the budget"):
+        total = dt.timedelta(seconds=20)
+        attempt = dt.timedelta(seconds=2)
+
+        # each attempt records itself then blocks well past `attempt`
+        command = "echo attempt >> /tmp/attempts; exec sleep 600 > /dev/null"
+
+        started = time.monotonic()
+        try:
+            machine.wait_until_succeeds(command, timeout=total, attempt_timeout=attempt)
+        except Exception:
+            pass
+        else:
+            raise Exception("wait_until_succeeds should have timed out")
+
+        elapsed = time.monotonic() - started
+        attempts = int(machine.succeed("wc -l < /tmp/attempts"))
+        # we can get in several attempts
+        assert attempts >= 4, f"command was tried {attempts} times, expected it to be retried"
+        # one final try after timeout, so the call costs about `total + attempt`
+        assert elapsed < 40, f"wait_until_succeeds took {elapsed:.1f}s"
+
+    with subtest("a blocking probe is bounded by the caller's budget"):
+        machine.succeed("iptables -A OUTPUT -p tcp -d 127.0.0.1 --dport 1234 -j DROP")
+
+        started = time.monotonic()
+        try:
+            machine.wait_for_open_port(1234, timeout=dt.timedelta(seconds=5))
+        except Exception:
+            pass
+        else:
+            raise Exception("wait_for_open_port should have timed out")
+        elapsed = time.monotonic() - started
+
+        # the bounded loop plus `retry`'s final attempt cost about ten seconds
+        assert elapsed < 60, f"wait_for_open_port took {elapsed:.1f}s"
+  '';
+}


### PR DESCRIPTION
Gives test driver methods an `attempt_timeout` as a `retry`-level dial in addition to its existing total `timeout`, which this defaults to. Time-out duration of the final attempt (past total time-out) reduces to `attempt_timeout`, shortening its worst-case, if `attempt_timeout` is set.

## Checks

- `nixos/tests/nixos-test-driver/attempt-timeout.nix` (new)
- `nixosTests.login` (exercises `wait_until_tty_matches`)
- `nixosTests.xterm` (`wait_for_x`, `wait_for_window`)
- `nixosTests.nixos-test-driver.busybox`

### Measured

| | with this change | without it |
|---|---|---|
| `wait_until_succeeds` on a command that blocks, `timeout=20s`, `attempt_timeout=2s` | 23.06 s, retried throughout | **2 attempts** -- the first run and `retry`'s final one |
| `wait_for_open_port(1234, timeout=5s)` with the SYNs dropped by `iptables` | **11.05 s** | **271.3 s** |

`wait_until_succeeds` passed its total budget straight to `execute` as the per-attempt bound, so a command that blocks consumes the whole budget on the first run and the retry loop never gets a second one. The `wait_for_*` probes passed no bound at all, so each probe fell back to `execute`'s 15-minute default while `retry` only decided whether to start another one. `retry` also runs one final attempt after the budget is spent, unbounded by anything related to the remaining time. A `wait_for_open_port(port, timeout=5s)` against an address that drops packets took 271.3 s.

Assisted-by: Claude:claude-opus-5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
