### PR TITLE
python3Packages.triton-bin: 3.7.0 -> 3.7.1; python3Packages.torch-bin: 2.12.0 -> 2.12.1

### DIFF
--- a/pkgs/development/python-modules/torch/bin/binary-hashes.nix
+++ b/pkgs/development/python-modules/torch/bin/binary-hashes.nix
@@ -7,81 +7,81 @@
 
 version:
 builtins.getAttr version {
-  "2.12.0" = {
+  "2.12.1" = {
     x86_64-linux-310 = {
-      name = "torch-2.12.0+cu130-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
-      hash = "sha256-hFoXKaUq7HZh0bbauuiBXrFNurXHxnpf4LrxlKr6Ef4=";
+      name = "torch-2.12.1+cu130-cp310-cp310-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
+      hash = "sha256-9/WsBh92dJF8rLqUIfChXo3zUQV/kBMs1GzMup36dyE=";
     };
     x86_64-linux-311 = {
-      name = "torch-2.12.0+cu130-cp311-cp311-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
-      hash = "sha256-UDjwnuFhM5pSFF0Ab2BfYM6qc1Yn4uNRuTQZy6YGlsM=";
+      name = "torch-2.12.1+cu130-cp311-cp311-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
+      hash = "sha256-YjXzogtglMfoiCxlqGp/PG6MOsjb7AtX5XWTfQFm7Q8=";
     };
     x86_64-linux-312 = {
-      name = "torch-2.12.0+cu130-cp312-cp312-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
-      hash = "sha256-n1EupRwXCnzBoEh8CPAVS3je+6TrhhnK0BMMhhXthSY=";
+      name = "torch-2.12.1+cu130-cp312-cp312-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+      hash = "sha256-S6/DVvu2IuJ1YXlAaCXDpWwXtAEZZDWhSHxbQMZXcGw=";
     };
     x86_64-linux-313 = {
-      name = "torch-2.12.0+cu130-cp313-cp313-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
-      hash = "sha256-/l/vt4SjcNG6SVneboe807NUQQQKmb/+MvXNA7vINMA=";
+      name = "torch-2.12.1+cu130-cp313-cp313-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
+      hash = "sha256-1eGEBELSGClXs9L3eMwyXJD6XLQqqLGslJ8CnpvdfwY=";
     };
     x86_64-linux-314 = {
-      name = "torch-2.12.0+cu130-cp314-cp314-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
-      hash = "sha256-P/c2b2kZIy8JnvcCw+vTUJyRqzfDZ+QIyzeZxr7SFKQ=";
+      name = "torch-2.12.1+cu130-cp314-cp314-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
+      hash = "sha256-yExZiLPkFmae03kNdyR5r1k00XiBGSiNi93ZxMsgcoU=";
     };
     aarch64-darwin-310 = {
-      name = "torch-2.12.0-cp310-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0-cp310-cp310-macosx_14_0_arm64.whl";
-      hash = "sha256-GDS9mE+KL08WvfvuzKkUYYSyIKpGJ2v1dWc1tdrhKBI=";
+      name = "torch-2.12.1-cp310-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp310-cp310-macosx_14_0_arm64.whl";
+      hash = "sha256-7FboK+aosMA2dxp399Mq08KZdwVxr5gVs9r+YUNDidU=";
     };
     aarch64-darwin-311 = {
-      name = "torch-2.12.0-cp311-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl";
-      hash = "sha256-EIAv04O7/tZGIS52WnLDfSGFIF1PJusZeiVOisfdyyU=";
+      name = "torch-2.12.1-cp311-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp311-cp311-macosx_14_0_arm64.whl";
+      hash = "sha256-74H1A5Eu/+os49mxKi46btSIlD6RJxyQx6gp9guvaqI=";
     };
     aarch64-darwin-312 = {
-      name = "torch-2.12.0-cp312-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl";
-      hash = "sha256-tBM535PUkUNeeQ/4vLrhwM53cXWIm/0SgdEZhieT5qI=";
+      name = "torch-2.12.1-cp312-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp312-cp312-macosx_14_0_arm64.whl";
+      hash = "sha256-0t0PLF98y92vNMreDer0doCDaPkCuc2382oqtCMBvA4=";
     };
     aarch64-darwin-313 = {
-      name = "torch-2.12.0-cp313-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl";
-      hash = "sha256-kN1Yel9hv+EwcUi1geIIT8W8SgbiuQog6aNrgQh/8Ws=";
+      name = "torch-2.12.1-cp313-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl";
+      hash = "sha256-x16TFzxwC8zWv8xKnRnOJCq22s0fF4FIMCehYjm55lA=";
     };
     aarch64-darwin-314 = {
-      name = "torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl";
-      hash = "sha256-99+uSlGRl9+gUOmNjjY3ig+1iZYlqHXCtURFAFouQE4=";
+      name = "torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl";
+      hash = "sha256-6bb30t1m6oejrmIAadMTNdWUwG7/saODvdIc/mHkTs4=";
     };
     aarch64-linux-310 = {
-      name = "torch-2.12.0+cpu-cp310-cp310-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
-      hash = "sha256-x0pEmtf5e4eXNLWk8QkqkbF4DizVJew2nCn9mHfvc8A=";
+      name = "torch-2.12.1+cpu-cp310-cp310-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
+      hash = "sha256-k7jOs2ieNKkkZdTKx9COZd/PSdENbUfRXbXzkXuqEVI=";
     };
     aarch64-linux-311 = {
-      name = "torch-2.12.0+cpu-cp311-cp311-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
-      hash = "sha256-Ts2OzbnqGv+l810QUBgJ1i3HE/feljXoCY52DdvrhSw=";
+      name = "torch-2.12.1+cpu-cp311-cp311-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
+      hash = "sha256-bRth5TosAA4eXMSfyIrrxmW98CxjkQwkMRbTldfLwWQ=";
     };
     aarch64-linux-312 = {
-      name = "torch-2.12.0+cpu-cp312-cp312-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
-      hash = "sha256-zi3biAsIE/zJGnN/CP3Zc6gRWnTGTMs06cCaeWS01Eg=";
+      name = "torch-2.12.1+cpu-cp312-cp312-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
+      hash = "sha256-0WILx7z4CH8+SIIbXbmUoD4y3bCD1YwAC44DL4puLRU=";
     };
     aarch64-linux-313 = {
-      name = "torch-2.12.0+cpu-cp313-cp313-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
-      hash = "sha256-aLfd1NtGA6A+EG50xwmMjYyJQ9M8HlraAJykzYhXWcM=";
+      name = "torch-2.12.1+cpu-cp313-cp313-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
+      hash = "sha256-jUfgz8WWedTjZ2RsPfTPQzx9FZWzEwfg57I5HFjKIWA=";
     };
     aarch64-linux-314 = {
-      name = "torch-2.12.0+cpu-cp314-cp314-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
-      hash = "sha256-eXwGY2d5LJLrl8r7p/0Mqo10VeYHik7ogGMAdzeNw3I=";
+      name = "torch-2.12.1+cpu-cp314-cp314-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
+      hash = "sha256-G5rXDQowDWvYg//8FTpsD5vGS/QZBRmu7tA3OAe/+8w=";
     };
   };
 }

--- a/pkgs/development/python-modules/torch/bin/default.nix
+++ b/pkgs/development/python-modules/torch/bin/default.nix
@@ -38,7 +38,7 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "2.12.0";
+  version = "2.12.1";
 in
 buildPythonPackage {
   inherit version;

--- a/pkgs/development/python-modules/torchvision/bin.nix
+++ b/pkgs/development/python-modules/torchvision/bin.nix
@@ -22,7 +22,7 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "0.27.0";
+  version = "0.27.1";
 in
 buildPythonPackage {
   inherit version;

--- a/pkgs/development/python-modules/torchvision/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchvision/binary-hashes.nix
@@ -7,81 +7,81 @@
 
 version:
 builtins.getAttr version {
-  "0.27.0" = {
+  "0.27.1" = {
     x86_64-linux-310 = {
-      name = "torchvision-0.27.0-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
-      hash = "sha256-Xs5N8/Jq7zmBicaHP5vpW7FUhu8GTElx0WHhpkcMVqI=";
+      name = "torchvision-0.27.1-cp310-cp310-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
+      hash = "sha256-RtNxOnPEU70t8DM0DAWkz0Rh1v25IUMm6GAJGDT9oMo=";
     };
     x86_64-linux-311 = {
-      name = "torchvision-0.27.0-cp311-cp311-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
-      hash = "sha256-+QI3OY77jOcAG4DhhwySGzo3XZHIkrqLRkFfgIWjcR0=";
+      name = "torchvision-0.27.1-cp311-cp311-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
+      hash = "sha256-VRS3+oog7QcwEHsQi/Lpb8iIEOsIMJRua7U9aF4SnU4=";
     };
     x86_64-linux-312 = {
-      name = "torchvision-0.27.0-cp312-cp312-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
-      hash = "sha256-Zk3/RvrJenMMkKl2o3CuLK1SeA32rkD610vnfu6LRSg=";
+      name = "torchvision-0.27.1-cp312-cp312-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+      hash = "sha256-q7/HJFl8FtoXcAKhaXmqjETEiYyXvLcxtkfMV1B/V3I=";
     };
     x86_64-linux-313 = {
-      name = "torchvision-0.27.0-cp313-cp313-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
-      hash = "sha256-r6QSjzcGa4OvnUJoQaUxR908II7+qJPJPcPrb6KvIoc=";
+      name = "torchvision-0.27.1-cp313-cp313-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
+      hash = "sha256-+fAI1LGy8BPq977Bqf8iEmNYHXdmjU4eDpw+01HVZGU=";
     };
     x86_64-linux-314 = {
-      name = "torchvision-0.27.0-cp314-cp314-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
-      hash = "sha256-dMLjPv/NrSV4AMF4+H8iz/MR7+cDdWiz/q57Thkc4gk=";
+      name = "torchvision-0.27.1-cp314-cp314-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
+      hash = "sha256-xS179F2vZqghkWYOf4VSB0bCca097xQXzngnlnT+Q6A=";
     };
     aarch64-darwin-310 = {
-      name = "torchvision-0.27.0-cp310-cp310-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0-cp310-cp310-macosx_14_0_arm64.whl";
-      hash = "sha256-CCK1jSxdMlzQxxUrdErL0V+JjAdXLiz7cLB1qGWk9vk=";
+      name = "torchvision-0.27.1-cp310-cp310-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp310-cp310-macosx_14_0_arm64.whl";
+      hash = "sha256-aLpjtIr5LwbbmVrbI9hBGZPbod7nBaTpJBG4OgCTC38=";
     };
     aarch64-darwin-311 = {
-      name = "torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl";
-      hash = "sha256-3wwWa2vffEf4joHotDvAhUUdXFDQxdFpG8R0wSJ9b+0=";
+      name = "torchvision-0.27.1-cp311-cp311-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp311-cp311-macosx_14_0_arm64.whl";
+      hash = "sha256-rYdDqcEsjBJK0KFJHlTDygx0npHjdOPZITYGCyLJ4PQ=";
     };
     aarch64-darwin-312 = {
-      name = "torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl";
-      hash = "sha256-Gm3XQqFQZFEm354LLkSYdMHWNYl8dzsyLC4Gfpg4Lf4=";
+      name = "torchvision-0.27.1-cp312-cp312-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp312-cp312-macosx_14_0_arm64.whl";
+      hash = "sha256-RIq/w7q6mE2kV39zcgnkRdpr6T47X0eZ2QFiv2Hj9IU=";
     };
     aarch64-darwin-313 = {
-      name = "torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl";
-      hash = "sha256-Qdba5z4a8J+oLe1ZeuV/KiMUKFrN5UsliQqPjlG5mdc=";
+      name = "torchvision-0.27.1-cp313-cp313-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp313-cp313-macosx_14_0_arm64.whl";
+      hash = "sha256-1gMRptCN+QX5ZWo6MS8Kj1Xw1GMhvHN7rTCo3slkQwk=";
     };
     aarch64-darwin-314 = {
-      name = "torchvision-0.27.0-cp314-cp314-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0-cp314-cp314-macosx_14_0_arm64.whl";
-      hash = "sha256-wfrA/Cp63ylIH8GTig54RcV7oRR6mGeEEJxNmPQ06ow=";
+      name = "torchvision-0.27.1-cp314-cp314-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp314-cp314-macosx_14_0_arm64.whl";
+      hash = "sha256-n171mtYOaVeW7Ka2TpfLmyG51UY8rFrA74bPtytuXbk=";
     };
     aarch64-linux-310 = {
-      name = "torchvision-0.27.0-cp310-cp310-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
-      hash = "sha256-J5oFamQ29p92dnWx8dgrZ+ysoboYcbEc4K9HRKMkqiI=";
+      name = "torchvision-0.27.1-cp310-cp310-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
+      hash = "sha256-MyPtuQDKRtKduiZ+6AnlX+X+Cc09n1QSSnxe0zpqLb4=";
     };
     aarch64-linux-311 = {
-      name = "torchvision-0.27.0-cp311-cp311-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
-      hash = "sha256-mdBdBx/zQwUzTuGFT17ffCdnuWuln+kudthKH6csjgY=";
+      name = "torchvision-0.27.1-cp311-cp311-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
+      hash = "sha256-P6NBdGcak08Wb5UnrLd4ctjKFs1ewh76o4VkYDPgUG4=";
     };
     aarch64-linux-312 = {
-      name = "torchvision-0.27.0-cp312-cp312-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
-      hash = "sha256-Gwb0LUi2IJgRSSPYo/6fqGQYJxXbBlhKUVFV2wqo6zA=";
+      name = "torchvision-0.27.1-cp312-cp312-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
+      hash = "sha256-Y3g4M4sGCC8h/T9A1Lxw+H+MtcQXUwx06J2COVKAS8c=";
     };
     aarch64-linux-313 = {
-      name = "torchvision-0.27.0-cp313-cp313-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
-      hash = "sha256-aQk7ZLJ2LEPfF74tsr4WMCmWPZC8PxgBUA/etyPlSDM=";
+      name = "torchvision-0.27.1-cp313-cp313-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
+      hash = "sha256-fV0JoOmEQREdAm6pJMIC43UtYkJbhLB2jZjAuwdHR/8=";
     };
     aarch64-linux-314 = {
-      name = "torchvision-0.27.0-cp314-cp314-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
-      hash = "sha256-x+PFZiJ4q11k0VDMF2lAYOnOWHW4c5CU2t8HpLpFuQ4=";
+      name = "torchvision-0.27.1-cp314-cp314-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
+      hash = "sha256-KQ67FCiA38qh/uw7RI3NPHBMLwORIyoe7Z7/XqXGWzU=";
     };
   };
 }

--- a/pkgs/development/python-modules/triton/bin.nix
+++ b/pkgs/development/python-modules/triton/bin.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "triton";
-  version = "3.7.0";
+  version = "3.7.1";
   format = "wheel";
   __structuredAttrs = true;
 

--- a/pkgs/development/python-modules/triton/binary-hashes.nix
+++ b/pkgs/development/python-modules/triton/binary-hashes.nix
@@ -7,56 +7,56 @@
 
 version:
 builtins.getAttr version {
-  "3.7.0" = {
+  "3.7.1" = {
     x86_64-linux-310 = {
-      name = "triton-3.7.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      hash = "sha256-DWfwgNzCW+9f7WkqkbeI8Drq6pSJq9JTXhgrETBofzA=";
+      name = "triton-3.7.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      hash = "sha256-PWKx3zWPSfzCKdW3fno0bWapPpPBn2hyk26tupqsXwE=";
     };
     x86_64-linux-311 = {
-      name = "triton-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      hash = "sha256-PBIlPvbItqSqBDO/PibdYt/eF41OcoDD3PRodajhyN4=";
+      name = "triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      hash = "sha256-QQ03hrLc8e95IEZnB4fcdCuo+ADPLG3d9W4GVvImDbY=";
     };
     x86_64-linux-312 = {
-      name = "triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      hash = "sha256-H3DCuStFoa2Xj5zASHL+wLosg4v7l1wfY2nUzk2D9U4=";
+      name = "triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      hash = "sha256-IlkQ55FJgH3nSgymMWCqKFlWqNZKKVHVWJl8V+JYSuE=";
     };
     x86_64-linux-313 = {
-      name = "triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      hash = "sha256-0BA4KB83Yz8GFC8dTazEh+pNRRsC6zPt/edY0TZii6I=";
+      name = "triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      hash = "sha256-WWiLm5JPiHMW3ND66ejL5pfuHR9qs4ZyOYLMns3r7gE=";
     };
     x86_64-linux-314 = {
-      name = "triton-3.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
-      hash = "sha256-lrEJlBySIGSt4Nc4Ni4DqTB57H5IMjL2/bqAO3YCFMw=";
+      name = "triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      hash = "sha256-xWy4EDSdNpkCC1t2lUKbm5l1dNqxufRrK2P6I9eVSJQ=";
     };
     aarch64-linux-310 = {
-      name = "triton-3.7.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      hash = "sha256-2sAV6VWrDzCKoSqaFb4jI0LknH5nvtv0lhLAZQA3gNg=";
+      name = "triton-3.7.1-cp310-cp310-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp310-cp310-linux_aarch64.whl";
+      hash = "sha256-fwLYlMF26bgDI8RnkEnLEiGYkAJ1UBlFUFSKBMcLXC4=";
     };
     aarch64-linux-311 = {
-      name = "triton-3.7.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      hash = "sha256-544DgwVnCFaytHMUJpTE48W2idvyxCX7ELya2kRTqAA=";
+      name = "triton-3.7.1-cp311-cp311-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp311-cp311-linux_aarch64.whl";
+      hash = "sha256-4EtCUt28vG1PUYuz6z1Yay531A7TKAHZp1EW2NbBFps=";
     };
     aarch64-linux-312 = {
-      name = "triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      hash = "sha256-FDX2q4g0OXa9S3WmGNIFRJIkr0nxnIV0gqi7fN3/hIE=";
+      name = "triton-3.7.1-cp312-cp312-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp312-cp312-linux_aarch64.whl";
+      hash = "sha256-HwRqjSYV44mxuOik0QCgPzyx30vBoQemtnixhkQ7ssk=";
     };
     aarch64-linux-313 = {
-      name = "triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      hash = "sha256-m4KV9sctz4QNP0ysJcGy/0gu8enq0jQVtI/C2Dc6Fw0=";
+      name = "triton-3.7.1-cp313-cp313-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp313-cp313-linux_aarch64.whl";
+      hash = "sha256-NIlNUa/xq/ewF/vQxen+chEwXDWZFX/KJR4/QryPAM8=";
     };
     aarch64-linux-314 = {
-      name = "triton-3.7.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/triton-3.7.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl";
-      hash = "sha256-Zo7ZiY+ZmzY79dep1ZUWzkH41di/D0p3cNLufdD57HE=";
+      name = "triton-3.7.1-cp314-cp314-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/triton-3.7.1-cp314-cp314-linux_aarch64.whl";
+      hash = "sha256-8JH+hQZXlxxxkfeqW8kDdmmtBF2p036rx1GSatu0Vt4=";
     };
   };
 }

--- a/pkgs/development/python-modules/triton/prefetch.sh
+++ b/pkgs/development/python-modules/triton/prefetch.sh
@@ -13,11 +13,11 @@ url_and_key_list=(
   "x86_64-linux-312 $bucket/triton-${version}-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl triton-${version}-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
   "x86_64-linux-313 $bucket/triton-${version}-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl triton-${version}-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
   "x86_64-linux-314 $bucket/triton-${version}-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl triton-${version}-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-  "aarch64-linux-310 $bucket/triton-${version}-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl triton-${version}-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
-  "aarch64-linux-311 $bucket/triton-${version}-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl triton-${version}-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
-  "aarch64-linux-312 $bucket/triton-${version}-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl triton-${version}-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
-  "aarch64-linux-313 $bucket/triton-${version}-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl triton-${version}-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
-  "aarch64-linux-314 $bucket/triton-${version}-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl triton-${version}-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
+  "aarch64-linux-310 $bucket/triton-${version}-cp310-cp310-linux_aarch64.whl triton-${version}-cp310-cp310-linux_aarch64.whl"
+  "aarch64-linux-311 $bucket/triton-${version}-cp311-cp311-linux_aarch64.whl triton-${version}-cp311-cp311-linux_aarch64.whl"
+  "aarch64-linux-312 $bucket/triton-${version}-cp312-cp312-linux_aarch64.whl triton-${version}-cp312-cp312-linux_aarch64.whl"
+  "aarch64-linux-313 $bucket/triton-${version}-cp313-cp313-linux_aarch64.whl triton-${version}-cp313-cp313-linux_aarch64.whl"
+  "aarch64-linux-314 $bucket/triton-${version}-cp314-cp314-linux_aarch64.whl triton-${version}-cp314-cp314-linux_aarch64.whl"
 )
 
 hashfile="binary-hashes-$version.nix"


### PR DESCRIPTION
## Things done

- **python3Packages.triton-bin: 3.7.0 -> 3.7.1** ([Changelog](https://github.com/triton-lang/triton/releases/tag/v3.7.1), [Diff](https://github.com/triton-lang/triton/compare/v3.7.0...v3.7.1))
- **python3Packages.torch-bin: 2.12.0 -> 2.12.1** ([Changelog](https://github.com/pytorch/pytorch/releases/tag/v2.12.1), [Diff](https://github.com/pytorch/pytorch/compare/v2.12.0...v2.12.1))
- **python3Packages.torchvision-bin: 0.27.0 -> 0.27.1** ([Changelog](https://github.com/pytorch/vision/releases/tag/v0.27.0), [Diff](https://github.com/pytorch/vision/compare/v0.27.0...v0.27.1))

cc @nixos/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
