### PR TITLE
nixos/cpupower-gui, cpupower-gui: fix python 3.14 compatibility, cleanup

### DIFF
--- a/nixos/modules/services/desktops/cpupower-gui.nix
+++ b/nixos/modules/services/desktops/cpupower-gui.nix
@@ -24,7 +24,7 @@ in
         wantedBy = [ "graphical-session.target" ];
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = "${lib.getExe cfg.package} config";
+          ExecStart = "${lib.getExe cfg.package} config --apply";
         };
       };
     };
@@ -34,7 +34,7 @@ in
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = "${lib.getExe cfg.package} config";
+          ExecStart = "${lib.getExe cfg.package} config --apply";
         };
       };
       cpupower-gui-helper = {

--- a/nixos/modules/services/desktops/cpupower-gui.nix
+++ b/nixos/modules/services/desktops/cpupower-gui.nix
@@ -10,29 +10,21 @@ in
 {
   options = {
     services.cpupower-gui = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        example = true;
-        description = ''
-          Enables dbus/systemd service needed by cpupower-gui.
-          These services are responsible for retrieving and modifying cpu power
-          saving settings.
-        '';
-      };
+      enable = lib.mkEnableOption "cpupower-gui, along with the D-Bus and systemd services it uses to retrieve and modify CPU power saving settings";
+      package = lib.mkPackageOption pkgs "cpupower-gui" { };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.cpupower-gui ];
-    services.dbus.packages = [ pkgs.cpupower-gui ];
+    environment.systemPackages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
     systemd.user = {
       services.cpupower-gui-user = {
         description = "Apply cpupower-gui config at user login";
         wantedBy = [ "graphical-session.target" ];
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = "${pkgs.cpupower-gui}/bin/cpupower-gui config";
+          ExecStart = "${lib.getExe cfg.package} config";
         };
       };
     };
@@ -42,7 +34,7 @@ in
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = "${pkgs.cpupower-gui}/bin/cpupower-gui config";
+          ExecStart = "${lib.getExe cfg.package} config";
         };
       };
       cpupower-gui-helper = {
@@ -51,7 +43,7 @@ in
         serviceConfig = {
           Type = "dbus";
           BusName = "org.rnd2.cpupower_gui.helper";
-          ExecStart = "${pkgs.cpupower-gui}/lib/cpupower-gui/cpupower-gui-helper";
+          ExecStart = "${cfg.package}/lib/cpupower-gui/cpupower-gui-helper";
         };
       };
     };

--- a/nixos/modules/services/desktops/cpupower-gui.nix
+++ b/nixos/modules/services/desktops/cpupower-gui.nix
@@ -18,6 +18,9 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];
+
+    # The helper authorises every request against PolicyKit; the package ships action and rule files
+    security.polkit.enable = true;
     systemd.user = {
       services.cpupower-gui-user = {
         description = "Apply cpupower-gui config at user login";

--- a/pkgs/by-name/cp/cpupower-gui/package.nix
+++ b/pkgs/by-name/cp/cpupower-gui/package.nix
@@ -3,6 +3,7 @@
   python3Packages,
   fetchFromGitHub,
   fetchpatch,
+  fetchpatch2,
   appstream-glib,
   gettext,
   glib,
@@ -41,6 +42,12 @@ python3Packages.buildPythonApplication rec {
     (fetchpatch {
       url = "https://github.com/vagnum08/cpupower-gui/commit/22ea668aa4ecf848149ea4c150aa840a25dc6ff8.patch";
       sha256 = "sha256-Mri7Af1Y79lt2pvZl4DQSvrqSLIJLIjzyXwMPFEbGVI=";
+    })
+    # Fixes Python 3.14 compatibility
+    (fetchpatch2 {
+      url = "https://github.com/vagnum08/cpupower-gui/commit/08b076b731a5106e9e72bf02dceb7ed96649ea98.patch";
+      includes = [ "cpupower_gui/cpupower-gui.in" ];
+      hash = "sha256-XjlnK5dOd0fBut5lARjyNuaHEzircTUHfGpwA4xjjHM=";
     })
   ];
 

--- a/pkgs/by-name/cp/cpupower-gui/package.nix
+++ b/pkgs/by-name/cp/cpupower-gui/package.nix
@@ -4,12 +4,10 @@
   fetchFromGitHub,
   fetchpatch,
   appstream-glib,
-  desktop-file-utils,
   gettext,
   glib,
   gobject-introspection,
   gtk3,
-  hicolor-icon-theme,
   libappindicator,
   libhandy,
   meson,
@@ -51,11 +49,9 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     appstream-glib
-    desktop-file-utils # needed for update-desktop-database
     gettext
     glib # needed for glib-compile-schemas
     gobject-introspection # need for gtk namespace to be available
-    hicolor-icon-theme # needed for postinstall script
     meson
     ninja
     pkg-config
@@ -79,8 +75,15 @@ python3Packages.buildPythonApplication rec {
     "-Dsystemddir=${placeholder "out"}/lib/systemd"
   ];
 
-  preConfigure = ''
-    patchShebangs build-aux/meson/postinstall.py
+  # Drop the post-install script; NixOS updates desktop database and icon cache itself
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "meson.add_install_script('build-aux/meson/postinstall.py')" ""
+  '';
+
+  # glib's setup hook only relocates the schemas, it does not compile them
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
   '';
 
   dontWrapGApps = true;

--- a/pkgs/by-name/cp/cpupower-gui/package.nix
+++ b/pkgs/by-name/cp/cpupower-gui/package.nix
@@ -13,6 +13,7 @@
   libappindicator,
   libhandy,
   meson,
+  ninja,
   pkg-config,
   wrapGAppsHook3,
 }:
@@ -45,6 +46,9 @@ python3Packages.buildPythonApplication rec {
     })
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     appstream-glib
     desktop-file-utils # needed for update-desktop-database
@@ -53,24 +57,20 @@ python3Packages.buildPythonApplication rec {
     gobject-introspection # need for gtk namespace to be available
     hicolor-icon-theme # needed for postinstall script
     meson
-    python3Packages.ninja # TODO: maybe swap out for the non-python package
+    ninja
     pkg-config
     wrapGAppsHook3
-    python3Packages.dbus-python
-    libappindicator
-    python3Packages.pygobject3
-    python3Packages.pyxdg
   ];
 
   buildInputs = [
     glib
     gtk3
+    libappindicator
     libhandy
   ];
 
   propagatedBuildInputs = [
     python3Packages.dbus-python
-    libappindicator
     python3Packages.pygobject3
     python3Packages.pyxdg
   ];
@@ -83,13 +83,14 @@ python3Packages.buildPythonApplication rec {
     patchShebangs build-aux/meson/postinstall.py
   '';
 
-  strictDeps = false;
   dontWrapGApps = true;
 
-  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   postFixup = ''
-    wrapPythonProgramsIn $out/lib "$out $propagatedBuildInputs"
+    wrapPythonProgramsIn $out/lib "$out"
   '';
 
   meta = {


### PR DESCRIPTION
See individual commits for changes

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
