### PR TITLE
gdal: Fix cross compilation for gdalMinimal

### DIFF
--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -80,6 +80,7 @@
   zlib,
   zstd,
   buildPackages,
+  pkgsCross,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdal" + lib.optionalString useMinimalFeatures "-minimal";
@@ -98,6 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
     graphviz
     pkg-config
+    (buildPackages.python3.withPackages (ps: [ ps.numpy ]))
     python3Packages.setuptools
     python3Packages.wrapPython
     swig
@@ -324,9 +326,13 @@ stdenv.mkDerivation (finalAttrs: {
     popd # autotest
   '';
 
-  passthru.tests = callPackage ./tests.nix { gdal = finalAttrs.finalPackage; };
+  passthru.tests = callPackage ./tests.nix {
+    gdal = finalAttrs.finalPackage;
+    inherit pkgsCross;
+  };
 
   __darwinAllowLocalNetworking = true;
+  strictDeps = true;
 
   meta = {
     changelog = "https://github.com/OSGeo/gdal/blob/${finalAttrs.src.tag}/NEWS.md";

--- a/pkgs/by-name/gd/gdal/tests.nix
+++ b/pkgs/by-name/gd/gdal/tests.nix
@@ -4,6 +4,7 @@
   jdk,
   lib,
   testers,
+  pkgsCross,
 }:
 
 let
@@ -66,4 +67,6 @@ in
     ${lib.getExe jdk} -Djava.library.path=${gdal}/lib/ -cp ${gdal}/share/java/gdal-${version}.jar main.java
     touch $out
   '';
+
+  aarch64-multiplatform-minimal = pkgsCross.aarch64-multiplatform.gdalMinimal;
 }


### PR DESCRIPTION
Dependent on https://github.com/NixOS/nixpkgs/pull/554874. Fixes cross compilation by specifying a buildPlatform python3 and numpy for use in the swig generation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
