### PR TITLE
karakeep: fix worker crash by switching to nodejs_22

### DIFF
--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   nixosTests,
-  nodejs,
+  nodejs_22,
   node-gyp,
   gnutar,
   inter,
@@ -41,7 +41,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     python3
-    nodejs
+    # nodejs 22 avoids a worker crash on 24.19+ while waiting for a proper fix to https://github.com/karakeep-app/karakeep/issues/2989
+    # should be safe to revert after seeing forward movement at https://github.com/karakeep-app/karakeep/blob/main/docker/Dockerfile#L13
+    nodejs_22
     node-gyp
     pnpmConfigHook
     pnpm_11
@@ -67,8 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Based on matrix-appservice-discord
     pushd node_modules/better-sqlite3
-    npm run build-release --offline "--nodedir=${srcOnly nodejs}"
-    find build -type f -exec ${removeReferencesTo}/bin/remove-references-to -t "${srcOnly nodejs}" {} \;
+    npm run build-release --offline "--nodedir=${srcOnly nodejs_22}"
+    find build -type f -exec ${removeReferencesTo}/bin/remove-references-to -t "${srcOnly nodejs_22}" {} \;
     popd
 
     export CI=true
@@ -124,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace "$KARAKEEP_LIB_PATH/$HELPER_SCRIPT_NAME" \
         --subst-var-by KARAKEEP_LIB_PATH "$KARAKEEP_LIB_PATH" \
         --subst-var-by VERSION "${finalAttrs.version}" \
-        --subst-var-by NODEJS "${nodejs}"
+        --subst-var-by NODEJS "${nodejs_22}"
       chmod +x "$KARAKEEP_LIB_PATH/$HELPER_SCRIPT_NAME"
       patchShebangs "$KARAKEEP_LIB_PATH/$HELPER_SCRIPT_NAME"
     done


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/554550.

Karakeep workers have a [known crash bug starting with nodejs v24.19](
https://github.com/karakeep-app/karakeep/issues/2989). This patch avoids the crash by switching to nodejs v22 while waiting for an upstream fix.

It should be safe to revert this change after seeing forward movement of the [nodejs version in karakeep's container release](https://github.com/karakeep-app/karakeep/blob/main/docker/Dockerfile#L13).

I've tested the build with nixpkgs-review and verified basic runtime functionality on my own instance by setting `services.karakeep.package = myfork.karakeep` in the nixos module.

Here's the journal output of workers running without issue:

```console
λ systemctl status karakeep-workers.service
● karakeep-workers.service - Karakeep Workers
     Loaded: loaded (/etc/systemd/system/karakeep-workers.service; enabled; preset: ignored)
     Active: active (running) since Thu 2026-08-20 11:18:04 PDT; 21min ago
 Invocation: 5c0e8edbade14a9b8a802bc739220d49
   Main PID: 1226 (node)
         IP: 207.1K in, 28.7K out
         IO: 54.8M read, 1M written
      Tasks: 11 (limit: 18867)
     Memory: 224.5M (peak: 367.6M)
        CPU: 40.312s
     CGroup: /system.slice/karakeep-workers.service
             └─1226 /nix/store/hyw97nxddgxfc6ag6db87rnawss2pw1a-nodejs-22.23.2/bin/node /nix/store/v7mf32x6pr169v95rwkvi5r9yj3khj0h-karakeep-0.33.1/lib/karakeep/apps/workers/dist/index.js

Aug 20 11:19:30 makoto start-workers[1226]: 2026-08-20T18:19:30.202Z info: [Crawler][4587:0] Downloading image from "https://www.bassbuzz.com/wp-content/uploads/2024/09/BB_B2B_Course_Thumb.jpg"
Aug 20 11:19:31 makoto start-workers[1226]: 2026-08-20T18:19:31.520Z info: [Crawler][4587:0] Downloaded image as assetId: b61aa94f-97fc-41f8-97ba-a5fdd1b8170e (124407 bytes)
Aug 20 11:19:31 makoto start-workers[1226]: 2026-08-20T18:19:31.560Z info: [Crawler][4587] Completed successfully
Aug 20 11:19:31 makoto start-workers[1226]: 2026-08-20T18:19:31.864Z info: [search][4591] Attempting to index bookmark with id eqank2f4jinzaxtc4w5rvprb (run 0, batch=true) ...
Aug 20 11:19:32 makoto start-workers[1226]: 2026-08-20T18:19:32.386Z debug: [meilisearch] Flushing add batch: size=1
Aug 20 11:19:32 makoto start-workers[1226]: 2026-08-20T18:19:32.509Z debug: [inference][4589] No inference client configured, nothing to do now
Aug 20 11:19:32 makoto start-workers[1226]: 2026-08-20T18:19:32.509Z info: [inference][4589] Completed successfully
Aug 20 11:19:32 makoto start-workers[1226]: 2026-08-20T18:19:32.538Z debug: [inference][4590] No inference client configured, nothing to do now
Aug 20 11:19:32 makoto start-workers[1226]: 2026-08-20T18:19:32.538Z info: [inference][4590] Completed successfully
Aug 20 11:19:33 makoto start-workers[1226]: 2026-08-20T18:19:33.021Z info: [search][4591] Completed successfully
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**Question for Maintainers:** I don't see any problems with basic usage. Are you aware of any advanced functionality depending on nodejs 24+ that would turn this into a breaking change?

## Temp fix for people waiting on merge

You can use an overlay to switch karakeep over to nodejs_22 yourself, though it means building on your own. Takes ~6min for me.

```nix
self: super: {
  karakeep = super.callPackage "${inputs.nixpkgs}/pkgs/by-name/ka/karakeep/package.nix" {
    # Avoid nodejs 24 while waiting on bugfix for https://github.com/karakeep-app/karakeep/issues/2989
    nodejs = super.nodejs_22;
  };
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
