### PR TITLE
angle: fix eval for exotic platforms

### DIFF
--- a/pkgs/by-name/an/angle/package.nix
+++ b/pkgs/by-name/an/angle/package.nix
@@ -24,11 +24,7 @@ let
   llvmPackages = llvmPackages_21;
   llvmMajorVersion = lib.versions.major llvmPackages.llvm.version;
   arch = stdenv.hostPlatform.parsed.cpu.name;
-  triplet = lib.getAttr arch {
-    "x86_64" = "x86_64-unknown-linux-gnu";
-    "aarch64" = "aarch64-unknown-linux-gnu";
-    "riscv64" = "riscv64-unknown-linux-gnu";
-  };
+  triplet = stdenv.hostPlatform.config;
 
   clang = symlinkJoin {
     name = "angle-clang-llvm-join";
@@ -115,30 +111,32 @@ stdenv.mkDerivation (finalAttrs: {
     ./fix-uninitialized-const-pointer-error-001.patch
   ];
 
-  postPatch = ''
-    substituteInPlace build/config/clang/BUILD.gn \
-      --replace-fail \
-        "_dir = \"${triplet}\"" \
-        "_dir = \"${triplet}\"
-         _suffix = \"-${arch}\""
+  postPatch =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace build/config/clang/BUILD.gn \
+        --replace-fail \
+          "_dir = \"${triplet}\"" \
+          "_dir = \"${triplet}\"
+           _suffix = \"-${arch}\""
+    ''
+    + ''
+      # Don't precompile Metal shaders, because the compiler is non-free.
+      substituteInPlace src/libANGLE/renderer/metal/metal_backend.gni \
+        --replace-fail \
+          "metal_internal_shader_compilation_supported =" \
+          "metal_internal_shader_compilation_supported = false &&"
 
-    # Don't precompile Metal shaders, because the compiler is non-free.
-    substituteInPlace src/libANGLE/renderer/metal/metal_backend.gni \
-      --replace-fail \
-        "metal_internal_shader_compilation_supported =" \
-        "metal_internal_shader_compilation_supported = false &&"
+      cat > build/config/gclient_args.gni <<EOF
+      # Generated from 'DEPS'
+      checkout_angle_internal = false
+      checkout_angle_mesa = false
+      checkout_angle_restricted_traces = false
+      generate_location_tags = false
+      EOF
 
-    cat > build/config/gclient_args.gni <<EOF
-    # Generated from 'DEPS'
-    checkout_angle_internal = false
-    checkout_angle_mesa = false
-    checkout_angle_restricted_traces = false
-    generate_location_tags = false
-    EOF
-
-    # For sandboxed build on darwin.
-    patchShebangs build/toolchain/apple
-  '';
+      # For sandboxed build on darwin.
+      patchShebangs build/toolchain/apple
+    '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
#540665 fixes angle for riscv64-linux, but it seems we have a more general fix...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
