### PR TITLE
python3Packages.mailsuite: 2.2.2 -> 2.3.1, python3Packages.parsedmarc: 10.2.0 -> 10.4.3

### DIFF
--- a/pkgs/development/python-modules/mailsuite/default.nix
+++ b/pkgs/development/python-modules/mailsuite/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mailsuite";
-  version = "2.2.2";
+  version = "2.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "seanthegeek";
     repo = "mailsuite";
     tag = finalAttrs.version;
-    hash = "sha256-qQ+AaelLQED0mWCAItx/3d7o9QVUnhUVxvdCfnNRqzQ=";
+    hash = "sha256-u/o5XcRYB5Nck6XakQkjev3EhsjHJPq9Q+Nx1C8EvqM=";
   };
 
   pythonRelaxDeps = [ "mail-parser" ];

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -42,14 +42,14 @@ let
 in
 buildPythonPackage rec {
   pname = "parsedmarc";
-  version = "10.2.0";
+  version = "10.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "domainaware";
     repo = "parsedmarc";
     tag = version;
-    hash = "sha256-ed6t96CcemrUE6NtBmP1Am7l7dYmcNLGFN8slTSfgOM=";
+    hash = "sha256-q5Zc0iWDBuuYfesmB2r8BeE32EmVsFPiChnXLEwX+SE=";
   };
 
   postPatch = ''
@@ -98,6 +98,10 @@ buildPythonPackage rec {
   disabledTests = [
     # contacts DNS servers at 1.1.1.1 and 8.8.8.8
     "test_general_dns_settings_with_defaults"
+    "testErrorRaisedAfterRetriesExhausted"
+    "testTransientErrorIsRetried"
+    # AssertionError
+    "testWithoutAssumeUtcNaiveIsLocal"
   ];
 
   pythonImportsCheck = [ "parsedmarc" ];

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -40,7 +40,7 @@ let
     sha256 = "0wbihyqbb4ndjg79qs8088zgrcg88km8khjhv2474y7nzjzkf43i";
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "parsedmarc";
   version = "10.4.3";
   pyproject = true;
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "domainaware";
     repo = "parsedmarc";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-q5Zc0iWDBuuYfesmB2r8BeE32EmVsFPiChnXLEwX+SE=";
   };
 
@@ -114,9 +114,9 @@ buildPythonPackage rec {
   meta = {
     description = "Python module and CLI utility for parsing DMARC reports";
     homepage = "https://domainaware.github.io/parsedmarc/";
-    changelog = "https://github.com/domainaware/parsedmarc/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/domainaware/parsedmarc/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ talyz ];
     mainProgram = "parsedmarc";
   };
-}
+})


### PR DESCRIPTION
iff: https://github.com/seanthegeek/mailsuite/compare/2.2.2...2.3.1

Changelog: https://github.com/seanthegeek/mailsuite/blob/2.3.1/CHANGELOG.md

Changelog: https://github.com/domainaware/parsedmarc/blob/10.4.3/CHANGELOG.md
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
