### PR TITLE
qmapshack: 1.20.3 → 1.21.0

### DIFF
--- a/pkgs/by-name/qm/qmapshack/dont_fetch_dependencies.patch
+++ b/pkgs/by-name/qm/qmapshack/dont_fetch_dependencies.patch
@@ -1,0 +1,49 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index 33ec4e4a..9dff47cb 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -232,7 +232,6 @@ include(FetchContent)
+ ###############################################################################################
+ # Both are cloned by FetchContent. Fail here with a clear message instead of deep inside the
+ # populate sub-build if git is not on the PATH. Set GIT_EXECUTABLE if it is elsewhere.
+-find_package(Git REQUIRED)
+ 
+ # asmjit does not do official releases so pinned it to what was HEAD at time of writing this
+ set(ASMJIT_GIT_TAG  "0bd5787b54b575ed94bf32ac452153b34385c514" CACHE STRING "AsmJit git revision to fetch")
+@@ -243,34 +242,14 @@ set(BLEND2D_GIT_TAG "def0d1238c3e5d0983bb848e5676049d829e435b" CACHE STRING "Ble
+ # directory with no CMakeLists.txt so FetchContent_MakeAvailable populates without calling
+ # add_subdirectory(). Blend2D adds asmjit itself (via ASMJIT_DIR) and, because we build it
+ # statically, embeds it directly into the blend2d library.
+-FetchContent_Declare(asmjit
+-    GIT_REPOSITORY https://github.com/asmjit/asmjit.git
+-    GIT_TAG        ${ASMJIT_GIT_TAG}
+-    GIT_SHALLOW    FALSE # FALSE required when using a commit hash
+-    GIT_PROGRESS TRUE
+-    SOURCE_SUBDIR  __populate_only__
+-)
+-FetchContent_MakeAvailable(asmjit)
+-set(ASMJIT_DIR "${asmjit_SOURCE_DIR}" CACHE PATH "AsmJit source directory" FORCE)
++find_package(asmjit REQUIRED)
+ 
+-set(BLEND2D_STATIC TRUE)
+-FetchContent_Declare(blend2d
+-    GIT_REPOSITORY https://github.com/blend2d/blend2d.git
+-    GIT_TAG        ${BLEND2D_GIT_TAG}
+-    GIT_SHALLOW    FALSE
+-    GIT_PROGRESS TRUE
+-)
+-FetchContent_MakeAvailable(blend2d)
++find_package(blend2d REQUIRED)
+ 
+ # Blend2D's public headers use constructs our warning flags reject (anonymous structs vs
+ # -Wpedantic, ...). Re-publish its interface include dirs as system to supress any warnings.
+ # Once we bump our minimum cmake version to >= 3.25 we can instead just declare it `SYSTEM`
+ # in the `FetchContent_Declare` call and get rid of this.
+-get_target_property(BLEND2D_IFACE_INCLUDE_DIRS blend2d INTERFACE_INCLUDE_DIRECTORIES)
+-if(BLEND2D_IFACE_INCLUDE_DIRS)
+-    set_target_properties(blend2d PROPERTIES
+-        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${BLEND2D_IFACE_INCLUDE_DIRS}")
+-endif()
+ 
+ ###############################################################################################
+ # Create library from Garmin's FIT SDK

--- a/pkgs/by-name/qm/qmapshack/package.nix
+++ b/pkgs/by-name/qm/qmapshack/package.nix
@@ -6,6 +6,8 @@
   qt6,
   qt6Packages,
   alglib,
+  asmjit,
+  blend2d,
   gdal,
   proj,
   routino,
@@ -13,14 +15,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qmapshack";
-  version = "1.20.3";
+  version = "1.21.0";
 
   src = fetchFromGitHub {
     owner = "Maproom";
     repo = "qmapshack";
     tag = "V_${finalAttrs.version}";
-    hash = "sha256-U9sOIcQKE9v5vXsfvloLbfxtrCNliJEYnbc1mlwk9bo=";
+    hash = "sha256-8GQT83CqNBWJlWkiVDOgLEXkw1kohCCIKfS3TP9NFFs=";
   };
+
+  patches = [ ./dont_fetch_dependencies.patch ];
 
   nativeBuildInputs = [
     cmake
@@ -30,6 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     alglib
+    asmjit
+    blend2d
     gdal
     proj
     routino


### PR DESCRIPTION
https://github.com/Maproom/qmapshack/releases/tag/V_1.21.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
