### PR TITLE
pythonPackages.prefect: 3.7.0 -> 3.8.3

### DIFF
--- a/pkgs/development/python-modules/prefect/default.nix
+++ b/pkgs/development/python-modules/prefect/default.nix
@@ -7,7 +7,6 @@
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
-  replaceVars,
   writableTmpDirAsHomeHook,
   writeShellScriptBin,
 
@@ -79,6 +78,7 @@
   semver,
   sniffio,
   sqlalchemy,
+  starlette,
   toml,
   typing-extensions,
   uv,
@@ -92,14 +92,17 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "prefect";
-  version = "3.7.0";
+  version = "3.8.3";
   pyproject = true;
+
+  # keeps list elements containing spaces intact, which disabledTests below needs
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "PrefectHQ";
     repo = "prefect";
     tag = finalAttrs.version;
-    hash = "sha256-AfiXH9u6W6UpE8hepNzPGIm1cxC+5RonhtBYWMu2IaQ=";
+    hash = "sha256-C20gFzsswVOVfJiz2UcDamUSSMbvm+KVIM115ZAzEyM=";
   };
 
   postPatch = ''
@@ -115,9 +118,11 @@ buildPythonPackage (finalAttrs: {
         '__development_base_path__: pathlib.Path = pathlib.Path("${finalAttrs.src}")'
   '';
 
-  # versioningit: NotVCSError: Git not installed; assuming this isn't a Git repository
   nativeBuildInputs = [
+    # versioningit: NotVCSError: Git not installed; assuming this isn't a Git repository
     (writeShellScriptBin "git" "false")
+    # prefect wants to create ~/.prefect on import, which pythonImportsCheck triggers
+    writableTmpDirAsHomeHook
   ];
 
   build-system = [
@@ -177,6 +182,7 @@ buildPythonPackage (finalAttrs: {
     ruamel-yaml-clib
     semver
     sniffio
+    starlette
     toml
     typing-extensions
     uvicorn
@@ -258,12 +264,15 @@ buildPythonPackage (finalAttrs: {
     ];
   };
 
-  passthru.tests = {
-    inherit (nixosTests) prefect;
+  passthru = {
+    tests = {
+      inherit (nixosTests) prefect;
+    };
 
+    # Upstream publishes every pre‐release (3.8.4.dev1, …) as a GitHub release,
+    # so restrict the updater to plain three‐component stable tags.
     updateScript = nix-update-script {
       extraArgs = [
-        # avoid pre‐releases
         "--version-regex"
         "^(\\d+\\.\\d+\\.\\d+)$"
       ];
@@ -271,6 +280,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   # FIXME: build killed at ~30%
+
   doCheck = false;
   nativeCheckInputs = [
     pytestCheckHook
@@ -295,6 +305,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Workflow orchestration framework for building resilient data pipelines in Python";
     homepage = "https://github.com/PrefectHQ/prefect";
+    changelog = "https://github.com/PrefectHQ/prefect/releases/tag/${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       happysalada


### PR DESCRIPTION
update prefect to latest stable


Mostly done for CVEs.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
