### PR TITLE
terragrunt: cleanup and enable tests

### DIFF
--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -1,9 +1,15 @@
 {
   lib,
+
   buildGoModule,
   fetchFromGitHub,
+
+  gitMinimal,
+  gitSetupHook,
+  opentofu,
+  writableTmpDirAsHomeHook,
+
   versionCheckHook,
-  mockgen,
 }:
 buildGoModule (finalAttrs: {
   pname = "terragrunt";
@@ -19,27 +25,71 @@ buildGoModule (finalAttrs: {
     hash = "sha256-JovTD88P/9IUX1y1AG/NhkIRRPCa0eAwJSx5qfg+4Ck=";
   };
 
-  nativeBuildInputs = [
-    mockgen
-  ];
-
   proxyVendor = true;
-
-  preBuild = ''
-    make generate-mocks
-  '';
 
   vendorHash = "sha256-eqoT9On/nGwJIbWug4RQVmibbsqbTRa5MzOoFXgGmxc=";
 
-  excludedPackages = [ "test/flake" ];
-
-  doCheck = false;
+  excludedPackages = [
+    # utility for identifying flakey tests
+    "test/flake"
+  ];
 
   ldflags = [
     "-s"
     "-w"
     "-X github.com/gruntwork-io/terragrunt/internal/version.Version=v${finalAttrs.version}"
   ];
+
+  nativeCheckInputs = [
+    # required for git to resolve $HOME/.gitconfig
+    # terragrunt's CAS feature also wants to write inside $HOME
+    writableTmpDirAsHomeHook
+    gitSetupHook
+    # needs to run git mid test
+    gitMinimal
+    opentofu
+  ];
+
+  preCheck = ''
+    # make executable so it's a valid target for `patchShebangs`
+    chmod +x test/fixtures/feature-flags/run-all-isolated-defaults/fake-tf.sh
+
+    # patch scripts used in tests
+    patchShebangs \
+      internal/os/exec/testdata \
+      internal/tf/testdata \
+      internal/shell/testdata \
+      test/fixtures/
+
+    # prep directory so git commands during testing will work
+    git config --global init.defaultBranch master
+    git init
+    # dir needs to be part of history
+    git add test/fixtures/config-terraform-functions
+    git commit --quiet --message "initial commit"
+  '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # calls out to the internet
+        "TestToSourceUrl"
+        # requires cloning it's own terragrunt repo via github.com
+        "TestCatalogWithLocalDefaultTemplate"
+        # requires cloning https://github.com/gruntwork-io/terraform-fake-modules.git/
+        "TestScaffoldGitModule"
+        "TestScaffoldGitRepo"
+        # requires cloning https://github.com/Azure/terraform-azurerm-avm-res-compute-virtualmachine.git
+        "TestScaffold3rdPartyModule"
+        # requires terraform
+        "TestDependencyOutputSkipDependencyOutputsFlag"
+        "TestCatalogGitRepoUpdate"
+        "TestRunAllHonorsTerraformBinaryWithBothOnPath"
+        # requires remote terraform/tofu providers
+        "TestTerragruntFullLockfile"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -9,6 +9,9 @@ buildGoModule (finalAttrs: {
   pname = "terragrunt";
   version = "1.1.3";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "gruntwork-io";
     repo = "terragrunt";

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -37,8 +37,8 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
+    "-w"
     "-X github.com/gruntwork-io/terragrunt/internal/version.Version=v${finalAttrs.version}"
-    "-extldflags '-static'"
   ];
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -1,13 +1,18 @@
 {
   lib,
+  stdenv,
 
   buildGoModule,
   fetchFromGitHub,
+
+  installShellFiles,
 
   gitMinimal,
   gitSetupHook,
   opentofu,
   writableTmpDirAsHomeHook,
+
+  buildPackages,
 
   versionCheckHook,
 }:
@@ -28,6 +33,10 @@ buildGoModule (finalAttrs: {
   proxyVendor = true;
 
   vendorHash = "sha256-eqoT9On/nGwJIbWug4RQVmibbsqbTRa5MzOoFXgGmxc=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   excludedPackages = [
     # utility for identifying flakey tests
@@ -94,6 +103,29 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
+
+  postInstall =
+    let
+      cmd = finalAttrs.meta.mainProgram;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/${cmd}"
+        else
+          lib.getExe buildPackages.terragrunt;
+    in
+    ''
+      # terragrunt will only directly install completions
+      # completion install looks for expected file paths for a shell or it wont do an install
+      # provide the fish dir it looks for
+      mkdir -p ./completion/fish
+      export COMPLETION_DIR="$PWD/completion"
+
+      # go's os/user.Current which looks in /etc/passwd with no $HOME override
+      XDG_CONFIG_HOME="$COMPLETION_DIR" ${exe} --install-autocomplete
+      installShellCompletion --cmd ${cmd} \
+        --fish "$COMPLETION_DIR/fish/completions/${cmd}.fish"
+    '';
+
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 

--- a/pkgs/by-name/te/terragrunt/package.nix
+++ b/pkgs/by-name/te/terragrunt/package.nix
@@ -130,9 +130,9 @@ buildGoModule (finalAttrs: {
   doInstallCheck = true;
 
   meta = {
-    homepage = "https://terragrunt.gruntwork.io";
+    homepage = "https://terragrunt.com/";
     changelog = "https://github.com/gruntwork-io/terragrunt/releases/tag/v${finalAttrs.version}";
-    description = "Thin wrapper for Terraform that supports locking for Terraform state and enforces best practices";
+    description = "Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale";
     mainProgram = "terragrunt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
- **terragrunt: apply strictDeps and __structuredAttrs**
- **terragrunt: make ldflags more consistent with nixpkgs**
- **terragrunt: enable tests**
- **terragrunt: provide fish completion**
- **terragrunt: update meta**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
