### PR TITLE
nixos/terraform-backend: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -100,6 +100,8 @@
 
 - [kvrocks_exporter](https://github.com/RocksLabs/kvrocks_exporter), a Prometheus exporter for Kvrocks metrics. Available as [services.prometheus.exporters.kvrocks](#opt-services.prometheus.exporters.kvrocks.enable).
 
+- [terraform-backend](https://github.com/nimbolus/terraform-backend), a Terraform/OpenTofu HTTP state backend with pluggable authentication, storage, locking and state encryption. Available as [services.terraform-backend](#opt-services.terraform-backend.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -634,6 +634,7 @@
   ./services/development/lorri.nix
   ./services/development/nixseparatedebuginfod2.nix
   ./services/development/rstudio-server/default.nix
+  ./services/development/terraform-backend.nix
   ./services/development/turborepo-remote-cache.nix
   ./services/development/vsmartcard-vpcd.nix
   ./services/development/zammad.nix

--- a/nixos/modules/services/development/terraform-backend.nix
+++ b/nixos/modules/services/development/terraform-backend.nix
@@ -1,0 +1,211 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.terraform-backend;
+in
+{
+  options.services.terraform-backend = {
+    enable = lib.mkEnableOption "terraform-backend, a Terraform/OpenTofu HTTP state backend";
+
+    package = lib.mkPackageOption pkgs "terraform-backend" { };
+
+    kmsKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/terraform-backend-kms-key";
+      description = ''
+        Path to the key used by the `local` KMS backend to encrypt state at rest.
+
+        The file must contain the base64 encoding of 16, 24 or 32 raw bytes, with no
+        trailing newline, as produced by `openssl rand -base64 32 | tr -d '\n'`.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/terraform-backend.env";
+      description = ''
+        Path of a file with additional environment variables, as defined in
+        {manpage}`systemd.exec(5)`.
+
+        This file is not added to the Nix store, so it is the place for the remaining
+        secrets, such as {env}`STORAGE_S3_SECRET_KEY`, {env}`POSTGRES_CONNECTION`,
+        {env}`REDIS_PASSWORD` and {env}`VAULT_TOKEN`.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Open the port of [](#opt-services.terraform-backend.settings) `LISTEN_ADDR` in
+        the firewall. The metrics listener is left closed.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf (
+          lib.types.nullOr (
+            lib.types.oneOf [
+              lib.types.bool
+              lib.types.int
+              lib.types.str
+            ]
+          )
+        );
+        options = {
+          LISTEN_ADDR = lib.mkOption {
+            type = lib.types.str;
+            default = ":8080";
+            example = "127.0.0.1:8080";
+            description = ''
+              Address to serve the state API (`/state/{project}/{name}`) and `/health` on.
+            '';
+          };
+
+          METRICS_LISTEN_ADDR = lib.mkOption {
+            type = lib.types.str;
+            default = ":8081";
+            example = "127.0.0.1:8081";
+            description = ''
+              Address to serve Prometheus metrics (`/metrics`) on. When it equals
+              `LISTEN_ADDR`, metrics are served by the main listener instead.
+            '';
+          };
+
+          STORAGE_FS_DIR = lib.mkOption {
+            type = lib.types.path;
+            default = "/var/lib/terraform-backend/states";
+            description = ''
+              Directory holding the encrypted state files, used by the `fs` storage
+              backend. It is created with mode 0700 on startup.
+            '';
+          };
+        };
+      };
+      default = { };
+      example = {
+        LOG_LEVEL = "debug";
+        STORAGE_BACKEND = "s3";
+        STORAGE_S3_BUCKET = "terraform-state";
+      };
+      description = ''
+        Environment variables configuring the backend. See
+        <https://github.com/nimbolus/terraform-backend#configuration> for the full list;
+        the backend is configured through environment variables only, there is no
+        configuration file.
+
+        Clients authenticate with HTTP basic auth, where the username selects the
+        authentication backend (`basic` or `jwt`). Note that the `basic` backend does not
+        restrict access: it namespaces state, deriving the state id from
+        `sha256("<password>:<project>/<name>")`, so a client presenting a different
+        password sees a different, initially empty state rather than being rejected.
+
+        Values set here end up in the world-readable Nix store, so secrets belong in
+        [](#opt-services.terraform-backend.kmsKeyFile) and
+        [](#opt-services.terraform-backend.environmentFile) instead.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          (cfg.settings.KMS_BACKEND or "local") != "local"
+          || cfg.kmsKeyFile != null
+          || cfg.environmentFile != null
+          || cfg.settings ? KMS_KEY_FILE
+          || cfg.settings ? KMS_KEY;
+        message = ''
+          services.terraform-backend: the `local` KMS backend needs a key, otherwise the
+          service exits at startup. Set services.terraform-backend.kmsKeyFile, or supply
+          KMS_KEY through services.terraform-backend.environmentFile.
+        '';
+      }
+    ];
+
+    warnings = lib.optional (cfg.settings ? KMS_KEY) ''
+      services.terraform-backend.settings.KMS_KEY puts the state encryption key in the
+      world-readable Nix store. Use services.terraform-backend.kmsKeyFile instead.
+    '';
+
+    services.terraform-backend.settings.KMS_KEY_FILE = lib.mkIf (cfg.kmsKeyFile != null) (
+      lib.mkDefault "%d/kms-key"
+    );
+
+    systemd.services.terraform-backend = {
+      description = "Terraform/OpenTofu HTTP state backend";
+      documentation = [ "https://github.com/nimbolus/terraform-backend" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        # Rendered here rather than through `environment` so that systemd expands the
+        # `%d` credentials-directory specifier in KMS_KEY_FILE.
+        Environment = lib.mapAttrsToList (
+          name: value: "${name}=${if lib.isBool value then lib.boolToString value else toString value}"
+        ) (lib.filterAttrs (_: value: value != null) cfg.settings);
+        ExecStart = lib.getExe cfg.package;
+        LoadCredential = lib.optional (cfg.kmsKeyFile != null) "kms-key:${cfg.kmsKeyFile}";
+        EnvironmentFile = cfg.environmentFile;
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        DynamicUser = true;
+        StateDirectory = "terraform-backend";
+        StateDirectoryMode = "0700";
+        UMask = "0077";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = [ "" ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        # AF_UNIX for a local PostgreSQL socket.
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+      };
+    };
+
+    networking.firewall.allowedTCPPorts =
+      let
+        port = lib.toInt (lib.last (lib.splitString ":" cfg.settings.LISTEN_ADDR));
+      in
+      lib.mkIf cfg.openFirewall [ port ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ kiara ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1773,6 +1773,7 @@ in
   teleports = runTest ./teleports.nix;
   temporal = runTest ./temporal.nix;
   terminal-emulators = handleTest ./terminal-emulators.nix { };
+  terraform-backend = runTest ./terraform-backend.nix;
   test-containers-bittorrent = runTest ./test-containers-bittorrent.nix;
   thanos = runTest ./thanos.nix;
   thelounge = handleTest ./thelounge.nix { };

--- a/nixos/tests/terraform-backend.nix
+++ b/nixos/tests/terraform-backend.nix
@@ -1,0 +1,111 @@
+{ lib, pkgs, ... }:
+let
+  kmsKey = pkgs.writeText "kms-key" "b/rbQCdWbzx+x0trNRVp3ZWZ1Ta1nWbLxeJQjVolxgU=";
+
+  stateUrl = "http://127.0.0.1:8080/state/testproject/main";
+
+  # The `basic` auth backend namespaces state by `sha256("<password>:<state id>")`, so
+  # the password decides which state a client sees.
+  tofuEnv =
+    password:
+    lib.concatStringsSep " " [
+      "HOME=/tmp"
+      "TF_IN_AUTOMATION=1"
+      "TF_HTTP_ADDRESS=${stateUrl}"
+      "TF_HTTP_LOCK_ADDRESS=${stateUrl}"
+      "TF_HTTP_UNLOCK_ADDRESS=${stateUrl}"
+      "TF_HTTP_USERNAME=basic"
+      "TF_HTTP_PASSWORD=${password}"
+    ];
+
+  ownerEnv = tofuEnv "correct-horse-battery-staple";
+  otherEnv = tofuEnv "some-other-password";
+
+  mainTf = pkgs.writeText "main.tf" ''
+    terraform {
+      required_providers {
+        random = {
+          source = "hashicorp/random"
+        }
+      }
+
+      backend "http" {}
+    }
+
+    resource "random_password" "test" {
+      length = 42
+    }
+
+    output "value" {
+      value     = random_password.test.result
+      sensitive = true
+    }
+  '';
+in
+{
+  name = "terraform-backend";
+  meta.maintainers = with lib.maintainers; [ kiara ];
+
+  nodes.machine = {
+    services.terraform-backend = {
+      enable = true;
+      kmsKeyFile = kmsKey;
+    };
+
+    environment.systemPackages = [
+      (pkgs.opentofu.withPlugins (p: [ p.hashicorp_random ]))
+      pkgs.curl
+    ];
+  };
+
+  testScript = ''
+    import json
+    import shlex
+
+    machine.wait_for_unit("terraform-backend.service")
+    machine.wait_for_open_port(8080)
+    machine.wait_for_open_port(8081)
+
+    with subtest("the key file survives the store unmodified"):
+        machine.succeed("test $(wc -c < ${kmsKey}) -eq 44")
+
+    with subtest("health and metrics endpoints respond"):
+        machine.succeed("curl --fail http://127.0.0.1:8080/health")
+        machine.succeed("curl --fail http://127.0.0.1:8081/metrics | grep tfbackend_backend_info")
+
+    with subtest("opentofu can write state through the backend"):
+        machine.succeed("mkdir -p /tmp/tf && cp ${mainTf} /tmp/tf/main.tf")
+        machine.succeed("cd /tmp/tf && env ${ownerEnv} tofu init -no-color")
+        machine.succeed("cd /tmp/tf && env ${ownerEnv} tofu apply -auto-approve -no-color")
+        secret = machine.succeed("cd /tmp/tf && env ${ownerEnv} tofu output -raw value").strip()
+        machine.succeed("ls -A /var/lib/terraform-backend/states | grep .")
+
+    with subtest("state is encrypted at rest"):
+        # Positive control first: without it, a quoting bug or a missing directory would
+        # make the negative check below pass for the wrong reason.
+        machine.succeed(f"printf '%s' {shlex.quote(secret)} > /tmp/expected")
+        machine.succeed(f"grep -F -- {shlex.quote(secret)} /tmp/expected")
+        machine.fail(
+            f"grep -r --text -F -- {shlex.quote(secret)} /var/lib/terraform-backend/states/"
+        )
+
+    with subtest("state can be read back into a fresh working directory"):
+        machine.succeed("mkdir -p /tmp/tf2 && cp ${mainTf} /tmp/tf2/main.tf")
+        machine.succeed("cd /tmp/tf2 && env ${ownerEnv} tofu init -no-color")
+        read_back = machine.succeed("cd /tmp/tf2 && env ${ownerEnv} tofu output -raw value").strip()
+        assert read_back == secret, f"read back {read_back!r}, expected {secret!r}"
+        # Positive control for the namespacing check below: `tofu output -json` reports
+        # the outputs of a state that has them, so an empty result there is meaningful.
+        owner_outputs = json.loads(machine.succeed("cd /tmp/tf2 && env ${ownerEnv} tofu output -json"))
+        assert list(owner_outputs) == ["value"], f"unexpected outputs {owner_outputs!r}"
+
+    with subtest("a different password sees a different, empty state"):
+        machine.succeed("mkdir -p /tmp/tf3 && cp ${mainTf} /tmp/tf3/main.tf")
+        machine.succeed("cd /tmp/tf3 && env ${otherEnv} tofu init -no-color")
+        other_outputs = json.loads(machine.succeed("cd /tmp/tf3 && env ${otherEnv} tofu output -json"))
+        assert other_outputs == {}, f"another password saw outputs {other_outputs!r}"
+
+    with subtest("state can be destroyed"):
+        machine.succeed("cd /tmp/tf && env ${ownerEnv} tofu destroy -auto-approve -no-color")
+  '';
+}

--- a/pkgs/by-name/te/terraform-backend/package.nix
+++ b/pkgs/by-name/te/terraform-backend/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -28,6 +29,10 @@ buildGoModule (finalAttrs: {
     cp "$GOPATH/bin/cmd" $out/bin/terraform-backend
     runHook postInstall
   '';
+
+  passthru.tests = {
+    nixos = nixosTests.terraform-backend;
+  };
 
   meta = {
     description = "State backend server which implements the Terraform HTTP backend API with pluggable modules for authentication, storage, locking and state encryption";


### PR DESCRIPTION
Adds a NixOS module for [`pkgs.terraform-backend`](https://github.com/nimbolus/terraform-backend).

Assisted-by: Claude:claude-opus-5

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. - `nix-build -A nixosTests.terraform-backend`
  - [x] [Package tests] at `passthru.tests`. - `nix-build -A terraform-backend.tests.nixos`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
