### PR TITLE
firrtl2: add new package for v.6.0.0

### DIFF
--- a/pkgs/by-name/fi/firrtl2/package.nix
+++ b/pkgs/by-name/fi/firrtl2/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  jre,
+  setJavaClassPath,
+  coursier,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "firrtl2";
+  version = "6.0.0";
+  scalaVersion = "2.13"; # pin, for determinism
+
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version;
+    nativeBuildInputs = [ coursier ];
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      cs fetch edu.berkeley.cs:${pname}_${scalaVersion}:${version} > deps
+      mkdir -p $out/share/java
+      cp $(< deps) $out/share/java
+    '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-gO//jEM+Gb+SktSbVnqGTUbDXgHucsEHQe0S+uWSHQ0=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    setJavaClassPath
+  ];
+  buildInputs = [ deps ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-cp $CLASSPATH firrtl2.stage.FirrtlMain"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/firrtl2 --firrtl-source "${''
+      circuit test:
+        module test:
+          input a: UInt<8>
+          input b: UInt<8>
+          output o: UInt
+          o <= add(a, not(b))
+    ''}" -o test.v
+    cat test.v
+    grep -qFe "module test" -e "endmodule" test.v
+  '';
+
+  meta = {
+    description = "Flexible Intermediate Representation for RTL";
+    mainProgram = "firrtl2";
+    longDescription = ''
+      Firrtl is an intermediate representation (IR) for digital circuits
+      designed as a platform for writing circuit-level transformations.
+    '';
+    homepage = "https://www.chisel-lang.org/firrtl/";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/by-name/fi/firrtl2/package.nix
+++ b/pkgs/by-name/fi/firrtl2/package.nix
@@ -10,7 +10,11 @@
 stdenv.mkDerivation rec {
   pname = "firrtl2";
   version = "6.0.0";
-  scalaVersion = "2.13"; # pin, for determinism
+  scalaVersion = "2.13";
+
+  # Required by CI
+  strictDeps = true;
+  __structuredAttrs = true;
 
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";


### PR DESCRIPTION
Firrtl currently only has a package for the last archived release of version 1.5.6.

However there was a release a year later on a different repository that contains all of the commits after 1.5.6 up to when the repository was archived, this is called firrtl2 and is hosted here:
https://github.com/ucb-bar/firrtl2/releases/tag/v6.0.0

I think there should be a separate package for this version of firrtl.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
