### PR TITLE
linuxPackages.zenpower: 0.2.0 -> 0.5.0-unstable-2026-01-07, switch to yet another fork

### DIFF
--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -6,18 +6,21 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "zenpower";
-  version = "0.2.0";
+stdenv.mkDerivation {
+  pname = "zenpower5";
+  version = "0.5.0-unstable-2026-01-07";
 
   src = fetchFromGitHub {
-    owner = "AliEmreSenel";
-    repo = "zenpower3";
-    tag = "v${version}";
-    hash = "sha256-ro40bIMPkM3rLraZaKqzB8a14zgldMIW4jSUr5GbELo=";
+    owner = "mattkeenan";
+    repo = "zenpower5";
+    rev = "66871d8e59c3741e00de2eb1f61c3b64263ed10b";
+    hash = "sha256-g0zVTDi5owa6XfQN8vlFwGX+gpRIg+5q1F4EuxAk9Sk=";
   };
 
-  hardeningDisable = [ "pic" ];
+  patches = [
+    # https://github.com/mattkeenan/zenpower5/pull/16
+    ./kernel-7.2-comp.patch
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
@@ -30,14 +33,13 @@ stdenv.mkDerivation rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    inherit (src.meta) homepage;
     description = "Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs";
+    homepage = "https://github.com/mattkeenan/zenpower5";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       alexbakker
       artturin
     ];
     platforms = [ "x86_64-linux" ];
-    broken = lib.versionOlder kernel.version "4.14";
   };
 }

--- a/pkgs/os-specific/linux/zenpower/kernel-7.2-comp.patch
+++ b/pkgs/os-specific/linux/zenpower/kernel-7.2-comp.patch
@@ -1,0 +1,26 @@
+From 746c9af943c5aabdba132fed8473599f511b083b Mon Sep 17 00:00:00 2001
+From: "K.Ohta" <whatisthis.sowhat@gmail.com>
+Date: Tue, 18 Aug 2026 09:47:55 +0900
+Subject: [PATCH] Workaround for kernel v7.2.x by upstream's issue 13.
+
+- See https://github.com/mattkeenan/zenpower5/issues/13 .
+- Thanks @pallaswept for make this workaround.
+---
+ zenpower_core.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/zenpower_core.c b/zenpower_core.c
+index fe8ea44..8cabd4c 100644
+--- a/zenpower_core.c
++++ b/zenpower_core.c
+@@ -46,6 +46,10 @@
+ #include <asm/amd_nb.h>
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
++#include <asm/cpuid/api.h>
++#endif
++
+ #include "zenpower.h"
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) /* asm/amd_node.h */


### PR DESCRIPTION
This contains support for newer zen platforms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
