### PR TITLE
cliproxyapi: init at 7.2.137, nixos/cliproxyapi: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,8 @@
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).
 
+- [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), an API proxy server designed to manage and route requests to various LLM services. Available as [services.cliproxyapi](#opt-services.cliproxyapi.enable).
+
 - [btrfs-heatmap](https://github.com/knorrie/btrfs-heatmap), setcap wrapper for `btrfs-heatmap` package, a visualizer of how a btrfs filesystem is using the underlying disk space of the block devices. Available as [programs.btrfs-heatmap](#opt-programs.btrfs-heatmap.enable)
 
 - [compsize](https://github.com/kilobyte/compsize), setcap wrapper for `compsize` package, a cli utility to to inspect compression type/ratio on BTRFS filesystems. Available as [programs.compsize](#opt-programs.compsize.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1184,6 +1184,7 @@
   ./services/networking/chisel-server.nix
   ./services/networking/cjdns.nix
   ./services/networking/clatd.nix
+  ./services/networking/cliproxyapi.nix
   ./services/networking/cloudflare-ddns.nix
   ./services/networking/cloudflare-dyndns.nix
   ./services/networking/cloudflare-warp.nix

--- a/nixos/modules/services/networking/cliproxyapi.nix
+++ b/nixos/modules/services/networking/cliproxyapi.nix
@@ -1,0 +1,155 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+
+  cfg = config.services.cliproxyapi;
+  yamlFormat = pkgs.formats.yaml { };
+
+  generatedConfigFile = yamlFormat.generate "cliproxyapi.yaml" (
+    lib.recursiveUpdate {
+      inherit (cfg) port host;
+      auth-dir = "/var/lib/cliproxyapi/auths";
+    } cfg.settings
+  );
+
+  configFile = if cfg.configFile != null then cfg.configFile else generatedConfigFile;
+in
+{
+  options.services.cliproxyapi = {
+    enable = lib.mkEnableOption "CLI Proxy API server";
+
+    package = lib.mkPackageOption pkgs "cliproxyapi" { };
+
+    host = lib.mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = ''
+        The host address that the CLI Proxy API daemon listens on.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = types.port;
+      default = 8317;
+      description = ''
+        The port that the CLI Proxy API daemon listens on.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          api-keys = [ "my-secret-key" ];
+          routing = {
+            strategy = "round-robin";
+          };
+        }
+      '';
+      description = ''
+        Structured configuration for CLIProxyAPI as YAML.
+        Secrets in `settings` are stored world-readable in the Nix store.
+        For sensitive secrets, use `configFile` or `environmentFile` instead.
+      '';
+    };
+
+    configFile = lib.mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/etc/cliproxyapi/config.yaml";
+      description = ''
+        Path to an existing configuration file. If specified, this takes precedence over `settings`.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/etc/cliproxyapi/cliproxyapi.env";
+      description = ''
+        Environment file as defined in {manpage}`systemd.exec(5)`.
+      '';
+    };
+
+    localModel = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to use embedded models only and skip remote model catalog updates.
+      '';
+    };
+
+    extraFlags = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--no-browser" ];
+      description = ''
+        Extra command-line flags to pass to the `cli-proxy-api` daemon.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to open the firewall port for CLI Proxy API.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
+    systemd.services.cliproxyapi = {
+      description = "CLI Proxy API Daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment.HOME = "/var/lib/cliproxyapi";
+
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe cfg.package)
+            "--config"
+            (toString configFile)
+          ]
+          ++ lib.optional cfg.localModel "--local-model"
+          ++ cfg.extraFlags
+        );
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+        Restart = "on-failure";
+        RestartSec = 5;
+        DynamicUser = true;
+        StateDirectory = "cliproxyapi";
+        WorkingDirectory = "/var/lib/cliproxyapi";
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ rachalaraj ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -379,6 +379,7 @@ in
     inherit runTest;
     package = pkgs.clickhouse-lts;
   };
+  cliproxyapi = runTest ./cliproxyapi.nix;
   cloud-init = runTest ./cloud-init.nix;
   cloud-init-hostname = runTest ./cloud-init-hostname.nix;
   cloudcompare = import ./cloudcompare.nix { inherit pkgs runTest; };

--- a/nixos/tests/cliproxyapi.nix
+++ b/nixos/tests/cliproxyapi.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+{
+  name = "cliproxyapi";
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        services.cliproxyapi = {
+          enable = true;
+          localModel = true;
+          settings = {
+            api-keys = [ "test-secret-key" ];
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("cliproxyapi.service")
+    machine.wait_for_open_port(8317)
+    machine.succeed("curl -fsS -H 'Authorization: Bearer test-secret-key' http://127.0.0.1:8317/v1/models")
+  '';
+
+  meta.maintainers = with lib.maintainers; [ rachalaraj ];
+}

--- a/pkgs/by-name/cl/cliproxyapi/package.nix
+++ b/pkgs/by-name/cl/cliproxyapi/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "cliproxyapi";
+  version = "7.2.137";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "router-for-me";
+    repo = "CLIProxyAPI";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8YipHopQcbr+mw8c34o8EArgzDJtIXu88fF6PBlGGyU=";
+  };
+
+  vendorHash = "sha256-CrDp7MOr+AwJUhTovklXx3F1yaktQlvD7VYhYSY6VvY=";
+
+  subPackages = [ "cmd/server" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+    "-X main.Commit=v${finalAttrs.version}"
+    "-X main.BuildDate=1970-01-01"
+  ];
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/cli-proxy-api
+    ln -s $out/bin/cli-proxy-api $out/bin/cliproxyapi
+    install -Dm444 config.example.yaml $out/share/doc/cliproxyapi/config.example.yaml
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) cliproxyapi;
+    };
+  };
+
+  meta = {
+    description = "Proxy server providing OpenAI/Gemini/Claude/Codex/Grok compatible API interfaces for CLI models";
+    homepage = "https://github.com/router-for-me/CLIProxyAPI";
+    changelog = "https://github.com/router-for-me/CLIProxyAPI/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "cli-proxy-api";
+  };
+})


### PR DESCRIPTION
- **Package**: Adds [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) at version `7.2.137` from source with `buildGoModule`.
  - Installs the official `cli-proxy-api` binary.
  - Adds a symlink from `cliproxyapi` to `cli-proxy-api`.
  - Copies `config.example.yaml` to `$out/share/doc/cliproxyapi/`.
  
- **NixOS Module**: Adds `services.cliproxyapi` in `nixos/modules/services/networking/cliproxyapi.nix`.
  - Runs the service as a systemd unit with `DynamicUser = true`.
  - Sets `StateDirectory = "cliproxyapi"` and `environment.HOME = "/var/lib/cliproxyapi"` for data storage.
  - Supports declarative YAML settings, secret files (`environmentFile`, `configFile`), and the `localModel` flag.
  
- **NixOS Test**: Adds a VM test in `nixos/tests/cliproxyapi.nix`. The test verifies service start, open port `8317`, and `/v1/models` HTTP 200 response.

- **Release Notes**: Adds an entry under `## New Modules` in `nixos/doc/manual/release-notes/rl-2611.section.md`.

This PR supersedes #532540 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
