### PR TITLE
waybar-headsetcontrol: init at 0.1.5

### DIFF
--- a/pkgs/by-name/wa/waybar-headsetcontrol/package.nix
+++ b/pkgs/by-name/wa/waybar-headsetcontrol/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  headsetcontrol,
+  nix-update-script,
+  fetchpatch,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "waybar-headsetcontrol";
+  version = "0.1.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Henriklmao";
+    repo = "waybar-headsetcontrol";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-GX+/SizxFeyt3UoxKCSJgaqBl/7oD5KZAeXzP+UNX+M=";
+  };
+
+  # Next release will include Cargo.lock, so we can remove this once that happens
+  cargoPatches = [
+    (fetchpatch {
+      url = "https://github.com/Henriklmao/waybar-headsetcontrol/commit/523ebf9e440167b3206b0b36632095c1cee9810c.patch";
+      sha256 = "sha256-dXqlNW4vZLyEwzU0+hjq1ZdOzK1pTW1oAbnNZYRtyl8=";
+    })
+  ];
+
+  cargoHash = "sha256-FdRNBkjeFB3Pr72Jso99reh6pZkzIQ2DlcI7rzx9fJ4=";
+
+  patches = [
+    # update dependencies to match Cargo.lock, remove once next release is out
+    (fetchpatch {
+      url = "https://github.com/Henriklmao/waybar-headsetcontrol/commit/7e66e4bcfa0ff59cff639799751f8d5020e6b93d.patch";
+      sha256 = "sha256-j9MU6rfwHCEXUkXM9Cc9rekdxVhwea+LCudNNSZ1FQw=";
+    })
+  ];
+
+  postPatch = ''
+    # Use the nix store path for headsetcontrol instead of assuming it's in PATH
+    substituteInPlace src/main.rs \
+      --replace-fail \
+       'Command::new("headsetcontrol")' \
+       'Command::new("${headsetcontrol}/bin/headsetcontrol")'
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A simple Rust and ratatui based integration of HeadsetControl features into Waybar";
+    homepage = "https://github.com/Henriklmao/waybar-headsetcontrol";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "wb-headset";
+    maintainers = with lib.maintainers; [ joaosreis ];
+  };
+})


### PR DESCRIPTION
Adds `waybar-headsetcontrol`, a TUI based integration of HeadsetControl features into Waybar. Shows wireless headphone battery status with colored icons and provides an interactive TUI for sidetone control for HeadsetControl-supported devices.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
