### PR TITLE
clj-kondo: fix startup crash with GraalVM >= 25.1

### DIFF
--- a/pkgs/by-name/cl/clj-kondo/package.nix
+++ b/pkgs/by-name/cl/clj-kondo/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGraalvmNativeImage,
   fetchurl,
+  versionCheckHook,
 }:
 
 buildGraalvmNativeImage (finalAttrs: {
@@ -16,7 +17,15 @@ buildGraalvmNativeImage (finalAttrs: {
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "--no-fallback"
+    # GraalVM >= 25.1 removed @AutomaticFeature discovery, so the bundled
+    # graal-build-time feature no longer runs and the binary crashes at
+    # startup. Register it explicitly. Remove once a release carrying
+    # https://github.com/clj-kondo/clj-kondo/pull/2949 is packaged.
+    "--features=InitAtBuildTimeFeature"
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Linter for Clojure code that sparks joy";


### PR DESCRIPTION
Followup to https://github.com/NixOS/nixpkgs/pull/553693, noted when clj-kondo broke in actual usage after merge.

GraalVM 25.1 removed @AutomaticFeature discovery, so the bundled graal-build-time feature stopped working correctly. This PR registers it explicitly, so the current version works again. This workaround can be removed if/when clj-kondo/clj-kondo#2949 ships and compatibility with 25.1+ is restored.

Going forward, add `versionCheckHook` so a binary that cannot start fails the build.

Assisted-by: Claude Code (claude-fable-5)


## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
