### PR TITLE
mk-kde-derivation: make use of `lib.licensesSpdx` instead of custome map

### DIFF
--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -15,40 +15,35 @@ let
   projectInfo = lib.importJSON ../generated/projects.json;
 
   licenseInfo = lib.importJSON ../generated/licenses.json;
-  licensesBySpdxId =
-    (lib.mapAttrs' (_: v: {
-      name = v.spdxId or "unknown";
-      value = v;
-    }) lib.licenses)
-    // {
-      # https://community.kde.org/Policies/Licensing_Policy
-      "LicenseRef-KDE-Accepted-GPL" = lib.licenses.gpl3Plus;
-      "LicenseRef-KFQF-Accepted-GPL" = lib.licenses.gpl3Plus;
-      "LicenseRef-KDE-Accepted-LGPL" = lib.licenses.lgpl3Plus;
+  licensesBySpdxId = lib.licensesSpdx // {
+    # https://community.kde.org/Policies/Licensing_Policy
+    "LicenseRef-KDE-Accepted-GPL" = lib.licenses.gpl3Plus;
+    "LicenseRef-KFQF-Accepted-GPL" = lib.licenses.gpl3Plus;
+    "LicenseRef-KDE-Accepted-LGPL" = lib.licenses.lgpl3Plus;
 
-      # https://sjfonts.sourceforge.net/
-      "LicenseRef-SJFonts" = lib.licenses.gpl2Plus;
+    # https://sjfonts.sourceforge.net/
+    "LicenseRef-SJFonts" = lib.licenses.gpl2Plus;
 
-      # https://invent.kde.org/education/kiten/-/blob/master/LICENSES/LicenseRef-EDRDG.txt
-      "LicenseRef-EDRDG" = lib.licenses.cc-by-sa-30;
+    # https://invent.kde.org/education/kiten/-/blob/master/LICENSES/LicenseRef-EDRDG.txt
+    "LicenseRef-EDRDG" = lib.licenses.cc-by-sa-30;
 
-      # https://invent.kde.org/kdevelop/kdevelop/-/blob/master/LICENSES/LicenseRef-MIT-KDevelop-Ideal.txt
-      "LicenseRef-MIT-KDevelop-Ideal" = lib.licenses.mit;
+    # https://invent.kde.org/kdevelop/kdevelop/-/blob/master/LICENSES/LicenseRef-MIT-KDevelop-Ideal.txt
+    "LicenseRef-MIT-KDevelop-Ideal" = lib.licenses.mit;
 
-      # FIXME: typo lol
-      "ICS" = lib.licenses.isc;
-      "BSD-3-Clauses" = lib.licenses.bsd3;
+    # FIXME: typo lol
+    "ICS" = lib.licenses.isc;
+    "BSD-3-Clauses" = lib.licenses.bsd3;
 
-      # These are only relevant to Qt commercial users
-      "Qt-Commercial-exception-1.0" = null;
-      "LicenseRef-Qt-Commercial" = null;
-      "LicenseRef-Qt-Commercial-exception-1.0" = null;
+    # These are only relevant to Qt commercial users
+    "Qt-Commercial-exception-1.0" = null;
+    "LicenseRef-Qt-Commercial" = null;
+    "LicenseRef-Qt-Commercial-exception-1.0" = null;
 
-      # FIXME: ???
-      "LicenseRef-Qt-LGPL-exception-1.0" = null;
-      "LicenseRef-Qt-exception" = null;
-      None = null;
-    };
+    # FIXME: ???
+    "LicenseRef-Qt-LGPL-exception-1.0" = null;
+    "LicenseRef-Qt-exception" = null;
+    None = null;
+  };
 
   moveOutputsHook = makeSetupHook {
     name = "kf6-move-outputs-hook";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
