### PR TITLE
fetchYarnDeps: fix filename collisions for git deps with different revisions

### DIFF
--- a/pkgs/build-support/node/fetch-yarn-deps/common.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/common.js
@@ -1,11 +1,14 @@
 const path = require('path')
 
-const urlToName = url => {
+const urlToName = (url, hash) => {
   const isCodeloadGitTarballUrl = url.startsWith('https://codeload.github.com/') && url.includes('/tar.gz/')
 
   if (url.startsWith('file:')) {
     return url
-  } else if (url.startsWith('git+') || isCodeloadGitTarballUrl) {
+  } else if (url.startsWith('git+')) {
+    const base = path.basename(url);
+    return hash ? `${base}-${hash}` : base;
+  } else if (isCodeloadGitTarballUrl) {
     return path.basename(url)
   } else {
     return url

--- a/pkgs/build-support/node/fetch-yarn-deps/fixup.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/fixup.js
@@ -29,7 +29,7 @@ const fixupYarnLock = async (lockContents, verbose) => {
       }
 
       if (verbose) console.log(`Rewriting URL ${url} for dependency ${dep}`)
-      pkg.resolved = urlToName(url)
+      pkg.resolved = urlToName(url, hash)
       if (hash)
         pkg.resolved += `#${hash}`
 

--- a/pkgs/build-support/node/fetch-yarn-deps/index.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/index.js
@@ -107,7 +107,7 @@ const downloadPkg = (pkg, verbose) => {
 
   const [ url, hash ] = pkg.resolved.split('#')
   if (verbose) console.log('downloading ' + url)
-  const fileName = urlToName(url)
+  const fileName = urlToName(url, hash)
   const s = url.split('/')
   if (url.startsWith('https://codeload.github.com/') && url.includes('/tar.gz/')) {
     return downloadGit(fileName, `https://github.com/${s[3]}/${s[4]}.git`, s[s.length-1])

--- a/pkgs/build-support/node/fetch-yarn-deps/tests/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/tests/default.nix
@@ -11,7 +11,7 @@
   };
   gitDep = testers.invalidateFetcherByDrvHash fetchYarnDeps {
     yarnLock = ./git.lock;
-    sha256 = "sha256-f90IiEzHDiBdswWewRBHcJfqqpPipaMg8N0DVLq2e8Q=";
+    sha256 = "sha256-PsCQGLc5NCXJBU+eSE+OLymX5iEZyKTw8ZET8gefGhs=";
   };
   githubDep = testers.invalidateFetcherByDrvHash fetchYarnDeps {
     yarnLock = ./github.lock;
@@ -24,5 +24,9 @@
   gitUrlDep = testers.invalidateFetcherByDrvHash fetchYarnDeps {
     yarnLock = ./giturl.lock;
     sha256 = "sha256-VPnyqN6lePQZGXwR7VhbFnP7/0/LB621RZwT1F+KzVQ=";
+  };
+  gitMultiRevDep = testers.invalidateFetcherByDrvHash fetchYarnDeps {
+    yarnLock = ./git-multi-rev.lock;
+    sha256 = "sha256-y4ulvP99lMjmjnjoSSivWW/1iQBsvvLLwT5zwqSrmn8=";
   };
 }

--- a/pkgs/build-support/node/fetch-yarn-deps/tests/git-multi-rev.lock
+++ b/pkgs/build-support/node/fetch-yarn-deps/tests/git-multi-rev.lock
@@ -1,0 +1,7 @@
+"semver-new@git+https://github.com/npm/node-semver.git#6e05b7637396ac66522cff8731f07cfe0ef49a29":
+  version "7.8.5"
+  resolved "git+https://github.com/npm/node-semver.git#6e05b7637396ac66522cff8731f07cfe0ef49a29"
+
+"semver-old@git+https://github.com/npm/node-semver.git#8640bd68f1653e504b53e9be4030eccdfe4c307a":
+  version "7.8.4"
+  resolved "git+https://github.com/npm/node-semver.git#8640bd68f1653e504b53e9be4030eccdfe4c307a"


### PR DESCRIPTION
`fetchYarnDeps` produces a broken yarn artifact when `yarn.lock` contains more than one of the same git dependency with different revisions. This can happen when two `git+...#rev` dependencies coexist anywhere in the dependency tree.

The cache filename for a git dependency is derived from the git repo URL alone, with `#rev` discarded. This means two `nix-prefetch-git` invocations of the same repo will race writing to `RepoName.git.tmp`, ultimately failing the build over an existing git lockfile, or nondeterministically overwriting one version with another.

This PR appends the git revision to the end of the derived file name. Non-git dependencies are unaffected, since their filenames include the package version.

## Reproducible Example

`yarn.lock`
```yaml
"semver-new@git+https://github.com/npm/node-semver.git#6e05b7637396ac66522cff8731f07cfe0ef49a29":
  version "7.8.5"
  resolved "git+https://github.com/npm/node-semver.git#6e05b7637396ac66522cff8731f07cfe0ef49a29"

"semver-old@git+https://github.com/npm/node-semver.git#8640bd68f1653e504b53e9be4030eccdfe4c307a":
  version "7.8.4"
  resolved "git+https://github.com/npm/node-semver.git#8640bd68f1653e504b53e9be4030eccdfe4c307a"
```

`repro.nix`
```nix
{ pkgs ? import <nixpkgs> {} }:
pkgs.fetchYarnDeps {
  yarnLock = ./yarn.lock;
  hash = "sha256-y4ulvP99lMjmjnjoSSivWW/1iQBsvvLLwT5zwqSrmn8=";
}
```

```sh
$ nix-build repro.nix
...
error: Cannot build '/nix/store/4phsc6xs0q256jpxbq88a3y7zwm8xzlj-offline.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/gym4vcajg2kasbnmc68ngip2y4hs9j8v-offline
       Last 23 log lines:
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > downloading git+https://github.com/npm/node-semver.git
       > downloading git+https://github.com/npm/node-semver.git
       > Error: Command failed: nix-prefetch-git --out node-semver.git.tmp --url https://github.com/npm/node-semver.git --rev 6e05b7637396ac66522cff8731f07cfe0ef49a29 --builder
       > fatal: cannot copy '/nix/store/hiw6ii978dc8s153v60fzy6myzqxymm7-git-2.55.0/share/git-core/templates/info/exclude' to '/nix/store/gym4vcajg2kasbnmc68ngip2y4hs9j8v-offline/node-semver.git.tmp/.git/info/exclude': File exists
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
