### PR TITLE
libsysprof-capture: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/development/tools/profiling/sysprof/capture.nix
+++ b/pkgs/development/tools/profiling/sysprof/capture.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation {
     ninja
   ];
 
+  strictDeps = true;
+
   mesonFlags = [
     "-Dsysprofd=none"
     "-Dgtk=false"

--- a/pkgs/development/tools/profiling/sysprof/capture.nix
+++ b/pkgs/development/tools/profiling/sysprof/capture.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation {
     "-Ddebuginfod=disabled"
   ];
 
+  __structuredAttrs = true;
+
   meta = sysprof.meta // {
     description = "Static library for Sysprof capture data generation";
     license = lib.licenses.bsd2Patent;


### PR DESCRIPTION
No change in output CA hash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
