### PR TITLE
clasp-common-lisp: 2.7.0 -> 3.0.1

### DIFF
--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -1,29 +1,37 @@
 {
   lib,
-  llvmPackages_18,
+  llvmPackages_22,
   fetchzip,
+  ninja,
   sbcl,
   pkg-config,
-  fmt_9,
+  writableTmpDirAsHomeHook,
+  boost,
+  fmt,
   gmpxx,
   libelf,
-  boost,
-  libunwind,
-  ninja,
 }:
 
 let
-  inherit (llvmPackages_18) stdenv llvm libclang;
+  inherit (llvmPackages_22)
+    stdenv
+    llvm
+    libclang
+    libunwind
+    ;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "clasp";
-  version = "2.7.0";
+  version = "3.0.1";
 
   src = fetchzip {
-    url = "https://github.com/clasp-developers/clasp/releases/download/${version}/clasp-${version}.tar.gz";
-    hash = "sha256-IoEwsMvY/bbb6K6git+7zRGP0DIJDROt69FBQuzApRk=";
+    url = "https://github.com/clasp-developers/clasp/releases/download/${finalAttrs.version}/clasp-${finalAttrs.version}.tar.gz";
+    hash = "sha256-C6FwbLz/kjBcuI3225TczWaInkbQ3chtDhWCYh+a/2E=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   patches = [
     ./remove-unused-command-line-argument.patch
@@ -35,16 +43,21 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    sbcl
-    pkg-config
-    fmt_9
-    gmpxx
-    libelf
-    boost
-    libunwind
+    llvm.dev
     ninja
-    llvm
+    pkg-config
+    sbcl
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    boost
+    fmt
+    gmpxx
     libclang
+    libelf
+    libunwind
+    llvm
   ];
 
   ninjaFlags = [
@@ -53,13 +66,13 @@ stdenv.mkDerivation rec {
   ];
 
   configurePhase = ''
+    runHook preConfigure
     export SOURCE_DATE_EPOCH=1
-    export ASDF_OUTPUT_TRANSLATIONS=$(pwd):$(pwd)/__fasls
     sbcl --script koga \
       --skip-sync \
-      --build-mode=bytecode-faso \
       --cc=$NIX_CC/bin/cc \
       --cxx=$NIX_CC/bin/c++ \
+      --jobs=$NIX_BUILD_CORES \
       --reproducible-build \
       --package-path=/ \
       --bin-path=$out/bin \
@@ -67,6 +80,7 @@ stdenv.mkDerivation rec {
       --dylib-path=$out/lib \
       --share-path=$out/share \
       --pkgconfig-path=$out/lib/pkgconfig
+    runHook postConfigure
   '';
 
   postInstall = ''
@@ -84,4 +98,4 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/clasp-developers/clasp";
     mainProgram = "clasp";
   };
-}
+})

--- a/pkgs/development/compilers/clasp/remove-unused-command-line-argument.patch
+++ b/pkgs/development/compilers/clasp/remove-unused-command-line-argument.patch
@@ -1,11 +1,11 @@
 diff --git a/src/koga/units.lisp b/src/koga/units.lisp
-index 808cebd17..2bbf965fd 100644
+index aa51d2bcd1..ef2ef48692 100644
 --- a/src/koga/units.lisp
 +++ b/src/koga/units.lisp
-@@ -197,7 +197,7 @@
-                                :type :cxxflags)
-   #+darwin (append-cflags configuration "-stdlib=libc++" :type :cxxflags)
-   #+darwin (append-cflags configuration "-I/usr/local/include")
+@@ -224,7 +224,7 @@
+   ;; prefix.  Add it to the search path when present.
+   #+darwin (when (probe-file #P"/opt/homebrew/include/")
+              (append-cflags configuration "-I/opt/homebrew/include"))
 -  #+linux (append-cflags configuration "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fno-stack-protector -stdlib=libstdc++"
 +  #+linux (append-cflags configuration "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fno-stack-protector"
                                         :type :cxxflags)


### PR DESCRIPTION
https://github.com/clasp-developers/clasp/releases/tag/3.0.0
https://github.com/clasp-developers/clasp/releases/tag/3.0.1

our primary motivation in making this pr is to help move away from the very old and soon-to-be-removed llvm 18. our basic testing of `clasp` and `iclasp` generally seems to appear okay, but we do not know much about the lisp ecosystem and we're happy to take any other modifications as necessary / have folks who are more knowledgeable about lisp take another approach.

there's also some general cleanup, e.g. properly separating `nativeBuildInputs` and `buildInputs` since it helped us make a lot more sense of this derivation as a whole, but we can revert those changes if desired.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
