### PR TITLE
kate-discord-rpc: init at 0-unstable-2026-03-17

### DIFF
--- a/pkgs/by-name/ka/kate-discord-rpc/package.nix
+++ b/pkgs/by-name/ka/kate-discord-rpc/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  kdePackages,
+  rapidjson,
+}:
+
+stdenv.mkDerivation {
+  pname = "kate-discord-rpc";
+  version = "0-unstable-2026-03-17";
+
+  src = fetchFromGitHub {
+    owner = "leia-uwu";
+    repo = "kate-discord-rpc";
+    rev = "93a14a03887540f819b3b4885fd8c789aee05b19";
+    hash = "sha256-TWMYy6oeFJZ1WTS9tNQLk9RcRBwkvVrZy9kVU2Kr90s=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kdePackages.ktexteditor
+    kdePackages.kcoreaddons
+    kdePackages.kconfig
+    kdePackages.ki18n
+    kdePackages.qtbase
+    rapidjson
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Discord Rich Presence plugin for KDE Kate";
+    homepage = "https://github.com/leia-uwu/kate-discord-rpc";
+    license = licenses.gpl2Plus;
+    maintainers = [ ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
### Summary

This PR adds `kate-discord-rpc`, a Discord Rich Presence plugin for the KDE Kate text editor.

- **Homepage:** https://github.com/leia-uwu/kate-discord-rpc
- **License Note:** Upstream includes the standard GPL v2 boilerplate ("version 2, or (at your option) any later version"), so this derivation uses `lib.licenses.gpl2Plus`. Please let me know if Nixpkgs prefers `gpl2Only` here instead.

---

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test