### PR TITLE
tmines: init at 1.0.2

### DIFF
--- a/pkgs/by-name/tm/tmines/package.nix
+++ b/pkgs/by-name/tm/tmines/package.nix
@@ -1,0 +1,30 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tmines";
+  version = "1.0.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "colepearson27";
+    repo = "tmines";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u1cP7akKt0YQZKGHZlwsvXGgQ2TLLMnsWuRKSNY086U=";
+  };
+
+  vendorHash = "sha256-gEu57cKAPJRfzbx6tI7BycazzpgP3VIpr+B9nbZhIu8=";
+
+  meta = {
+    description = "Simple terminal based minesweeper project.";
+    homepage = "github.com/colepearson27/tmines";
+    maintainers = with lib.maintainers; [ colepearson27 ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Init tmines. Simple terminal based minesweeper project.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
