### PR TITLE
bun: 1.3.13 -> 1.4.0

### DIFF
--- a/pkgs/by-name/bu/bun/package.nix
+++ b/pkgs/by-name/bu/bun/package.nix
@@ -17,7 +17,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  version = "1.3.13";
+  version = "1.4.0";
   pname = "bun";
 
   src =
@@ -69,15 +69,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sources = {
       "aarch64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-darwin-aarch64.zip";
-        hash = "sha256-VGfj9l26Umuf6pjwzOBO+vwMY+Fpcz7Ce4dqOtMtoZA=";
+        hash = "sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-linux-aarch64.zip";
-        hash = "sha256-cLrkGzkIsKEg4eWMXIrzDnSvrjuNEbDT/djnh937SyI=";
+        hash = "sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=";
       };
       "x86_64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-linux-x64-baseline.zip";
-        hash = "sha256-nYokKSpwaAkCBdqsCloiP19pc29Sh+N7+I07QDHtx1A=";
+        hash = "sha256-GE+0WV8NQBohfPfHjBvEMLqDMU2reouUgFurv3+nCX8=";
       };
     };
     updateScript = writeShellScript "update-bun" ''


### PR DESCRIPTION
Bumps `bun` from 1.3.13 to 1.4.0 (released 2026-08-20).

Changelog: https://bun.com/blog/bun-v1.4.0

### Disclosure

Per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy): this change, this summary, and the linked issue #555162 were prepared with **Claude Code (claude-opus-5)** under my direction. The commit now carries an `Assisted-by: Claude Code (claude-opus-5)` trailer.

Apologies for the initial submission — it used a `Co-authored-by:` trailer, which the policy explicitly does not accept, and carried no disclosure on the summary. Both are fixed. I have moved this back to **draft** while I complete my own review of the diff, per the draft exemption in the policy; I will not mark it ready until I have done that and can answer for it.

Confidence in the output was established programmatically, not by eye:

- All three source hashes were re-derived independently with `nix store prefetch-file` and match the values in the diff.
- The derivation was built on `x86_64-linux` and the resulting binary exercised (`bun --revision` → `1.4.0+34cbb9a40`, running a script, and `bun build --compile` followed by executing the output).

### Relation to #519796

The diff is identical to [#519796](https://github.com/NixOS/nixpkgs/pull/519796) by @delafthi, who did the original hash work and deserves the credit. That PR has been in draft since 2026-05-13. Happy to close this in favour of it.

### The hold on #519796 appears to be resolved upstream

#519796 was held because `bun build --compile` produced segfaulting binaries under nix ([oven-sh/bun#31023](https://github.com/oven-sh/bun/issues/31023)), breaking `opencode`, `filen-cli`, `gitlab-duo` and `ghui`.

Upstream fixed it in [oven-sh/bun#31024](https://github.com/oven-sh/bun/pull/31024) (merged 2026-07-29, with a regression test simulating the NixOS `patchelf` layout): `write_bun_section` now selects the writable `PT_LOAD` by vaddr containment of `.bun` instead of taking the first one. 1.4.0 ships with that fix, and the reproducer no longer segfaults here.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Notes on the unchecked boxes:

- **`nixpkgs-review` not run** — I do not have the capacity to rebuild the 39 dependent packages. The 4 that failed the May review against 1.3.14 (`opencode`, `filen-cli`, `gitlab-duo`, `ghui`) still need re-checking against 1.4.0. The upstream fix above is a reason to expect them to pass, not evidence that they do. This is the main gap in this PR.
- `aarch64-linux` / `aarch64-darwin` not built; their hashes were verified via `nix store prefetch-file` only.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Context and the upstream-fix trail: #555162
