### PR TITLE
lib.services: init `process.runtimeDirectory`

### DIFF
--- a/lib/services/service.nix
+++ b/lib/services/service.nix
@@ -37,6 +37,62 @@ let
       def // { value = lib.mkOrder unadornedFlagPriority def.value.content; }
     else
       def;
+
+  directoryType = types.nullOr (types.submodule {
+    options = {
+      path = mkOption {
+        type = types.str;
+        description = "Relative underlying service manager runtime directory path.";
+      };
+
+      # NOTE: probably want to be aware of https://github.com/NixOS/nixpkgs/issues/545287
+      user = mkOption {
+        type = types.bool;
+        default = false;
+        description = "The user that owns this directory.";
+      };
+      group = mkOption {
+        type = types.bool;
+        default = false;
+        description = "The group that owns this directory";
+      };
+
+      createOnStartup = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Creates the directory on process startup.";
+      };
+
+      removeOnShutdown = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Removes the directory upon process shutdown.";
+      };
+
+      cleanupInterval = mkOption {
+        type = types.nullOr (
+          types.submodule {
+            options = lib.genAttrs [
+              "secconds"
+              "minutes"
+              "hours"
+              "days"
+              "weeks"
+            ] (
+                name:
+                mkOption {
+                  type = types.int;
+                  default = 0;
+                  description = "Cleanup interval in ${name}.";
+                }
+              );
+          }
+        );
+        default = null;
+        description = "How often to clean up the directory when process is running. Set to null to disable.";
+      };
+    };
+  });
 in
 {
   # https://nixos.org/manual/nixos/unstable/#modular-services
@@ -187,6 +243,10 @@ in
         description = ''
           Command used for reloading in the underlying service manager to reload.
         '';
+      };
+
+      runtimeDirectory = mkOption {
+        type = directoryType
       };
     };
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> [!NOTE]
> This pr is still in progress and do not suggest testing/reviewing. 
> You can review if you want, however it is expected changes will happen. 

Adds support for defining a `runtimeDirectory` that services can used. 
Also for NixOS adds the ability to define tmpfiles, however for the user and group, you probably want https://github.com/NixOS/nixpkgs/issues/545287 first.

Related to: https://github.com/NixOS/nixpkgs/pull/546886 defining tmpfiles for a directory.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
