### PR TITLE
dcpomatic: init at 2.19.1

### DIFF
--- a/pkgs/by-name/dc/dcpomatic/asdcplib.nix
+++ b/pkgs/by-name/dc/dcpomatic/asdcplib.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+
+  wafHook,
+  python3,
+  gitMinimal,
+  pkg-config,
+  openssl,
+  boost,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "asdcplib";
+  version = "1.0.11";
+
+  src = fetchgit {
+    url = "https://git.carlh.net/git/asdcplib";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VkXDiNYPXU4eOgOfhZB3RMoSp1ujL2jMdAYwjdyIei0=";
+  };
+
+  # for some reason the version is not set properly upstream
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace-fail \
+        "VERSION = open('VERSION').read().strip()" \
+        "VERSION = '${finalAttrs.version}'"
+  '';
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    boost
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "asdcplib library for low-level DCP handling";
+    homepage = "https://git.carlh.net/cgit/asdcplib";
+    downloadPage = "https://git.carlh.net/cgit/asdcplib";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ logn ];
+  };
+})

--- a/pkgs/by-name/dc/dcpomatic/leqm-nrt-libsndfile-linking.patch
+++ b/pkgs/by-name/dc/dcpomatic/leqm-nrt-libsndfile-linking.patch
@@ -1,0 +1,12 @@
+diff --git a/src/wscript b/src/wscript
+index cbea215..62b0a06 100644
+--- a/src/wscript
++++ b/src/wscript
+@@ -6,6 +6,7 @@ def build(bld):
+     obj.source = 'leqm_nrt.cc'
+ 
+     if bld.env.WITH_LIBSNDFILE:
++        obj.uselib = 'SNDFILE'
+         obj = bld(features='cxx cxxprogram')
+         obj.name = 'leqm_nrt_cli'
+         obj.target = 'leqm_nrt'

--- a/pkgs/by-name/dc/dcpomatic/leqm-nrt.nix
+++ b/pkgs/by-name/dc/dcpomatic/leqm-nrt.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  fetchgit,
+  wafHook,
+  python3,
+  gitMinimal,
+  pkg-config,
+  libsndfile,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "leqm-nrt";
+  version = "0.0.2";
+
+  src = fetchgit {
+    url = "https://git.carlh.net/git/leqm-nrt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rynqxvh2FT03Fs5XOV5ZBLzB6lJlop793cMv0FB3s1g=";
+  };
+
+  patches = [
+    ./leqm-nrt-libsndfile-linking.patch
+  ];
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    libsndfile
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "a non-real-time implementation of Leq(M) measurement";
+    homepage = "https://git.carlh.net/cgit/leqm-nrt";
+    downloadPage = "https://git.carlh.net/cgit/leqm-nrt";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ logn ];
+  };
+})

--- a/pkgs/by-name/dc/dcpomatic/libcxml.nix
+++ b/pkgs/by-name/dc/dcpomatic/libcxml.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+
+  wafHook,
+  python3,
+  gitMinimal,
+  pkg-config,
+  libxmlxx,
+  boost,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libcxml";
+  version = "0.17.17";
+
+  src = fetchgit {
+    url = "https://git.carlh.net/git/libcxml.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fd6KYSQnFw3aHCQOT6TTcGUvTxIWrJeRT5rmk2CgbrQ=";
+  };
+
+  # for some reason the version is not set properly upstream
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace-fail \
+        "this_version = subprocess.Popen(shlex.split('git tag -l --points-at HEAD'), stdout=subprocess.PIPE).communicate()[0].decode('UTF-8')" \
+        "this_version = 'v${finalAttrs.version}'"
+  '';
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    libxmlxx
+    boost
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "libxml++ helper library";
+    homepage = "https://git.carlh.net/cgit/libcxml";
+    downloadPage = "https://git.carlh.net/cgit/libcxml";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ logn ];
+  };
+})

--- a/pkgs/by-name/dc/dcpomatic/libdcp.nix
+++ b/pkgs/by-name/dc/dcpomatic/libdcp.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+
+  wafHook,
+  python3,
+  gitMinimal,
+  pkg-config,
+  openssl,
+  libxmlxx,
+  libcxml,
+  xmlsec,
+  imagemagick,
+  libsndfile,
+  openjpeg,
+  boost,
+  xercesc,
+  ffmpeg-headless,
+  fmt,
+  fast-float,
+  libtool,
+  libharu,
+  asdcplib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdcp";
+  version = "1.10.61";
+
+  src = fetchgit {
+    url = "https://git.carlh.net/git/libdcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MV2kANCq8IqsSJIk95rqIX7iSGmnDVetXPMLn5mEOEs=";
+  };
+
+  # for some reason the version is not set properly upstream
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace-fail \
+        "this_version = subprocess.Popen(shlex.split('git tag -l --points-at HEAD'), stdout=subprocess.PIPE).communicate()[0].decode('UTF-8')" \
+        "this_version = 'v${finalAttrs.version}'"
+  '';
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    libxmlxx
+    libcxml
+    xmlsec
+    imagemagick
+    libsndfile
+    openjpeg
+    asdcplib
+    xercesc
+    boost
+    ffmpeg-headless
+    fmt
+    fast-float
+    libtool
+    libharu
+  ];
+
+  propagatedBuildInputs = [
+    asdcplib
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "DCP handling library";
+    homepage = "https://git.carlh.net/cgit/libdcp";
+    downloadPage = "https://git.carlh.net/cgit/libdcp";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ logn ];
+  };
+})

--- a/pkgs/by-name/dc/dcpomatic/libsub.nix
+++ b/pkgs/by-name/dc/dcpomatic/libsub.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+
+  wafHook,
+  python3,
+  gitMinimal,
+  pkg-config,
+  openssl,
+  boost,
+  fmt,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libsub";
+  version = "1.6.62";
+
+  src = fetchgit {
+    url = "https://git.carlh.net/git/libsub";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NSCg+YnxUPII16K1SGozBRYorm0UVGTGozJOhLti4kc=";
+  };
+
+  # for some reason the version is not set properly upstream
+  postPatch = ''
+    substituteInPlace wscript \
+      --replace-fail \
+        "this_version = subprocess.Popen(shlex.split('git tag -l --points-at HEAD'), stdout=subprocess.PIPE).communicate()[0].decode('UTF-8')" \
+        "this_version = 'v${finalAttrs.version}'"
+  '';
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    boost
+    fmt
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Subtitle handling library";
+    homepage = "https://git.carlh.net/cgit/libsub";
+    downloadPage = "https://git.carlh.net/cgit/libsub";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ logn ];
+  };
+})

--- a/pkgs/by-name/dc/dcpomatic/libttf.nix
+++ b/pkgs/by-name/dc/dcpomatic/libttf.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+
+  wafHook,
+  python3,
+  gitMinimal,
+  pkg-config,
+  boost,
+  fmt,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libttf";
+  version = "0.0.7";
+
+  src = fetchgit {
+    url = "https://git.carlh.net/git/libttf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pLduKqcfCw8m4hZn8KsVa8rHESEPSQrvW4NCBcwXT5g=";
+  };
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    fmt
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Limited TTF manipulation library";
+    homepage = "https://git.carlh.net/cgit/libttf";
+    downloadPage = "https://git.carlh.net/cgit/libttf";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ logn ];
+  };
+})

--- a/pkgs/by-name/dc/dcpomatic/package.nix
+++ b/pkgs/by-name/dc/dcpomatic/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  callPackage,
+
+  wafHook,
+  wrapGAppsHook3,
+  python3,
+  gitMinimal,
+  pkg-config,
+  boost,
+  curl,
+  icu,
+  libsamplerate,
+  glib,
+  libzip,
+  bzip2,
+  fontconfig,
+  pangomm,
+  libxmlxx,
+  libssh,
+  xmlsec,
+  xercesc,
+  ffmpeg-headless,
+  fmt,
+  nettle,
+  libjpeg,
+  sqlite,
+  wxwidgets_3_2,
+  rtaudio,
+  libGL,
+  libGLU,
+  libsndfile,
+  libtool,
+  libharu,
+  openssl,
+  nlohmann_json,
+}:
+let
+  libcxml = callPackage ./libcxml.nix { };
+  leqm-nrt = callPackage ./leqm-nrt.nix { };
+  asdcplib = callPackage ./asdcplib.nix { };
+  libttf = callPackage ./libttf.nix { };
+  libsub = callPackage ./libsub.nix { };
+  libdcp = callPackage ./libdcp.nix { inherit libcxml asdcplib; };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dcpomatic";
+  version = "2.19.1";
+
+  src = fetchgit {
+    url = "https://git.carlh.net/git/dcpomatic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-c+An8V/A7Vk0ChGQULk9uj0zN5slLb8wSKlWl+3uL1Y=";
+  };
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    gitMinimal
+    pkg-config
+    fontconfig
+    wrapGAppsHook3
+    wxwidgets_3_2
+  ];
+
+  buildInputs = [
+    boost
+    curl
+    icu
+    libsamplerate
+    glib
+    libzip
+    bzip2
+    pangomm
+    leqm-nrt
+    libttf
+    libcxml
+    libxmlxx
+    libssh
+    libdcp
+    xmlsec
+    xercesc
+    ffmpeg-headless
+    fmt
+    libsub
+    nettle
+    libjpeg
+    sqlite
+    wxwidgets_3_2
+    rtaudio
+    libGL
+    libGLU
+    libsndfile
+    libtool
+    libharu
+    openssl
+    nlohmann_json
+  ];
+
+  postInstall = ''
+    ln -s ${openssl}/bin/openssl $out/bin/dcpomatic2_openssl
+    ln -s ${libdcp}/share/libdcp $out/share/libdcp
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Convert video, audio and subtitles into DCP";
+    homepage = "https://dcpomatic.com/";
+    downloadPage = "https://git.carlh.net/cgit/dcpomatic";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ logn ];
+  };
+})


### PR DESCRIPTION
Adds [DCP-o-Matic](https://dcpomatic.com/), a tool for encoding Digital Cinema Packages for playback on cinema projectors.

Upstream has like 5 libraries of his own, I included them all in the one package on a nixpkgs level however because many are forks or unused otherwise.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
