### PR TITLE
plangothic: init at 2.9.5795

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10870,6 +10870,11 @@
     github = "GZGavinZhao";
     githubId = 74938940;
   };
+  h-yuqi = {
+    name = "Yuqi Huang";
+    github = "h-yuqi";
+    githubId = 62862318;
+  };
   h3cth0r = {
     name = "Hector Miranda";
     email = "hector.miranda@tec.mx";

--- a/pkgs/by-name/pl/plangothic/package.nix
+++ b/pkgs/by-name/pl/plangothic/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "plangothic";
+  version = "2.9.5795";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  dontBuild = true;
+
+  src = fetchzip {
+    url = "https://github.com/Fitzgerald-Porthmouth-Koenigsegg/Plangothic_Project/releases/download/V${finalAttrs.version}/Plangothic-Static-V${finalAttrs.version}.zip";
+    hash = "sha256-jZHiCkhEKnfcW4iIp1RWwX/a8nMnUI7hxQXJS0Bgv8o=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    installFonts
+  ];
+
+  # The Static archive also contains the equivalent TTC collection.
+  # Install only the standalone P1 and P2 TTF files.
+  dontInstallFonts = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    installFont ttf "$out/share/fonts/truetype"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CJK Unified Ideographs extension font based on Source Han Sans";
+    homepage = "https://github.com/Fitzgerald-Porthmouth-Koenigsegg/Plangothic_Project";
+    changelog = "https://github.com/Fitzgerald-Porthmouth-Koenigsegg/Plangothic_Project/releases/tag/V${finalAttrs.version}";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      h-yuqi
+    ];
+  };
+})


### PR DESCRIPTION
Packages [Plangothic](https://github.com/Fitzgerald-Porthmouth-Koenigsegg/Plangothic_Project), a Source Han Sans-based font covering CJK Unified
Ideographs Extensions B–J.

The Static release also contains the equivalent TTC collection. This
package installs only the standalone P1 and P2 TTF files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
