### PR TITLE
stellar-core: 27.1.0 -> 28.0.1

### DIFF
--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -49,13 +49,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "stellar-core";
-  version = "27.1.0";
+  version = "28.0.1";
 
   src = fetchFromGitHub {
     owner = "stellar";
     repo = "stellar-core";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EXtfkjNOl3Loml7GXWYE8hh/IqItqA677YEh0Ve6dOI=";
+    hash = "sha256-yRwUwk0CNIQlPEKitXCjuF47qm8BFt9EYJXUfx28bMs=";
     fetchSubmodules = true;
   };
 
@@ -69,10 +69,11 @@ stdenv.mkDerivation (finalAttrs: {
         p25 = "sha256-9NhnB3bDQI1FLmr0zTYTjEYl8V8KteWbMefWObLDB/A=";
         p26 = "sha256-OxkiWTzNtmYxB64OtLUwghAkcT//SnMZVfUXynFg2Bg=";
         p27 = "sha256-KcsyPBJLUOwRAtp95IYFiZZNMi1xWmYW7XXG+bMucmY=";
+        p28 = "sha256-SGA69mE0VZSumZKOBcZqvzYtZRkFVSIMHFI5R9xcTWE=";
       };
       mainCargoDeps = rustPlatform.fetchCargoVendor {
         inherit (finalAttrs) src;
-        hash = "sha256-8seehYc2W0lvW9WPewPHC3cLR9Lgj2qCib/EXK0gwVA=";
+        hash = "sha256-7gU7vtYMOXX4qf3PkqriAxANhV3vraF71WMj/sS83ak=";
       };
       sorobanCargoDeps = lib.mapAttrs (
         protocol: hash:
@@ -120,6 +121,18 @@ stdenv.mkDerivation (finalAttrs: {
         }
       }
     done
+
+    # Git dependencies do not include Cargo's published-crate VCS metadata.
+    # Recreate it so crate-git-revision can provide GIT_REVISION.
+    for crate in "$cargoDepsCopy"/source-git-*/stellar-xdr-*; do
+      version="$(basename "$crate")"
+      version="''${version#stellar-xdr-}"
+      xdrRevision="$(rg -U -o -r '$1' \
+        "name = \"stellar-xdr\"\nversion = \"$version\"\nsource = \"git\\+https://github.com/stellar/rs-stellar-xdr[^\"]*#([0-9a-f]{40})\"" \
+        Cargo.lock)"
+      test -n "$xdrRevision"
+      printf '{"git":{"sha1":"%s"}}\n' "$xdrRevision" > "$crate/.cargo_vcs_info.json"
+    done
   '';
 
   strictDeps = true;
@@ -146,7 +159,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  # Build the large Rust crate separately to avoid its peak memory use
+  # overlapping with parallel C++ compilation. On aarch64, the release
+  # profile's fat LTO and single codegen unit also exceed typical builder limits.
+  preBuild =
+    lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      export CARGO_PROFILE_RELEASE_LTO=off
+      export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
+    ''
+    + ''
+      make -C src -j"$NIX_BUILD_CORES" ../target/release/librust_stellar_core.a
+    '';
+
   doCheck = true;
+  # The standalone consensus test binds to localhost.
+  __darwinAllowLocalNetworking = true;
 
   preConfigure = ''
     # Due to https://github.com/NixOS/nixpkgs/issues/8567 we cannot rely on


### PR DESCRIPTION
https://github.com/stellar/stellar-core/releases/tag/v28.0.0
https://github.com/stellar/stellar-core/releases/tag/v28.0.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
