### PR TITLE
tuitab: init at 0.9.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6897,6 +6897,12 @@
     githubId = 62989;
     name = "Demyan Rogozhin";
   };
+  denisotree = {
+    email = "denxvd@gmail.com";
+    github = "denisotree";
+    githubId = 14933172;
+    name = "Denis Vdovin";
+  };
   Denommus = {
     email = "yuridenommus@gmail.com";
     github = "Denommus";

--- a/pkgs/by-name/tu/tuitab/package.nix
+++ b/pkgs/by-name/tu/tuitab/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tuitab";
+  version = "0.9.5";
+
+  src = fetchFromGitHub {
+    owner = "denisotree";
+    repo = "tuitab";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0cotCc3dOFSJXZcRHzkHm2UML1ub1jA39GiDtlxPUpI=";
+  };
+
+  cargoHash = "sha256-/U1mxPWwjboOZJSecV56F9wo4F8P2JXO/mAjx6SQ+J4=";
+
+  __structuredAttrs = true;
+
+  # ttab and ttb are separate [[bin]] targets whose source is byte-identical to
+  # `fn main() { tuitab::run() }`, so building them yields three full copies of a
+  # ~110 MB binary. Build one and symlink the aliases; argv[0] is never read.
+  # Do not restrict cargoTestFlags the same way: tests/mcp_tests.rs needs
+  # CARGO_BIN_EXE_tuitab.
+  cargoBuildFlags = [
+    "--bin"
+    "tuitab"
+  ];
+
+  # checkPhase runs before installPhase and may leave ttab/ttb in target/release
+  # for installPhase to pick up, hence `ln -sf` rather than `ln -s`.
+  postInstall = ''
+    ln -sf tuitab $out/bin/ttab
+    ln -sf tuitab $out/bin/ttb
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast, keyboard-driven terminal explorer for tabular data";
+    longDescription = ''
+      tuitab opens CSV, TSV, JSON, JSONL, YAML, TOML, Parquet, Arrow, Excel,
+      SQLite and DuckDB files as a table and lets you filter, sort, pivot, join,
+      add computed columns and draw charts without leaving the terminal.
+    '';
+    homepage = "https://github.com/denisotree/tuitab";
+    changelog = "https://github.com/denisotree/tuitab/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "tuitab";
+    maintainers = with lib.maintainers; [ denisotree ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds `tuitab`, a keyboard-driven terminal explorer for tabular data — CSV, TSV, JSON, JSONL,
YAML, TOML, Parquet, Arrow, Excel, SQLite and DuckDB — with filtering, sorting, pivots, joins,
computed columns and charts. Homepage: https://github.com/denisotree/tuitab

I am the upstream author and will maintain the package.

Two decisions a reviewer will likely ask about, answered up front.

**DuckDB and SQLite are statically linked from the crates' own bundled sources.**
`libduckdb-sys` ships the DuckDB amalgamation inside the crate and builds it with `cc` — no
network, no CMake, no bindgen — so the default build is already hermetic in the sandbox and needs
no `buildInputs` at all. Unbundling just DuckDB via `--no-default-features` would be a half
measure: `rusqlite`'s `bundled` feature is hard-wired in upstream's `[dependencies]` and cannot be
switched off without patching `Cargo.toml`, so SQLite stays vendored either way. It would also
couple the package to `pkgs.duckdb`'s version — they match today (both 1.5.5), but the crate pins a
specific DuckDB release, so the next duckdb bump would break the build. For the record, if you do
want the system library: `pkgs.duckdb` installs no `duckdb.pc`, so it needs
`DUCKDB_LIB_DIR`/`DUCKDB_INCLUDE_DIR` rather than pkg-config. Happy to switch if you prefer.

**`ttab` and `ttb` are symlinks to `tuitab`.**
Upstream declares them as separate `[[bin]]` targets whose sources are byte-identical to
`fn main() { tuitab::run() }`, so an unrestricted build installs three full copies of a ~150 MB
binary. `cargoBuildFlags = [ "--bin" "tuitab" ]` plus `postInstall` symlinks avoids that;
`argv[0]` is never read anywhere in the source. `cargoTestFlags` is deliberately left
unrestricted, because `tests/mcp_tests.rs` needs `CARGO_BIN_EXE_tuitab`. The AUR and Homebrew
packages do the same.

The full upstream test suite runs in `checkPhase` and passes unmodified — 30 suites, no
`checkFlags`, no `doCheck = false`. It exercises the SQLite, DuckDB and Parquet read/write paths,
which is what actually demonstrates the vendored libraries work. As an extra check I created a
`.duckdb` and a `.sqlite` file with `pkgs.duckdb`/`pkgs.sqlite` and read both back with the
installed binary. `nix-store -q --references` on the output lists only `glibc` and `gcc-lib`.

**Heads-up on build resources.** `checkPhase` links 29 separate test binaries, each a full
release-LTO link of a statically-bundled DuckDB + Polars binary. This peaked around 15 GB RSS on
my builder; an 8 GB machine OOM-killed `polars-core` outright. `cargoBuildFlags` keeps the install
side to one binary, but the test link is unavoidable short of disabling tests.

**Platform coverage.** Only `aarch64-linux` was built and tested locally, sandboxed. I declare
`meta.platforms = lib.platforms.unix` on the strength of upstream's own CI, which builds and tests
on both Linux and macOS and ships darwin release binaries — but I have no Nix darwin builder, so
the other platforms are unverified by me. Happy to narrow to `platforms.linux` if darwin fails.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
      (Not run: nothing in Nixpkgs depends on this new leaf package, and my builder is a
      container without a full clone. `ci.nixpkgs-vet` passes: "Validated successfully".)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation disclosure

Per the [automation/AI policy]: this contribution was produced with substantial assistance from
Claude Code (model `claude-opus-5`), covering the packaging investigation, the `package.nix`
expression, the maintainer entry, and this pull request summary. Both commits carry an
`Assisted-by: Claude Code (claude-opus-5)` trailer.

I am the upstream author of tuitab and I have reviewed the diff and both commits before
submission; I am accountable for them. The output was verified rather than taken on trust: the
package was built in a sandboxed `nixos/nix` container on aarch64-linux, upstream's full test
suite runs and passes in `checkPhase`, `ci.nixpkgs-vet` reports "Validated successfully",
`nixfmt-rfc-style --check` and `lib/tests/maintainers.nix` are clean, and the installed binaries
were exercised by hand — including reading a `.duckdb` and a `.sqlite` file written by
`pkgs.duckdb`/`pkgs.sqlite`, and a JSON-RPC round trip against the binary's MCP mode. The
verification tooling is exactly the standard Nixpkgs CI checks named above.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
