### PR TITLE
balena-cli: 25.1.6 -> 25.2.5 + refactor

### DIFF
--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -20,14 +20,14 @@ let
     nodejs = nodejs_24;
   };
 in
-buildNpmPackage' rec {
+buildNpmPackage' (finalAttrs: {
   pname = "balena-cli";
   version = "25.1.6";
 
   src = fetchFromGitHub {
     owner = "balena-io";
     repo = "balena-cli";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ipl8eK9DpMGd4kyr46QTMUqYfr5ghOY3u5WS1GXVeIw=";
   };
 
@@ -72,11 +72,11 @@ buildNpmPackage' rec {
       and the balena SDK, and can also be directly imported in Node.js applications.
     '';
     homepage = "https://github.com/balena-io/balena-cli";
-    changelog = "https://github.com/balena-io/balena-cli/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/balena-io/balena-cli/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       kalebpace
     ];
     mainProgram = "balena";
   };
-}
+})

--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -13,16 +13,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "balena-cli";
-  version = "25.1.6";
+  version = "25.2.5";
 
   src = fetchFromGitHub {
     owner = "balena-io";
     repo = "balena-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ipl8eK9DpMGd4kyr46QTMUqYfr5ghOY3u5WS1GXVeIw=";
+    hash = "sha256-8o06p2tCxqe95kZRaLlybqUGDbMrlRqF+ITQP8CD75I=";
   };
 
-  npmDepsHash = "sha256-HAOZlCRcPjX0u9GBLaYR03Jb+bvg679MqcGGHkQ2FPM=";
+  npmDepsHash = "sha256-jAG2MXGPqoohfrYkg8lSVQtvD9PBYC1OZLdxR0HS71w=";
 
   makeCacheWritable = true;
 
@@ -37,6 +37,17 @@ buildNpmPackage (finalAttrs: {
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     udev
   ];
+
+  env = {
+    # This is a bit heavy handed but resolves errors stemming from the Node.js
+    # USB package, such as
+    #
+    # > /build/source/node_modules/usb/node_modules/node-addon-api/napi-inl.h:1433:8: note: 'std::string_view' is only available from C++17 onwards
+    #
+    # The issue seems to have been resolved upstream but not released yet:
+    # https://github.com/node-usb/node-usb/pull/964
+    CXXFLAGS = "-std=c++20";
+  };
 
   postInstall = ''
     cp ${lib.getExe balena-compose-parser} $out/lib/node_modules/balena-cli/node_modules/@balena/compose-parser/bin/

--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -4,7 +4,6 @@
   balena-compose-parser,
   buildNpmPackage,
   fetchFromGitHub,
-  nodejs_24,
   versionCheckHook,
   node-gyp,
   python3,
@@ -12,15 +11,7 @@
   xcbuild,
 }:
 
-let
-  buildNpmPackage' = buildNpmPackage.override {
-    nodejs = nodejs_24;
-  };
-  node-gyp' = node-gyp.override {
-    nodejs = nodejs_24;
-  };
-in
-buildNpmPackage' (finalAttrs: {
+buildNpmPackage (finalAttrs: {
   pname = "balena-cli";
   version = "25.1.6";
 
@@ -36,7 +27,7 @@ buildNpmPackage' (finalAttrs: {
   makeCacheWritable = true;
 
   nativeBuildInputs = [
-    node-gyp'
+    node-gyp
     python3
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
This updates the package to the latest version, also makes a few modernizations and simplifications. Have verified that it is possible to query fleets and make deployments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
