### PR TITLE
myx: init at 0.4.0

### DIFF
--- a/pkgs/by-name/my/myx/package.nix
+++ b/pkgs/by-name/my/myx/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  stdenv,
+  alsa-lib,
+  openssl,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "myx";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "HaseebKhalid1507";
+    repo = "Myx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-72Q0AkUT8ms0+zbtVEBjqnku7njUAzVk/Y/d2AyQVeQ=";
+  };
+
+  cargoHash = "sha256-aNDKxvz918mwLteGpgQR7cpXs3VK12OHrfm4Q/jT+1s=";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    openssl
+  ];
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lean, beautiful terminal Spotify player";
+    homepage = "https://github.com/HaseebKhalid1507/Myx";
+    changelog = "https://github.com/HaseebKhalid1507/Myx/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "myx";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ miniharinn ];
+  };
+})


### PR DESCRIPTION
Myx is a Spotify client written in rust with ratatui. It streams musics natively using Spotify Connect.

Repo: https://github.com/HaseebKhalid1507/Myx
Release: https://github.com/HaseebKhalid1507/Myx/releases/tag/v0.4.0

Screenshot:
<img width="2542" height="1394" alt="image" src="https://github.com/user-attachments/assets/e1d01bf0-c6ff-49e3-8766-08b29613923c" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
