### PR TITLE
framr: init at 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30362,6 +30362,13 @@
     githubId = 59031302;
     name = "vmfunc";
   };
+  vmohammad = {
+    email = "git@vmohammad.dev";
+    github = "vMohammad24";
+    githubId = 62218284;
+    name = "vMohammad";
+    keys = [ { fingerprint = "2C85 FE6E 65F9 4C41 247E  A88D 2BCE A4D1 3803 80B8"; } ];
+  };
   vncsb = {
     email = "viniciusbernardino1@hotmail.com";
     github = "vncsb";

--- a/pkgs/by-name/fr/framr/package.nix
+++ b/pkgs/by-name/fr/framr/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  dbus,
+  wayland,
+  libxkbcommon,
+  cairo,
+  pango,
+  libxcursor,
+  mesa,
+  libgbm,
+  libdrm,
+  ffmpeg,
+  alsa-lib,
+  pipewire,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "framr";
+  version = "0.17.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vMohammad24";
+    repo = "framr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-w3IUyWANnn8VTXFPyoyHiQRsozx6ML0kHlEyP3+QT18=";
+  };
+
+  cargoHash = "sha256-rUhATkJ0R066ljC0ybGG43xNKc+YRaav+n8YZDEhSXM=";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    installShellFiles
+  ];
+
+  buildInputs = [
+    alsa-lib
+    cairo
+    dbus
+    ffmpeg
+    libdrm
+    libgbm
+    libxcursor
+    libxkbcommon
+    mesa
+    pango
+    pipewire
+    wayland
+  ];
+
+  postInstall = ''
+    install -Dm644 assets/framr-handler.desktop \
+      $out/share/applications/framr-handler.desktop
+
+    installShellCompletion --cmd framr \
+      --bash <($out/bin/framr completions bash) \
+      --zsh <($out/bin/framr completions zsh) \
+      --fish <($out/bin/framr completions fish)
+
+    $out/bin/framr man man-pages
+    installManPage man-pages/*.1
+  '';
+
+  meta = {
+    description = "Wayland screenshot, annotation and screen recording tool with ShareX-compatible uploads";
+    homepage = "https://github.com/vMohammad24/framr";
+    changelog = "https://github.com/vMohammad24/framr/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ vmohammad ];
+    mainProgram = "framr";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added [framr](https://github.com/vMohammad24/framr/)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
