### PR TITLE
nixos/containers: fixup 21e032ff9522

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -526,7 +526,7 @@ let
 
   # Parses an IP address with an optional prefix
   ipFromString =
-    str:
+    str: defaultPrefix:
     let
       segments = lib.splitString "/" str;
       prefix = lib.elemAt segments 1;
@@ -534,7 +534,7 @@ let
     in
     {
       address = lib.head segments;
-      prefixLength = if hasPrefix then builtins.fromJSON prefix else 32;
+      prefixLength = if hasPrefix then builtins.fromJSON prefix else defaultPrefix;
     };
 
 in
@@ -610,10 +610,10 @@ in
                                 networking.interfaces = lib.mkIf config.privateNetwork (
                                   lib.mkMerge [
                                     (lib.mkIf (config.localAddress != null) {
-                                      eth0.ipv4.addresses = [ (ipFromString config.localAddress) ];
+                                      eth0.ipv4.addresses = [ (ipFromString config.localAddress 32) ];
                                     })
                                     (lib.mkIf (config.localAddress6 != null) {
-                                      eth0.ipv6.addresses = [ (ipFromString config.localAddress6) ];
+                                      eth0.ipv6.addresses = [ (ipFromString config.localAddress6 128) ];
                                     })
                                   ]
                                 );


### PR DESCRIPTION
Fixup of https://github.com/NixOS/nixpkgs/pull/536638.
The default prefix length should be 128 for IPv6.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`nixosTests.containers-*`)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
