### PR TITLE
klipper-flash: derive -s/--start for stm32 boards

### DIFF
--- a/pkgs/servers/klipper/klipper-flash.nix
+++ b/pkgs/servers/klipper/klipper-flash.nix
@@ -18,7 +18,7 @@ let
     with builtins;
     let
       lines = lib.splitString "\n" (readFile firmwareConfig);
-      matchLine = line: match ''${field}="([a-zA-Z0-9_]+)".*'' line;
+      matchLine = line: match ''${field}="([a-zA-Z0-9_]+)".*'' (lib.trim line);
       matched = lib.findFirst (line: matchLine line != null) null lines;
     in
     if matched != null then head (matchLine matched) else null;

--- a/pkgs/servers/klipper/klipper-flash.nix
+++ b/pkgs/servers/klipper/klipper-flash.nix
@@ -18,13 +18,16 @@ let
     with builtins;
     let
       lines = lib.splitString "\n" (readFile firmwareConfig);
-      matchLine = line: match ''${field}="([a-zA-Z0-9_]+)".*'' (lib.trim line);
+      matchLine = line: match ''${field}="?([a-zA-Z0-9_]+)"?.*'' (lib.trim line);
       matched = lib.findFirst (line: matchLine line != null) null lines;
     in
     if matched != null then head (matchLine matched) else null;
   matchPlatform = getConfigField "CONFIG_BOARD_DIRECTORY";
   matchBoard = getConfigField "CONFIG_MCU";
   matchAvrdudeProtocol = getConfigField "CONFIG_AVRDUDE_PROTOCOL";
+  matchFlashApplicationAddress = getConfigField "CONFIG_FLASH_APPLICATION_ADDRESS";
+  # Only stm32's require -s/--start (flash_stm32f4 in scripts/flash_usb.py)
+  flashStartAddress = if matchPlatform == "stm32" then matchFlashApplicationAddress else null;
   flashUsbSupportedBoards = [
     "sam3"
     "sam4"
@@ -67,7 +70,9 @@ writeShellApplication {
     if flashDevice != null then
       if (builtins.elem matchBoard flashUsbSupportedBoards) && matchPlatform != null then
         ''
-          ${klipper}/lib/scripts/flash_usb.py -t ${matchBoard} -d ${flashDevice} ${klipper-firmware}/klipper.bin "$@"
+          ${klipper}/lib/scripts/flash_usb.py -t ${matchBoard} -d ${flashDevice}${
+            lib.optionalString (flashStartAddress != null) " -s ${flashStartAddress}"
+          } ${klipper-firmware}/klipper.bin "$@"
         ''
       else if matchPlatform == "avr" && matchAvrdudeProtocol != null && matchBoard != null then
         ''

--- a/pkgs/servers/klipper/klipper-flash.nix
+++ b/pkgs/servers/klipper/klipper-flash.nix
@@ -17,9 +17,11 @@ let
     field:
     with builtins;
     let
-      matches = match ''^[^#\r\n]*${field}="([a-zA-Z0-9_]+)".*$'' (readFile firmwareConfig);
+      lines = lib.splitString "\n" (readFile firmwareConfig);
+      matchLine = line: match ''${field}="([a-zA-Z0-9_]+)".*'' line;
+      matched = lib.findFirst (line: matchLine line != null) null lines;
     in
-    if matches != null then head matches else null;
+    if matched != null then head (matchLine matched) else null;
   matchPlatform = getConfigField "CONFIG_BOARD_DIRECTORY";
   matchBoard = getConfigField "CONFIG_MCU";
   matchAvrdudeProtocol = getConfigField "CONFIG_AVRDUDE_PROTOCOL";


### PR DESCRIPTION
Depends on #554913

Passes `CONFIG_FLASH_APPLICATION_ADDRESS` to `flash_usb.py --start {address}`.
Same as Klipper's stm32 Makefile does.

Without this callers have always had to manually pass in script calls
```
klipper-flash-$mcu --start {address}
```

FWIW: atsamd boards need start address as well, but it is derived differently, and I do not have that hardware to verify against.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
