### PR TITLE
zennotes-desktop: 2.31.0 -> 2.34.0

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.32.0";
-  npmDepsHash = "sha256-81wERwkfhsOfPGjaXVvCUTZUmhyUx3RtgJhiXW6GgcI=";
+  version = "2.33.0";
+  npmDepsHash = "sha256-uGGJHHlQ5kACktJ15K394utoy6EY61AjRVZ7LD6nSOw=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-idt/oQFRkl9Lybm4fss2KLSmF3F82tv/fkQAFWTYwpg=";
+    hash = "sha256-cqCGRv//h0CkDuXRN9QcLjk6IVQmknTLNbVRu5upm10=";
   };
 
   npmWorkspace = "apps/desktop";

--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.31.0";
-  npmDepsHash = "sha256-3PvR/WcQj3Eu0qr4o+MNY+rH5SIAgLVhbHk14vzjX/Q=";
+  version = "2.32.0";
+  npmDepsHash = "sha256-81wERwkfhsOfPGjaXVvCUTZUmhyUx3RtgJhiXW6GgcI=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-iptW9Pplvh8hGZcEXGAm1oC1y/5NOefbjHlYrft443o=";
+    hash = "sha256-idt/oQFRkl9Lybm4fss2KLSmF3F82tv/fkQAFWTYwpg=";
   };
 
   npmWorkspace = "apps/desktop";

--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.33.0";
-  npmDepsHash = "sha256-uGGJHHlQ5kACktJ15K394utoy6EY61AjRVZ7LD6nSOw=";
+  version = "2.34.0";
+  npmDepsHash = "sha256-NVpP0BK4UowGih39ViOvD5UEFSZoHV4o4s85NrGZz2U=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cqCGRv//h0CkDuXRN9QcLjk6IVQmknTLNbVRu5upm10=";
+    hash = "sha256-OKNEeZf7OLTVVqcvsQ+u4ehx+JAqF1YJvHiA+3Kw4Ao=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update zennotes-desktop 2.31.0 -> 2.34.0 (three upstream releases, 2.32.0, 2.33.0 and 2.34.0, one commit each). I am the upstream author of ZenNotes.

2.32.0 makes wrapped Vim motions configurable between display-row and logical-line behavior, adds Ctrl+D selective cleanup to Open Buffers, and fixes server-backed custom task statuses reverting after watcher rescans or refreshes. Nothing changes in how the package builds or is wrapped; this is the version plus the two fixed-output hashes.

Hash provenance: npmDepsHash and the source hash were computed by the upstream Nix packaging workflow on a real Nix runner, then verified by building both upstream Nix packages: https://github.com/ZenNotes/zennotes/actions/runs/32394157960

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.32.0

2.33.0 followed the same day: ZenNotes Cloud sync now reports an incomplete sync honestly (a capacity rejection shows the real limit and a Review action instead of a green status), unlinking a device and deleting a cloud vault are separate confirmed actions, and the usage card counts synced files by kind. Again nothing changes in how the package builds or is wrapped; the second commit is version plus the two hashes.

Hash provenance for 2.33.0: same pipeline, build-verified on a Nix runner in the upstream repo for v2.33.0: https://github.com/ZenNotes/zennotes/actions/runs/32404647138

Changelog 2.33.0: https://github.com/ZenNotes/zennotes/releases/tag/v2.33.0

2.34.0 fixes two `zn open` (CLI) behaviors: opening a folder from the terminal after closing every window no longer brings the previous vault window back, and Move to Trash inside a temporary folder session sends the note to the system Trash with a visible toast instead of silently doing nothing. Again nothing changes in how the package builds or is wrapped; the third commit is version plus the two hashes.

Hash provenance for 2.34.0: same pipeline, build-verified on a Nix runner in the upstream repo for v2.34.0: https://github.com/ZenNotes/zennotes/actions/runs/32420632932

Changelog 2.34.0: https://github.com/ZenNotes/zennotes/releases/tag/v2.34.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux (the same source and dependency hashes were build-verified in upstream Nix CI)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).