### PR TITLE
python3Packages.django-oauth-toolkit: 3.3.0 -> 3.4.1

### DIFF
--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -21,6 +21,15 @@ let
     packageOverrides = self: super: {
       django_5 = super.django_5.override { withGdal = true; };
       django = super.django_5;
+
+      django-oauth-toolkit = super.django-oauth-toolkit.overrideAttrs (old: {
+        version = "3.3.0";
+
+        src = old.src.override {
+          hash = "sha256-eRQzAFUvSgoDiP7LW/+hMrNxHuXVxY+wc/E3VU/zeXo=";
+        };
+      });
+
       # custom python module part of froide
       dogtail = super.buildPythonPackage {
         pname = "dogtail";

--- a/pkgs/development/python-modules/django-oauth-toolkit/default.nix
+++ b/pkgs/development/python-modules/django-oauth-toolkit/default.nix
@@ -7,27 +7,30 @@
   # propagates
   django,
   jwcrypto,
-  requests,
   oauthlib,
+  requests,
+  urllib3,
 
   # tests
+  django-ninja,
   djangorestframework,
   pytest-cov-stub,
   pytest-django,
   pytest-mock,
+  pytest-xdist,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "django-oauth-toolkit";
-  version = "3.3.0";
+  version = "3.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jazzband";
     repo = "django-oauth-toolkit";
     tag = finalAttrs.version;
-    hash = "sha256-eRQzAFUvSgoDiP7LW/+hMrNxHuXVxY+wc/E3VU/zeXo=";
+    hash = "sha256-UsnfGOyVk5w0grG6cTgMmfo+HyrZtsER338YobLyk08=";
   };
 
   build-system = [ setuptools ];
@@ -37,20 +40,20 @@ buildPythonPackage (finalAttrs: {
     jwcrypto
     oauthlib
     requests
+    urllib3
   ];
 
   preCheck = ''
     export DJANGO_SETTINGS_MODULE=tests.settings
   '';
 
-  # xdist is disabled right now because it can cause race conditions on high core machines
-  # https://github.com/jazzband/django-oauth-toolkit/issues/1300
   nativeCheckInputs = [
+    django-ninja
     djangorestframework
     pytest-cov-stub
     pytest-django
-    # pytest-xdist
     pytest-mock
+    pytest-xdist
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/drf-spectacular/default.nix
+++ b/pkgs/development/python-modules/drf-spectacular/default.nix
@@ -18,7 +18,6 @@
   drf-nested-routers,
   drf-spectacular-sidecar,
   fetchFromGitHub,
-  fetchpatch,
   inflection,
   jsonschema,
   psycopg2,
@@ -52,6 +51,8 @@ buildPythonPackage rec {
     uritemplate
   ];
 
+  optional-dependencies.sidecar = [ drf-spectacular-sidecar ];
+
   nativeCheckInputs = [
     dj-rest-auth
     django-allauth
@@ -73,25 +74,16 @@ buildPythonPackage rec {
   ]
   ++ django-allauth.optional-dependencies.socialaccount;
 
-  disabledTests = [
-    # Test requires django with gdal
-    "test_rest_framework_gis"
-    # Outdated test artifact
-    "test_callbacks"
-    # django-rest-knox is not packaged
-    "test_knox_auth_token"
-    # slightly different error messages which get asserted
-    "test_model_choice_display_method_on_readonly"
-  ];
-
   disabledTestPaths = [
+    # django-rest-knox is not packaged
+    "tests/contrib/test_knox_auth_token.py"
     # Outdated test artifact
     "tests/contrib/test_pydantic.py"
+    # Test requires django with gdal
+    "tests/contrib/test_rest_framework_gis.py"
   ];
 
   pythonImportsCheck = [ "drf_spectacular" ];
-
-  optional-dependencies.sidecar = [ drf-spectacular-sidecar ];
 
   meta = {
     description = "Sane and flexible OpenAPI 3 schema generation for Django REST framework";

--- a/pkgs/development/python-modules/drf-spectacular/default.nix
+++ b/pkgs/development/python-modules/drf-spectacular/default.nix
@@ -75,6 +75,8 @@ buildPythonPackage rec {
   ++ django-allauth.optional-dependencies.socialaccount;
 
   disabledTestPaths = [
+    # django-oauth-toolkit 3.4.1 added a new error that the example application has
+    "tests/test_command.py::test_command_check"
     # django-rest-knox is not packaged
     "tests/contrib/test_knox_auth_token.py"
     # Outdated test artifact


### PR DESCRIPTION
Diff: https://github.com/jazzband/django-oauth-toolkit/compare/3.3.0...3.4.1

Changelog: https://github.com/jazzband/django-oauth-toolkit/blob/3.4.1/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
