### PR TITLE
fetch: 2.1.0 -> 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25472,6 +25472,12 @@
     githubId = 107703;
     name = "Samuel Rivas";
   };
+  samuelskovbakke = {
+    email = "samuel@skovbakke.dk";
+    github = "samuelskovbakke";
+    githubId = 25748723;
+    name = "Samuel Skovbakke";
+  };
   samueltardieu = {
     email = "nixpkgs@sam.rfc1149.net";
     github = "samueltardieu";

--- a/pkgs/by-name/fe/fetch/package.nix
+++ b/pkgs/by-name/fe/fetch/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fetch";
-  version = "2.1.0";
+  version = "2.3.0";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "areofyl";
     repo = "fetch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9ixx7XJcY4ktcN/lUfjvFljvHIEO2ktOebeGgL0ulHg=";
+    hash = "sha256-YEHvV07d02SzYO+lGT0Q+NkVoQNqxapBZfh44NOf/cw=";
   };
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
@@ -43,6 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
       samuelskovbakke
     ];
     mainProgram = "fetch";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/fe/fetch/package.nix
+++ b/pkgs/by-name/fe/fetch/package.nix
@@ -38,7 +38,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/areofyl/fetch";
     changelog = "https://github.com/areofyl/fetch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ ghastrum ];
+    maintainers = with lib.maintainers; [
+      ghastrum
+      samuelskovbakke
+    ];
     mainProgram = "fetch";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
Updates `fetch` from 2.1.0 to 2.3.0.

Changelog: https://github.com/areofyl/fetch/releases/tag/v2.3.0

Notable: this release includes a security fix for command injection via popen() during version-string extraction, alongside new fields (cursor, display manager, GPU labeling) and various fixes. No new build inputs required.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].