### PR TITLE
tirith: 0.3.1 -> 0.3.3

### DIFF
--- a/pkgs/by-name/ti/tirith/package.nix
+++ b/pkgs/by-name/ti/tirith/package.nix
@@ -8,15 +8,15 @@
 }:
 rustPlatform.buildRustPackage (final: {
   pname = "tirith";
-  version = "0.3.1";
+  version = "0.3.3";
   src = fetchFromGitHub {
     owner = "sheeki03";
     repo = "tirith";
     tag = "v${final.version}";
-    hash = "sha256-RdStW5ubqypdmFqNk9DHtUp5jHnZdXiWW/lAlSaBb3c=";
+    hash = "sha256-kU/HeCW4QNS1Ica69YZkdSgL3gsbDOJVGTyINZOnHUQ=";
   };
 
-  cargoHash = "sha256-/V2vv02x0zSsJCcJMSttG9eekRZMK7KTk6m2VYePFa8=";
+  cargoHash = "sha256-r13gquMmfJhR5N8Vu3/R+3SWUyVWyJFE6fiJbqbE5n4=";
 
   cargoBuildFlags = [
     "-p"
@@ -30,8 +30,18 @@ rustPlatform.buildRustPackage (final: {
 
   checkFlags = [
     # requires a fully functional shell environment, generating init scripts needs a patch under nix to work at build time
+    "--skip=bash_capability_cache_steers_default_mode"
+    "--skip=bash_enter_degradation_is_visible_not_silent"
+    "--skip=cli::clipboard::tests::copy_path_does_not_consult_sidecar"
+    "--skip=clipboard_watch_exits_when_stdout_pipe_closed"
     "--skip=init_bash_output"
+    "--skip=init_prompt_status_emits_marker_wrapped_snippet_zsh"
+    "--skip=init_prompt_status_is_idempotent_when_run_twice"
+    "--skip=init_prompt_status_supports_bash_and_fish_and_powershell"
+    "--skip=init_without_prompt_status_does_not_emit_snippet"
     "--skip=init_zsh_output"
+    # fails with: no such file or directory
+    "--skip=cli::checkpoint::tests::restore_checkpoint_nonzero_on_partial_failure"
   ];
 
   nativeBuildInputs = lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [


### PR DESCRIPTION
Diff: https://github.com/sheeki03/tirith/compare/v0.3.1...v0.3.3

Changelog: https://github.com/sheeki03/tirith/blob/v0.3.3/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
