### PR TITLE
rclone-ui: 3.5.4 -> 3.7.2

### DIFF
--- a/pkgs/by-name/rc/rclone-ui/package.nix
+++ b/pkgs/by-name/rc/rclone-ui/package.nix
@@ -20,26 +20,26 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rclone-ui";
-  version = "3.5.4";
+  version = "3.7.2";
 
   src = fetchFromGitHub {
     owner = "rclone-ui";
     repo = "rclone-ui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VnMNKBtZu5mdsvW7ljl+RNNj44bK+s5QrdGFaYvS2o0=";
+    hash = "sha256-H/4qU1FJ+EHSdXB0DH8YrfUa8sKfXOGnwOZrQeQfLYI=";
   };
 
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
     forceGitDeps = true;
-    hash = "sha256-cBPJgaPHjgn+SByZFZ/SCOZG/YY4OQWUUlX844YHyUU=";
+    hash = "sha256-i1czFB8EvS1KE8ukWp+02/K51FK/M9pabcNcbhtGWnM=";
   };
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  cargoHash = "sha256-r4orImEIUC+wQgnvkiO8/apXSgQ18LxJFoWgweYGgks=";
+  cargoHash = "sha256-KVrHpJsB8yMknWPxXE3F/SdIlMoRhqFWmxdKe/HIIxE=";
 
   # Disable tauri bundle updater, can be removed when #389107 is merged
   patches = [ ./remove_updater.patch ];
@@ -74,6 +74,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapProgram $out/bin/rclone-ui \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libappindicator ]}
   '';
+
+  checkFlags = [
+    # don't have internet access
+    "--skip=notifications::webhooks::tests::dispatch_posts_and_records_outcomes_end_to_end"
+    "--skip=notifications::webhooks::tests::dispatch_records_last_error_on_unreachable_endpoint"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Resolves: #553388
Updating hash. Test launched in NixOS-WSL. Add a tests for ignore.
The build failed on Darwin due to webkitgtk issues:
```
error: Refusing to evaluate package 'webkitgtk-2.52.6+abi=4.1' in /nix/store/222vq4223vfgx4jmdbrws7aajqxywgmm-source/pkgs/development/libraries/webkitgtk/default.nix:263 because it has problems:
       - broken: This package is broken.

       See also https://nixos.org/manual/nixpkgs/unstable#sec-problems
       To allow evaluation regardless, use:
       - Nixpkgs import: import nixpkgs { config = <below code>; }
       - NixOS: nixpkgs.config = <below code>;
       - nix-* commands: Put below code in ~/.config/nixpkgs/config.nix

         {
           problems.handlers = {
             webkitgtk.broken = "warn"; # or "ignore"
           };
         }
```
On linux built successful


- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
