### PR TITLE
python3Packages.bap: fix version metadata

### DIFF
--- a/pkgs/development/python-modules/bap/default.nix
+++ b/pkgs/development/python-modules/bap/default.nix
@@ -21,6 +21,10 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-d9HST4AF5Jxycfbv/033GAtcU+Moqxf03VHhY1nNE6o=";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail '1.1.0' ${finalAttrs.version}
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [


### PR DESCRIPTION
This package currently fails to build with:

> The 'bap' derivation has version '1.3.1' but .dist-info/METADATA specifies version '1.1.0'.
> This usually means that the wrong version is hardcoded in pyproject.toml or setup.{py,cfg}.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
