### PR TITLE
extism-js-core: move nodejs and npmConfigHook to depsBuildBuild

### DIFF
--- a/pkgs/by-name/ex/extism-js-core/package.nix
+++ b/pkgs/by-name/ex/extism-js-core/package.nix
@@ -49,11 +49,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wasm-opt --enable-reference-types --enable-bulk-memory --strip -O3 $out/bin/js_pdk_core.wasm -o $out/bin/js_pdk_core.wasm
   '';
 
+  depsBuildBuild = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
   nativeBuildInputs = [
     binaryen
     lld
-    nodejs
-    npmHooks.npmConfigHook
     rustPlatform.bindgenHook
   ];
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/552708#issuecomment-5368040167

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
