### PR TITLE
python3Packages.griffecli: inherit version and src from griffelib

### DIFF
--- a/pkgs/development/python-modules/griffecli/default.nix
+++ b/pkgs/development/python-modules/griffecli/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   colorama,
-  fetchFromGitHub,
   griffelib,
   hatchling,
   pdm-backend,
@@ -11,15 +10,9 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "griffecli";
-  version = "2.2.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "mkdocstrings";
-    repo = "griffe";
-    tag = finalAttrs.version;
-    hash = "sha256-RiQRc83o0gZ2jjBjUvmwFQY1Q/kAyF4u2ajBPXrkhzM=";
-  };
+  inherit (griffelib) version src;
 
   sourceRoot = "${finalAttrs.src.name}/packages/griffecli";
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
