### PR TITLE
nixos/passless: remove hardening for now as it broke functionality

### DIFF
--- a/nixos/modules/programs/passless.nix
+++ b/nixos/modules/programs/passless.nix
@@ -127,6 +127,11 @@ in
 
       };
     };
+
+    # So users can use the `passless client` command
+    users.users = lib.genAttrs cfg.users (_: {
+      packages = [ cfg.package ];
+    });
   };
 
   meta.maintainers = with lib.maintainers; [ erictapen ];

--- a/nixos/modules/programs/passless.nix
+++ b/nixos/modules/programs/passless.nix
@@ -67,64 +67,6 @@ in
         NoNewPrivileges = true;
         LimitMEMLOCK = "2M";
         SyslogIdentifier = "passless";
-
-        # Found with shh
-        ProtectSystem = "strict";
-        PrivateTmp = "disconnected";
-        PrivateMounts = "true";
-        ProtectKernelTunables = "true";
-        ProtectKernelModules = true;
-        ProtectKernelLogs = true;
-        LockPersonality = true;
-        RestrictRealtime = true;
-        ProtectClock = true;
-        MemoryDenyWriteExecute = true;
-        RestrictAddressFamilies = "AF_UNIX";
-        SocketBindDeny = [
-          "ipv4:tcp"
-          "ipv4:udp"
-          "ipv6:tcp"
-          "ipv6:udp"
-        ];
-        CapabilityBoundingSet = [
-          "~CAP_BLOCK_SUSPEND"
-          "CAP_BPF"
-          "CAP_CHOWN"
-          "CAP_MKNOD"
-          "CAP_NET_RAW"
-          "CAP_PERFMON"
-          "CAP_SYS_BOOT"
-          "CAP_SYS_CHROOT"
-          "CAP_SYS_MODULE"
-          "CAP_SYS_NICE"
-          "CAP_SYS_PACCT"
-          "CAP_SYS_PTRACE"
-          "CAP_SYS_TIME"
-          "CAP_SYSLOG"
-          "CAP_WAKE_ALARM"
-        ];
-        SystemCallFilter = [
-          "~@aio:EPERM"
-          "@chown:EPERM"
-          "@clock:EPERM"
-          "@cpu-emulation:EPERM"
-          "@debug:EPERM"
-          "@ipc:EPERM"
-          "@keyring:EPERM"
-          "@module:EPERM"
-          "@mount:EPERM"
-          "@obsolete:EPERM"
-          "@pkey:EPERM"
-          "@privileged:EPERM"
-          "@raw-io:EPERM"
-          "@reboot:EPERM"
-          "@resources:EPERM"
-          "@sandbox:EPERM"
-          "@setuid:EPERM"
-          "@swap:EPERM"
-          "@sync:EPERM"
-        ];
-
       };
     };
 


### PR DESCRIPTION
Passless didn't work anymore since https://github.com/NixOS/nixpkgs/pull/554078

I'm struggling with a shh bug to generate new harding options, so let's just leave them like this for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
