### PR TITLE
buildRustCrate: share one rustc jobserver across the derivation

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -271,7 +271,7 @@ in
           "$_i" "$_i" "$_i" "$_en" "$_ep"
         _i=$((_i + 1))
       done
-    } | make --no-print-directory -j"''${NIX_BUILD_CORES:-1}" -f -
+    } | MAKEFLAGS="$CARGO_MAKEFLAGS" make --no-print-directory -f -
   fi
 
   # Remove object files to avoid "wrong ELF type"

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -179,6 +179,16 @@ in
   export RUSTC="rustc"
   export RUSTDOC="rustdoc"
 
+  # One jobserver for the whole derivation: without one rustc creates its own,
+  # and choose the number of jobs without regard to NIX_BUILD_CORES
+  RUSTC_JOBSERVER_FIFO="$NIX_BUILD_TOP/rustc-jobserver.fifo"
+  rm -f "$RUSTC_JOBSERVER_FIFO"
+  mkfifo "$RUSTC_JOBSERVER_FIFO"
+  exec {RUSTC_JOBSERVER_FD}<>"$RUSTC_JOBSERVER_FIFO"
+  printf '%*s' "$((NIX_BUILD_CORES > 1 ? NIX_BUILD_CORES - 1 : 0))" "" \
+    | tr ' ' '+' >&"$RUSTC_JOBSERVER_FD"
+  export CARGO_MAKEFLAGS="-j --jobserver-auth=fifo:$RUSTC_JOBSERVER_FIFO"
+
   BUILD=""
   if [[ ! -z "${build}" ]] ; then
      BUILD=${build}


### PR DESCRIPTION
Without a jobserver rustc creates one of its own with a size disregarding NIX_BUILD_CORES. A crate built with `codegenUnits > 1` scales its codegen threads against that number instead of the cores nix allocated to the build.

Create one fifo jobserver in the configure phase with a size NIX_BUILD_CORES and export it through CARGO_MAKEFLAGS.

Also drop `-j` from the make invocation: a job count on make's command line while a jobserver is inherited makes make open a pool of its own.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
