### PR TITLE
openterface-qt: 0.3.18 -> 0.5.28

### DIFF
--- a/pkgs/by-name/op/openterface-qt/package.nix
+++ b/pkgs/by-name/op/openterface-qt/package.nix
@@ -7,6 +7,12 @@
   writeText,
   qt6,
   libusb1,
+
+  libva,
+  nix-update-script,
+  udev,
+  pkg-config,
+  ffmpeg,
 }:
 let
   # Based on upstream instructions: https://github.com/TechxArtisanStudio/Openterface_QT#for-linux-users
@@ -22,29 +28,39 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openterface-qt";
-  version = "0.3.18";
+  version = "0.5.28";
+
   src = fetchFromGitHub {
     owner = "TechxArtisanStudio";
     repo = "Openterface_QT";
-    rev = "${finalAttrs.version}";
-    hash = "sha256-yD71UOi6iRd9N3NeASUzqoeHMcTYIqkysAfxRm7GkOA=";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-MHmTG/9b/BZFPcIBtCrZrQe4uFQ/tttbQMZUpDCwRuc=";
   };
+
   nativeBuildInputs = [
+    pkg-config
     copyDesktopItems
     qt6.wrapQtAppsHook
     qt6.qmake
     qt6.qttools
   ];
+
   buildInputs = [
     libusb1
     qt6.qtbase
     qt6.qtmultimedia
     qt6.qtserialport
     qt6.qtsvg
+    qt6.qthttpserver
+    udev
+    ffmpeg
+    libva
   ];
+
   preBuild = ''
     lrelease openterfaceQT.pro
   '';
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
@@ -68,6 +84,9 @@ stdenv.mkDerivation (finalAttrs: {
       categories = [ "Utility" ];
     })
   ];
+
+  # use a github releases for autoupdate
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
 
   meta = {
     description = "Openterface mini-KVM host application for linux";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Resolves: #554251
## Things done
- Updated the package hash
- Added a `nix-update-script` for automated updates
- Added a missing library dependency
- Changed `rev` to `tag`
- Verified basic functionality
---
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
