### PR TITLE
s-ecosystem: init at 1.0.0

### DIFF
--- a/pkgs/by-name/s-/s-ecosystem/package.nix
+++ b/pkgs/by-name/s-/s-ecosystem/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "s-ecosystem";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "hubbydenny";
+    repo = "S-ecosystem";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "g++" "${stdenv.cc}/bin/g++"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -Dm755 sfetch $out/bin/sfetch
+    install -Dm755 scat $out/bin/scat
+    install -Dm755 sls $out/bin/sls
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Shell utilities: sfetch, scat, sls";
+    homepage = "https://github.com/hubbydenny/S-ecosystem";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "sfetch";
+    maintainers = [ ];
+  };
+});


### PR DESCRIPTION
## New package: s-ecosystem 1.0.0

**s-ecosystem** — shell utilities suite:
- **sfetch**: system fetch with 20 distro logos, side-by-side layout, auto-detection
- **scat**: file concatenation utility
- **sls**: simple ls utility

Homepage: https://github.com/hubbydenny/S-ecosystem
License: GPL-3.0-or-later

> Note: `hash` is a placeholder and needs to be updated with the real hash via `nix-prefetch-github`.