### PR TITLE
nixos/acme: retry a failed order instead of waiting for the daily timer

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -471,6 +471,9 @@ let
           // {
             Group = data.group;
 
+            # Retry on failure rather than leaving the self-signed fallback for a day
+            Restart = "on-failure";
+
             # Let's Encrypt Failed Validation Limit allows 5 retries per hour, per account, hostname and hour.
             # This avoids eating them all up if something is misconfigured upon the first try.
             RestartSec = 15 * 60;


### PR DESCRIPTION
Fixes #554998.

`acme-order-renew-<cert>.service` already carries `RestartSec = 15 * 60`, but lacking a `Restart`, that interval would not schedule, leaving just the self-signed fallback until fixed by the daily renew timer.

For what it's worth, `SuccessExitStatus` is unset, so both 10 and 11 count as failures and are retried. Users who prefer the old behaviour for a given cert can still set it, as the comment at the `exit 10` already suggests.

Assisted-by: Claude:claude-opus-5

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
