### PR TITLE
redisinsight: electron_41 -> electron_43; redisinsight: 3.6.0 -> 3.8.0

### DIFF
--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   fetchYarnDeps,
   makeDesktopItem,
+  nix-update-script,
 
   copyDesktopItems,
   dart-sass,
@@ -171,6 +172,17 @@ stdenv.mkDerivation (finalAttrs: {
       startupWMClass = "redisinsight";
     })
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--custom-dep"
+      "baseOfflineCache"
+      "--custom-dep"
+      "innerOfflineCache"
+      "--custom-dep"
+      "apiOfflineCache"
+    ];
+  };
 
   meta = {
     description = "Developer GUI for Redis";

--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -9,7 +9,7 @@
   copyDesktopItems,
   dart-sass,
   makeWrapper,
-  nodejs-slim_24,
+  nodejs-slim_26,
   pkg-config,
   yarnConfigHook,
 
@@ -20,17 +20,17 @@
 
 let
   electron = electron_43;
-  nodejs = nodejs-slim_24;
+  nodejs = nodejs-slim_26;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "redisinsight";
-  version = "3.6.0";
+  version = "3.8.0";
 
   src = fetchFromGitHub {
     owner = "redis";
     repo = "RedisInsight";
     rev = finalAttrs.version;
-    hash = "sha256-YnBy++KshDVNw3p1gf7gHydQyyh03fkSULhnZsqZMxs=";
+    hash = "sha256-BxK+b2gQQZaURKjnxO3L7imojkA5eiYR6Ld8lM0SafM=";
   };
 
   patches = [
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   baseOfflineCache = fetchYarnDeps {
     name = "redisinsight-${finalAttrs.version}-base-offline-cache";
     inherit (finalAttrs) src patches;
-    hash = "sha256-lfCasq3C0jD4wNpguxSOxwrR0Sx3ZfwK95Ib31TShSQ=";
+    hash = "sha256-GRAelr2czhPzje/4cwGLk7WiQqPJQpt+31Lk9Sbk1+U=";
   };
 
   innerOfflineCache = fetchYarnDeps {
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "redisinsight-${finalAttrs.version}-api-offline-cache";
     inherit (finalAttrs) src patches;
     postPatch = "cd redisinsight/api";
-    hash = "sha256-8u4igcegknwydNsVLcPv6E5/uwQJpwNWhIpCujfoXqk=";
+    hash = "sha256-GyJVXgU7vBes8JD4OCsxtbS9d0LRXH4hrQwBqxid1wQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -13,13 +13,13 @@
   pkg-config,
   yarnConfigHook,
 
-  electron_41,
+  electron_43,
   libsecret,
   sqlite,
 }:
 
 let
-  electron = electron_41;
+  electron = electron_43;
   nodejs = nodejs-slim_24;
 in
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
* `electron_41` is marked as EOL, migrate pkg to use `electron_43`
* cherry-pick 2b85c4eceb5b0c0e04ca82bc432f8ee6cb7ea329 from #553443
* cherry-pick a7ef79dfd6a4643879798ffe98303f95a060a132 from #553443

Related to: NixOS/nixpkgs#555100
Supercedes: #553443 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
