### PR TITLE
infisicalsdk: modernize, move to python-packages

### DIFF
--- a/pkgs/by-name/in/infisicalsdk/package.nix
+++ b/pkgs/by-name/in/infisicalsdk/package.nix
@@ -4,17 +4,26 @@
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "infisicalsdk";
   version = "1.0.16";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "Infisical";
     repo = "python-sdk-official";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2bfT99ynl14CSbqIOG2SMQb3oW+uAWD+iJifdMQG8CE=";
   };
+
+  # fix version in setup.py AND pyproject.toml
+  postPatch = ''
+    substituteInPlace ./setup.py --replace-fail \
+      'VERSION = "1.0.1"' 'VERSION = "${finalAttrs.version}"'
+  '';
+  nativeBuildInputs = [ python3Packages.pyprojectVersionPatchHook ];
 
   build-system = [ python3Packages.setuptools ];
 
@@ -26,13 +35,15 @@ python3Packages.buildPythonPackage rec {
     botocore
   ];
 
-  doCheck = false;
   pythonImportsCheck = [ "infisical_sdk" ];
+
+  doCheck = false; # tests require network access + api keys
 
   meta = {
     homepage = "https://github.com/Infisical/python-sdk-official";
     description = "Infisical Python SDK";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ artur-sannikov ];
+    teams = [ lib.teams.infisical ];
   };
-}
+})

--- a/pkgs/development/python-modules/infisicalsdk/default.nix
+++ b/pkgs/development/python-modules/infisicalsdk/default.nix
@@ -1,10 +1,17 @@
 {
   lib,
-  python3Packages,
+  buildPythonPackage,
   fetchFromGitHub,
+  pyprojectVersionPatchHook,
+  setuptools,
+  python-dateutil,
+  aenum,
+  requests,
+  boto3,
+  botocore,
 }:
 
-python3Packages.buildPythonPackage (finalAttrs: {
+buildPythonPackage (finalAttrs: {
   pname = "infisicalsdk";
   version = "1.0.16";
   pyproject = true;
@@ -23,11 +30,11 @@ python3Packages.buildPythonPackage (finalAttrs: {
     substituteInPlace ./setup.py --replace-fail \
       'VERSION = "1.0.1"' 'VERSION = "${finalAttrs.version}"'
   '';
-  nativeBuildInputs = [ python3Packages.pyprojectVersionPatchHook ];
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
-  build-system = [ python3Packages.setuptools ];
+  build-system = [ setuptools ];
 
-  dependencies = with python3Packages; [
+  dependencies = [
     python-dateutil
     aenum
     requests

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1146,6 +1146,7 @@ mapAliases {
   incrtcl = throw "'incrtcl' has been renamed to/replaced by 'tclPackages.incrtcl'"; # Converted to throw 2025-10-27
   indicator-application-gtk2 = throw "'indicator-application-gtk2' has been removed as it depended on the deprecated GTK 2 engine. Consider using 'indicator-application-gtk3' instead."; # Added 2026-08-10
   infamousPlugins = infamousplugins; # Added 2026-02-08
+  infisicalsdk = python3Packages.infisicalsdk; # Added 2026-08-23
   inotifyTools = throw "'inotifyTools' has been renamed to/replaced by 'inotify-tools'"; # Converted to throw 2025-10-27
   insync-emblem-icons = throw "'insync-emblem-icons' has been removed, use 'insync-nautilus' instead"; # Added 2025-05-14
   intel2200BGFirmware = warnAlias "'intel2200BGFirmware' has been renamed to 'ipw2200-firmware'" ipw2200-firmware; # Added 2026-02-08

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8292,6 +8292,8 @@ self: super: with self; {
 
   infinity = callPackage ../development/python-modules/infinity { };
 
+  infisicalsdk = callPackage ../development/python-modules/infisicalsdk { };
+
   inflate64 = callPackage ../development/python-modules/inflate64 { };
 
   inflect = callPackage ../development/python-modules/inflect { };


### PR DESCRIPTION
- **infisicalsdk: modernize, add infisical team**
- **infisicalsdk: move to python-packages**

This is clearly a library... should not be a top-level package!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
