### PR TITLE
firrtl: 1.5.3 -> 1.5.6

### DIFF
--- a/pkgs/by-name/fi/firrtl/package.nix
+++ b/pkgs/by-name/fi/firrtl/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation rec {
   pname = "firrtl";
-  version = "1.5.3";
+  version = "1.6.0";
   scalaVersion = "2.13"; # pin, for determinism
 
   deps = stdenv.mkDerivation {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       cp $(< deps) $out/share/java
     '';
     outputHashMode = "recursive";
-    outputHash = "sha256-xy3zdJZk6Q2HbEn5tRQ9Z0AjyXEteXepoWDaATjiUUw=";
+    outputHash = "sha256-gAdGGsFXPktqPPUEXD373e6R9psaeESZdpZTnMElGAc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fi/firrtl/package.nix
+++ b/pkgs/by-name/fi/firrtl/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation rec {
   pname = "firrtl";
-  version = "1.6.0";
+  version = "1.5.6";
   scalaVersion = "2.13"; # pin, for determinism
 
   deps = stdenv.mkDerivation {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       cp $(< deps) $out/share/java
     '';
     outputHashMode = "recursive";
-    outputHash = "sha256-gAdGGsFXPktqPPUEXD373e6R9psaeESZdpZTnMElGAc=";
+    outputHash = "sha256-afxA+QffQpt/sGA/Ri9RFMePAv4h9KoPqK5Mi5IusDc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updated firrtl to a version that works with current chipyard builds.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
