### PR TITLE
satdump: 1.2.2 -> 2.0.0-unstable-2026-08-17

### DIFF
--- a/pkgs/by-name/sa/satdump/package.nix
+++ b/pkgs/by-name/sa/satdump/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   nix-update-script,
   cmake,
   pkg-config,
@@ -13,12 +12,16 @@
   jemalloc,
   volk,
   nng,
+  sqlite,
   curl,
   # Optional dependencies
   withZIQRecordingCompression ? true,
   zstd,
   withGUI ? true,
+  dbus,
   glfw,
+  libx11,
+  libxrandr,
   zenity,
   withAudio ? true,
   portaudio,
@@ -44,28 +47,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "satdump";
-  version = "1.2.2";
+  version = "2.0.0-unstable-2026-08-17";
 
   src = fetchFromGitHub {
     owner = "SatDump";
     repo = "SatDump";
-    tag = finalAttrs.version;
-    hash = "sha256-+Sne+NMwnIAs3ff64fBHAIE4/iDExIC64sXtO0LJwI0=";
+    rev = "19b73529f16f30776f190cba2abe4ded478f5c8e";
+    hash = "sha256-xfKfxrhTRBFdhirBjGO2CeT1ZmaPRyAGFB7ILu+YZnA=";
   };
-
-  patches = [
-    # fixes build with GCC 15 until newer satdump release is available
-    (fetchpatch {
-      url = "https://github.com/SatDump/SatDump/commit/2b0a874f38d9310e3e4cbc56cfcc69cb0a59e035.patch";
-      name = "fix-build-with-gcc15.patch";
-      hash = "sha256-RYNLax/VA7cT7wP88hG5cb2BDkEMMZu2v2CKo/hqwCE=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace src-core/CMakeLists.txt \
-      --replace-fail '$'{CMAKE_INSTALL_PREFIX}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR}
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -79,11 +68,15 @@ stdenv.mkDerivation (finalAttrs: {
     jemalloc
     volk
     nng
+    sqlite
     curl
   ]
   ++ lib.optionals withZIQRecordingCompression [ zstd ]
   ++ lib.optionals withGUI [
+    dbus
     glfw
+    libx11
+    libxrandr
     zenity
   ]
   ++ lib.optionals withAudio [ portaudio ]


### PR DESCRIPTION
For over two years, v1.x has not received any updates.
Developers have been working on v2.0.0 since then and recommended in June 2026 that users switch to it, even though there is not yet an official release.

Version 2.0.0 adds support for many new satellites, a new signal analysis system, as well as significant improvements in performance and support for existing ones

- The detailed blog post from August 2025: [Towards 2.0.0 (Finally!?)](https://www.satdump.org/articles/2025-08-12-towards-2.0.0.htm)
- The more concise blog post from June 2026: [First 2.0.0 Alpha Releases](https://www.satdump.org/articles/2026-02-21-releasing-alpha.2.0.0.htm)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
