### PR TITLE
faac: 1.50 -> 2.1 and modernize

### DIFF
--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";
     homepage = "https://github.com/knik0/faac";
     pkgConfigModules = [ "faac" ];
+    mainProgram = "faac";
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [ tmarkus ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -49,7 +49,15 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/knik0/faac";
     pkgConfigModules = [ "faac" ];
     mainProgram = "faac";
-    license = lib.licenses.unfreeRedistributable;
+    license = with lib.licenses; [
+      # faac itself
+      lgpl21Plus
+      # frontend/getopt.h
+      isc
+      # frontend/getopt.c
+      bsd2
+      publicDomain
+    ];
     maintainers = with lib.maintainers; [ tmarkus ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   meson,
   ninja,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,6 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     changelog = "https://github.com/knik0/faac/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";
     homepage = "https://github.com/knik0/faac";
     license = lib.licenses.unfreeRedistributable;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tmarkus ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  testers,
   stdenv,
   fetchFromGitHub,
   meson,
@@ -34,12 +35,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      # tag is "faac-2.1", but specified meson project version is "2.1.0"
+      versionCheck = false;
+    };
   };
 
   meta = {
     changelog = "https://github.com/knik0/faac/releases/tag/${finalAttrs.src.tag}";
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";
     homepage = "https://github.com/knik0/faac";
+    pkgConfigModules = [ "faac" ];
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [ tmarkus ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -18,16 +18,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+t8NNPaNlGXeDylEeBupOe5fbI1BD7JKDzdCRxRu52c=";
   };
 
+  __structuredAttrs = true;
+  strictDeps = true;
+  separateDebugInfo = true;
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [
     meson
     ninja
   ];
 
   mesonFlags = [
-    "-Db_lto=false" # plugin needed to handle lto object
+    (lib.mesonBool "b_lto" false) # plugin needed to handle lto object
   ];
-
-  enableParallelBuilding = true;
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "faac";
-  version = "1.50";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner = "knik0";
     repo = "faac";
     tag = "faac-${finalAttrs.version}";
-    hash = "sha256-264+OHyqG5Ccwx15cHhDqsk+9Z6UsdYr0bvrPWHP5xw=";
+    hash = "sha256-+t8NNPaNlGXeDylEeBupOe5fbI1BD7JKDzdCRxRu52c=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates:
- https://github.com/knik0/faac/releases/tag/faac-2.0
- https://github.com/knik0/faac/releases/tag/faac-2.1

See commits: 
- update to 2.1
- add update script
- specify and test `meta.pkgConfigModules`
- set structuredAttrs, strictDeps, separateDebugInfo
- specify `meta.mainProgram`
- update license


Regarding the license: ~~It is not clear to me why the package was previously marked `unfreeRedistributable`.~~
Notes: 
- Upstream declares itself to be LGPL 2.1+
- Arch simply specified LGPL 2.1+ as the license: https://gitlab.archlinux.org/archlinux/packaging/packages/faac/-/blob/0041d75509ff1712a843419d55c8e0e0f6bec8cb/PKGBUILD
- Debian notes the differing licenses of `frontend/getopt.{c.h}`, but those are FOSS as well: https://metadata.ftp-master.debian.org/changelogs//main/f/faac/faac_2.0-1_copyright
I've updated `meta.license` to be equivalent to Debian's specification, which seems complete and correct to me.

Edit: I've since realized that upstream actually rewrote parts of the codebase to allow it to be LGPL, quote: 
> Relicense: rewrite stereo, quantize, channels, bitstream, filtbank, tns, huffdata, huff2, and the MP4 output code as original work under LGPL-2.1-or-later, and drop the matching MPEG reference-code preamble from README.md, --license, and docs/. Every source file is now free software. Update the license header itself from GNU Library GPL to Lesser GPL wording.

Note to self: We can enable `faacSupport` in `gst-plugins-bad` if this is PR is merged, but we might have to use this patch from Arch, depending on whether this has been fixed in GStreamer 1.28.6 (not sure about that, but I don't really think so reading the release notes): https://gitlab.archlinux.org/archlinux/packaging/packages/gstreamer/-/blob/492411a28bb1d1b1e680d5615f2f0635942c93af/gstreamer-1.28.5-faac-2.0-compatibility.patch
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
