### PR TITLE
linuxPackages.amneziawg: fix stupid typo

### DIFF
--- a/pkgs/os-specific/linux/amneziawg/sk-715.patch
+++ b/pkgs/os-specific/linux/amneziawg/sk-715.patch
@@ -27,10 +27,10 @@ index 3be1113..f5437cc 100644
 +
  #endif /* _WG_COMPAT_H */
 diff --git a/device.c b/device.c
-index c8f4312..4e7848e 100644
+index c8f4312..011e718 100644
 --- a/device.c
 +++ b/device.c
-@@ -379,12 +379,12 @@ static int wg_newlink(struct net_device *dev,
+@@ -379,7 +379,7 @@ static int wg_newlink(struct net_device *dev,
  #endif
  
  	wg->handshake_receive_wq = alloc_workqueue("wg-kex-%s",
@@ -39,11 +39,14 @@ index c8f4312..4e7848e 100644
  	if (!wg->handshake_receive_wq)
  		goto err_free_tstats;
  
- 	wg->handshake_send_wq = alloc_workqueue("wg-kex-%s",
--			WQ_UNBOUND | WQ_FREEZABLE, 0, dev->name);
-+			WQ_UNBOUND | WQ_FREEZABLE | WQ_PERCPU, 0, dev->name);
- 	if (!wg->handshake_send_wq)
+@@ -389,7 +389,7 @@ static int wg_newlink(struct net_device *dev,
  		goto err_destroy_handshake_receive;
+ 
+ 	wg->packet_crypt_wq = alloc_workqueue("wg-crypt-%s",
+-			WQ_CPU_INTENSIVE | WQ_MEM_RECLAIM, 0, dev->name);
++			WQ_CPU_INTENSIVE | WQ_MEM_RECLAIM | WQ_PERCPU, 0, dev->name);
+ 	if (!wg->packet_crypt_wq)
+ 		goto err_destroy_handshake_send;
  
 diff --git a/netlink.c b/netlink.c
 index b1da877..28f1efa 100644


### PR DESCRIPTION
Oops wrong workqueue.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
