### PR TITLE
budgie-control-center: 2.1.2 -> 2.1.3

### DIFF
--- a/pkgs/by-name/bu/budgie-control-center/package.nix
+++ b/pkgs/by-name/bu/budgie-control-center/package.nix
@@ -20,12 +20,12 @@
   gst_all_1,
   gnome-desktop,
   gnome-settings-daemon,
+  gnome-tecla,
   gsettings-desktop-schemas,
   gsound,
   gtk3,
   ibus,
   libepoxy,
-  libgnomekbd,
   libgtop,
   libgudev,
   libhandy,
@@ -68,14 +68,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "budgie-control-center";
-  version = "2.1.2";
+  version = "2.1.3";
 
   src = fetchFromGitHub {
     owner = "BuddiesOfBudgie";
     repo = "budgie-control-center";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-y/3qXIn8HI4S7K02ovZGT4ec/KJ93k/U82g4Rw3ZJQA=";
+    hash = "sha256-zxhMRmRfwBX8a7T0G4hq+zf3xVyryOiCYSOl4BbSObc=";
   };
 
   patches = [
@@ -83,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
       budgie_desktop = budgie-desktop;
       inherit
         cups
-        libgnomekbd
         shadow
         ;
       inherit networkmanagerapplet tzdata;
@@ -111,6 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     glib-networking
     gnome-desktop
+    gnome-tecla
     gst_all_1.gstreamer
     gnome-settings-daemon
     gsettings-desktop-schemas

--- a/pkgs/by-name/bu/budgie-control-center/paths.patch
+++ b/pkgs/by-name/bu/budgie-control-center/paths.patch
@@ -37,32 +37,6 @@ index 25cda02d3..db664bc56 100644
                              &contents,
                              &length,
                              &error))
-diff --git a/panels/keyboard/cc-input-list-box.c b/panels/keyboard/cc-input-list-box.c
-index 191207490..37e0fddc2 100644
---- a/panels/keyboard/cc-input-list-box.c
-+++ b/panels/keyboard/cc-input-list-box.c
-@@ -62,7 +62,7 @@ struct _CcInputListBox {
- };
- 
- G_DEFINE_TYPE (CcInputListBox, cc_input_list_box, GTK_TYPE_LIST_BOX)
-- 
-+
- typedef struct
- {
-   CcInputListBox *panel;
-@@ -223,10 +223,10 @@ row_layout_cb (CcInputListBox *self,
-   layout_variant = cc_input_source_get_layout_variant (source);
- 
-   if (layout_variant && layout_variant[0])
--    commandline = g_strdup_printf ("gkbd-keyboard-display -l \"%s\t%s\"",
-+    commandline = g_strdup_printf ("@libgnomekbd@/bin/gkbd-keyboard-display -l \"%s\t%s\"",
- 				   layout, layout_variant);
-   else
--    commandline = g_strdup_printf ("gkbd-keyboard-display -l %s",
-+    commandline = g_strdup_printf ("@libgnomekbd@/bin/gkbd-keyboard-display -l %s",
- 				   layout);
- 
-   g_spawn_command_line_async (commandline, NULL);
 diff --git a/panels/network/connection-editor/net-connection-editor.c b/panels/network/connection-editor/net-connection-editor.c
 index 505b8ee25..62e94009f 100644
 --- a/panels/network/connection-editor/net-connection-editor.c


### PR DESCRIPTION
https://github.com/BuddiesOfBudgie/budgie-control-center/compare/v2.1.2...v2.1.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
