### PR TITLE
chromium: don't show misleading Terms of Service dialog on first run

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -656,6 +656,28 @@ let
       # which is annoying, so let's make it use Go from $PATH for
       # both (all) architectures instead.
       ./patches/chromium-151-dawn-use-Go-from-PATH.patch
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "151.0.7922.169" && !ungoogled) [
+      # Don't show misleading Terms of Service dialog on first run that literally says [^1]
+      #
+      # > This Space Intentionally Blank
+      # >
+      # > In official builds this space will show the terms of service.
+      #
+      # "official builds" refers to offical Google Chrome builds, not Chromium, for which we
+      # explicitly set is_official_build=true as gn flag. If this does ever change to something
+      # actually worthwhile, we can drop this revert and update our VM test to handle this dialog.
+      # Exclude ungoogled-chromium, as it ships its own variant of this patch.
+      # [^1]: https://chromium.googlesource.com/chromium/src/+/151.0.7922.169/components/resources/terms/terms_chromium.txt
+      (fetchpatch {
+        name = "chromium-151-revert-Show-Linux-first-run-terms-of-service-dialog-by-default.patch";
+        # https://chromium-review.googlesource.com/c/chromium/src/+/8257374
+        url = "https://chromium.googlesource.com/chromium/src/+/ae9b17ac975d4b10af762e9344083d858f1347ce^!?format=TEXT";
+        decode = "base64 -d";
+        revert = true;
+        includes = [ "chrome/browser/first_run/first_run.h" ];
+        hash = "sha256-d1Zm2flZPG++ROF4CCawn9U8T7/qgZFMHTXArqIShTk=";
+      })
     ];
 
     postPatch =


### PR DESCRIPTION
This new dialog was introduced by upstream in [CL 8257374] and slipped through our testing in [1]. It also managed to break our `nixosTests.chromium` VM test. We could just make our VM test use `--no-first-run` and have it pass that way, but the [dialog text] is actively misleading.

[1]: https://github.com/NixOS/nixpkgs/pull/554479
[CL 8257374]: https://chromium-review.googlesource.com/c/chromium/src/+/8257374i
[dialog text]: https://chromium.googlesource.com/chromium/src/+/151.0.7922.169/components/resources/terms/terms_chromium.txt

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixosTests.chromium`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
