### PR TITLE
wordpressPackages: add activitypub and polls-for-activitypub

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -131,6 +131,12 @@
     "sha256": "0g98qgl1svf6jcybbqih466hp2w0ckjgbgwz6cl6ljr6fghk68k8",
     "version": "2.0.2"
   },
+  "polls-for-activitypub": {
+    "path": "polls-for-activitypub/tags/1.0.11",
+    "rev": "3631874",
+    "sha256": "0s45a8zj94jrgvingw6k4sdmsdkqqq9xvl2x1hcbhi4qik5syfjw",
+    "version": "1.0.11"
+  },
   "simple-login-captcha": {
     "path": "simple-login-captcha/tags/1.3.6",
     "rev": "3549724",

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -1,4 +1,10 @@
 {
+  "activitypub": {
+    "path": "activitypub/tags/9.2.2",
+    "rev": "3642412",
+    "sha256": "1cq02p9fmz8mb0r7vrd7aak1xc4pxmnnmja1dw9471nbv9k68y51",
+    "version": "9.2.2"
+  },
   "add-widget-after-content": {
     "path": "add-widget-after-content/tags/2.5.4",
     "rev": "3548285",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -1,5 +1,6 @@
 {
-  "add-widget-after-content": "gpl3Plus"
+  "activitypub": "mit"
+, "add-widget-after-content": "gpl3Plus"
 , "akismet": "gpl2Plus"
 , "antispam-bee": "gpl2Plus"
 , "async-javascript": "gpl2Plus"

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -21,6 +21,7 @@
 , "mailpoet": "gpl3Only"
 , "merge-minify-refresh": "gpl2Plus"
 , "opengraph": "asl20"
+, "polls-for-activitypub": "agpl3Only"
 , "simple-login-captcha": "gpl2Plus"
 , "simple-mastodon-verification": "gpl2Plus"
 , "sqlite-database-integration": "gpl2Plus"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
--> 
Adds `polls-for-activitypub` and its dependency `activitypub` plugin to wordpress
- Ref: https://github.com/ngi-nix/projects/issues/917

This work is done as part of Summer of Nix 2026.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
