### PR TITLE
plezy: 2.13.0 -> 2.16.0

### DIFF
--- a/pkgs/by-name/pl/plezy/git-hashes.json
+++ b/pkgs/by-name/pl/plezy/git-hashes.json
@@ -3,7 +3,7 @@
   "auto_updater_macos": "sha256-787cMkeT2BlfwVcy4y46XkWioNqLKJgQ/CCxQvERa+A=",
   "auto_updater_platform_interface": "sha256-787cMkeT2BlfwVcy4y46XkWioNqLKJgQ/CCxQvERa+A=",
   "auto_updater_windows": "sha256-787cMkeT2BlfwVcy4y46XkWioNqLKJgQ/CCxQvERa+A=",
-  "background_downloader": "sha256-y37tzAxOwql1193E+aTJOIi2B0gXLxL3azghEYzcRGA=",
+  "background_downloader": "sha256-x1Z+Nlyvy+cc1EdRUikqZMDjVKdGHe7FOH2Yx9K0zhE=",
   "connectivity_plus": "sha256-sVUG5/6GF0Eu47BgUCkgbGi8w1ip5o0yQS00NnNjAGs=",
   "os_media_controls": "sha256-UkrBz52dkdlSJ+UJwC2E7RhuSOcXzJx+dVo0JcW8pEY="
 }

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -27,13 +27,13 @@
 
 let
   pname = "plezy";
-  version = "2.13.0";
+  version = "2.16.0";
 
   src = fetchFromGitHub {
     owner = "edde746";
     repo = "plezy";
     tag = version;
-    hash = "sha256-pSGHB2sN/iySd3WKskvZeBo9H9M3YrsLtfw1LoW15tA=";
+    hash = "sha256-i4QJ8o8zOivUKarXgEmKJeX5XyYTyaqxjevD6nwMjII=";
   };
 
   simdutf = fetchurl {
@@ -146,7 +146,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/edde746/plezy/releases/download/${version}/plezy-macos.dmg";
-      hash = "sha256-BF9jKIOzQYpQnJUXD8d2e2GSgIc6ZsjZaqceAc01QI0=";
+      hash = "sha256-h1aBFYEP1ie6v9BZZ/vH0b+fQL047tMZz3tASwnkcWI=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pl/plezy/pubspec.lock.json
+++ b/pkgs/by-name/pl/plezy/pubspec.lock.json
@@ -118,12 +118,12 @@
       "dependency": "direct main",
       "description": {
         "path": ".",
-        "ref": "021e2075260e324b7440a5c81b57bf0242d35020",
-        "resolved-ref": "021e2075260e324b7440a5c81b57bf0242d35020",
+        "ref": "12ef3ff758709e3ceab8eccd6d43e0dea1c68ca1",
+        "resolved-ref": "12ef3ff758709e3ceab8eccd6d43e0dea1c68ca1",
         "url": "https://github.com/edde746/background_downloader"
       },
       "source": "git",
-      "version": "9.5.5"
+      "version": "9.5.6"
     },
     "boolean_selector": {
       "dependency": "transitive",


### PR DESCRIPTION
diff: https://github.com/edde746/plezy/compare/2.13.0...2.16.0

Tested on linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
