### PR TITLE
actual-client: bump electron to v42

### DIFF
--- a/pkgs/by-name/ac/actual-client/package.nix
+++ b/pkgs/by-name/ac/actual-client/package.nix
@@ -2,7 +2,7 @@
   lib,
   actual-server,
   copyDesktopItems,
-  electron_41,
+  electron_42,
   imagemagick,
   jq,
   makeDesktopItem,
@@ -11,7 +11,7 @@
   stdenv,
 }:
 let
-  electron = electron_41;
+  electron = electron_42;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "actual-client";
@@ -45,12 +45,14 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
+    # TODO: uncomment once actual updates their electron version to v42+
+    # https://github.com/actualbudget/actual/issues/8767
     # verify electron version
-    upstreamElectronMajor=$(${lib.getExe jq} -r '.devDependencies.electron | match("[0-9]+").string' packages/desktop-electron/package.json)
-    if [[ "$upstreamElectronMajor" != "${lib.versions.major electron.version}" ]]; then
-      echo "Electron major version mismatch: Actual expects $upstreamElectronMajor, nixpkgs provides ${electron.version}" >&2
-      exit 1
-    fi
+    # upstreamElectronMajor=$(${lib.getExe jq} -r '.devDependencies.electron | match("[0-9]+").string' packages/desktop-electron/package.json)
+    # if [[ "$upstreamElectronMajor" != "${lib.versions.major electron.version}" ]]; then
+    #   echo "Electron major version mismatch: Actual expects $upstreamElectronMajor, nixpkgs provides ${electron.version}" >&2
+    #   exit 1
+    # fi
 
     export HOME=$(mktemp -d)
 

--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -161,6 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = [
+      lib.maintainers.PerchunPak
       lib.maintainers.oddlama
       lib.maintainers.patrickdag
       lib.maintainers.yash-garg


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
See https://github.com/NixOS/nixpkgs/issues/555100 and https://github.com/actualbudget/actual/issues/8767

The app seems to work fine, did not test it thoroughly, though




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. No AI used

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
