### PR TITLE
nixos/upki: symlink upki config file in etc

### DIFF
--- a/nixos/modules/programs/upki.nix
+++ b/nixos/modules/programs/upki.nix
@@ -38,6 +38,8 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
+    environment.etc."upki/config.toml".source = configFile;
+
     services.upki.settings = {
       cache-dir = lib.mkDefault "/var/cache/upki";
       revocation.fetch-url = lib.mkDefault "https://upki.rustls.dev/";
@@ -54,11 +56,14 @@ in
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
 
+      restartTriggers = [ config.environment.etc."upki/config.toml".source ];
+
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${lib.getExe cfg.package} --config-file ${configFile} fetch";
+        ExecStart = "${lib.getExe cfg.package} --config-file /etc/upki/config.toml fetch";
         User = "upki";
         Group = "upki";
+        ConfigurationDirectory = "upki";
         CacheDirectory = "upki";
         CacheDirectoryMode = "0755";
         UMask = "0022";
@@ -93,5 +98,9 @@ in
         OnUnitActiveSec = cfg.interval;
       };
     };
+  };
+
+  meta = {
+    maintainers = [ lib.maintainers.skyesoss ];
   };
 }


### PR DESCRIPTION
Providing a symlink from /etc/upki/config.toml to the nix-generated configuration file ensures that unprivileged users running upki can properly discover the system configuration.

```sh
$ # Before
$ upki show-config-path
/home/skye/.config/upki/config.toml
$ # After
$ upki show-config-path
/etc/upki/config.toml
```

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
