### PR TITLE
marksman: fix build in darwin sandbox

### DIFF
--- a/pkgs/by-name/ma/marksman/package.nix
+++ b/pkgs/by-name/ma/marksman/package.nix
@@ -4,6 +4,7 @@
   buildDotnetModule,
   dotnetCorePackages,
   nix-update-script,
+  stdenv,
   versionCheckHook,
 }:
 
@@ -29,6 +30,12 @@ buildDotnetModule (finalAttrs: {
 
   doCheck = true;
   testProjectFile = "Tests/Tests.fsproj";
+  # __darwinAllowLocalNetworking is not working with IPv4-mapped IPv6.
+  # See: https://github.com/NixOS/nix/pull/11270#issuecomment-3936740134
+  dotnetTestFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--environment"
+    "DOTNET_SYSTEM_NET_DISABLEIPV6=1"
+  ];
 
   nugetDeps = ./deps.json;
 


### PR DESCRIPTION
IPv4 mapped IPv6 addresses are not recognized by localhost sandbox rule:

https://github.com/NixOS/nix/pull/11270#issuecomment-3936740134

This patch forces dotnet test env to use IPv4, avoiding the problematic
situation. This is inspired by a similar workaround for java sandbox
from:

https://github.com/anthropic-experimental/sandbox-runtime/blob/bcad38810efcc2b7342bbc6ec26d15b7bbbabcfb/src/sandbox/macos-sandbox-utils.ts#L1098

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
