### PR TITLE
[26.05] electron{,-bin,-chromedriver}: 41 -> 43

### DIFF
--- a/pkgs/by-name/mu/musicfree-desktop/package.nix
+++ b/pkgs/by-name/mu/musicfree-desktop/package.nix
@@ -7,7 +7,7 @@
   copyDesktopItems,
   makeWrapper,
   nix-update-script,
-  electron,
+  electron_41,
   python3,
   nodejs,
   vips,
@@ -16,7 +16,9 @@
   xcodebuild,
   zip,
 }:
-
+let
+  electron = electron_41;
+in
 buildNpmPackage (finalAttrs: {
   pname = "musicfree-desktop";
   version = "0.0.8";

--- a/pkgs/by-name/sh/sharedown/package.nix
+++ b/pkgs/by-name/sh/sharedown/package.nix
@@ -15,10 +15,12 @@
   libsecret,
   ffmpeg,
   yt-dlp,
-  electron,
+  electron_41,
   chromium,
 }:
-
+let
+  electron = electron_41;
+in
 buildNpmPackage (finalAttrs: {
   pname = "Sharedown";
   version = "5.3.6-unstable-2025-12-16";

--- a/pkgs/by-name/so/solidtime-desktop/package.nix
+++ b/pkgs/by-name/so/solidtime-desktop/package.nix
@@ -5,11 +5,13 @@
   fetchFromGitHub,
   copyDesktopItems,
   makeDesktopItem,
-  electron,
+  electron_41,
   xcodebuild,
   desktopToDarwinBundle,
 }:
-
+let
+  electron = electron_41;
+in
 buildNpmPackage (finalAttrs: {
   pname = "solidtime-desktop";
   version = "0.2.7";

--- a/pkgs/by-name/yt/ytdownloader/package.nix
+++ b/pkgs/by-name/yt/ytdownloader/package.nix
@@ -7,9 +7,11 @@
   ffmpeg-headless,
   yt-dlp,
   makeDesktopItem,
-  electron,
+  electron_41,
 }:
-
+let
+  electron = electron_41;
+in
 buildNpmPackage rec {
   pname = "ytDownloader";
   version = "3.19.3";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5175,9 +5175,9 @@ with pkgs;
     electron_42
     electron_43
     ;
-  electron = electron_41;
-  electron-bin = electron_41-bin;
-  electron-chromedriver = electron-chromedriver_41;
+  electron = electron_43;
+  electron-bin = electron_43-bin;
+  electron-chromedriver = electron-chromedriver_43;
 
   autoconf = callPackage ../development/tools/misc/autoconf { };
   autoconf269 = callPackage ../development/tools/misc/autoconf/2.69.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual (partial) backport of #545971, without marking `session-desktop` as broken.

Previously: https://github.com/NixOS/nixpkgs/pull/506585

Bumps the default electron version to `electron_43`. `electron_41` will be EOL on 2026-08-25.
`electron_43` goes EOL on 2027-01-05, so this should be the only bump of the electron default version required for 26.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
