### PR TITLE
portless: init at 0.15.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10788,6 +10788,12 @@
     githubId = 95086304;
     name = "Guilherme Lima";
   };
+  GuillaumeDesforges = {
+    email = "guillaume.desforges.pro@gmail.com";
+    github = "GuillaumeDesforges";
+    githubId = 1882000;
+    name = "Guillaume Desforges";
+  };
   guillaumekoenig = {
     email = "guillaume.edward.koenig@gmail.com";
     github = "guillaumekoenig";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -633,6 +633,7 @@
   ./services/development/livebook.nix
   ./services/development/lorri.nix
   ./services/development/nixseparatedebuginfod2.nix
+  ./services/development/portless.nix
   ./services/development/rstudio-server/default.nix
   ./services/development/turborepo-remote-cache.nix
   ./services/development/vsmartcard-vpcd.nix

--- a/nixos/modules/services/development/portless.nix
+++ b/nixos/modules/services/development/portless.nix
@@ -1,0 +1,103 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.portless;
+  # systemd StateDirectory = "portless" always resolves to /var/lib/portless
+  stateDir = "/var/lib/portless";
+in
+{
+  options.services.portless = {
+    enable = lib.mkEnableOption "portless, a local HTTPS reverse proxy for development";
+
+    package = lib.mkPackageOption pkgs "portless" { };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 443;
+      description = ''
+        Port for the HTTPS proxy to listen on.
+
+        Ports below 1024 require `CAP_NET_BIND_SERVICE`, which this module
+        grants automatically.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "portless";
+      description = "User account under which the portless daemon runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "portless";
+      description = ''
+        Group under which the portless daemon runs.
+
+        Add your user to this group to allow registering app routes with the
+        running proxy:
+
+        ```nix
+        users.users.yourname.extraGroups = [ "portless" ];
+        ```
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users = lib.mkIf (cfg.user == "portless") {
+      portless = {
+        isSystemUser = true;
+        group = cfg.group;
+        description = "Portless daemon user";
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "portless") {
+      portless = { };
+    };
+
+    # Expose the state directory so that `portless run` in user shells finds
+    # the running daemon without extra configuration.
+    environment.variables.PORTLESS_STATE_DIR = stateDir;
+
+    systemd.services.portless = {
+      description = "Portless local HTTPS reverse proxy";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+
+        # Creates /var/lib/portless owned by cfg.user:cfg.group.
+        # Mode 0770 allows group members (developers) to register routes.
+        StateDirectory = "portless";
+        StateDirectoryMode = "0770";
+
+        ExecStart = "${lib.getExe cfg.package} proxy start --foreground --port ${toString cfg.port}";
+
+        Environment = [
+          "PORTLESS_STATE_DIR=${stateDir}"
+          # portless falls back to $HOME/.portless; point HOME at the state
+          # directory so it never writes outside of it.
+          "HOME=${stateDir}"
+        ];
+
+        # Grant the capability to bind to privileged ports when needed.
+        AmbientCapabilities = lib.mkIf (cfg.port < 1024) [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = lib.mkIf (cfg.port < 1024) [ "CAP_NET_BIND_SERVICE" ];
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ GuillaumeDesforges ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1407,6 +1407,7 @@ in
   ] ./podman/tls-ghostunnel.nix { };
   polaris = runTest ./polaris.nix;
   pomerium = handleTestOn [ "x86_64-linux" ] ./pomerium.nix { };
+  portless = runTest ./portless.nix;
   portmaster = runTest ./portmaster.nix;
   portunus = runTest ./portunus.nix;
   porxie = runTest ./porxie.nix;

--- a/nixos/tests/portless.nix
+++ b/nixos/tests/portless.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+
+{
+  name = "portless";
+
+  meta.maintainers = with lib.maintainers; [ GuillaumeDesforges ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.portless = {
+        enable = true;
+        # Use a non-privileged port to avoid needing CAP_NET_BIND_SERVICE in
+        # the test VM, keeping the test focused on daemon behaviour.
+        port = 9443;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("portless.service")
+    machine.wait_for_open_port(9443)
+    machine.wait_until_succeeds("test -f /var/lib/portless/ca.pem", timeout=30)
+    machine.succeed("test -f /var/lib/portless/ca-key.pem")
+    machine.succeed("openssl x509 -in /var/lib/portless/ca.pem -noout -subject | grep -i 'portless'")
+  '';
+}

--- a/pkgs/by-name/po/portless/package.nix
+++ b/pkgs/by-name/po/portless/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  nodejs_24,
+  makeWrapper,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "portless";
+  version = "0.15.5";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/portless/-/portless-${finalAttrs.version}.tgz";
+    hash = "sha256-92+3+NOQ1uCDaiXg+VShBmVCjqzUxy83CMqix7UEPS4=";
+  };
+
+  # npm tarballs extract under a "package/" subdirectory
+  sourceRoot = "package";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/lib/portless" "$out/bin"
+    cp -r dist package.json "$out/lib/portless/"
+    makeWrapper "${lib.getExe nodejs_24}" "$out/bin/portless" \
+      --add-flags "$out/lib/portless/dist/cli.js"
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Replace port numbers with stable, named .localhost URLs for local development";
+    homepage = "https://portless.sh";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GuillaumeDesforges ];
+    platforms = lib.platforms.linux;
+    mainProgram = "portless";
+  };
+})


### PR DESCRIPTION
## Summary

- Adds `portless` package (`pkgs/by-name/po/portless/package.nix`)
- Adds `services.portless` NixOS module (`nixos/modules/services/development/portless.nix`)
- Adds a NixOS VM test

[portless](https://portless.sh) is a local HTTPS reverse proxy for development that replaces port numbers with stable `*.localhost` URLs, with automatic TLS via a local CA.

## Module design

The daemon runs as a dedicated `portless` system user. `CAP_NET_BIND_SERVICE` is granted automatically when `port < 1024` (the default is 443), so no interactive `sudo` prompt is needed.

`/var/lib/portless` is group-writable (`0770`) so developers added to the `portless` group can register app routes with the running proxy:

```nix
users.users.yourname.extraGroups = [ "portless" ];
```

`PORTLESS_STATE_DIR` is exported system-wide so `portless run` in user shells finds the daemon without extra configuration.

### CA trust

On first start, portless generates a local CA at `/var/lib/portless/ca.pem`. To trust it system-wide, add it to your configuration after the first service start:

```nix
security.pki.certificateFiles = [ /var/lib/portless/ca.pem ];
```

## Test

```
nix-build nixos/tests/portless.nix
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)