### PR TITLE
notesnook: Fix .desktop file

### DIFF
--- a/pkgs/by-name/no/notesnook/package.nix
+++ b/pkgs/by-name/no/notesnook/package.nix
@@ -81,7 +81,7 @@ let
       install -Dm444 ${appimageContents}/notesnook.desktop -t $out/share/applications
       install -Dm444 ${appimageContents}/notesnook.png -t $out/share/icons
       substituteInPlace $out/share/applications/notesnook.desktop \
-        --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${pname}'
+        --replace-fail 'Exec=AppRun %U' 'Exec=${pname}'
     '';
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since https://github.com/NixOS/nixpkgs/pull/531795 updated Notesnook, its app icon no longer appears in the Gnome app launcher.

I compared the `.desktop` file across generations and found that the `Exec` line is now `AppRun`, which is supposed to be replaced when installed by the derivation.

```console
$ diff -u  /nix/var/nix/profiles/system-{137,138}-link/etc/profiles/per-user/km/share/applications/notesnook.desktop
--- /nix/var/nix/profiles/system-137-link/etc/profiles/per-user/km/share/applications/notesnook.desktop	1969-12-31 17:00:01.000000000 -0700
+++ /nix/var/nix/profiles/system-138-link/etc/profiles/per-user/km/share/applications/notesnook.desktop	1969-12-31 17:00:01.000000000 -0700
@@ -1,12 +1,13 @@
 [Desktop Entry]
 Name=Notesnook
-Exec=notesnook
+Exec=AppRun %U
 Terminal=false
 Type=Application
 Icon=notesnook
 StartupWMClass=Notesnook
-X-AppImage-Version=3.3.21
+X-AppImage-Version=3.4.5
 Comment=Your private note taking space
+MimeType=x-scheme-handler/nn;x-scheme-handler/nn;
 Categories=Office;
```

The upstream .desktop file removed the ` --no-sandbox` arg so the `substituteInPlace` pattern doesn't match and is silently ignored. 

This updates the pattern and switches to `replace-fail` so it will be caught if changed again in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
