### PR TITLE
google-cloud-sdk: fix byte-code never being loaded

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -155,6 +155,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # create cached byte-code at build time, see https://docs.python.org/3/library/compileall.html
+    # must match the optimization level in CLOUDSDK_PYTHON_ARGS, otherwise python ignores the .pyc files
     # the excluded files contain python 2 syntax that fails to compile with python 3
     find $out/google-cloud-sdk -name "*.py" \
       -not -path "*/lib/third_party/yaml/scanner.py" \
@@ -180,7 +181,7 @@ stdenv.mkDerivation rec {
       -not -path "*/lib/third_party/fancy_urllib/__init__.py" \
       -not -path "*/oauth2client/_pkce.py" \
       -not -path "*/ext-runtime/nodejs/test/runtime_test.py" \
-      -exec ${pythonEnv}/bin/python -OO -m compileall {} +
+      -exec ${pythonEnv}/bin/python -m compileall {} +
   '';
 
   doInstallCheck = true;
@@ -195,6 +196,9 @@ stdenv.mkDerivation rec {
     $out/bin/gcloud kms asymmetric-sign --help > /dev/null
     PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb $out/bin/gcloud kms asymmetric-sign --help > /dev/null
     $out/bin/gsutil version | grep -w "$(cat platform/gsutil/VERSION)"
+    # byte-code must exist at the path python looks up with the wrapper's CLOUDSDK_PYTHON_ARGS
+    ${pythonEnv}/bin/python -S -B -c 'import importlib.util, os, sys; sys.exit(not os.path.exists(importlib.util.cache_from_source(sys.argv[1])))' \
+      $out/google-cloud-sdk/lib/gcloud.py
   '';
 
   # Replace all vendored copies of CA bundle with the one used by Nixpkgs.


### PR DESCRIPTION
postInstall compiled with -OO (*.opt-2.pyc), but the wrappers run python without -O, so python looks for plain *.pyc and recompiled ~500 modules on every invocation. `gcloud version` is ~3x faster with plain .pyc.

Add an installCheck so compileall and CLOUDSDK_PYTHON_ARGS stay in sync.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
