### PR TITLE
schildi-revenge: 26.07.13 -> 26.08.08-1

### DIFF
--- a/pkgs/by-name/sc/schildi-revenge/deps.json
+++ b/pkgs/by-name/sc/schildi-revenge/deps.json
@@ -2,44 +2,40 @@
  "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
  "!version": 1,
  "https://dl.google.com/dl/android/maven2": {
-  "androidx/activity#activity-compose/1.10.1": {
-   "module": "sha256-HtE6UO27iFlidR4by1uKQgeiDLeA6iSP+mU6qz+xD+k=",
-   "pom": "sha256-5k22txJvtRI5S8PPQzKjiCgAnaqN1W7L5sDHMAshJ/U="
+  "androidx/activity#activity-compose/1.13.0": {
+   "module": "sha256-2/18SvXVgokjQW8YJZrOE866H7GVY5dfo+Xe4pHul5Q=",
+   "pom": "sha256-y2qP+J/7fxB/IUBQ6fsysNCw9mXY3nyeTipNX+qZUek="
   },
-  "androidx/activity#activity-ktx/1.10.1": {
-   "module": "sha256-fBg4lRiaJ/16pZ/c9QKfpk+tKOnTkSmpyzDkC15CZ64=",
-   "pom": "sha256-QhNJDkzitXUOREUkbf6d5PZlXCEjwEp5qCSMyIk+K/Q="
+  "androidx/activity#activity-ktx/1.13.0": {
+   "module": "sha256-80tfh0fesKKlvbE1lmbZFM8ycIWWJJZZ7haOjKYQLxM=",
+   "pom": "sha256-edY9exPEP5L69jren8akq0Xo5CST26oTjHpzYYSkx3U="
   },
   "androidx/activity#activity-ktx/1.7.0": {
    "module": "sha256-9AAacJtvcTKyKl4Xwk+Lips8RipZjeOw8WzFekNEurY=",
    "pom": "sha256-cEmjrk2pyvNQojMroLECJd7ovohU1gioN76X0ipxk8g="
   },
-  "androidx/activity#activity/1.10.1": {
-   "module": "sha256-iTtzpLFtGcAzhnWtC5+lEi2cacRPYRhxvYxAfTviOmg=",
-   "pom": "sha256-CuTeiIl09c75gmYJAOwyoz8QlodQ23r6lDja7Bg/FOc="
+  "androidx/activity#activity/1.13.0": {
+   "module": "sha256-q40egVnflxVwVYq7hOKpPOguxPKHGYPw7DIHju8Ispk=",
+   "pom": "sha256-pcU+B0dUg10wYhYYYW54O1txh1wueYirBggjSBUuMU4="
   },
   "androidx/activity#activity/1.7.0": {
    "module": "sha256-KnRrASaoqy9XbnFn8aeFtFLvfumXq9l57gxaKcNvbqY=",
    "pom": "sha256-7eFnck23n8fFLPAv4JeZtFqUpTHX8CaFp4M3vAYsA5s="
   },
-  "androidx/activity/activity-compose/1.10.1/activity-compose-1.10.1": {
-   "aar": "sha256-+JrxsmzMg0Y0OHyFfC3U9GVNN2UIkAOcUnwv7QfbamE="
+  "androidx/activity/activity-compose/1.13.0/activity-compose-1.13.0": {
+   "aar": "sha256-K12jAz1JJOgzho4UDD7fwMAyCHELa5+yydmkdWC6Vfo="
   },
-  "androidx/activity/activity-ktx/1.10.1/activity-ktx-1.10.1": {
-   "aar": "sha256-85b1jb13LAZbhzaWt0o9TQh1VLN2YoDmO0myXbtTqxY="
+  "androidx/activity/activity-ktx/1.13.0/activity-ktx-1.13.0": {
+   "aar": "sha256-tVQdxfdONTifHp/cqLV3DEnSwTYN4W85jOXB4HoAMkQ="
   },
   "androidx/activity/activity-ktx/1.7.0/activity-ktx-1.7.0": {
    "aar": "sha256-/OMX1hoi8SlntHW/y4DIndpm5BiXXokOpwPLdOErWxE="
   },
-  "androidx/activity/activity/1.10.1/activity-1.10.1": {
-   "aar": "sha256-titSjJF96b5Jfrb4iDAZfCDp0hJnw5FsYTSS5e6DfU0="
+  "androidx/activity/activity/1.13.0/activity-1.13.0": {
+   "aar": "sha256-vU8ZpfAO/+0O7K0KMQsfIWm5/GYjajunQ6Ii63d0fuE="
   },
   "androidx/activity/activity/1.7.0/activity-1.7.0": {
    "aar": "sha256-5EsgMiczhxVpgpEsWR734t1IW6Cy5om1KLWkLycaTyc="
-  },
-  "androidx/annotation#annotation-experimental/1.4.0": {
-   "module": "sha256-WTDqfyH8ttDesroydIoO98j9LEI4SGBYK6fNIN65A3k=",
-   "pom": "sha256-QdK52Hn8kiGs2o6HPsfSaxU7m44EdwrHlJHgV2uu8Dg="
   },
   "androidx/annotation#annotation-experimental/1.4.1": {
    "module": "sha256-KsL3EG4S8mNCW0pN/ICYlEf7iVZ1/pAthnWap0/RK30=",
@@ -50,18 +46,19 @@
    "module": "sha256-Qq/KN0GUJz5AZ7k3z8RHvTyMT9RB9B1E+VQFDf1hBt0=",
    "pom": "sha256-XuzgkDtIEKodqFQU3EwnRgRth4pUOqEt1PH+dBcfdQY="
   },
-  "androidx/annotation#annotation-jvm/1.8.1": {
-   "module": "sha256-yVnjsM3HXBXv4BYF+laqefAz45I44VBji4+r3mqhIaA=",
-   "pom": "sha256-1JIDczqm+uBGw6PeTnlu7TR1lXVUhqZCc5iYRHWXULQ="
-  },
   "androidx/annotation#annotation-jvm/1.9.1": {
    "jar": "sha256-HjQ5F+vye6lv5NxSscrX/TK3OPvGNVu2zVs7MF1yEtA=",
    "module": "sha256-A/tlkXfIYY5HQlklwRvJHzhHA+omwmW+myXNeSkrURw=",
    "pom": "sha256-ibmcIY1gAZMWtQqreYFnB7whaWyJagMOGxrgOJYby44="
   },
   "androidx/annotation#annotation/1.10.0": {
+   "jar": "sha256-AdWm0BLtdjh/iXNPnxXd8MxNaYeTCPkjAwVZu4TzQH4=",
    "module": "sha256-Wy1Dh/OE5ZE6SuyXmiDs4Tu1zpkryQqWLeof7qf6iek=",
    "pom": "sha256-iA979LNdBgdGy+8xnUoFK0vYJrtxtAUA5VMZch/6TnY="
+  },
+  "androidx/annotation#annotation/1.2.0": {
+   "module": "sha256-Lvyrge+RshG6zSBuqs2ZWlH2M6Lpa1eo/AAUTF+cVrM=",
+   "pom": "sha256-Yvttyid37+COcHfWuHLWkRBhnff8Icmab1QGZJnMA4M="
   },
   "androidx/annotation#annotation/1.8.1": {
    "module": "sha256-5jhuha/dhlBE4hZXXkk+05pjpjJb2SU3miFCnDlByLU=",
@@ -72,11 +69,12 @@
    "module": "sha256-8gSwW3KKl1YXGLxxYkLkfGKcAIWoDudPylPU1ji8vj8=",
    "pom": "sha256-xzOIHC4X1ffIZhzAKpFZyxYLeyCUon1ZORbIfT4lBjY="
   },
-  "androidx/annotation/annotation-experimental/1.4.0/annotation-experimental-1.4.0": {
-   "aar": "sha256-xut+Z2AR7GWzJCg3PUUN69/EUXnE+LOnUhdPuHwXsIo="
-  },
   "androidx/annotation/annotation-experimental/1.4.1/annotation-experimental-1.4.1": {
    "aar": "sha256-a9THx0dvgmDNO9u4EYNYPpP8n3kMJ96n3DFBgcv4eqA="
+  },
+  "androidx/appcompat#appcompat-resources/1.7.0": {
+   "module": "sha256-18ygtVPsEJ7yCscK5kOPWE/Gu16yaaf1tAmOAsbWh/k=",
+   "pom": "sha256-u/Kluax4kEydp5LhZzF5MnT5X7SmEjBxkUCz4O9za6o="
   },
   "androidx/appcompat#appcompat-resources/1.7.1": {
    "module": "sha256-FjzF4PJJQz3bABb70BGrjeB88j4H5hjHRkRojibNGOg=",
@@ -115,6 +113,9 @@
    "jar": "sha256-k5tKhpdkDnfYPk6LTEqdGPgTAZjFlhGUr43Z253Hw1M=",
    "module": "sha256-QiiJTiXux+FzKbIGunLoqtJVvFNQGNxirMXv87XHqqU=",
    "pom": "sha256-mD+NBjDQctW/zRZqSYrHIT86RKmMCQUQBM6WQp2GfOo="
+  },
+  "androidx/collection#collection/1.0.0": {
+   "pom": "sha256-p5E6UnWtaOVV0mEuvowUw2exU+FMpIoYcqZImQIOVO8="
   },
   "androidx/collection#collection/1.1.0": {
    "pom": "sha256-Z+kGbKSs/cbjzFCCk8MboDmAV/8Rjk9wseGBPJo0VtE="
@@ -172,9 +173,18 @@
   "androidx/compose/foundation/foundation-layout-android/1.11.2/foundation-layout-android-1.11.2": {
    "aar": "sha256-Pp7jmd6n+4M03Otv7fXiD34vYZcZ9o6gVv7RFmVR7Ug="
   },
+  "androidx/compose/material#material-android/1.11.2": {
+   "module": "sha256-DVpwWhZcSboT1vqFR6H/JdFyEeBjmWN0vj2uv8KcuIQ=",
+   "pom": "sha256-/YmzX+3b1F3z+G4/8cDktfLp5Dpv6iB+rot+uOB2WCg="
+  },
   "androidx/compose/material#material-icons-core-android/1.7.6": {
    "module": "sha256-eietGojQmSEqfhomiis0BXeFUrAtAgvl8Gprn2o+yUI=",
    "pom": "sha256-DyMnhhbx+raN5Ipg2UQGjelGROS3JucFqIHB53gJj9Q="
+  },
+  "androidx/compose/material#material-icons-core-desktop/1.7.6": {
+   "jar": "sha256-tXKSIOJCEysisMAxejBP8WegXMaFw+nmSD1d/KNJX1Y=",
+   "module": "sha256-3V4DkVITF5NXN64zkNfZ1x4pIRfAJhXr07+lQ+GynvE=",
+   "pom": "sha256-RwvnoBxF5HQUAMHwK48zbaUqZDOx+o5mkvkdfuv9tKg="
   },
   "androidx/compose/material#material-icons-core/1.7.6": {
    "module": "sha256-sRuDHpv+L6ZMeSiVb5/otZT4uPQLQliwmEAGKz9Wsr8=",
@@ -184,17 +194,29 @@
    "module": "sha256-YGlqfsGPzoI3DMbiFqT56yFgMth8q0A0LjNKdHI+vas=",
    "pom": "sha256-JdIXQwTDF55rO/3YzjzpXJCpLEvUro4Me5QeWBeEAGA="
   },
+  "androidx/compose/material#material-icons-extended-desktop/1.7.6": {
+   "jar": "sha256-Ct4LfVXLAIE217WLcRAM4Bfe24S+IK9toudrWLCQ9pk=",
+   "module": "sha256-XQdKkww2dUVbpWDkojgAD5CFUrTAqxvgwPXnCekzfjQ=",
+   "pom": "sha256-FOi4l0Lie+aPb6sQe+/3CleiqlGpk8CS776zCU0ymw4="
+  },
   "androidx/compose/material#material-icons-extended/1.7.6": {
    "module": "sha256-7NczNuE23rRe267g3qEPelSQHh54FcS9FicJeXmJN4M=",
    "pom": "sha256-rFSvA/qAXWNsC/pFi+Fqw1mL+7NtvsGA9loGGFA/o70="
   },
-  "androidx/compose/material#material-ripple-android/1.9.3": {
-   "module": "sha256-E7KTlP/fTKvl0ykB28khwaVNVolsS0LQIjGSosNQsOc=",
-   "pom": "sha256-vez15umfjUgjj/TZKH++ZqhxTfPbEVt92OE2gY493VM="
+  "androidx/compose/material#material-ripple-android/1.11.2": {
+   "module": "sha256-OdMbMNcRXtMCKRhs1Dc0/qlnjhGNYteVls99iTsz01I=",
+   "pom": "sha256-aRV+FeL78zFdmSnfHC5OsmAQRpWBE+oVVqObJl4iGwE="
   },
-  "androidx/compose/material#material-ripple/1.9.3": {
-   "module": "sha256-5F/QpN9hdGLtrfkiBoiZNXk/vhwHlY89WFa6OYZAM5U=",
-   "pom": "sha256-jzXiBWbwG9TL3ETMza5U9qWTiPsj4NDiPa4/ZkB2j1A="
+  "androidx/compose/material#material-ripple/1.11.2": {
+   "module": "sha256-Tt2LlYqxto3KGNVr6zYaSItonJNr3f0ZSMzQew75qa4=",
+   "pom": "sha256-xxv4MkHdfziTB3Kfih5fBtYC97/snGuW1e56tndXMCw="
+  },
+  "androidx/compose/material#material/1.11.2": {
+   "module": "sha256-sz0Wv2sUFVrbY3+kbBMo3IDuld+l3qNIYvd3tHM8faQ=",
+   "pom": "sha256-fAYT/rTnGZBKKQFIXuIFne14KUISpekEh8CndD1/ebE="
+  },
+  "androidx/compose/material/material-android/1.11.2/material-android-1.11.2": {
+   "aar": "sha256-lh2q9yy9CMw479u86NID2gNvN+cOGLCbfgdx2jXYgqw="
   },
   "androidx/compose/material/material-icons-core-android/1.7.6/material-icons-core-android-1.7.6": {
    "aar": "sha256-SNGCBRI2sd/sgpszv00/0G0DwodtUyII4/dJAVnWXEY="
@@ -202,8 +224,8 @@
   "androidx/compose/material/material-icons-extended-android/1.7.6/material-icons-extended-android-1.7.6": {
    "aar": "sha256-B+l+UvNdeJ70ddnGh+XKRsxU+aDUr44dypKsJfshRQw="
   },
-  "androidx/compose/material/material-ripple-android/1.9.3/material-ripple-android-1.9.3": {
-   "aar": "sha256-gWH+Pr737PP0ClO3tpMIUHuxCwI7P9x7WO+zFxNohHk="
+  "androidx/compose/material/material-ripple-android/1.11.2/material-ripple-android-1.11.2": {
+   "aar": "sha256-VRzxiDTZCgo1e8ur5AEZkaHmnyjQw542UsqtoS0CuhI="
   },
   "androidx/compose/material3#material3-android/1.4.0": {
    "module": "sha256-/M1qjQ0z/PfDJ3vEPrRSxzgD7GIFl8gdvEp54pCnGpc=",
@@ -224,30 +246,15 @@
    "module": "sha256-O6eGZLUOkrOgJeFqThKfjTYmcwmznVufNfHRDNyxZyE=",
    "pom": "sha256-/5hwEFAR3UYq3yB59k+9pHgUOm+5UN1iIui69Q1lFCQ="
   },
-  "androidx/compose/runtime#runtime-annotation-jvm/1.11.0-rc01": {
-   "jar": "sha256-4oaoUgcJ173GZIHCcmYMKo0msSdA92ECVDzkVwQ3A5Y=",
-   "module": "sha256-JJMFQNItrRK1aVpERxiOx5N/eKYqVKRapnPK2ftwRlI=",
-   "pom": "sha256-wshTQYcZD+NmeWky/a0PL6PqPjYIj+5Qp5AvyXIdSB8="
-  },
   "androidx/compose/runtime#runtime-annotation-jvm/1.11.2": {
    "jar": "sha256-4oaoUgcJ173GZIHCcmYMKo0msSdA92ECVDzkVwQ3A5Y=",
    "module": "sha256-mAOREpmtfxBJH7AM7QZ3H0dLv7UNLLk0sExeV79pFZA=",
    "pom": "sha256-Wn8tmNFKL4YHDqKdhJDiYpn0jwhQtpG3lU0293kQ5T8="
   },
-  "androidx/compose/runtime#runtime-annotation/1.11.0-rc01": {
-   "jar": "sha256-GQ42On8pUXlPW08JhtpFTzmkJbh3mbLVksKniXLRdd8=",
-   "module": "sha256-pnylTwY8OPboC3lNrvVJNVUVS69V6xil3z7n7ct4N0A=",
-   "pom": "sha256-/V+nj8Fb55Ttiaikhp5CdiQqpGjc7FI4SSpB41QDhzc="
-  },
   "androidx/compose/runtime#runtime-annotation/1.11.2": {
    "jar": "sha256-GQ42On8pUXlPW08JhtpFTzmkJbh3mbLVksKniXLRdd8=",
    "module": "sha256-NhSpP6QePns7dSfjf64wXhswojyyKF+s428wXbuC9Fk=",
    "pom": "sha256-Smd2+thKJeT9sP3AaLiAilcuXMDpvscSsilMHjmsCTY="
-  },
-  "androidx/compose/runtime#runtime-desktop/1.11.0-rc01": {
-   "jar": "sha256-UMm1xchPpj0MKqcTGjxvVbM9FrUhFXWWReQ3D0yZhY8=",
-   "module": "sha256-WuLpf5rVMLT9FWxbJzjII9glpQFdP1kHjnt7sMikYYY=",
-   "pom": "sha256-xUBbjIh6dBleBjsbR9Wd5uq4cwUIJrIQzASS0N6RMN8="
   },
   "androidx/compose/runtime#runtime-desktop/1.11.2": {
    "jar": "sha256-aVUa7o+SEUkhgW89mqpmBiEE2yKO1XEKZmb3rb36/jw=",
@@ -258,20 +265,10 @@
    "module": "sha256-vtZ9MEQZVvLYzsnEL6R+CaLrX4jfipp6BngVRYj73CU=",
    "pom": "sha256-UtQgmPUe90hJOfieLT7sEJ2pnk3Lo56bxjxWJtuJaWI="
   },
-  "androidx/compose/runtime#runtime-retain-desktop/1.11.0-rc01": {
-   "jar": "sha256-m35ip98zPDPv+eGm1sJQik2P5LekN3gHVTj+PaS8RIU=",
-   "module": "sha256-rYhJPsh9RcM4BOFBSWvvuRUqyDP6A3pPjiIHPyxQz1k=",
-   "pom": "sha256-wB6g2unzf3ouoBbiMFgR+0Uw3FdKCVymkX3CdRmzD8Y="
-  },
   "androidx/compose/runtime#runtime-retain-desktop/1.11.2": {
    "jar": "sha256-m35ip98zPDPv+eGm1sJQik2P5LekN3gHVTj+PaS8RIU=",
    "module": "sha256-jnF2lFlOIuU+IBhrzSS9g6J/QcAQP1sr3LPsRXNCQn0=",
    "pom": "sha256-x7EjehNSlhZPkgt+FUwmSyv9rQVSVQBDdhV4cA6jNdA="
-  },
-  "androidx/compose/runtime#runtime-retain/1.11.0-rc01": {
-   "jar": "sha256-o2qxCWSG9aiFkeqG9u1S8RLD+E8b+cM0PcGS00EOhCo=",
-   "module": "sha256-d7+iDvl5cCm/1OeY+q7OmWf3OAqfnEADlwKLCWBT5uQ=",
-   "pom": "sha256-lUVDAEJaV/dC7d4G2YRGBzNIcxC/GZZajaIS8S2yukM="
   },
   "androidx/compose/runtime#runtime-retain/1.11.2": {
    "jar": "sha256-o2qxCWSG9aiFkeqG9u1S8RLD+E8b+cM0PcGS00EOhCo=",
@@ -286,20 +283,14 @@
    "module": "sha256-FPU88sgBBcde61vxmQRDmtXfpDJ93ZRIKdy3KDraCWA=",
    "pom": "sha256-NB5w5ZLSQyjAvfAz9nk5Wz1r6Ps/T/hh2GBkvUrZw3E="
   },
-  "androidx/compose/runtime#runtime-saveable-desktop/1.11.0-rc01": {
-   "jar": "sha256-saF+bCJt67Qsoif1gEWdnZ3qYtQqqOaF71bNfOdwsaE=",
-   "module": "sha256-LlNO/IXS7Of611IBgz2SAnWXq7jU+EyOQs8vrJLPlCE=",
-   "pom": "sha256-OwnxBF1mzdZ9aIA3eS53NkRbN9YXHv1slz6wRMbuQXA="
-  },
   "androidx/compose/runtime#runtime-saveable-desktop/1.11.2": {
    "jar": "sha256-saF+bCJt67Qsoif1gEWdnZ3qYtQqqOaF71bNfOdwsaE=",
    "module": "sha256-qRjbULEcx/dEJhf9My0a3Ut72bIqIOpMfYHfAeZNe1g=",
    "pom": "sha256-nUKDfFDNQ3n/5QKT55cT1APh4+73w4HEES6XX24TtDk="
   },
-  "androidx/compose/runtime#runtime-saveable/1.11.0-rc01": {
-   "jar": "sha256-16wwfVhrLKq/C97ElJohyPSaZT+miOZi2fSn6y2UdW4=",
-   "module": "sha256-fHZc5oTwYER/CkeFgB4Nz0GWATkAAx7a4VQKGJ/SvhQ=",
-   "pom": "sha256-vl2THwygv0IJwVJODwJ81FXvFZe8l/U6tSGe4Sam2JU="
+  "androidx/compose/runtime#runtime-saveable-desktop/1.7.0": {
+   "module": "sha256-F0NzXaQOObNqKsFZOhDp04Xo7sgUKmenKny0serpvaI=",
+   "pom": "sha256-lSqr8EI0DvOl8TNOUy/4vcQYOa/TjP9MzHRmTLo7H7M="
   },
   "androidx/compose/runtime#runtime-saveable/1.11.2": {
    "jar": "sha256-16wwfVhrLKq/C97ElJohyPSaZT+miOZi2fSn6y2UdW4=",
@@ -309,11 +300,6 @@
   "androidx/compose/runtime#runtime-saveable/1.7.0": {
    "module": "sha256-V096AtKqST7Zo0pfOFZyJm6XS77qNQMnRU6gCL3S7Zc=",
    "pom": "sha256-UG3TGS4UUkxsHClvNFl7hGoyZPqtF820AuHszCJNDko="
-  },
-  "androidx/compose/runtime#runtime/1.11.0-rc01": {
-   "jar": "sha256-iOf2l5HyKyfudkmfYMltbJ335UGYVnwgqjlW8J5Lti0=",
-   "module": "sha256-9qoW/UKCWGMRau0MFAqIPj7KRSjihhCRTnqhFCIaMXE=",
-   "pom": "sha256-kQ9SBuUzbh/ekzZH/n/oxA/uWZ8CO47JZtfoxSzgWFg="
   },
   "androidx/compose/runtime#runtime/1.11.2": {
    "jar": "sha256-EjyO2UUlDPUP+610tYV8s32u9aU/hTeHC1VFJbNkExw=",
@@ -412,6 +398,10 @@
    "module": "sha256-7WT/sFlotqW6seWh5QqwPVnHzb1GLvbS7AMRBecupmA=",
    "pom": "sha256-Twps2Hz8SXdQmdKc+OV+I+vEemKhiHvZqyeuk4+cUUw="
   },
+  "androidx/compose/ui#ui/1.7.0": {
+   "module": "sha256-x/4OGf9OogH/3N5WN7CCJbhFYQvdbagbhtvV96v7TZw=",
+   "pom": "sha256-KRexUTV7WWioZ7BQIhTp4SYdi1u9AWiFwGczSSugtsw="
+  },
   "androidx/compose/ui/ui-android/1.11.2/ui-android-1.11.2": {
    "aar": "sha256-oNf5MK8sp3XOXg5VyD8oo2w7mzXuBHUZDD/wYvaWJXI="
   },
@@ -456,10 +446,6 @@
    "module": "sha256-d2OaCwUeIlELrZOv/OoOvXge8SS/m3YhqVdJk3vPzf0=",
    "pom": "sha256-dIo0610T0Z0Yet7K6oJmf97V8bC5imVeE+0uSos9iuY="
   },
-  "androidx/core#core-ktx/1.13.0": {
-   "module": "sha256-o+agaS4F/VnmrDgHFe1ysyXGJaNidkbGnRCL3N3EJg8=",
-   "pom": "sha256-fPbU+y9hq0kkIyuS1lgLZd+RA8BDfNrmDOFDiMNzEhA="
-  },
   "androidx/core#core-ktx/1.13.1": {
    "module": "sha256-q1MLBOL75zIFSEiZo75WyQlohz60lvxS5ep1ltkQNdE=",
    "pom": "sha256-Mcw0W4xs3SBG3PZ4ct+KjLT0TqDK3k34AALKp+O3GAk="
@@ -468,13 +454,17 @@
    "module": "sha256-ifuSyhJ1lM3NEcXvtasOjrI0ZrxBuN91eVFNL+9uEoE=",
    "pom": "sha256-RmDPtgbtiYKLo+EPebKYCf+2d+5dI0b+m8sD38S5tkU="
   },
+  "androidx/core#core-ktx/1.19.0": {
+   "module": "sha256-tGJE6PW4T63vmkx6Azr2QINtpSzRtuGfvaWPKL4Tg/k=",
+   "pom": "sha256-uP4VaKHLRiyZxmDOuvgDSMLdGIEFS+XZZZwaJYnMO6g="
+  },
+  "androidx/core#core-splashscreen/1.2.0": {
+   "module": "sha256-HIgQZAbN+mnTsNvWnlrvTDdqQFmZyOjbvq0scoH0q7I=",
+   "pom": "sha256-NRxJ+mBwKhY1dJ3B0kxsAkUK+HT7Z4UsvbCt4Gvqxmo="
+  },
   "androidx/core#core-viewtree/1.0.0": {
    "module": "sha256-EThs+kbLv922pAWfFDVMAGkc9l09Y8NhiBioMybvPH8=",
    "pom": "sha256-1PLtEXb6jFYSuA90yVKoeZFCqe02AioaI4/eWxQFgNk="
-  },
-  "androidx/core#core/1.13.0": {
-   "module": "sha256-Lg5uXBIFt0YqDFw+MrWMLlJUNYEu2JlGx75nN0k7UeM=",
-   "pom": "sha256-RQLk7YtZEiAhrJocExLiMm5LD0P37Lu8m1Dud0KVdNQ="
   },
   "androidx/core#core/1.13.1": {
    "module": "sha256-KhCXm7s7zXslt/Zkq06bAW+r8hdKJnaLZ34S5L6kx8Q=",
@@ -484,20 +474,31 @@
    "module": "sha256-SrSjsLwWZOOixg3saZr2NXeOFcbuNzlxaQlI8HPdch4=",
    "pom": "sha256-B0l0oVUCIa96qF3taQPD2Eyb3t+ea0/zsMtHEym1rHc="
   },
-  "androidx/core/core-ktx/1.13.0/core-ktx-1.13.0": {
-   "aar": "sha256-WcVOYSnpJhxtgQ+O6kpu4vSZTYFisc2fyIychMkqzPw="
+  "androidx/core#core/1.19.0": {
+   "module": "sha256-VKTkVvP3EQ6Ro9MBlsrdmKdHhpFnn11j8sQCOkjS7GE=",
+   "pom": "sha256-Gpn+aQd17Q6EeI1YlfSlVmRHkXZzfKCYYzYxns/OhTg="
+  },
+  "androidx/core#core/1.6.0": {
+   "module": "sha256-g0jitcDH4oM3C4UDfOyLMrSsq41zp6UyNaNyRGsTh8g=",
+   "pom": "sha256-MglHXj3eLNDcxghAQw9RwZzPLAjGVuEj1sxQxkb6Zug="
   },
   "androidx/core/core-ktx/1.16.0/core-ktx-1.16.0": {
    "aar": "sha256-F2bb2C9koS3NNZ7LbxXzzzXbTWbSKWGnxRsv/GRoMUw="
   },
+  "androidx/core/core-ktx/1.19.0/core-ktx-1.19.0": {
+   "aar": "sha256-2xriSxXDY1itRkl9VhsZwyVkJWVDLVZHnr5H7juqDX4="
+  },
+  "androidx/core/core-splashscreen/1.2.0/core-splashscreen-1.2.0": {
+   "aar": "sha256-Ws6GXE634PJDaXkNLHbt2v0Nux6+oyiPVcGNlgXqDuA="
+  },
   "androidx/core/core-viewtree/1.0.0/core-viewtree-1.0.0": {
    "aar": "sha256-3BtnjVjrzyv6FYe+aP+CZpTOPSISUbnvMNTUs2KX5t4="
   },
-  "androidx/core/core/1.13.0/core-1.13.0": {
-   "aar": "sha256-G5bI6xDEtAKD/dbpqnT//wX65PFdVPYbpp1Rf80URpU="
-  },
   "androidx/core/core/1.16.0/core-1.16.0": {
    "aar": "sha256-a/A9OdvjdErM4ifTtpc3TDYlquECX77IrZ/XvVi85DE="
+  },
+  "androidx/core/core/1.19.0/core-1.19.0": {
+   "aar": "sha256-VURa0P8CWWOSmJJWmgv8a0xo5g2LfJZdz/ugkEjDbI4="
   },
   "androidx/customview#customview-poolingcontainer/1.0.0": {
    "module": "sha256-kDA01RUt0uAWKxRo6iWiLhyjhABrPSgtWhQ8x2AyGgE=",
@@ -506,13 +507,13 @@
   "androidx/customview/customview-poolingcontainer/1.0.0/customview-poolingcontainer-1.0.0": {
    "aar": "sha256-NYQQL8Sb85nFbjt75L/hIADEYRIyDNjPhcwKj5Pz51I="
   },
-  "androidx/databinding#databinding-common/8.13.2": {
-   "jar": "sha256-Zsq4JjnawPbCQzRkwJOwdNYIxLuIfsOKm4vErJgSZzI=",
-   "pom": "sha256-HRsskeiTEHht7ncOkSby+iDtEuPmF+Q5yiif9d85E7E="
+  "androidx/databinding#databinding-common/9.3.1": {
+   "jar": "sha256-goFjgqKp3sTwqxfHnO8IqeT+S5fYlqwg1/IVtt14ixg=",
+   "pom": "sha256-qdQ1bgKqKskFwFQOT1EHUDY/Ah4EN6QVTDO2ox5sXis="
   },
-  "androidx/databinding#databinding-compiler-common/8.13.2": {
-   "jar": "sha256-osP/8MOaxyxMIcQVAXBmwmPv4XDYrrnTOaPsp8DXnx4=",
-   "pom": "sha256-b+dyhf/5yqYWJqP8b/Y1JUj4GQosdDS+kh7P70a+o+s="
+  "androidx/databinding#databinding-compiler-common/9.3.1": {
+   "jar": "sha256-j0LeOrbWyuH7U6FNM5bEmwHWpEkhznDP0WQXe65e07g=",
+   "pom": "sha256-ceJN+kTdsGtpuytUGR9PNm8VmfmJVnDcgseNisQcbnU="
   },
   "androidx/datastore#datastore-core-android/1.2.1": {
    "module": "sha256-bQdjAukJZcxR2STEtnplqfqRvd59EHvFeco6IhVQhtU=",
@@ -621,33 +622,25 @@
   "androidx/legacy/legacy-support-core-utils/1.0.0/legacy-support-core-utils-1.0.0": {
    "aar": "sha256-p+3PAdW1KzA0BzAnvEd1t4pHZLtiAruR1hyCmt2N0cc="
   },
-  "androidx/lifecycle#lifecycle-common-java8/2.10.0": {
-   "jar": "sha256-SX3YTeny/UYyTyX5o68DLToj0IfoevUVxLGUNfbWplE=",
-   "module": "sha256-RTKPdawHejY4HcU9aMBSiLoZgTfKvEH91NJNxEfu3bo=",
-   "pom": "sha256-r6pdhRk6axCKJfb6iorj57KwsrK3z1NZf3K8tPWUJxg="
+  "androidx/lifecycle#lifecycle-common-java8/2.11.0": {
+   "jar": "sha256-iV5xZ5zTGduBQGZNZQr2aVsFMPWJa+m47MzSTMT2Z08=",
+   "module": "sha256-HIw/yEDkxWVWi6pXuohq7l7Yad8xYzWwVtks27yEr28=",
+   "pom": "sha256-PQL0CviNuhYdS+QH7QdyPXExrEZBk//gXJa8nLcukDQ="
   },
-  "androidx/lifecycle#lifecycle-common-java8/2.6.1": {
-   "module": "sha256-G+sLn/+2MKAF3sodNYPSrL7IaF1t6AmjpuDkM/QYtsM=",
-   "pom": "sha256-HeG0opB9T5Oym6QzmvRluaJOHA/2p0ks8d/N+AJdRew="
-  },
-  "androidx/lifecycle#lifecycle-common-jvm/2.10.0": {
-   "jar": "sha256-FZQwgth7zXiDA5j6N38sixJkPeKQ0JBu2OSaLTNd21Q=",
-   "module": "sha256-k9kBazr9A2OaQH9RoRnVyk2umI3jdsOA8OUd2diOaG0=",
-   "pom": "sha256-ygYrmrsCmLDUCuEMLRygbUEp9fYO/cXoxExsKzN10Vs="
+  "androidx/lifecycle#lifecycle-common-jvm/2.11.0": {
+   "jar": "sha256-5qZuZ7n2Og+2NE8WXB2HI3bl/m0jW/+xOK9FEiz0Uqk=",
+   "module": "sha256-yUd9Z4TI3LmS8aF3Tdld8x8+EB5dHpy3sBqv85JKGUI=",
+   "pom": "sha256-QhkY4B3YUIsMN2IHqemBWe93/tEesdkJgpQ0TtZ3UMc="
   },
   "androidx/lifecycle#lifecycle-common-jvm/2.9.4": {
    "jar": "sha256-N9ibIQHwdKxsJgkX2rsYVgdkXuIAqjAYx8W95w7c8YQ=",
    "module": "sha256-HRg385QrM+owqiMB/c6iY5QIoP1v1DaMIkePqBU6678=",
    "pom": "sha256-MXNemVOq7qtOB/z/pMarNRn5CzMcSx2oFz35EWB9OQY="
   },
-  "androidx/lifecycle#lifecycle-common/2.10.0": {
-   "jar": "sha256-nTqZgAlbdp3rTzKPfzJUObGIFHEk1m3ELt1V4+e+6jc=",
-   "module": "sha256-XRJHse373J3e3L5SXJ0mKVZ7HFOMt6nGIM0EShJLXHM=",
-   "pom": "sha256-EAT03wURixPCqQmEa63GZkbtJ3lEcGpgTk3YKE1TVIs="
-  },
-  "androidx/lifecycle#lifecycle-common/2.6.1": {
-   "module": "sha256-k3R6kUXLNrxxAF9Zjt4y4rEUmt5aFuYrDklpNFvGLYU=",
-   "pom": "sha256-PmaDDVn65S4QMLS+ckseV3rIFNJzNf34GnEoPcCCnxo="
+  "androidx/lifecycle#lifecycle-common/2.11.0": {
+   "jar": "sha256-qb0prIZneYdQGrfQI2CXNK4Hpn3gsTkOFYwaqJ7rPrI=",
+   "module": "sha256-Wz20MsYajxZoAj0K6z4svD7zN+XaItua+xC3UT0dTlo=",
+   "pom": "sha256-ErcKLUQ4P5diQwfG2aP/hugmV7uOwwC5VUG6SBc+26w="
   },
   "androidx/lifecycle#lifecycle-common/2.6.2": {
    "module": "sha256-D6fyj1z/ikBqT3hwskPLDW16fCD6p6K+yv9ZB64S+cw=",
@@ -662,33 +655,33 @@
    "module": "sha256-xXi9dV6kbXp3gRMJo1OVOOLX+4agX8KtgcZV7Pff96Q=",
    "pom": "sha256-DjoMh5jSb0kjhVCj3E1r1GXUm4K8t1nKPEY6MWAOchw="
   },
-  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.10.0": {
-   "module": "sha256-KyigMgHzB3sq4+KFP5g5RK/fUYsCk5rPyf6eX8q4cnU=",
-   "pom": "sha256-2YIILDJ57rnBh9mJdmXKmpDTRD812txokmH0snxy2aw="
+  "androidx/lifecycle#lifecycle-livedata-core-ktx/2.11.0": {
+   "module": "sha256-tmy0E6yc3oEcm5bk0rPU/y70AyNhh7PbM/5PHajpX80=",
+   "pom": "sha256-z12GURguQ2dZaOS/9bAYp7XZrXXXd97VlP/HwtjAlIo="
   },
   "androidx/lifecycle#lifecycle-livedata-core-ktx/2.9.4": {
    "module": "sha256-CpQOeeJWzH++xp2Os1NirHlZmrSyGrSEarpkuklgoZI=",
    "pom": "sha256-yiBzrEbTZBB/302DLFtynmEM3H0S5zbZFRtaURm+gLk="
   },
-  "androidx/lifecycle#lifecycle-livedata-core/2.10.0": {
-   "module": "sha256-HYO9XzzMEpjtolue0SjowYf4MOfzr40ClL5oirsDw10=",
-   "pom": "sha256-S+1ekc0qfAFVgyC2oXbbuGf8o8TGl9uUjiA75F+RDWQ="
+  "androidx/lifecycle#lifecycle-livedata-core/2.11.0": {
+   "module": "sha256-0cFBDIzpzxRjYWwZyn2K/KY7y7rJ2r0p2jEh1hvUE0M=",
+   "pom": "sha256-vtvowiMPIHx7J8FaZ/qFr/ffaBsUWkX9T9nWzO2vstQ="
   },
   "androidx/lifecycle#lifecycle-livedata-core/2.9.4": {
    "module": "sha256-3uYGVquxlNoCjZO5vWUrSxZM2rNaAAtHXWMwPF0AmUs=",
    "pom": "sha256-zsEWEUjj9sS31ROqmJcp6EqO6UcfDEfANHiz+zxJ6iE="
   },
-  "androidx/lifecycle#lifecycle-livedata/2.10.0": {
-   "module": "sha256-Om1HOzEEyYNQHeSIPWunaE3IMzDEYO+Vg5CoJlsHgxA=",
-   "pom": "sha256-trk2hsVaHKjsIOfYSl/jQSZ+XaxuOQ+xzKOYODER6wg="
+  "androidx/lifecycle#lifecycle-livedata/2.11.0": {
+   "module": "sha256-2ZC8kgrkNynXAtgAdzKOill4HqWjWyTAK8R9MmrnPX0=",
+   "pom": "sha256-7Ef66h0vaGJaxJrSYPX1Iz2bQNqSIlO1eqFT1JtfXKg="
   },
   "androidx/lifecycle#lifecycle-livedata/2.9.4": {
    "module": "sha256-moFToHri7di3kZo0rZGVhHAF6u1p+j5QYGNiCKcowxI=",
    "pom": "sha256-JPi5RFSZEqtoOqcOYdMrXhqoPC8fnULwno7aMjd2CrE="
   },
-  "androidx/lifecycle#lifecycle-process/2.10.0": {
-   "module": "sha256-xorsfMHQ0Z9RMo59KMkdz7SsjhqYQ8/WGB4aqUrhnJs=",
-   "pom": "sha256-osMGIyCHP5rCne0dnKSiQVUpwuRWjVO18rgT7FKtxmQ="
+  "androidx/lifecycle#lifecycle-process/2.11.0": {
+   "module": "sha256-fZ161HM3CmFH2fybHRxq8UtVpHSElIPll0lAvfi1L90=",
+   "pom": "sha256-Y/MwPLDw7OQk/tq6Vc05hOREIufdUHHevKSkQjIWxCA="
   },
   "androidx/lifecycle#lifecycle-process/2.4.1": {
    "module": "sha256-46rj7QS0dE/zFFLpj9KZ4639KNO1cjZh2WeLkvoJzrQ=",
@@ -702,64 +695,63 @@
    "module": "sha256-981QUbrLP0uOx9xArGNCph7qEUdZLdqfNkokz4gsfds=",
    "pom": "sha256-XqxaCicThHf0Dwqg50nNB/v1WA1KmtxtLVnbZMrEmxA="
   },
-  "androidx/lifecycle#lifecycle-runtime-android/2.10.0": {
-   "module": "sha256-dJtuekQikUWB4HldnUj7T5bao/7pd0dCH/QjSGAYX0c=",
-   "pom": "sha256-6X7gHa9vTcy5AL23Zyuqta08fCXEVJH9zPXroztur/8="
+  "androidx/lifecycle#lifecycle-runtime-android/2.11.0": {
+   "module": "sha256-Jdepuuty+9umV1aGWpAMN6YUbls/g1xE/ASTsVvRkoY=",
+   "pom": "sha256-Hf0fc51xlXFmoFEab7LL/I2nZsGEDVZkBjiY7W2siqY="
   },
   "androidx/lifecycle#lifecycle-runtime-android/2.9.4": {
    "module": "sha256-x4iOhQxA/QWfssHsW/RuiDE+m11RUhM8OFoar7hDP0c=",
    "pom": "sha256-Jx5UAJ/fOizVq0FOignmr0JRtj1ISkLFMKuGiXSl6h8="
   },
-  "androidx/lifecycle#lifecycle-runtime-compose-android/2.10.0": {
-   "module": "sha256-pZT365OTD+9SwsuxlPj0GyWQZ5+eZq7DNZVMRRosCPg=",
-   "pom": "sha256-gHgw76JxMGSShrAGHJcq2dwLGmHRv8LXGi6N33H2K8U="
+  "androidx/lifecycle#lifecycle-runtime-compose-android/2.11.0": {
+   "module": "sha256-UM7jgRLjFA4JNeh4Zztselo9FTLxwMr42r+NlbHzJSU=",
+   "pom": "sha256-AGhysT6XmiYsFbQOFCLq686QurJAsaCKyf1/YCD8yo4="
   },
   "androidx/lifecycle#lifecycle-runtime-compose-android/2.9.4": {
    "module": "sha256-4Ieiwr3+NgSXM5M1ulHbzdFQPAp8n0+ChdtwI+BClDk=",
    "pom": "sha256-p6Bzx9sQl0Ynuog/ZIo0/oBT9QwpTZGS4YPJAdrqjGU="
   },
-  "androidx/lifecycle#lifecycle-runtime-compose-desktop/2.10.0": {
-   "jar": "sha256-TSM+7sxuJ2mnZEKDDF/RiEBXw20M4nRRZxk6EMyJdvg=",
-   "module": "sha256-JXsLxt9zrYYOazeLlIkIZ5ZMdDDanIhKZfZnz+XL3BA=",
-   "pom": "sha256-DVXZUfjn5VGIMZwhP4lx37pZ2Re2ZYhSe5ZUcCc7u1Y="
+  "androidx/lifecycle#lifecycle-runtime-compose-desktop/2.11.0": {
+   "jar": "sha256-1TNnU+pNWIHM+4sGE+A06yQfDYtDSVNt8c0OyGz2NmQ=",
+   "module": "sha256-mU/EMdP9YnKLnOyNs9Mi/6jbnwIoa93sbIe5/OnqaOU=",
+   "pom": "sha256-01v6FXK6nKSxkpgT8oLd+70t8H4mCBb3iWc5/VCAlcw="
   },
   "androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.4": {
    "jar": "sha256-0lwIPfk9pxihh2oyk70V99x6gR6ZhzWUO85ZBoOleDU=",
    "module": "sha256-xANG1Q0gglWZKxsFPINcljYxhBtw34tvxp8kUpmI3MU=",
    "pom": "sha256-EHpGt+Pp/+28BWd4Ler5/3ZztYgdDFX72Bsv49r9CHQ="
   },
-  "androidx/lifecycle#lifecycle-runtime-compose/2.10.0": {
-   "jar": "sha256-wFuz86yHG28cdomAuFGtBWRZ8pKuxV7HbOzHF4GB7fc=",
-   "module": "sha256-YyuoWyQ6BAT28zrW58mW97qaQvN32whHNK56MY6qbsg=",
-   "pom": "sha256-D3kM4VGREBDVN80gRSZ1AX/yX9/x+1zfSZvzoFrULKo="
+  "androidx/lifecycle#lifecycle-runtime-compose/2.11.0": {
+   "jar": "sha256-BFk4v/aAM3z/UEgcr32WQx7xzp8vOOFkeRADkjuIDOo=",
+   "module": "sha256-eBYwlxttY/Xe7YRv6YcBuUbLX9xmDX44lMYsdjKnMqI=",
+   "pom": "sha256-K9uH/7HYARDRFUtugntBhyaGYUQG2SDHoQE1vriBeWA="
   },
   "androidx/lifecycle#lifecycle-runtime-compose/2.9.4": {
    "jar": "sha256-iDVBasWaI/cVLrDyF72rdCo3fphUYjB2OcErr8FAjkE=",
    "module": "sha256-J9hk9AyjC5Z7hdqsa5F7va6mN9Y+EjlIyVBFwhvlhIM=",
    "pom": "sha256-DvP7KPibgLkMeK1ro0UWTVWQiJ7jRZsCfyZpWTYpFXU="
   },
-  "androidx/lifecycle#lifecycle-runtime-desktop/2.10.0": {
-   "jar": "sha256-b3C3b7eiYvR7mTF8IyccKKia0YQAVHtL/vvS7wRQD5A=",
-   "module": "sha256-Lu74CEz2cSnhmSJ6P6us+FBvV/ruywqrD3ZdXE5ZBAo=",
-   "pom": "sha256-SQEy3ZcZUnyYf6pBMkaax+QcJXub5DU/Kc2rFcVS568="
+  "androidx/lifecycle#lifecycle-runtime-desktop/2.11.0": {
+   "jar": "sha256-CfdaSo12PO5davNvQiE5oCBdP23y4sUojK5Cg28LNuo=",
+   "module": "sha256-qHslfdJ9Aros6DOWwSaEaeyft4ZuFHKFYXKYiI42y3o=",
+   "pom": "sha256-lBWWnZsu0zrgOGUC806P7h1bnT661SdL2vwyEx38gNs="
   },
   "androidx/lifecycle#lifecycle-runtime-desktop/2.9.4": {
    "jar": "sha256-L7SfdtECF5L7NZ4KkkbBUJ8vW1VfCkZZHSTVjetovVw=",
    "module": "sha256-+VLq6Qa8BiePYEGvs8EzPp1rAL5DeIV7zWahulg2eQk=",
    "pom": "sha256-+yriSTRTAzy/Kzp0qh36Z8/bwYmlTRkJg9/RVQLQtuc="
   },
-  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.10.0": {
-   "module": "sha256-mAob4UbK+harOxaAmR3eFLIHeksT1bMUJ8uY3Ikw8ks=",
-   "pom": "sha256-XBomndDwrOh/IoMog7iYvXtCUtaofwTBc0fYPjEoZg4="
+  "androidx/lifecycle#lifecycle-runtime-ktx-android/2.11.0": {
+   "module": "sha256-LnVqCE6SjzZ7ItzLifd11VYv9jTUucTl5UFangD4rM0=",
+   "pom": "sha256-peWYg49c4xTP87e1zU7VMRmuejB6UamlGf758f6V1X8="
   },
   "androidx/lifecycle#lifecycle-runtime-ktx-android/2.9.4": {
    "module": "sha256-aiBw6dkkO9O11aEIudtVg7zEx0KzLvtF/jP0lCnrcZM=",
    "pom": "sha256-eKrOefvO2OuMF+CwKy1VvpkG+92gU+amF+5uWV/KzhQ="
   },
-  "androidx/lifecycle#lifecycle-runtime-ktx/2.10.0": {
-   "jar": "sha256-XXTR6cRdU4qvxIsjE+WY7/m0oTv+6fLz13b1J01c3iI=",
-   "module": "sha256-VW8VlXN2hYtuOrwI+z31ZupetAZxSSUxlL8qBJYG204=",
-   "pom": "sha256-BgrRdTOB56+deluJgp85Tvb9R/d+MbpMgSRivDe9phg="
+  "androidx/lifecycle#lifecycle-runtime-ktx/2.11.0": {
+   "module": "sha256-u2ujFQUJaUGpiMxp99SQUUYpzUXLXaKc2nmpveS83OU=",
+   "pom": "sha256-i46wEeSliHOCNAb7RSIOUPOQWPyav7LAgGc1r2Xt95o="
   },
   "androidx/lifecycle#lifecycle-runtime-ktx/2.6.1": {
    "module": "sha256-OYVPMsmwEPZS9OUEHKTOBpgdy2lUEowejhzALmOrGF8=",
@@ -773,14 +765,10 @@
    "module": "sha256-BeV4jgAF06oz4tZaXctRvasGCUolTBNbggMW1kkxq8c=",
    "pom": "sha256-CvaMzSgqP5jYMvORtmVQmNR28Z2R9A+QnTxpWBShHKs="
   },
-  "androidx/lifecycle#lifecycle-runtime/2.10.0": {
-   "jar": "sha256-2UTSBKRQ7QGjLv/M+0gyv51kYAkLcXqIoBM4HSBKtjk=",
-   "module": "sha256-2oBfoBekrM4T9QFGmnWj8wYkjuvFj1vMKAGbABXfumU=",
-   "pom": "sha256-Sote7FTV7N8JnqU7Lk6fJNspZ+pdOTCXtqbFSe1pMI0="
-  },
-  "androidx/lifecycle#lifecycle-runtime/2.6.1": {
-   "module": "sha256-pMuwGkLQcEe9jYcAF8lqGwt7RnMyDoa2YxehO+LsEMc=",
-   "pom": "sha256-QecdAD1DfxadToraWcsZgvG0e30lwjAQuPyB1SinQNU="
+  "androidx/lifecycle#lifecycle-runtime/2.11.0": {
+   "jar": "sha256-fySFJRJtwLpW47DaolSp0snWbOXS97p0qB+GKSBgHpM=",
+   "module": "sha256-XPHBXOH9kym473VRfDCeOquWe9eF2WrhAMPZyJBuMX4=",
+   "pom": "sha256-yATnL3eV4XtEq35L6Vzrf8IsGaB4GOKfijFO9Dz4d2k="
   },
   "androidx/lifecycle#lifecycle-runtime/2.6.2": {
    "module": "sha256-6gExhGq+H+nepZrG3+Hw+52LbWAMnv+aH9StXuXny8c=",
@@ -791,39 +779,41 @@
    "module": "sha256-3LxbW1BmboQlinS/2OUUkYxZOk/87wwDWFYqAvvYDFg=",
    "pom": "sha256-1helGd2zajCCE/W5r5kWOwo6NznOA4G2yND6aBRhOgg="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-android/2.10.0": {
-   "module": "sha256-BrB6B64Xx1kqMMUzw9RqEl/LG+8JbX5hNOJCDbJGTQo=",
-   "pom": "sha256-CqFxpQ9QqFyQaHrYLc038xr90b/SRjwhXRMilg5R4ig="
+  "androidx/lifecycle#lifecycle-viewmodel-android/2.11.0": {
+   "module": "sha256-ZGgT9MULxfGYu5aibxrM8xnaCdCcC/+/Nejc8hc9g5M=",
+   "pom": "sha256-xteHQcQ8zxDV2l8OBA3t//2iC5dIyqA43Fi+JdNckKM="
   },
   "androidx/lifecycle#lifecycle-viewmodel-android/2.9.4": {
    "module": "sha256-tjes3YqrU0iXRmGDCHSnRWusNB9DoLKBgnzGsPz8c8E=",
    "pom": "sha256-lmC1otgP/g8OW0+ZO1gdFZcqjBSq5ReEtgl7yXvgN54="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-compose-android/2.10.0": {
-   "module": "sha256-VSolTWLF2aqDC9edophyCCUeHIGv2Tw8K/+wJtQvRco=",
-   "pom": "sha256-NjOHpx8PMSUXUUvs2aQB7IWJ+8uNCTShysPF8F6wDIo="
+  "androidx/lifecycle#lifecycle-viewmodel-compose-android/2.11.0": {
+   "module": "sha256-oWO+5IuKCFb8aiXp3qxlHm1Cdyms2zXD2O/cHsDBaDw=",
+   "pom": "sha256-NQ2vSISUT08Mgu3T5m6hlTQrz/1JRWiQV6X62pzXn0w="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-compose/2.10.0": {
-   "module": "sha256-J8EDbQHMgtAUKwTg1NfbPJkQBHKlkr6vdYvC6GWfLuc=",
-   "pom": "sha256-SAtwtmyTWh9JJ0LvWuFt+XTXtJV6AR8nlQAgctXtUlk="
+  "androidx/lifecycle#lifecycle-viewmodel-compose-desktop/2.11.0": {
+   "jar": "sha256-G0xYElx7NpNET0DIq3aIHRf6dHJoYMJIcqPew+D600s=",
+   "module": "sha256-lVGofsYwSTAkjZV4/Q3aynK6123kZ0hAWGajToJ6EsQ=",
+   "pom": "sha256-plerhFij/3kbnpWMaV587OSLRNBL/GB63o7Lfjng2AA="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-desktop/2.10.0": {
-   "jar": "sha256-58hqXlxm/UH9PMnJrTGimXEQsaY4DEQbo/e2sLBw4ys=",
-   "module": "sha256-zaMZ18njJgKFmnK+gcACblbReX75umfpFz6QXT90d08=",
-   "pom": "sha256-z5W8pQ/AIStIWGre/gQ9VF+B+/YeNF8LeR6tlrLnNuE="
+  "androidx/lifecycle#lifecycle-viewmodel-compose/2.11.0": {
+   "jar": "sha256-srDoYppTvNkwi2ScNP4RO5AC8a6FLp97mYcxTaOb6SQ=",
+   "module": "sha256-mXsqODMYP5TmATrUCYL89efIYA4QcJlPMwZFRipUbBg=",
+   "pom": "sha256-0NACyd6pQ/T84Le8sL0ncPuA2wVL51wz5YF/Pm+4hOo="
+  },
+  "androidx/lifecycle#lifecycle-viewmodel-desktop/2.11.0": {
+   "jar": "sha256-F1w0kmbMu2ogNmFXJbcGbuPzMZZlyYr0IgarOlgqQ8M=",
+   "module": "sha256-89wO7hdOKXAHGaQDgz2t+7jn36k9yHQjXgCPOG0ollk=",
+   "pom": "sha256-Tpgo0jp2H/l4HOwNM40yAF8S5Y3V5FAdhP0OJzgTFnA="
   },
   "androidx/lifecycle#lifecycle-viewmodel-desktop/2.9.4": {
    "jar": "sha256-mPgWvmhpQHyH1GBYdW+XeA+mxs9hrNupchb0E3Ma8V0=",
    "module": "sha256-73aG2pDJWnP0A+vKyHzwbNdR5JGecf4gqRFFm8tIT1s=",
    "pom": "sha256-sLwaHSilS9d4oSYQRI0o/tYDh3gfHNWa+r40sdA0XSs="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.10.0": {
-   "module": "sha256-g3v92Eju/vd1RPoonb/0xChoDdmCBkHq24Qcx6dMg/k=",
-   "pom": "sha256-4TnbsaAM4Iqu2GVXqpaO7HFR1tSzBMMk4uVyJ1qs2Qg="
-  },
-  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.6.1": {
-   "module": "sha256-pREPhXiLwWffn+j74IAE3cXF3ZsVy3N2zurvAl/Mqvg=",
-   "pom": "sha256-D0XiJCYK980beeN8VfnSPf+U/UExbtn2ACU/rM/0wc8="
+  "androidx/lifecycle#lifecycle-viewmodel-ktx/2.11.0": {
+   "module": "sha256-KzWhOBOXYUrRPPMByzaFoVvk1Q0VhDduflQYAQvUCW0=",
+   "pom": "sha256-mM7kAGI0QGPu8/cfnWYDLWnmMEughYVh/II9c8YbY7Q="
   },
   "androidx/lifecycle#lifecycle-viewmodel-ktx/2.9.2": {
    "module": "sha256-y4SLtnJXBWOSmoa6bINhgfSoqIQrE4+mdo6+AS9YJeY=",
@@ -833,112 +823,108 @@
    "module": "sha256-VjHv6reX95oa26XfZLLwzKVOCLQodW33YwyyO5AJimc=",
    "pom": "sha256-DM0OnTYa1ptqclOrTtISSjvU+/mzOONsFDGzxe57x5Q="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.10.0": {
-   "module": "sha256-lJ0qhitrWEzuka9wqeAXvbEX0iW7RgltqUJKFyjKeek=",
-   "pom": "sha256-X81Cm6V+Hd4bQ4U05Twj1idNI04zx0iWP2+qn4GTPIc="
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.11.0": {
+   "module": "sha256-Q1HpHBOx5igsrpJCdnmeDv26Z7gB8SFCR5lk4Lm59+4=",
+   "pom": "sha256-ZY0ya2agdozNNd+Fx0h0lFacY5UeCQw6GwGbl7uKARA="
   },
   "androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.9.4": {
    "module": "sha256-v2TEw89a1f5db9Dgd4fsaAVMwib59nDgWvXvnaZ8JZM=",
    "pom": "sha256-NKuEkea2MRI85ffwrgbfojjCEdzz5xAz7WFlb51HcYw="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.10.0": {
-   "jar": "sha256-kpRFl4QqaXYj0HRtcZ2K86y59MeA2mEQYvpg2ZOUTSw=",
-   "module": "sha256-Wbc2f72Ct0pgUykaEnQ8rAws8f6WkpN4xR2Cv4/pqV0=",
-   "pom": "sha256-i2wwG0UvOIUsD9VRfFFDl2uwLDaSHb+F3TDYiz9gOAE="
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.11.0": {
+   "jar": "sha256-yiFyDOfzcMshyrtTKblZ7aYkEH7AYoLjvcklgpF7HSc=",
+   "module": "sha256-ln0f2kJkS1Xo+PWU3aKHBJ0TE8H9JDehZiVnaD9+jAc=",
+   "pom": "sha256-ecHtcIfoJLNfjz7NVpLOeG7KTQw9LI6UuvFPf84uiag="
   },
   "androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.9.4": {
    "jar": "sha256-PgtE4lFOr91pONVFfZ9G5HhQd8RdO0NktcI8TcuT79M=",
    "module": "sha256-Zz9dNS3D2hsaNY5aMO9+FjIZs6HXA27hjJNQxT8F8rE=",
    "pom": "sha256-MV7u84MhWBlbUY4+zOEEWkqSmexIP1YYh2BuVf9qHLk="
   },
-  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.10.0": {
-   "jar": "sha256-sYFE6RxHgLOwWUMlYFPX1NzMRbFTBm1fX/zhg5qgURs=",
-   "module": "sha256-UIV3gePd+OOZBeTkpXowSWwkX5kB0bfT8XOCOCGINH0=",
-   "pom": "sha256-WWVv/K4eDhRwQ7DW2JlmpflnUvBSkev6AoQG7ZRETdE="
+  "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.11.0": {
+   "jar": "sha256-6slgN7pqI0mCgVTT0snJKuDJTzd+suuT6ZdU86f44nk=",
+   "module": "sha256-3GdQppkb+qwIF0aYZf4sywHiYYagOGKZpdBWusLMcsw=",
+   "pom": "sha256-SFIf6vnWMXQ8sHwTjnfDT59/YhgE5/TpFip/teKM1Oo="
   },
   "androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.4": {
    "jar": "sha256-wMw+Mfw1hIbZbwJw3+Kw9E+YXwyrDvp3OipWfVX3YaU=",
    "module": "sha256-Q4nMoKmoAace/664j4nwoD2Zwivgk8U5qcD5w5YpVBY=",
    "pom": "sha256-aRK1XHRcV57G/L6wBl1aF9i18G3QpYeIA31B5A21AgI="
   },
-  "androidx/lifecycle#lifecycle-viewmodel/2.10.0": {
-   "jar": "sha256-UIvzKEdXFp/Ff0K4S+8LhTjJOvK9C+xbo+/pPUWlv3k=",
-   "module": "sha256-T9cd9zMkXEbkuI6FtKkLgsmvSjWe8x8r3yUPk6AsdFI=",
-   "pom": "sha256-HYYK/wylmNSOjoPaP05naQeEmFdKGNO4iewrjECQsZg="
-  },
-  "androidx/lifecycle#lifecycle-viewmodel/2.6.1": {
-   "module": "sha256-K0BvrqXBLyuN9LemCTH4RmSPLh9NeDYeGY0RhPGaR5c=",
-   "pom": "sha256-3C6OZdtT0hZZon7ZO5Zt7jNsHC6OhyhhZ3OJqZuLkTQ="
+  "androidx/lifecycle#lifecycle-viewmodel/2.11.0": {
+   "jar": "sha256-fLpKoc6KaeWlTNt2sua25b1jbXM7drgtIxMKQ22/p/Q=",
+   "module": "sha256-g5OqCT5+hIkC3ps8zAoSJpEGrG53PXX/l/l1QpXEkpg=",
+   "pom": "sha256-4i6g/KNu7T9kkSD9rc8dlvf5pH1YRyBZ0jSwzGLJ9XA="
   },
   "androidx/lifecycle#lifecycle-viewmodel/2.9.4": {
    "jar": "sha256-VBDN/cPyW8y1pNvYEhpdN2sTeQQc7Gsdol+ZZ8oJ8Bk=",
    "module": "sha256-lk1p1rh3KW6Lead7uCbvX7GGrsqnoaf/d2+yJQyZMAY=",
    "pom": "sha256-BU22+S2SMBA7OsqLDavMDWPeJuRA/5jrWxmiVV0+sDc="
   },
-  "androidx/lifecycle/lifecycle-livedata-core-ktx/2.10.0/lifecycle-livedata-core-ktx-2.10.0": {
-   "aar": "sha256-XxhCl0mhg+GReNhmWuQr97YxC1A1iung4MxFKv1uC8M="
+  "androidx/lifecycle/lifecycle-livedata-core-ktx/2.11.0/lifecycle-livedata-core-ktx-2.11.0": {
+   "aar": "sha256-QI+smbYafKnQYg9PJIkfhcFO4AfP0Cerw991mjGwCGo="
   },
   "androidx/lifecycle/lifecycle-livedata-core-ktx/2.9.4/lifecycle-livedata-core-ktx-2.9.4": {
    "aar": "sha256-9Vt6jUM+m4FjFUzKpC+ivlXHDNHt5e7qUhpLS4hN1P4="
   },
-  "androidx/lifecycle/lifecycle-livedata-core/2.10.0/lifecycle-livedata-core-2.10.0": {
-   "aar": "sha256-Et1hqYQ8zrtFR9Pr4vbQMMqPaYjSL4+tGcCvk7SpfpU="
+  "androidx/lifecycle/lifecycle-livedata-core/2.11.0/lifecycle-livedata-core-2.11.0": {
+   "aar": "sha256-ObJu8eCB/IjXBU/xpj0KXXGHY3PDOnEat4nIIo0CWtE="
   },
   "androidx/lifecycle/lifecycle-livedata-core/2.9.4/lifecycle-livedata-core-2.9.4": {
    "aar": "sha256-6oZvDDedH5KDeZQBCrWsCl1UmdurUh78cbO8K0l9a6Q="
   },
-  "androidx/lifecycle/lifecycle-livedata/2.10.0/lifecycle-livedata-2.10.0": {
-   "aar": "sha256-PowAn8iNocUuTtBagSadWsm9QFBG8wAwf146F+IBpt8="
+  "androidx/lifecycle/lifecycle-livedata/2.11.0/lifecycle-livedata-2.11.0": {
+   "aar": "sha256-G8KOQOBv9eBHi5J2ymKHzmmTQVtwkQdFrJFrFN7Jty8="
   },
   "androidx/lifecycle/lifecycle-livedata/2.9.4/lifecycle-livedata-2.9.4": {
    "aar": "sha256-8kDCyUqW1KXq5dN5wqhYnUJqM7mJ2Drp8OAfaVAsAYE="
   },
-  "androidx/lifecycle/lifecycle-process/2.10.0/lifecycle-process-2.10.0": {
-   "aar": "sha256-ELtbsSdz3KEdg0PAFM/RfftAln1uzjfo8V0E2M6wd1w="
+  "androidx/lifecycle/lifecycle-process/2.11.0/lifecycle-process-2.11.0": {
+   "aar": "sha256-l0Pwx7ryfTRJe36aHNSX2CYCUbAxJFB5Y6v6rWbD9VI="
   },
   "androidx/lifecycle/lifecycle-process/2.9.4/lifecycle-process-2.9.4": {
    "aar": "sha256-R4S40IPCEeB22RFb+hc39+D2K1U+gBz1DKpEAONKldY="
   },
-  "androidx/lifecycle/lifecycle-runtime-android/2.10.0/lifecycle-runtime-android-2.10.0": {
-   "aar": "sha256-IZOhVz1iPzeyDH0n0aj5A6cvZRzG8y5XlPhd2nRP7nU="
+  "androidx/lifecycle/lifecycle-runtime-android/2.11.0/lifecycle-runtime-android-2.11.0": {
+   "aar": "sha256-hxGGX402A7wF3swDu0Kqsvqo2LxVs7EqCo5Ra1YrYMo="
   },
   "androidx/lifecycle/lifecycle-runtime-android/2.9.4/lifecycle-runtime-android-2.9.4": {
    "aar": "sha256-hvFqEzDrI2ALqQ0DNLPh2zjTowyLHvzZLKIaqFr6gXM="
   },
-  "androidx/lifecycle/lifecycle-runtime-compose-android/2.10.0/lifecycle-runtime-compose-android-2.10.0": {
-   "aar": "sha256-RumW1SaClZb220YmFpqWfwVv3nEDUH/1lrzRd7c8NnU="
+  "androidx/lifecycle/lifecycle-runtime-compose-android/2.11.0/lifecycle-runtime-compose-android-2.11.0": {
+   "aar": "sha256-ezFInm4WIUPEgfFOGuWk3AifjsWOZZdqBQK5EMZBmH8="
   },
   "androidx/lifecycle/lifecycle-runtime-compose-android/2.9.4/lifecycle-runtime-compose-android-2.9.4": {
    "aar": "sha256-toA/kGqJ/YXHffND3Urus0kSXKeeEtVdaNTPQvQiMfY="
   },
-  "androidx/lifecycle/lifecycle-runtime-ktx-android/2.10.0/lifecycle-runtime-ktx-android-2.10.0": {
-   "aar": "sha256-hxiDcDM5+HKE0jLLQ24xfG9K9WEtkrQ/J8axO5IQn6c="
+  "androidx/lifecycle/lifecycle-runtime-ktx-android/2.11.0/lifecycle-runtime-ktx-android-2.11.0": {
+   "aar": "sha256-H+rZZgf4tOvSvFhAxvzwiwn8R86xZl5LOB3OgLGfMqA="
   },
   "androidx/lifecycle/lifecycle-runtime-ktx-android/2.9.4/lifecycle-runtime-ktx-android-2.9.4": {
    "aar": "sha256-lwGZye0awT1iCqjef4q7wozoBlPDzjKNCsLxUnK1bhs="
   },
-  "androidx/lifecycle/lifecycle-viewmodel-android/2.10.0/lifecycle-viewmodel-android-2.10.0": {
-   "aar": "sha256-kwMocDACfKC4z5inSN3rEh7Bv6ExLABpQo5HZburzng="
+  "androidx/lifecycle/lifecycle-viewmodel-android/2.11.0/lifecycle-viewmodel-android-2.11.0": {
+   "aar": "sha256-UJqlwHEeYaFXECS0+EMdyaoglg0jy62wHyGjP9hkNSo="
   },
   "androidx/lifecycle/lifecycle-viewmodel-android/2.9.4/lifecycle-viewmodel-android-2.9.4": {
    "aar": "sha256-SyNrLlBNtcpdCTNP7wWqjNwx7jWkM8OqTQQg76lhMzI="
   },
-  "androidx/lifecycle/lifecycle-viewmodel-compose-android/2.10.0/lifecycle-viewmodel-compose-android-2.10.0": {
-   "aar": "sha256-IlkE5UrVFUdoYwRx4Qi5jhQ8Jh3wwIOA/0PqfoMtrX4="
+  "androidx/lifecycle/lifecycle-viewmodel-compose-android/2.11.0/lifecycle-viewmodel-compose-android-2.11.0": {
+   "aar": "sha256-K6/UAoB71K8FwGz1jEjL2tCVIeIUUnP6rpCQi3cS9ok="
   },
-  "androidx/lifecycle/lifecycle-viewmodel-ktx/2.10.0/lifecycle-viewmodel-ktx-2.10.0": {
-   "aar": "sha256-VClayGtniG3AYT449iHFMZldBmIAX8dj40DhmpCZT4Q="
+  "androidx/lifecycle/lifecycle-viewmodel-ktx/2.11.0/lifecycle-viewmodel-ktx-2.11.0": {
+   "aar": "sha256-Iwr2yGYHbTINksIsfES7Uq/Kl/aJLd+YfikG7ykZmY8="
   },
   "androidx/lifecycle/lifecycle-viewmodel-ktx/2.9.4/lifecycle-viewmodel-ktx-2.9.4": {
    "aar": "sha256-t9WLuGu44szGB9H4Vw5xSBD3z7P+ujfTdf8WRjg0NaE="
   },
-  "androidx/lifecycle/lifecycle-viewmodel-savedstate-android/2.10.0/lifecycle-viewmodel-savedstate-android-2.10.0": {
-   "aar": "sha256-GUBCOfpYQyLC+B6WWeFivAEbdG0p3JUKEdJgYk2DIl4="
+  "androidx/lifecycle/lifecycle-viewmodel-savedstate-android/2.11.0/lifecycle-viewmodel-savedstate-android-2.11.0": {
+   "aar": "sha256-F2FwfB3e4AK9l+GgiJpQFvfNa9jgtrBpvLqLJSPWNyM="
   },
   "androidx/lifecycle/lifecycle-viewmodel-savedstate-android/2.9.4/lifecycle-viewmodel-savedstate-android-2.9.4": {
    "aar": "sha256-B5RBxD+j/46noC3zsS7sSDw+V1g/gyz6/2Y3UFJ8FCE="
   },
-  "androidx/lifecycle/lifecycle-viewmodel/2.10.0/lifecycle-viewmodel-2.10.0": {
+  "androidx/lifecycle/lifecycle-viewmodel/2.11.0/lifecycle-viewmodel-2.11.0": {
    "aar": "sha256-S4Cc+etzI9IAUE6Vkh/rd3/wgCFcrbgjd0LV7Qult5I="
   },
   "androidx/lifecycle/lifecycle-viewmodel/2.9.4/lifecycle-viewmodel-2.9.4": {
@@ -956,25 +942,48 @@
   "androidx/localbroadcastmanager/localbroadcastmanager/1.0.0/localbroadcastmanager-1.0.0": {
    "aar": "sha256-5xwyjO71xKfXby2G3xtl1l/irPhosaTv2Eo/NDNhhtg="
   },
+  "androidx/navigationevent#navigationevent-android/1.0.0": {
+   "module": "sha256-b8YiSwG/j8V2ckv9jsyq1twZ5JFQSZEAywzaJOKMlH0=",
+   "pom": "sha256-XKu7QPP7oRFmV2qDms9OtttZq15evLFjYdQfi+yAW1A="
+  },
+  "androidx/navigationevent#navigationevent-compose-android/1.0.0": {
+   "module": "sha256-OOEb49bVROGgC5h/dPVttS93u9ShNE8CLDbFLwFOFi8=",
+   "pom": "sha256-ajt+mJsYqyUnTb0FMdzE1m5O+43kmF2v9TnVExKFv/g="
+  },
+  "androidx/navigationevent#navigationevent-compose/1.0.0": {
+   "module": "sha256-pRyPY8tfGIVhkD2PLvFJbZ7/V+es3fh9VoWbCYWbqq8=",
+   "pom": "sha256-WImcZP76B2gGZiHImUOFGCxSoISKeMiCcF9efavZhHE="
+  },
+  "androidx/navigationevent#navigationevent-compose/1.0.1": {
+   "jar": "sha256-LDVRxFHcUHv80eX1H6YdHpYxY5wqvZlPbxb8cnO4ibk=",
+   "module": "sha256-KALUd6Dw9CZ9+voyMRd2gsasxDouET6vN7hgAqHFwRc=",
+   "pom": "sha256-zIkB0X4mBgv69cACJvAMqesF5dOpBlpifyPq30OU0B0="
+  },
   "androidx/navigationevent#navigationevent-desktop/1.0.1": {
    "jar": "sha256-Q97rV3T9c3+pReCaR/k7bxpQjRf6yPO2XxyGPn99BmA=",
    "module": "sha256-kJ46U7h2B1HXmu9YZfS/SRoWCV2eGvvfueSKxovR/Gg=",
    "pom": "sha256-MluouGydEyyXeA53cbo8k51iLIfAxYcHlen0OCmd93E="
+  },
+  "androidx/navigationevent#navigationevent/1.0.0": {
+   "module": "sha256-8z8eAwoKfRCqtgilpdP/cNJd8yXOglyiBKoZwOBXi1M=",
+   "pom": "sha256-3n+uQrQjT2/tx3YlELy125hgGHvlbzv+w0tz225KIqI="
   },
   "androidx/navigationevent#navigationevent/1.0.1": {
    "jar": "sha256-PXBoRNxJYGyxqjzX1rJ/R/GA38TG1Le4DqR4/4jcvZM=",
    "module": "sha256-NrRI1xJsSW2bEryrKNzWguxI7IP6x+VizS5LZSeB7xE=",
    "pom": "sha256-h9uD3BBM9BeKnov3Wy44nbkXa1iDoTuNeiqEEGkG99k="
   },
+  "androidx/navigationevent/navigationevent-android/1.0.0/navigationevent-android-1.0.0": {
+   "aar": "sha256-zaS7g9HIkqIIcy6ZwtWeTyR6tcI6HSUk/ABNsuTpp4A="
+  },
+  "androidx/navigationevent/navigationevent-compose-android/1.0.0/navigationevent-compose-android-1.0.0": {
+   "aar": "sha256-XO4Bjb4TC1ONLEPMbzg6EJqY8ZupyNem3ajKkKIDRnE="
+  },
   "androidx/print#print/1.0.0": {
    "pom": "sha256-YkgsBZSEG+4ku5lqu2y3syCmo7d9yp8KC6T+O+VTCqc="
   },
   "androidx/print/print/1.0.0/print-1.0.0": {
    "aar": "sha256-HVx/MTWhu6Zh/Dc/1y4R6wpK27M5Z4eCbdjkGQ1dnt0="
-  },
-  "androidx/profileinstaller#profileinstaller/1.3.0": {
-   "module": "sha256-oW/lEeWZwgQtoSK+CVaa7NP0+QytN+8IvQu8ORGMksg=",
-   "pom": "sha256-EsvAHIpa5LQSyvPFoGYszSgALe3P8dvmwqs2Zb6fdYw="
   },
   "androidx/profileinstaller#profileinstaller/1.4.0": {
    "module": "sha256-Ob+ZeijY7tLLMZgZ9vNSobo6eLnJeQBPvgXia499Fgs=",
@@ -1012,10 +1021,6 @@
    "jar": "sha256-6WXtegEb6DonGsfYIkmndjaEee46KweUjDRFtR1kCFY=",
    "module": "sha256-5z8s+IGOzjR9i13/mQ0Ntjmn37j8yF7uyyYYOD9+zvc=",
    "pom": "sha256-jxFKQnNTWta9y+0Zhs/dmNlV6804oyqP7k7n3I4hH14="
-  },
-  "androidx/savedstate#savedstate-ktx/1.2.1": {
-   "module": "sha256-lDWRhLK6UcD0mKK5BV03s3IjHvm8xUpJcqyZ8DA6//E=",
-   "pom": "sha256-0JVTIR9nA7Ga79YI1gB8dxMtJ6KBVWqOaJ2Sdk7CfTs="
   },
   "androidx/savedstate#savedstate-ktx/1.3.1": {
    "module": "sha256-WQB9jTPPFm/f0am/Vsz9IS6YIsBLOnQZZvrOWRhhBlU=",
@@ -1072,16 +1077,28 @@
   "androidx/transition/transition/1.6.0/transition-1.6.0": {
    "aar": "sha256-JIxF4SVNMRgdIEewsBOU8JouU5pdnom3c9U8YsloYPY="
   },
+  "androidx/vectordrawable#vectordrawable-animated/1.1.0": {
+   "pom": "sha256-J2ogEWtwX7dbkAPulJbFb2/TsyN1+yMkcoEeumCgQL0="
+  },
   "androidx/vectordrawable#vectordrawable-animated/1.2.0": {
    "module": "sha256-sTOjPAE0wIDnBSyixhK/R/cmeHOnT1i9JVmzZ3HmbJY=",
    "pom": "sha256-JkHJmjkZ8MIDkkDHyH9U+Hn3PNoEQA9DeFl3PMTqRAU="
+  },
+  "androidx/vectordrawable#vectordrawable/1.1.0": {
+   "pom": "sha256-Ww4tWyF55UgEeFy8Ic5fRzteHd1VpX2kgulNzTlJK7I="
   },
   "androidx/vectordrawable#vectordrawable/1.2.0": {
    "module": "sha256-UTX1gPnNQVF9j4h/zEO3V2BwO+33DoT2FkcOMHN3Edw=",
    "pom": "sha256-lKPqq257kyBFtoovbul/BHHWvV05V3WhiSLilv1FMwY="
   },
+  "androidx/vectordrawable/vectordrawable-animated/1.1.0/vectordrawable-animated-1.1.0": {
+   "aar": "sha256-dtosUCNx2cOAVN9eKySNANqHgJ7QWPM2Pq6Hzl4kA/g="
+  },
   "androidx/vectordrawable/vectordrawable-animated/1.2.0/vectordrawable-animated-1.2.0": {
    "aar": "sha256-oHC90EIioEB5Tl6fpLd41XX3uPToTQbZo47E1Zl3Cmk="
+  },
+  "androidx/vectordrawable/vectordrawable/1.1.0/vectordrawable-1.1.0": {
+   "aar": "sha256-Rv1jOsAbSbf8q8JjvwmMWouemml3TSNO3MoE+wLfjiY="
   },
   "androidx/vectordrawable/vectordrawable/1.2.0/vectordrawable-1.2.0": {
    "aar": "sha256-T0S5SBetJm7YZBsLj6tObQOJAqYoQLtlKEcyIuHNz8k="
@@ -1110,31 +1127,34 @@
   "androidx/window/window/1.5.0/window-1.5.0": {
    "aar": "sha256-XeLUiqV4QC9G3rUpSpVc7mLwx9jBhA72Jvx6+4q+Ivk="
   },
-  "com/android#signflinger/8.13.2": {
-   "jar": "sha256-wdyixoNjTuGilCmPnHF5V4r2qG4IC9xA+WGRW8XIFC8=",
-   "pom": "sha256-CfafQNTgDVIHLrDdB6xnaugjEyeaYIUw043RSAD1X8Q="
+  "com/android#signflinger/9.3.1": {
+   "jar": "sha256-fYISbJSDtUAXOmWwNU/ifwZ+yFyOZGdnlYc2QKBrKI0=",
+   "pom": "sha256-CSYW0eNrT/5fw1klNlR7erkRpgSIpDlbLmZuVVQNUqk="
   },
-  "com/android#zipflinger/8.13.2": {
-   "jar": "sha256-BwYAacNeRp18NDq8FfHWNivBNWuBv0YlOduIpT7WU/E=",
-   "pom": "sha256-4u7Td4LaTYx5nUxLc3w1rYjTkS9RNs/f4sAUzNQLNQw="
+  "com/android#zipflinger/9.3.1": {
+   "jar": "sha256-ChmE0UzIBw9zTdzFqUfxIt/uNkzb4YWVr7aRqoA4kOA=",
+   "pom": "sha256-FGbpNWjSTGsySL/b5Mg7D1XgW2G5WAyJRYKf3kZgCr4="
   },
-  "com/android/application#com.android.application.gradle.plugin/8.13.2": {
-   "pom": "sha256-1FkMwEiO+6eC+zfRPlKBKTL37/8QIi7SqWt1IL/aoq8="
+  "com/android/application#com.android.application.gradle.plugin/9.3.1": {
+   "pom": "sha256-lnT8wnuCmLIRWufuJYNtv1yZyKHcRzVhtRZ6GsK2a3o="
   },
-  "com/android/databinding#baseLibrary/8.13.2": {
-   "jar": "sha256-eUETcJ2rIbBsJis3lec8twj7rK5hcV80Nh4a9iN6GHA=",
-   "pom": "sha256-3/d3DxXM6F4bqoYuCUeh9ubuxNZJcLuz7MevDcFKbRw="
+  "com/android/databinding#baseLibrary/9.3.1": {
+   "jar": "sha256-lroqXwAIRtMXrN2Q3mp0KXAaxWVz3izMhCPSukBEb9k=",
+   "pom": "sha256-EokmuyH/5wL4nsO8+Eplulg0dJDNWCUHLjyS+G+Od/8="
   },
-  "com/android/library#com.android.library.gradle.plugin/8.13.2": {
-   "pom": "sha256-xYVT/MkO41ec7v/K6WH0rEciskhUkhr6rJt6ZomG670="
+  "com/android/kotlin/multiplatform/library#com.android.kotlin.multiplatform.library.gradle.plugin/9.3.1": {
+   "pom": "sha256-zA0uAddI+V0od8ZzLSzk/Rl2SGQbe6dj7KMVoy1rnRc="
   },
-  "com/android/tools#annotations/31.13.2": {
-   "jar": "sha256-O0u5YgwX0Z5b2RrBmICAVTVztMO3Of3ZJBb0Ly2vPng=",
-   "pom": "sha256-63PyFYFKl68he6cabGhZ+xx+V7E8XWzNmVneLJdCR1U="
+  "com/android/library#com.android.library.gradle.plugin/9.3.1": {
+   "pom": "sha256-kKf14FXa2ErEOLBYmbxfHgRCQUkIm/HhrG+aS1ClTA4="
   },
-  "com/android/tools#common/31.13.2": {
-   "jar": "sha256-1OvhcR3gz1CcTVYiRWJLohqxR5RLzd5jUb+26NrM+CY=",
-   "pom": "sha256-JhPXZpT9SkW7xosWXBRTfVtUadvqbap32cMuj4VCFHM="
+  "com/android/tools#annotations/32.3.1": {
+   "jar": "sha256-MukCJq5Me1ntYbBmia6DVrqwgM159laUVf2SklQ5ozk=",
+   "pom": "sha256-Su4/tPXrrJ20JGWiIHfsHmz7J5jZopeZljsgwkLyel4="
+  },
+  "com/android/tools#common/32.3.1": {
+   "jar": "sha256-LLXftf/xRAiPGIh8Y8jnNoA07eMedBNAWsMlHR65oUc=",
+   "pom": "sha256-JrqSM5TvGcvT4qUxqIwBjR96hz7mG64YeAtccaqSmQM="
   },
   "com/android/tools#desugar_jdk_libs/2.1.5": {
    "jar": "sha256-2ARL764JV4G5qAvx+qku3DA4LXXUN0dnhMG/mRWYqXY=",
@@ -1144,103 +1164,103 @@
    "jar": "sha256-e8kFGzoewZgGMR3Laqm5un75wiyqb0gQ2lW94oX7d3A=",
    "pom": "sha256-sgmXNbk5BdbwG1LhNtE2QoDNanLG5+o74nSmxncD8rQ="
   },
-  "com/android/tools#dvlib/31.13.2": {
-   "jar": "sha256-488/3JR3iN7o1bqnbLcqZlcRdLxHQe3w47q5enypDhs=",
-   "pom": "sha256-HKqrkCIWAyLLMQfz/p4VuBXr0391aLxklStZCi3c5wY="
+  "com/android/tools#dvlib/32.3.1": {
+   "jar": "sha256-UuJ/E2TNtdT1MfUuTuxa5I2gQNqpQX1PBt32oXmaBl4=",
+   "pom": "sha256-oWwMX99GotcWPF8MylNb/9VtxfLw4H5nTiPBmWUaqAY="
   },
-  "com/android/tools#repository/31.13.2": {
-   "jar": "sha256-6VCbMNCI6JmUj4yw1zKTwe/S4fEh/Mu+JdUztki5P6E=",
-   "pom": "sha256-7+6KWA6sdHjIrvnTC85aQydT0m2UCl2VP/SCzkE8Zjo="
+  "com/android/tools#play-sdk-proto/32.3.1": {
+   "jar": "sha256-Q5UdjSh/J7PBJCE5F5iZr1xWToYrdgNT1Vjk9zqIHgM=",
+   "pom": "sha256-Tw3uGA+rxCYGnL9HGfzTR4YL2lgXfiVHndE07kmyW3s="
   },
-  "com/android/tools#sdk-common/31.13.2": {
-   "jar": "sha256-jP35nW8XaJ5907zxg01zT23Rxk2MQ5BGMsZdVGlWWTQ=",
-   "pom": "sha256-ezPXPdQoR7BPWaUeqrcbNFLA1pn3xpZZFSuDhjzJDMQ="
+  "com/android/tools#repository/32.3.1": {
+   "jar": "sha256-uUcLsB+9j8rUhH4dEJZ7IPqTJVNhwNKyED/G3P8TsXc=",
+   "pom": "sha256-I5WOK1KCf4u6/ffnRX9RHq6GqstfaXJXXWxKCCGf3wA="
   },
-  "com/android/tools#sdklib/31.13.2": {
-   "jar": "sha256-3vmw5/ROVK3ThcrBcVSDck+CfxZlEevAwQMZdCqoCGU=",
-   "pom": "sha256-/saYRrZwqz267yBnul+YKa77gEd8n3aA+Q9Ka+NpWlg="
+  "com/android/tools#sdk-common/32.3.1": {
+   "jar": "sha256-fTQwgkEHHkgvR8y3xbpT6DhYNmkFBhl5rk7UYjxtzdY=",
+   "pom": "sha256-p9Lii7VvfZWScm63lumPFicwRmxupyLM7Bi+19bC5n4="
   },
-  "com/android/tools/analytics-library#crash/31.13.2": {
-   "jar": "sha256-zKl6wpoTKb0xCj6DK25X9GIn5QGqUpwApj3yF8XX30E=",
-   "pom": "sha256-+Rdh8nEZmwiOhbYjLgWYM+EU9WoT8RpVeVx2/rljZpM="
+  "com/android/tools#sdklib/32.3.1": {
+   "jar": "sha256-RDPKN52wqfe9Cl1bkxsKxnF0exB5FwbcDUKjSNrLt4I=",
+   "pom": "sha256-6w/o5i36EakHdlmM57bxHj8XNRq3X0IgonHTVWbF+eg="
   },
-  "com/android/tools/analytics-library#protos/31.13.2": {
-   "jar": "sha256-st7SCol/upZJ7+sYui/AYu455QDU63EgRcsONLQ7Xvs=",
-   "pom": "sha256-h+Vtxrwei3h2ACBQiqMn14SubOmq3mwenHpPPyZSXOA="
+  "com/android/tools/analytics-library#crash/32.3.1": {
+   "jar": "sha256-ieM7Pq8F53V2yIyhSkWMR9/gc177+kjuGOX6hflfbyo=",
+   "pom": "sha256-MXeJhfsOZK1mEGb0Ai0mtp7crCH9KBbr7b0zm2RCSAg="
   },
-  "com/android/tools/analytics-library#shared/31.13.2": {
-   "jar": "sha256-dUNYFvICt6PITZyvMSqJViWiRJkfj8UtBEYjnjrimpw=",
-   "pom": "sha256-iosZjZfS6noBpq5TxyRwfWa6N6BATLmCNJzs5F9VDHg="
+  "com/android/tools/analytics-library#protos/32.3.1": {
+   "jar": "sha256-6eP1AhuOxkFpsumkkjK76LKiPi3PMSI/mCFjIWsy0w8=",
+   "pom": "sha256-CKnyxaNvGJFOcpQYt6kZyhorqg3aN+JkLikHkE7NINs="
   },
-  "com/android/tools/analytics-library#tracker/31.13.2": {
-   "jar": "sha256-G2ZRS/KRUkIu6KGbmOAgDZLrCj0oBI60hXVk6aHHuFs=",
-   "pom": "sha256-fyfJXcqu/ZLc7ss35hsam3AUHs7oaiENnFf0bK5Pkck="
+  "com/android/tools/analytics-library#shared/32.3.1": {
+   "jar": "sha256-FyoDexHa4PLLa1xHoAHJAa/PNjHGN1JvVF5FF7lztos=",
+   "pom": "sha256-lY0cItqasU4SOGkObKuhWOZqBRgKStJnL+1BOvcv6cw="
   },
-  "com/android/tools/build#aapt2-proto/8.13.2-14304508": {
-   "jar": "sha256-ps2oLVCOw7MlqeN/ePn6hFVv80DPQ7sjxiew8550bw4=",
-   "module": "sha256-fVtyhfR2yCAI8NOfUGsLjFPxsCa9Yk163GiCFr6Opb4=",
-   "pom": "sha256-+f1XBgvd7CGC3Mk1dBbpk5DUq4t4YWVLZ7cqdOCQ/6U="
+  "com/android/tools/analytics-library#tracker/32.3.1": {
+   "jar": "sha256-8IPoJieYHb4TErXoBelHDSa0/1bQmuj93M6Phi0ugHo=",
+   "pom": "sha256-g48pgttR8kzTCJXEeBJCjwxYT83evL0G/1oSeDHktnE="
   },
-  "com/android/tools/build#aaptcompiler/8.13.2": {
-   "jar": "sha256-9vZwbTt6Jh4kKCDaXIVRI9PCNzgVnKNybgw05IK4B3A=",
-   "module": "sha256-DjumtDrZj6aRMd4di2xqdUGzr3FEPctdUqLP/CVY7ms=",
-   "pom": "sha256-sQ/OQPXnkalYeGlI/NanTEc7yHTLScuYpnePGBz3MeQ="
+  "com/android/tools/build#aapt2-proto/9.3.1-15703166": {
+   "jar": "sha256-W83XH954Y8aMZ+5Kac+GIG+9Oi3mb1o+RiXOX7Tq0rU=",
+   "module": "sha256-o8WXbWWnh4IrQn0RQRDG5qt/qvuAcQeMM4BLskYDh4I=",
+   "pom": "sha256-+Baxu8UUqqY1UYZbNQQSs1OZRiYowdwLE4DsghYlKzI="
   },
-  "com/android/tools/build#apksig/8.13.2": {
-   "jar": "sha256-wHDtE5RinXRkGqCQb2Cy/6Hud+Y2ah+TQ39ZcXsa64k=",
-   "pom": "sha256-Ij3tgmjn8O6d8BCdgEnO1hR0tevYSMLToIiTKixcyCM="
+  "com/android/tools/build#aaptcompiler/9.3.1": {
+   "jar": "sha256-qqPajpWKyUwzUihCJMgsDxU9y8k3bZ3cDY6TUIeEkwI=",
+   "module": "sha256-BxWgM637xsA0NJ5Fh/wSYy8vo/76hZF041CTnOko4DE=",
+   "pom": "sha256-kHDXzZm0mqeu4/3jogAZPEXCvdRkhaX5/p3/Og4OOJQ="
   },
-  "com/android/tools/build#apkzlib/8.13.2": {
-   "jar": "sha256-KQkclFclL5l93+r7M91lo3OtRYQBKPlFgy2Or9kRhWE=",
-   "pom": "sha256-szSNoCWwi1M/Lm45E4aS6gsaiZVd3D4bjbF5alUxRtQ="
+  "com/android/tools/build#apksig/9.3.1": {
+   "jar": "sha256-VizQqIiQlg0uzkjhFsYfEociIvHcwwaJB5k4K8AZsgE=",
+   "pom": "sha256-d++GaP+QFATu4vPowhI1D24yHu/ZCHVtJr+qVuPwNO4="
   },
-  "com/android/tools/build#builder-model/8.13.2": {
-   "jar": "sha256-rl6VUVqzSNNKNb6D7TFcX7fowGZ+GG9OFWxl36omFf4=",
-   "module": "sha256-WuEdekCFfhpLC8an9CGCVclhabcBFTX5owt3tfbjJ6E=",
-   "pom": "sha256-TyWfQx/NK5q6MxCW8Q+Xq0ttX+kn32N+yy08+Vw8/eA="
+  "com/android/tools/build#apkzlib/9.3.1": {
+   "jar": "sha256-pxRphRErupEYwEsOl0W6tzamZzqBQ/FGfC8+TCYr3iQ=",
+   "pom": "sha256-dGpOQfFztE+vSoFe+lD+ZtD3zCdiZjknZUsxBEc14FQ="
   },
-  "com/android/tools/build#builder-test-api/8.13.2": {
-   "jar": "sha256-PP7QuuwufQ5kVm9oCKAO9eBRrXb8T7qdRk0Ro8L5hqk=",
-   "module": "sha256-T3Lzqf0+n1FsNs76xpeNzAQEliELjPrX0pVMg7ug6ZA=",
-   "pom": "sha256-E1tr6DkVxZFu6TBTxUTaQb0Avc8Y6wjEsNT8SsnLyb8="
+  "com/android/tools/build#builder-model/9.3.1": {
+   "jar": "sha256-8do5jdQNKJrlZgIrBXx8572Ttg0NdH+ZONtkXwyHK/w=",
+   "module": "sha256-FWVoWoCVsXD8jYu7nBGX3U9L3FUuVBrwbzySiIFSoOg=",
+   "pom": "sha256-rgtHtqCsI1SLoJaomFEKEVUAlK/+YJPVE1I1BDYV1R8="
   },
-  "com/android/tools/build#builder/8.13.2": {
-   "jar": "sha256-fTk/hVMSDH16hpyzPEJ5qtlIWYZ3P2Ovl68I6i4f83o=",
-   "module": "sha256-SooQjeXwQUKmdXhhoKV6KYuTa3t/f5xbkeXKqafv2pA=",
-   "pom": "sha256-Gqs99HpacMRsGOT6BuNjrVf3UPtGDHHvFl9xqHb3hyY="
+  "com/android/tools/build#builder-test-api/9.3.1": {
+   "jar": "sha256-PN8Mr4sqEE62I51Oo+labCC6Lnb6CtETTI6T53V71DI=",
+   "module": "sha256-IhOs5hBmNc8XDhw/aSznBT56oLJCBJDZgRfag7Evg8A=",
+   "pom": "sha256-yQNOMW1P+N79xh8dOgJB/SK01Wc5h/Qe+BooSWl/Vd8="
   },
-  "com/android/tools/build#bundletool/1.18.1": {
-   "jar": "sha256-pzNBp5RavLDmuJccexsoAb12UAZEfKDSQ3pCYNVyzqw=",
-   "pom": "sha256-XE33suMfF/IOS429YqK3hloJpJof0pMaNZ/TlOy5taU="
+  "com/android/tools/build#builder/9.3.1": {
+   "jar": "sha256-hz4On+2odi6tD/HOYMMMwr8cCFnhOSRacjJI2ZiwCfo=",
+   "module": "sha256-LmEbS3sL6/33lJfM+JnnL2BThTcCVjcqSiLM6bTKUoU=",
+   "pom": "sha256-1uwopMlNEWJ/flwz53SGhZXqb3/dNUtrKYeptc6HUdA="
   },
-  "com/android/tools/build#gradle-api/8.13.2": {
-   "jar": "sha256-qNzcbxM49wVfaxvCZTF+FNZYM+bH9yshAsVWjh3015I=",
-   "module": "sha256-G+ABgWcGZoc80BKOnexu6ZzSriB7q5CezBH/DPcpvF0=",
-   "pom": "sha256-B6fxsnM2mtT8EjpMy0f7Hg2WixGjjHPNRchTPWTOx4s="
+  "com/android/tools/build#bundletool/1.18.3": {
+   "jar": "sha256-zK0YUU/ZfbAQhWsrvtQPSB+LqTSTaMl65U1y41Z9AXE=",
+   "pom": "sha256-+mdLOblsrpgBXzhQ82bP6wD+bHrqLZCyDAF7kOCZba4="
   },
-  "com/android/tools/build#gradle-common-api/8.13.2": {
-   "jar": "sha256-/N6AX81XOa7WB6nNwyUxb0IvoFpG4UCikdLyTso6Wf4=",
-   "module": "sha256-nm7c2Vn27YeiJzuF3g9O+sJufNy/S9ako/TgXI5+fBw=",
-   "pom": "sha256-DTY2ikCNkKt/cEhkHezZ6ALoIZdYV1651CGKRmNlUVg="
+  "com/android/tools/build#gradle-api/9.3.1": {
+   "jar": "sha256-Iv4StzDJElqDSo0Ax4RTzh+UtTiDMePTHXhAnXKYgS0=",
+   "module": "sha256-GrsKs4U3FN4h1YnUp6jXwB8siLenDnYE+WLwuCzfomg=",
+   "pom": "sha256-lpwraf+XSG7BGtcEbZxC01yRNTkZsLrtozxz/XdpuQY="
   },
-  "com/android/tools/build#gradle-settings-api/8.13.2": {
-   "jar": "sha256-NwQ4vPd4LYxbQHNwNlsEe/Bj+Zp3ReH18YUxgzmNB6Y=",
-   "module": "sha256-5crHmMEyNO6kOtsITFyBwgrRw2zEtbV/OSLZH07AJNY=",
-   "pom": "sha256-iJlOxc2yOO23vY51Rx2NCXkvtSUEa3hBNabN6+DUwz8="
+  "com/android/tools/build#gradle-common-api/9.3.1": {
+   "jar": "sha256-X4zrFzgDdwfRZvebE73gUgJKY/xSuK0RrSy8eA77uNI=",
+   "module": "sha256-ZUQS6Y5s7ZQNPTCGKGYvwf7Heql5C6wpHEHQm+pqHB8=",
+   "pom": "sha256-npZjthy8rwlAJ7txjESy5pQsOdIsvAPH2kuqyxmKj7Q="
   },
-  "com/android/tools/build#gradle/8.13.2": {
-   "jar": "sha256-5JT3znXKbBq/8wHUpwsY/dPWr4VYdfT4UIK7dgjwQd4=",
-   "module": "sha256-CqwL7hpPxlzWmmeIVIp+IdJGJQyFgBfhHjvyMWPLdac=",
-   "pom": "sha256-/H7bqTxbkc5yZ/p7/cH6SUIu/GM6wnmjY+AusP0pvK0="
+  "com/android/tools/build#gradle-settings-api/9.3.1": {
+   "jar": "sha256-IoR+ifElKUwwHVHuW2Ab9UGk4MU4MM3P6oMARs3GImc=",
+   "module": "sha256-BKJlGiunlPSerC40HDCN2fTROJ9Hw1JiDaM7+DSHIm0=",
+   "pom": "sha256-f7G2OJ3uoHXqlVnJ33QSpALlobqp5iKE6fu5PzrEqUw="
   },
-  "com/android/tools/build#manifest-merger/31.13.2": {
-   "jar": "sha256-QNJfWUDC5Qv34Y4yX3+7nIbPRdtahdHO+O+YVAQieh8=",
-   "module": "sha256-S9nUffB7eBdKcvqpJCOTWvKdF8mJaoS2WLkh9vGpI0g=",
-   "pom": "sha256-cEzxt4bSDIBGo7Ml/DKQ+pgulwlfZK0hmHzz7jN53bI="
+  "com/android/tools/build#gradle/9.3.1": {
+   "jar": "sha256-Sun1XO8RWXjef1AuSeoWPonHioq0CUNQSjfJSLlOrbU=",
+   "module": "sha256-YjfuJG0h/lxjeMsGGindxEJqTw3PG8ZuckVqSFvTIYI=",
+   "pom": "sha256-MQuHrVDZMsfOiKQk6YKNRgU2pSSi+RwrFlaRUYPEJt0="
   },
-  "com/android/tools/build#transform-api/2.0.0-deprecated-use-gradle-api": {
-   "jar": "sha256-TeSj0F4cU0wtueRYi/NAgrsr0jLYq7lyfEMCkM4iV0A=",
-   "pom": "sha256-fGLzhW6KvKHXkleSXybBJmhpP12VkEBWu6yIYFz9hXU="
+  "com/android/tools/build#manifest-merger/32.3.1": {
+   "jar": "sha256-41/3qgpLKWYNWLCmZ997VDqoX38d1GKh3SsCGjoXWjA=",
+   "module": "sha256-iyvToBePbjJfO5v36oe2kmVos49K0v9SXbWLvV7ZMS0=",
+   "pom": "sha256-bhBSu+KElFzeDHjodFct7+pNmXgkXMAMd0pqwO7zH/0="
   },
   "com/android/tools/build/jetifier#jetifier-core/1.0.0-beta10": {
    "jar": "sha256-Jqu0oTkn2QYhacUEyelP6A6a46T3tauIdasAdTapH14=",
@@ -1252,167 +1272,204 @@
    "module": "sha256-NsJVdrGZk982AXBSjMYrckbDd3bWFYFUpnzfj8LVjhM=",
    "pom": "sha256-M7F/OWmJQEpJF0dIVpvI7fTjmmKkKjXOk9ylwOS6CEI="
   },
-  "com/android/tools/ddms#ddmlib/31.13.2": {
-   "jar": "sha256-g5lX+WEQBxPqDu1iioaEzDmqR5Yxw2JJeT5t9+DNY9g=",
-   "pom": "sha256-mohLOgztXxl+011f8o3UQIJK62qMQh/GgnbrgZIq0MA="
+  "com/android/tools/ddms#ddmlib/32.3.1": {
+   "jar": "sha256-i8jt8GN6m1IP6/g7ELV/MSDeX18ylcsjLJBGT2XUQxg=",
+   "pom": "sha256-GTO4SU/N5LCx730I57Is53Nisx4w/lIq1AogfBWuZqQ="
   },
-  "com/android/tools/emulator#proto/31.13.2": {
-   "jar": "sha256-t3+BzAdR15OT7EsusEb5ENIavNdgi1sPWh7+obMkO0g=",
-   "pom": "sha256-NPBZInrVOOvI7RkjRJDO1YpuKUhFpyy6sRTrV6MRNWo="
+  "com/android/tools/emulator#proto/32.3.1": {
+   "jar": "sha256-KZemSJjn6IZ0bFWIJFPVaXv8aU2VY1OyQqiDH7EqydY=",
+   "pom": "sha256-LouXh+h56VWNoi7Bty11SNA/XKu4F3kESwHel6zfyhU="
   },
-  "com/android/tools/layoutlib#layoutlib-api/31.13.2": {
-   "jar": "sha256-0GvGUCR2MqSk5llrhzEgGfRekAJnxUdsR6W/puP9MTI=",
-   "pom": "sha256-ttE1l7KS5SNcEe3gBH/c5wjtnwreawOcXwJ3C6jWEFM="
+  "com/android/tools/external/com-intellij#intellij-core/32.3.1": {
+   "jar": "sha256-TsapFjA2aZopbIrlqDjHdOqluR/cj5fOy9+PbTzhQVU=",
+   "pom": "sha256-JBAuMEuTr4WtV9IYaqrXkEQeg+2DfrFFZYQx4W8t8Rg="
   },
-  "com/android/tools/lint#lint-model/31.13.2": {
-   "jar": "sha256-nuVdj9ACc27ZXul/sF9N964B9Pl29zj7837Kt5Xlkxk=",
-   "pom": "sha256-kmFkH147W3zkzc07dddGebywrMb65cyAh99QGJOVm4E="
+  "com/android/tools/external/com-intellij#kotlin-compiler/32.3.1": {
+   "jar": "sha256-92BezY5RV/HfaJlR4PIA/3zLCxRD6MSrNaWVyxzNyIY=",
+   "pom": "sha256-4Hl+ZXo0OwuBsybV9e0gfLMYf6p2KUPIMTl/EoU0G40="
   },
-  "com/android/tools/lint#lint-typedef-remover/31.13.2": {
-   "jar": "sha256-Sjujur/Xnm/Ge872R/tOz+r1m0gbEI98LrpNHFxt6o4=",
-   "pom": "sha256-VSFuggl5u3yVA/fqPBApj3xBj/O8cvsp+v7VQdn45CE="
+  "com/android/tools/external/org-jetbrains#uast/32.3.1": {
+   "jar": "sha256-cI40CtE8XNGDfWoM6589up7tnxLXAvrJeia0aqWUzI0=",
+   "pom": "sha256-X48wkTUR7+KRh1h8u+7TsHFcQ80Y/U5Kxei6nleiUz4="
   },
-  "com/android/tools/utp#android-device-provider-ddmlib-proto/31.13.2": {
-   "jar": "sha256-BHrs3WbhBhN/d6UsRC8bg9t9boSWiZgAJR8gbH853mU=",
-   "pom": "sha256-QRYjc/qmac/XQQEHfsKc8oUiLpMbqInFPmD/YOz2Yx4="
+  "com/android/tools/layoutlib#layoutlib-api/32.3.1": {
+   "jar": "sha256-Ek8E66gAM+UIB0igV5cAOoHJBt61t2Zjq8KJ0AmUPoI=",
+   "pom": "sha256-dN3bgr+mYYG1jkynMoj3y5wnY3ADpb3sjEW2hZLZR8k="
   },
-  "com/android/tools/utp#android-device-provider-ddmlib/31.13.2": {
-   "jar": "sha256-sW6/71tjsDuAPq0KXhlO404N02HB4ZFVfZmPAVNHRP8=",
-   "module": "sha256-FXRXBPuVGjYpsaJjWsbiEIWw9uYyWWbUdyXlDDpfrFs=",
-   "pom": "sha256-0+eBcTpLa9BjVD3ktUfc3DtADzM/uSHo64fOyXihxc4="
+  "com/android/tools/lint#lint-api/32.3.1": {
+   "jar": "sha256-3TwMHxLgTIthhUEZ0PKVWLlrWBtxaFMY14CPyDsOprc=",
+   "pom": "sha256-YyBUV/xR3RtmkPa3OHJMh8eIRu2xlpnffHv+IXZcwwc="
   },
-  "com/android/tools/utp#android-device-provider-profile-proto/31.13.2": {
-   "jar": "sha256-PnsJj24+yuMbb3kJw0O07AmqGNion0G/kgd7pLBW9FM=",
-   "pom": "sha256-1VV0td2msIt2qxCpJklZNMfdwQ9hfTNud5tgO1Vem6I="
+  "com/android/tools/lint#lint-checks/32.3.1": {
+   "jar": "sha256-HnlPPYU2s6tORF3E7sKnYNIpRz5JsB9J2dJIljVpVx0=",
+   "pom": "sha256-NSjNnMScgEo0ZrTWleT8+TcuAkjXbA+uHkXy4Zv6LJQ="
   },
-  "com/android/tools/utp#android-device-provider-profile/31.13.2": {
-   "jar": "sha256-lWDCWFnJwVx3FEy7WDcLrTlIguzDFp/V5Ym31OUuhm8=",
-   "module": "sha256-fM5ga+y1hTIhypALdUDQ5su4we1MKt8LBu45w20OTek=",
-   "pom": "sha256-smVzfBte/3zXQm9ii2gr4a79CsR1oRk/0eQIQOEj9Nc="
+  "com/android/tools/lint#lint-gradle/32.3.1": {
+   "jar": "sha256-nkV6W9s+WUKOqx6LdF2yNitDlRMeMaNGx6G3TMr3eiM=",
+   "pom": "sha256-hgyyfd++V4tOufrxmvRy1hRjsu9H2GJB1wttQJq4HVs="
   },
-  "com/android/tools/utp#android-test-plugin-host-additional-test-output-proto/31.13.2": {
-   "jar": "sha256-a6fmrCII10wbtfHRRkq6/GpF2HELIEVaLcAq34cmvIM=",
-   "pom": "sha256-ryqLvOmjdsDe9Kryh6GdzoUgLxJ7UjJC/+H4BB4U3yg="
+  "com/android/tools/lint#lint-model/32.3.1": {
+   "jar": "sha256-26dxnsK6n36AAUfdIftXvmXg7zFaNzVvaHjYEiLoL8Y=",
+   "pom": "sha256-6oSnaf3jICQmmMjqtQtM7TLKLgLLnpLu6pRvkBrlCKE="
   },
-  "com/android/tools/utp#android-test-plugin-host-additional-test-output/31.13.2": {
-   "jar": "sha256-+q5CoWz3bXUptZsbmk2/nLG+3KWBGOuoJP3bgxLcdlU=",
-   "module": "sha256-sKPFs1jWtiZ0SOtqv+r2rQJasfB8s7ZQr1L9cCut/AU=",
-   "pom": "sha256-NGdCkqoA/jQOWfcLoOYplspdjKRkns2gsqTGjvOwTzg="
+  "com/android/tools/lint#lint-typedef-remover/32.3.1": {
+   "jar": "sha256-4oHpCm/8gxgA5kUXvo8bIwpjZ77CJvGwzhqA1Fc96t4=",
+   "pom": "sha256-UGyBfXGfsH0N8TXhiIjexXF8HJtwGlq5Eb2Ja1fLmEI="
   },
-  "com/android/tools/utp#android-test-plugin-host-apk-installer-proto/31.13.2": {
-   "jar": "sha256-TythBULpGjWjlrBDaKeEA25CuHhwIUYFULmjSVu4JFs=",
-   "pom": "sha256-qL1ZxNO6Howe4EJm9q8qRtKonyCeXllrFjdZwb1IDyo="
+  "com/android/tools/lint#lint/32.3.1": {
+   "jar": "sha256-F4wArciLdppvxVVyWQfvzU3voxhyboiLn8xJvm7q318=",
+   "pom": "sha256-38yqL3/IjremJlwLgw0tFOUNzcKFeKz4uHHF7XV0hG8="
   },
-  "com/android/tools/utp#android-test-plugin-host-apk-installer/31.13.2": {
-   "jar": "sha256-lJxvZRIhKdPs1ZsImYYOjiTpaCzsHACNHxGlzJM2b2Q=",
-   "module": "sha256-rklFwRAtyPUwdfYeuooPZmx0N//r4rn7FnGWjMRUcxM=",
-   "pom": "sha256-bXJmUtjrmRGvrvVsYdgwhw0Nc/f2FIz+OdMHHS96owk="
+  "com/android/tools/utp#android-device-provider-ddmlib-proto/32.3.1": {
+   "jar": "sha256-niEMgPx0BKhHvniQ3k2+aI7HYldLy2/tEcSBhImNoOY=",
+   "pom": "sha256-WKHRctGsN0LXScCQpo1jflOUxFV3UEkPZZ4jfuypQGI="
   },
-  "com/android/tools/utp#android-test-plugin-host-coverage-proto/31.13.2": {
-   "jar": "sha256-+oZxmj3F3kZffgwCMYRBTCf4/VOjT9VXKJwL9t80AkQ=",
-   "pom": "sha256-5W3OG2cA6f1KG5tPXK2q0IZNOYLuZJM5IrXU4MCKp0U="
+  "com/android/tools/utp#android-device-provider-ddmlib/32.3.1": {
+   "jar": "sha256-ao/JOZ9Vh4a3OAyJ+IfeqZQko5SXp7SHtX0r/rt4kT8=",
+   "module": "sha256-1RQUNMxbebedHnJS0dhct5VaHT6jR2wNFisnV9MFuhg=",
+   "pom": "sha256-Vow29ZcA4f8/N8UsM46iQaGi/yHDm6ThNJgSfoFrGvY="
   },
-  "com/android/tools/utp#android-test-plugin-host-coverage/31.13.2": {
-   "jar": "sha256-SZOpUEnlLE0xR+nE38aWzFp2r4MDpCBrtgwr+rxWOuk=",
-   "module": "sha256-2vHyeSUp3ETOxol/l/yEXbqmP+wtaTnJfifC/upNs/Y=",
-   "pom": "sha256-KZZUgBQenSuZYfNzTD+5rdkKS63o11oHur7udP6OnQ0="
+  "com/android/tools/utp#android-test-plugin-host-additional-test-output-proto/32.3.1": {
+   "jar": "sha256-G6tNC5ggwf85DIMxbK8jPov4y+rSQ2TkOF+LL+ikUd8=",
+   "pom": "sha256-VIIJrq39faIZUMppwiQefxcVbQEKH897RCYkIDSxHQ0="
   },
-  "com/android/tools/utp#android-test-plugin-host-device-info-proto/31.13.2": {
-   "jar": "sha256-loOsdkinpBvpoTSfaYFZKUT2JxZImMPIkloL7t6LuLs=",
-   "pom": "sha256-KtC5oodv9I1QsPQIPQfj2/1Dp8Gn1sjRcKn0+uyTlR4="
+  "com/android/tools/utp#android-test-plugin-host-additional-test-output/32.3.1": {
+   "jar": "sha256-+knkTFa9BreZd9SJ/X8jQa2k/sUCu5+IGUxX4gsLAPg=",
+   "module": "sha256-ZBR/Vu0cjp+EfUhfZWipm53VkMW4+utdjdbW9vOQycY=",
+   "pom": "sha256-Tf0FrUaFc1GVszw+bsi5v1liSuD3mXn+zW1Q2RIiCAw="
   },
-  "com/android/tools/utp#android-test-plugin-host-device-info/31.13.2": {
-   "jar": "sha256-pTufdk2AvtKeDy4O5iV23Am4c4Zgi7Yu8UU9Ay+XaWg=",
-   "module": "sha256-bBIiuD/k1MxYT29EGfak6Vcj3KpFPHoyRp/yTAgJ4qA=",
-   "pom": "sha256-O3fGvofJKUpgp6jiqEo/Sa0jIJy7fIG7WF3lRySXSzY="
+  "com/android/tools/utp#android-test-plugin-host-apk-installer-proto/32.3.1": {
+   "jar": "sha256-FsiwRiDJ74mlnfMMi5KgINIdf62Hr0OSHtDlaE//oNM=",
+   "pom": "sha256-SV1+YFRVv7Xs4f2aq7FGf3HtGbx03T1uXOLAiWYb6qs="
   },
-  "com/android/tools/utp#android-test-plugin-host-emulator-control-proto/31.13.2": {
-   "jar": "sha256-pPNKrg+f+gJtv3FRQ23XrlO+y3JiK0DyxHnKyJQ9kxk=",
-   "pom": "sha256-jxTna0jka6UmSo+PpNmPgIWrZUxPF1p+BPQPrGAZ15Q="
+  "com/android/tools/utp#android-test-plugin-host-apk-installer/32.3.1": {
+   "jar": "sha256-S7SW1EGsFKEDlVj54QH6b5/iWCmVyIpCEkKBROmwHvs=",
+   "module": "sha256-9YHxU14WP9JoJK6MfPVF0KKVqetCtMfaAmBnasjU4tg=",
+   "pom": "sha256-5qgP5YK/uwa1RM0FjGMCan3ILn/qK8x2C32bZ4gGpD0="
   },
-  "com/android/tools/utp#android-test-plugin-host-emulator-control/31.13.2": {
-   "jar": "sha256-cwIsKid57qz7/OZ92nz7sh47PPVhClTjX8MNj8yGCTA=",
-   "module": "sha256-AZYRJVaOGMsxJEbw4cTt/TZp/IqQxFn/UFcp7+Lgc84=",
-   "pom": "sha256-dUbsbfAjTkabNh4PLA/Lr2N4BEX4VOsqxMJ2sHyZ8o4="
+  "com/android/tools/utp#android-test-plugin-host-coverage-proto/32.3.1": {
+   "jar": "sha256-Gyc+FrjrDzGATRv+7coMs+Y/Ub7cJBpSMAT0EmndOPo=",
+   "pom": "sha256-i8+fOZVxrJiTFMskNDjEEjX5wiPwJ2KJTtcwp1JGXEw="
   },
-  "com/android/tools/utp#android-test-plugin-host-logcat-proto/31.13.2": {
-   "jar": "sha256-wfbrus2tVZtu/k6qKVYVUrMxVjlfBpzZcD/aCcRi3qY=",
-   "pom": "sha256-/zDRtJGIKYz5JqMKkU21ZWm+AuRFqm0DVlIHUKyYxag="
+  "com/android/tools/utp#android-test-plugin-host-coverage/32.3.1": {
+   "jar": "sha256-fKgQ2IBXZP+A0hF4MU9Hiabhoxn7tYUL1AngWhAwcfs=",
+   "module": "sha256-jSyIthdwUI6PkfOdbeHZF3cO3w6Nzms4QM86uXYVGDM=",
+   "pom": "sha256-3CSrA4wemFa5Le2xSWD+HS6qkhGvKbIxpjbM6t4r6xs="
   },
-  "com/android/tools/utp#android-test-plugin-host-logcat/31.13.2": {
-   "jar": "sha256-9Vm3xUTimsNUczmAXF6Y2TjionZGkddOur6zbh/KD7o=",
-   "module": "sha256-3z0on/um/yj6iHVGJHfZEfAJzAlMfKVZc7lrMdoCaek=",
-   "pom": "sha256-La4mMDSObLGhRR4gJCAjk9RWErRUZmdxn6msE9gfglE="
+  "com/android/tools/utp#android-test-plugin-host-device-info-proto/32.3.1": {
+   "jar": "sha256-+mVtrpSvGM/TIcY1FM0qtxPuXsHbg4k4vEWmOKPjGLc=",
+   "pom": "sha256-AzOY71u263nZYJ8JCIutY6bBFdCutE/pCvbMAqpo17w="
   },
-  "com/android/tools/utp#android-test-plugin-result-listener-gradle-proto/31.13.2": {
-   "jar": "sha256-1Cm5MS3/oFAzgdHuGxipmb2QHnRWYSsvtIxqXVosr4g=",
-   "pom": "sha256-NURycXV95NFmjrHctNobh2pLlEQHYky9661bHttESPo="
+  "com/android/tools/utp#android-test-plugin-host-device-info/32.3.1": {
+   "jar": "sha256-WfKeNC2CRvslqXm53SCnq8PM8os2e6K1u8IpjYgTf8s=",
+   "module": "sha256-wjN/JfLCp+R8QAyD1HM/PcnsK8RrN7n04rxdat1up2k=",
+   "pom": "sha256-AJMnpvzIOaXQhxKkjnciqcyM5yxojvntTsGbnZEfb/Q="
   },
-  "com/android/tools/utp#android-test-plugin-result-listener-gradle/31.13.2": {
-   "jar": "sha256-9e057Np3aEcwsmFtES1p+S9Qnj1sOIKKvGqGPvd/4OU=",
-   "module": "sha256-aJrPHlaZS/50AVIYvYlZXVf+wUFXxc5mocdcfgEfiJ8=",
-   "pom": "sha256-aWdAHML+nRizUOPlQuf2l45UxA4UDLEbgrDPEDmkv9k="
+  "com/android/tools/utp#android-test-plugin-host-emulator-control-proto/32.3.1": {
+   "jar": "sha256-nUIJLqhyaQ8k3JxM5kOEGvox+TPIkQrmG+ZUq+YdDwU=",
+   "pom": "sha256-2W+IbjoGQBP1hVKNhh4BSYc4fOphPVFMmzDH7g6Ir48="
   },
-  "com/android/tools/utp#utp-common/31.13.2": {
-   "jar": "sha256-zeZ4pksTBBzdLMna0WhZkKHQkPsE/12iJh/3WoNZgQY=",
-   "pom": "sha256-su8omyDL3HUwfnQc8RXaFVRZ4aWLXQwuCh/aPK0TtnE="
+  "com/android/tools/utp#android-test-plugin-host-emulator-control/32.3.1": {
+   "jar": "sha256-+sUtYRIEHxpiu3oDY5NHmPrGuRd2sEedmguoqT19Y18=",
+   "module": "sha256-tfU5Qgn1wAVIWy1oSP+1onEALqGNXGLX8NiCzUosaK0=",
+   "pom": "sha256-aV5BpsFpc8v5dWGkifAAR1OC3BwtZ3kQPtfk3TevFs0="
   },
-  "com/google/testing/platform#android-device-provider-local/0.0.9-alpha03": {
-   "jar": "sha256-ZnpNNbu6h9PIb1GA36Uh/b16TvXGDZSRVLAwHz4jLhs=",
-   "pom": "sha256-kTs67pWnFYGkCQOLHMonPOg10/K48qtaYAu+12nqbf0="
+  "com/android/tools/utp#android-test-plugin-host-logcat-proto/32.3.1": {
+   "jar": "sha256-8ZBjEDGryL8R5zkp1piEpFcXlimDXMhgFFeU8ZbRtL8=",
+   "pom": "sha256-I3VTzC9p5Tm5u7wVaZKr3KYxDDZOL3DiqMuLvX8yKWo="
   },
-  "com/google/testing/platform#android-driver-instrumentation/0.0.9-alpha03": {
-   "jar": "sha256-UHxjLsfbd7yymbVRnVmxTMYkOqxUF2fGMv2+3cYiawc=",
-   "pom": "sha256-AtXBStCZWXGhCIGQdacXXRAHa9cVJ3LO00QrsZxMG1M="
+  "com/android/tools/utp#android-test-plugin-host-logcat/32.3.1": {
+   "jar": "sha256-IvSQ8tJ1jMAvJV/J54X1g5WSElbghTEEy5g5/+wsALU=",
+   "module": "sha256-Ajdft/MaH/cqL1X0BukMGa+hFZJF5W7erbAy2MOXpTY=",
+   "pom": "sha256-5lREdmGK+f79jIKsgjIrBV/Zc6/yPmYDWG7jBrCSykA="
   },
-  "com/google/testing/platform#android-test-plugin/0.0.9-alpha03": {
-   "jar": "sha256-1st+Em9DMDcZC808O5BLGbqELUaxew/SfDjMTM7L7JA=",
-   "pom": "sha256-qCucEMqqjl0fPNtjhHqbA6yXOKUlswmrcNTRZh7f6iI="
+  "com/android/tools/utp#android-test-plugin-result-listener-gradle-proto/32.3.1": {
+   "jar": "sha256-rnY6BErH/EiM4NE81KScyuX8kRLnBgGhRcmp5xVr+bE=",
+   "pom": "sha256-RiU/ICaWf17xd4YQSNxSUQX2L5ZVygX4DTPnPUM6s5U="
   },
-  "com/google/testing/platform#core-proto/0.0.9-alpha03": {
-   "jar": "sha256-0AHrDMu/yMueqhk6NY5jcSl0Y5d1ZHvpSasjLCsptAc=",
-   "pom": "sha256-O7RSgN8d0clrmgFySmFFZrfWDTNFP81SwsdB+ZmcOk4="
+  "com/android/tools/utp#android-test-plugin-result-listener-gradle/32.3.1": {
+   "jar": "sha256-kxFP5cUIECrq6FJUqaEsg/LE5jByQ7KIhwi9cwn+xTU=",
+   "module": "sha256-r1tRYSL3l1Vnpp4gkdZvmiUu3Bo56EzTTKdf7vsGtKg=",
+   "pom": "sha256-FWeoc+ERLm0xq0MkimQkcy4iD6PnmO74D+KRw3Z+K4M="
   },
-  "com/google/testing/platform#core/0.0.9-alpha03": {
-   "jar": "sha256-bhgG0BXEFllvU6RaMQDiV0PDE6bj/E9S8k6LJX8sgs4=",
-   "pom": "sha256-nwPalZsyYcweuciIa/iu1vXWC7lbjYY4vtVUQ65iDCo="
+  "com/android/tools/utp#gradle-work-action-api/32.3.1": {
+   "jar": "sha256-3od3Omd+h/YZx1HDBq9u5zoEp7JuXyBf/yh3KNivSs4=",
+   "module": "sha256-Qz18BGs0B5EMKIPki6SUUekol8IDHavU34U+xalcGoA=",
+   "pom": "sha256-VzjG3Xe21wuEoO2Piowmweb/UbeLhq3my8Z75uTF6y4="
   },
-  "com/google/testing/platform#launcher/0.0.9-alpha03": {
-   "jar": "sha256-ABL5gKBZoMTCFtDx0AFoZ6sx64B54/j4efHwK3vjpuc=",
-   "pom": "sha256-GLgPNKXp+hpe7CJQ/XHlRl8utLTQnhgZQOOPG24GRFI="
+  "com/android/tools/utp#gradle-work-action/32.3.1": {
+   "jar": "sha256-yJQi99NGK9VSXm55q7WpgIBQ46E1Lgxu93Gxt6Iv0wc=",
+   "module": "sha256-PVhYZWS0GC/OnrqHtqlhxUD8guoVlhL5JSzoRNAYDmU=",
+   "pom": "sha256-cRfBhtD9amNXRMpUMlK1Lavu8FKExe0gak1vj6HHwGI="
+  },
+  "com/android/tools/utp#utp-common/32.3.1": {
+   "jar": "sha256-MU8u9TgU85MHh+oCr7TO7ZWJHtbJ9NQlnXwqY6Nt110=",
+   "module": "sha256-LT3v0UmSNj2d7US8noDF0ZYEVSK1uBYthZW71Wwo/f4=",
+   "pom": "sha256-e3Ey3Uu7CbtvtpiQPiegzx9oEC23iysHFCN0wk+5aSQ="
+  },
+  "com/google/testing/platform#android-device-provider-local/0.0.9-alpha04": {
+   "jar": "sha256-B0QtwA4p0/G4iOjh0CeGGE/DSN+98EBAYl4lpK+TfXc=",
+   "pom": "sha256-AMjkJ9XKqO/Y2somR7IhPLQCudOSdaOoLYiXfycP9xM="
+  },
+  "com/google/testing/platform#android-driver-instrumentation/0.0.9-alpha04": {
+   "jar": "sha256-zpiuoyDISshww8Q3wgFUybQ4tl1LGI8wBs+9mVQLizU=",
+   "pom": "sha256-Dj7vrn7BShAP7eaPtYaxazmQ1TporOTvP++8pmwruDU="
+  },
+  "com/google/testing/platform#android-test-plugin/0.0.9-alpha04": {
+   "jar": "sha256-rWP5T/wKSXtBrqxlb8JA0BQ5JwM7j/LaB3uFvL9+838=",
+   "pom": "sha256-KFY9aVuuo8RTY8h5K5lU9+fBc82kiYSPtSqRnpDflXY="
+  },
+  "com/google/testing/platform#core-proto/0.0.9-alpha04": {
+   "jar": "sha256-8avhsmNzy4YjwGoin4WLRa8Xwv+2gLBPsL7v7Wl5wIc=",
+   "pom": "sha256-YijZa1VDNPkExFbxm9YIjU7GI4D0EGbcP1bbA529wvA="
+  },
+  "com/google/testing/platform#core/0.0.9-alpha04": {
+   "jar": "sha256-2MbOsKXewFk9vlbZTw0EUfwUaYqJ1zLCdpCLtHSDd/4=",
+   "pom": "sha256-p7btFRZ8ejwm3spWL3buma7bK4/TXKbzLFqb+4Q/abE="
+  },
+  "com/google/testing/platform#launcher/0.0.9-alpha04": {
+   "jar": "sha256-+ybQ+Dxtlc1wCbiFvEQweQYOmcxNm9UUBCmiF78EPC4=",
+   "pom": "sha256-XLwCm+PDy5z3V6WXnw0YRd1WGCZgHj9p+DvY4LE5KAw="
   }
  },
  "https://plugins.gradle.org/m2": {
-  "com/github/ben-manes#gradle-versions-plugin/0.54.0": {
-   "jar": "sha256-GwK15/qy3AUq4vlHU+5tsezaQoE/dXGycpqURbROpdU=",
-   "module": "sha256-2WoCXAumonbmVKE4UxXPExZ9CN+2uQuwSQo5RTUvmsg=",
-   "pom": "sha256-WX6mffXE8mkYP1y+WZAa2cBuExeLVZHNII2bMwQZ2J8="
+  "com/github/jk1#gradle-license-report/3.1.4": {
+   "jar": "sha256-ZV7WKJxTwQVB+uHzru1F0HPpu6rdVfUqjrIsc1TPvpE=",
+   "module": "sha256-OVpezsP5ep89Q0GynnF84l0MCciDJ+NF70M/moPPLUU=",
+   "pom": "sha256-vRptNIeECKI5NtuBcEdu6QN4RuaqaVpFQuEu4naKia0="
   },
-  "com/github/ben-manes/versions#com.github.ben-manes.versions.gradle.plugin/0.54.0": {
-   "pom": "sha256-o07zaR8ZggeMe8ef2fuJojK3xzxFpYuBEVH+m/dgb+I="
+  "com/github/jk1/dependency-license-report#com.github.jk1.dependency-license-report.gradle.plugin/3.1.4": {
+   "pom": "sha256-IP8VMlnx10bXHZ0iUVlEBu2cuP2sH3IGSESIfVRwZzc="
   },
-  "com/github/jk1#gradle-license-report/3.1.2": {
-   "jar": "sha256-usYblgjaDRDRS+dHknUJ1xkjxQXLFunIBatR53gv2jg=",
-   "module": "sha256-g/wB/sH7gX2Zk3PDolzmr7HVCDGY28D9LOJwgdF6rBM=",
-   "pom": "sha256-PdcOs3qnhw3Lu3FhPsrJsQCf0gu5bZ6qnYbyyiUCGvc="
+  "com/google/code/gson#gson-parent/2.11.0": {
+   "pom": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
   },
-  "com/github/jk1/dependency-license-report#com.github.jk1.dependency-license-report.gradle.plugin/3.1.2": {
-   "pom": "sha256-DtyZC8qthXD2Ek0T89Mzmyc8EUdsl9r0kiBNEKh9WMA="
+  "com/google/code/gson#gson/2.11.0": {
+   "jar": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s=",
+   "pom": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
   },
-  "com/google/code/gson#gson-parent/2.8.9": {
-   "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
+  "com/google/errorprone#error_prone_annotations/2.27.0": {
+   "jar": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU=",
+   "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
   },
-  "com/google/code/gson#gson/2.8.9": {
-   "jar": "sha256-05mSkYVd5JXJTHQ3YbirUXbP6r4oGlqw2OjUUyb9cD4=",
-   "pom": "sha256-r97W5qaQ+/OtSuZa2jl/CpCl9jCzA9G3QbnJeSb91N4="
+  "com/google/errorprone#error_prone_parent/2.27.0": {
+   "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
   },
-  "org/gradle/kotlin#gradle-kotlin-dsl-plugins/5.2.0": {
-   "jar": "sha256-SKlcMPRlehDfloYC01LJ2GTZemYholfoFQjINWDE/q4=",
-   "module": "sha256-fxo3x8yLU7tmBAqrbAacidiqWOJ/+nH3s2HGROtaD7A=",
-   "pom": "sha256-uB9ZcQ4lOEW0+Pbe27BWPWfD5/UPg7AiQZXjo2GAtH8="
+  "io/github/ben-manes#gradle-versions-plugin/0.58.0": {
+   "jar": "sha256-b58wxQL2Cis9Xz5TnR/SENuuVKspMmWp7DkSOblohPE=",
+   "module": "sha256-owSUGOs11GKlWWcbjJdza6I1Yae+dz1OL3NFZtHkfgs=",
+   "pom": "sha256-t7jTGs2OckkS9C02Mj0DqVVwgW6HC9WWLtzm9X+hWK8="
   },
-  "org/gradle/kotlin/kotlin-dsl#org.gradle.kotlin.kotlin-dsl.gradle.plugin/5.2.0": {
-   "pom": "sha256-pXu0ObpCYKJW8tYIRx1wgRiQd6Ck3fsCjdGBe+W8Ejc="
+  "io/github/ben-manes/versions#io.github.ben-manes.versions.gradle.plugin/0.58.0": {
+   "pom": "sha256-6RMmMGdQVZF0VX7pwabnX+n47OF5MHfR2VI+wlrw35o="
+  },
+  "org/gradle/kotlin#gradle-kotlin-dsl-plugins/6.5.7": {
+   "jar": "sha256-zIyqQQGjXQzwQzpj6K04kRpMhIBz/MlPQ64CUfM+Ta8=",
+   "module": "sha256-ENa9ZquwiOylvjYP9yVQyWFU0mdu/t10rzHEUAF8OQk=",
+   "pom": "sha256-q+nzlg+nNZciqHUuYb/ElnYeFdFHNeTGQiB5cHYGq74="
+  },
+  "org/gradle/kotlin/kotlin-dsl#org.gradle.kotlin.kotlin-dsl.gradle.plugin/6.5.7": {
+   "pom": "sha256-Ldg2zAlxLNrd/u/GgNLqZutD2NxjOGvVlSZYE0l/Ry0="
   },
   "org/gradle/toolchains#foojay-resolver/1.0.0": {
    "jar": "sha256-eLhqR9/fdpfJvRXaeJg/2A2nJH1uAvwQa98H4DiLYKg=",
@@ -1426,120 +1483,114 @@
    "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
    "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
   },
-  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
-   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
-   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  "org/jetbrains/kotlin#abi-tools-api/2.3.20": {
+   "jar": "sha256-U2hfV4OwSQaDiY11Wrrk1Bi26DugYTSFiv3ctZRYmek=",
+   "pom": "sha256-qIbJ/X8rlmlFf+wCHxnc8V8EY+DbS9rVOuGBJTZsxvk="
   },
-  "org/jetbrains/kotlin#kotlin-assignment/2.0.21": {
-   "module": "sha256-8638yrZURNtqqzwNfSVoZG7AyS8kWCh/KLKu5POXNtw=",
-   "pom": "sha256-QBfCQqfb3Oca6ApXB7S/OyOoIr8jpodahFp7UTYhzQ8="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.3.20": {
+   "module": "sha256-bNjWSw5lN3kE8wb2qFja/ZMcQTUkD4RMk9UpTumP6Dk=",
+   "pom": "sha256-SgpFTor25QOv5ngwoYVjubaA3u67GhcGoNe0S8UHQKE="
   },
-  "org/jetbrains/kotlin#kotlin-assignment/2.0.21/gradle85": {
-   "jar": "sha256-USUeNCELiNTJCAXKZS6Xe93IR4OkVAY5ydIQkJhbrOY="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.3.20/gradle813": {
+   "jar": "sha256-pPEKPw6l3dH1VaT3BuCep/VSs8hSK7EAY2HdMG4152o="
   },
-  "org/jetbrains/kotlin#kotlin-build-statistics/2.0.21": {
-   "jar": "sha256-gBILdN8DYz1veeCIZBMe7jt6dIb2wF0vLtyGg3U8VNo=",
-   "pom": "sha256-/iTcYG/sg+yY3Qi8i7HPmeVAXejpF8URnVoMt++sVZ0="
+  "org/jetbrains/kotlin#kotlin-assignment/2.3.20": {
+   "module": "sha256-GCp0ZM5mvM/ejjG+aPoO7DE8HZDD2POWeclyJyliFjg=",
+   "pom": "sha256-f3R8uTA9Hfqh1hJfZsFUG+o4PsuZh2ta28riSAVZZ48="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-api/2.0.21": {
-   "jar": "sha256-j8orSvbEzyRWXZp/ZMMXhIlRjQSeEGmB22cY7yLK4Y4=",
-   "pom": "sha256-zL2XaTA2Y0gWKVGY5JRFNPr7c9d4+M1NQ588h7CQ9JQ="
+  "org/jetbrains/kotlin#kotlin-assignment/2.3.20/gradle813": {
+   "jar": "sha256-tYin5gfij7WAIo4SDdX/+L6nO9J3JnM6F35kRYLooB0="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.0.21": {
-   "jar": "sha256-n6jN0d4NzP/hVMmX1CPsa19TzW2Rd+OnepsN4D+xvIE=",
-   "pom": "sha256-vUZWpG7EGCUuW8Xhwg6yAp+yqODjzJTu3frH6HyM1bY="
+  "org/jetbrains/kotlin#kotlin-build-statistics/2.3.20": {
+   "jar": "sha256-ptJ7PINhdlLdBlYG+Yz1nPviY/jCDr5OvVpvJonrDU8=",
+   "pom": "sha256-nQqNf/FyPV1y00ldVVc9jTxrd3TWHYBXlxT3nCQmX48="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-runner/2.0.21": {
-   "jar": "sha256-COYFvoEGD/YS0K65QFihm8SsmWJcNcRhxsCzAlYOkQQ=",
-   "pom": "sha256-+Wdq1JVBFLgc39CR6bW0J7xkkc+pRIRmjWU9TRkCPm0="
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.3.20": {
+   "jar": "sha256-IvGrIjhUuUkJn2slnO9UHVtYo2Q9+aScRXfGPEFuhDs=",
+   "pom": "sha256-G14LLDaQXcL1XgpLeBKuY+MSXe/PaG0sD0kPg7c9nV4="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-client/2.0.21": {
-   "jar": "sha256-Nx6gjk8DaILMjgZP/PZEWZDfREKVuh7GiSjnzCtbwBU=",
-   "pom": "sha256-8oY4JGtQVSC/6TXxXz7POeS6VSb6RcjzKsfeejEjdAA="
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.3.20": {
+   "jar": "sha256-wGnzCkA75wyBUviqnyXsy6GI7q1UJjrgKvFEIUN6Igg=",
+   "pom": "sha256-jYTqDt1gs4vOpWLeUXgVKiZxqaAFPWcPkxRSs9sBMig="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.0.21": {
-   "jar": "sha256-saCnPFAi+N0FpjjGt2sr1zYYGKHzhg/yZEEzsd0r2wM=",
-   "pom": "sha256-jbZ7QN1gJaLtBpKU8sm8+2uW2zFZz+927deEHCZq+/A="
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.3.20": {
+   "jar": "sha256-xxp8G+j7/wTgr0XJ7oy3ph2JU7ymuL8iWlcZxyWpC0Q=",
+   "pom": "sha256-nnyLgHJBF/cqrOZfa+SNg224/Dl1OtlR8ruQhi1+cIA="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.0.21": {
-   "jar": "sha256-W0cHoy5GfvvhIsMY/2q9yhei/H2Mg/ZgN8mhILbcvC8=",
-   "pom": "sha256-P+CLlUN7C074sWt39hqImzn1xGt+lx1N+63mbUQOodg="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.3.20": {
+   "jar": "sha256-4WYu10cyK2P2HU+t2Zq3gQTEXq8JwRp4mGJBXoHBjcQ=",
+   "pom": "sha256-aP+Cf8E1DZPw1nM2jAZHm2K31eXDBlipWM+TBmgx6Nk="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.0.21": {
-   "jar": "sha256-Uur1LOMDtSneZ6vDusE+TxNZY1dUPfqDHE1y0tYxDlA=",
-   "module": "sha256-z29dNExVVVS/rGQFHq0AhcvUM4Z2uqP8h7UD6eSrvjQ=",
-   "pom": "sha256-gV5yqZ4ZFD1mLSTkYlKlnOdWMC18W9/FlIF9fMexI3g="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.3.20": {
+   "module": "sha256-04UBEP9ajrcP7S1Xi0X7B+vESvaika5M88eUMMZRKLo=",
+   "pom": "sha256-AdVSITSRyFPVb4frdIEwON+e4dhekIaqN70GY7JJb4g="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.0.21/gradle85": {
-   "jar": "sha256-Uur1LOMDtSneZ6vDusE+TxNZY1dUPfqDHE1y0tYxDlA="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.3.20/gradle813": {
+   "jar": "sha256-ybwX32m/OZB8WXweGb7EtHnHWqx1+/1jIeNEW0lxLog="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.0.21": {
-   "jar": "sha256-UzVXQrV7qOFvvfCiBDn4s0UnYHHtsUTns9puYL42MYg=",
-   "pom": "sha256-OMyaLLf55K/UOcMQdvgzFThIsfftITMgCDXRtCDfbqs="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.3.20": {
+   "jar": "sha256-5Cicv5/0lAfwQd3GM24bV3pspM8r4dKjEzgnHBPu0+0=",
+   "pom": "sha256-9veHObqf4nEunwyeW8T16TcZzP6pW0fC9JslC+F2NX4="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.0.21": {
-   "jar": "sha256-wfTqDBkmfx7tR0tUGwdxXEkWes+/AnqKL9B8u8gbjnI=",
-   "module": "sha256-YqcNAg27B4BkexFVGIBHE+Z2BkBa6XoQ2P2jgpOI0Uk=",
-   "pom": "sha256-1GjmNf3dsw9EQEuFixCyfcVm6Z1bVIusEMIjOp7OF74="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.3.20": {
+   "jar": "sha256-lS5zlI4qINOYwmuHprtwzPZkGPuvFSfDUVsYjqnUvWA=",
+   "module": "sha256-b7XZcwCl5Vmv1Nn/msA1bE2Wb31pS2Yvrhaf2HQhUx4=",
+   "pom": "sha256-WROHIVGNgqND99wvCRK3BJjT7vM2PJ66wiCssPyTjsw="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-model/2.0.21": {
-   "jar": "sha256-lR13mJs1cAljH/HvsSsBYczzKcUpxUalKfih0x+bwDw=",
-   "module": "sha256-6qn9n4b71E/2BwoZfce90ZgPDUHo20myUoA9A6pMVaw=",
-   "pom": "sha256-5RVeYOyr2v1kUmVKaYALyyp37n0fxucH+tOo5p8HTCw="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.3.20": {
+   "module": "sha256-lVUmc7gbNXitmy86/xRUtjzoBsb9SrfGBJIx6GQKtHE=",
+   "pom": "sha256-EcMjwt2KgE6fWOBHwsAYZLKgHcDYEys2PApDEiFbwJs="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.0.21": {
-   "module": "sha256-D5iXoGwHo+h9ZHExzDSQofctGuVMEH8T9yJp1TRLCHo=",
-   "pom": "sha256-RenM7OM+TY36mUHMkS81RYIBqdPwQ3IMMket3lf0f/Y="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.3.20/gradle813": {
+   "jar": "sha256-RuFu4mWU9ID+y5LJbarjdTDoNQJreON+8yUelX8D9vs="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.0.21/gradle85": {
-   "jar": "sha256-nfXH/xOx/GislFDKY8UxEYkdb2R73ewPQ5iz5yJb9tk="
+  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.3.20": {
+   "module": "sha256-+CvXZF0MPv609PZVIKPGWz6MMCsIMyIDegABuHsC6ZA=",
+   "pom": "sha256-3WuRkZfhMv5x3axw9vxdj65/Und6/YN7FN6HG4wKVAA="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.0.21": {
-   "module": "sha256-8JRUh/5RlZ/fi2oUQXB6Ke1fGsMaIxx/3r4sPd0i/fE=",
-   "pom": "sha256-Z1AT1Mvu4JyIkgriuiRvmfKKeJuHT2NASeAS+j7r9Mg="
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.3.20": {
+   "jar": "sha256-vpN3SFQS0A8B54KZyzC+SAJZHCcwNCtuva/AiU91J0M=",
+   "pom": "sha256-IbFbpb1i0h1Ta7egyMtnQ1cfwPQwklSKQjWybyodIgs="
   },
-  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.0.21": {
-   "jar": "sha256-R1eJEWW2mPvazo9NpvK8DpiOrvnvNnE1SIZajycGmv0=",
-   "pom": "sha256-Y/6HvSI1sSlAnHIqCbYsIKe3eueQGeIgMSSK9zawPFQ="
+  "org/jetbrains/kotlin#kotlin-native-utils/2.3.20": {
+   "jar": "sha256-QxnCdkeV773/K3julUVRV9evC5FVaYuqG6Uqar46vy0=",
+   "pom": "sha256-LAp+ADViCIXUN+fxJidEdbpYqiJC+1279D+R8gyvpwg="
   },
-  "org/jetbrains/kotlin#kotlin-native-utils/2.0.21": {
-   "jar": "sha256-ResIo5Kfl8SKkpEsliV3nRVAvG8/IS+56UYg0DJrzAA=",
-   "pom": "sha256-ZpB3PnZJ0dD61V0GCaTiHh68mF3Q+iYenG/9OJhnBh0="
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.3.20": {
+   "module": "sha256-nhEhx/ZQMDvdx/BH/tMCf4FjuzZ1Gy3w+vNjfumFsh8=",
+   "pom": "sha256-Y/Gk4+TT3jrPghTwWgtW/5IM4L9ZYVSnkE8gVuP41RE="
   },
-  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.0.21": {
-   "module": "sha256-kJCVCx7oa4b+KWmV2AKG6opPN5+yshjoVvzt0ErS1Hk=",
-   "pom": "sha256-7lYZBmzLB5zDMy4kcnQ1n9dQXeLVQPuRtyd5ICW2Siw="
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.3.20/gradle813": {
+   "jar": "sha256-oHxdPMvaP8dWTkB0RybhNz5UvSXwVGPT9D1DnXeOy90="
   },
-  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.0.21/gradle85": {
-   "jar": "sha256-HSNuNiIzuaJx5QsiOlDI2+rdA1C2OiRkYIJWhS2jaKM="
+  "org/jetbrains/kotlin#kotlin-stdlib/2.3.20": {
+   "jar": "sha256-CuElBKUEDrrzdwOQhINCDRpWJN0dk/NXZl+Md8hIoB4=",
+   "module": "sha256-9Os0T8TR46KK4WwIbsPkL1I3O0ZtQwgYL7OG45LA76M=",
+   "pom": "sha256-yDwC2afi6VRzBJHDPC8dwDwnZi4ntWbsK0TS0Bhjm5g="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.0.21": {
-   "jar": "sha256-8xzFPxBafkjAk2g7vVQ3Vh0SM5IFE3dLRwgFZBvtvAk=",
-   "module": "sha256-gf1tGBASSH7jJG7/TiustktYxG5bWqcpcaTd8b0VQe0=",
-   "pom": "sha256-/LraTNLp85ZYKTVw72E3UjMdtp/R2tHKuqYFSEA+F9o="
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.3.20": {
+   "jar": "sha256-NnFCeBKZvA+RIMHe7A5ik0oa+ep/AaqpxaU1TcXY19k=",
+   "pom": "sha256-R+Ou/SS1vmLYB7bLzXnFW4P5S1XP4Y79xuM84RvxkOQ="
   },
-  "org/jetbrains/kotlin#kotlin-tooling-core/2.0.21": {
-   "jar": "sha256-W28UhUj+ngdN9R9CJTREM78DdaxbOf/NPXvX1/YC1ik=",
-   "pom": "sha256-MiVe/o/PESl703OozHf4sYXXOYTpGxieeRZlKb36XVo="
+  "org/jetbrains/kotlin#kotlin-util-io/2.3.20": {
+   "jar": "sha256-DnbnRx6RxT6mjS0k7x8p+1kqxfuw0dEPqpFkMO/z2so=",
+   "pom": "sha256-lcKKgo/B8eWeZWOCR6ZPdm2B2LWfbY3r7y0YoMwyH4k="
   },
-  "org/jetbrains/kotlin#kotlin-util-io/2.0.21": {
-   "jar": "sha256-Dv7kwg8+f5ErMceWxOR/nRTqaIA+x+1OXU8kJY46ph4=",
-   "pom": "sha256-4gD5F2fbCFJsjZSt3OB7kPNCVBSwTs/XzPjkHJ8QmKA="
+  "org/jetbrains/kotlin#kotlin-util-klib-metadata/2.3.20": {
+   "jar": "sha256-qJlOC8poRt+xn0WMTMFdexN3nKGw2fNIgLX/LCorc7M=",
+   "pom": "sha256-jxApEHGu+rvY5m/5r3dDojiB1pxqryjhNhbMDpW9F7c="
   },
-  "org/jetbrains/kotlin#kotlin-util-klib/2.0.21": {
-   "jar": "sha256-oTtziWVUtI5L702KRjDqfpQBSaxMrcysBpFGORRlSeo=",
-   "pom": "sha256-724nWZiUO5b1imSWQIUyDxAxdNYJ7GakqUnmASPHmPU="
+  "org/jetbrains/kotlin#kotlin-util-klib/2.3.20": {
+   "jar": "sha256-lWK407egS+uisUwFZx5xOFnqVLvAohB+ZbK88nP6hEg=",
+   "pom": "sha256-WlhMPMK6O0HR5c1+eiCDV2wbjDl6ebuBY2dtjvew6hc="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
-   "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.0": {
+   "pom": "sha256-Ejnp2+E5fNWXE0KVayURvDrOe2QYQuQ3KgiNz6i5rVU="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
-   "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
-   "module": "sha256-DZTIpBSD58Jwfr1pPhsTV6hBUpmM6FVQ67xUykMho6c=",
-   "pom": "sha256-Cdlg+FkikDwuUuEmsX6fpQILQlxGnsYZRLPAGDVUciQ="
-  },
-  "org/sonatype/oss#oss-parent/7": {
-   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.8.0": {
+   "jar": "sha256-mGCQahk3SQv187BtLw4Q70UeZblbJp8i2vaKPR9QZcU=",
+   "module": "sha256-/2oi2kAECTh1HbCuIRd+dlF9vxJqdnlvVCZye/dsEig=",
+   "pom": "sha256-pWM6vVNGfOuRYi2B8umCCAh3FF4LduG3V4hxVDSIXQs="
   }
  },
  "https://repo.maven.apache.org/maven2": {
@@ -1617,6 +1668,12 @@
    "jar": "sha256-ysG1EkRpNnrJBlYATheeFmG3PaFlIhlP3NMnR7P4sjc=",
    "module": "sha256-hRT4XEby1I04dPmzkG/JOIIHPDfb9tFx7+smenVd0mw=",
    "pom": "sha256-7gHJjNR9lVtZmKbK68N8H+SouOI1crHufEylupSd22w="
+  },
+  "com/caverock#androidsvg-aar/1.4": {
+   "pom": "sha256-p4kZZoGu/2Ojde1L9BfHIfCHcp6ckMXk78zbyel+kko="
+  },
+  "com/caverock/androidsvg-aar/1.4/androidsvg-aar-1.4": {
+   "aar": "sha256-AqWwiis10tWOsurKnYSsAPs0Hacl/b1lPqPtEwQ36Vo="
   },
   "com/github/ajalt/clikt#clikt-core-jvm/5.1.0": {
    "jar": "sha256-f3gEn6gVm6wFzgnd70MTJI1MrQAUp0QhTBFQ0U42Yec=",
@@ -1785,6 +1842,10 @@
    "jar": "sha256-05mSkYVd5JXJTHQ3YbirUXbP6r4oGlqw2OjUUyb9cD4=",
    "pom": "sha256-r97W5qaQ+/OtSuZa2jl/CpCl9jCzA9G3QbnJeSb91N4="
   },
+  "com/google/crypto/tink#tink/1.18.0": {
+   "jar": "sha256-MN8SofWQRWNyE0d2VuAfb7zAJhbCDaFpbL1GQ62maO8=",
+   "pom": "sha256-CMLcrJzjdCispzsdaqapPzXDhSJNsDs8roQ7dOZNHt8="
+  },
   "com/google/crypto/tink#tink/1.7.0": {
    "jar": "sha256-iJcKRWoIukxmsBsj5YRsoQlcwU5Uy0g2Pl0uFaEwcwg=",
    "pom": "sha256-Ku41I3FfjyzRCyYDyNGeVhrHWDELfiyYU5RtLF57S/c="
@@ -1800,6 +1861,9 @@
   "com/google/errorprone#error_prone_annotations/2.18.0": {
    "pom": "sha256-kgE1eX3MpZF7WlwBdkKljTQKTNG80S9W+JKlZjvXvdw="
   },
+  "com/google/errorprone#error_prone_annotations/2.22.0": {
+   "pom": "sha256-tyXFIVFBaOnCDTcZp2qgG1DlpygoWfTqhMJRz5+EIIA="
+  },
   "com/google/errorprone#error_prone_annotations/2.23.0": {
    "jar": "sha256-7G858Gi2/5rDI8aOKLkpn4wKgMpRLcyx1KcPQKw+wFQ=",
    "pom": "sha256-1auxfyMbY78Ak1j6ZAKBt0SBDLlYflmUl3g0lZwH29g="
@@ -1807,19 +1871,18 @@
   "com/google/errorprone#error_prone_annotations/2.27.0": {
    "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
   },
-  "com/google/errorprone#error_prone_annotations/2.28.0": {
-   "jar": "sha256-8/yKOgpAIHBqNzsA5/V8JRLdJtH4PSjH04do+GgrIx4=",
-   "pom": "sha256-DOkJ8TpWgUhHbl7iAPOA+Yx1ugiXGq8V2ylet3WY7zo="
-  },
   "com/google/errorprone#error_prone_annotations/2.3.1": {
    "pom": "sha256-PtzmtxG6No7+Frm3qssCFPvWSEFMublllTouftiagZo="
   },
-  "com/google/errorprone#error_prone_annotations/2.30.0": {
-   "jar": "sha256-FE86771uJ9rsVdN1OyxrE8Gv2vDPBIFs21ZFiO2S8b0=",
-   "pom": "sha256-9xOEnCOzSVPoVFZdzoqnlcrgwUFmEbcgwhRhMix5X4Y="
+  "com/google/errorprone#error_prone_annotations/2.36.0": {
+   "jar": "sha256-d0QOJwsLyaJJkDxaB2w2pyLEiGyk9CZ18pA6HFPtYaU=",
+   "pom": "sha256-15z9N8hfdta3VMdQHuHchEe3smQsI4LXeCUhZr0zHpw="
   },
   "com/google/errorprone#error_prone_parent/2.18.0": {
    "pom": "sha256-R/Iumce/RmOR3vFvg3eYXl07pvW7z2WFNkSAVRPhX60="
+  },
+  "com/google/errorprone#error_prone_parent/2.22.0": {
+   "pom": "sha256-XSUivqg99aWBzNayJ2Nco04NOXt2ct50ispBVwgFc8c="
   },
   "com/google/errorprone#error_prone_parent/2.23.0": {
    "pom": "sha256-9UcKSzEE/jCfvpSoDRbDxU0g90j0xd5PaKQoaI8wy9Q="
@@ -1827,14 +1890,11 @@
   "com/google/errorprone#error_prone_parent/2.27.0": {
    "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
   },
-  "com/google/errorprone#error_prone_parent/2.28.0": {
-   "pom": "sha256-rM79u1QWzvX80t3DfbTx/LNKIZPMGlXf5ZcKExs+doM="
-  },
   "com/google/errorprone#error_prone_parent/2.3.1": {
    "pom": "sha256-dnUl2agRKc0IGWg4KYAzYye+QWKx4iUaGCkR2qczwSM="
   },
-  "com/google/errorprone#error_prone_parent/2.30.0": {
-   "pom": "sha256-Xog0zMDl7Qxy8wbCULUY5q0Q0HWpt7kQz2lcuh7gKi0="
+  "com/google/errorprone#error_prone_parent/2.36.0": {
+   "pom": "sha256-Okz8imvtYetI6Wl5b8MeoNJwtj5nBZmUamGIOttwlNw="
   },
   "com/google/flatbuffers#flatbuffers-java/1.12.0": {
    "jar": "sha256-P4wIi03QSphYch8uFiUIyU2w3Yb5YeMG7mPvLtqHG/c=",
@@ -1857,14 +1917,21 @@
   "com/google/guava#guava-parent/33.3.1-jre": {
    "pom": "sha256-VUQdsn6Iad/v4FMFm99Hi9x+lVhWQr85HwAjNF/VYoc="
   },
+  "com/google/guava#guava-parent/33.4.0-jre": {
+   "pom": "sha256-Okme00oNnuDxvMOSMAIaHNTi990EJqtoRPWFRl1B3Nc="
+  },
   "com/google/guava#guava/32.0.1-jre": {
    "jar": "sha256-vX+iJ1kfuFCWd9DREiz5UVjzuKn0VlP1goHYefbcSMU=",
    "pom": "sha256-QsJX9/c203ezGv7u6XirJtcwzXCvYN3nZi4YI1LiSCo="
   },
   "com/google/guava#guava/33.3.1-jre": {
-   "jar": "sha256-S/Dixa+ORSXJbo/eF6T3MH+X+EePEcTI41oOMpiuTpA=",
    "module": "sha256-QYWMhHU/2WprfFESL8zvOVWMkcwIJk4IUGvPIODmNzM=",
    "pom": "sha256-MTtn/BPrOwY07acVoSKZcfXem4GIvCgHYoFbg6J18ZM="
+  },
+  "com/google/guava#guava/33.4.0-jre": {
+   "jar": "sha256-uRjJin5E2+lOvZ/j5Azdqttak+anjrYAi0LfI3JB5Tg=",
+   "module": "sha256-gg6BfobEk6p6/9bLuZHuYJJbbIt0VB90LLIgcPbyBFk=",
+   "pom": "sha256-+pTbQAIt38d1r57PsTDM5RW5b3QNr4LyCvhG2VBUE0s="
   },
   "com/google/guava#listenablefuture/1.0": {
    "jar": "sha256-5K12B+XAR3xviQ7yaknLjRu03/tlC6tFAq/uZGROMGk=",
@@ -1892,44 +1959,53 @@
   "com/google/protobuf#protobuf-bom/3.22.3": {
    "pom": "sha256-E6Mt+53m/Bw8P3r1Pk1cd/130rR2uuOLdLdYHN7i5lU="
   },
-  "com/google/protobuf#protobuf-bom/3.24.4": {
-   "pom": "sha256-BOz9UsUN8Hp1VR+bCeDvMGMO5CN9CRyg7KceW/t4zOU="
-  },
   "com/google/protobuf#protobuf-bom/3.25.5": {
    "pom": "sha256-CA4phBcyOLUOBkwiav/7sbAjNSApXHkKf9PWrkWT8GM="
+  },
+  "com/google/protobuf#protobuf-bom/4.28.2": {
+   "pom": "sha256-Q2Zs0HJyjGRsxFphSu7q0eCyP4GPZSmC3yeaDlra8xY="
+  },
+  "com/google/protobuf#protobuf-bom/4.28.3": {
+   "pom": "sha256-vjuqm0GIZLXtfTnDvrMUHYP6eNEkVU6qkggyQ9y/sno="
   },
   "com/google/protobuf#protobuf-java-util/3.22.3": {
    "jar": "sha256-xhX3aHncXDA+TfW5Smr6OVNAWMdUXbLUg/2V2fY8i/4=",
    "pom": "sha256-tEcBsGoGSGXsm1YUqT6eKPrdfU38S0YPIcgZ71Pb4tY="
   },
-  "com/google/protobuf#protobuf-java-util/3.24.4": {
-   "jar": "sha256-EzySniz+OZChBdGOrMxJEistL7SStCDvAtXZ+Tfq67g=",
-   "pom": "sha256-nwzsJ21NnVpD1uKcwrAk5GgEyThqlvpSfu/Xv3SI5/A="
-  },
   "com/google/protobuf#protobuf-java-util/3.25.5": {
    "jar": "sha256-2sxYssPS+o1L3cGsuIHnjWz3wTfdeLwdZ/aspzJDao0=",
    "pom": "sha256-oJ0ZDqpqeWFrxfS1QE6UsMq1WYA6mMigkMQJmWL0H5I="
   },
-  "com/google/protobuf#protobuf-java/3.24.4": {
-   "jar": "sha256-5WVVIr4apcwfLwkqoDawRFFX8pSSju3xMyrJOMe2loY=",
-   "pom": "sha256-OUEiHKZXgZ3evZX+i3QPRwr3q/MEYLE+ocmrefEPq5E="
+  "com/google/protobuf#protobuf-java-util/4.28.3": {
+   "jar": "sha256-1wbre0+7Y7ejmJEQY0EIDrutu3jdja7Lp6bmjSgxyc0=",
+   "pom": "sha256-iAC+TsBG2X2VmSzE88YjnIbOtHTqVXgsPQCz4+Ajwh0="
   },
   "com/google/protobuf#protobuf-java/3.25.5": {
    "jar": "sha256-hUAkf62eBrrvqPtF6zE4AtAZ9IXxQwDg+da1Vu2I51M=",
    "pom": "sha256-51IDIVeno5vpvjeGaEB1RSpGzVhrKGWr0z5wdWikyK8="
   },
-  "com/google/protobuf#protobuf-kotlin/3.24.4": {
-   "jar": "sha256-UIyhPZe1D1QE6qN+tEk8sHiEFi63lxv5JNj4A9TCG7Q=",
-   "pom": "sha256-O7Hm75SmpDa9L/Zq8N1gPCPtOilDsvuJn4PZ+Hktcqk="
+  "com/google/protobuf#protobuf-java/4.28.2": {
+   "pom": "sha256-Hq7M4j+0exrlSZbxbA1UhVY6ly7CYreKgYDgfwqnclM="
+  },
+  "com/google/protobuf#protobuf-java/4.28.3": {
+   "jar": "sha256-ugKXfA/vi0Cvn4X+aa82LY4T8mhbSal1J1CxjacmFX4=",
+   "pom": "sha256-9wvqdL0LUyXC0vxNWNhhY3RAGXONHKQ24GfXM8X3wSU="
+  },
+  "com/google/protobuf#protobuf-kotlin/4.28.3": {
+   "jar": "sha256-AvZQvvET/YMNJuGTKutUPcSIJ8FpBQM9OswMVv5RtJs=",
+   "pom": "sha256-DaXxcIeVCUCECUk8cinKo6P4tyKSCAxg9tEdz1hCVfE="
   },
   "com/google/protobuf#protobuf-parent/3.22.3": {
    "pom": "sha256-OZEz1/b1eTTddsSxjoY0j0JFMhCNr0oByPgguGZfCSk="
   },
-  "com/google/protobuf#protobuf-parent/3.24.4": {
-   "pom": "sha256-+37AUFh2/bnseVEKztLR6wTDuM/GkLWJBJdXypgcrbM="
-  },
   "com/google/protobuf#protobuf-parent/3.25.5": {
    "pom": "sha256-ZMwOOtboX1rsj53Pk0HRN56VJTZP9T4j4W2NWCRnPvc="
+  },
+  "com/google/protobuf#protobuf-parent/4.28.2": {
+   "pom": "sha256-9/I/wW7UY89SV5//r6A5QOjmU7M8a08QYILFvxUFD3U="
+  },
+  "com/google/protobuf#protobuf-parent/4.28.3": {
+   "pom": "sha256-U2TNwFiy5aISr238GJQpkHDdQ0AmoVgnu+MTd0SJ9AM="
   },
   "com/googlecode/htmlcompressor#htmlcompressor/1.5.2": {
    "jar": "sha256-psxeXeBb7nQgj9MHj8H66uVPdK1wzlbqX0k2TFbSw4M=",
@@ -1939,9 +2015,9 @@
    "jar": "sha256-dXv+kGGTuLZR553CbNZ9a1XQdwos37A4FZFQT3edSnY=",
    "pom": "sha256-eEY5mzXHzWQqmzoADD4tYtBOs3pFR7aTPMixi8wvCGs="
   },
-  "com/squareup#javapoet/1.10.0": {
-   "jar": "sha256-IO9LguQ/98ZSKBohMTzzuUEJJGet0/pzUJwm9pae/as=",
-   "pom": "sha256-FpA0CiIiefLLrfNz6Igm+iD388w+wCUvNoGP7TJwGrE="
+  "com/squareup#javapoet/1.13.0": {
+   "jar": "sha256-THUX6EinGzbQadErs79Gpw/UzaMQXYIrDtLhnAC2kpE=",
+   "pom": "sha256-VKNPqFAqRryQ79tJJiYAWR+oC/mjT1pMeYMRrsFsqXc="
   },
   "com/squareup#javawriter/2.5.0": {
    "jar": "sha256-/PsJ+w6gqpfTz+fqeSOYCBNI5GjxJrNgPLOAPyQBl/A=",
@@ -1991,15 +2067,8 @@
    "module": "sha256-m5C0J0pa1gLdV01tS0iQNmOy3ppgufw0AiSCk9hD4SE=",
    "pom": "sha256-06DDd+epr8zbsCqrXgUNwhL/2pQNvUcOo5cSpDQt8I4="
   },
-  "com/sun/activation#all/1.2.0": {
-   "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
-  },
   "com/sun/activation#all/1.2.1": {
    "pom": "sha256-NgiDv2RIbs7xYbjygvZQNTbdGmcNU6Coccj7IBcOZ5U="
-  },
-  "com/sun/activation#javax.activation/1.2.0": {
-   "jar": "sha256-mTMCsWzXBW8h53nMV30XWoELtJAO9zzY+/K1D5KLqc4=",
-   "pom": "sha256-+Hm26UWFTGkAsNvuHIOE16s95+FX/XrISTdAXEFtKl4="
   },
   "com/sun/istack#istack-commons-runtime/3.0.8": {
    "jar": "sha256-T/q7Br5FSgXkOY4gx3+itjCNS4jfvvfKMKdrW31VBe8=",
@@ -2027,6 +2096,10 @@
   "com/sun/xml/fastinfoset#fastinfoset-project/1.2.16": {
    "pom": "sha256-kFgkJa3B9AtBNi2vuVFzkxIlrKpeeWINXmvVL2Rikro="
   },
+  "com/typesafe#config/1.4.5": {
+   "jar": "sha256-SksK/7IqlXJAnTpr3pnOPyBFxVHK3Byn/glpCJLFJsM=",
+   "pom": "sha256-/zJV7sDsi9XwZTc47BtINCpqkOPU6selb5BMauLhLtU="
+  },
   "com/vanniktech#blurhash-android/0.3.0": {
    "module": "sha256-1a1640mCYGf1M7DgLrfKkhvoHpJEaQYXNMT6YtjYJg0=",
    "pom": "sha256-NcviEiaV6br3iglVQI4XXwRd8fJ1SmZetaBJGRy+Oxw="
@@ -2044,9 +2117,9 @@
   "com/vanniktech/blurhash-android/0.3.0/blurhash-android-0.3.0": {
    "aar": "sha256-Mw7O8WpwCX1++g+JB2qJzYGObZ0LaIQg0+dwXLUpbjE="
   },
-  "commons-codec#commons-codec/1.11": {
-   "jar": "sha256-5ZnVMY6Xqkj0ITaikn5t+k6Igd/w5sjjEJ3bv/Ude30=",
-   "pom": "sha256-wecUDR3qj981KLwePFRErAtUEpcxH0X5gGwhPsPumhA="
+  "commons-codec#commons-codec/1.17.1": {
+   "jar": "sha256-+fbLED8t3DyZqdgK2irnvwaFER/Wv/zLcgM9HaTm/yM=",
+   "pom": "sha256-f6DbTYFQ2vkylYuK6onuJKu00Y4jFqXeU1J4/BMVEqA="
   },
   "commons-io#commons-io/2.16.1": {
    "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
@@ -2060,137 +2133,159 @@
    "jar": "sha256-8cwY8VldRBroOc2hRlwIsefbRrcsHX87NzIK4WQexys=",
    "pom": "sha256-tNgod+BwsV0dTmdrQV9qVCnw4i3U75gX2F5MWcU7yr8="
   },
-  "dev/zacsweers/metro#compiler/1.1.1": {
-   "jar": "sha256-MdND/GKbblD01JYxka2yau894e+iXYElBo596UheoSI=",
-   "module": "sha256-ddGfsqptq5lmPw8q3FAvy3yV3REOC+uYJZy7K8DQZks=",
-   "pom": "sha256-O2EQQfLfXlHKuw/Qyefz1u8HjR9oj2T7jeQ7i7zU5DQ="
+  "dev/zacsweers/metro#compiler/1.4.0": {
+   "jar": "sha256-Qf+QZDBzAMmrB61/F7G5K9ZjNUcmQtgxNK1KPrVOLHk=",
+   "module": "sha256-k9ymz+nkPNFO06QS/YSlvbzn5nmI04GYztKFqGvkKDw=",
+   "pom": "sha256-AJ+UKj1tqVN5myMw4y5qdPCdo87vusHFNp4LGT2HXPc="
   },
-  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/1.1.1": {
-   "pom": "sha256-HhMABm4TrgyLsUbMF/WzanV1zi0mSbU3t/+u5Sfxl7E="
+  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/1.4.0": {
+   "pom": "sha256-7LMyc2+NiU98G0c1YSdwsb+ejSUzjcNaHiU3IV5r5qU="
   },
-  "dev/zacsweers/metro#gradle-plugin/1.1.1": {
-   "jar": "sha256-mVgHMfSr7Hn8dGxCnQVMCXWiLHEZDXjvQguMDg18PuY=",
-   "module": "sha256-dnkR5xlz+f7fNRx2etacST+4hYO2E4ivTN6sJSAToEg=",
-   "pom": "sha256-DMa65DhfdVTon9W2pKjm98x5llcjCdX6h8jDpuppNNo="
+  "dev/zacsweers/metro#gradle-plugin/1.4.0": {
+   "jar": "sha256-38qoYdFLYO/Cl6VahF/46cRlZRLQb8p5p20VTqKfYFc=",
+   "module": "sha256-IbKrNHn8fcSKuyPsF9Zx/0wPtn57+7cIrph0vtISxB8=",
+   "pom": "sha256-nIIk9XBP9RggxFeppGXDgsNE++88EdR/NLBwCle48Rk="
   },
-  "dev/zacsweers/metro#runtime-jvm/1.1.1": {
-   "jar": "sha256-NFnWGIxNw8ycjgZ+I7gfO6Thll3tLXvG6L2CfSSy2LE=",
-   "module": "sha256-6VwmWgY+1Qbs7I4GXoZR1WMRDc9tYfOXcaQodrIk7Uc=",
-   "pom": "sha256-/Z9ZjxIc0SKldm5tCCEL01iDD/59+qw7vUahwkj69Hg="
+  "dev/zacsweers/metro#metro-common/1.4.0": {
+   "jar": "sha256-WFSwJLf1B1IPp8w1ddPUaTdeUcl9YA/DCS5xhwh8GNU=",
+   "module": "sha256-60iah5Xjr05g0+mWBNVOOLJQMRto0jHbtt+fQrVMCLs=",
+   "pom": "sha256-+jp+OVghCkBzf9finDNN0DKzwpDTyS02hU2m/Px0YV4="
   },
-  "dev/zacsweers/metro#runtime/1.1.1": {
-   "jar": "sha256-gZ/YKrOMEwFadi4jrHl1Z43h6IXBqvoRg+ESHGFosrw=",
-   "module": "sha256-d40CCk+mbG5vSblbLq4cErulW9nSuh0cKAwgSVrEMPM=",
-   "pom": "sha256-E+C5YR2XHcDzQFgtSGZ6L7bR/dyaGdtP/UOwvI2rlnc="
+  "dev/zacsweers/metro#runtime-jvm/1.4.0": {
+   "jar": "sha256-bFlp0p6tOMJyq8kD4BUIrzVN460auu2/I1uwK42Z5B0=",
+   "module": "sha256-XEE9MaifzCzuRtBhQp83a0yhGSmi1pdatf95jN7Nw48=",
+   "pom": "sha256-BaCCsRjtRS//GdIClzU/CWVb4oIwYfEv43A1fHiIaj4="
   },
-  "io/coil-kt/coil3#coil-android/3.5.0-beta01": {
-   "module": "sha256-mxFKXy6ESgYWIUBygotIP1bWG7pGoy7OyIs2RBDsJNY=",
-   "pom": "sha256-I+DBB588BtBF+IF+PyniToim64WVwYKUKmIH6/M3z90="
+  "dev/zacsweers/metro#runtime/1.4.0": {
+   "jar": "sha256-hLrLeGdK65qkCO72UC8bN9mFYrsbrp5etx56MV3eKMg=",
+   "module": "sha256-uYQYGuFTMvzK/byGV6JkayOGgZaPZWsM4J7uspPZ5eM=",
+   "pom": "sha256-alO3I1NIl1bjVjo3RqvrLo/a7Mv3yz624DJM3bQhReU="
   },
-  "io/coil-kt/coil3#coil-compose-android/3.5.0-beta01": {
-   "module": "sha256-bo/nHPP2mxlJXIm65SnuUWiA26CBW4ObETul6FPO3CA=",
-   "pom": "sha256-H/E3U2s0HvBWq8zfxT+4DphHq5N1Wu78kHIDjczkKKw="
+  "io/coil-kt/coil3#coil-android/3.5.0": {
+   "module": "sha256-xj0b9vXW4fUpGSKIzfAnBGzopUABhNX/e6IH60XPmWU=",
+   "pom": "sha256-tjaXy/DNcD7FJ7Q02OJEnNEFSr9edgXDhZctyBKUzEQ="
   },
-  "io/coil-kt/coil3#coil-compose-core-android/3.5.0-beta01": {
-   "module": "sha256-T4aXsdYY0GTN8xwmixkwBd0uEKVbangFZrxpi3njHgw=",
-   "pom": "sha256-7aTvfZX5fJq81pn3TdYZvurl53toBSYkhaVy2ebVzfw="
+  "io/coil-kt/coil3#coil-compose-android/3.5.0": {
+   "module": "sha256-0kJHjXUyB6lxQTABhREhEoOGiQ4fPjn/atuTzRLjb20=",
+   "pom": "sha256-m0lhHSQ8voovAFH3t8DbVH5ITDTAXc/QBcwwy10fuaI="
   },
-  "io/coil-kt/coil3#coil-compose-core-jvm/3.5.0-beta01": {
-   "jar": "sha256-1bggBh9BiCqQEFw6SNkDuyUktQq4Go+UBA3Eevj6qgw=",
-   "module": "sha256-zVJuXqo+bABuVTeD63YbhDQjkjR/KAY88vQIjcnOA0A=",
-   "pom": "sha256-rNxSvLVZq9EoHGB8R+UAbLv6PFzHenxaugkoJxdWMYU="
+  "io/coil-kt/coil3#coil-compose-core-android/3.5.0": {
+   "module": "sha256-2dU3QgcHFbIeOpLF3jdJBaBDIV/UQv8DDhQSPspYP98=",
+   "pom": "sha256-PsxMg63zJoP5+WILfnuaFIGARqMvXxi1Lfvnq/bMueI="
   },
-  "io/coil-kt/coil3#coil-compose-core/3.5.0-beta01": {
-   "jar": "sha256-3rpZ/T6+xD+OKMtNpu3h3Q9YC8ha8ZZPrsbmgixFph0=",
-   "module": "sha256-b0Nd6a280k3/3gVk5/sEXYkbRfG5rCO3zbziZpfhZOs=",
-   "pom": "sha256-v1yuxq2mNdhXu+/BYbk9Tiw56hiz0EPKQteb6plCBcI="
+  "io/coil-kt/coil3#coil-compose-core-jvm/3.5.0": {
+   "jar": "sha256-ONgOU82dzaH6hEcL06p6YIBFG2zFKwPJ3/oiVwt/Djs=",
+   "module": "sha256-DT1BREh0xTtkcIi0wJ/zaV+RgHszPQUPrL3IIL2tQF4=",
+   "pom": "sha256-Ui50fnx943T8QTAqlov8SQ0YDc2tO2RWNfoSnse2BcI="
   },
-  "io/coil-kt/coil3#coil-compose-jvm/3.5.0-beta01": {
-   "jar": "sha256-hEC1U8TWZ9Tqa4ocJdv+hXhl6h++7LHrmWX4Z/fRlus=",
-   "module": "sha256-dX1DXViMW4hbaHqyqzd3K6Upd5dzAOYoXC5L7muThTc=",
-   "pom": "sha256-HyIdVlQdF1TTCmLvR1hpxpfcKp9xU+c2GYEmMY/x4Ow="
+  "io/coil-kt/coil3#coil-compose-core/3.5.0": {
+   "jar": "sha256-snkO5Mh5WbH5kcTG2mG2HIR0tQWP6FFNoUbxJcAFHKk=",
+   "module": "sha256-s/JTzWL5ov39GnzEhWH8wGaLxCft9enQUAEvxxGcIRQ=",
+   "pom": "sha256-k5bLPvlAUEvaKwxhLonoAx6zu8YumGRpUYESvqKY5Ug="
   },
-  "io/coil-kt/coil3#coil-compose/3.5.0-beta01": {
-   "jar": "sha256-HW23bMsvhgjr/XGmRLFXlQ7+U1ALEzvcyO60iu5w6uM=",
-   "module": "sha256-ToGXqXT0kwOJhH9/KYq08tnXKcpuoF/lX4b+t+CyByo=",
-   "pom": "sha256-t6YNifKhjJE91ps6qjUHRo0AIbRBILgd/zetl7n6PCI="
+  "io/coil-kt/coil3#coil-compose-jvm/3.5.0": {
+   "jar": "sha256-7HjdXqoMQyaxl4gOXnpEwxsObaps0rhjbKfhwDLONWc=",
+   "module": "sha256-GuzmZYiIKCAb9iRKdffmbKAO45Kso+RQ9V2ggBG4604=",
+   "pom": "sha256-Lc97ffgtv4hScSN8flVcA44hCnWa8yO6S/AOvRviK0A="
   },
-  "io/coil-kt/coil3#coil-core-android/3.5.0-beta01": {
-   "module": "sha256-YzK9ZD+e6SksOcyrF3g/AszoOy4mfzePyPZ1N2FEgpM=",
-   "pom": "sha256-SX2zjcIQwvOy3H5UZfMGX/2izxHZ/AZ1ymwAPNJRH+o="
+  "io/coil-kt/coil3#coil-compose/3.5.0": {
+   "jar": "sha256-/nF5oHlfdOHo/pAWQr1/HBoRUBltnMIDfg9ac1npefI=",
+   "module": "sha256-MvIs2stFswQnXjVbh9a1UiXYjg95owYwG7WeAc+mh8o=",
+   "pom": "sha256-wHrUPUFRuB9NdATEm2teDpTeO6KeK3QS+n+cBW0aGYo="
   },
-  "io/coil-kt/coil3#coil-core-jvm/3.5.0-beta01": {
-   "jar": "sha256-p12Kp4UF9dNaTpxrBUxvWMMZQmIvLlyz9sVAKQO90oc=",
-   "module": "sha256-cDAPYSpXzEI3fLUXzChFIzY5kh/WJXUYh0A4onEDvZo=",
-   "pom": "sha256-meZ54pjrIfRZf2Ne25JSsfWFACxecyesYj3FE9udRNY="
+  "io/coil-kt/coil3#coil-core-android/3.5.0": {
+   "module": "sha256-xFW39yUVBwXsb8QlWKNPwLFXNNNVNyJrbrTuMJcvP30=",
+   "pom": "sha256-FPf6Hdn3NHFUiO+75pkd9mmu/pC/e8VQiTx49WYIYPI="
   },
-  "io/coil-kt/coil3#coil-core/3.5.0-beta01": {
-   "jar": "sha256-11MYayv1c8q7UGRu4/AivT1ZrCc8kaRwzGZdGFxwloA=",
-   "module": "sha256-aPn/xzlxCbW0vYmDbfY7CP80pI7mW64NCRxprbUvSW0=",
-   "pom": "sha256-XacP9kPOGyJeYbxuS1SWPl/i+UoBYlPeJ8RW6/xWavk="
+  "io/coil-kt/coil3#coil-core-jvm/3.5.0": {
+   "jar": "sha256-R5MR31Z6Q12IrvT6u+wEWFVWdw54gdhsF1iwfVsSb0A=",
+   "module": "sha256-PGcCC5wwI3tOUpcgag6z6ryaVUJLDb7xBiISFP2NnTk=",
+   "pom": "sha256-GG+zuR92UiTCYKX/qEhNZx//X9MQICBiH/rAStV2K4g="
   },
-  "io/coil-kt/coil3#coil-gif/3.5.0-beta01": {
-   "module": "sha256-00qJ6/w7MoGnSfCCIxo3Cl/3Q+Qw0nw26XU/vBZHqPo=",
-   "pom": "sha256-k/vcQcIbLApBXw0KWhuDP/Wn8aN0eg1BcQ52Vr+cWXc="
+  "io/coil-kt/coil3#coil-core/3.5.0": {
+   "jar": "sha256-kvzkOZHG/8czx8fQpKhuZA1Gg0p+PgoRxtwfxENcKtU=",
+   "module": "sha256-rDdDBgllEqRfCBatYdtIYvjHRoID3GcL6mjaO9odZXE=",
+   "pom": "sha256-mfQPAnIBPPsi7mW1AeZ/qlJtbxzarj1djVGR7jX3PsA="
   },
-  "io/coil-kt/coil3#coil-jvm/3.5.0-beta01": {
-   "jar": "sha256-FuRMFYG9fFczMNTIMUU9gdLKUGWtgZxFyuj/lkExepQ=",
-   "module": "sha256-yeTTr2pkjU73aXVOCIk/jtQNqwUh7n9+aohRT52yoQY=",
-   "pom": "sha256-ixtB8PEPMIUR0r96/u46KmooBcB6dMfi13K/UMOUSFU="
+  "io/coil-kt/coil3#coil-gif/3.5.0": {
+   "module": "sha256-n5S0553doFh5sMXDUsqh/AnIsoj/97R4GlCCe4h990s=",
+   "pom": "sha256-T++guqHsFr3Yu11MimosKx0DzsQkz1yzL5tsV4hOuV4="
   },
-  "io/coil-kt/coil3#coil-network-core-android/3.5.0-beta01": {
-   "module": "sha256-PZfCUTC2+kjxl/bj8R/RA4Rif3P/hu1yaRi1rcJV6p8=",
-   "pom": "sha256-x98DK2vfpJBBIvMCX6Wuufn5njmgixlZna0y47pPIf4="
+  "io/coil-kt/coil3#coil-jvm/3.5.0": {
+   "jar": "sha256-ooDTOMsipr3C9/J6yh/szDFCpnwp9c2UW9lI1bMScnw=",
+   "module": "sha256-vJMhGSQDbldwrvRUiFlDRD80ns8WiKX5g6xRzsz1mXw=",
+   "pom": "sha256-rygl/tKTKae4577HmP6T9eEAXmdmh3K9V60LOSZeZO0="
   },
-  "io/coil-kt/coil3#coil-network-core-jvm/3.5.0-beta01": {
-   "jar": "sha256-FXEFoZjH0aZDC7ANpPfIXWhxfbpZOOuREmrsURg9B5Q=",
-   "module": "sha256-3WyJ/F6rgLIVqTzMehdzvxWCWN+5vzLlzUlzVXC+H8Y=",
-   "pom": "sha256-O+W2gdZA7BQfWYtOQTEYWinYk7Khwaniaf+je+c//Yo="
+  "io/coil-kt/coil3#coil-network-core-android/3.5.0": {
+   "module": "sha256-GzrUiWlo/cJpRomvdKO5WbJojQsC5qpfxVNNyxAq6rE=",
+   "pom": "sha256-ngQ2S0TCgPJhzX1d0ybGwktF9N2eBmbOknRDko7B2WA="
   },
-  "io/coil-kt/coil3#coil-network-core/3.5.0-beta01": {
-   "jar": "sha256-irMBKkLATfMmmw1MzoLTYLzc6PyIKy2Mc+ZGbcO0G5o=",
-   "module": "sha256-EdegVJkMBY5O5XrPhgc4GNCS88gsRzzj4/bkl15zw6M=",
-   "pom": "sha256-le7vs3offwSGSLB8h3RJKI87KUXp7M1zKEERSjKKotI="
+  "io/coil-kt/coil3#coil-network-core-jvm/3.5.0": {
+   "jar": "sha256-PrLqeCMkYMm5rl6+luO/s7ULLEGzknfvtK5FSthlLWo=",
+   "module": "sha256-lay1QHUipwwI56DljJDI0OEWmod7sddN2gvz2pzluRY=",
+   "pom": "sha256-hyOXypVdpkY0iAOdS6x42wgyKgtTvIUTRGGKHRU6CvU="
   },
-  "io/coil-kt/coil3#coil-network-okhttp-android/3.5.0-beta01": {
-   "module": "sha256-4WIYVlAJNJisD/qxQ7+eZPNIlBKubM4Wv4BLpJrC0xU=",
-   "pom": "sha256-xlr1aGiYw72NiXnhZWy/K9G3wLIxXwK1kNNeLk1dNQo="
+  "io/coil-kt/coil3#coil-network-core/3.5.0": {
+   "jar": "sha256-GKOaO2nmBxn9Toueu8CQ+VPmDZC7EpIE54i4pN9QXY0=",
+   "module": "sha256-l1jlB3oWnZZ66d7Zb+68dFU/eQVcT9r/emdvoxqHxJE=",
+   "pom": "sha256-XaWUFSdgDZl2p+s2Of87LU5h3SKz3ljFBORe9C3ML+I="
   },
-  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.5.0-beta01": {
-   "jar": "sha256-wtJ1Oc/OHgyPiTQsSvPrxG2TtJlUP3MD2z4/OS9iAhY=",
-   "module": "sha256-YLRVEMmdUA+N7xrPN9AmpSe0lc/bhzYVrIhdm7iiLmk=",
-   "pom": "sha256-XseMXREdINV7/neMg2e3woD5Zx7EXLic9WXwYOleSf0="
+  "io/coil-kt/coil3#coil-network-okhttp-android/3.5.0": {
+   "module": "sha256-XJpsa8vtVWQiFz3wmr7YV3U+XYCr3/nK8FKL0JL1jfc=",
+   "pom": "sha256-HG/XarmnCZW7ti5P+ystgDRW8RNkONxY/xDPMn1zdSw="
   },
-  "io/coil-kt/coil3#coil-network-okhttp/3.5.0-beta01": {
+  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.5.0": {
+   "jar": "sha256-c7EYleMkgSpEA9MtbF2Mtn2tP8Px1X/7BVXaBsWSll8=",
+   "module": "sha256-0vwcRS7E4014cMY4EvePV9XqqNIaVW87auu69B6kfQI=",
+   "pom": "sha256-YaCTPhuzGSyCz0P5Y/gVgYq7OuRSIEIWp1VdiCLmvLU="
+  },
+  "io/coil-kt/coil3#coil-network-okhttp/3.5.0": {
    "jar": "sha256-mUDHZn3QbRihsY0j0ktKlXvXEFif66VLUNlhiEUtHpY=",
-   "module": "sha256-KwxxNAeN+iGBEapuqzQFbQy8vYzOf1k64YwPy0lXbk0=",
-   "pom": "sha256-gay9LyJJtLkzXC8650pAsNHInjls1XPOPiK7dmZVwGk="
+   "module": "sha256-LTzqV7DWpjIiC1luVRahwB8bhtLZgEKRIUnED/D5AGA=",
+   "pom": "sha256-0pqRZ8xGlRh+hWEvqz6NNDTBrrLyCbIL6q7zpbwZ4no="
   },
-  "io/coil-kt/coil3#coil/3.5.0-beta01": {
-   "jar": "sha256-fhq+PVgs1+kxFetX5ryjpCLDjtKHXRHnqfOfF1sJYF8=",
-   "module": "sha256-Y6u/NcatELbrNBNh0sgKcVJAqIrbu59JjywVhCCAdnk=",
-   "pom": "sha256-3zQRrqSTGs/PiqV8kLDjh3scJA+2K2hA3E51LY/TFDQ="
+  "io/coil-kt/coil3#coil-svg-android/3.5.0": {
+   "module": "sha256-TegTOJ+aAFCpgJUm8wrdbX7JxX4fhCxOcN7tT7jw/9Y=",
+   "pom": "sha256-AUR1FeR/etaLecPj7F/5A0BMaOhXyuDa1N+I1qF3ST0="
   },
-  "io/coil-kt/coil3/coil-android/3.5.0-beta01/coil-android-3.5.0-beta01": {
-   "aar": "sha256-4eCvVI1KilNZAiHDBzZzka0GtCYZ3wQuJ8mwAjV1tX0="
+  "io/coil-kt/coil3#coil-svg-jvm/3.5.0": {
+   "jar": "sha256-X7U1Fs8IPCvdPPQqi+SWUoiWXJ9tGOh3YnxmgF69JZQ=",
+   "module": "sha256-A7zOmK69qBzAT1aXqUSgGKrXVji2JuPo8PhFFtSfPD0=",
+   "pom": "sha256-QqLl97XVFrjvzMM/BGVmgtl2SlhUCoOc6sQ1TPASZ7I="
   },
-  "io/coil-kt/coil3/coil-compose-android/3.5.0-beta01/coil-compose-android-3.5.0-beta01": {
-   "aar": "sha256-qgzc8LzqR8hBTvTG20ZNNi+L/8plKD6xNqXtKE+CuNk="
+  "io/coil-kt/coil3#coil-svg/3.5.0": {
+   "jar": "sha256-Km5vLhrHJzjRmGjKVy/nY7BNU9ULm+EI3XFlAMV/FHQ=",
+   "module": "sha256-pWtep+cI6gRPusAYZaMrAlJY0lxmxy9J1MRzHAzW4D0=",
+   "pom": "sha256-g8FdE+5Mid7ikI2TFMcFkkQlFmb+dNcIKgG7vJ/x238="
   },
-  "io/coil-kt/coil3/coil-compose-core-android/3.5.0-beta01/coil-compose-core-android-3.5.0-beta01": {
-   "aar": "sha256-h9pmGwUI0ZxjStzP/liPttoLC1/PUuC7HQAbjBC3jVE="
+  "io/coil-kt/coil3#coil/3.5.0": {
+   "jar": "sha256-UlVn9j7ckTvfQRfd5fPeEGGhGtaOxltx6BQ7MZdRP8U=",
+   "module": "sha256-biyG2PvnFnYnXmTVhqCU5+ObW71/dQEKLY23vPvcWgE=",
+   "pom": "sha256-6vIl0PbBLtS+ahvU3skjAYplRAi2uFKW0ia7Yg21nTw="
   },
-  "io/coil-kt/coil3/coil-core-android/3.5.0-beta01/coil-core-android-3.5.0-beta01": {
-   "aar": "sha256-hjoM21bp6l17l7YBo+DVFqytKSaRmY5eNqAWx3eo9+s="
+  "io/coil-kt/coil3/coil-android/3.5.0/coil-android-3.5.0": {
+   "aar": "sha256-o4h/id47m/VP6U0B+L240r0iTABgfmohrJApLCsg0Z4="
   },
-  "io/coil-kt/coil3/coil-gif/3.5.0-beta01/coil-gif-3.5.0-beta01": {
-   "aar": "sha256-80lx4EcIaExv9Hgsn+6T+bVwUVzY5v/6OJPUIvhOZYU="
+  "io/coil-kt/coil3/coil-compose-android/3.5.0/coil-compose-android-3.5.0": {
+   "aar": "sha256-f4zhXi/hRW8qFtVfPl7J00XW4bOEAmldz6obXVctocI="
   },
-  "io/coil-kt/coil3/coil-network-core-android/3.5.0-beta01/coil-network-core-android-3.5.0-beta01": {
-   "aar": "sha256-1bEVcTQ18ScKzBw9LuTUIdyDvOSRhIW/g4if+fkDcO4="
+  "io/coil-kt/coil3/coil-compose-core-android/3.5.0/coil-compose-core-android-3.5.0": {
+   "aar": "sha256-4mS9fAggF4DGmQJc5pr1jUDeJ2pEA24QNYscZBA3wWI="
   },
-  "io/coil-kt/coil3/coil-network-okhttp-android/3.5.0-beta01/coil-network-okhttp-android-3.5.0-beta01": {
-   "aar": "sha256-NDon7OByAjAPDmobjWI+U1PAU2aYRP76skFrGtzKdgE="
+  "io/coil-kt/coil3/coil-core-android/3.5.0/coil-core-android-3.5.0": {
+   "aar": "sha256-nnCyiJ1c1qDkvd2C66L2MCK3eQokQjBg+0mhMazl2nU="
+  },
+  "io/coil-kt/coil3/coil-gif/3.5.0/coil-gif-3.5.0": {
+   "aar": "sha256-EoOk8E7wv7p0BOb8ckc6PIw42RrAw5HXxBSxlf+k7/I="
+  },
+  "io/coil-kt/coil3/coil-network-core-android/3.5.0/coil-network-core-android-3.5.0": {
+   "aar": "sha256-M0DsFW3I9fRa3ATPd4PBnX6tIS67AvokL6K4T1Ofg6s="
+  },
+  "io/coil-kt/coil3/coil-network-okhttp-android/3.5.0/coil-network-okhttp-android-3.5.0": {
+   "aar": "sha256-FIYDXva+eSaJJiPvYhFsUzu3+uCBaTY1j3SLPhHy4tU="
+  },
+  "io/coil-kt/coil3/coil-svg-android/3.5.0/coil-svg-android-3.5.0": {
+   "aar": "sha256-JvTgWFBqY4nBM9cejqggvB4PsELLMklc6uOwVGbxfmo="
   },
   "io/github/java-diff-utils#java-diff-utils-parent/4.12": {
    "pom": "sha256-2BHPnxGMwsrRMMlCetVcF01MCm8aAKwa4cm8vsXESxk="
@@ -2203,15 +2298,15 @@
    "module": "sha256-Yr0DpoiTACCwevVi8YDE5HAZRvhjx++mITlp3IHKWDg=",
    "pom": "sha256-XESpbotbhEnKaAf2WDeod9P6waERqw+xKW37aTFk8D8="
   },
-  "io/github/kdroidfilter#composenativetray-jvm/1.3.0": {
-   "jar": "sha256-9WFazSLSGP8smuRttNoUHImIuhz1UvP5QWDiTki6zis=",
-   "module": "sha256-/evLsbosiegfNcFr6R3vJQEbCC8fi5Nr/vmM12WI/kU=",
-   "pom": "sha256-qnSy6V6hgOquqcPQRwPi5w0nNdZILEsjAePq1iW7rUI="
+  "io/github/kdroidfilter#composenativetray-jvm/1.3.3": {
+   "jar": "sha256-F8B12fsLN+a+kJoNJ9bHrhwm+KxEFUzOL3QbTIsbdzI=",
+   "module": "sha256-xV7iYEfVmceX3qCYLN+FY9QWluvxyDb1MeDQSR9JZ50=",
+   "pom": "sha256-Gz0+ry3HVxCcJpzlOo68UxswX+wiSGiVMJCR0TQ8ia4="
   },
-  "io/github/kdroidfilter#composenativetray/1.3.0": {
+  "io/github/kdroidfilter#composenativetray/1.3.3": {
    "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
-   "module": "sha256-/HuKepuvs8ohUcOpm9FceTrqFfgFxeYC0+Z8VmVGMT0=",
-   "pom": "sha256-ox2suexJ3ArJnnq2e5gimsITy8tXaPyAhX74u+DSt90="
+   "module": "sha256-jd+NctkHizJCrXzjCP+XZn1EEtpKDp4iBbccfVSoRL0=",
+   "pom": "sha256-HnJD8doNqY/PMwkU+4CFUNIcKVSwW3PZgzTtLDV7DuM="
   },
   "io/github/kdroidfilter#knotify-compose-jvm/0.4.3": {
    "jar": "sha256-T0fvdaCRBa56tibZ30IX1sYnSQVYx0KXKXg+ZxklSw0=",
@@ -2280,6 +2375,15 @@
   "io/github/kdroidfilter/platformtools.darkmodedetector-android/0.7.5/platformtools.darkmodedetector-android-0.7.5": {
    "aar": "sha256-WS8N3Brt8GS7/LoEKjia5M416c6QAeh/f/5LTNvwNKc="
   },
+  "io/github/oshai#kotlin-logging-jvm/8.0.03": {
+   "jar": "sha256-YL4NH596yVQSO9LOi8BLzijLlYKDG2mNBjtg5sr3zrY=",
+   "module": "sha256-GeL+XQA3OvXpYBIFxXKIjkcl1SPgfKwU8hVZNXh1oJc=",
+   "pom": "sha256-U+LNOyOdfsZJr4Jr64FxYSgrhmTgLYxIwA+r9dKAEEw="
+  },
+  "io/github/oshai#kotlin-logging/8.0.03": {
+   "module": "sha256-r47Cbzag83hN4HfkIUgh96EVS1RuFZEba3YZmzNqPIM=",
+   "pom": "sha256-ybI+IQltbdj+K3ATr0SlejCwIm+xAtwvGWNF02vc+Ng="
+  },
   "io/grpc#grpc-api/1.57.2": {
    "jar": "sha256-QrcuZXLAhAVaw84D5u/kM+sF72ILPa9RNqQ1n8csw+E=",
    "pom": "sha256-x99FUaZPAoKnZugJUU1COEUKdCkFX5x3GIgdFqMQoCY="
@@ -2306,10 +2410,6 @@
   "io/grpc#grpc-core/1.69.1": {
    "jar": "sha256-UTUsra7L+aSkqkLZP28fxyjx/QGwUWgDg+0J5WMf+9A=",
    "pom": "sha256-loCY9KhFG7zT17iMaoq1t6dO+A397npgUvNS//eDssU="
-  },
-  "io/grpc#grpc-inprocess/1.69.1": {
-   "jar": "sha256-t8asDjq/S41YJhDWMteUF7w9qBJU4aS89/Aejbe9Ve8=",
-   "pom": "sha256-/rswpc8jgjfQdaOSPok5khg9rxcaHrQ0rPEyEUpff4o="
   },
   "io/grpc#grpc-netty/1.57.2": {
    "jar": "sha256-mAnUwQyU0R57KUbN61sohL4goJUQKJVE83Vp8CyHeiE=",
@@ -2351,117 +2451,279 @@
    "jar": "sha256-3Vl71nXqoELz41eGSNkFDIE8RZXF3mhp753btEkAYDE=",
    "pom": "sha256-0g00aMt01WvlXtPUb2PKOO5LygkY2arXJ3pEj24HpbQ="
   },
-  "io/ktor#ktor-client-core-jvm/3.5.0": {
-   "jar": "sha256-VPHR8goaFXYdC0RaisGyb4WVOsNf4id2N3xbQWb7N34=",
-   "module": "sha256-M9wLAQXnJM5N3l37qyIws/FE+4czdSqHWXOQJ/q7YE0=",
-   "pom": "sha256-uN/og5qZl25LOIg+MEepXWbpjCICinGZvSuWtItGQmk="
+  "io/ktor#ktor-client-core-jvm/3.5.2": {
+   "jar": "sha256-PgPXHFxjcNEo9IPPY8/mJijVwNGxrF5F2+Kmgl5pavQ=",
+   "module": "sha256-5Wd4i2WHWCiih9/Z1mx7L67a0YP2rH8mFO0/b8y00Qk=",
+   "pom": "sha256-OCnQqtatf187nXfKa97h3Vw/OJrItwSXp7EjCYDPP3o="
   },
-  "io/ktor#ktor-client-core/3.5.0": {
-   "jar": "sha256-MZOSBfhiEFwvY0YnKrtVSRRaFbRgJf5o3xrT6bXErPY=",
-   "module": "sha256-vSX44EwJcZ7txWV5aW5xjZxhLVypZMDp3oEVtCSwO/Y=",
-   "pom": "sha256-bihc2pmG1VOcBJNCwqftMRY1MYRKt/3JJQCwBSe9NHg="
+  "io/ktor#ktor-client-core/3.5.2": {
+   "jar": "sha256-NYl86DJjCk4z8EFpUbiyYDpd6zvmUpqxeoUEPPASRjk=",
+   "module": "sha256-IcCLNdRFVpQZMFgldjUiCS4E+9su9eOvQ2e/B47AzXw=",
+   "pom": "sha256-ivRBpkstvC5MHwCNsqt6G9QglV4GH/iUQaDAViGbKCk="
   },
-  "io/ktor#ktor-events-jvm/3.5.0": {
-   "jar": "sha256-jUm530dFrH4hOGTdQkmwmLTr0VZviwCHuL+3rM4CS1Q=",
-   "module": "sha256-VsG1N4ALdcgks1iZ+pBOkhjk5N9sGVi0j4FQXPLf1Kw=",
-   "pom": "sha256-pHpoFsDiyVauryyEiaxAxKGupz1fblmlvCyXVEkkHkI="
+  "io/ktor#ktor-events-jvm/3.4.3": {
+   "jar": "sha256-DwShuDgBMaFOlwW/HcvJ3yMvEkFTP8W40avYMHR93KQ=",
+   "module": "sha256-eeEIV/SWgUg1Pei+2HDfZqifPr8d6K4LaM9ff2T2+Gg=",
+   "pom": "sha256-9UhK45rMTWxivK2R+LbzroYqxrxoaemh8s8bo+7jalA="
   },
-  "io/ktor#ktor-events/3.5.0": {
+  "io/ktor#ktor-events-jvm/3.5.2": {
+   "jar": "sha256-dxLtHVFxYYCpZm/ojaXF7w5JEjSDrizRSuPpJS7nEUg=",
+   "module": "sha256-+sTDeXDiLRbWTbZodoRPxUjkUSPcUGqJOR5FR2drWPw=",
+   "pom": "sha256-3pbDg0qvmqwqhSGPIJGoZxKnjSrZ31BfsceliQaQQPI="
+  },
+  "io/ktor#ktor-events/3.4.3": {
+   "module": "sha256-iFOMVNRUJlYsI/dtPg0Xh5dQu2dJla0gERa4UrAIhdU=",
+   "pom": "sha256-AMiqw04HLRxxjWn5e7Xaejg0YvaNiOoMHFp+3kd95+k="
+  },
+  "io/ktor#ktor-events/3.5.2": {
    "jar": "sha256-y2t/GV/ZyDsXJxL7E2i7me5gHCM66+/7nt8XK2oQKkA=",
-   "module": "sha256-TgRkCpmobTazws8DxgNvhflbqbr1WQG6PBwR9XalVL0=",
-   "pom": "sha256-3tNQHKZZ/2hVayAfsiMfA2k/YgQ2pV3cu5t1xJPFfS4="
+   "module": "sha256-E8ITjdOBvsYoXxcKGqBf3XM6oVF2AR1WMOVSQzcqQVs=",
+   "pom": "sha256-2dBbwHE8A1CJXfc4Re0v0U+Ip8BnL7K6xw8dULpxYDU="
   },
-  "io/ktor#ktor-http-cio-jvm/3.5.0": {
-   "jar": "sha256-j+H7Hlz5hJ74XAnqjxmrXXom90ZEEBytSZBMakkVR1s=",
-   "module": "sha256-Wd2hYUh8kz7gJbzdlrO3XpkrUAtvsfbkj6AUiMWGG+I=",
-   "pom": "sha256-fCxaKuXskgIU3hcoryjJnoicm37cOTnRjvoORroduao="
+  "io/ktor#ktor-http-cio-jvm/3.4.3": {
+   "jar": "sha256-8ElYQSa29Nouk9fUMzYpYxLiqI1dUmPx0dJPG41m/zo=",
+   "module": "sha256-ySfYy+G12KCFyJRlS4rLwJoHkn0cGhxjW1VtN+NBTFQ=",
+   "pom": "sha256-JZ9NsLXMSaR1c0v3hIehFaGS6S/AmJHhHhlhqmiaDwM="
   },
-  "io/ktor#ktor-http-cio/3.5.0": {
+  "io/ktor#ktor-http-cio-jvm/3.5.2": {
+   "jar": "sha256-PIej47NomUpIXi9i9Zy+IgHXZwlAGLcm6B/76bSXZVQ=",
+   "module": "sha256-kH8fGOehtb/tmI23iSsTYJTHAnilCTkXDqKsKO95teM=",
+   "pom": "sha256-MLo3kP6ddRV9OmzmhsRgYUX5e9Hd2XWdNpEpdkLXFRE="
+  },
+  "io/ktor#ktor-http-cio/3.4.3": {
+   "module": "sha256-bJGF/f35izzYbLpwez4NoUr7ihTePe20hccafwPMyuU=",
+   "pom": "sha256-62gfWQOGEvNs8oXWt6bpyuWDBCTwrPmaAWUUu8nYjp8="
+  },
+  "io/ktor#ktor-http-cio/3.5.2": {
    "jar": "sha256-z+ZRVd4Smrx6O5bfYsizebK7Tj83ER+IQ8Fb8O+1Qc8=",
-   "module": "sha256-7fcPLn3Y5aGTqZ5NPdRaYw5DVCVAZNPk8ob2VIvHyec=",
-   "pom": "sha256-CL/Hjmc5tOE8F1/vRzI+wQaGN0Fh3U4Ug1isrlBAIzM="
+   "module": "sha256-Jir8yxjcNckKTj5CqUpS0DjNg7P+4PXs22YzPF1EEzQ=",
+   "pom": "sha256-KEOq++mO0/BjjMQtRcYw7W/PtAU+P66zzz1Tg1W1pbA="
   },
-  "io/ktor#ktor-http-jvm/3.5.0": {
-   "jar": "sha256-K6usNV3jZMRzsnsGDRyBD8L4PtbkSCLqvGw/Rq3xVaM=",
-   "module": "sha256-cH+4Jd5xPg8hcp4K1tQYSZC4PPtaYceUC55Ooaugx44=",
-   "pom": "sha256-9v8xXUJu/ovnQCiUykxI30j8xeM0TxJJnShri+q6Mmc="
+  "io/ktor#ktor-http-jvm/3.4.3": {
+   "jar": "sha256-sxNMLGxJvMl0ekJCeNByPtuiSiU7NkUOq8x/pWLirak=",
+   "module": "sha256-gq5sIoutescyEwStMduZdvPP0zOPOazWtPNIKEAkvpo=",
+   "pom": "sha256-wdL9ezT+PT/mFSZXkZJvIBeAwfUHJk1uodKk3AHdmsU="
   },
-  "io/ktor#ktor-http/3.5.0": {
+  "io/ktor#ktor-http-jvm/3.5.2": {
+   "jar": "sha256-avyAdPYHMu1gzZBKPlK0aphCWzWhuURtLPpFfy7mO0E=",
+   "module": "sha256-cisd1GB8hrsFzsancIirFuug+aB5VE1usJMJ6A9ruZA=",
+   "pom": "sha256-DXHI6rXj+kD1Ow60WucRYFuxBWLbVWdfUYcNP+KrLvw="
+  },
+  "io/ktor#ktor-http/3.4.3": {
+   "module": "sha256-N0VSChyPVCRmCovRJ34JlqH/Ehp1aVJmqR7PEti5/iM=",
+   "pom": "sha256-TRz1iMxd+vLlf1+yrnMjxA3pY22q2/5lLofqmPW8VkM="
+  },
+  "io/ktor#ktor-http/3.5.2": {
    "jar": "sha256-Hf1GUk4bvz7XtPUjdlTYcY+RGGRYgoQlX7bLcv2FsnU=",
-   "module": "sha256-VkIoS3asAW2DnBwoySXAbiq09tFt+nN6H/iJZfHZN9Q=",
-   "pom": "sha256-OrhYDEYAvqGhTA9pgm1n5hHzEnhbsIpGRaZ91BAojkA="
+   "module": "sha256-LVImlZNGRAeVM9tEwjm+WtYU/b+XUDWYOjY5SWnWeq8=",
+   "pom": "sha256-hEwLmtymxHJS7/uXhP2s21Cv27L6q5hEffkj+wZImUY="
   },
-  "io/ktor#ktor-io-jvm/3.5.0": {
-   "jar": "sha256-yp+UQ0eSBP6XoAvVO8Pe5bBRTBoIjp3x4OTUzPxgXlE=",
-   "module": "sha256-/QxmE+yCfPCdICdT5sZj57OT92awmNPhAbUCtnfb26g=",
-   "pom": "sha256-xQyDA/OG6CX+fmdxIq4rnaAbJhr6Ph9woWwIiHcmbMU="
+  "io/ktor#ktor-io-jvm/3.4.3": {
+   "jar": "sha256-RdpGKS4cKwWAxIfrp2fX28tQRg3y1uiTf0PoddkrRN8=",
+   "module": "sha256-nc98up0ZHkVwxE1EP5TWCyhJiIkc40feWWBXocNsppE=",
+   "pom": "sha256-LtT6ft1CHFIGV2/wlOXwHodDjonSYqVOZZmSMlKGCWk="
   },
-  "io/ktor#ktor-io/3.5.0": {
-   "jar": "sha256-slbt/JjznwD8Ysjq1HCsrce7tuYoiJoOMcYX+a37kdM=",
-   "module": "sha256-y2FR4vesZcJwKLFt7jMqTbvMwVMFgM/T/o9PKwyKc0c=",
-   "pom": "sha256-biSVDcRyz1+8qGoFeC0ujT4QSi9kWPOb3d3m0bescrU="
+  "io/ktor#ktor-io-jvm/3.5.2": {
+   "jar": "sha256-uZC0MZtxEhj7zuL5jh3PKJoloXGUg3mS77W5cLO2xkw=",
+   "module": "sha256-tk4XinhkcQworIWiOi9AHHlz1f186AI9aaqbxOWnCik=",
+   "pom": "sha256-IJbnf8HMo6gNk4QClGNIhRtBPTqR3BQ4Rv5i2jBpLPA="
   },
-  "io/ktor#ktor-network-jvm/3.5.0": {
-   "jar": "sha256-IBWJCI8PIZom0S4B58TlszWP0okHXBt5nRXECEccGYU=",
-   "module": "sha256-Riu72moAj0JA7m2DHgUWgupy86GIvgbEE+a69pIHMt4=",
-   "pom": "sha256-9GIDluO2+pTy+F4KQasERQV8naRT4QJjASkDm+dLrZo="
+  "io/ktor#ktor-io/3.4.3": {
+   "module": "sha256-//2lHn3hMeIpcl+0IVMSi++p5rkRNAmxD4gZ0ehhdi0=",
+   "pom": "sha256-vqyeo/zmS0cuMVI2afPLIX0xnqs8qd5LHq26ZBZV1Jo="
   },
-  "io/ktor#ktor-network/3.5.0": {
-   "module": "sha256-XodNKhs4VuDiisLzG+ACVCLTm/kX1lx7b9SGL4zipKs=",
-   "pom": "sha256-Ow70GRGvz0G0o4Rvch1GRWVZ0tE5h5QJuqgr0bRC1Y0="
+  "io/ktor#ktor-io/3.5.2": {
+   "jar": "sha256-1O7MEIKpqCgOph3Z/PdTGa7XGqTlmm8cRrK/+s4dapw=",
+   "module": "sha256-jYyiWyCU/a75BQ5fAVbJfamBaUl3ZaBvXxvlqwoMyiY=",
+   "pom": "sha256-egddBpj08lPqsBiULP7O1cJt4EeCHlMUolcCEIWeEg4="
   },
-  "io/ktor#ktor-serialization-jvm/3.5.0": {
-   "jar": "sha256-0Ivvxng8T+n1wIV5mzLqcCf94eXQinrveVQTpjPGhjw=",
-   "module": "sha256-1DKnY8QrF4xkffgkVo1IT40yQb/fqYVaAhScI5eB02U=",
-   "pom": "sha256-NebJO0lWpFB2d54X4P5lzWBnuwa/Zg/C+KbHzuwWreY="
+  "io/ktor#ktor-network-jvm/3.4.3": {
+   "jar": "sha256-pro+Kta7OKI7CPCO3DLjpgBArZUsbDqeCIctXZbdi0U=",
+   "module": "sha256-3wYcaZ9FR9LhGCepP0+I/lEfDK6/hXNOAU32gIkiqKA=",
+   "pom": "sha256-T8kNVYjgG5tXc+5MG6C9r80a1mLksHtXWLBMTR38FZU="
   },
-  "io/ktor#ktor-serialization/3.5.0": {
+  "io/ktor#ktor-network-jvm/3.5.2": {
+   "jar": "sha256-8dlm+vXprfkDqWhID2waQiPVllg6ly67rz+h/X+b510=",
+   "module": "sha256-cdkgxBtzep9wlsdvj7XzadvPaMXf5+P5CcuijMFL07Q=",
+   "pom": "sha256-oTdS54LS+mr2fVlbo9/1NZuOe/b5K7SJKjXT83Ut5ZA="
+  },
+  "io/ktor#ktor-network/3.4.3": {
+   "module": "sha256-Mo0KmmgMefqIDSvcGGBNuOB3U2sT/lb2KM/ILbRWAxw=",
+   "pom": "sha256-9HGimig98gDhJT/vCsw+yOMPGtSyFLFvWnQJy6zzZko="
+  },
+  "io/ktor#ktor-network/3.5.2": {
+   "module": "sha256-Qmohe+8iuGW1LQYAIS8s+nKARil27OVMHeN/3X5AwsE=",
+   "pom": "sha256-8/+oqIvLu6poHERIAT1VgtTUbq2yzq9vvcvxAl4vJuI="
+  },
+  "io/ktor#ktor-serialization-jvm/3.4.3": {
+   "jar": "sha256-WH37qUYnL2W0El/QpoJCxC2E3jn/wrguN7q/N+QtaRk=",
+   "module": "sha256-1tWshNysj1H91xB5cm0Wec8XSUxIF9VEfmY68pGgIMU=",
+   "pom": "sha256-23rkKbgpGlRXi4djqD0LJItBM64l6HjibDUGIHbluCo="
+  },
+  "io/ktor#ktor-serialization-jvm/3.5.2": {
+   "jar": "sha256-t8hdCHFM456cF6I1A43m+cKxIeX7V86QxaNJpl9h6fY=",
+   "module": "sha256-CQtA2Ouf+GIu0BJUuDsGb5M08E07PEn2FCHqfJxbl8M=",
+   "pom": "sha256-0M4BAEnK4tLNr/KZF0p+5hlt2bAmKFlzoQy4jMiboPQ="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json-jvm/3.4.3": {
+   "jar": "sha256-MoonKE5M3A0VVCFrfkrPhZ/jsM/UIcwgdcQ8E+PHYSc=",
+   "module": "sha256-MdS+vO4zLw0wYFg5TSRmeyJ/TIqR2+8JCL1yFUsyUME=",
+   "pom": "sha256-kPf60Llek/bdfZjmul/GPUdf4SXY1hK7toJ5/vBqaoE="
+  },
+  "io/ktor#ktor-serialization-kotlinx-json/3.4.3": {
+   "module": "sha256-Xqf6YGi9FiHHZD2ol3LT8yp6262XbVjEF9kZMFFV/3k=",
+   "pom": "sha256-LsmwRLkeBitK8sMaEGnV619KanUo/JihjcU/u6wvWc8="
+  },
+  "io/ktor#ktor-serialization-kotlinx-jvm/3.4.3": {
+   "jar": "sha256-ofFrLcd4EpTbX0zKqM6Xr5QwUbXzwG7fYbr7ftGKmzE=",
+   "module": "sha256-dqXUFXviiYYZgXlxQWrCi76gNEEkQCOKkthhxm+6RWQ=",
+   "pom": "sha256-4MYuxs0qofFW3fSkagT6PSWNHLslNJOxf65ingatqP4="
+  },
+  "io/ktor#ktor-serialization-kotlinx/3.4.3": {
+   "module": "sha256-fDOe4//LBDkZfupS10VHibKG1ZF4YSmKSku29KREqho=",
+   "pom": "sha256-JCJ5T8Q0kE78K13kB9X6EADvW7phQM3jMDtIxQ5skqY="
+  },
+  "io/ktor#ktor-serialization/3.4.3": {
+   "module": "sha256-T+4wl1yw6S4NYqMkioF0sfB7uI62DF1laKNRJedWCPs=",
+   "pom": "sha256-4upPJ0roD+p5VYJDWkOJ1cmH15Uanb5aYJsUMWrmFGw="
+  },
+  "io/ktor#ktor-serialization/3.5.2": {
    "jar": "sha256-/SrvFQlzPKSOhMeVPMdy52gWhCiVyTc6ctQqzPbBDlY=",
-   "module": "sha256-OPh4TdgVNYCecVoeMGxq88/TCW5N0IQbsTggOTuHQWo=",
-   "pom": "sha256-X8Lm5Daq0RuqQ4GowROk0wzQbmfU62ushXpFIs41q0Q="
+   "module": "sha256-mrPpT/6r0rk4uSwGUDxG91041OUV0GSsWpQ156IlOZU=",
+   "pom": "sha256-Sm4Jqi+sS1JuMb+1t4viIBW2zDysI6jRnkacoqBSglM="
   },
-  "io/ktor#ktor-sse-jvm/3.5.0": {
-   "jar": "sha256-lBhxZYxcm+1dFxKbB0chDphrCKV6R4+EzdmivNigCIQ=",
-   "module": "sha256-V7KFlTRixcTdg+oqatrF/hiEDxUVb3VUjGOSGPSGvns=",
-   "pom": "sha256-ZLF7TIWcMQKgCf2IMkFw7zNx2Oz95PpAIMuHj1lm2Kg="
+  "io/ktor#ktor-server-content-negotiation-jvm/3.4.3": {
+   "jar": "sha256-oEuI4lcu/C5+85bZ3kpDzwdeBt6iXhk7mS4SR4tCHBw=",
+   "module": "sha256-5cvT1+ct2QH8nj9djQ+kIZ5FNLSQHkTnPiItMP0xbWw=",
+   "pom": "sha256-C9uSScTgG7boK+ub74aBQR4XbdWb7aXHuaIYtx3ZdKQ="
   },
-  "io/ktor#ktor-sse/3.5.0": {
+  "io/ktor#ktor-server-content-negotiation/3.4.3": {
+   "module": "sha256-lt3fZUyynGq500CmtXBUaFAS5iAM4w2Mym2hCq34UUI=",
+   "pom": "sha256-8kXqJltxeEQPyArq03E9TVeIABDj/XNrLT5YkRTksrw="
+  },
+  "io/ktor#ktor-server-core-jvm/3.4.3": {
+   "jar": "sha256-NxAwcmjhTxeqkc7UveKGEC2EX3bXWaZ+cXCjd4Q5Fa4=",
+   "module": "sha256-z81p2Nkr29yfY6gLEFLA7MmY7774U6ys3EQD0ZZm4XA=",
+   "pom": "sha256-t9lxHS0R5vl+Rgm29AATD+dgOSHYNFE3pem3AMtY2Xc="
+  },
+  "io/ktor#ktor-server-core/3.4.3": {
+   "module": "sha256-tMAPI9hEQzuMMu/kb/sAXHq81G+1zmABwKSj/eh4CsI=",
+   "pom": "sha256-RkCxNQl6C7LHDno8xkCIAbdVvzUJYlesRBDBnNETfsY="
+  },
+  "io/ktor#ktor-server-sse-jvm/3.4.3": {
+   "jar": "sha256-kkLYSxkhp6zb8kPZ0YwhcgVmewPc/cikNXlh88loiBQ=",
+   "module": "sha256-APNEvk0AVm9QiOmHWOOXPgWw6OeXWgxPjWzYeOuTDVU=",
+   "pom": "sha256-DYN/mBZ0dyNtC/k7lqIFDJC8BxjQxChqcd+b9xEYJao="
+  },
+  "io/ktor#ktor-server-sse/3.4.3": {
+   "module": "sha256-ObHrFLieYcUSJa8HR6spwCzJEib8fGtxm4GVQ/SzQIU=",
+   "pom": "sha256-2FTHGafv7td1njY1WuPu4XJwoxkKYpAKfMaQKEUkg5A="
+  },
+  "io/ktor#ktor-server-websockets-jvm/3.4.3": {
+   "jar": "sha256-nMVw8+rxTXRyzcNJz8cyoZQaBL9B+QXYK8YJ5+AFfk0=",
+   "module": "sha256-7a3CGLEpF2FDPhbEAkYmDirT+e+Z3WkUbwzVWeVD+Xc=",
+   "pom": "sha256-TzGT1sfzI20iq0i6RCqBi6nekfUcdyhiq+kredD+zac="
+  },
+  "io/ktor#ktor-server-websockets/3.4.3": {
+   "module": "sha256-wFaghvLd+2Vs+9iY/Yt/sbKGEpDDeZUnqisZ/VPUdFk=",
+   "pom": "sha256-ZO392HWOjdrQj97tLL6X7+So8gcOnv+WCXWfGzbSKVw="
+  },
+  "io/ktor#ktor-sse-jvm/3.4.3": {
+   "jar": "sha256-qQaybsUziQFskuniSunXmXbj5YJncT0Muajyaj8/aQc=",
+   "module": "sha256-GAzZFl4HYVhbtTmjRTR9zKw8hqE8dMRnL0ytITfoGsw=",
+   "pom": "sha256-clI40vwgtKittZB6vTOQcUa2LJJG3UFp8Tp4pikskaA="
+  },
+  "io/ktor#ktor-sse-jvm/3.5.2": {
+   "jar": "sha256-xRCQT+Dn3Wud8vp8VHRpb9pk1zZhKc5fqazi6/RQ0og=",
+   "module": "sha256-Cqb+8A9qGxB2vq/JRD7osnv124ddIzjyTOgzAF4N/dE=",
+   "pom": "sha256-s0JeiUjrS0b9O1AdAGtpmH4Yiv14kDXjzNMfOm1uQjo="
+  },
+  "io/ktor#ktor-sse/3.4.3": {
+   "module": "sha256-44dTyTiU/6SGb2ftjhDjd9xwCdJPdsJ3aIsu6dEsTMs=",
+   "pom": "sha256-iZfzk4e1n8qxvvFcfuQ7eymDJOs5U+MXOfDJ7hDDn4Q="
+  },
+  "io/ktor#ktor-sse/3.5.2": {
    "jar": "sha256-H0g43bfVfoS905E69LQGJ2Yqvbyi+6iSG4Z/GmLQv10=",
-   "module": "sha256-6Usv/TfLarDOwXQKxr+bE4PosmzLkIgMcAEh6xMpxgk=",
-   "pom": "sha256-wahVhBWICx1OHJ87tkivI+AzQiw8grjQqLNnk3nUCp8="
+   "module": "sha256-dtbg1OksUQE/kx5cjtisyEFO9SWJFbcQ82Pam1TSEE0=",
+   "pom": "sha256-xtqlT4TvVMpvXPIxYVYeDuTGuzlTQRRoUbb3nEzL1mM="
   },
-  "io/ktor#ktor-utils-jvm/3.5.0": {
-   "jar": "sha256-IUIA8HSv6dS5FdNHOXtcH3aPvdEOrXGS6K39Zi3Upy8=",
-   "module": "sha256-lr8SZTPTjLiz8WkRw2mAwts+dGxkh4KIADoLbhk4WuM=",
-   "pom": "sha256-We88Ni2DBk8LBkx5SKzjixmfZxcYPgqtCOnoJ5Kbh2s="
+  "io/ktor#ktor-utils-jvm/3.4.3": {
+   "jar": "sha256-5Iuc5Rhw9BDHq1wEDI5tAmlIJ+v9/ForhPCGrQSbtWE=",
+   "module": "sha256-OxfQWvPm0mTnYqh9wor5ipRcvXIJtqbu0/KrXIH5Xx4=",
+   "pom": "sha256-M0ozEdk/iJ0R9D4Mt5/jq8TZjaYVTTt/z7oXbbmDS6w="
   },
-  "io/ktor#ktor-utils/3.5.0": {
+  "io/ktor#ktor-utils-jvm/3.5.2": {
+   "jar": "sha256-XLnAQNKQqjHOXkkw2CXdpdJWJahgMHSymUPFGdWwIrs=",
+   "module": "sha256-/492fEhLgLlIwSn/qGhQdMk/FJRg7Q6QE7QqOi2kSQU=",
+   "pom": "sha256-I7hLPLfAFfRYlIZ7Y5IzCJRnqty7NZ8WoCHjo5OFnHE="
+  },
+  "io/ktor#ktor-utils/3.4.3": {
+   "module": "sha256-NRoL9TGXRIj0tH82hNfiMJK4+epGwWDw7TCl89NQgQE=",
+   "pom": "sha256-nKnA3GjHIk2iLx4uM7LvPmXLBOtL8SaJwZcLX3JIzbs="
+  },
+  "io/ktor#ktor-utils/3.5.2": {
    "jar": "sha256-1syTBOx3QJllHiDG0y3kpn9t04FvkefJllN4PJKQ9Xo=",
-   "module": "sha256-KSPNpVwBptcAWoYPW4/9CHLucEuLKNFM6QWl6ma7qsg=",
-   "pom": "sha256-JJKBcvdfDHkHSo+9rgL0KNR2E/Dz9asyonz2mRHCDS4="
+   "module": "sha256-wRMwbaxsKoNXqJVnkoneB+aXDkUiYxwz2Cdt/jNkKa8=",
+   "pom": "sha256-ouwaroolZFKfkrtiUOjoDO3xech04+YJMoaghYalIFQ="
   },
-  "io/ktor#ktor-websocket-serialization-jvm/3.5.0": {
-   "jar": "sha256-z5MerkR9y+dgKIkd0YW2ReEbbHoQhyv83k/kCoLTs0I=",
-   "module": "sha256-6D00HGh91ohvvbVie9stNXOGI8Iuth+ZY4lmF/O48bM=",
-   "pom": "sha256-Ib4S+MPSfGr5cxV9w2ruXETAKHi8aK+LdbXSSzXKkuI="
+  "io/ktor#ktor-websocket-serialization-jvm/3.4.3": {
+   "jar": "sha256-2ZmnuQs9mtLvDRF8Ss5isQvXrBNFzRxqdoCkP/++DtA=",
+   "module": "sha256-aA7NoHNJxf+3FzVwVRd7fehIpu690bXIhvlzzzpwgDg=",
+   "pom": "sha256-uFOTESsUbe6LlrdxuoyiCjY9bmtO8W5T1ZP1bgXPcnU="
   },
-  "io/ktor#ktor-websocket-serialization/3.5.0": {
+  "io/ktor#ktor-websocket-serialization-jvm/3.5.2": {
+   "jar": "sha256-f/ysftPXI+C9M7IZuePfbVlT5bgQ9mxMjmhvVx9djmw=",
+   "module": "sha256-fk4SIFNfNJWTzoOln4M2pu5vXcuiFz9Xqgx1MgvQU7M=",
+   "pom": "sha256-O7qGgLJLeszwxTJkGX7rCkK81vOZH9bXCPwbtUul9s0="
+  },
+  "io/ktor#ktor-websocket-serialization/3.4.3": {
+   "module": "sha256-13WjyEC6DDt9WOtQZ33kG0OtZbBsrVlBAhF+XlxRXZc=",
+   "pom": "sha256-QSPdZhKyV50uomw1TwhNJyxDkZw0ansWvUNedYK4hNA="
+  },
+  "io/ktor#ktor-websocket-serialization/3.5.2": {
    "jar": "sha256-t0VVWddBP5wLMIiSCfgkQBokNNj1zF6grTiLSFQ7dTs=",
-   "module": "sha256-dZVABH5cT1DbmSd9ECsY+ItHAZ/mhKoti5QTYtw+fCg=",
-   "pom": "sha256-14Oaz68+KwRzJkmakT4JDSQJjP6fWs+9sIFub8Svx/s="
+   "module": "sha256-8hzBBuoyBD/+XLSdODYRhZcgwFnJT7yXrlqljxbNerc=",
+   "pom": "sha256-seZOSnbwA6zcS27vILICFNefKrCtvJW7DYMrjSp5xpE="
   },
-  "io/ktor#ktor-websockets-jvm/3.5.0": {
-   "jar": "sha256-7Ae0veE6PDrWFp1ix1owj9ERZ+q0qhqpuqJIRww5fOE=",
-   "module": "sha256-dl5OdlQONxCYC/z2xoQorvyypk4tq8R2JlkG73yIxOE=",
-   "pom": "sha256-oIc0oBdVRrwjZKFuQ6e5LjXxmmW9q9QTyLXB9dOhTyU="
+  "io/ktor#ktor-websockets-jvm/3.4.3": {
+   "jar": "sha256-7S+/uB0wKc8FpirHttRbOKhzoC+O5gsErmU0btUpnuQ=",
+   "module": "sha256-eXohs+3Xxgs6GiMKYbEfkoEAJVD9LwCnmB73XUblJkc=",
+   "pom": "sha256-k2UZSibMt2zh5QG+UngqZRULt0XdzUibgcFHwL6r44U="
   },
-  "io/ktor#ktor-websockets/3.5.0": {
-   "jar": "sha256-3vZ9V1vRQtHXXk8XWHlW9IPAlWJYapzAL5KaLyEcIEQ=",
-   "module": "sha256-kvvRwTkxxVqWGB8fM4CyiKpWiLPHdgtGzBN+4DybY80=",
-   "pom": "sha256-WhVJDgXGmEzUgY1OoHlzxnoz1TtUayJXOVdon5ytwcA="
+  "io/ktor#ktor-websockets-jvm/3.5.2": {
+   "jar": "sha256-9a605u4QjoFWQ+LPBlgNTKGtxSn2z00waom2n7SIC0s=",
+   "module": "sha256-npwn+fyA26Ln3wjz2GeqJC96qA+5NFZZsX57odAZKkY=",
+   "pom": "sha256-KwD0ZZUWuc5A2s0oXxgLEZdjbvgOdPxZxErEpf6URvw="
   },
-  "io/netty#netty-bom/4.2.12.Final": {
-   "pom": "sha256-Sx6sh5HJMaM9ni+4wINDJVLPh0adtBm30kNBeONPBww="
+  "io/ktor#ktor-websockets/3.4.3": {
+   "module": "sha256-xTwREBNT5YY31k9EevyRPGVUHbgDOeB+q7PeWiGD8BI=",
+   "pom": "sha256-UWoi9aLNpSqE9e4WFcfKtvKABy9GqYNY5bRjS2zh/mQ="
+  },
+  "io/ktor#ktor-websockets/3.5.2": {
+   "jar": "sha256-jQ/RtZ6wqspCLhmvHLid0I5l+Y1mhL4gkJYcTyG+qd4=",
+   "module": "sha256-IDcC1X3F44A0gwdDp0HmghRYC1b3KKLiwTlLWfBr3qo=",
+   "pom": "sha256-GAZwy/stapHbc6Kb70B0wA6/EnRmy8DWaFK99dZZNO0="
+  },
+  "io/modelcontextprotocol#kotlin-sdk-core-jvm/0.13.0": {
+   "jar": "sha256-hT1iH4gmbDHtIcN0OvzVSR3dKjS5tabAixixpuoSXls=",
+   "module": "sha256-+lwU3A5qQASE0jmiidUmZz4KF2Zz3bQD0wq6NJ1KLmY=",
+   "pom": "sha256-b6gXH9qr42w8of7Cq98HuzE5fTKi8zSY5Ptzsr0Irqs="
+  },
+  "io/modelcontextprotocol#kotlin-sdk-core/0.13.0": {
+   "module": "sha256-cs1UVuu8J4NN6klOnkg4sXgg3EeC4nC63AlOm9RkiHI=",
+   "pom": "sha256-Ub1IbIjlyf15ud8conS77ayAiCmoJ8CR1mgQ4x2eeDI="
+  },
+  "io/modelcontextprotocol#kotlin-sdk-server-jvm/0.13.0": {
+   "jar": "sha256-069WrYHlBJ7z2rqJZntAPONLW5O2xJrCnfj0GDIzMf0=",
+   "module": "sha256-/6ZWJOrBZ5xnl8+H9bOh+NwEV6FrTCnMLP2+TQ9eMBo=",
+   "pom": "sha256-GGd3XnTcCul6H6YqKR+FBF+e2d5cZAbBjMr9BuZapgw="
+  },
+  "io/modelcontextprotocol#kotlin-sdk-server/0.13.0": {
+   "module": "sha256-2auRGosY8R3/V+OqjgpuPeli7tFcnQvsOwc2yagHmvI=",
+   "pom": "sha256-YwAYy6jHAcr8goiZ7JrLLcBEVGB0NHUO2b4hUknx2Zg="
+  },
+  "io/netty#netty-bom/4.2.16.Final": {
+   "pom": "sha256-WdUPXJUeZFXEdP5SYbfYSyxUa5wfxzl2+yzWbbWEkzg="
   },
   "io/netty#netty-buffer/4.1.110.Final": {
    "jar": "sha256-RtdOeRJarMBVwx8YFS/cXUpWmqjWAJEgPQuqgzlzrDw=",
@@ -2598,9 +2860,6 @@
    "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
    "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
   },
-  "net/java#jvnet-parent/1": {
-   "pom": "sha256-KBRAgRJo5l2eJms8yJgpfiFOBPCXQNA4bO60qJI9Y78="
-  },
   "net/java#jvnet-parent/3": {
    "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
   },
@@ -2628,16 +2887,16 @@
    "jar": "sha256-s6lAjnxR4I7w47/MCPRD9uwPYZG6jNfBjVPSsi5b28A=",
    "pom": "sha256-UBoP8F2EpK0Q9t4lvpT0k5i3CjG+jzoO2fTGtE++/uQ="
   },
-  "net/java/dev/jna#jna/5.18.1": {
-   "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",
-   "pom": "sha256-mLYq5v8oDXR/s1n8QuSP7RE9Rbw3Kagj3DC4MIqAZkU="
+  "net/java/dev/jna#jna/5.19.1": {
+   "jar": "sha256-T7FB3Y72sFhf/O6kvElgL7xjEvqXfixIh5TqPmqv7K4=",
+   "pom": "sha256-kRt1SgO2avD+0rvf3DqGgHNg3QNq07SB71FixoXkVr8="
   },
   "net/java/dev/jna#jna/5.6.0": {
    "jar": "sha256-VVfiNaiqL5dm1dxgnWeUjyqIMsLXls6p7x1svgs7fq8=",
    "pom": "sha256-X+gbAlWXjyRhbTexBgi3lJil8wc+HZsgONhzaoMfJgg="
   },
-  "net/java/dev/jna/jna/5.18.1/jna-5.18.1": {
-   "aar": "sha256-fwU+PsmeFN1xJZyCwcigJzjWShPDEiayrMFw8wYJUeA="
+  "net/java/dev/jna/jna/5.19.1/jna-5.19.1": {
+   "aar": "sha256-tXEly30WJT8NZagPfTpMNmTv+nEbi9u3+H+1cs4WJO0="
   },
   "net/sf/jopt-simple#jopt-simple/4.9": {
    "jar": "sha256-JsWFbpVLX4ZNt28TuGkZtZxu7Pn9kwuWuqiIRia68vU=",
@@ -2656,31 +2915,42 @@
   "org/apache#apache/21": {
    "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
   },
-  "org/apache#apache/23": {
-   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
-  },
   "org/apache#apache/31": {
    "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
   },
-  "org/apache/commons#commons-compress/1.21": {
-   "jar": "sha256-auz9VFlyillWAc+gcljRMZcv/Dm0kutIvdWWV3ovJEo=",
-   "pom": "sha256-Z1uwI8m+7d4yMpSZebl0Kl/qlGKApVobRi1Mp4AQiM0="
+  "org/apache#apache/32": {
+   "pom": "sha256-z9hywOwn9Trmj0PbwP7N7YrddzB5pTr705DkB7Qs5y8="
+  },
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  },
+  "org/apache/commons#commons-compress/1.27.1": {
+   "jar": "sha256-KT2A9UtTa3QJXc1+o88KKbv8NAJRkoEzJJX0Qg03DRY=",
+   "pom": "sha256-34zBqDh9TOhCNjtyCf3G0135djg5/T/KtVig+D+dhBw="
+  },
+  "org/apache/commons#commons-lang3/3.16.0": {
+   "jar": "sha256-CHCd101gK3Bc5AF9JlRCEAVqS6WD1bIMCTc0Bv56APg=",
+   "pom": "sha256-4oA4OVbC5ywd6zowezt18F7kNkm31D8CFfe2x7Fe6iw="
   },
   "org/apache/commons#commons-parent/34": {
    "pom": "sha256-Oi5p0G1kHR87KTEm3J4uTqZWO/jDbIfgq2+kKS0Et5w="
   },
-  "org/apache/commons#commons-parent/42": {
-   "pom": "sha256-zTE0lMZwtIPsJWlyrxaYszDlmPgHACNU63ZUefYEsJw="
-  },
-  "org/apache/commons#commons-parent/52": {
-   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
-  },
   "org/apache/commons#commons-parent/69": {
    "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/commons#commons-parent/71": {
+   "pom": "sha256-lbe+cPMWrkyiL2+90I3iGC6HzYdKZQ3nw9M4anR6gqM="
+  },
+  "org/apache/commons#commons-parent/72": {
+   "pom": "sha256-Q0Xev8dnsa6saKvdcvxn0YtSHUs5A3KhG2P/DFhrIyA="
   },
   "org/apache/httpcomponents#httpclient/4.5.14": {
    "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
    "pom": "sha256-8YNVr0z4CopO8E69dCpH6Qp+rwgMclsgldvE/F2977c="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.6": {
+   "jar": "sha256-wD+BMZXnqA42CNDd2NqAshaWpMkqaiKYhlvxSQcVUcc=",
+   "pom": "sha256-fvwSQec+f7smi/0zJC0R69PKBwYdfYXyli3DKg8LiFU="
   },
   "org/apache/httpcomponents#httpcomponents-client/4.5.14": {
    "pom": "sha256-W60d5PEBRHZZ+J0ImGjMutZKaMxQPS1lQQtR9pBKoGE="
@@ -2734,6 +3004,10 @@
    "module": "sha256-+BYzJyRauGJVMpSMcqkwVIzZfzTWw/6GD6auxaNNebQ=",
    "pom": "sha256-kxO/U7Pv2KrKJm7qi5bjB5drZcCxZRDMbwIxn7rr7UM="
   },
+  "org/codehaus/groovy#groovy/3.0.22": {
+   "jar": "sha256-ySySxLmxg/mYG6c5nzZZLl461vTNrHEBtaIswXmY0T8=",
+   "pom": "sha256-Ubcx5c/xIe/W0yD0qAHNYWhpxb7U6cDjU7KQYLHSNV8="
+  },
   "org/codehaus/mojo#animal-sniffer-annotations/1.23": {
    "jar": "sha256-n/5Sa/Q6Y0jp2LM7nNb1gKf17tDPBVkTAH7aJj3pdNA=",
    "pom": "sha256-VhDbBrczZBrLx6DEioDEAGnbYnutBD+MfI16+09qPSc="
@@ -2759,6 +3033,13 @@
   },
   "org/eclipse/ee4j#project/1.0.5": {
    "pom": "sha256-kWtHlNjYIgpZo/32pk2+eUrrIzleiIuBrjaptaLFkaY="
+  },
+  "org/fusesource#fusesource-pom/1.12": {
+   "pom": "sha256-xA2WDarc73sBwbHGZXr7rE//teUxaPj8sLKLhOb9zKE="
+  },
+  "org/fusesource/jansi#jansi/2.4.2": {
+   "jar": "sha256-C3uLADqQ6kkVebYvURiCjkURKRTGVYmwD6pJ1ux4WDk=",
+   "pom": "sha256-Lory+B0MmVUIvWfJid4ewhbrakdgk/WY9CFOz2ESjfA="
   },
   "org/glassfish/jaxb#jaxb-bom/2.3.2": {
    "pom": "sha256-oQGLtUZ47Z9ayy96QITjhf9RAgH06dv1913GpnX2a+c="
@@ -2790,75 +3071,130 @@
    "jar": "sha256-ew8ZckCCy/y8ZuWr6iubySzwih6hHhkZM+1DgB6zzQU=",
    "pom": "sha256-yUkPZVEyMo3yz7z990P1P8ORbWwdEENxdabKbjpndxw="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.10.0": {
-   "jar": "sha256-3j27CwYYK1NcRKbyqhtr8Y4hA1LVetbkyDnDbh/lunk=",
-   "module": "sha256-Zg7q/+b69J/qIIOkNCqAsbhNK/yXYx9tfmeLSFsZm5o=",
-   "pom": "sha256-4Fs07/GcQaRQesMEW7ngiVmInyRoRzuV1nhuhCjHgLQ="
+  "org/jetbrains/androidx/lifecycle#lifecycle-common-jvm/2.11.0": {
+   "jar": "sha256-UKgm7w0b0n/zhOTdnRR70fNDzHjQRPezKn7Gzps/0ro=",
+   "module": "sha256-vW8mg1YkONPYwvyLpuI96VmJNoaet8X60wvJxoOEcaE=",
+   "pom": "sha256-D7aBsMvw3wJPeBW8EHqHi+i8vcNSEIWHgkXNoF6pSX0="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.11.0": {
+   "jar": "sha256-mp3WDTK/j58ryl1PYmcMD0V2iW7yQ4h4jNetaFJO/W8=",
+   "module": "sha256-He10MHWQzJcwFjLSaEeOHmMEl1kWrp3H+xCVMrozc/4=",
+   "pom": "sha256-N8ZqpQbb61Yn+nTTUNehtf4cmUyc1UcXAubgzbSvQGM="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.6": {
    "jar": "sha256-shoUn+KMzMfs43tVCY0QAnq6PS4Nsx0S083JB97SNoo=",
    "module": "sha256-gF5FIbAzeYEISMesMUzzyVT8jS3zSlsJEcRW1Djc2iY=",
    "pom": "sha256-0yUq74s29h2gYJD4T+URQCGCA0Tq0dZAw3NXohkYVBk="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.10.0": {
-   "jar": "sha256-McPEtt6jjweMRoKd7ixDq7or+HV7fuig9mDzEhc2SJg=",
-   "module": "sha256-FKEs03MDhyfssw91RF+H5sqf9DzwFcZm0HLr3U7PHBs=",
-   "pom": "sha256-R/Y3Vq9c4hBRByM0+oBYjAPBZNo3HSTLTO362OGyglU="
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-android/2.11.0": {
+   "module": "sha256-74pdUtUEQt0qvE2B7dqgjOMvX6Oti0ha9Q9rE5aRkvI=",
+   "pom": "sha256-T60gqDaXEKBL9En00s+BvulH4FqMimaA+T3TItXUZeQ="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-android/2.11.0": {
+   "module": "sha256-sY/qpsum/v4E8ckr057LeMxVnL72Vv6gCKTu5nc4k0A=",
+   "pom": "sha256-/kJ3fPYs8+X+UGuI9SOqAyyknkYJ8GqOgQlsHzIGIz0="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.11.0": {
+   "jar": "sha256-TJSl+pi4OKNLhO7LD8pbKRtBerOvhRiGK0iPhYaKIZU=",
+   "module": "sha256-g8u5sXHGSzybgOyOhm69VKgd2Wi6YGOg8Vt9WtosnEM=",
+   "pom": "sha256-6LXVArKdns5ax0sHhAk3JlRhCW4Rwa9XYpOzg2PWAy8="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.6": {
    "jar": "sha256-McPEtt6jjweMRoKd7ixDq7or+HV7fuig9mDzEhc2SJg=",
    "module": "sha256-h4v4qGH7h4NN834eunP946WSEV/A17pm6iPhkVcoMx4=",
    "pom": "sha256-LUvR/bTef5L9Bdav5YWZCJOLzBXsisNrKfafL1C+1fs="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.10.0": {
-   "jar": "sha256-qxCFpmmBEDvE+eVpu5QDsvEsmX6hlyMNDmFaGLrlmME=",
-   "module": "sha256-wsBsS6GmDvmIlIX2+lFVslfH6GTJo+tvN0M84N7xhvs=",
-   "pom": "sha256-NaXwX5/pggJulEwaYuXV7Sp10zsOhJvwchSasMXYAxo="
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.11.0": {
+   "jar": "sha256-6vjO3R9wMKnhCrzQ034hHOXEpv70Esd7eIfly/PXCcQ=",
+   "module": "sha256-xU2ZLActVEnQ2fRBBCZbw/ybe98YGQWk+3e+iu7errk=",
+   "pom": "sha256-r9bKjaF7xBe8MyYw7Ey0TLf8jV797115L2HoZoCBHdI="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.6": {
    "jar": "sha256-rbdbK4nWjzONlCC4sk3ZulNohypPxw4yKCwvoPGToPw=",
    "module": "sha256-gAMMZAio8gsZVXh+GmE8tp8Fh26vW5GF++FZSAwPZyE=",
    "pom": "sha256-OFjDsK0gsHhobakHitFk7MbF5Y8wlvLS5vpmznPHg98="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.10.0": {
-   "jar": "sha256-5JiBOn4qvorXEjnd0h4pUwmEX9aMSW2y+BOeDSACrpY=",
-   "module": "sha256-9HuN0p6QQBl8OpMYzGkzHYOUwj7iYVLwO9IEe71NgAI=",
-   "pom": "sha256-t2ghIp9UPorV8uaFgF5r4FE/sV7UHvS94IDTtezoYiU="
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-desktop/2.11.0": {
+   "jar": "sha256-PltWxUyCbbwqjYFir00CCEDb0+dCuL4794VGr9wvc3Y=",
+   "module": "sha256-LYvhWkb//hbItadXRfxN2cxVGi3AhYQxQ9OXXXNTTlg=",
+   "pom": "sha256-E3wc4H7FL40D3kUJBixdzUUmprgbsPMJvIZwRShkQOQ="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.11.0": {
+   "jar": "sha256-SbuQk0ce/VO01qpjWXQ64oIpCuPn1Viqvv3DMOy1V8g=",
+   "module": "sha256-Ffk9XtRIa/WR2CWUMdHZr5ntPon60xkslcY4v44PMd8=",
+   "pom": "sha256-tUK7CjvUEJwn8POj9vpIWNMz8WCbTbzq/LY+5Goeeo8="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.6": {
    "jar": "sha256-ndWDtwkTbgqv5g4bkCSb9jvIDNe6bgZBznShqzYTxk8=",
    "module": "sha256-LSN78RA5ccVpZ6GVMbwI8QBuSZOoQxmpL04V+w+Qyhs=",
    "pom": "sha256-8ju8dgqLqe3xr4gbY7h84LcUMFl8DhLtXq9YJ2DTjnw="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-desktop/2.10.0": {
-   "jar": "sha256-//wI8Bzcy2pntfqqTXj1D1TS5qwzNbu/5SHE9lTik+o=",
-   "module": "sha256-3FGjrFhX726z5yPqBt6A5ae3tDkILB0i6B5olyNpnsM=",
-   "pom": "sha256-HefIj1nGVgdacytJIF3K8TuRI/wSMIXYfGbcCjTXO1w="
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-android/2.11.0": {
+   "module": "sha256-eHtcOSBZowKIaJp39Ih4ujcvwNpOyRmFjWjnTF2onoY=",
+   "pom": "sha256-CFtwmm8SwznbqJTQsdDruY8X3XFM6/NLrKQXSpg3BH8="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose/2.10.0": {
-   "jar": "sha256-Er3QbeT7l9RkmHwnDBLNmok+vKotKmabOY4YIhfKwWs=",
-   "module": "sha256-9PfVd5cTHjL9fR5pu5TYvoVSIjQeBaeAaGOxjKL6v/I=",
-   "pom": "sha256-5wsT+t2Tid4FNsLiWc/YwG1SLGCrStQerpzQ+lMR2P4="
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-android/2.11.0": {
+   "module": "sha256-Yr3IADWsuqxpBxdxOpO1xVCmu6Oh6FGeJUbX5BP1b3c=",
+   "pom": "sha256-0zHI+nDxsu/4dqeAiXVpb7eQW86/NglGwfjiZkvE+xA="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.10.0": {
-   "jar": "sha256-jKi+y0jC8p1Yc0pKFcI7ZUHqwX/u8L9q8I7OMhcsP/8=",
-   "module": "sha256-r4zVML1zj+GsH+Dg/IYhnyToE4yN4/lMGFzuwvqly/o=",
-   "pom": "sha256-eZav2khVeVAQN+XFXVwE7omQ7RT2Y+T9PtN72jfaSZg="
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose-desktop/2.11.0": {
+   "jar": "sha256-tErijCVXCeukNxkXmrWkont6jSB14gAw4uJlIR8yCg8=",
+   "module": "sha256-FsiIP7I8bBEG/U31MX+B593VD3MpbrWr7lY8PhKuZpQ=",
+   "pom": "sha256-qbEWBdgZWwJNYTS3IbJa84x/7BAzGxqsAJMtpZG/nnw="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-compose/2.11.0": {
+   "jar": "sha256-yAtbKlwZ1/ZPmK76rKD9CdW5KYPpVEULQKEZnyanD7g=",
+   "module": "sha256-U95l9fYbP2y1J7otrVV1co9e/6k32IaRUmcVfVKaB+8=",
+   "pom": "sha256-85sOWsG0egNYewJzhEfHhz8QtnVoZbJBJqyi0moZurg="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-desktop/2.11.0": {
+   "jar": "sha256-ODhK0RTzIxpb/gRgjCxRR0dXT/8+NHpyZuEuatNaahw=",
+   "module": "sha256-nR8+DN5U7W2NNWZpIKlM59Z6z5fkAPwPU1/kbo3uIn0=",
+   "pom": "sha256-q0uG5qIY8PEH6/wXlR8Ke+bNAtrxa6iubbDWpzAiK70="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate-android/2.11.0": {
+   "module": "sha256-u7SWV+JgooKRRa0r+8JfuIk5+u30bpaEIuSo7PQ87og=",
+   "pom": "sha256-1Cf21KyoSRxlwpN4fpc+TXySqahGOTSrGMJxiQppkqo="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate-desktop/2.11.0": {
+   "jar": "sha256-Xb+WPlvlVbYc5H4Y+N+oL607XA55y+7XydymxVb1OEc=",
+   "module": "sha256-m33QjcfOtZOrdQUmD4SSB9ECnyst12ag4aiajeMzvSg=",
+   "pom": "sha256-KYJMXvW5wirXdYpkRQrc04HbeGUUYFD3yd4/nc7F1Jk="
+  },
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.11.0": {
+   "jar": "sha256-BN52j7aKPn9W2C+velCEW7w4oAioVaAiCPJSh1nM8Yk=",
+   "module": "sha256-hNq/r39s2nqMYFMlfT403RKub9VIw7sUTx0KTEGELew=",
+   "pom": "sha256-+s+IRhQ2qyMk31NYB+8hiNaK1eG9thx5NCM24NYzFpk="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.6": {
    "jar": "sha256-dCOTmMsfIKgROze5PTCfH1dJShT3DWV4ZI6LsIP4D10=",
    "module": "sha256-rQ264j3Z3KujqV0dCCwb+0xASxe7kySQ9ASayTgl3E8=",
    "pom": "sha256-hC0AC7vnoGloZw6B/tCSr3gLhtbjCLaqGo+QwjsrZ2w="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.10.0": {
-   "jar": "sha256-Bjgp+C+SGDV7aBV6yQSF2ooiZNDX1StoAqN1gX7mk7s=",
-   "module": "sha256-BeXmNx8kIzertlVRuq29uDTDF4auOuhH+BKSd1w9RcY=",
-   "pom": "sha256-EF3rS+RhEND7iGT0o0Qr/b1Cw90jEUCzrOa5dMkZoXA="
+  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.11.0": {
+   "jar": "sha256-vUs6ObqBcbCUYcVpvvM1dg9cUqeROz9UvDavKjdP1bg=",
+   "module": "sha256-eDMH+C0WHbsfNnYs4W+0l/2SydvLK19A9ac0qMRfYsk=",
+   "pom": "sha256-pu1wNM8admQQL0f0fqDKAb3wHd0c/Givi2zHu8D+SZM="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.6": {
    "jar": "sha256-ns0rxhNl+0+j9vKEq6khSNv9PRrKOGYq1UvOysKrVUY=",
    "module": "sha256-JMv8NlN1knXknL9Wl748L+fEpqHByk+CWAWk82EbYJU=",
    "pom": "sha256-oJpT4rFQ+ZKfyN33sZ0qhl1K8TRGnYFx5aiFhEA/zsM="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-runtime-android/2.11.0/lifecycle-runtime-android-2.11.0": {
+   "aar": "sha256-rdnvKxh02N1ahhXIkw+fVNPd1psrLJ2DoiZHDtQB4yw="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-runtime-compose-android/2.11.0/lifecycle-runtime-compose-android-2.11.0": {
+   "aar": "sha256-EByk3E6ToaUj8NuUszYKfAXIu7NODzFPWfET6RNZbuw="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-viewmodel-android/2.11.0/lifecycle-viewmodel-android-2.11.0": {
+   "aar": "sha256-UQldS0W+zlpnDF5fn7f01+X1f398KsAuFLO9etp29Sg="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-viewmodel-compose-android/2.11.0/lifecycle-viewmodel-compose-android-2.11.0": {
+   "aar": "sha256-fZXaUDAIwW2xlm6fiqAQR/yT3doo9LhjXzm9pdT09Uw="
+  },
+  "org/jetbrains/androidx/lifecycle/lifecycle-viewmodel-savedstate-android/2.11.0/lifecycle-viewmodel-savedstate-android-2.11.0": {
+   "aar": "sha256-sMj9DZ1YLEh/hB3IokdqhshJXXuW8nN3GKfJT+wn3is="
   },
   "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.3.6": {
    "jar": "sha256-Dz0EXF/X4TAatsOM0HeAZ7BITPOaysEjO+cacjpqgHU=",
@@ -2888,48 +3224,20 @@
   "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.11.1": {
    "pom": "sha256-l0NsU/5PZQPKybETrkdAVuAE2UB4JfSgC+54Yitqm8w="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.11.0-beta03": {
-   "jar": "sha256-Gzr40gYnsBEB2Cf3LibbrczI0hLA/8DAL/Km/JZ6bKg=",
-   "module": "sha256-dayy25cZPo48G46wRJnYupZ1wf2VqxCMWv/3ZRrUfY0=",
-   "pom": "sha256-EDNFH/5muRzTA9SPKwy1cJqfmtryCW9O/FPSCQuF0co="
-  },
   "org/jetbrains/compose/animation#animation-core-desktop/1.11.1": {
    "jar": "sha256-Gzr40gYnsBEB2Cf3LibbrczI0hLA/8DAL/Km/JZ6bKg=",
    "module": "sha256-RcYWgKu7S0Pjeu6AGADn+McNYQVsbhHNOAZhSiMEHmQ=",
    "pom": "sha256-z3Gjr4mGYDoAyTVLm3Ql8zAfGfm4Q2C4xPsQCQ4NXW8="
-  },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.9.1": {
-   "module": "sha256-hgdAqi8Icj+Iq5y9pDwTI/0Dbvfdw11tURa0ZDnAROc=",
-   "pom": "sha256-1VVL+PdDa479M8WdaENtV8T0woD2wK+oqBRDrGtGV78="
-  },
-  "org/jetbrains/compose/animation#animation-core/1.11.0-beta03": {
-   "jar": "sha256-yVDtLCc6sA4VznLQTqo4AYiNXVXkM18C1NACkAnffXo=",
-   "module": "sha256-Lyg8tBqEJe4z+el2WvpqpXHe32uUCt75Me1iTUV2pyE=",
-   "pom": "sha256-mzS3KMEUniUwiVW/tsQiy+opZdI24udDU1ZxhzrIRag="
   },
   "org/jetbrains/compose/animation#animation-core/1.11.1": {
    "jar": "sha256-yVDtLCc6sA4VznLQTqo4AYiNXVXkM18C1NACkAnffXo=",
    "module": "sha256-PNhXR4ESEdkz69mwnAZ47QoTdEJUTUWXfH+0y7xpYeg=",
    "pom": "sha256-WZd8s6w6nSmzcDTmf7HB0OpggME41inpqaQ3XzlBvio="
   },
-  "org/jetbrains/compose/animation#animation-core/1.9.1": {
-   "module": "sha256-sLNcaXIN2EWqMr9DTUyMalYOE4elIAh0jvlGeJSOoyQ=",
-   "pom": "sha256-u3hZBa0EmVIiHZzNxcJFY5ri9TfiEICldU/YZ0UhvK0="
-  },
-  "org/jetbrains/compose/animation#animation-desktop/1.11.0-beta03": {
-   "jar": "sha256-u0HGxVCkccaMURhcO7BFhIKk6APuB0vyFa3Igy4gB+E=",
-   "module": "sha256-F82Km0qkV2AvXmzcFhzCrb28Z2reZM7IJcivacRPUzM=",
-   "pom": "sha256-rME5ZlLRuMsUTMcbPf9bOpKvXyhnTPPnIQ9J3ReapsE="
-  },
   "org/jetbrains/compose/animation#animation-desktop/1.11.1": {
    "jar": "sha256-u0HGxVCkccaMURhcO7BFhIKk6APuB0vyFa3Igy4gB+E=",
    "module": "sha256-Xspxyb3gALsU4gUE5VfMPUzoVZdEpiowMTTdCyImKsU=",
    "pom": "sha256-1cmnfoKnK6vZ+nAcHGdj76d5LFvxdIo2QCT9r8ooOXo="
-  },
-  "org/jetbrains/compose/animation#animation/1.11.0-beta03": {
-   "jar": "sha256-CzkZYHS7VWNHvRiSt32kT4nXysl4jRV70i5Ea2xwk64=",
-   "module": "sha256-1fsd1sWN0y1qhTqpqOCYP0Gp390nBEXCF0D5aWOwuYQ=",
-   "pom": "sha256-tktWrhGVzsdcUIPKOA2q6jLhheB/fa2m9prDdiNUXoo="
   },
   "org/jetbrains/compose/animation#animation/1.11.1": {
    "jar": "sha256-CzkZYHS7VWNHvRiSt32kT4nXysl4jRV70i5Ea2xwk64=",
@@ -2987,93 +3295,78 @@
    "module": "sha256-91Hc17faBt+lcbSQJQ5+johwxpmegVieo4OjjrWb300=",
    "pom": "sha256-DTBaW5mD5ygF1YrGVHuDn4SkwIbC5cN2JvBQgz0rwD8="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.11.0-beta03": {
-   "jar": "sha256-ex5Udj63UU5Mp4YzYREt9/8qiv/egSHkPo3Cf8GrktE=",
-   "module": "sha256-VmzkCAMY5fTL/kgMYzhW9Gu6lPBSlIshiveOqKTlANw=",
-   "pom": "sha256-XYILp7WmvQfTAsGzjBf739ENwPebmTQb4AuqJmsF6Kg="
-  },
   "org/jetbrains/compose/foundation#foundation-desktop/1.11.1": {
    "jar": "sha256-MmAWU2N+R8xEL6d8nl3ZWlV6BTOlMEulIAzHLFZfB0o=",
    "module": "sha256-MYn6H3Eb30h5ewnt7DbxxEYDG21s/HiULXJY3wFH7bI=",
    "pom": "sha256-OkA9BQm/hR0p7LqSdJW1wmn+sQCYXBcfdjWF7uIAtWk="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.11.0-beta03": {
-   "jar": "sha256-iJ/2np/rLzUYaKUOPyGw6wA0gck1t9XBLMjFWPFVGqY=",
-   "module": "sha256-Me/vBdRVthRszjUOlLKixYPn8koMSGiNRjA3oZFm76s=",
-   "pom": "sha256-Acx9MixEYurLgudM+OVbDAeJSJOmfp1/WC8BF+bIbQU="
   },
   "org/jetbrains/compose/foundation#foundation-layout-desktop/1.11.1": {
    "jar": "sha256-15kptFUh3/DHfTGEQSAHs7lpV1XIsZM9X/nk8ek/oTE=",
    "module": "sha256-0o6VTq2HvE4cIg0Tm8FJVUHBjdEWbK9U7cj+Au/OeVk=",
    "pom": "sha256-eQO2y+HHwzMm1B+6pWm5G60IKPCTeQNArkzQERkqhe0="
   },
-  "org/jetbrains/compose/foundation#foundation-layout/1.11.0-beta03": {
-   "jar": "sha256-sUYAI/yC0pioGhcNGPPnL+39QoRI0r5gUCPbFbg2xWo=",
-   "module": "sha256-tJfEXxA1kNcNo2cu6t2Zg6tsuFsFyxUG3hUx03YokKw=",
-   "pom": "sha256-+JMUlJ+eHNkat9VoJAP1E7N1shrauDcTEFq/8D31TQE="
-  },
   "org/jetbrains/compose/foundation#foundation-layout/1.11.1": {
    "jar": "sha256-sUYAI/yC0pioGhcNGPPnL+39QoRI0r5gUCPbFbg2xWo=",
    "module": "sha256-QuPM5CdYs9tRHynzfhhoD0wsPKbY/Zr/Pbar2Z7BJQk=",
    "pom": "sha256-1EJsKsBwAIzN/MPV/NGtBbC9xMu9+ysFRVWDnQHV9Kc="
-  },
-  "org/jetbrains/compose/foundation#foundation/1.11.0-beta03": {
-   "jar": "sha256-TSDNftbAbktx+pCa7iY3wVEyDzgmvarzLZt6VVZJM7I=",
-   "module": "sha256-j7CB2b1ZeLldP1JPOr3UHwaoGj40lbzRfiS8vzY3xWE=",
-   "pom": "sha256-2AxtwYrDqFx9D6M+dOdORh4w+UBwn/pzOsp+MhzsubM="
   },
   "org/jetbrains/compose/foundation#foundation/1.11.1": {
    "jar": "sha256-TSDNftbAbktx+pCa7iY3wVEyDzgmvarzLZt6VVZJM7I=",
    "module": "sha256-6/fS6fGq7hC1sUyJpTPIB/Di9YJl5mZlD3cq4eEM7JM=",
    "pom": "sha256-M7AOmYx1WEw3v5OSfg45iXySV2LBNVoDl3T6+4Ly7dA="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.1.1": {
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.2.0": {
    "jar": "sha256-9QbjmAxn+HbJUUvgIJW8rTvv969P3tu/WXlD2G3wcPM=",
-   "module": "sha256-tzLbcqfMhTnByPNVYmMeq5aeADP3DU3mzYcXwS02bdI=",
-   "pom": "sha256-DT6Dj8VwSkIGkuTkxGFS0EmN/t9Mv9QnZqjnlBiJkW4="
+   "module": "sha256-6sJ2wzw36l8ryd3C3bzTHxSpT9QzM9W9CwoaNhbaHIQ=",
+   "pom": "sha256-/PfOyVwOTkFo5tDemdIcAGlrPeo6guQYstJ2qaIPJhU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.1.1": {
-   "jar": "sha256-FfTQYpKf6T46z2ri6laAfh0LKhWPmfiE3nva2vpvc5c=",
-   "module": "sha256-GzIidigY3IspcNtNmW9JALlqtg2ZGLO/BGdQYITYkQw=",
-   "pom": "sha256-4MJcqn8j1wZ+dQTsxY4OEK7eEzDWJk+iC17F9ZgORm8="
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.2.0": {
+   "jar": "sha256-pegeEYe6ut0xH5a8FJtMNqK013MTrA5+kTybmRR3wOk=",
+   "module": "sha256-LUoAHzWEnstTT5x9cqtMn3Onli6rs1f/cu2BHuo4Ml0=",
+   "pom": "sha256-5ABj8Go0vxpxFo9q0Ge+Zp4Ctls96xkXyKB9m/s5lzA="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-core/1.1.1": {
-   "jar": "sha256-DBLxjNb1mFr0Af8MOwMT4xaW8o6tsgBGgNoRx7AW1ps=",
-   "module": "sha256-EZ1rqh8S8A+yoh3ZX2kkD8UQ1qCH1FvPdB2gOnMkB3U=",
-   "pom": "sha256-F94xHE/mPK5mLl0PugrYdWWXRrkx0Pov+6C9HzRDEc0="
+  "org/jetbrains/compose/hot-reload#hot-reload-core/1.2.0": {
+   "jar": "sha256-6EhM7WBD8HZK5FohzdMu6TPGtCF9jtO8Rp5QXzpJvmY=",
+   "module": "sha256-JfmU/zdung5SuZ453BFybIFpB+H/sj0fw06GbibJLxk=",
+   "pom": "sha256-d5QCtwAArpDEP5KUWRjxkFD4Arg+JdPmohSqY3lNIbU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.1.1": {
-   "jar": "sha256-X7Cqbk00kczz7GcdPLvx8rz88OBnbz4thWEs/ejfbVE=",
-   "module": "sha256-8iAegT/4RSdDHsV7j/q9dNQVV0TUZrucUhqPQHzdDFM=",
-   "pom": "sha256-M1JwjocZRXcOuwWb0ofxUOoO3xiMJVLJov+le5zvMPU="
+  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.2.0": {
+   "jar": "sha256-SQUmsczjRIpyz5N+jRxWamZn5RQKIdBTgFQP0U7heYM=",
+   "module": "sha256-71E906rmOcKiShpXMHPT+wjztmo7V3tFRQYfy5CMgw4=",
+   "pom": "sha256-fiELxVbDR7dDSxB2yZ+hLnLrzMWcMx8QW9aDBeThn+w="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.1.1": {
-   "jar": "sha256-yErWizz55/HRj43qTlCXo86YYAIPpVA0JU8AnA3mndM=",
-   "module": "sha256-3rLhUP0khvjJMScGzQuIOfy5FqkKGihtQqn5JoWSlZs=",
-   "pom": "sha256-HzNyUqXvicvUGpsVOsmRRdK54K4u0mbGgEj0BUH8oGM="
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.2.0": {
+   "jar": "sha256-uVVQAfLcOguleam0zSBD4eQPR0r9tZj1QrU4x0vibyM=",
+   "module": "sha256-+6znweobGoMG9gzn/CazY/pOaJlWUPWkmGe6v76K5C8=",
+   "pom": "sha256-aeFs/NHgVN74Y0M4ySomi56z/bDjau2V3celF9UmQ/o="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.1.1": {
-   "jar": "sha256-OJyfTOFdQIOjykh8+YIIWXxG4wn3DhXT2DXf4w/4mTk=",
-   "module": "sha256-zqLGhUYawKYlkdwPVxN5lbx/L0yWVhx+dh0vT8+0Q0E=",
-   "pom": "sha256-VzrjxEI1VHILRiii9ZWXH9d3r4c67Gfgor2SElu+JZg="
+  "org/jetbrains/compose/hot-reload#hot-reload-mcp/1.2.0": {
+   "jar": "sha256-Mn5fZ1DuYY0TPV2Uj4Ik/g8ndlvmnaEy1EhAvAlcuQE=",
+   "module": "sha256-4mVvZEhRQ0foW8u8dAwYEK5rQ57tDmFQhBdbPVBsoJg=",
+   "pom": "sha256-BtoASnaBMf9OGd7i/hmTxgE5qZoiP0ZUi8B0vMCiAG8="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.1.1": {
-   "jar": "sha256-AiGFq+fdw9i49lBnN/jFXKu+X8jUn+EoN3/3GEcl6vw=",
-   "module": "sha256-v3WtT4g84yZhqRttSMxcMLk10g7tGCAu3l8m4hddG+8=",
-   "pom": "sha256-D+FZhNuX0wiPA3CwQG0ON2GeawD7gNL/wklJWhO9Zhc="
+  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.2.0": {
+   "jar": "sha256-yOZtSk3a1ZdAj5MzyaMXyxGW8FH0SN46q8ykaCnIvtM=",
+   "module": "sha256-8gQ2e9dpVVrR5Sx6PmM8u3j0CTnN8v3cwZlGbopkmlg=",
+   "pom": "sha256-Om6GL2CmAfucgwxnpYNJ1b90C/vUrjl9NyHI/56La1I="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.1.1": {
-   "jar": "sha256-DXwGz7KAihdDfKSLcuxjSljAmM9AhQdOALcc60fCmeQ=",
-   "module": "sha256-xMGOOQLn8bcY53511o1+PTr7KgDGYEFnpSdaGKkcK3M=",
-   "pom": "sha256-GOhkDldZzxqo5pcJmNTUZQBj+H877uBk4Sg8i4sreyU="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.2.0": {
+   "jar": "sha256-VZULFPN7q8+qofWwGuOnuSICaK5Qdz3C6yYGp5NFx8g=",
+   "module": "sha256-TW2/LEowtnxpSByeCqZ9uH+Rs3P03SuSGOfKVyZBqjk=",
+   "pom": "sha256-NE43XfoZK00COp3gB/+b3zx6ZjD6MNSCElmRb9NjDD4="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.1.1": {
-   "jar": "sha256-9iQCE7NYXC82OI+MWXSqqVBw/QFxTkfqNbSPgob/70E=",
-   "module": "sha256-L0vVQf0Ofe0pESxWRwjHuhuVgGknUKy0uJVl7wtHX5U=",
-   "pom": "sha256-wcnX5pm7pTWgUtvw6sKXxn62zwN5X9AlUC8vnKHNA3s="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.2.0": {
+   "jar": "sha256-EbyT08rBkVwpgax6pBAFkrW9DqAD26CxRHh7ykirStY=",
+   "module": "sha256-MRRA+i1+dGIXzNkBzEmvjJpi2AptjIDv4S4Ia+iXeWs=",
+   "pom": "sha256-u3tY5TCAOzadUFZLkUYl4Nd2r5rdeMcaq3THLTmeK0c="
   },
-  "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.1.1": {
-   "pom": "sha256-1MflNuUHav7FKqKagxvikzEz4dOY/TdHVttu5CP5Yd4="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.2.0": {
+   "jar": "sha256-cNtM0mJe/MisFe9bcV3MokvXH9hi0hvyS7EqJC3K6vY=",
+   "module": "sha256-nmudX05fD2FLZCe/DCxhPHGFB5iFCTfF3cHntsEzhT4=",
+   "pom": "sha256-f9znrEgz78W88ZBXQFJwlaFf3PPPOQ0MsFaBrMDd5sc="
+  },
+  "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.2.0": {
+   "pom": "sha256-Ae30mDrgQozANk50CsjkdARLGV9fLPXJdflR8x1461c="
   },
   "org/jetbrains/compose/material#material-desktop/1.11.1": {
    "jar": "sha256-/NiBITYov1Cx4niSXbiS9VLCO9Y7x+25m5aHkMngl/g=",
@@ -3105,19 +3398,10 @@
    "module": "sha256-VIlnE1bPlsJY+xLEmuYL33TtHYW3CxLpv+1ASkVLKhA=",
    "pom": "sha256-9B1CZZeqEaa2HiYVkhzylupzSobj1mQnKTuAGzWMOZs="
   },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.9.1": {
-   "module": "sha256-BlaiK1iKg5uADqwoWqPrTQNd89VSIccGxdNfpil+bYk=",
-   "pom": "sha256-T5wpVlxWK/sQxbeoEGzHkuJZp2z3iJnemi71R4cADBM="
-  },
   "org/jetbrains/compose/material#material-ripple/1.11.1": {
    "jar": "sha256-aCKiJ1yYknuGNUbXdYUydrFZkhTkI02btHEHstpwdOM=",
    "module": "sha256-4cXp8ji+k3PPrs17nYPvvpU/zFzheZYrr6PyIAWJIlg=",
    "pom": "sha256-8S2WkwTwAJJVQoC6ah+0rpuZ9LAa5FjpI12aIEXXrJc="
-  },
-  "org/jetbrains/compose/material#material-ripple/1.9.1": {
-   "jar": "sha256-KS0rP7u8wkuzJvP2QtrJqM1V4Y1bUYNlusbayiOlz3Q=",
-   "module": "sha256-iY2+mg5iyco5GzdewaJ7SZZXQ7dKBq2F9ucQoLu0o9o=",
-   "pom": "sha256-9S84Kui5GL5SNnYUELp9jdEuC2rJkjB5fFOyQLoaMeg="
   },
   "org/jetbrains/compose/material#material/1.11.1": {
    "jar": "sha256-8pMkH9XVFXmeT3wbfOQrPghdIaSZoZVZH7Pq2UyZVXU=",
@@ -3134,40 +3418,20 @@
    "module": "sha256-+np0XfkXBZHZjzdzMDvPU4KTE6z7Q8csGqT4+5m6RaQ=",
    "pom": "sha256-lyjwhwOCTgT6yPhOZuHn8obuQwiQ8yf/ix51Qx3fGto="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.11.0-beta03": {
-   "jar": "sha256-vOssUG5CCZNL4BrA9FMysMEreIbuANw5DHu9+/WPQhc=",
-   "module": "sha256-8oK4GYgmtmdnQi3rdoCwW0S2XebRzccgUNWw0iW3Hnk=",
-   "pom": "sha256-vu8B5OdOsVfmWE5/8+Wkc14hAkHL//k0NRVObtFfFts="
-  },
   "org/jetbrains/compose/runtime#runtime-desktop/1.11.1": {
    "jar": "sha256-vOssUG5CCZNL4BrA9FMysMEreIbuANw5DHu9+/WPQhc=",
    "module": "sha256-IqGKlVggz4zIxmQPUf2+feRncV6suiXMU4aIPZQrzWo=",
    "pom": "sha256-+B5PSD8GxVjXclg/KNig9bPrpZZw7phPluQOEf7lmOk="
-  },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.11.0-beta03": {
-   "jar": "sha256-dpbBXdI94BQNgVDxEV9Z0qIRMx47qiQ/QYR0R36Ylxw=",
-   "module": "sha256-vcQ6n/CC1Lt9SFdIEAYs6zSu+um1J1CcQVgtmUR1W4s=",
-   "pom": "sha256-o8WlwM47B3ND4gZFPtQPZeBjiP3fZVqltiUM8wKAFnA="
   },
   "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.11.1": {
    "jar": "sha256-dpbBXdI94BQNgVDxEV9Z0qIRMx47qiQ/QYR0R36Ylxw=",
    "module": "sha256-nT3r1HAKUl7E4JspOOwX/mkw+AccE0/FTVqmiOkHB5Q=",
    "pom": "sha256-90MTqloWvsPZAbjYKYHNKgci/dwqxqji5Psne/hTTOI="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.11.0-beta03": {
-   "jar": "sha256-aZ+/dGYW6ifIkD9QuV04BZDB8Hw5VaI7fAvwual51A0=",
-   "module": "sha256-fLfCEhxH1b+klQI+rs89V0ZXiIio7MWae+O2k+JABw4=",
-   "pom": "sha256-cqHT9I2uI002RzEiBL2X5HClq0KqtlPA0zkwDJsf8sM="
-  },
   "org/jetbrains/compose/runtime#runtime-saveable/1.11.1": {
    "jar": "sha256-aZ+/dGYW6ifIkD9QuV04BZDB8Hw5VaI7fAvwual51A0=",
    "module": "sha256-cG31drzu1+6WQLpyHHWZwitc5Il23mW+vYXFaSfGtaU=",
    "pom": "sha256-oE+rRUIsu/z5rnu8/DT4dIpbIev067rua1NAOQE5TnY="
-  },
-  "org/jetbrains/compose/runtime#runtime/1.11.0-beta03": {
-   "jar": "sha256-dJL4PPeRpyeIDFVcrCmLkd/S4MqSJK2vkiO9gj64wMw=",
-   "module": "sha256-ppHzsuiouhmW3QExhh20VLnBSdBNwtCoyMGjB1Fhuew=",
-   "pom": "sha256-2oRUH9Bi3rS7cag6EvyJOVSETNIZusNG9p/jiWfvHn0="
   },
   "org/jetbrains/compose/runtime#runtime/1.11.1": {
    "jar": "sha256-dJL4PPeRpyeIDFVcrCmLkd/S4MqSJK2vkiO9gj64wMw=",
@@ -3186,20 +3450,10 @@
    "module": "sha256-wm5ZfRh4NgAA2PZvCW4XTnsqEEIY0v/gfhrg2xMkW+8=",
    "pom": "sha256-KJdxsgWQBooM6fHuSRonOoA+9ayDWUyKVQN+A94iQr8="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.11.0-beta03": {
-   "jar": "sha256-AH+5qD+kBbi/4d2+/vPdkp3qK+QpU+ZRDORvhf9jXjA=",
-   "module": "sha256-st2Y3GD0GMpEgJVEPBABE8UHQU4R0fZTDPJAv8Cdq34=",
-   "pom": "sha256-ay4QcRVV5RVjKs11siDsbJ50qjHzKRpz6ajRNx9GGm4="
-  },
   "org/jetbrains/compose/ui#ui-backhandler-desktop/1.11.1": {
    "jar": "sha256-AH+5qD+kBbi/4d2+/vPdkp3qK+QpU+ZRDORvhf9jXjA=",
    "module": "sha256-0QGxD3yuXegOFJdTyNg7lRaSLm79BCJaM5wJvdrEVGk=",
    "pom": "sha256-KopUqbkj11gjfd/ZXm57NxJ2gIYDJOWN0gjlqGGH+5Q="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler/1.11.0-beta03": {
-   "jar": "sha256-ni/S+T5C4kpwidSx1VIpp2f1G1MspEqDDpjknWrd6DQ=",
-   "module": "sha256-pUJEbcbYQXGTbmYbkeiVuO12/3EGqrQub1U9e5kUowI=",
-   "pom": "sha256-UBu8+9vWLgsqdhasNuIxG8NsBM8dM3Pk2eqALZEgtg0="
   },
   "org/jetbrains/compose/ui#ui-backhandler/1.11.1": {
    "jar": "sha256-ni/S+T5C4kpwidSx1VIpp2f1G1MspEqDDpjknWrd6DQ=",
@@ -3210,50 +3464,25 @@
    "module": "sha256-Md+hhs1xs1XLG+eGB//VJW3Mg8/xFaJg6k1pdJIJJYI=",
    "pom": "sha256-jKkBhNsSyAgoKenTNle2BzBOI6o2nTbfy7sQjib+DuI="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.11.0-beta03": {
-   "jar": "sha256-4X6Wgg+HXHKCVZwec/xE3hR2daQTEInVoOXUUJzck/0=",
-   "module": "sha256-KuTvIslxmIpC//n59gkez1naEgmMHDa19CSQgT+SX10=",
-   "pom": "sha256-VR+emWnI9fLOLHDLBdKPVQ55iabxhMleRk9bauK+NJo="
-  },
   "org/jetbrains/compose/ui#ui-desktop/1.11.1": {
    "jar": "sha256-RC1KLw2VBURTtoGRME3KmVJn5y/Ny7wKY5l7/03N+Uk=",
    "module": "sha256-J26MT45zVFyDgdA1SQcvu7hsO5j0fzqS5N3mO3hwGt4=",
    "pom": "sha256-OBBx4nN56euSbGNATHbtIm+4+CEQ+PJkMANFYkzQwtQ="
-  },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.11.0-beta03": {
-   "jar": "sha256-rW1VV1cnCKzuvxqmJsWQDo/OYfBAptXZcbGtylhpq4w=",
-   "module": "sha256-7nOj5PCvwqleoDzoGQ24x2wT671Drj6TklydalfGzTE=",
-   "pom": "sha256-ZTY5x2xtRfUpFXrOe6cBbMjpD6FU2OyQjvkb4tqWZg8="
   },
   "org/jetbrains/compose/ui#ui-geometry-desktop/1.11.1": {
    "jar": "sha256-rW1VV1cnCKzuvxqmJsWQDo/OYfBAptXZcbGtylhpq4w=",
    "module": "sha256-nkZ3Rd+KER895SD6pftnlFFEdTCrmbak58QnyEww0ig=",
    "pom": "sha256-4TnWipls4mpydKoJrfPl9yGtjse0gnVzz7N6Bn8rMAs="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.11.0-beta03": {
-   "jar": "sha256-+3sqZUb2gbwrjukuVlD83kKpHaBmnYG4g4VFISnj3eI=",
-   "module": "sha256-olopE+gEhIL/ohKUO1+CK/CjepWN4SEc7AG4a75IAO8=",
-   "pom": "sha256-OBu9zibKolLz+sAewF0yuJlDE0mYn9dQQCiMdgSI7MY="
-  },
   "org/jetbrains/compose/ui#ui-geometry/1.11.1": {
    "jar": "sha256-+3sqZUb2gbwrjukuVlD83kKpHaBmnYG4g4VFISnj3eI=",
    "module": "sha256-8frXRcmYYY5Tgm+iSVfYjhwKFueCs/ctNxYAA78MerQ=",
    "pom": "sha256-uhc2rmi4+mQZMdUpkwXoPRCpzn0cZOWIbUyfou+AJEU="
   },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.11.0-beta03": {
-   "jar": "sha256-zpz6uzK04iaxG/sLU48FHu9McFAEkQzXf+KRkYnnyCo=",
-   "module": "sha256-XYAm9BcoLlhZ/01c4xnu32BMsizL+AZ+Mo8hnbEokiw=",
-   "pom": "sha256-b8ACQ2Kh20U+Af1u/RYUKEJGUZHDtWOrMjVwtE7C26o="
-  },
   "org/jetbrains/compose/ui#ui-graphics-desktop/1.11.1": {
    "jar": "sha256-x9diDHjw5kBS8fKN9UqWmzbPSRjnlltWaHWFVWk0blk=",
    "module": "sha256-eMKnTI0R9NfIxAE9ksmqkhML4wYloE7VvyK7UkziRcM=",
    "pom": "sha256-sbg9CWCygnJssIXQPwsmx2CvmcQ1mgeuiIqmAOwZ+8U="
-  },
-  "org/jetbrains/compose/ui#ui-graphics/1.11.0-beta03": {
-   "jar": "sha256-txpnyyuomXi00QvmmykNVvltxuCfahAgR+8S+YFB+Kc=",
-   "module": "sha256-mYh8YwTbaYZyP1ghSQE/D1DGPGjl3r1rFa4KVaHxhCk=",
-   "pom": "sha256-zEM9waFzO+vESHmB5WxCeu2lbc1beO4ufZf4TOSEc2k="
   },
   "org/jetbrains/compose/ui#ui-graphics/1.11.1": {
    "jar": "sha256-txpnyyuomXi00QvmmykNVvltxuCfahAgR+8S+YFB+Kc=",
@@ -3264,29 +3493,15 @@
    "module": "sha256-ttJkrI5cSN1PbxPZ/YGQeA8aOG5KEL2Qw7sFVlLUdAE=",
    "pom": "sha256-Fg1bjrRrnNaYMU32OM+sNDC5aC3fm1RAG3kWxjd7z6c="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.11.0-beta03": {
-   "jar": "sha256-wajOseh1xvG7LmfsqHePwEAn3WGPMaafiGNoy9017uw=",
-   "module": "sha256-EuEkZ75vI6v8ETW9ZK0jp0nh7z7zixrQ+XGf4IPfdyk=",
-   "pom": "sha256-AighDkf3GUAJU1iAE/VACFCsZqHNBbEGZ42PCHOA8eM="
-  },
   "org/jetbrains/compose/ui#ui-text-desktop/1.11.1": {
    "jar": "sha256-wajOseh1xvG7LmfsqHePwEAn3WGPMaafiGNoy9017uw=",
    "module": "sha256-9scak1ko0uAWzsZveE52qtzUKhnXaKyBrXpFUXSgt1I=",
    "pom": "sha256-hcEWmHvTA0hEYx1kLTP9goNcuZqc7J2bZ94s4wNDQNE="
   },
-  "org/jetbrains/compose/ui#ui-text/1.11.0-beta03": {
-   "jar": "sha256-XdkHaJyLQ6YQAFx/qGkYDCC2ozWhOnLM7Sw7w3di1ug=",
-   "module": "sha256-EJFByb8fbBTakvlbvuPKoDvbwTVJC44uv8VGzhkWS50=",
-   "pom": "sha256-KbvfF8yk+j4YokEW8GTX9AKu09BKnOmHe5tLC0MQ5X4="
-  },
   "org/jetbrains/compose/ui#ui-text/1.11.1": {
    "jar": "sha256-XdkHaJyLQ6YQAFx/qGkYDCC2ozWhOnLM7Sw7w3di1ug=",
    "module": "sha256-YymeOu/iaYtpeI/e/NDyz6C41ybk/Uxw0119qvexek0=",
    "pom": "sha256-LoyJ7XELS9uTjWgqHFaY+ubFVMleMoRCAchw1mAEpNQ="
-  },
-  "org/jetbrains/compose/ui#ui-text/1.9.1": {
-   "module": "sha256-lEvw4Xg0uVarRga3jgXG90MxqSVAcnYJ0Qq1cjd6F9k=",
-   "pom": "sha256-jEFrj59tZfdBvaLWzwySOJjfJyA99Q2alHSiLNDhQig="
   },
   "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.11.1": {
    "jar": "sha256-YNOpE+VQpAdiSNYhBc0Ki1xsgHzwnF3nLLr0KI3FKpA=",
@@ -3298,60 +3513,30 @@
    "module": "sha256-eI6dM0RECTpSX6AYmyTJak3yVxX5NhV11yxzuVAyttI=",
    "pom": "sha256-n+vWaCE0Zl/E6ucbMa3AtpZcHO6nOaBH1PoovUdi06o="
   },
-  "org/jetbrains/compose/ui#ui-uikit/1.11.0-beta03": {
-   "jar": "sha256-axl+MetJAS/Qvc0HxVjrXVpXYkZoXpVBvD0rcTNa7ug=",
-   "module": "sha256-K5N3yyyrBbZ3nq9tVoLms1QKUTHXC64uAju1rvK5Cyo=",
-   "pom": "sha256-HVM/yiMbbHjNsm+U/TwdWKH1kzBuNIaBG+8vQujVk2U="
-  },
   "org/jetbrains/compose/ui#ui-uikit/1.11.1": {
    "jar": "sha256-axl+MetJAS/Qvc0HxVjrXVpXYkZoXpVBvD0rcTNa7ug=",
    "module": "sha256-ITx8vB7IvSEct1kZ2OIl1uZ4/hn+llLYJFL/6D1yvFI=",
    "pom": "sha256-vCeDFBSpwqrywW6XwY4uG3U8cWBPf87lo8Ws19SUBJg="
-  },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.11.0-beta03": {
-   "jar": "sha256-nJGGiwvZZ9ZPcm7cMZyJXjWYcaRO9+ddxp/wytRqwNo=",
-   "module": "sha256-Nnw06UVjeFSGYuGy9kEPc7A1+NZHwCrvmbsO8knlhwQ=",
-   "pom": "sha256-ZrSIAeOXKPUA7zE6Y1kXAnCzxsMv13TuoFHjY8ZIdwU="
   },
   "org/jetbrains/compose/ui#ui-unit-desktop/1.11.1": {
    "jar": "sha256-nJGGiwvZZ9ZPcm7cMZyJXjWYcaRO9+ddxp/wytRqwNo=",
    "module": "sha256-mmIUrNREcxfb9da5Xj7DopDK15Gca8W7p/n2ETT/LzY=",
    "pom": "sha256-QWbnNxm2rjaMRwE8mTjZ032FOOmST2YhsxRj92gg83s="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.11.0-beta03": {
-   "jar": "sha256-aoewfvoRvawJxaZZ9oLMjDc+DiwntHkWUwtzC0g9Jc4=",
-   "module": "sha256-r6wiakOeSfF5efbRj/LLM03yB4qWoG+VMR0Og4uOApw=",
-   "pom": "sha256-SnhCIaTl54XVT1I+RUAFPaMkJF58mE4iPGNEl/jM66c="
-  },
   "org/jetbrains/compose/ui#ui-unit/1.11.1": {
    "jar": "sha256-aoewfvoRvawJxaZZ9oLMjDc+DiwntHkWUwtzC0g9Jc4=",
    "module": "sha256-zR8anUPkHHrlt9gVAEbd4BPjxlayx62fol4c3gI2gLg=",
    "pom": "sha256-4CbxFkMTGn+jwtZzTgP4JX4+NS6eHxJpxDUh80EwiWs="
-  },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.11.0-beta03": {
-   "jar": "sha256-c9BJMKkfuaIETywZjsbj8dphaWzLWaKI0f8KFbqwju0=",
-   "module": "sha256-TVAepThaSn0SGYWhzoQMX0kOLAiil4GTUHejKKIfwOc=",
-   "pom": "sha256-2z6lgDJyeS96EJqX/A2NOqxmLQP6DQSQlCXA7kC1rP0="
   },
   "org/jetbrains/compose/ui#ui-util-desktop/1.11.1": {
    "jar": "sha256-c9BJMKkfuaIETywZjsbj8dphaWzLWaKI0f8KFbqwju0=",
    "module": "sha256-Y/eRvdSFrp2hu+mhKs192NlJRUi3rSxih7OCfgh99yM=",
    "pom": "sha256-x1kLUwQm1IyRQ+KYivDfHuWzWuIPm5kjrILdiJw4L8w="
   },
-  "org/jetbrains/compose/ui#ui-util/1.11.0-beta03": {
-   "jar": "sha256-zb1LEe9BZ7FIOHnExuxS0VLBtQfwyBdBuD+UNACoOvU=",
-   "module": "sha256-gn/7w7YxvAXdXY0D2z0Yh1+XHnNq6CrWoJFdlE2eTJU=",
-   "pom": "sha256-GyslM5cSbeSyHcleAspH9vDiXl/mtHOcVEse9hS9K5Q="
-  },
   "org/jetbrains/compose/ui#ui-util/1.11.1": {
    "jar": "sha256-zb1LEe9BZ7FIOHnExuxS0VLBtQfwyBdBuD+UNACoOvU=",
    "module": "sha256-j488kSfdGBmN9aMoBH7vbum/UU9aMNo9MD8D52ryrQg=",
    "pom": "sha256-adivGuv/w0tIRdaGyLuam1IJwDhhDFDDeBO6Az5dJhg="
-  },
-  "org/jetbrains/compose/ui#ui/1.11.0-beta03": {
-   "jar": "sha256-8Rl3lcLsw4Vp90iVrO+UaGkydD+vEjcteM0xY9GVj9s=",
-   "module": "sha256-dyfymNnS5zYkTMamtjeqjbHOLMLpFzNHgeSqgFuhfhc=",
-   "pom": "sha256-hRpdUDvAR5JKomYWUTCInuzTY4rXty8flov03x/TNbM="
   },
   "org/jetbrains/compose/ui#ui/1.11.1": {
    "jar": "sha256-Plv/lbmorLcTPvj87ENDgvcHDRyLWsPc5soSyAKlJRY=",
@@ -3364,173 +3549,205 @@
   "org/jetbrains/compose/ui/ui-backhandler-android/1.9.1/ui-backhandler-android-1.9.1": {
    "aar": "sha256-j4830Osz9Zdgi8IPh1AhsdgNtvg1wTjNfO+Qk8etTCQ="
   },
-  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
-   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
-   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  "org/jetbrains/kotlin#abi-tools-api/2.3.20": {
+   "jar": "sha256-U2hfV4OwSQaDiY11Wrrk1Bi26DugYTSFiv3ctZRYmek=",
+   "pom": "sha256-qIbJ/X8rlmlFf+wCHxnc8V8EY+DbS9rVOuGBJTZsxvk="
   },
-  "org/jetbrains/kotlin#abi-tools-api/2.3.21": {
-   "jar": "sha256-3HIcf6qETff11utiAh3J6t/RmY4ejfkYNB8W6zw5Guo=",
-   "pom": "sha256-c5V4i6yoKSFpTSZh9L6mc32eeFRbO1arpiQQDgUF2MI="
+  "org/jetbrains/kotlin#abi-tools/2.3.20": {
+   "jar": "sha256-R9fBgRPZhYUGWrUky6HEcLTDaTB2l8qdHIEOULk9C9E=",
+   "pom": "sha256-Pi8inRHuIgaFPTAL/l0R3dzpYFqJ5cmvrwa3Ij0Zh1c="
   },
-  "org/jetbrains/kotlin#abi-tools/2.3.21": {
-   "jar": "sha256-Z2FlYgXDUUBQ9o/efDKyvrRyRnhiR9rPsnnbQypwVis=",
-   "pom": "sha256-4sAPASdLb0ZFpyikxuSpCnydRjlAlqMDJvfDGvCVZ7M="
+  "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.4.10": {
+   "module": "sha256-ex+asAI2BHlhjuCapscAWgKCw55wXlYSUPNYaoKDcpY=",
+   "pom": "sha256-yQrVB/LaHKtZSj7Z/kPLZeuK6+y68uxWDkzo9t6VDm0="
   },
-  "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.3.21": {
-   "module": "sha256-PK/UG7QMv9ghDJobaQG3OXUKSKSwUzdJrcN5GRrnqv4=",
-   "pom": "sha256-ySfXxEcNIrxYU3TGBWx9zqWzhlB9xFQMHJiLn7JZl2w="
+  "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.4.10/gradle813": {
+   "jar": "sha256-uC9WR9gdOsloj2PUUZJHKoLGmTZhjmu6HNKw/fqGFTM="
   },
-  "org/jetbrains/kotlin#compose-compiler-gradle-plugin/2.3.21/gradle813": {
-   "jar": "sha256-B5V8OelCS3WZSpThAZBKF5D6iSvJdlsh3rysg7g2fCM="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.4.10": {
+   "module": "sha256-jtWvXG2kojPK2J8L7az8z9PvDhk5agILuXTi/tviPpc=",
+   "pom": "sha256-Cifo09QsTnMJBOQ1C9SpTgUrC1OBOXUHz9VVIle7spQ="
   },
-  "org/jetbrains/kotlin#compose-group-mapping/2.3.21": {
-   "jar": "sha256-T8gpfrPkZr83vKgjrbZ/LQ9lHo11OOrsxsCBIYWAVfo=",
-   "pom": "sha256-Hn0hE+XDWTfhSPFBmobsIsIr0TnEKKb20tO2q5OFkRI="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.4.10/gradle813": {
+   "jar": "sha256-0xLrfWmo1axTd8cSVGZlyblKY8qPyc3TFUMfEGcugJE="
   },
-  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.3.21": {
-   "module": "sha256-jkdTFzSm1uiWG04P0a6GefvL0SRxPdLP5+mhLEe8c44=",
-   "pom": "sha256-BY3N0jaAFCxnal7LzCDFSPmuCyDwD8+UGbnLADcRc7o="
+  "org/jetbrains/kotlin#kotlin-android-extensions-runtime/1.9.23": {
+   "jar": "sha256-8Gn4ePD840pbgRFk67PAaiDRWxBhFZPSnVtLDoVeAt8=",
+   "pom": "sha256-ZZ8aK6OUEelqP6gt/U6z4XuEXDLH2/BU7ivg3XJzQhI="
   },
-  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.3.21/gradle813": {
-   "jar": "sha256-czebOE2dpmQZtfTVyD3hqZ3X8ZVmK8RcOUQ4WeY+GLI="
+  "org/jetbrains/kotlin#kotlin-assignment-compiler-plugin-embeddable/2.3.20": {
+   "jar": "sha256-EjVTkgnMVtLi7G+XeYaHiHK3Cgh4H2Sv/0Ubwfe9VrE=",
+   "pom": "sha256-m9zHQ84iL4oxnuYJe2Cq7unmvqe1vzKXYVp1tLpsFDM="
   },
-  "org/jetbrains/kotlin#kotlin-assignment-compiler-plugin-embeddable/2.0.21": {
-   "jar": "sha256-VNSBSyF3IXiP2GU5gSMImi/P91FQ17NdjnMKI34my9E=",
-   "pom": "sha256-rIU9chaJ+vEV8RiBCjU2/CcvE1to0CdFOqpW6eY79wc="
+  "org/jetbrains/kotlin#kotlin-bom/2.4.10": {
+   "pom": "sha256-O6/jfBQqdSfxEHgjrWQ66y84kz2yBZR7n/IdXdMSjow="
   },
-  "org/jetbrains/kotlin#kotlin-bom/2.0.21": {
-   "pom": "sha256-1Ufg3iVCLZY+IsepRPO13pQ8akmClbUtv/49KJXNm+g="
+  "org/jetbrains/kotlin#kotlin-build-statistics/2.4.10": {
+   "jar": "sha256-uidItn+3sk7hQB7s/uMutn3QVchaWaV0IYj3lUd6Ecw=",
+   "pom": "sha256-AcwyrTsRJ0REk50GQky/Q6PiB+h3aD0chRGWyhkIisE="
   },
-  "org/jetbrains/kotlin#kotlin-build-common/2.0.21": {
-   "jar": "sha256-cLmHScMJc9O3YhCL37mROSB4swhzCKzTwa0zqg9GIV0=",
-   "pom": "sha256-qNP7huk2cgYkCh2+6LMBCteRP+oY+9Rtv2EB+Yvj4V0="
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.3.20": {
+   "jar": "sha256-IvGrIjhUuUkJn2slnO9UHVtYo2Q9+aScRXfGPEFuhDs=",
+   "pom": "sha256-G14LLDaQXcL1XgpLeBKuY+MSXe/PaG0sD0kPg7c9nV4="
   },
-  "org/jetbrains/kotlin#kotlin-build-statistics/2.3.21": {
-   "jar": "sha256-Ey1sgC5F3rpMXtoa+WAcZpXa8TR9Xcs4hH8YfhesM3g=",
-   "pom": "sha256-djN952QHddu7bAhmK+vhB1UeC7Us2nG1xYk8MVuzpVo="
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.4.0": {
+   "jar": "sha256-ZpFzNUl/mrdaNsNLPZC60ryNwlbDSyQT7NDJRn/PWX0=",
+   "pom": "sha256-lob6jxaGeyq6LlwOTPxKCu7PWf5t5Bn4n3vYOP3ejnQ="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-api/2.0.21": {
-   "jar": "sha256-j8orSvbEzyRWXZp/ZMMXhIlRjQSeEGmB22cY7yLK4Y4=",
-   "pom": "sha256-zL2XaTA2Y0gWKVGY5JRFNPr7c9d4+M1NQ588h7CQ9JQ="
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.4.10": {
+   "jar": "sha256-OVPSg+dxDJkGcuQDqH3zk9lyapvz4XIZTrtcM+Bi/LA=",
+   "pom": "sha256-eCQqlED5JADq89+NIQitcG9mmlMSWEWn0x0998TeRDk="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-api/2.3.21": {
-   "jar": "sha256-suXMJmbBAAee00NhhSjrgg3PpQlQleMPLdGcYN/35GI=",
-   "pom": "sha256-cfil/z5A5xkQT1Mw4oMyDhnYWINO+S0Sv6DQZtvDcdc="
+  "org/jetbrains/kotlin#kotlin-build-tools-compat/2.3.20": {
+   "jar": "sha256-RMMHtO3UysUflgqBNBEtZkyTB2cAzaXoZulNmkKWNA4=",
+   "pom": "sha256-rpC+JesEdhCNlo6+Mqjd9SXhQIhYj6BUc9sSgVoPG3Q="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-compat/2.3.21": {
-   "jar": "sha256-mWMrd3uKhaej+EMd70l+MfdgShR1u6PAEavjBfWF2NY=",
-   "pom": "sha256-gA3wZQgt3NhJXQvNT6EF0uXYDJ1864UaR8CiRFEEeas="
+  "org/jetbrains/kotlin#kotlin-build-tools-compat/2.4.10": {
+   "jar": "sha256-zcxQ2AFvQlDn3GGCLyjyJ7qam30/nrVQPDFesSGI2VI=",
+   "pom": "sha256-oIGnlvgormRLWZUPByzQC9ZKx08SsS6DA5najeLk+jQ="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-cri-impl/2.3.21": {
-   "jar": "sha256-z/CptmWFGjJcIZWFfi4aWnR5VMlDfQDeC6FVGaQpTEY=",
-   "pom": "sha256-Z1U7yyHpwRZ3AOwyd6x/q5cuays2j5W/bUZ+BGTb2jM="
+  "org/jetbrains/kotlin#kotlin-build-tools-cri-impl/2.3.20": {
+   "jar": "sha256-VOztYw8oEkzP4uRk5srMKB5SiopQqJclchVUyWk1SP4=",
+   "pom": "sha256-5zeMZYHvXw4stA46TOxR0rlj5iVkWpK2fqCVJa+XxMM="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.0.21": {
-   "jar": "sha256-um6iTa7URxf1AwcqkcWbDafpyvAAK9DsG+dzKUwSfcs=",
-   "pom": "sha256-epPI22tqqFtPyvD0jKcBa5qEzSOWoGUreumt52eaTkE="
+  "org/jetbrains/kotlin#kotlin-build-tools-cri-impl/2.4.0": {
+   "jar": "sha256-UWi4ZpRfasH/y21MiM9YJJcklGnC5KTq/AvNNbWiZKk=",
+   "pom": "sha256-hW1ZOVSJJ26T7bQ5DJk5feg+INJ1csUjjFbtIeQ0M9o="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.3.21": {
-   "jar": "sha256-LNcDlkBKDkPAWq95qLNf86j/Lilq7fdw9uWSP7+srjs=",
-   "pom": "sha256-0F9jI8F/lhholWgx+dWvrTEQNbGMP1Q//S88hGaT2VI="
+  "org/jetbrains/kotlin#kotlin-build-tools-cri-impl/2.4.10": {
+   "jar": "sha256-eByVoo8FPe0tGDuBi9rpjbPW0V68BVXOz2SAD+oAOzs=",
+   "pom": "sha256-rabst8tUTvL87nPiUsMfgMjjQsO9tRu5mZ/lf+wEH9I="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.0.21": {
-   "jar": "sha256-n6jN0d4NzP/hVMmX1CPsa19TzW2Rd+OnepsN4D+xvIE=",
-   "pom": "sha256-vUZWpG7EGCUuW8Xhwg6yAp+yqODjzJTu3frH6HyM1bY="
+  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.3.20": {
+   "jar": "sha256-loG8IWSovZ9t30wIXPSoNrktJ1BmZ9c7q59thVM2yRA=",
+   "pom": "sha256-gswavl5j0/5nV+eXKE8F25r9fq3D6D0ROcOlW2TUstU="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.3.21": {
-   "jar": "sha256-0+cPsBFnXnfvAPGmiRjTzZHu0mBYl30ePqKjeikyM68=",
-   "pom": "sha256-lSPI/q3LF/QtBP+pf+KpwI5dsY8JD225A9ylw2x65cQ="
+  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.4.0": {
+   "jar": "sha256-B2wKf4TTA/HjkHdEEMhni4tYT6o/ZCQ1+T0uToHavnw=",
+   "pom": "sha256-SFyj1RGqOEIH21cG4HQdx5rORdQOBIn57ylzGq+xT3w="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-runner/2.0.21": {
-   "jar": "sha256-COYFvoEGD/YS0K65QFihm8SsmWJcNcRhxsCzAlYOkQQ=",
-   "pom": "sha256-+Wdq1JVBFLgc39CR6bW0J7xkkc+pRIRmjWU9TRkCPm0="
+  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.4.10": {
+   "jar": "sha256-SjL2NSLvRyavve4Xg/BWmEmavHpeyt46bK+j5AdFYu4=",
+   "pom": "sha256-8bQxw3cX8NRyzQU9yB2JMgTLWSgPgDXWNvU0vHxdjbQ="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-runner/2.3.21": {
-   "jar": "sha256-bbcIYinbidBxg6m0duCZL4YSDbwh9mCSzRJMftbXRDQ=",
-   "pom": "sha256-H6VIXunMzI6TOZU0scUqB1/NRj1poinJyqYBzAkdwog="
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.3.20": {
+   "jar": "sha256-l2+YnQtfXYDo6KitS3PaC/wn/dllufo4Nisr557MEzc=",
+   "pom": "sha256-DDWu7jcvB1FOvtN7lAe44RgdFCd1UTnlzudxnKBf5+g="
   },
-  "org/jetbrains/kotlin#kotlin-compose-compiler-plugin-embeddable/2.3.21": {
-   "jar": "sha256-Zljt/SXePeyJve3AMIAUouvZdzHG90nfCCfFvh75VRU=",
-   "pom": "sha256-/c06QjYfnpowPnzQmFflwUn5oVhszb5qY6AbvzR5sNo="
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.4.0": {
+   "jar": "sha256-wrJejByT7EFrpDJ/XjHq7A8MiEckG5NT4pS4253OVk8=",
+   "pom": "sha256-9deFQBCOe7yRYiU85SxCUH6tLlMJRSE90qO3k7WQxTw="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-client/2.0.21": {
-   "jar": "sha256-Nx6gjk8DaILMjgZP/PZEWZDfREKVuh7GiSjnzCtbwBU=",
-   "pom": "sha256-8oY4JGtQVSC/6TXxXz7POeS6VSb6RcjzKsfeejEjdAA="
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.4.10": {
+   "jar": "sha256-kwljii7gPmvenvS3REBVqUuEq5BlY2ddcf+a7LZNqRM=",
+   "pom": "sha256-w6209m+/qoQ8AZtALSx+XwiA0ylWvY3YQCKUYXclEQI="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-client/2.3.21": {
-   "jar": "sha256-+nZ8m0DQafFkxhem5r0wJkPHuowHkujtnkEsGPhLUL4=",
-   "pom": "sha256-1wqhMeENnEDUT/s9iMhcrFSmSjBUIXn4R/gD7HGuG60="
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.3.20": {
+   "jar": "sha256-wGnzCkA75wyBUviqnyXsy6GI7q1UJjrgKvFEIUN6Igg=",
+   "pom": "sha256-jYTqDt1gs4vOpWLeUXgVKiZxqaAFPWcPkxRSs9sBMig="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.0.21": {
-   "jar": "sha256-saCnPFAi+N0FpjjGt2sr1zYYGKHzhg/yZEEzsd0r2wM=",
-   "pom": "sha256-jbZ7QN1gJaLtBpKU8sm8+2uW2zFZz+927deEHCZq+/A="
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.4.0": {
+   "jar": "sha256-rZYIFSdA6S2Uoni0/yyoLEv1/47yGSIOPAeutVRjjO4=",
+   "pom": "sha256-Xh7RVsuNOLYeLMxUbb2LK953g2frKY+Idb2CD7/QsPI="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.3.21": {
-   "jar": "sha256-Ii/BCjwi500wNpv4oMpsT5Ny6sfUoAgeKQwlb6TTD7I=",
-   "pom": "sha256-9cV3dsXsNQSkFjZBZGALDL6F6+qPFuvvYH6trw/Wv0M="
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.4.10": {
+   "jar": "sha256-noadZlBFcoUvQhvLFiXA1WTCs8jOy/bNX+9+fzPgAT4=",
+   "pom": "sha256-GAc4diyJQcTjDXF0qSBxlVvYaVhzMteF5hORFnyCvFo="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.3.21": {
-   "jar": "sha256-4k36gQu102+DvzIPJcIwNLLSgMx5A+KQFMS3vRJIUGI=",
-   "pom": "sha256-Cm4AthBXLfGe60hgsjzhyUOJfShqfe9LPg3nqgi+KAw="
+  "org/jetbrains/kotlin#kotlin-compose-compiler-plugin-embeddable/2.4.10": {
+   "jar": "sha256-B+3/lsYZbFNUyqJ1t0hhZ5TMiIOvAuOA0JHSIfAr3IA=",
+   "pom": "sha256-3LrrzWOOrqKt4Uzq81Xy0YN1cKA4sNZdMtf44+Z6co4="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.3.21": {
-   "module": "sha256-TIDhxRjiLuhPQYns4T12swL70HhraSZGnNGdLg97x+U=",
-   "pom": "sha256-U8Zbb7K4HfO712wWlK/3ISURMaRbWPEJJLpLbBriVDc="
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.3.20": {
+   "jar": "sha256-xxp8G+j7/wTgr0XJ7oy3ph2JU7ymuL8iWlcZxyWpC0Q=",
+   "pom": "sha256-nnyLgHJBF/cqrOZfa+SNg224/Dl1OtlR8ruQhi1+cIA="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.3.21/gradle813": {
-   "jar": "sha256-rVjSY47gQfbOTnPpeC6/Uo4Yz5ADsQmapwReyVjjwZU="
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.4.0": {
+   "jar": "sha256-9Ubws2mcSYTzIN0DCA3gXK1hBkIIuo833w0/j0p/0Uo=",
+   "pom": "sha256-FDeTYnOC2QXtqT4VKijJk/YyP8S3SDcKRce63JmRShM="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.3.21": {
-   "jar": "sha256-ASEJ0X4MrSA7Y2OFDUZ7hqA0n6f0BPwRMGqrbGOjIjI=",
-   "pom": "sha256-dMlhFwLfjLOgpRGBfBWQ/u5z0tIIQTHueLYghLTYgpE="
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.4.10": {
+   "jar": "sha256-o9GlhU/ZJ2beHKN/8AOoItPaIDmQIAg4TdH3N189XPk=",
+   "pom": "sha256-9t6eOg6JrdjgQ/p2hm2aL/EPuHljsTljd7uwDCKf3m4="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.3.21": {
-   "jar": "sha256-lS5zlI4qINOYwmuHprtwzPZkGPuvFSfDUVsYjqnUvWA=",
-   "module": "sha256-AchKGocd5pwHAiKZIL09Dfy0YEXg3YMOUc82GffzdiY=",
-   "pom": "sha256-SepLd1fok3YudcKXj73A8kujUhqU7nETc49ihUoDC5E="
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.3.20": {
+   "jar": "sha256-iHC6uEC4CHyWxN3AYIi0rt9RMcQIrzZ0MGME8flq8/Q=",
+   "pom": "sha256-YVQOWzoywLEZYkSWZZJMbNdVTqmu4IVb2OT1t/YQoKs="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.3.21": {
-   "module": "sha256-4E06ViPPjdAf6cdLkYPuJBhQKYuoodz9J0b5SS3zprg=",
-   "pom": "sha256-am4v5xyYMtD2a+do4gIozgJSUUnqkvJ0K2YSXjl6WMk="
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.4.0": {
+   "jar": "sha256-ODCTr14HhDW2AEPRm/qD62GRvg9NE6KPscig86sk/mY=",
+   "pom": "sha256-yzbngPyznuCaq245j5vV6if5grtuGTKXQqIOsuvcKTY="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.3.21/gradle813": {
-   "jar": "sha256-tX+s5dvRXJ0G7RfNccMSqCQcl1lVB4KsYo6FebztU/4="
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.4.10": {
+   "jar": "sha256-VH2Wmi6rYC/gvf2fyxtWOlxtMAmdM1E5TWQn66gohGc=",
+   "pom": "sha256-RO0aSQpLZGMT/AvCaDiXoerE2Ma1fAgl0+gfp8o3bTU="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.3.21": {
-   "module": "sha256-XyDoze3JaVuIQAsDCwVkGWDhASORd2974f4k6gRNEtI=",
-   "pom": "sha256-et8h026Tdq1EUInhkadxXJqx+VA6IxJAlGQdhO5fy30="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.4.10": {
+   "jar": "sha256-FcO5jxjIdLmsW+JWXzcks+r2xs9X3HhNc1FqIqnkcM8=",
+   "pom": "sha256-RPxaCnEckt8W8A01ddDyxKJk9Dqy9YjkVbPGBDEk/VM="
   },
-  "org/jetbrains/kotlin#kotlin-klib-abi-reader/2.3.21": {
-   "jar": "sha256-xFQbDaJUUqjqZFWv8N1ZC51WfR2mj2WyutsoH/0UzrY=",
-   "pom": "sha256-bDTzpbw28/2ZIG0q4au3NP4iVIga6s8pFUHmq8qIlLc="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.4.10": {
+   "module": "sha256-reKOGDGyIuFh4AwSDVydVvnU/jsKq+2eVJEtcatu6Ms=",
+   "pom": "sha256-3nNT1znWscbH0KnwKrsXL/zEJbEws4xWfTdm1pvvm64="
   },
-  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.3.21": {
-   "jar": "sha256-fBGSL3xsinXyF0bvj8oAKu5Zdl92713/8bvYRtdaOOA=",
-   "pom": "sha256-dNC5uiuwtCpMjWTGoqJzBRHsYutpA2rkqxnX2rVLC68="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.4.10/gradle813": {
+   "jar": "sha256-dMTk99A36FC6tmbbEskKSeBl2Ulf0t/ap7w53ZYwg9Y="
   },
-  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/2.0.21": {
-   "jar": "sha256-2Gv0M4pthBzM37v/LaBb0DpJw9uMP5erhed+AhrQhFs=",
-   "pom": "sha256-esgfO7B8TWqo+pj/WjmaR6vRzhx4bU8/rZbvKBIL34o="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.4.10": {
+   "jar": "sha256-NVrFZv90100jD3y21V4u1QFYtMKPwYb8jYJo6P6YaPQ=",
+   "pom": "sha256-B07g3UCN5UKo5Lcm2q2CncM6nlbdtPQ6AOubn2ev8X8="
   },
-  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/2.3.21": {
-   "jar": "sha256-VBJEACe/WlffQbEgitWexffHthJHOjDiiZiCyY/gcd0=",
-   "pom": "sha256-75BsX4qPlQB8qhUQpGBDQkzHOrf1+CJDwu+FtuiN3zA="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.4.10": {
+   "jar": "sha256-CGc0SEx+3xmmIKsaYX0JfEDgO8UmAud4QOpevWOA5RQ=",
+   "module": "sha256-fog/v+nSyc7UqPqZIXqN1BO7FKfqky7bvaNdXpGlEZo=",
+   "pom": "sha256-lg7wg2JqdGbqFgeWuUAEeqO9tr2598vQ1bi3TqNw5mE="
   },
-  "org/jetbrains/kotlin#kotlin-metadata-jvm/2.3.21": {
-   "jar": "sha256-AFkPJqWnaHd/BCUsbPk8AWozYaa8k2Nt9nN1rU0ZVX0=",
-   "pom": "sha256-g7erCwEj57FCij1fdNwVHpBKEMjNMgY5kaYGUIvCHoA="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.4.10": {
+   "module": "sha256-DncT2EYF2gvuA4tXjzF5WILM1yEiCnnMNnNqya+ctBI=",
+   "pom": "sha256-W/jyYC561MeHXyp08HNgxBY+SAPgcz7ci2nyDRBJWgs="
   },
-  "org/jetbrains/kotlin#kotlin-native-utils/2.3.21": {
-   "jar": "sha256-CA6LPO7rLvzlHQI4T14i/w2N8am7qUrpAV4wrCGhdJA=",
-   "pom": "sha256-uRJdcl70/Xj8L0pLc1G/apS8G7OeZT9p+u4o2FgH8n0="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.4.10/gradle813": {
+   "jar": "sha256-E+Ishp3zly25SWtHvygV+8+2HgQ5+Wy9jWrrkStIE3U="
   },
-  "org/jetbrains/kotlin#kotlin-parcelize-compiler/2.3.21": {
-   "jar": "sha256-K9QfTCQAbJtVM5OshtMjqUuRqs50N71EeTJF+mY1eRk=",
-   "pom": "sha256-7jcD6PKafitwaBpM+ibj16EPMcqERCgbsFNuym21TVc="
+  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.4.10": {
+   "module": "sha256-SOtHVihNHX6iRjnSKGHxX/DLaFoVMxpsajZ0/0S68Ck=",
+   "pom": "sha256-cz/M2gOuNHc+e1yF0OJ4yJffKDNwBZyzmCX3wDgeSbY="
   },
-  "org/jetbrains/kotlin#kotlin-parcelize-runtime/2.3.21": {
-   "jar": "sha256-oh1fhUde+yfxfdl9GiidZIdPLd/bUI6khEd6TPGv6Wk=",
-   "pom": "sha256-Xy5Ehc/7o28EqsBV8qgwFREz2VB09fG1icVhCaS5tAc="
+  "org/jetbrains/kotlin#kotlin-klib-abi-reader/2.3.20": {
+   "jar": "sha256-XAo6pyBAjdL2PnYIdd0/Z9t+0Ws/AAKA4IgcYHDOT2M=",
+   "pom": "sha256-ui+7W5OjnlGraeWCJPGNdxYqDrYDkIbl9lVne8O3xno="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.4.10": {
+   "jar": "sha256-lxu5aLSvEJMrzBjzOVch7kjMFmWXtQkmcxru/zNAhto=",
+   "pom": "sha256-E5s86NZVgH62ikV5jwQyl2CyEGZpqzMtKsEIhD11iyk="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/2.3.20": {
+   "jar": "sha256-4FeWYwUcbaKyPZX8LDpBKnYnnbg6eQHuhqfjrPbnHjQ=",
+   "pom": "sha256-shhlfghlbEa018djdux6BOoGAJpGLTpkcBFvr92OPss="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/2.4.10": {
+   "jar": "sha256-xeVDQS+Boy/0YRqIbhg5n6WvoVx34+8v3A+qOXrYq84=",
+   "pom": "sha256-vr3VthFajTd+3Y0A6MHUz8rL8rwL27ckjUPFx6Gbr6s="
+  },
+  "org/jetbrains/kotlin#kotlin-metadata-jvm/2.3.20": {
+   "jar": "sha256-FyZLlpD+7TSqi459VW+y55UfaABGLxFyQ/upYgEBT30=",
+   "pom": "sha256-DF/7/5dG1Ca56GasBWviiSizGKJc3FaDkIHsRJspzZc="
+  },
+  "org/jetbrains/kotlin#kotlin-native-utils/2.4.10": {
+   "jar": "sha256-duxV+Wfcj1dIGiez54aMyXyzKWTW0oVReu8xDD11SkQ=",
+   "pom": "sha256-m5HjjPyE6qNBgxQBksMH3caPSkxgNfVUxMIuFfM5Fsc="
+  },
+  "org/jetbrains/kotlin#kotlin-parcelize-compiler/2.4.10": {
+   "jar": "sha256-chkekq5ZtM6xYzxNZL8nYFkF1kxuxg5S+uNK7Sawio4=",
+   "pom": "sha256-r6T3x5+asRg/7omLcKvEHu/XMGo0fM9VTEzhjc9ppr0="
+  },
+  "org/jetbrains/kotlin#kotlin-parcelize-runtime/1.9.23": {
+   "jar": "sha256-0IGHmZPtWS2zMynDLbMJHf5oQbJY2rd7ggXaaVGjfGk=",
+   "pom": "sha256-b6RjynGl3woQPHEYUQKuT/wBMWWES5H9JhgB0Qv4H34="
+  },
+  "org/jetbrains/kotlin#kotlin-parcelize-runtime/2.4.10": {
+   "jar": "sha256-dBK/a6/FXAVuS/iH/jT9prCzvDNHh2LEH1UtuOatNzQ=",
+   "pom": "sha256-IktN41lqeJR+DQYixG1juI3AGo0VnyZa3Zr71AFOSOY="
   },
   "org/jetbrains/kotlin#kotlin-reflect/1.6.10": {
    "jar": "sha256-MnesECrheq0QpVq+x1/1aWyNEJeQOWQ0tJbnUIeFQgM=",
@@ -3540,64 +3757,76 @@
    "jar": "sha256-imzVo88JKs7idM4sRE3Dbu/bYxV5hZ3U2FezMJpSnJE=",
    "pom": "sha256-OdeNszIizbsythjHxSI9RFfMGXQoVtEWqFCQ5KlvYjo="
   },
-  "org/jetbrains/kotlin#kotlin-reflect/2.0.21": {
-   "jar": "sha256-OtL8rQwJ3cCSLeurRETWEhRLe0Zbdai7dYfiDd+v15k=",
-   "pom": "sha256-Aqt66rA8aPQBAwJuXpwnc2DLw2CBilsuNrmjqdjosEk="
+  "org/jetbrains/kotlin#kotlin-reflect/2.2.10": {
+   "jar": "sha256-xI20+M0b/Wf3LVklUGX7Qb/aQ8opQtrE2d64l6oSa6Q=",
+   "pom": "sha256-rkZhSQZBRATO/EGkZ0NSBdbe5nojkFmDKKY5rSusvRE="
   },
-  "org/jetbrains/kotlin#kotlin-sam-with-receiver-compiler-plugin-embeddable/2.0.21": {
-   "jar": "sha256-x88d6VXfIqFihyImvQZ3yaDItmMKLi1z0R0UfNDFO3M=",
-   "pom": "sha256-cWKsEOFFTpJ2c7FcrQMp2jgvt1jmVPWfy0AHRZ2eyEE="
+  "org/jetbrains/kotlin#kotlin-reflect/2.3.0": {
+   "jar": "sha256-cU30voGVRf9N4fNqohg+DeqUtMjN98op6ciZGbrzY2I=",
+   "pom": "sha256-89F2jvL7UxBIPb6R4w6fo2x7Pi/e5pRaCLujEBQtKcE="
   },
-  "org/jetbrains/kotlin#kotlin-script-runtime/2.0.21": {
-   "jar": "sha256-nBEfjQit5FVWYnLVYZIa3CsstrekzO442YKcXjocpqM=",
-   "pom": "sha256-lbLpKa+hBxvZUv0Tey5+gdBP4bu4G3V+vtBrIW5aRSQ="
+  "org/jetbrains/kotlin#kotlin-reflect/2.3.20": {
+   "jar": "sha256-40b6PD/0RR9fcHoxKIf9TIVV2kjMFfqdsrqTwz+J+BM=",
+   "pom": "sha256-iwC9L+srtVON85aVQXTZ3cDsVA00ElhjA1ObHpZVwzM="
   },
-  "org/jetbrains/kotlin#kotlin-script-runtime/2.3.21": {
-   "jar": "sha256-7GG/EinIN/qfQlXzTKaYFhOLcxWOeum42WTPkspt/S4=",
-   "pom": "sha256-LPXREj2KYovMXudPWwewjFWoetTpyR4T24O7Wi/2qi0="
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver-compiler-plugin-embeddable/2.3.20": {
+   "jar": "sha256-hvch6zOswK/QbdZoDnenZLY0qb2LEbc77yv8CQnxiUA=",
+   "pom": "sha256-Vg23nSOjmud5dqVmkZRw3sQazHeqUa6qVlzAKbkXGqw="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-common/2.0.21": {
-   "jar": "sha256-+H3rKxTQaPmcuhghfYCvhUgcApxzGthwRFjprdnKIPg=",
-   "pom": "sha256-hP6ezqjlV+/6iFbJAhMlrWPCHZ0TEh6q6xGZ9qZYZXU="
+  "org/jetbrains/kotlin#kotlin-script-runtime/2.3.20": {
+   "jar": "sha256-b8232m5lz4zEPlqrq5S9zEiCXnkzaG+KG/aU64j44A4=",
+   "pom": "sha256-ZgmWdnA6CB/ZrEMTlmWIPlwUUCC2QHWd4FOdiRb/JH8="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-common/2.3.21": {
-   "jar": "sha256-aYhXUb3OfU4dG5dYuvS8D+A7JIJ6vXt2h+WnwLTQKe0=",
-   "pom": "sha256-vs1qSEFg/hN/BtdtNflbZ3b6Ca5vdR5TlOaTWa7i9fY="
+  "org/jetbrains/kotlin#kotlin-script-runtime/2.4.0": {
+   "jar": "sha256-GW6Oy/Y9r0d+NOZ8L4ce4jKue/izd0Mth20bv50nPeM=",
+   "pom": "sha256-znBcUOfgr7IimKz/Cpg8226g9/4tG0c87kKzhAW8NX8="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.0.21": {
-   "jar": "sha256-JBPCMP3YzUfrvronPk35TPO0TLPsldLLNUcsk3aMnxw=",
-   "pom": "sha256-1Ch6fUD4+Birv3zJhH5/OSeC0Ufb7WqEQORzvE9r8ug="
+  "org/jetbrains/kotlin#kotlin-script-runtime/2.4.10": {
+   "jar": "sha256-9KWzDC/fvjhrCXEBt5idvuo3Q8BjlhNmZHhOCOFcaJk=",
+   "pom": "sha256-7c8OLNcJZGxOWUW+DwpJIKDz9BfzKHVnRqKdkrI7FZM="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.3.21": {
-   "jar": "sha256-oE/wbvtKWuB6ko2pT5tdBhIwyW1/69rri8dDjhqjGBE=",
-   "pom": "sha256-8aTyFh2fPULJrE7Lm5zuKhmQNoE1CdW1pP85oRy7n+M="
+  "org/jetbrains/kotlin#kotlin-scripting-common/2.3.20": {
+   "jar": "sha256-tMI52HsjvhgvBb9Xz16B+V1wv370qYnrmLczicbryJ8=",
+   "pom": "sha256-h+/vFa4RjxNDUmPrEJcAZGD7qDlph340uKcvDjPIOsk="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.0.21": {
-   "jar": "sha256-btD6W+slRmiDmJtWQfNoCUeSYLcBRTVQL9OHzmx7qDM=",
-   "pom": "sha256-0ysb8kupKaL6MqbjRDIPp7nnvgbON/z3bvOm3ITiNrE="
+  "org/jetbrains/kotlin#kotlin-scripting-common/2.4.10": {
+   "jar": "sha256-1TmZgs2/WZT386cxr6z7xcIbeX2X/9cyi2LOpnAQMHY=",
+   "pom": "sha256-GFY2qRwY8J+K+H+H6heIwtVfcqaIAhCgNlpaakTWGDM="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.3.21": {
-   "jar": "sha256-ieeKMybhIFqUIKGUQaTzgvenIkHVLJZCXonlsTA4coY=",
-   "pom": "sha256-L3wkrV6C4ttdtdqNwHDub8D1bCDpkGOaVMppB2vOPm0="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.3.20": {
+   "jar": "sha256-vVX49hvUHOxSllbC1HeEvLpawmDpT0FWwnLDFJZu71k=",
+   "pom": "sha256-1l8YaBd9zkuKkv+93bVrFzH5+66IyOcw7XvLcAy7soo="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.0.21": {
-   "jar": "sha256-iEJ/D3pMR4RfoiIdKfbg4NfL5zw+34vKMLTYs6M2p3w=",
-   "pom": "sha256-opCFi++0KZc09RtT7ZqUFaKU55um/CE8BMQnzch5nA0="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.4.10": {
+   "jar": "sha256-FWxo/4FiUcnSl8kNd+fo5RPqrVlCd87lCjb67dvoiTU=",
+   "pom": "sha256-B9mROoMxfCjKdwS+DBCaFCmidiNuQ76LmPh9vU0Cr60="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.3.21": {
-   "jar": "sha256-jLY3Ey/H+lEccA7n8rY7KCYwFn9evWmaJjoLZ7XUhqs=",
-   "pom": "sha256-WAssmFfzpmLFOj3rSFHXoa+jvV9Ku+mQX1tV+1Ih+BY="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.3.20": {
+   "jar": "sha256-gG/WOzvOxea17rGghD1qsJTVV4aoRl5HSiQ5KVocCiU=",
+   "pom": "sha256-xKkTo4XzTjKlbyBd8XoI3U4RfDBsV+XkfcXUlSPw6+E="
   },
-  "org/jetbrains/kotlin#kotlin-serialization-compiler-plugin-embeddable/2.3.21": {
-   "jar": "sha256-VCo2/lrlw1t7tMwpcQDzY007X5fHtfeM5ENiGDC7vvQ=",
-   "pom": "sha256-xARZ8GJeuKt2KJcbQvqint7UvIdcJe+7owkmlLD/vpE="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.4.10": {
+   "jar": "sha256-Hc/FSV2MdJZvy705JAqcD4qza7T6rS6l/8AAxdd4UXE=",
+   "pom": "sha256-qAtGPcTj3ldVXE4bbnNljUCsIVsniPTBk/VskbNJTKk="
   },
-  "org/jetbrains/kotlin#kotlin-serialization/2.3.21": {
-   "module": "sha256-Zh45Pz6mchz5ZcIDHUZgi713Y55ImdV1H1c04j83RUI=",
-   "pom": "sha256-ThKQ9JKxREoSZtO4OKCzHUo6cVOs1KfMo5BwZP4MNKc="
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.3.20": {
+   "jar": "sha256-cEfOA1P0kSXDx0Z5LU92wyZde3L+YmlLfuwHW7oCUow=",
+   "pom": "sha256-B8Ba4tHs4K4e1mAQ7TGNnN3LNYcEbGM8GGvRTM8EYdU="
   },
-  "org/jetbrains/kotlin#kotlin-serialization/2.3.21/gradle813": {
-   "jar": "sha256-DhI+4919qUppjA+SqmDyRESVJKzeYu7KSjbixgcbM0U="
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.4.10": {
+   "jar": "sha256-C3UYIZ2mm0J+Cz+EDxPigNueYag5x9P/CU3kYw3byfU=",
+   "pom": "sha256-QDoSkR3HG0+kwuPcMFzZjg7z/qH6vOctCmVtz4kLN3U="
+  },
+  "org/jetbrains/kotlin#kotlin-serialization-compiler-plugin-embeddable/2.4.10": {
+   "jar": "sha256-sUZ7UVx92LJKeb1AKkGsfSwgjGvpa1tT0h+BR9ZWb14=",
+   "pom": "sha256-WRqT+XWZVNJPolbKuVGCMFl7hrfyGOrTxZqie5H4ZU8="
+  },
+  "org/jetbrains/kotlin#kotlin-serialization/2.4.10": {
+   "module": "sha256-7vr5lYCYil0SDiLDDr61XPa07kZJRlcaQb+8vL34Sb0=",
+   "pom": "sha256-tuUt3Qrzzrww/d+nwPyFWNe+6xJBWCuzv6MsclWejHU="
+  },
+  "org/jetbrains/kotlin#kotlin-serialization/2.4.10/gradle813": {
+   "jar": "sha256-4OaeExlPOkj+csXh0MGHTQbWmjtLmmHwqSubufRQAVc="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-common/1.8.21": {
    "jar": "sha256-akTJ7MnXdU2elD+x41iMdNSj8Xhb5RB09J1sVyNoKnM=",
@@ -3607,21 +3836,13 @@
    "jar": "sha256-KDJ0IEvXwCB4nsRvj45yr0JE1/VQszkqV+XKAGrXqiw=",
    "pom": "sha256-NmDTanD+s6vknxG5BjPkHTYnNXbwcbDhCdqbOg3wgqU="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-common/2.0.21": {
-   "module": "sha256-b134r2M2AKa5z7D8x2SvPVEZ83Zndne5G2rugWsdMKs=",
-   "pom": "sha256-X0As+413MZW5ZwUBJMnom1+EsXJGThiUkpeJv1xMLyk="
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.2.10": {
+   "module": "sha256-M2r7UShSAosdpdXQem+4M8+aeX7kszUZaU0xL2gyJ8k=",
+   "pom": "sha256-4ZmwT3NvDHM07V3rc3iZIzRCs2I4pZMQeQsha2k0wGc="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-common/2.2.0": {
-   "module": "sha256-WPwNZk/Dpn5+a+n9vq7b0hLfo+Un90T4YeeSzacsDkc=",
-   "pom": "sha256-U3q0BzqEelm6dtmaZFqGCbU4L/pdJZGjVLL6MR9JlzM="
-  },
-  "org/jetbrains/kotlin#kotlin-stdlib-common/2.3.21": {
-   "module": "sha256-atL1eJGlTZamkiES91jflXzhq4o9WlchXLdPo+EF4lU=",
-   "pom": "sha256-3kz/N522KFN9r20aYfAqIL8YVIDxIMq0IU/uPcMzo+g="
-  },
-  "org/jetbrains/kotlin#kotlin-stdlib-common/2.4.0": {
-   "module": "sha256-sDh/gRgDrxUU8aojhbRgw7gTxvQ861bPreavqiBpedg=",
-   "pom": "sha256-/RpljtvteICsPgoNvSCuGkbJh+QK9UTjprEQglu+/PU="
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.4.10": {
+   "module": "sha256-Xa9+3NbWMF0LASG+WXqdUElrq/0pkL32sI/XACWpTdE=",
+   "pom": "sha256-AG6dbnsq+nfK5w4W2Ak1yeaqv1r/WUOClXrgcV8tNoc="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.20": {
    "jar": "sha256-rx7EDDuVGv3MDCoBc8e4F2PFKBwtW6+/CoVEokxdzAw=",
@@ -3631,9 +3852,13 @@
    "jar": "sha256-M9FI2w4R3r0NkGd9KCQrztkH+cd3MAAP1ZeGcIkDnYY=",
    "pom": "sha256-m7EH1dXjkwvFl38AekPNILfSTZGxweUo6m7g8kjxTTY="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.0": {
-   "jar": "sha256-DRC8DUK4YF8jYpo/MeonwZzbyp3N9PU/bSLNY2aDbRg=",
-   "pom": "sha256-lcIYnDXve/xIlRwyrXCEeyHzgJ0m9dCnbiNXCHmYjDA="
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.10": {
+   "jar": "sha256-z5XszGzHhN/0ed7guINPNYS5MpLMXZGXLoL117nhPjs=",
+   "pom": "sha256-vklJB+DhnHi7ghFUr6F3bVrXoFi0qzAJD3Q1Sw4TON4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.4.10": {
+   "jar": "sha256-56j+fKzzucg49rP8sm391B+ERVGjumf9P5WaDZ1cC+8=",
+   "pom": "sha256-kk1NXVO8CbyNA8JiMZ3QG3/YdtQfTP4wlvWFxC/2qkg="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.20": {
    "jar": "sha256-45i2eXdiJxi/GP+ZtznH2doGDzP7RYouJSAyIcFq8BA=",
@@ -3643,9 +3868,13 @@
    "jar": "sha256-PbdSowB08G7mxXmEqm8n2kT00rvH9UQmUfaYjxyyt9c=",
    "pom": "sha256-ODnXKNfDCaXDaLAnC0S08ceHj/XKXTKpogT6o0kUWdg="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.0": {
-   "jar": "sha256-rcFmSNu881sNEOfsMBw110bRwv5GDGBqulnxKxF8+bA=",
-   "pom": "sha256-I00G/b3CncvAdEfijEomq6uVmdXD2qPZKjTmrt6iNqY="
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.10": {
+   "jar": "sha256-iXS/3Qix2BhD/o0R8HKatuWzwfiNZx6+DABjWBKc4Uk=",
+   "pom": "sha256-JWnPWpgHJPFAFXUB2zbf+rkZzQ1EPS4UtaNaL5b4T6w="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.4.10": {
+   "jar": "sha256-CDRrf0z7pAwRORYcnzC2gZn0Jc7PO2PeZ4OAY/NKBcc=",
+   "pom": "sha256-O0/XwE1zlcr+fh4d7oSSYb/gPGjQVFlBjLNWBXUM2ic="
   },
   "org/jetbrains/kotlin#kotlin-stdlib/1.8.21": {
    "jar": "sha256-BCoc0ayXbNz+XrY/HY4LC4kskkjhWmnIz7pJXVRupSo=",
@@ -3655,80 +3884,86 @@
    "jar": "sha256-Na7/vi21qkRgcs7lD87ki3+p4vxRyjfAzH19C8OdlS4=",
    "pom": "sha256-N3UiY/Ysw+MlCFbiiO5Kc9QQLXJqd2JwNPlIBsjBCso="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.0.21": {
-   "jar": "sha256-8xzFPxBafkjAk2g7vVQ3Vh0SM5IFE3dLRwgFZBvtvAk=",
-   "module": "sha256-gf1tGBASSH7jJG7/TiustktYxG5bWqcpcaTd8b0VQe0=",
-   "pom": "sha256-/LraTNLp85ZYKTVw72E3UjMdtp/R2tHKuqYFSEA+F9o="
-  },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.0.21/all": {
-   "jar": "sha256-UP+t6yC00kVqUmWVpPep6FiJaCcVBz5s26Gx2A461Fg="
-  },
   "org/jetbrains/kotlin#kotlin-stdlib/2.1.21": {
    "jar": "sha256-JjvcZ54fYgEtt7CReWJ5ttcc829Hl6mP8azgWDXyAcg=",
    "module": "sha256-DTc1BD1ot6WvtE0n3mX4Cp0rIIRicJwu27SP1bOVrYo=",
    "pom": "sha256-xVJAhso+SaZ5ht+P3M1mA3uvXzxaNYt2+d1gm+57tjg="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.2.0": {
-   "jar": "sha256-ZdEthaO4ZcFg25FHhRcSpksQ2t1osi7qIqlb+KhnDco=",
-   "module": "sha256-pbmP3NnbAX1ULhlyJdzuGNZYpW3h2yzEHhMZbWsXaaQ=",
-   "pom": "sha256-jDyCEAfBNBFVhzm589U4LrgVUds4lc/7iVYeVsD03BY="
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.10": {
+   "jar": "sha256-nGfMee/WuSFbSdKkMI9fNDNTc3bHyI6JvdZym9CW5ho=",
+   "module": "sha256-23jfCCg1kctnyLnSeWEJ61K2CI1N/hArVF8gEYJJcT8=",
+   "pom": "sha256-RUulB6PTa0rCU99t+W+HOb0m6hnfPzMrELE/LFcV94c="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.3.20": {
+   "jar": "sha256-CuElBKUEDrrzdwOQhINCDRpWJN0dk/NXZl+Md8hIoB4=",
+   "module": "sha256-9Os0T8TR46KK4WwIbsPkL1I3O0ZtQwgYL7OG45LA76M=",
+   "pom": "sha256-yDwC2afi6VRzBJHDPC8dwDwnZi4ntWbsK0TS0Bhjm5g="
   },
   "org/jetbrains/kotlin#kotlin-stdlib/2.3.21": {
    "jar": "sha256-b2TqxzbblDTdaSW0pRi50dFxd2UjIMN5Fs+bo859fXo=",
    "module": "sha256-e06ksiQrsXektKu2PD89hXMx1A01hl42/MPbZm7BAXQ=",
    "pom": "sha256-PgtI2qFNxz+AKdjZ4V7TKUA3fK97kVUQ+I0zIZs1AYY="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.3.21/all": {
-   "jar": "sha256-IZeuB3iLCdA9Xz8qLVIHOFnjUkgbtv60M145EJMRYnA="
-  },
   "org/jetbrains/kotlin#kotlin-stdlib/2.4.0": {
    "jar": "sha256-zLFP+D+ryxFFi3mNvJgkdIzN/+7HnJq6eJ5u0c2oaxw=",
    "module": "sha256-wkpH3L2Sldd29EO+Qdd6wkUwlgHtBTcR3uKwJUvgLbY=",
    "pom": "sha256-gZT/eanuJKf6P3SmsXnAShhZ3ouYek8JgwVuWUUXId4="
   },
-  "org/jetbrains/kotlin#kotlin-test-junit/2.3.21": {
-   "jar": "sha256-VUc58oLqyhFIgq1+/82FI94mUettZRiWJEJREJkspM4=",
-   "module": "sha256-djn7jgufyLuMIZ/9Kp/Jg8jiZTsw5NL6N1zbqsADa/4=",
-   "pom": "sha256-4Mm6vp/OazQOshOz0E7NYWqhxSKW4Sr5H3t7wfXxGOY="
+  "org/jetbrains/kotlin#kotlin-stdlib/2.4.10": {
+   "jar": "sha256-TsApO8N1FCOyA/HYSTJRxXxC5z62N3prhWDQl0/wpt8=",
+   "module": "sha256-HASpjxIAyHBdAV3wiXchFYnuy8h88cTG0oqSaC/oRG4=",
+   "pom": "sha256-n4HyXpa5GRUzkt7VO9MyFudmJJCc/QgKPtsnjUT8NPA="
   },
-  "org/jetbrains/kotlin#kotlin-test/2.3.21": {
-   "jar": "sha256-A499LH3xA5RQgJxIYGjzAaKcbpA1bJpLWV409PSoE+c=",
-   "module": "sha256-12QTrSr4QiZPyjbGeAqMxmUAZn2ZA2byVPdah4Qqibw=",
-   "pom": "sha256-U75O2fM08UVHLazi81tIW75hG1PSqwuvr+MKZhryPzQ="
+  "org/jetbrains/kotlin#kotlin-stdlib/2.4.10/all": {
+   "jar": "sha256-0OSdYm1Dxmd8nduTluiLSK/uSyG0CCsPtx2JSy+gbA8="
   },
-  "org/jetbrains/kotlin#kotlin-test/2.3.21/all": {
-   "jar": "sha256-UcEVgCerlmP4Qgz8yJObOusFQHuQgvznwuPy14E+0rQ="
+  "org/jetbrains/kotlin#kotlin-test-junit/2.4.10": {
+   "jar": "sha256-GXy3pC/3c+sMdv10fyWd0VWJeQNk0VWf8tOOCY1QZAE=",
+   "module": "sha256-RoI0PpsHXgra8Yn8E1PoXIXcxyGvsc7IwBtC85aNuII=",
+   "pom": "sha256-VCECbc+PhpxxnZzuv0byWcgttZ5SQsR6PS4XtDK7fgM="
   },
-  "org/jetbrains/kotlin#kotlin-tooling-core/2.3.21": {
+  "org/jetbrains/kotlin#kotlin-test/2.4.10": {
+   "jar": "sha256-XTNKexfOmyI+TbNeNV8AgvsFUdNsBCSlmb81aGuiq3s=",
+   "module": "sha256-r8t4FGk9lNPmJDO0e0N9dvwBuEL1ixraRCKgRNKc1PA=",
+   "pom": "sha256-bKZpz366HDJ8TR0xLfH2JfpNKQXzlsTloVxTmaGY9S8="
+  },
+  "org/jetbrains/kotlin#kotlin-test/2.4.10/all": {
+   "jar": "sha256-V2DVLudpZBnA/Z9zrrs4Z7yGLMpxbtkgtHCyd2fLx4Q="
+  },
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.3.20": {
    "jar": "sha256-NnFCeBKZvA+RIMHe7A5ik0oa+ep/AaqpxaU1TcXY19k=",
-   "pom": "sha256-bUmGsDzsaBW3sTLst2rWwLcczaeQSzoRTPOXAOnKyOQ="
+   "pom": "sha256-R+Ou/SS1vmLYB7bLzXnFW4P5S1XP4Y79xuM84RvxkOQ="
   },
-  "org/jetbrains/kotlin#kotlin-util-io/2.3.21": {
-   "jar": "sha256-t2hAXLhDvDAOzhpegDI+cPEb3hLw2RUG0MyZARvi8tc=",
-   "pom": "sha256-n0P507get+JPh6EIDggL+R7DedSpElEzm/QZ2oVbB8o="
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.4.10": {
+   "jar": "sha256-WeowU3LjordBd2Tc/s9kUGag2bF5KrQK/RXBzIU1tYo=",
+   "pom": "sha256-WQJIMoqGPY8ADvBjrA7otEg/UtPiL6UcokPOf2p4x1w="
   },
-  "org/jetbrains/kotlin#kotlin-util-klib-metadata/2.3.21": {
-   "jar": "sha256-dqEKVcpEgx6gapkjhNiAgF8qkyAW8ebBSsc0UWPSbiQ=",
-   "pom": "sha256-dd/VZv0HoRFxxNibG2cFFHXpbwUsKv/NgUNipx97tFE="
+  "org/jetbrains/kotlin#kotlin-util-io/2.4.10": {
+   "jar": "sha256-Bqmg+JiEwcGoa6qWJgI42Sf7AnB3ume7XSlYr2/Xdtc=",
+   "pom": "sha256-PJykPr/4Q2bn/yh0K3R1VTYZxfD4rMLXqXmm9LQ3yBo="
   },
-  "org/jetbrains/kotlin#kotlin-util-klib/2.3.21": {
-   "jar": "sha256-3goaZsoKH5X4WACtwMdxnAhGB2zE7Ne+SFd7dAvub7s=",
-   "pom": "sha256-Bi70j2uBMJw4sqBER7ysF3OyWG6NPWvv6Qi+l5Rto10="
+  "org/jetbrains/kotlin#kotlin-util-klib-metadata/2.4.10": {
+   "jar": "sha256-+bDMM1QsU9gwBKtK7/b2UV1QnSbhTnj0IO6uKkWfSSc=",
+   "pom": "sha256-YG9w2HiKI/mwFwORB9AFJI0Ih0gfCBXmKEupppM6e3s="
   },
-  "org/jetbrains/kotlin/jvm#org.jetbrains.kotlin.jvm.gradle.plugin/2.3.21": {
-   "pom": "sha256-L9MmbuE+dF52egEwXkhUEn655AbJgSAqr6oBzgkUnUY="
+  "org/jetbrains/kotlin#kotlin-util-klib/2.4.10": {
+   "jar": "sha256-QI070W4PUTrC9PBKeIcXAZJINggcLMd0qis/c5J45DA=",
+   "pom": "sha256-Yx2/78467+od41c9jcHlSRm+mviMFCUF0zUhJ9hKu4Q="
   },
-  "org/jetbrains/kotlin/multiplatform#org.jetbrains.kotlin.multiplatform.gradle.plugin/2.3.21": {
-   "pom": "sha256-1yvYOUmgwm/mzL2+X9gY151YvdldCEzqlj5xiYfrgKM="
+  "org/jetbrains/kotlin/jvm#org.jetbrains.kotlin.jvm.gradle.plugin/2.4.10": {
+   "pom": "sha256-IC7H9YxuI/vsopOD6jPOyaToVHgm5wrIeAA3THh7P4A="
   },
-  "org/jetbrains/kotlin/plugin/compose#org.jetbrains.kotlin.plugin.compose.gradle.plugin/2.3.21": {
-   "pom": "sha256-SecF24pUPn5ZxAyx4RYz2bw3NIv/5PEV8Zec34ifkig="
+  "org/jetbrains/kotlin/multiplatform#org.jetbrains.kotlin.multiplatform.gradle.plugin/2.4.10": {
+   "pom": "sha256-gjDYT7eB0WFCSJtYWWymc1mJOdooe1Vs9gEq7Qq4EsY="
   },
-  "org/jetbrains/kotlin/plugin/parcelize#org.jetbrains.kotlin.plugin.parcelize.gradle.plugin/2.3.21": {
-   "pom": "sha256-KK59VS1Dtw4MZAgfAqu9IZa8qOElBe86H7+f9aJcF7Q="
+  "org/jetbrains/kotlin/plugin/compose#org.jetbrains.kotlin.plugin.compose.gradle.plugin/2.4.10": {
+   "pom": "sha256-o0zV1432lv0PnCmjfC/3AN98IJURev3+DEfEGyFaL0w="
   },
-  "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.21": {
-   "pom": "sha256-yIhTYIUUX6NyHzlWQ7PIDLYim9iayrC4etXTYuOd7Gk="
+  "org/jetbrains/kotlin/plugin/parcelize#org.jetbrains.kotlin.plugin.parcelize.gradle.plugin/2.4.10": {
+   "pom": "sha256-OZZNut4E3dUFjQ48L33YnzKYnCNlylfxRU1dtcxuU/A="
+  },
+  "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.4.10": {
+   "pom": "sha256-PuZ5adgb3vNw+DHx1T7Z9jjR/q0DL8ZAX98Bg8pR2vU="
   },
   "org/jetbrains/kotlinx#atomicfu-jvm/0.22.0": {
    "jar": "sha256-LaBzcn86teVYTnTBLhFRnJCK4t+vausl3tQrZoIpeII=",
@@ -3768,10 +4003,19 @@
    "module": "sha256-kpgCjz11BHs+QSdFl9iK4gLFmoyHmJJHadEgOkdXjsM=",
    "pom": "sha256-Lu9uDGgGK7h1lWYaHGeajJ/4JJy/qA4lF394vNcXqAo="
   },
+  "org/jetbrains/kotlinx#kotlinx-collections-immutable-jvm/0.5.1": {
+   "jar": "sha256-1eS7JdbpD3RxZis1ACWeJHUjpBDmqCDcxAANOGsMJIw=",
+   "module": "sha256-KHZ5Cs3XoHxXy5htiv1qItadT8nBPLnyUGfeqUC/+P4=",
+   "pom": "sha256-lu/eMQRvsSU4uIj2qUE4v4qbDyic93iZ4DULibXZ8sU="
+  },
   "org/jetbrains/kotlinx#kotlinx-collections-immutable/0.4.0": {
-   "jar": "sha256-PYTb1SPfRrpx2BMNR+Ilc6kD05jPdAxKxTFIejKfdwY=",
    "module": "sha256-hcc5iv+JMuodhuYKsl/IsngaVsbrZIVfz/TcZaG3d6U=",
    "pom": "sha256-NPZcN43q2J+3yi0Sr4Pdg0A8uoXI7bOlxrxa1R/+90k="
+  },
+  "org/jetbrains/kotlinx#kotlinx-collections-immutable/0.5.1": {
+   "jar": "sha256-jvyTtkSus1OWR8wwHuu8+HdEEHyKYPSfa6+IJirIhf0=",
+   "module": "sha256-4x6Nhhqi7m28YVyQsPn8pXRTKIg039FnxNlrGaM4phU=",
+   "pom": "sha256-Mam3N5agFwFvYFLT34iK9n1VoVdTuDGd0b+Wt3zTBmU="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-android/1.11.0": {
    "jar": "sha256-wssgbScBfH0b9f8Xl4c5dUPRN0jbq7DXI34VheCykEQ=",
@@ -3786,9 +4030,6 @@
    "jar": "sha256-vXg6zS+XOIRdWDgPRvRbXN6V0MsDAn1WclM4smv8TXI=",
    "module": "sha256-ffHgTXfwzEEYkNmZqUSbDjvNTxWaRsMGCxECBMpgfUM=",
    "pom": "sha256-voYCDNW5O4poykMYWgSbmwuqNF/Rvh/aoBT9rvktbnw="
-  },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.10.2": {
-   "pom": "sha256-+vDGU45T3cBJmmNmTY52PCFlgLLhjnIsy98bQxpq/iY="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.11.0": {
    "pom": "sha256-9lhgvOWKK/rfBf3FFtODM0IfDjh/74fiREnAOUyA0lQ="
@@ -3805,18 +4046,12 @@
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.9.0": {
    "pom": "sha256-vqVRHpAB8sWTq1CA3xMbIZq14ghcxZec5YPqzUlG/Xg="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.10.2": {
-   "jar": "sha256-XKF1s43zMf1kFVs1zYyuElH6nuNpcJs21C4KKIzM4/0=",
-   "module": "sha256-6eSnS02/4PXr7tiNSfNUbD7DCJQZsg5SUEAxNcLGTFM=",
-   "pom": "sha256-ZY9Xa5bIMuc4JAatsZfWTY4ul94Q6W36NwDez6KmDe8="
-  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.11.0": {
    "jar": "sha256-0ddaoB3/u00cUg5n5MTn9fYXRxjny0YyQSUD8vDmBPo=",
    "module": "sha256-WyVWU61rHyHgxGEIYF8SnjqlbtlBSEnMn1tDZEFRdSg=",
    "pom": "sha256-3VS5eqP6uR/CT13ykWwivpQpoznS9Ft/8JIzL2wZ3Dk="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
-   "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
    "module": "sha256-DZTIpBSD58Jwfr1pPhsTV6hBUpmM6FVQ67xUykMho6c=",
    "pom": "sha256-Cdlg+FkikDwuUuEmsX6fpQILQlxGnsYZRLPAGDVUciQ="
   },
@@ -3834,11 +4069,6 @@
    "jar": "sha256-rYnCiSI15nDyItgZyz2BGIFDyxmgW1nfmImuQmn1xwo=",
    "module": "sha256-syGomeQNPONFcHqiz9qZg60NzGn+p0qbi/kGoWwc+Kk=",
    "pom": "sha256-GcSImUGzqgmL1XzGTwL5razGVNVxoSqVbeS1uxSMZJk="
-  },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.10.2": {
-   "jar": "sha256-MZtlMAnUnHCYL5jfKcyE/HAlsJLLBXHI51MuOtQ2ba4=",
-   "module": "sha256-j+JUF35xGnzRijwG2CQvzpRfQcLMoT3BmzOuQqVDUBY=",
-   "pom": "sha256-UZ2lQACW80YqTa6AeDrQUEE9S8gex65T+udq7wzL7Uw="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.11.0": {
    "jar": "sha256-BOdzf7Fc9fOu2DqRFBpTA6CyrNiG9bvDXNvnka1j3+4=",
@@ -3907,23 +4137,38 @@
    "module": "sha256-0RrPnfTLjwsBXNARZici1ySQwIiZhCJOpW3+TCc0rqQ=",
    "pom": "sha256-jQD25Qd/O76Bod8yi+te79AIzI+B//5srNUm8BXcnoQ="
   },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.9.1": {
+   "jar": "sha256-hYneC3xHa/3QKiRkFoX2Ca3nL15ZXPKQnBaKzbp+a6Q=",
+   "module": "sha256-bg1bxVGvKIRyg5eerohOnfGsSgldSM9nCQtpYe288uU=",
+   "pom": "sha256-xC9KI5StvopK5ViFKPX2Tl1O3ddDQkCMLyU8xslcI6U="
+  },
   "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.9.0": {
-   "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
    "module": "sha256-hhg+j506LZqCiIN4+tb5V1hhk1nkXfty7K9sCwcmOFA=",
    "pom": "sha256-1DAvY5qQe0AlwH89LuQ+3KC369+2rtWA2k0gdjQLIGc="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.9.1": {
+   "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
+   "module": "sha256-ACtgq7Zief9ZVJz6LnnHLI2uKeGbDEZJjtlZsOcClYE=",
+   "pom": "sha256-kuCEpM0bw0w4gQNbC/dV9M44Tdg/2ddyZWCEuTEt3g8="
   },
   "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.9.0": {
    "jar": "sha256-M4hyFI+qSkSsyb+pE0OBPVF4To1H8AWtRAZkcpf4UEE=",
    "module": "sha256-GtjQ5PgKNhxWevWqkEYHYp5TAN7hU6RnPmUX+HayFDY=",
    "pom": "sha256-fLkR4mPRz0Lm1zY+1WAaYaxYgZdo1SB9+RsPaeIqbOg="
   },
+  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.9.1": {
+   "jar": "sha256-dl2IUdjKaUcGkxMxuSOGhEgAhn4EG3IPHxk9vah003A=",
+   "module": "sha256-tToKE0wAD4MvTfJcRgRdaOYVMkkUHapOBs9VZCOH5R4=",
+   "pom": "sha256-aaAhOJ7iqClIQtPdHEAIxcXfIMJdcmprrWZD70IM3yA="
+  },
   "org/jetbrains/kotlinx#kotlinx-io-core/0.9.0": {
-   "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
    "module": "sha256-+QJWEkHN4gRxfh6u368DBumKuZZ5rLemY6rqgfFaNiA=",
    "pom": "sha256-rYa7iYQNaLA2Wz0hnRACStrUxkZOBBNsakKeG7do/qY="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.10.0": {
-   "pom": "sha256-Lpc+Tfw7xjjdLmg9qVncK5eSMpe/O49gx/8A1h6sOwc="
+  "org/jetbrains/kotlinx#kotlinx-io-core/0.9.1": {
+   "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
+   "module": "sha256-kK017PfkovutRYa+tMcSQEgKB1ZPLCtcG773v3GJwb4=",
+   "pom": "sha256-VKzgH5zhflCIiKWTQ8ZCzNUpgA8SZIay7GYBjV49/UQ="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.11.0": {
    "pom": "sha256-O+IhttqG3NpRysbEskBLielasJzI0GoFaJvi7zZzXew="
@@ -3931,10 +4176,8 @@
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.7.3": {
    "pom": "sha256-QiakkcW1nOkJ9ztlqpiUQZHI3Kw4JWN8a+EGnmtYmkY="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.10.0": {
-   "jar": "sha256-FNbyfOKPYevEpRbVYvkRt7wBz75Tl/uITEXqDbBExjU=",
-   "module": "sha256-7tVPsrYUrZV8CP7iDeZeAK1dVs6jkORLpgorhUKBtgw=",
-   "pom": "sha256-XEwMgBAEK39UKrSE3qijaHuWwglE5ywGPqwWonOa2OQ="
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.9.0": {
+   "pom": "sha256-bX/zZcDvHNN2+1SxoWyAoh7Vj+tGwz80ULbPIuKxNT0="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.11.0": {
    "jar": "sha256-9KgBxkfUNRMnzZ4axBE+K+nqN6ZKsKuuJpwlpS4o810=",
@@ -3946,10 +4189,6 @@
    "module": "sha256-c7tMAnk/h8Ke9kvqS6AlgHb01Mlj/NpjPRJI7yS0tO8=",
    "pom": "sha256-c09fdJII3QvvPZjKpZTPkiKv3w/uW2hDNHqP5k4kBCc="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.10.0": {
-   "module": "sha256-pJJxm8QF9QTg2EjzTpQfL5RvgntHhzayW6nGlwjZyao=",
-   "pom": "sha256-ZCi5KEMl0zYxmSHrBY71Fd8BzY6O9s3BNB7PqO9rNXQ="
-  },
   "org/jetbrains/kotlinx#kotlinx-serialization-core/1.11.0": {
    "jar": "sha256-Xw0W3F0IA7c+FLupBFUHVl0vp7AYbQ3DgkqUA6Bx0Hs=",
    "module": "sha256-TgEUBvLCKFpam6jDtkcawWj26Cr4KxqTtxoHMdJwNk4=",
@@ -3960,10 +4199,22 @@
    "module": "sha256-OdCabgLfKzJVhECmTGKPnGBfroxPYJAyF5gzTIIXfmQ=",
    "pom": "sha256-MdERd2ua93fKFnED8tYfvuqjLa5t1mNZBrdtgni6VzA="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.10.0": {
-   "jar": "sha256-rx4+Ho7jF2Ro4exynfhTsgZgcd6UqExBKtn6E1yzfzo=",
-   "module": "sha256-pf5GHIQaWLDKWZaUF8ZaWe9wWHzJw4eD3ox4sKP5UMg=",
-   "pom": "sha256-eGypyBw8fsU9kkuyNqAI8hTCwJbRMX3J97N47NEP1c0="
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-jvm/1.11.0": {
+   "jar": "sha256-u/MAVSJCasS6Ks1tw49H6loydO6CuTK4hBg1x+rdq3Q=",
+   "module": "sha256-093oGAZbawtfOhC491ivJ5bgqcdceZ1TRCWz2W4hi2Y=",
+   "pom": "sha256-YcFU4V9lVKvdDb6jwvLPvp47o/66HhK0VvIWxQVN6gA="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io-jvm/1.9.0": {
+   "module": "sha256-Ulyljv7R1umPyqpU1SVREZDtF7uOVnP4TSiZnwi8Zbc=",
+   "pom": "sha256-s3U1BAhN78b0c6JYIz1gPtoTPEe40oYs/olDHNKcxfM="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io/1.11.0": {
+   "module": "sha256-Cvkom1or0Ta3Ornv574l0idSrz+Y5uCWHQJkc4h0NJI=",
+   "pom": "sha256-ry9Wp7NqXl0GuHomr1phiv9nlZX0UjMSwJ7uj4zvfho="
+  },
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-io/1.9.0": {
+   "module": "sha256-vcVd2t2bARaFIanBk+KDkkGLOdZKalVdDbw163Jpltk=",
+   "pom": "sha256-qLTanfNROjgysRYUhPrwPiKCN05MsOWvy1LLqX1RhOE="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.11.0": {
    "jar": "sha256-VjoltOtckSiunCR589GlxE3NF2ESuRzwNoLpBuulyTU=",
@@ -3974,10 +4225,6 @@
    "jar": "sha256-sekThJntjSA3Xt2j8rHJXzEDoljv9q+e3F6gcQDyspw=",
    "module": "sha256-D/cOITHypldYIvdhHAXig8SuCBczA/QQSUy0Eom9PvY=",
    "pom": "sha256-0zRdKAgXvgfpwnrNYHPUleF73/VxxHADTglmQgeGp90="
-  },
-  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.10.0": {
-   "module": "sha256-yfNeuGIPLTiZoFgoXEF3NciVbu0rGFO+2jrBPHeCuMc=",
-   "pom": "sha256-+uXntE6iGb3qzoSlC/8y06x/bdGb5KjiRTbhgzxUoNY="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-json/1.11.0": {
    "jar": "sha256-V3iMNxB/VfqYDvNsFX5w7O9XMVinYng7/TDtSCRBnoA=",
@@ -4013,29 +4260,19 @@
   "org/jetbrains/skiko#skiko-awt-runtime-macos-arm64/0.9.22.2": {
    "pom": "sha256-sqCj8EKIL9aGPFpynw1S3TpVTWpxCYfW8PNVifDY3oY="
   },
-  "org/jetbrains/skiko#skiko-awt/0.144.5": {
-   "jar": "sha256-GeMozzmjOcDYDGSx6YbYI4B8391Eta0egJHEsDTy5S0=",
-   "module": "sha256-5omIIKF4zeZa1nb1xi92P615R/AA8U6DkATfr9VT4gI=",
-   "pom": "sha256-77/4J7kSusLfh23xkTpiyKhBVS+quOs9XoXCyik80YQ="
-  },
   "org/jetbrains/skiko#skiko-awt/0.144.6": {
    "jar": "sha256-V0IBIu0B/vBc20lBV2yY6mIlxSXzc4DCFqPARrK1Up0=",
    "module": "sha256-+HxTqxf2SfK4U8c7UkTsyUMSimXTCRczRV5j3HXt1Gw=",
    "pom": "sha256-hYumSDgVeq/Oe0lvNq3HPyLLjfk4W4Rw3G6UYp7Ckos="
-  },
-  "org/jetbrains/skiko#skiko/0.144.5": {
-   "jar": "sha256-JwF75Q+DlQyJgm9TM/FkMYqcEfyA+CXTbyRL3cKTRvE=",
-   "module": "sha256-664bLBc2v4iUWHH8gkyRG8p4KA+x2CpVkiqoyfvCVs0=",
-   "pom": "sha256-oUr6OtK+4DmVwrXu5DtCHrPNhINUuMQJIlSMhVZ5k0o="
   },
   "org/jetbrains/skiko#skiko/0.144.6": {
    "jar": "sha256-JwF75Q+DlQyJgm9TM/FkMYqcEfyA+CXTbyRL3cKTRvE=",
    "module": "sha256-WERq+5TVVDcMFmDrn7aM1G0X3jlfrSyClHcXvU8H0q0=",
    "pom": "sha256-VMhrNiyMumSLoJ0bRgaqgamX1hK+dnMVKeqMWkA4xzE="
   },
-  "org/jsoup#jsoup/1.22.2": {
-   "jar": "sha256-WWeFmW08bfFvVEwjLRCpodiHg7KkdAz1JRy2FvK+cE0=",
-   "pom": "sha256-VPq5kKDvVilwiMJSIT+oM5T6/O+lFgWQRMCeOo4F5VI="
+  "org/jsoup#jsoup/1.23.1": {
+   "jar": "sha256-ixXiso7rHgqIqbfatNwMI1JEkcVpWXhd6iL3hGiXtmg=",
+   "pom": "sha256-EPq6Um1mdgzzpXF2Y2l2zHiGWTXpT63b8WN/PM5kwhs="
   },
   "org/jspecify#jspecify/1.0.0": {
    "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",
@@ -4045,6 +4282,10 @@
   "org/junit#junit-bom/5.10.2": {
    "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
    "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.11.0-M2": {
+   "module": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4=",
+   "pom": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
   },
   "org/junit#junit-bom/5.13.4": {
    "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
@@ -4058,46 +4299,38 @@
    "jar": "sha256-IFIlSQVunlCqNe8LRFouR6U9Br4LCpRn1wTiSD/7BJo=",
    "pom": "sha256-j8hPNs5tps6MiTtlOBmaf2mmmgcG2bF6PuajoJRS7tY="
   },
-  "org/kodein/emoji#emoji-kt-jvm/2.4.0": {
-   "jar": "sha256-jL2rOkWG0lnx6+ZGOy5xcp8lgjfPDgj2HRbTsnELPqI=",
-   "module": "sha256-/p9USod54adSeMfnwx/Xz1hD+oiVaAvpcFhCcjerF5k=",
-   "pom": "sha256-zqcDuPFZn7+anKB9V7ICkiIBgMw4bqKtZsvK3H3QZ2I="
+  "org/kodein/emoji#emoji-kt-jvm/2.5.0": {
+   "jar": "sha256-9Q+YLkR4joQ0JCGK7TZ1j6LtHyWf2sMKaOJuvd5zl7Q=",
+   "module": "sha256-H53l8RNXJUUxsshWw5gQwmNOG29/T8tiCeGG+TPHHlc=",
+   "pom": "sha256-txA2gPiV3ZA9j1AEX+ufVlUdWyn1vQQzkEIfUWP4CWk="
   },
-  "org/kodein/emoji#emoji-kt/2.4.0": {
-   "jar": "sha256-HIeMdjUt8RPRqLPckh0/r2Pg5oLsXy/Oq/yguvkL56A=",
-   "module": "sha256-hsBQw028DEH5wilvWN9qascAMhn99EHUpncrRNPyZyE=",
-   "pom": "sha256-Z36gCnKoilousQexig/VsSnPvFq9jUz1J/rfHQHpG3M="
+  "org/kodein/emoji#emoji-kt/2.5.0": {
+   "jar": "sha256-rAJlRAjz1RmzeEoJJsQLadkBkGTDX5ITrES2b23rDwc=",
+   "module": "sha256-lJqFU1NY2cIKTBWgKFvZIoN4QNTM9auIpr6jtEudN0c=",
+   "pom": "sha256-wJhAvuRccLCuOdQ96D3buVi/7bYoFrF5qubHXpT6XVc="
   },
   "org/ow2#ow2/1.5.1": {
    "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
   },
-  "org/ow2/asm#asm-analysis/9.8": {
-   "jar": "sha256-5kBzL7zTxicZJaUE8SXjg4Roj037v5LIYi387g0J7bk=",
-   "pom": "sha256-xXR+JccuGwfVJjx1x4rWGmJt0kWPr8r8I/gdMlPuQu0="
+  "org/ow2/asm#asm-analysis/9.9": {
+   "jar": "sha256-ahXSjovSm6T9W8pLr5tQ6Pui17Ufv3jPoMh1pyFMZ4s=",
+   "pom": "sha256-kJ8kpxDHKODl1kPsC0g0pjyz0wAiEA1YPV3Wom41zaY="
   },
-  "org/ow2/asm#asm-commons/9.8": {
-   "jar": "sha256-MwGhwctMWfzFKSZI2sHXxa7UwPBn376IhzuM3+d0BPQ=",
-   "pom": "sha256-95PnjwH3A3F9CUcuVs3yEv4piXDIguIRbo5Un7bRQMI="
+  "org/ow2/asm#asm-commons/9.9": {
+   "jar": "sha256-2y9vJhULvnwSZga0oRUYNrzCKh4FpCOzWFaYvs6ZX/g=",
+   "pom": "sha256-GKXT7xN351RLPKMhDyYTlrmH9gEO9ZHThyra5jEZ7kM="
   },
-  "org/ow2/asm#asm-tree/9.8": {
-   "jar": "sha256-FLeIDLfIXu0QHicQQy/D/7gydVMqaolNxMQJXUmtWfE=",
-   "pom": "sha256-cUnn+qDhkSlvh5ru2SCciULTmPBpjSzKGpxijy4qj3c="
+  "org/ow2/asm#asm-tree/9.9": {
+   "jar": "sha256-QhePN3XJxj+eXhRGdH0ptOyk2RvW515cQ8+jcqR9OMY=",
+   "pom": "sha256-0BeI7Y5ujiSsr2y0p73MJzNBYlL6oAIylZ4+Lp3xv0Q="
   },
-  "org/ow2/asm#asm-tree/9.9.1": {
-   "jar": "sha256-DzVVCWtyC4ILusqwtRVYm+4CAL7gmb2hTFYXOK6De6E=",
-   "pom": "sha256-Z/7kRrpRKHEwBzjw+Vb2GlAKhS9oYf9w8KPHvwwPpAU="
+  "org/ow2/asm#asm-util/9.9": {
+   "jar": "sha256-OELhPP4yTumrfNxJFL6ZQ1QerTl8F+JtrwuKdVvt5xc=",
+   "pom": "sha256-qYWT/aHFOp5w12YPQWcg4wjSTbjhxFb6F+drp40nK2s="
   },
-  "org/ow2/asm#asm-util/9.8": {
-   "jar": "sha256-i6BGDsso/Q4pgOXz7zQzpROkV7wHf4GlO9x1tYegjRU=",
-   "pom": "sha256-JNCXDhceKRe4Oo8PBdUKHNtcguUIVVtS28ydM2HE8Ow="
-  },
-  "org/ow2/asm#asm/9.8": {
-   "jar": "sha256-h26raoPa7K1cpn65/KuwY8l7WuuM8fynqYns3hdSIFE=",
-   "pom": "sha256-wTZ8O7OD12Gef3l+ON91E4hfLu8ErntZCPaCImV7W6o="
-  },
-  "org/ow2/asm#asm/9.9.1": {
-   "jar": "sha256-bzgoohXJIAWaXvovtVwjPWxU7FytypnOGxvdEAd8fd0=",
-   "pom": "sha256-rKaN7pui9s2Q/95yjv3H4+v89Z8/Qfv+JI0tAdW4Zq8="
+  "org/ow2/asm#asm/9.9": {
+   "jar": "sha256-A9madK0e5ccTNO9nQ39O9P40iMqnyW2GRavHPI4gF9Q=",
+   "pom": "sha256-z4Ye8edF1XFUr3muFN80DtU0Hl3NAVfO/NLrfxqgXFc="
   },
   "org/slf4j#slf4j-api/1.7.30": {
    "jar": "sha256-zboHlk0btAoHYUhcax6ML4/Z6x0ZxTkorA1/lRAQXFc=",
@@ -4138,22 +4371,22 @@
   }
  },
  "https://www.jitpack.io/com/github/beeper": {
-  "matrix-messageformat-compose#messageformat-android/5ac720dbe1a46f228df673cc2c554584731f932c": {
-   "module": "sha256-rgzSoj3H+Kt7ysCZ3I0jbYflLLj2giWHR81XGSSve8E=",
-   "pom": "sha256-5ULao2clDL2jQKAP/YkfNDdrMEJJgvHbZRpQMfFAheU="
+  "matrix-messageformat-compose#messageformat-android/fca1dc79c84cf65195624c35f926acbff852ba81": {
+   "module": "sha256-2h0fEFBI/0yShj2i/SvxfAW+p3b9GnhKz3hXVmYJDJM=",
+   "pom": "sha256-TcJlqpdFwquXWoB5HjvA80o5eDb+ivqHPAbZSxTeQBo="
   },
-  "matrix-messageformat-compose#messageformat-jvm/5ac720dbe1a46f228df673cc2c554584731f932c": {
-   "jar": "sha256-XiHH93nwFIKa1kM6f3jhnohGGw2XRaZ7vNGt2QS8rfo=",
-   "module": "sha256-xFighI7x4M2UzBxhuUhqbY9/zMAH+9nbKnOmUxfCs5s=",
-   "pom": "sha256-Tgml1Kjr3pI9GWxuk+6llGmih5zkApnz2i/Ny4VTKUs="
+  "matrix-messageformat-compose#messageformat-jvm/fca1dc79c84cf65195624c35f926acbff852ba81": {
+   "jar": "sha256-tzdWF3XBtVgbue8iXvfBuaCUAG02+wyGd5Cozi0wUD8=",
+   "module": "sha256-EqWpZ4NWR3387aQrdotH9MfAvED8EbJRLcSGAFnGcd0=",
+   "pom": "sha256-Gjkl0+hcCWCilJbzsRk42xGQ1gE1MpssAtVs+u6ychk="
   },
-  "matrix-messageformat-compose#messageformat/5ac720dbe1a46f228df673cc2c554584731f932c": {
+  "matrix-messageformat-compose#messageformat/fca1dc79c84cf65195624c35f926acbff852ba81": {
    "jar": "sha256-swtSuuU+MpS8OiDuKQqxIvX8j/5M1+maux3D93XE8j0=",
-   "module": "sha256-dn5zinoZXu7Pm03e06QBSNOgKGAI6znPLC1p9qsVsX4=",
-   "pom": "sha256-2dxqevZRD0Uap1g3MFzRk+fLc0tUKqJsTVqmWICO3CQ="
+   "module": "sha256-fY/1I6Y81Wmnkdm59H0d97gGbeVX837IYk15Q2CdCw0=",
+   "pom": "sha256-AEJ5ThzgcUGnErtIAkZt6z3U3GpeqNTom17N03cTsTM="
   },
-  "matrix-messageformat-compose/messageformat-android/5ac720dbe1a46f228df673cc2c554584731f932c/messageformat-android-5ac720dbe1a46f228df673cc2c554584731f932c": {
-   "aar": "sha256-oRcxncL4PiTd3Kb2OzTfgOoA+IHajXOBMnkgG+M2FLM="
+  "matrix-messageformat-compose/messageformat-android/fca1dc79c84cf65195624c35f926acbff852ba81/messageformat-android-fca1dc79c84cf65195624c35f926acbff852ba81": {
+   "aar": "sha256-5Bfih3jmzDjKqr8PTBLgi2TN8o+dacnSTIgUKhRLHZA="
   }
  }
 }

--- a/pkgs/by-name/sc/schildi-revenge/package.nix
+++ b/pkgs/by-name/sc/schildi-revenge/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle,
+  gradle_9,
   nix-update-script,
   libGL,
   jdk21,
@@ -14,30 +14,36 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "schildi-revenge";
-  version = "26.07.13";
+  version = "26.08.08-1";
 
   src = fetchFromGitHub {
     owner = "SchildiChat";
     repo = "schildi-revenge";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1Akm57GxGtEymDbfq879uglxEoENp/g+aFUNM1O0qRo=";
+    hash = "sha256-SbDdC910EdQy4HEwovuHjTzK4zEbzeI1w6pEQ1EQAGI=";
     fetchSubmodules = true;
   };
 
   cargoRoot = "matrix-rust-sdk";
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-TIpT2g00f99qTGPA+bBaEz4kj5BC1scEywv6oDCFlkQ=";
+    hash = "sha256-P0NcsKNmLHlfZ8tMjkfOChLrJ7l5tc9xy6FtZqyL1As=";
   };
 
   nativeBuildInputs = [
     jdk21
-    gradle
+    gradle_9
     git
     cargo
     rustc
     rustPlatform.cargoSetupHook
   ];
+  #broken entry unused entry in Cargo.toml, can probably be removed with next update
+  postUnpack = ''
+      substituteInPlace ./source/matrix-rust-sdk/Cargo.toml --replace-fail \
+      "ruma = { git = \"https://github.com/matrix-org/ruma\", rev = \"2a1d714314f6f711d5bca755c73cf2ce3053c3d1\" }" \
+    ""
+  '';
 
   gradleBuildTask = "createReleaseDistributable";
 
@@ -51,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     #gradle createReleaseDistributable --write-verification-metadata sha256
   '';
 
-  mitmCache = gradle.fetchDeps {
+  mitmCache = gradle_9.fetchDeps {
     pkg = finalAttrs.finalPackage;
     data = ./deps.json;
   };


### PR DESCRIPTION
Updated schildi-revenge to 26.08.08-1
Simply upgrading input didnt work, as schildi-revenge now requires gradle_9 and vendored version of the matrix-rust-sdk has a broken entry in the Cargo.toml file.

The broken entry adds a patch to override the source of a dependency, but is unused as the fork replaces the dependency.
This breaks the build process, because, even though the dependency is unused, cargo expects the source to be vendored and aborts the build without it.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
