### PR TITLE
ocamlPackages.bitstring: 4.1.1 → 5.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/bitstring/default.nix
+++ b/pkgs/development/ocaml-modules/bitstring/default.nix
@@ -1,21 +1,25 @@
 {
   lib,
   fetchFromGitHub,
+  ocaml,
   buildDunePackage,
   stdlib-shims,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "bitstring";
-  version = "4.1.1";
-
-  duneVersion = "3";
+  version = if lib.versionAtLeast ocaml.version "5.3" then "5.0.2" else "4.1.1";
 
   src = fetchFromGitHub {
     owner = "xguerin";
     repo = "bitstring";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-eO7/S9PoMybZPnQQ+q9qbqKpYO4Foc9OjW4uiwwNds8=";
+    tag = "v${finalAttrs.version}";
+    hash =
+      {
+        "5.0.2" = "sha256-MN16b37EM5NIZcvd59Y9Bd+YgcM62RdhrgCskd21tSg=";
+        "4.1.1" = "sha256-eO7/S9PoMybZPnQQ+q9qbqKpYO4Foc9OjW4uiwwNds8=";
+      }
+      ."${finalAttrs.version}";
   };
 
   propagatedBuildInputs = [ stdlib-shims ];

--- a/pkgs/development/ocaml-modules/bitstring/ppx.nix
+++ b/pkgs/development/ocaml-modules/bitstring/ppx.nix
@@ -1,8 +1,6 @@
 {
   lib,
   buildDunePackage,
-  fetchpatch,
-  ocaml,
   bitstring,
   ppxlib,
   ounit,
@@ -12,21 +10,15 @@ buildDunePackage {
   pname = "ppx_bitstring";
   inherit (bitstring) version src;
 
-  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
-    url = "https://github.com/xguerin/bitstring/commit/b42d4924cbb5ec5fd5309e6807852b63f456f35d.patch";
-    hash = "sha256-wtpSnGOzIUTmB3LhyHGopecy7F/5SYFOwaR6eReV+6g=";
-  });
-
   buildInputs = [
     bitstring
     ppxlib
   ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
   checkInputs = [ ounit ];
 
   meta = bitstring.meta // {
     description = "Bitstrings and bitstring matching for OCaml - PPX extension";
-    broken = lib.versionOlder ppxlib.version "0.18.0";
   };
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
