### PR TITLE
python3Packages.expression: init at 5.6.0, add to litellm proxy dependency

### DIFF
--- a/pkgs/development/python-modules/expression/default.nix
+++ b/pkgs/development/python-modules/expression/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  typing-extensions,
+  poetry-core,
+  pydantic,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "expression";
+  version = "5.6.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    sha256 = "sha256-RU9v4Tg0cZSkPH+HjZWO/puEucx3DkYgEMelLhgFgGU=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ typing-extensions ];
+
+  optional-dependencies = {
+    pydantic = [ pydantic ];
+  };
+
+  pythonImportsCheck = [
+    "expression"
+  ];
+
+  meta = {
+    description = "Functional programming for Python";
+    homepage = "https://github.com/dbrattli/Expression";
+    changelog = "https://github.com/dbrattli/Expression/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ happysalada ];
+  };
+})

--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -13,6 +13,7 @@
   buildPythonPackage,
   click,
   cryptography,
+  expression,
   fastapi,
   fastapi-sso,
   fastuuid,
@@ -120,6 +121,7 @@ buildPythonPackage rec {
       backoff
       boto3
       cryptography
+      expression
       fastapi
       fastapi-sso
       gunicorn

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5729,6 +5729,8 @@ self: super: with self; {
 
   explorerscript = callPackage ../development/python-modules/explorerscript { };
 
+  expression = callPackage ../development/python-modules/expression { };
+
   exrex = callPackage ../development/python-modules/exrex { };
 
   extension-helpers = callPackage ../development/python-modules/extension-helpers { };


### PR DESCRIPTION
## Things done

Since https://github.com/NixOS/nixpkgs/pull/553826, LiteLLM crashes with:
```
$ ./result/bin/litellm
Traceback (most recent call last):
  File "/nix/store/nwwwzd31hjiib28115n7ablx1x39d27i-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/proxy_cli.py", line 1004, in run_server
    from .proxy_server import (
    ...<4 lines>...
    )
...
...
...
  File "/nix/store/nwwwzd31hjiib28115n7ablx1x39d27i-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/proxy_cli.py", line 1011, in run_server
    raise ModuleNotFoundError(f"Missing dependency {e}. Run `pip install 'litellm[proxy]'`")
ModuleNotFoundError: Missing dependency No module named 'expression'. Run `pip install 'litellm[proxy]'`
```

This is caused by the missing `expression` dependency. Add it.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
