### PR TITLE
emerald-legacy-launcher{,-unwrapped}: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27050,6 +27050,13 @@
     githubId = 53029739;
     name = "Joshua Ortiz";
   };
+  sopyb = {
+    name = ''A. "Sopy" Soponar'';
+    email = "contact@sopy.one";
+    matrix = "sopyb:catgirl.cloud";
+    github = "sopyb";
+    githubId = 32602702;
+  };
   sorki = {
     email = "srk@48.io";
     github = "sorki";

--- a/pkgs/by-name/em/emerald-legacy-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/em/emerald-legacy-launcher-unwrapped/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  rustPlatform,
+  cargo-tauri,
+  nodejs,
+  pkg-config,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  wrapGAppsHook4,
+  openssl,
+  webkitgtk_4_1,
+  glib-networking,
+  libayatana-appindicator,
+  librsvg,
+  udev,
+}:
+
+let
+  pnpm = pnpm_10;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "emerald-legacy-launcher-unwrapped";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "LCE-Hub";
+    repo = "LCE-Emerald-Launcher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-v1CuQwyh7vki+SKBwZwYGJmHy7HvY1P3cf/OrunjYJk=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoHash = "sha256-GfDuleIaeq6dpSzg4wWlClY2iYM5izbGv1febKuCh7I=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-nY2DHKanLq6oe/NeWEdCU160OJ9srofVN34S/pfDk9I=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    pkg-config
+    pnpmConfigHook
+    pnpm
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    libayatana-appindicator
+    librsvg
+    udev
+    webkitgtk_4_1
+  ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+    substituteInPlace "$cargoDepsCopy"/*/libappindicator-sys-*/src/lib.rs \
+      --replace-fail "libayatana-appindicator3.so.1" \
+      "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+  '';
+
+  preBuild = ''
+    substituteInPlace src-tauri/tauri.conf.json \
+      --replace-fail '"beforeBuildCommand": "npm run build"' '"beforeBuildCommand": "pnpm run build"' \
+      --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
+  '';
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libayatana-appindicator
+          udev
+        ]
+      }
+    )
+  '';
+
+  meta = {
+    homepage = "https://github.com/LCE-Hub/LCE-Emerald-Launcher";
+    description = "FOSS cross-platform launcher for Minecraft Legacy Console Edition";
+    longDescription = ''
+      LCE Emerald Launcher is the easiest way to play Minecraft Legacy Console Edition on PC. Install community builds, manage versions, customize skins, and launch instantly from one lightweight hub.
+      Why Emerald? Traditional launchers often rely on bloated frameworks, consuming excessive resources. Emerald utilizes a modern Tauri architecture, using only a low amount of RAM, leaving your PC's resources dedicated to the game itself.
+    '';
+    changelog = "https://github.com/LCE-Hub/LCE-Emerald-Launcher/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "emerald-legacy-launcher";
+    maintainers = with lib.maintainers; [ sopyb ];
+    # It should work on nix-darwin, but I can't check nor mantain
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/em/emerald-legacy-launcher/package.nix
+++ b/pkgs/by-name/em/emerald-legacy-launcher/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  steam,
+  emerald-legacy-launcher-unwrapped,
+  libarchive,
+  python3,
+  extraPkgs ? pkgs: [ ],
+  extraLibraries ? pkgs: [ ],
+  extraEnv ? { },
+}:
+
+steam.buildRuntimeEnv {
+  pname = "emerald-legacy-launcher";
+  inherit (emerald-legacy-launcher-unwrapped) version meta;
+
+  runScript = lib.getExe emerald-legacy-launcher-unwrapped;
+
+  extraPkgs =
+    pkgs:
+    [
+      emerald-legacy-launcher-unwrapped
+      libarchive
+      python3
+    ]
+    ++ extraPkgs pkgs;
+
+  inherit extraLibraries extraEnv;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share
+    ln -s ${emerald-legacy-launcher-unwrapped}/share/applications $out/share
+    ln -s ${emerald-legacy-launcher-unwrapped}/share/icons $out/share
+  '';
+
+  privateTmp = false;
+}


### PR DESCRIPTION
My best attempt at packaging the [Emerald Launcher](https://github.com/LCE-Hub/LCE-Emerald-Launcher), a launcher for Minecraft Legacy Console Edition.

I downloaded and ran all versions available in the launcher, so to my knowledge, everything works as expected.

I looked into other packages to get used to the structure along with reading the docs. Packages I took inspiration from are mainly `zulip`, `heroic{,-unwrapped}`, and `mpv{,-unwrapped}`, along with the flake in the Emerald Launcher repo.

I built the unwrapped version on my headless aarch64 linux VPS without issues but I couldn't test it further than that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
