### PR TITLE
ocamlPackages.sqlite3: rename from ocaml_sqlite3

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -6,7 +6,7 @@
   extlib,
   fuse3,
   gapi-ocaml,
-  ocaml_sqlite3,
+  sqlite3,
   otoml,
   tiny_httpd,
   ounit2,
@@ -32,7 +32,7 @@ buildDunePackage (finalAttrs: {
     extlib
     fuse3
     gapi-ocaml
-    ocaml_sqlite3
+    sqlite3
     otoml
     tiny_httpd
   ];

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -54,7 +54,7 @@ ocamlPackages.buildDunePackage rec {
     nottui
     nottui-unix
     notty-community
-    ocaml_sqlite3
+    sqlite3
     ocolor
     oseq
     ppx_deriving

--- a/pkgs/by-name/in/infer/package.nix
+++ b/pkgs/by-name/in/infer/package.nix
@@ -161,7 +161,7 @@ stdenv.mkDerivation {
     saturn
     sedlex
     spawn
-    ocaml_sqlite3
+    sqlite3
     tdigest
     xmlm
     zarith

--- a/pkgs/by-name/li/liquidsoap/package.nix
+++ b/pkgs/by-name/li/liquidsoap/package.nix
@@ -141,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
     ocamlPackages.shine
     ocamlPackages.soundtouch
     ocamlPackages.speex
-    ocamlPackages.ocaml_sqlite3
+    ocamlPackages.sqlite3
     ocamlPackages.srt
     ocamlPackages.ssl
     ocamlPackages.taglib

--- a/pkgs/by-name/oc/ocaml-pds/package.nix
+++ b/pkgs/by-name/oc/ocaml-pds/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     process
     sedlex
     toml
-    ocaml_sqlite3
+    sqlite3
   ];
 
   buildFlags = [ "all" ];

--- a/pkgs/by-name/se/seppo/package.nix
+++ b/pkgs/by-name/se/seppo/package.nix
@@ -44,7 +44,7 @@ ocamlPackages.buildDunePackage {
     lambdasoup
     lwt_ppx
     mirage-crypto-rng
-    ocaml_sqlite3
+    sqlite3
     optint
     safepass
     timedesc

--- a/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
@@ -1,7 +1,7 @@
 {
   buildDunePackage,
   caqti,
-  ocaml_sqlite3,
+  sqlite3,
   alcotest,
   dune-site,
 }:
@@ -12,7 +12,7 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     caqti
-    ocaml_sqlite3
+    sqlite3
   ];
 
   checkInputs = [

--- a/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
@@ -2,7 +2,7 @@
   buildDunePackage,
   ocsipersist,
   logs,
-  ocaml_sqlite3,
+  sqlite3,
   ocsigen_server,
 }:
 
@@ -12,7 +12,7 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     logs
-    ocaml_sqlite3
+    sqlite3
     ocsipersist
   ];
 

--- a/pkgs/development/ocaml-modules/sqlite3/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3/default.nix
@@ -7,14 +7,13 @@
   dune-configurator,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "sqlite3";
   version = "5.4.2";
-  duneVersion = "3";
   minimalOCamlVersion = "4.12";
 
   src = fetchurl {
-    url = "https://github.com/mmottl/sqlite3-ocaml/releases/download/${version}/sqlite3-${version}.tbz";
+    url = "https://github.com/mmottl/sqlite3-ocaml/releases/download/${finalAttrs.version}/sqlite3-${finalAttrs.version}.tbz";
     hash = "sha256-MvaPB49L6u1R68J5/vRhRSBf2Yz2x5/pVSGGAfICYhw=";
   };
 
@@ -32,4 +31,4 @@ buildDunePackage rec {
       vbgl
     ];
   };
-}
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1513,8 +1513,6 @@ let
 
         ocaml-sat-solvers = callPackage ../development/ocaml-modules/ocaml-sat-solvers { };
 
-        ocaml_sqlite3 = callPackage ../development/ocaml-modules/sqlite3 { };
-
         ocaml-syntax-shims = callPackage ../development/ocaml-modules/ocaml-syntax-shims { };
 
         ocaml-version = callPackage ../development/ocaml-modules/ocaml-version { };
@@ -2063,6 +2061,8 @@ let
 
         spices = callPackage ../development/ocaml-modules/spices { };
 
+        sqlite3 = callPackage ../development/ocaml-modules/sqlite3 { };
+
         srt = callPackage ../development/ocaml-modules/srt {
           inherit (pkgs) srt;
         };
@@ -2382,6 +2382,7 @@ let
         ocaml-vdom = throw "2023-10-09: ocamlPackages.ocaml-vdom was renamed to ocamlPackages.vdom";
         ocaml_lwt = throw "ocamlPackages.ocaml_lwt has been renamed to ocamlPackages.lwt"; # Added 2025-12-05
         ocaml_mysql = throw "ocamlPackages.ocaml_mysql is not maintained, use ocamlPackages.mariadb instead";
+        ocaml_sqlite3 = sqlite3; # Added 2026-08-21
         ocamlfuse = throw "ocamlPackages.ocamlfuse has been removed as it depends on fuse2";
         ocamlgraph_gtk = throw "ocamlPackages.ocamlgraph_gtk has been removed as it depends onlibgnomecanvas, which has been removed from Nixpkgs. Consider using ocamlPackages.ocamlgraph instead."; # Added 2026-07-23
         torch = throw "ocamlPackages.torch has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05


### PR DESCRIPTION
Fix the path to this derivation which is currently incorrect & use the `finalAttrs` pattern.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
