### PR TITLE
adios2: 2.11.0 -> 2.12.1

### DIFF
--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   perl,
   cmake,
   ninja,
@@ -27,7 +26,6 @@
   yaml-cpp,
   nlohmann_json,
   openssl,
-  llvmPackages,
   gtest,
   ctestCheckHook,
   mpiCheckPhaseHook,
@@ -54,38 +52,20 @@ let
   };
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "2.11.0";
+  version = "2.12.1";
   pname = "adios2";
 
   src = fetchFromGitHub {
     owner = "ornladios";
     repo = "adios2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yHPI///17poiCEb7Luu5qfqxTWm9Nh+o9r57mZT26U0=";
+    hash = "sha256-3jMvVYYO93/Pu7RW2x5mzTRMrZ3oC3IwGrUz2tSqJxQ=";
   };
 
   postPatch = ''
     chmod +x cmake/install/post/adios2-config.pre.sh.in
     patchShebangs cmake/install/post/{generate-adios2-config,adios2-config.pre}.sh.in
   '';
-
-  # TODO: remove these patches when updating to > v2.11.x, which will already include these commits
-  patches = [
-    # use upstream GoogleTest.cmake
-    # see https://github.com/ornladios/ADIOS2/issues/4659
-    (fetchpatch2 {
-      name = "googletest-cmake-fix.patch";
-      url = "https://github.com/ornladios/ADIOS2/commit/20aab0f99d38dc4437b086edf6b44ecf4100ed76.patch?full_index=1";
-      hash = "sha256-CZD3QUATX0JI75Oip0LNwirWIwgQakWuCHs1fIjwzj0=";
-    })
-    # fix double import cmake conflict
-    # see https://github.com/ornladios/ADIOS2/issues/4760
-    (fetchpatch2 {
-      name = "cmake-target-guard-fix.patch";
-      url = "https://github.com/ornladios/ADIOS2/commit/23fd08a10b52a971150f93f99d341b83b8096e3d.patch?full_index=1";
-      hash = "sha256-+29a9JgiCv2kBz0uUT8Kn/Tf3KDD1JNPdzeb/DruTBo=";
-    })
-  ];
 
   nativeBuildInputs = [
     perl
@@ -96,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals pythonSupport [
     python3Packages.python
-    python3Packages.pybind11
+    python3Packages.nanobind
     python3Packages.pythonImportsCheckHook
   ];
 
@@ -145,6 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # declare thirdparty dependencies explicitly
     (lib.cmakeBool "ADIOS2_USE_EXTERNAL_DEPENDENCIES" true)
+    (lib.cmakeBool "ADIOS2_USE_EXTERNAL_PERFSTUBS" false)
     (lib.cmakeBool "ADIOS2_USE_Blosc2" true)
     (lib.cmakeBool "ADIOS2_USE_BZip2" true)
     (lib.cmakeBool "ADIOS2_USE_ZFP" (lib.meta.availableOn stdenv.hostPlatform zfp))
@@ -189,7 +170,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
     (lib.cmakeFeature "CMAKE_INSTALL_PYTHONDIR" python3Packages.python.sitePackages)
-  ];
+  ]
+  ++ lib.optional pythonSupport (
+    lib.cmakeFeature "nanobind_DIR" "${python3Packages.nanobind}/${python3Packages.python.sitePackages}/nanobind/cmake"
+  );
 
   # python binding libraries should be linked against installed libraries
   preInstall = lib.optionalString pythonSupport ''


### PR DESCRIPTION
Changelog: https://github.com/ornladios/ADIOS2/releases/tag/v2.12.1

Diff: https://github.com/ornladios/ADIOS2/compare/v2.11.0...v2.12.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
