### PR TITLE
sudo: update license

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -283,6 +283,12 @@ lib.mapAttrs mkLicense (
       fullName = "BSD 3-Clause Tso variant";
     };
 
+    bsdAskToEndorse = {
+      #spdxId = "BSD-ask-to-endorse"; # Accepted to SPDX waiting on next SPDX release
+      fullName = "BSD - ask to endorse";
+      url = "https://github.com/sudo-project/sudo/blob/c1307ea9ff340ce0538779f8e456501461fc44b7/plugins/sudoers/redblack.c#L24-L43";
+    };
+
     bsdAxisNoDisclaimerUnmodified = {
       fullName = "BSD-Axis without Warranty Disclaimer with Unmodified requirement";
       url = "https://scancode-licensedb.aboutcode.org/bsd-no-disclaimer-unmodified.html";

--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1481,12 +1481,6 @@ lib.mapAttrs mkLicense (
       fullName = "MIT-STK License";
     };
 
-    sudo = {
-      shortName = "sudo";
-      fullName = "Sudo License (ISC-style)";
-      url = "https://www.sudo.ws/about/license/";
-    };
-
     sustainableUse = {
       spdxId = "SUL-1.0";
       fullName = "Sustainable Use License";

--- a/pkgs/by-name/su/sudo/package.nix
+++ b/pkgs/by-name/su/sudo/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     license =
       with lib.licenses;
       AND [
-        sudo
+        isc
         bsdAskToEndorse
         bsd2
         bsd3

--- a/pkgs/by-name/su/sudo/package.nix
+++ b/pkgs/by-name/su/sudo/package.nix
@@ -106,12 +106,15 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://www.sudo.ws/";
     # From https://www.sudo.ws/about/license/
-    license = with lib.licenses; [
-      sudo
-      bsd2
-      bsd3
-      zlib
-    ];
+    license =
+      with lib.licenses;
+      AND [
+        sudo
+        bsdAskToEndorse
+        bsd2
+        bsd3
+        zlib
+      ];
     maintainers = with lib.maintainers; [ rhendric ];
     platforms = lib.platforms.linux ++ lib.platforms.freebsd ++ lib.platforms.openbsd;
     mainProgram = "sudo";


### PR DESCRIPTION
Went through the list at https://www.sudo.ws/about/license/ and added `BSD-ask-to-endorse` and `ISC` to the license list and dropped the `sudo` license as [SPDX](https://github.com/spdx/license-list-XML/issues/3010), [most other Linux distros (e.g. Fedora, Gentoo)](https://repology.org/project/sudo/information) and I think that this is just the `ISC` license. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
