### PR TITLE
par2cmdline: modernize

### DIFF
--- a/pkgs/by-name/pa/par2cmdline/package.nix
+++ b/pkgs/by-name/pa/par2cmdline/package.nix
@@ -3,20 +3,27 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "par2cmdline";
   version = "1.3.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "Parchive";
     repo = "par2cmdline";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-TEWfkjyjqG5cRsVkckIoIo/+/LwhwH1GVivX6Dpvpxw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TEWfkjyjqG5cRsVkckIoIo/+/LwhwH1GVivX6Dpvpxw=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/Parchive/par2cmdline";
@@ -26,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
       damage in data files and repair them if necessary. It can be used with
       any kind of file.
     '';
+    mainProgram = "par2";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ tallesCoelho ];
     platforms = lib.platforms.all;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
