### PR TITLE
applyPatches: unpack and patch directly in $out

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1071,7 +1071,22 @@ rec {
           "installPhase"
         ];
 
-        installPhase = "cp -R ./ $out";
+        # Unpack and patch inside $out so the tree is materialised once, not copied out afterwards.
+        preUnpack = ''
+          mkdir -p "$out/.applyPatches-unpack"
+          cd "$out/.applyPatches-unpack"
+        ''
+        + args.preUnpack or "";
+
+        installPhase = ''
+          shopt -s dotglob nullglob
+          entries=( "$PWD"/* )
+          cd "$out"
+          if (( ''${#entries[@]} )); then
+            mv -- "''${entries[@]}" "$out/"
+          fi
+          rm -rf -- "$out/.applyPatches-unpack"
+        '';
 
         # passthru the git and hash info for nix-update, as well
         # as all the src's passthru attrs.


### PR DESCRIPTION
`applyPatches` materialises the source tree **twice**: `unpackPhase` copies it into the build directory, then `installPhase = "cp -R ./ $out"` copies the whole thing again into the output.

Profiling the three phases it runs, on a 298 MB / 48590-file tree:

| phase | time | share |
| --- | --- | --- |
| `unpackPhase` (`cp -r --reflink=auto`) | 11.03 s | 52% |
| `chmod -R u+w` | 1.01 s | 5% |
| `patchPhase` (8 patches) | 0.07 s | 0.3% |
| `installPhase` (`cp -R ./ $out`) | 8.86 s | 42% |

The two copies are ~95% of the runtime; applying the patches is a rounding error.

This unpacks into a scratch directory inside `$out` instead, and promotes the source root by renaming its top-level entries. Those renames stay within a single mount, so they are effectively free.

Note that the simpler-looking `installPhase = ''mv -- "$PWD" "$out"''` produces correct output but gains nothing. In the sandbox `/build` and `/nix/store` are separate bind mounts (of the same device), and `rename(2)` refuses to cross mount points, not just devices, so it returns `EXDEV` and coreutils falls back to copy + recursive unlink — the full copy still happens, plus the extra unlink. `mv`'s exit status does not reveal this; a direct `os.rename` in a `runCommand` does.

Timing the install phase in isolation on a 351 MB / 53767-file tree, five interleaved runs each (medians): `cp -R ./ $out` 4740 ms, `mv` 8193 ms. End-to-end that ~3.5 s delta sits inside run-to-run noise, so `mv` is not a regression — it is simply not a fix, because it does not avoid the copy. Only unpacking into `$out` does.

`preUnpack` is concatenated rather than overwritten, because `lib.extendMkDerivation` merges as `previous // extendDrvArgs final previous` and would otherwise silently drop a caller's own `preUnpack`. No in-tree caller passes one (nor `setSourceRoot`, `unpackCmd`, or `dontMakeSourcesWritable`).

### Benchmark

`linux_latest.src` (153 MB xz, ~1.5 GB and ~90k files unpacked), three runs each, output deleted in between:

```
before: 33.80 / 32.77 / 38.84 s   (mean 35.1 s)
after:  14.11 / 13.90 / 13.35 s   (mean 13.8 s)
```

~2.5x faster. Peak disk usage is halved too, since the tree no longer exists in the build directory and the output simultaneously.

### Verification

Output NAR hashes (`nix-store --query --hash`) are **unchanged** before/after in every case tested:

| case | hash |
| --- | --- |
| path source: symlinks, executable bits, subdirectories | `sha256:068kmsl…` |
| tarball source with a two-level `sourceRoot` (`src/sub`) | `sha256:06f1b8d…` |
| dotfiles and dot-directories at the top level | `sha256:01dk1br…` |
| `speed-cloudflare-cli.src` (`fetchFromGitHub` + 3 × `fetchpatch`) | `sha256:0pcsxk2…` |

Assisted-by: claude-code with claude-opus-5[1m]-high

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
