### PR TITLE
nixos/crowdsec: always attempt to restart these services

### DIFF
--- a/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
+++ b/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
@@ -349,6 +349,10 @@ in
               DynamicUser = true;
               RuntimeDirectory = runtime-dir-name;
 
+              Restart = "always";
+              RestartSec = 1;
+              RestartSteps = 20;
+              RestartMaxDelaySec = 120;
               LockPersonality = true;
               PrivateDevices = true;
               ProcSubset = "pid";

--- a/nixos/modules/services/security/crowdsec.nix
+++ b/nixos/modules/services/security/crowdsec.nix
@@ -770,7 +770,10 @@ in
             User = cfg.user;
             Group = cfg.group;
             Type = "notify";
-            RestartSec = 60;
+            Restart = "always";
+            RestartSec = 1;
+            RestartSteps = 20;
+            RestartMaxDelaySec = 120;
             LimitNOFILE = 65536;
             NoNewPrivileges = true;
             LockPersonality = true;


### PR DESCRIPTION
The crowdsec services can be security critical and at the same time they can readily fail to start whenever the networking is flaky with errors such as

```
crowdsec-setup[79009]: Error: cscli hub update: failed to update hub:
  failed http request for https://cdn-hub.crowdsec.net/crowdsecurity/master/.index.json: ...
```

which can easily happen during boot or system activation (despite the
wait for network service dependency.) Similarly the firewall bouncer
then fails to find the main crowdsec service and fails as well.

Restarts have been setup with some backoff, so that early on the
restarts are attempted more frequently thus reducing the exposure
duration, but decaying down to 2 minutes between restarts to avoid
extensive resource use if the issues take a long time to resolve.

I chose to set `Restart=always` due to security focused nature of the
service (I personally want it running no matter what code the service
happens to exit with.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Tested locally by applying these directives to my local system configuration.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
