### PR TITLE
tmuxPlugins.mkTmuxPlugin: support finalAttrs

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -227,25 +227,25 @@ in
     };
   };
 
-  dracula = mkTmuxPlugin rec {
+  dracula = mkTmuxPlugin (finalAttrs: {
     pluginName = "dracula";
     version = "3.3.1";
     src = fetchFromGitHub {
       owner = "dracula";
       repo = "tmux";
-      tag = "v${version}";
+      tag = "v${finalAttrs.version}";
       hash = "sha256-UFK0PJFgGIBdpjuSn3stAJ7z73FgEj0yK6F+ETRQ5f4=";
     };
     meta = {
       homepage = "https://draculatheme.com/tmux";
       downloadPage = "https://github.com/dracula/tmux";
       description = "Feature packed Dracula theme for tmux";
-      changelog = "https://github.com/dracula/tmux/releases/tag/v${version}/CHANGELOG.md";
+      changelog = "https://github.com/dracula/tmux/releases/tag/v${finalAttrs.version}/CHANGELOG.md";
       license = lib.licenses.mit;
       platforms = lib.platforms.unix;
       maintainers = with lib.maintainers; [ ethancedwards8 ];
     };
-  };
+  });
 
   dotbar = mkTmuxPlugin rec {
     pluginName = "dotbar";

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -10,70 +10,61 @@
 let
   rtpPath = "share/tmux-plugins";
 
-  addRtp =
-    path: rtpFilePath: attrs: derivation:
-    derivation
-    // {
-      rtp = "${derivation}/${path}/${rtpFilePath}";
-    }
-    // {
-      overrideAttrs = f: mkTmuxPlugin (attrs // (if lib.isFunction f then f attrs else f));
-    };
+  mkTmuxPlugin = lib.extendMkDerivation {
+    constructDrv = stdenv.mkDerivation;
+    extendDrvArgs =
+      finalAttrs:
+      {
+        pluginName,
+        rtpFilePath ? (builtins.replaceStrings [ "-" ] [ "_" ] pluginName) + ".tmux",
+        namePrefix ? "tmuxplugin-",
+        src,
+        unpackPhase ? "",
+        configurePhase ? ":",
+        buildPhase ? ":",
+        addonInfo ? null,
+        preInstall ? "",
+        postInstall ? "",
+        path ? lib.getName pluginName,
+        ...
+      }:
+      {
+        pname = namePrefix + pluginName;
 
-  mkTmuxPlugin =
-    a@{
-      pluginName,
-      rtpFilePath ? (builtins.replaceStrings [ "-" ] [ "_" ] pluginName) + ".tmux",
-      namePrefix ? "tmuxplugin-",
-      src,
-      unpackPhase ? "",
-      configurePhase ? ":",
-      buildPhase ? ":",
-      addonInfo ? null,
-      preInstall ? "",
-      postInstall ? "",
-      path ? lib.getName pluginName,
-      ...
-    }:
-    if lib.hasAttr "dependencies" a then
-      throw "dependencies attribute is obselete. see NixOS/nixpkgs#118034" # added 2021-04-01
-    else
-      addRtp "${rtpPath}/${path}" rtpFilePath a (
-        stdenv.mkDerivation (
-          a
-          // {
-            pname = namePrefix + pluginName;
+        strictDeps = true;
+        __structuredAttrs = true;
 
-            strictDeps = true;
-            __structuredAttrs = true;
+        inherit
+          pluginName
+          unpackPhase
+          configurePhase
+          buildPhase
+          addonInfo
+          preInstall
+          postInstall
+          ;
 
-            passthru.updateScript = nix-update-script { };
+        installPhase = ''
+          runHook preInstall
 
-            inherit
-              pluginName
-              unpackPhase
-              configurePhase
-              buildPhase
-              addonInfo
-              preInstall
-              postInstall
-              ;
+          target=$out/${rtpPath}/${path}
+          mkdir -p $out/${rtpPath}
+          cp -r . $target
+          if [ -n "$addonInfo" ]; then
+            echo "$addonInfo" > $target/addon-info.json
+          fi
 
-            installPhase = ''
-              runHook preInstall
+          runHook postInstall
+        '';
 
-              target=$out/${rtpPath}/${path}
-              mkdir -p $out/${rtpPath}
-              cp -r . $target
-              if [ -n "$addonInfo" ]; then
-                echo "$addonInfo" > $target/addon-info.json
-              fi
+        passthru = {
+          updateScript = nix-update-script { };
+          # .rtp is used by things like programs.tmux.plugins
+          rtp = "${finalAttrs.finalPackage}/${rtpPath}/${path}/${rtpFilePath}";
+        };
+      };
 
-              runHook postInstall
-            '';
-          }
-        )
-      );
+  };
 
 in
 {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've been wanting to do this for a while to learn how `extendMkDerivation` works... tonight is the night!

Also I think dropping the `throw` after 5 years is fine...

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
