### PR TITLE
librechat: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/by-name/li/librechat/package.nix
+++ b/pkgs/by-name/li/librechat/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  nodejs_22,
   pkg-config,
   node-gyp,
   vips,
@@ -12,13 +11,13 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "librechat";
-  version = "0.8.6";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
     owner = "danny-avila";
     repo = "LibreChat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cWgjsLN7NnJNJ1hYPo0h3lh+W4wi9qqttevNfNrYdXg=";
+    hash = "sha256-egnmkYpQS/AshMmXP5C8qhwA+7TPZYnu0ct552HFjGg=";
   };
 
   patches = [
@@ -35,10 +34,7 @@ buildNpmPackage (finalAttrs: {
   ];
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-Y+oC9eigwzL8jei5Hs4YOf32oFgULPmHrSDApxPKh+0=";
-
-  # npm dependency install fails with nodejs_24: https://github.com/NixOS/nixpkgs/issues/474535
-  nodejs = nodejs_22;
+  npmDepsHash = "sha256-U2DzvfzKCmAYLFG0FbFcng5goj1mYCjTpJuQ36fVNuA=";
 
   nativeBuildInputs = [
     pkg-config
@@ -61,7 +57,12 @@ buildNpmPackage (finalAttrs: {
 
   # npmConfigHook only patches the root node_modules
   postConfigure = ''
-    patchShebangs client/node_modules
+    patchShebangs $(find "$PWD" -type d -name node_modules -prune ! -path "$PWD/node_modules" -print)
+  '';
+
+  preInstall = ''
+    # not sure why this is something npm pack tries to keep
+    rm -rf ./packages/data-schemas/node_modules/winston-transport/.nyc_output
   '';
 
   # For reasons beyond my understanding, the api and client directory disappears after the build finishes.


### PR DESCRIPTION
Changelog: https://www.librechat.ai/changelog/v0.8.7

Bumped the node version due to this

```
Installing dependencies
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@librechat/agents@3.2.46',
npm warn EBADENGINE   required: { node: '>=24.0.0' },
npm warn EBADENGINE   current: { node: 'v22.23.2', npm: '10.9.8' }
npm warn EBADENGINE }
```

Linked issue seemed to be resolved now.

Also had to patchShebang some more bits inside node_modules paths so made it use `find` to get `node_modules` paths.

And there was a weird issue where it was trying to move the contents of `/packages/data-schemas/node_modules/winston-transport/.nyc_output` during the npmInstallHook phase but it couldn't find anything and quit, so I just delete the dir.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
