### PR TITLE
osinfo-db: 20251212 -> 20260812

### DIFF
--- a/pkgs/by-name/os/osinfo-db/package.nix
+++ b/pkgs/by-name/os/osinfo-db/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osinfo-db";
-  version = "20251212";
+  version = "20260812";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/libosinfo/osinfo-db-${finalAttrs.version}.tar.xz";
-    hash = "sha256-BjeSUMkTBsmMuXJq9E6uWQnf3VRJ+QMx6QSuEiHY1ec=";
+    url = "https://gitlab.com/api/v4/projects/libosinfo%2Fosinfo-db/packages/generic/release-assets/v${finalAttrs.version}/osinfo-db-${finalAttrs.version}.tar.xz";
+    hash = "sha256-8T7W4eSAtSZtOcrX8AEP698CZd/EVXneL7NFQ7xrNd4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This PR manually updates osinfo-db, since [the new release](https://gitlab.com/libosinfo/osinfo-db/-/releases/v20260812) is not available at [the previous location](https://releases.pagure.org/libosinfo/) and so @r-ryantm [cannot successfully update it automatically](https://nixpkgs-update-logs.nix-community.org/osinfo-db/2026-08-14.log) this time:

```
trying https://releases.pagure.org/libosinfo/osinfo-db-20260812.tar.xz
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed

  0      0   0      0   0      0      0      0                              0
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Retrying in 1 second. 3 retries left.

  0      0   0      0   0      0      0      0                              0
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Retrying in 2 seconds. 2 retries left.

  0      0   0      0   0      0      0      0                              0
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Retrying in 4 seconds. 1 retry left.

  0      0   0      0   0      0      0      0                              0
curl: (22) The requested URL returned error: 404
error: cannot download osinfo-db-20260812.tar.xz from any mirror
```

One minor note is that this PR causes a rebuild of `gnomeExtensions.desktop-icons-ng-ding.tests.gnome-extensions` which fails in my `aarch64-linux` VM (see the `npb` report below), but attempting to locally rebuild the base derivation _also_ fails for me, so I believe it's just nondeterminism unrelated to this PR:

```sh
d=$(nix-instantiate -A nixosTests.gnome-extensions) && nix-store -r "$d" >/dev/null && nix-store -r "$d" --check
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
