### PR TITLE
nixos/gtk-icon-cache: enable for any graphical desktop

### DIFF
--- a/nixos/modules/config/gtk/gtk-icon-cache.nix
+++ b/nixos/modules/config/gtk/gtk-icon-cache.nix
@@ -8,10 +8,12 @@
   options = {
     gtk.iconCache.enable = lib.mkOption {
       type = lib.types.bool;
-      default = config.services.xserver.enable;
-      defaultText = lib.literalExpression "config.services.xserver.enable";
+      default = false;
       description = ''
         Whether to build icon theme caches for GTK applications.
+
+        This option should be enabled by default by the corresponding modules,
+        so you do not usually have to set it yourself.
       '';
     };
   };

--- a/nixos/modules/services/misc/graphical-desktop.nix
+++ b/nixos/modules/services/misc/graphical-desktop.nix
@@ -47,6 +47,8 @@ in
 
     fonts.enableDefaultPackages = lib.mkDefault true;
 
+    gtk.iconCache.enable = lib.mkDefault true;
+
     hardware.graphics.enable = lib.mkDefault true;
 
     programs.gnupg.agent.pinentryPackage = lib.mkOverride 1100 pkgs.pinentry-gnome3;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -742,6 +742,7 @@ in
     mirrored-boots = runTest ./grub/mirrored-boots.nix;
   };
   gs1200-exporter = runTest ./gs1200-exporter.nix;
+  gtk-icon-cache = runTest ./gtk-icon-cache.nix;
   guacamole-server = runTest ./guacamole-server.nix;
   guix = handleTest ./guix { };
   gvisor = runTest ./gvisor.nix;

--- a/nixos/tests/gtk-icon-cache.nix
+++ b/nixos/tests/gtk-icon-cache.nix
@@ -1,0 +1,37 @@
+{ lib, ... }:
+{
+  name = "gtk-icon-cache";
+  meta.maintainers = [ ];
+
+  nodes = {
+    # A Wayland session sets services.graphical-desktop.enable without
+    # services.xserver.enable, the way programs/wayland/wayland-session.nix does
+    # for sway, hyprland, niri and friends.
+    wayland =
+      { ... }:
+      {
+        services.graphical-desktop.enable = true;
+      };
+
+    headless =
+      { ... }:
+      {
+        services.graphical-desktop.enable = false;
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    wayland.wait_for_unit("multi-user.target")
+    headless.wait_for_unit("multi-user.target")
+
+    cache = "/run/current-system/sw/share/icons/hicolor/icon-theme.cache"
+
+    # A graphical session gets icon theme caches even without X11.
+    wayland.succeed(f"test -f {cache}")
+
+    # A headless system does not build them.
+    headless.fail(f"test -e {cache}")
+  '';
+}


### PR DESCRIPTION
The default was keyed on services.xserver.enable, which was described as a temporary approximation when the module landed in #48116:

  Right, _for now_ I pushed the approximation via `xserver.enable`.
  Wayland probably works on NixOS.

services.graphical-desktop is the option that discussion asked for, and Wayland sessions already set it via programs/wayland/wayland-session.nix. Key the icon cache off it instead, so sway, hyprland, niri and friends -- and GNOME on Wayland without services.xserver.enable -- get icon theme caches too. Headless systems are unaffected.

Assisted-by: claude-code with claude-opus-5[1m]-high
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
