### PR TITLE
devin-desktop: fix tool-launch errors by using the original static binaries

### DIFF
--- a/pkgs/by-name/de/devin-desktop/package.nix
+++ b/pkgs/by-name/de/devin-desktop/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildVscode,
+  fd,
   fetchurl,
   nixosTests,
   commandLineArgs ? "",
@@ -12,7 +13,7 @@ let
     (lib.importJSON ./info.json)."${stdenv.hostPlatform.system}"
       or (throw "windsurf: unsupported system ${stdenv.hostPlatform.system}");
 in
-buildVscode {
+(buildVscode {
   inherit commandLineArgs useVSCodeRipgrep;
 
   inherit (info) version vscodeVersion;
@@ -56,4 +57,27 @@ buildVscode {
     ];
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
-}
+}).overrideAttrs
+  (oldAttrs: {
+    # Run patchelf manually *before* restoring the staticaly linked binaries
+    dontAutoPatchelf = stdenv.hostPlatform.isLinux;
+
+    runtimeDependencies =
+      (oldAttrs.runtimeDependencies or [ ])
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        fd
+      ];
+
+    # devin-desktop ships statically-linked relocatable binaries;`patchelf --set-rpath` corrupts the self-relocation bootstrap,
+    # causing SIGSEGV. Since the autoPatchElfHook fires after postFixup, we need to disable it and patch before we replace the files.
+    postFixup =
+      (oldAttrs.postFixup or "")
+      + lib.optionalString stdenv.hostPlatform.isLinux ''
+        autoPatchelf -- "$out"
+        echo "Restoring static binaries"
+        cp ./resources/app/extensions/windsurf/devin/bin/devin "$out/lib/devin-desktop/resources/app/extensions/windsurf/devin/bin/devin"
+        cp ./resources/app/extensions/windsurf/bin/language_server_linux_x64 "$out/lib/devin-desktop/resources/app/extensions/windsurf/bin/language_server_linux_x64"
+
+        ln -sf "${lib.getExe fd}" "$out/lib/devin-desktop/resources/app/extensions/windsurf/bin/fd"
+      '';
+  })


### PR DESCRIPTION
`devin-desktop` (on Linux) reports `service failed` and the `devin` agent becomes unavailable. 

Logs:
```sh
2026-08-20 11:15:44.475 [info] Spawning process: /nix/store/mgl5n3hlirycmyfm55wya6lb3v882mn8-devin-desktop-3.5.17/lib/devin-desktop/resources/app/extensions/windsurf/devin/bin/devin acp
2026-08-20 11:15:44.508 [error] Initialization failed: AcpConnectionClosedError: ACP connection closed
2026-08-20 11:15:44.508 [info] Process exited with code=null, signal=SIGSEGV
2026-08-20 11:15:44.778 [info] Registering provider with host
2026-08-20 11:15:44.778 [info] Spawning process: /nix/store/mgl5n3hlirycmyfm55wya6lb3v882mn8-devin-desktop-3.5.17/lib/devin-desktop/resources/app/extensions/windsurf/devin/bin/devin acp
2026-08-20 11:15:45.292 [error] Initialization failed: AcpConnectionClosedError: ACP connection closed
2026-08-20 11:15:45.293 [info] Process exited with code=null, signal=SIGSEGV
2026-08-20 11:15:55.973 [error] Activation failed: ACP connection closed
```
The support team investigated and reports
> I did reproduce this crash, and believe I have a preliminary root cause; the bundled devin binary is a statically-linked position-independent executable. When nixpkgs' fixup phase runs patchelf --set-rpath on it, the rewrite corrupts the binary's self-relocation bootstrap, causing an immediate SIGSEGV at startup.

Fix:
1. Overrode `patchelf` to run before the next steps (as it would undo the restores):
2. Replace the processed `devin` binary with the original in `postFixup`
3. Do the same with `language_server_linux_x64`.
4. And, replace the bundled `fd` with nixpkgs' `fd`

Closes #541912

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
