### PR TITLE
Chaptarr nixos module init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -102,11 +102,15 @@
 
 - [Entropy](https://github.com/ergohaven/entropy), a configurator for programmable keyboards and input devices running Vial-QMK/RMK firmware. Available as [programs.entropy](#opt-programs.entropy.enable).
 
+
 - [Kvrocks](https://kvrocks.apache.org/), a distributed key value NoSQL database compatible with the Redis protocol. Available as [services.kvrocks](#opt-services.kvrocks.enable).
 
 - [kvrocks_exporter](https://github.com/RocksLabs/kvrocks_exporter), a Prometheus exporter for Kvrocks metrics. Available as [services.prometheus.exporters.kvrocks](#opt-services.prometheus.exporters.kvrocks.enable).
 
 - [Umbriel](https://docs.noctalia.dev/umbriel/), a Wayland compositor built on wlroots and SceneFX. Available as [programs.umbriel](#opt-programs.umbriel.enable).
+
+- [Chaptarr](https://github.com/Chaptarr/chaptarr), a Readarr fork for managing audiobook and eBook collections. Available as [services.chaptarr](options.html#opt-services.chaptarr.enable).
+
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -988,6 +988,7 @@
   ./services/misc/safeeyes.nix
   ./services/misc/sdrplay.nix
   ./services/misc/seerr.nix
+  ./services/misc/servarr/chaptarr.nix
   ./services/misc/servarr/lidarr.nix
   ./services/misc/servarr/prowlarr.nix
   ./services/misc/servarr/radarr.nix

--- a/nixos/modules/services/misc/servarr/chaptarr.nix
+++ b/nixos/modules/services/misc/servarr/chaptarr.nix
@@ -1,0 +1,162 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.chaptarr;
+  servarr = import ./settings-options.nix { inherit lib pkgs; };
+in
+{
+  meta.maintainers = [ lib.maintainers.lnk3 ];
+
+  options.services.chaptarr = {
+    enable = lib.mkEnableOption "Chaptarr";
+
+    package = lib.mkPackageOption pkgs "chaptarr" { };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.m4b-tool pkgs.ffmpeg ]";
+      description = "Extra packages available on Chaptarr systemd service's PATH for optional integrations .";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/chaptarr";
+      description = "The directory where Chaptarr stores its data files.";
+    };
+
+    extraReadWritePaths = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          "/data/audiobooks"
+          "/data/ebooks"
+          "/data/downloads"
+          "''${services.qbittorrent.profileDir}"
+          "''${services.transmission.settings.download-dir}"
+        ]
+      '';
+      description = ''
+        Additional paths Chaptarr is allowed to write to.
+        Add your media library folders.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the firewall for the Chaptarr web interface.";
+    };
+
+    settings = servarr.mkServarrSettingsOptions "chaptarr" 8789;
+
+    environmentFiles = servarr.mkServarrEnvironmentFiles "chaptarr";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "chaptarr";
+      description = "User account under which Chaptarr runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "chaptarr";
+      description = "Group under which Chaptarr runs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.tmpfiles.settings."10-chaptarr".${cfg.dataDir}.d = {
+      user = cfg.user;
+      group = cfg.group;
+      mode = "0700";
+    };
+
+    systemd.services.chaptarr = {
+      description = "Chaptarr";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network.target"
+      ]
+      ++ lib.optional (lib.attrByPath [ "postgres" "host" ] "" cfg.settings != "") "postgresql.service";
+      wants = lib.optional (
+        lib.attrByPath [ "postgres" "host" ] "" cfg.settings != ""
+      ) "postgresql.service";
+      environment = servarr.mkServarrSettingsEnvVars "chaptarr" cfg.settings;
+      path = cfg.extraPackages;
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${lib.getExe cfg.package} -nobrowser -data='${cfg.dataDir}'";
+        EnvironmentFile = cfg.environmentFiles;
+        Restart = "on-failure";
+        SyslogIdentifier = "chaptarr";
+        KillSignal = "SIGINT";
+        SuccessExitStatus = "0 156";
+        WorkingDirectory = cfg.dataDir;
+
+        # Hardening
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ cfg.dataDir ] ++ cfg.extraReadWritePaths;
+        ProtectHome = true;
+        ProtectClock = true;
+        ProtectKernelLogs = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        UMask = "0022";
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          "AF_NETLINK" # Required. Gives runtime error when not granted.
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@debug"
+          "~@mount"
+          "@chown"
+        ];
+      };
+
+      unitConfig.RequiresMountsFor = [ cfg.dataDir ];
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.settings.server.port ];
+    };
+
+    users.users = lib.mkIf (cfg.user == "chaptarr") {
+      chaptarr = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "chaptarr") {
+      chaptarr = { };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -364,6 +364,7 @@ in
   certmgr = import ./certmgr.nix { inherit pkgs runTest; };
   cfssl = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./cfssl.nix;
   cgit = runTest ./cgit.nix;
+  chaptarr = runTest ./chaptarr.nix;
   charliecloud = runTest ./charliecloud.nix;
   chhoto-url = runTest ./chhoto-url.nix;
   chromadb = runTest ./chromadb.nix;

--- a/nixos/tests/chaptarr.nix
+++ b/nixos/tests/chaptarr.nix
@@ -1,0 +1,64 @@
+{ lib, ... }:
+{
+  name = "chaptarr";
+  meta.maintainers = [ lib.maintainers.lnk3 ];
+
+  nodes.machine = { pkgs, ... }: {
+    services.chaptarr.enable = true;
+    services.chaptarr.openFirewall = true;
+    services.chaptarr.settings.server.port = 9999;
+
+    environment.systemPackages = [ pkgs.nftables ];
+
+    services.chaptarr.settings.postgres.host = "/run/postgresql";
+    services.postgresql.enable = true;
+    services.postgresql.initialScript = pkgs.writeText "chaptarr-init.sql" ''
+      CREATE ROLE chaptarr WITH LOGIN;
+      CREATE DATABASE "chaptarr-main" OWNER chaptarr;
+      CREATE DATABASE "chaptarr-log" OWNER chaptarr;
+      CREATE DATABASE "chaptarr-cache" OWNER chaptarr;
+    '';
+  };
+
+  testScript = ''
+    import re
+
+    machine.wait_for_unit("chaptarr.service")
+    machine.wait_for_open_port(9999, timeout=60)
+    machine.succeed("curl --fail http://localhost:9999/")
+    machine.succeed("nft list ruleset | grep 9999")
+
+    machine.succeed("id chaptarr")
+    machine.succeed("awk -F: '/^chaptarr:/{print $2}' /etc/shadow | grep -q '!'")
+
+    data_dir = "/var/lib/chaptarr"
+    machine.succeed(f"test -d {data_dir}")
+    machine.succeed(f"stat -c '%U %G %a' {data_dir} | grep 'chaptarr chaptarr 700'")
+
+    output = machine.succeed("systemd-analyze security chaptarr.service")
+    match = re.search(r"Overall exposure level.*?(\d+\.?\d*)", output)
+    assert match is not None, "Could not parse exposure level from systemd-analyze output"
+    score = float(match.group(1))
+    assert score <= 3.0, f"Exposure level too high: {score}"
+
+    journal = machine.succeed("journalctl -u chaptarr --no-pager -b")
+    assert "EPIC FAIL" not in journal, "Chaptarr logged a fatal error"
+    assert "Fatal" not in journal, "Chaptarr logged a fatal error"
+
+    after = machine.succeed("systemctl show chaptarr.service --property=After --value")
+    wants = machine.succeed("systemctl show chaptarr.service --property=Wants --value")
+    assert "postgresql.service" in after, "chaptarr.service missing After=postgresql.service"
+    assert "postgresql.service" in wants, "chaptarr.service missing Wants=postgresql.service"
+
+    table_count = machine.succeed(
+        "sudo -u postgres psql -d chaptarr-main -tAc "
+        "\"select count(*) from information_schema.tables where table_schema='public'\""
+        ).strip()
+    assert int(table_count) > 0, "chaptarr created no tables in postgres — likely didn't connect"
+
+    machine.succeed("systemctl restart chaptarr")
+    machine.wait_for_unit("chaptarr.service")
+    machine.wait_for_open_port(9999)
+    machine.succeed("curl --fail http://localhost:9999/")
+  '';
+}

--- a/pkgs/by-name/ch/chaptarr/deps.json
+++ b/pkgs/by-name/ch/chaptarr/deps.json
@@ -1,0 +1,893 @@
+[
+  {
+    "pname": "Azure.Core",
+    "version": "1.46.1",
+    "hash": "sha256-xpb9A2pFHEQ07yVrzq0gpeFBTN9LTqk7iHhg707a5Mg="
+  },
+  {
+    "pname": "Azure.Core",
+    "version": "1.47.1",
+    "hash": "sha256-YJR1bDI9H9lr6p/9QcOWEhnpMD8ePyxxO39S32VAOak="
+  },
+  {
+    "pname": "Azure.Identity",
+    "version": "1.14.2",
+    "hash": "sha256-PpGcGQrzcEzDtTm65gLmjWrt8yavst4VOKDlr+NuLQo="
+  },
+  {
+    "pname": "BouncyCastle.Cryptography",
+    "version": "2.6.2",
+    "hash": "sha256-Yjk2+x/RcVeccGOQOQcRKCiYzyx1mlFnhS5auCII+Ms="
+  },
+  {
+    "pname": "Dapper",
+    "version": "2.1.66",
+    "hash": "sha256-e5n/wnAFGPDSe30oQQ0fanXrvFZYYa+qCDSTHtfQmPw="
+  },
+  {
+    "pname": "Diacritical.Net",
+    "version": "1.0.5",
+    "hash": "sha256-b1Y7b/knhNqeqdySUMDZZjC2HHoyihZ/WpOa0tOlgE8="
+  },
+  {
+    "pname": "DryIoc.dll",
+    "version": "5.4.0",
+    "hash": "sha256-kZGsNpXi/YiyhhcBQcqYQywoMDUdWfZR/oopCnmXg+g="
+  },
+  {
+    "pname": "DryIoc.dll",
+    "version": "5.4.3",
+    "hash": "sha256-qk3sUiiQu4TxdkG4Ise8Sn5h3kV5p6w6t9wMw5dSc94="
+  },
+  {
+    "pname": "DryIoc.Microsoft.DependencyInjection",
+    "version": "6.2.0",
+    "hash": "sha256-C06B0tj3qFkVVGL0kSflf88As4t9TRaw/++N05Zaz0c="
+  },
+  {
+    "pname": "Dynamitey",
+    "version": "3.0.3",
+    "hash": "sha256-69DyYSGu1sjpr8DupZWEiwcVmW9vT197c00vQ7H9k1s="
+  },
+  {
+    "pname": "Equ",
+    "version": "2.3.0",
+    "hash": "sha256-LMGRC1Pq6RdiPnyBEjDP1yA7gesHxrXPXa353pGGlqw="
+  },
+  {
+    "pname": "FirebirdSql.Data.FirebirdClient",
+    "version": "10.3.3",
+    "hash": "sha256-v3yjFhVy/JybnmYD+0+fgtFrbLgBWRirdAkGvJQUOio="
+  },
+  {
+    "pname": "FluentMigrator",
+    "version": "7.2.0",
+    "hash": "sha256-2G/QA0fnqtthxjhigu3nEh6ConZVvcKgm5ha+fMJvNU="
+  },
+  {
+    "pname": "FluentMigrator.Abstractions",
+    "version": "7.2.0",
+    "hash": "sha256-9wpNrqN8fH+mv3IKzKTNzkRNtcYvZ9xoI3ZBwikeTYo="
+  },
+  {
+    "pname": "FluentMigrator.Extensions.MySql",
+    "version": "7.2.0",
+    "hash": "sha256-ithqOZaxpn6N2n0KObbmI/24H/mjRnV7aMZzBa+bCtQ="
+  },
+  {
+    "pname": "FluentMigrator.Extensions.Oracle",
+    "version": "7.2.0",
+    "hash": "sha256-lEmCRAby4IeA29o/8R+nxlkEdwIFKWCbjCWDkhPD38I="
+  },
+  {
+    "pname": "FluentMigrator.Extensions.Postgres",
+    "version": "7.2.0",
+    "hash": "sha256-LcxT9KCejx8e8LN1GTCSkZT2K1hgp677D8pRYsQ3ETs="
+  },
+  {
+    "pname": "FluentMigrator.Extensions.Snowflake",
+    "version": "7.2.0",
+    "hash": "sha256-NQzou1AjCc2ZTBKDdv96XpMlepEvEu0wEcO1gSA1Q+M="
+  },
+  {
+    "pname": "FluentMigrator.Extensions.SqlServer",
+    "version": "7.2.0",
+    "hash": "sha256-/Z4kRrsJMjOrmI0Qf2YB6ZtznrPcimitSFSWzWcnuxk="
+  },
+  {
+    "pname": "FluentMigrator.Runner",
+    "version": "7.2.0",
+    "hash": "sha256-ASguco8vTvUimQ/tG6DOy6vOm94+bWizHBCLD5EDgYo="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Core",
+    "version": "7.2.0",
+    "hash": "sha256-8ogHLTxgq0UeOtFZEwfOVTTUH7vwug+gswKaZ27PUgg="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Db2",
+    "version": "7.2.0",
+    "hash": "sha256-FxZHg8VVDf9JNQqjf6x+S7QDedQdjlU3Jwm7gU5mbQc="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Firebird",
+    "version": "7.2.0",
+    "hash": "sha256-xkw/IKb9H2dDsBOqhMdJvKdk1fUeIELiKtreHQDcapE="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Hana",
+    "version": "7.2.0",
+    "hash": "sha256-SxKilLGiB8QLgFroEiq2t1W1SGtVlGcXBtTHErCile8="
+  },
+  {
+    "pname": "FluentMigrator.Runner.MySql",
+    "version": "7.2.0",
+    "hash": "sha256-Xq9irM4QiDoo/axQpAyvf3a+qOvKcIuO4+87KHy+/0o="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Oracle",
+    "version": "7.2.0",
+    "hash": "sha256-pvFih5DYauiIuvUQGqSZNb0OM0CzikDG9NBTPXoSQHE="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Postgres",
+    "version": "7.2.0",
+    "hash": "sha256-vPFeDwotrKydvV/kK372QDVG9ZnY2/3hV9W+gPLtx+c="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Redshift",
+    "version": "7.2.0",
+    "hash": "sha256-9aktQjmypOF2VnGdNX1waulmUKDAcOZ63+mJNJe+jQA="
+  },
+  {
+    "pname": "FluentMigrator.Runner.Snowflake",
+    "version": "7.2.0",
+    "hash": "sha256-ErhF91kbm7xBqVQxVbGeIP4bHFaRcHo5Ov9uTE+/Fqw="
+  },
+  {
+    "pname": "FluentMigrator.Runner.SQLite",
+    "version": "7.2.0",
+    "hash": "sha256-ebu649WWuvBGYeYeMVkD5fJQHUSJQuoRBIl37ynwmIY="
+  },
+  {
+    "pname": "FluentMigrator.Runner.SqlServer",
+    "version": "7.2.0",
+    "hash": "sha256-U9R5Ld0rL/VLpL7XI6Tc0p1qf5liNqMSk9Tr70qmkCE="
+  },
+  {
+    "pname": "FluentValidation",
+    "version": "9.5.4",
+    "hash": "sha256-htL8KbjBt2rn+y+nUIc4lVBypWksQ+hsROxMBDzi5IU="
+  },
+  {
+    "pname": "Ical.Net",
+    "version": "5.2.0",
+    "hash": "sha256-pfA2cXGagw/mpGrFM0OFMMdzrBdA3wRsxK2m7vO6yHQ="
+  },
+  {
+    "pname": "ImpromptuInterface",
+    "version": "8.0.6",
+    "hash": "sha256-u0J8n7ShZX+lk5aX9copjwgym5TtglRGT7QtPdZeHeA="
+  },
+  {
+    "pname": "IPAddressRange",
+    "version": "6.3.0",
+    "hash": "sha256-RM3Bm07HzaKAMY64JiuJ2xCT399Bhj/Asyv1+o3kdNo="
+  },
+  {
+    "pname": "LazyCache",
+    "version": "2.4.0",
+    "hash": "sha256-TJp0K7P3VUjQDYDyKL0dtnA6laH/EPhpEOpNJANJ/+Q="
+  },
+  {
+    "pname": "MailKit",
+    "version": "4.16.0",
+    "hash": "sha256-4yyFxq8pJVTIgAJkyAYcuV2+/ZirENgUSk1OSD/gKIo="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+    "version": "10.0.1",
+    "hash": "sha256-fMLVW4xy3tU2pXbd/hX/JxxCRO02eGEuccc7uv9r+UE="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "8.0.0",
+    "hash": "sha256-9aWmiwMJKrKr9ohD1KSuol37y+jdDxPGJct3m2/Bknw="
+  },
+  {
+    "pname": "Microsoft.Bcl.Cryptography",
+    "version": "9.0.4",
+    "hash": "sha256-kc98Ghe2N/xl0ruvbDBUYGtFnetvfNIPRLyECmh8RnY="
+  },
+  {
+    "pname": "Microsoft.Build.Tasks.Git",
+    "version": "8.0.0",
+    "hash": "sha256-vX6/kPij8vNAu8f7rrvHHhPrNph20IcufmrBgZNxpQA="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "17.10.0",
+    "hash": "sha256-yQFwqVChRtIRpbtkJr92JH2i+O7xn91NGbYgnKs8G2g="
+  },
+  {
+    "pname": "Microsoft.Data.SqlClient",
+    "version": "6.0.1",
+    "hash": "sha256-BvkFlYGZ2+GMcqtqyv/YokiUPZ4ifTAHBcpi7Cj2ibM="
+  },
+  {
+    "pname": "Microsoft.Data.SqlClient",
+    "version": "6.1.3",
+    "hash": "sha256-q+yiisID42Dum8+pBTq9FcYaMwNKkzrhZIZPdt7ah38="
+  },
+  {
+    "pname": "Microsoft.Data.SqlClient.SNI.runtime",
+    "version": "6.0.2",
+    "hash": "sha256-CQuJfjZYoRxfc07cSzUNCOOdzmUJu0p10J+WpcG2BJ0="
+  },
+  {
+    "pname": "Microsoft.Data.Sqlite",
+    "version": "10.0.1",
+    "hash": "sha256-Lnu5Yq2y4T+AOt/UU7CHPFxN3+ctWODbPRgbb7ZBIgI="
+  },
+  {
+    "pname": "Microsoft.Data.Sqlite.Core",
+    "version": "10.0.1",
+    "hash": "sha256-ql+TOPpcO5JoqVGkcaAvITN9xta6YD8mfzL+nDY5Y+U="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-qVLAEqxPK/dNq+z1a6D9NqdcSg/18sfzZhlBWMkqV/A="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "2.1.0",
+    "hash": "sha256-kxlWYnQ1RmLrQdFr3lL2M78iLn8D30K0iFPOnS21OwE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "10.0.1",
+    "hash": "sha256-Qb7xK6VEZDas0lJFaW1suKdFjtkSYwLHHxkQEfWIU2A="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "2.1.0",
+    "hash": "sha256-/feT25xiMux/JnnIzRuhuBmPi3OSqTtGyDw9CDeoHQg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "9.0.4",
+    "hash": "sha256-5uynkW+dK61Zp1+vs5uW6mwpnkZl7mH/bGSQoGjJH2c="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "10.0.1",
+    "hash": "sha256-7xdHie4uHwoGZz5yUT4vWg2EWvkLvsSzItWCoqm4dTM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-s4PDp+vtzdxKIxnOT3+dDRoTDopyl8kqmmw4KDnkOtQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-Evg+Ynj2QUa6Gz+zqF+bUyfGD0HI5A2fHmxZEXbn3HA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.2",
+    "hash": "sha256-icRtfbi0nDRUYDErtKYx0z6A1gWo5xdswsSM6o4ozxc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "10.0.1",
+    "hash": "sha256-fiqTHE6EfaUXICaVrWzQEU/K6GjQNac6yRNErig6wRk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.CommandLine",
+    "version": "10.0.1",
+    "hash": "sha256-u70gHmAKAlbP2jbsSDLKCNt6Yqfcrl5wSpQ+3/FduFs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.EnvironmentVariables",
+    "version": "10.0.1",
+    "hash": "sha256-mslRDdtsV4C5t3k6WYxxH2nzT+FAmdT+fTUM/QBcahM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.FileExtensions",
+    "version": "10.0.1",
+    "hash": "sha256-DFIwBSRkFtjPzbsTgHzAaJ6dSIHA8avQx7sRLZ6W64A="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Json",
+    "version": "10.0.1",
+    "hash": "sha256-l1eDnd0rvV4bhGYrtxOLnrbTiP5juSyfrG51k5G3lQA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.UserSecrets",
+    "version": "10.0.1",
+    "hash": "sha256-gHzqwu06nfKftexrQaIexa3PiZI1eYkxkO0X+nkGKX0="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "10.0.1",
+    "hash": "sha256-RKOB+zPrtQNUbJY/1jR54rKOM8KHPgynPExxugku3I8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "6.0.0",
+    "hash": "sha256-gZuMaunMJVyvvepuzNodGPRc6eqKH//bks3957dYkPI="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "9.0.7",
+    "hash": "sha256-/TCCT7WPZpEWP9E3M441y+SZsmdqQ/WMTgL+ce7p2hw="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-zNUpau51ds7iQTaSUTFtyTHIUoinYc129W50CnufMdQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-SZke0jNKIqJvvukdta+MgIlGsrP2EdPkkS8lfLg7Ju4="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "7.0.0",
+    "hash": "sha256-55lsa2QdX1CJn1TpW1vTnkvbGXKCeE9P0O6AkW49LaA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics",
+    "version": "10.0.1",
+    "hash": "sha256-MoBF0X5AVT0xORvhNvpc9DA5dSOJhjrfGeWDvEJQOoc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-tEt6VaaDR7bICKHiCp0l2Cmz8u+FCYORLVNAaJymGM8="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-IYtaZ5nssj9RPHL+DODXt9Z2IvTtj8rKuLQuyoMqo+w="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Physical",
+    "version": "10.0.1",
+    "hash": "sha256-HdzR2Nz8Qna8IDA2kPhEbBwfn3JZ1gxcPGxza7hH1GQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileSystemGlobbing",
+    "version": "10.0.1",
+    "hash": "sha256-R9f52Tn3DyktDD5UtWj80Ee3nEXMo0BR+66b/8NxaV8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting",
+    "version": "10.0.1",
+    "hash": "sha256-e1BztWxT+PUJ0PCrMfHl+ZTrPhrX5+xsV8j9jhQ4W3M="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-2t+yF23Ac9MvytZK8hym+aUYynuAFZVdKdcRVvVsdXo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.WindowsServices",
+    "version": "10.0.1",
+    "hash": "sha256-Pv3KoIzaMsA+KJ+oLOVX+bbnhz83eC23EWvgVwnmqpc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "10.0.1",
+    "hash": "sha256-zuLP3SIpCToMOlIPOEv3Kq8y/minecd8k8GSkxFo13E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "6.0.0",
+    "hash": "sha256-8WsZKRGfXW5MsXkMmNVf6slrkw+cR005czkOP2KUqTk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "9.0.7",
+    "hash": "sha256-7n8guHFss8HPnJuAByfzn9ipguDz7dack/udL1uH3h0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "10.0.0",
+    "hash": "sha256-BnhgGZc01HwTSxogavq7Ueq4V7iMA3wPnbfRwQ4RhGk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-NRk0feNE1fgi/hyO0AVDbSGJQRT+9yte6Lpm4Hz/2Bs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-QNqcQ3x+MOK7lXbWkCzSOWa/2QyYNbdM/OEEbWN15Sw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.3",
+    "hash": "sha256-5MSY1aEwUbRXehSPHYw0cBZyFcUH4jkgabddxhMiu3Q="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Configuration",
+    "version": "10.0.1",
+    "hash": "sha256-/7ywcFsEmmQzWEcIvxoGAYHF0oDSXV/LTDAiW/MNQtg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Console",
+    "version": "10.0.1",
+    "hash": "sha256-m/E02c5NSCYyH4THNKxpnsi3Kp8gqOi2aPrfXx7sQ9s="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Debug",
+    "version": "10.0.1",
+    "hash": "sha256-IxuAcBxnUDfrb/diCXWC4wDA1Wa6QhCy3oinGIdfe1I="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.EventLog",
+    "version": "10.0.1",
+    "hash": "sha256-ZFhS/nxyEeHjg58P4gLZgEGEB++A2RCTYu2CS2zkYQ4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.EventSource",
+    "version": "10.0.1",
+    "hash": "sha256-NNIBY/yokZGmvcj+IgBttuAIk8JbjH8pocjPg9gEEOM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.1",
+    "hash": "sha256-vBiSS1vqAC7eDrpJNT4H3A9qLikCSAepnNRbry0mKnk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "6.0.0",
+    "hash": "sha256-DxnEgGiCXpkrxFkxXtOXqwaiAtoIjA8VSSWCcsW0FwE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "9.0.7",
+    "hash": "sha256-nfUnZxx1tKERUddNNyxhGTK7VDTNZIJGYkiOWSHCt/M="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "10.0.1",
+    "hash": "sha256-1CNSVXZ3RAH4vzbYDqcQHl9c/YBhuSfrFUXCLIx5/rY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.1",
+    "hash": "sha256-EXmukq09erT4s+miQpBSYy3IY4HxxKlwEPL43/KoyEc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "2.1.0",
+    "hash": "sha256-q1oDnqfQiiKgzlv/WDHgNGTlWfm+fkuY1R6t6hr/L+U="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "6.0.0",
+    "hash": "sha256-AgvysszpQ11AiTBJFkvSy8JnwIWTj15Pfek7T7ThUc4="
+  },
+  {
+    "pname": "Microsoft.Identity.Client",
+    "version": "4.73.1",
+    "hash": "sha256-cd5ArtDvQK4gdX8M0GHQEsCFWlqpdm6lxvaM2yMHkhc="
+  },
+  {
+    "pname": "Microsoft.Identity.Client.Extensions.Msal",
+    "version": "4.73.1",
+    "hash": "sha256-wc4oHBGKCJhAqNIyD4LlugCFvmyiW5iVzGYP88bnWqs="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "6.35.0",
+    "hash": "sha256-bxyYu6/QgaA4TQYBr5d+bzICL+ktlkdy/tb/1fBu00Q="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "7.7.1",
+    "hash": "sha256-v83O6Gb8s4wGhbRPvOA95t0LSX+MAhF6WpA6qZeK2XM="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "8.0.1",
+    "hash": "sha256-zPWUKTCfGm4MWcYPU037NzezsFE1g8tEijjQkw5iooI="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "7.7.1",
+    "hash": "sha256-vGUx0HYrhDGQiHuIZoe4YOXx3UV9hT+a0krlPGJPQzw="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "8.0.1",
+    "hash": "sha256-Xv9MUnjb66U3xeR9drOcSX5n2DjOCIJZPMNSKjWHo9Y="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "7.7.1",
+    "hash": "sha256-JtQclRXgzsFBFnD+kgD59OILf7XkMD2czLupLZkc100="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "8.0.1",
+    "hash": "sha256-FfwrH/2eLT521Kqw+RBIoVfzlTNyYMqlWP3z+T6Wy2Y="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols",
+    "version": "7.7.1",
+    "hash": "sha256-PVS46Ut/2814hy0tdNLahG266hBmepw/fzZ9pku1PNg="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols",
+    "version": "8.0.1",
+    "hash": "sha256-v3DIpG6yfIToZBpHOjtQHRo2BhXGDoE70EVs6kBtrRg="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+    "version": "7.7.1",
+    "hash": "sha256-zXRZLfgOG/0l8aF6mZuAVGWB3wYz5uTkTJwlucYPafw="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+    "version": "8.0.1",
+    "hash": "sha256-ZHKaZxqESk+OU1SFTFGxvZ71zbdgWqv1L6ET9+fdXX0="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "7.7.1",
+    "hash": "sha256-WgbdkeG0R/f+4GJeXlj1WMpFyGv7+iW1JM9Pgt95UFk="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "8.0.1",
+    "hash": "sha256-beVbbVQy874HlXkTKarPTT5/r7XR1NGHA/50ywWp7YA="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "17.10.0",
+    "hash": "sha256-rkHIqB2mquNXF89XBTFpUL2z5msjTBsOcyjSBCh36I0="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.OpenApi",
+    "version": "1.6.25",
+    "hash": "sha256-Y8/b5gl+VtHD48BOsnSnyIH9ncjy3EGvszIHn+pjzP4="
+  },
+  {
+    "pname": "Microsoft.SourceLink.Common",
+    "version": "8.0.0",
+    "hash": "sha256-AfUqleVEqWuHE7z2hNiwOLnquBJ3tuYtbkdGMppHOXc="
+  },
+  {
+    "pname": "Microsoft.SourceLink.GitHub",
+    "version": "8.0.0",
+    "hash": "sha256-hNTkpKdCLY5kIuOmznD1mY+pRdJ0PKu2HypyXog9vb0="
+  },
+  {
+    "pname": "Microsoft.SqlServer.Server",
+    "version": "1.0.0",
+    "hash": "sha256-mx/iqHmBMwA8Ulot0n6YFVIKsU1Tx7q4Tru7MSjbEgQ="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "17.10.0",
+    "hash": "sha256-3YjVGK2zEObksBGYg8b/CqoJgLQ1jUv4GCWNjDhLRh4="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "17.10.0",
+    "hash": "sha256-+yzP3FY6WoOosSpYnB7duZLhOPUZMQYy8zJ1d3Q4hK4="
+  },
+  {
+    "pname": "MimeKit",
+    "version": "4.16.0",
+    "hash": "sha256-yWGXVm+EHvBSsZlVHdWdD+rVwdf/5hHxsUfJMSd2Afo="
+  },
+  {
+    "pname": "Mono.Nat",
+    "version": "3.0.0",
+    "hash": "sha256-KH49R1YQ+8a/rzwwUPrE82QQTi8nxQc6b0KWyy+Tnp4="
+  },
+  {
+    "pname": "Mono.Posix.NETStandard",
+    "version": "5.20.1.34-servarr22",
+    "hash": "sha256-vvWalRTTPll3vw6nlP4/fujunvM4UhXT1+Gh3+mXfqI=",
+    "url": "https://pkgs.dev.azure.com/Servarr/7ab38f4e-5a57-4d70-84f4-94dd9bc5d6df/_packaging/9845f7c9-6c8c-4845-b5ee-58375c59e0d8/nuget/v3/flat2/mono.posix.netstandard/5.20.1.34-servarr22/mono.posix.netstandard.5.20.1.34-servarr22.nupkg"
+  },
+  {
+    "pname": "MonoTorrent",
+    "version": "3.0.2",
+    "hash": "sha256-R2XANCRRVAe1mOzccWV4So85kQYDU2pWSWOfrbXAigw="
+  },
+  {
+    "pname": "Net.IBM.Data.Db2",
+    "version": "9.0.0.300",
+    "hash": "sha256-orejM9ZbMteUwGeY9JSkjUzyVRA9mBkN63JXS3Xa4xg="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "2.0.0",
+    "hash": "sha256-Pp7fRylai8JrE1O+9TGfIEJrAOmnWTJRLWE+qJBahK0="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.4",
+    "hash": "sha256-8JCB1FdAW681qXP6DFDWvycu1oPyVoxaYgpJ2pUvZSk="
+  },
+  {
+    "pname": "NLog",
+    "version": "5.0.0",
+    "hash": "sha256-n7ts0V/V65LugiLLDmqCzWgVh1o+ObB0PdpNvB0OqoE="
+  },
+  {
+    "pname": "NLog",
+    "version": "5.1.3",
+    "hash": "sha256-ljrjt7A7NJ+3/STI0vuIuDRHVYVu6r6KfSV1xVK7CWQ="
+  },
+  {
+    "pname": "NLog",
+    "version": "5.1.4",
+    "hash": "sha256-QjC4YUStyRnotj/kqiqMyVXn5wuuXdzhPwmvliAbeIQ="
+  },
+  {
+    "pname": "NLog.Extensions.Logging",
+    "version": "5.2.3",
+    "hash": "sha256-glPhygVcSjhZruPQOux4HrGbfAadl5srnGTHQmiSf1w="
+  },
+  {
+    "pname": "NLog.Targets.Syslog",
+    "version": "7.0.0",
+    "hash": "sha256-Yy6REt1UxkdFz+twa0zJVm635YHch7B6t9Pjj5FZUZc="
+  },
+  {
+    "pname": "NodaTime",
+    "version": "3.2.2",
+    "hash": "sha256-4ZABw5+MFhgwk9/nj1pKx6QzpqhVmDDxR/Pc1ZgP5Ug="
+  },
+  {
+    "pname": "Npgsql",
+    "version": "10.0.1",
+    "hash": "sha256-cb4z+WH9qynS6n4I43FzSiifWLzgH26HAP/DnZvsjak="
+  },
+  {
+    "pname": "NUnit",
+    "version": "3.14.0",
+    "hash": "sha256-CuP/q5HovPWfAW3Cty/QxRi7VpjykJ3TDLq5TENI6KY="
+  },
+  {
+    "pname": "NUnit3TestAdapter",
+    "version": "4.2.1",
+    "hash": "sha256-g73i3yqr0KnC0etKcAw9CmB6ZFAFvpxZn88s1glsND4="
+  },
+  {
+    "pname": "PdfSharpCore",
+    "version": "1.3.67",
+    "hash": "sha256-67TIrmXIuNJcEpkh12B/WehjtVm5PSBhjbSwc49kNYQ="
+  },
+  {
+    "pname": "Polly",
+    "version": "8.6.5",
+    "hash": "sha256-2YRacrP3b3C6EBCb5Pjg6fQdGj+SgbTeaWHN/oZ1d8s="
+  },
+  {
+    "pname": "Polly.Contrib.WaitAndRetry",
+    "version": "1.1.1",
+    "hash": "sha256-InJ8IXAsZDAR4B/YzWCuEWRa/6Xf5oB049UJUkTOoSg="
+  },
+  {
+    "pname": "Polly.Core",
+    "version": "8.6.5",
+    "hash": "sha256-m12obNfMZdWQWJoCaF03H5qEbFDdp9FSdHTHcIIsACQ="
+  },
+  {
+    "pname": "RestSharp",
+    "version": "113.0.0",
+    "hash": "sha256-uNLsEOlaFXkWhgT1tjdU4AgdQDmMT4Y1q2+vsg8Lj+o="
+  },
+  {
+    "pname": "ReusableTasks",
+    "version": "4.0.0",
+    "hash": "sha256-8Z6wQaPQMXZFqvSi9WL5jdmLHolnLQwZmmG0+OUyPeo="
+  },
+  {
+    "pname": "Sentry",
+    "version": "6.0.0",
+    "hash": "sha256-BdtssqVC3ADuqhD+2HLNQPndrkyaqdaGZy9PBmFq79A="
+  },
+  {
+    "pname": "SharpZipLib",
+    "version": "1.4.2",
+    "hash": "sha256-/giVqikworG2XKqfN9uLyjUSXr35zBuZ2FX2r8X/WUY="
+  },
+  {
+    "pname": "SixLabors.Fonts",
+    "version": "1.0.0-beta17",
+    "hash": "sha256-KnHduFn5h/mtHCpCFKg+ZIZi6fKjz2H2sqTIzwXCqOI="
+  },
+  {
+    "pname": "SixLabors.ImageSharp",
+    "version": "1.0.4",
+    "hash": "sha256-mUa/3cWwdX4tZ07MPbfdmAIFgmAUJ3SffOb4SgKxrzo="
+  },
+  {
+    "pname": "SixLabors.ImageSharp",
+    "version": "3.1.12",
+    "hash": "sha256-FR8v74w4P/1AZdW5ARW0y8zgDqLtvhxQmL1CKv68xR0="
+  },
+  {
+    "pname": "SourceGear.sqlite3",
+    "version": "3.50.4.2",
+    "hash": "sha256-NsahZ3lW1JYXMq4NOH5nM/EhdjV05sbrhjsGNIinb+M="
+  },
+  {
+    "pname": "SQLitePCLRaw.bundle_e_sqlite3",
+    "version": "2.1.11",
+    "hash": "sha256-kWRapMTVEfcc0DxnI9Ai1+RwAAcR2+HUu+WF+OeLJCs="
+  },
+  {
+    "pname": "SQLitePCLRaw.bundle_e_sqlite3",
+    "version": "3.0.2",
+    "hash": "sha256-l3LqZUP4iVNyMJuBxr1VYDJr28VqoCPUPmXX6JC2ldU="
+  },
+  {
+    "pname": "SQLitePCLRaw.config.e_sqlite3",
+    "version": "3.0.2",
+    "hash": "sha256-Q8wi2rEqnE1n53DZ1wnaM8Dr5h/Bic1/EiytK3XQzrU="
+  },
+  {
+    "pname": "SQLitePCLRaw.core",
+    "version": "2.1.11",
+    "hash": "sha256-s/fxEoYlNf9c2C4HZueMzPCBvpiViDVlSpg7epB0GXY="
+  },
+  {
+    "pname": "SQLitePCLRaw.core",
+    "version": "3.0.2",
+    "hash": "sha256-AK1Yc78ykY3H0Jq1INq3O1x278CtcWH7dF9heKhWvno="
+  },
+  {
+    "pname": "SQLitePCLRaw.lib.e_sqlite3",
+    "version": "2.1.11",
+    "hash": "sha256-ZmffbHNgnLUdsPbikilEAihxXl1MedIBQ1Xzt9226Bw="
+  },
+  {
+    "pname": "SQLitePCLRaw.provider.e_sqlite3",
+    "version": "2.1.11",
+    "hash": "sha256-LdfV325AmYgBOwmwP7MNZxMJZkNO6bwrHvB6C5SyItA="
+  },
+  {
+    "pname": "SQLitePCLRaw.provider.e_sqlite3",
+    "version": "3.0.2",
+    "hash": "sha256-LOD39Pqx58tMjP4uc4j8BvzhnsIRFocX9e5a8I1ZgPg="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.Annotations",
+    "version": "9.0.6",
+    "hash": "sha256-7mglb4DBSHHmr3WL0zNJ++QwQAD1hx27kOvXqtZNdK0="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.Swagger",
+    "version": "9.0.6",
+    "hash": "sha256-Es+YZz5UXd48GotIqsjBweZmJQzGuhXAzzSdDumNJF8="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerGen",
+    "version": "9.0.6",
+    "hash": "sha256-JUNtvIFcP9RavAH/5ke5Jr3vrr0YUsqHbqW45346VK4="
+  },
+  {
+    "pname": "System.ClientModel",
+    "version": "1.5.1",
+    "hash": "sha256-n4PHKtjmFXo37s5yhfUQ9UbfnWplqHpC+wsvlHxctow="
+  },
+  {
+    "pname": "System.ComponentModel.Annotations",
+    "version": "5.0.0",
+    "hash": "sha256-0pST1UHgpeE6xJrYf5R+U7AwIlH3rVC3SpguilI/MAg="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "10.0.1",
+    "hash": "sha256-XmXL//tniOp4RYiXs9HzNbwODjyGYW/bsWO0OuWXAxE="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "9.0.4",
+    "hash": "sha256-hIde8A2EK+RpUSAMZx/xTVMRVeZWyaquVuSKmWbxrgw="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "10.0.1",
+    "hash": "sha256-Yn8jT9uKNnknLsSvtV9hyqfz/5x/aKnZt6XtfQOIdVM="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "9.0.4",
+    "hash": "sha256-afF72ywJo/vfJXt2XiI8Lf2zKcvn0F/p280P1w3Fmk4="
+  },
+  {
+    "pname": "System.IdentityModel.Tokens.Jwt",
+    "version": "7.7.1",
+    "hash": "sha256-6JfmtdChyt7zd/HKI+/T1HcyesEPx0NNMO/zFJ7lU2c="
+  },
+  {
+    "pname": "System.IdentityModel.Tokens.Jwt",
+    "version": "8.0.1",
+    "hash": "sha256-hW4f9zWs0afxPbcMqCA/FAGvBZbBFSkugIOurswomHg="
+  },
+  {
+    "pname": "System.IO.Abstractions",
+    "version": "17.0.24",
+    "hash": "sha256-brEupAGUEu6XdwiGYc3hA3f6nqeFLDIHt4luvOaauUY="
+  },
+  {
+    "pname": "System.IO.FileSystem.AccessControl",
+    "version": "5.0.0",
+    "hash": "sha256-c9MlDKJfj63YRvl7brRBNs59olrmbL+G1A6oTS8ytEc="
+  },
+  {
+    "pname": "System.Memory.Data",
+    "version": "8.0.1",
+    "hash": "sha256-cxYZL0Trr6RBplKmECv94ORuyjrOM6JB0D/EwmBSisg="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.7.0",
+    "hash": "sha256-GEtCGXwtOnkYejSV+Tfl+DqyGq5jTUaVyL9eMupMHBM="
+  },
+  {
+    "pname": "System.Security.Cryptography.Pkcs",
+    "version": "10.0.0",
+    "hash": "sha256-d3sLG+LZ3+N/h/6gdJcVKOgbBO6wYb66NfXalAEDqnE="
+  },
+  {
+    "pname": "System.Security.Cryptography.Pkcs",
+    "version": "9.0.4",
+    "hash": "sha256-dfOvsCYBR2bGGvwm6tthWB8kdNS6bxoMTS/lxL4t1gA="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "10.0.1",
+    "hash": "sha256-B2sQ5rfu4fROzUDbi0A2rHPq27QDmQa3k56MfpE1adA="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "4.5.0",
+    "hash": "sha256-Z+X1Z2lErLL7Ynt2jFszku6/IgrngO3V1bSfZTBiFIc="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "9.0.4",
+    "hash": "sha256-VSlwaKi5WU6J0LYVh/hFfZuSkCG4V99MH2iLwspTrYA="
+  },
+  {
+    "pname": "System.ServiceProcess.ServiceController",
+    "version": "10.0.1",
+    "hash": "sha256-MVMJJbfMjyCXN6SdOhigsVPiaHyGnrwXxno6Z2KS7oI="
+  },
+  {
+    "pname": "System.ValueTuple",
+    "version": "4.6.1",
+    "hash": "sha256-Hb87MPcNdHQRlREDzFEKU8ZqtKN26bjyAiimJmm6LWI="
+  },
+  {
+    "pname": "TagLibSharp-Lidarr",
+    "version": "2.2.0.19",
+    "hash": "sha256-RgZRGh3PBFhL3HBZQ/p2NWy4M1SNfS0Lt/XY0+aDjJY="
+  }
+]

--- a/pkgs/by-name/ch/chaptarr/package.nix
+++ b/pkgs/by-name/ch/chaptarr/package.nix
@@ -1,0 +1,117 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  buildDotnetModule,
+  dotnetCorePackages,
+  sqlite,
+  fetchYarnDeps,
+  yarn,
+  fixup-yarn-lock,
+  nodejs,
+  prefetch-yarn-deps,
+  writers,
+  nix-update-script,
+}:
+buildDotnetModule (finalAttrs: {
+  pname = "chaptarr";
+  version = "0.9.925";
+
+  src = fetchFromGitHub {
+    owner = "Chaptarr";
+    repo = "chaptarr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DCv+Bg6SiC1+LUtuipLfFIdsxmCPVTnCuc58M3OxQKk=";
+  };
+
+  postPatch = ''
+    mv src/NuGet.config NuGet.Config
+  '';
+
+  installPath = "${placeholder "out"}/lib/chaptarr/bin";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    nodejs
+    yarn
+    prefetch-yarn-deps
+    fixup-yarn-lock
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-82ITzb6WkWtSMcBv1PRjrf0z8VA6lza7zO5ywxxkTG8=";
+  };
+
+  postConfigure = ''
+    yarn config --offline set yarn-offline-mirror "$yarnOfflineCache"
+    fixup-yarn-lock yarn.lock
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    patchShebangs --build node_modules
+  '';
+  postBuild = ''
+    yarn --offline run build --env production
+  '';
+  postInstall =
+    let
+      packageInfo = writers.writeText "package_info" ''
+        PackageVersion=${finalAttrs.version}
+        PackageAuthor=[NixOS](https://nixos.org)
+      '';
+    in
+    ''
+      cp -a -- _output/UI "$out/lib/chaptarr/bin/UI"
+      ln -s ${packageInfo} $out/lib/chaptarr/package_info
+    '';
+
+  nugetDeps = ./deps.json;
+
+  runtimeDeps = [ sqlite ];
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;
+
+  doCheck = true;
+
+  executables = [ "Chaptarr" ];
+
+  projectFile = [
+    "src/NzbDrone.Console/Chaptarr.Console.csproj"
+    "src/NzbDrone.Mono/Chaptarr.Mono.csproj"
+  ];
+
+  testProjectFile = [
+    "src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj"
+  ];
+
+  testFilters = [
+    # No network in sandbox breaks these media cover tests
+    "FullyQualifiedName!=Chaptarr.Core.Test.MediaCover.MediaCoverRenditionFixture.canonical_download_should_reject_mascot_and_persist_the_real_fallback_identity"
+    "FullyQualifiedName!=Chaptarr.Core.Test.MediaCover.MediaCoverRenditionFixture.legacy_on_demand_mascot_file_should_be_rejected_without_a_network_request"
+    "FullyQualifiedName!=Chaptarr.Core.Test.MediaCover.MediaCoverRenditionFixture.on_demand_author_image_should_reject_known_provider_placeholder"
+    "FullyQualifiedName!=Chaptarr.Core.Test.MediaCover.MediaCoverRenditionFixture.rejected_preferred_photo_should_not_delete_a_verified_real_fallback"
+  ];
+
+  dotnetFlags = [
+    "--property:TargetFramework=net10.0"
+    "--property:EnableAnalyzers=false"
+    "--property:RuntimeIdentifier=${dotnetCorePackages.systemToDotnetRid stdenvNoCC.hostPlatform.system}"
+    "--property:SentryUploadSymbols=false"
+    "--property:AssemblyVersion=${finalAttrs.version}"
+    "--property:AssemblyConfiguration=main"
+    "--property:Copyright=Copyright © 2026 Chaptarr contributors (GNU General Public v3)"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An audiobook and eBook collection manager";
+    changelog = "https://github.com/Chaptarr/chaptarr/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/Chaptarr/chaptarr";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ lnk3 ];
+    mainProgram = "Chaptarr";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})

--- a/pkgs/by-name/ch/chaptarr/package.nix
+++ b/pkgs/by-name/ch/chaptarr/package.nix
@@ -12,6 +12,7 @@
   prefetch-yarn-deps,
   writers,
   nix-update-script,
+  nixosTests,
 }:
 buildDotnetModule (finalAttrs: {
   pname = "chaptarr";
@@ -103,7 +104,12 @@ buildDotnetModule (finalAttrs: {
     "--property:Copyright=Copyright © 2026 Chaptarr contributors (GNU General Public v3)"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) chaptarr;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "An audiobook and eBook collection manager";


### PR DESCRIPTION
I tested it for some days, seems to work.

The package still hasn't a wiki available: https://wiki.chaptarr.com/ should be here soon enough.
The package will be in nixpkgs after #550891
If you want audiobook conversion you are also interested in this pr getting merged: #550892 it's for m4b-tool which you can add with the `extraPackages` option.

I'm pinging the servarr maintainers: @Stunkymonkey @haylinmoore @rhoriguchi 
found with `git log --format='%ae' -- nixos/modules/services/misc/servarr/ | sort -u | parallel "grep {} maintainers/maintainer-list.nix" --after-context 1 | grep "github ="`

--- 

You can use the following nixos vm to try chaptarr:
```nix
# nix-build '<nixpkgs/nixos>' -A vm -I nixpkgs=$(pwd) -I nixos-config=$(pwd)/test-chaptarr.nix && QEMU_NET_OPTS="hostfwd=tcp::8789-:8789" ./result/bin/run-nixos-vm -nographic
{ pkgs, ... }:
{
  imports = [
    ./nixos/modules/services/misc/servarr/chaptarr.nix
  ];

  boot.loader.grub.enable = true;
  fileSystems."/" = {
    device = "/dev/vda";
    fsType = "ext4";
  };
  users.users.root.initialPassword = "test";
  system.stateVersion = "26.11";
  documentation.man.enable = false;
  environment.systemPackages = with pkgs; [
    tcpdump
    tmux
    screen
    sqlit-tui
    tree
    inotify-tools
  ];

  services.chaptarr = {
    enable = true;
    openFirewall = true;
    extraReadWritePaths = [
      "/data/media"
    ];
    settings = {
      # postgres.host = "localhost";
      # postgres.user = "chaptarr";
      # server = {
      #   bindAddress = "*";
      #   port = 1234;
      #   sslPort = 1234;
      #   enableSsl = true;
      #   launchBrowser = false;
      #   apiKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
      #   authenticationMethod = "None";
      #   authenticationRequired = "Disabled";
      #   authCookieStamp = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
      #   oidcAuthority = "cccc";
      #   oidcClientId = "cccc";
      #   oidcClientSecret = "dddd";
      #   oidcScopes = "openid profile something";
      #   oidcAllowedEmails = "asdfasdf@asf.com";
      #   oidcAllowedEmailDomains = "asdfasdfsd";
      #   oidcRequireEmailVerified = false;
      #   oidcAllowAnyVerifiedUser = true;
      #   plexAuthUserId = "asdfasdfasklfdjask";
      #   plexAuthUsername = "asfdasdf";
      #   branch = "develop";
      #   logLevel = "trace";
      #   sslCertPath = "/hello";
      #   sslCertPassword = "asdfa";
      #   urlBase = "/";
      #   instanceName = "Chaptarring";
      #   installationId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
      # };
    };
  };

  services.transmission.enable = true;
  services.transmission.package = pkgs.transmission_4;
  services.transmission.openFirewall = true;
  services.transmission.openRPCPort = true;
  services.transmission.settings.download-dir = "/data/media/downloads";
  systemd.services.transmission = {
    wants = [ "network-online.target" ];
    after = [ "network-online.target" ];
  };

  systemd.tmpfiles.settings."10-test-media" = {
    "/data/media".d = {
      user = "chaptarr";
      group = "chaptarr";
      mode = "0755";
    };
  };
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
