### PR TITLE
obscura: add darwin support

### DIFF
--- a/pkgs/by-name/ob/obscura/librusty_v8.nix
+++ b/pkgs/by-name/ob/obscura/librusty_v8.nix
@@ -9,6 +9,7 @@ let
   hashes = {
     x86_64-linux = "0rv5nl4gcbvdpk3mdwbqvw180nfx2wk173q1cqrvv2h1agg1ys52";
     aarch64-linux = "14kci8zl7i5cjrbf2jyky5i9gpa4bsjw8khfk4xc8yf1875x0s73";
+    aarch64-darwin = "0w70ykqip4a84z3cb5vibdqw91lywwahl9pc05mw8lp54ikksl30";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/by-name/ob/obscura/package.nix
+++ b/pkgs/by-name/ob/obscura/package.nix
@@ -74,6 +74,7 @@ rustPlatform.buildRustPackage rec {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
+      "aarch64-darwin"
     ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/ob/obscura/update.sh
+++ b/pkgs/by-name/ob/obscura/update.sh
@@ -36,6 +36,7 @@ let
   hashes = {
     x86_64-linux = "$(nix-prefetch-url --type sha256 "https://github.com/denoland/rusty_v8/releases/download/v${NEW_VERSION}/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz")";
     aarch64-linux = "$(nix-prefetch-url --type sha256 "https://github.com/denoland/rusty_v8/releases/download/v${NEW_VERSION}/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz")";
+    aarch64-darwin = "$(nix-prefetch-url --type sha256 "https://github.com/denoland/rusty_v8/releases/download/v${NEW_VERSION}/librusty_v8_release_aarch64-apple-darwin.a.gz")";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Add aarch64-darwin support: prebuilt librusty_v8 archive hash, meta.platforms entry, and update.sh prefetch for the aarch64-apple-darwin release.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
