### PR TITLE
joplin-desktop: 3.6.15 -> 3.6.16

### DIFF
--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  nodejs_22,
+  nodejs,
   makeDesktopItem,
   copyDesktopItems,
   makeWrapper,
@@ -26,9 +26,7 @@
 }:
 
 let
-  # nodejs pin should be obsolete once #522655 is in master
-  nodejs = nodejs_22;
-  yarn-berry = yarn-berry_4.override { inherit nodejs; };
+  yarn-berry = yarn-berry_4;
 
   releaseData = lib.importJSON ./release-data.json;
 in

--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -71,10 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     libGL
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
     libnotify
   ];
 

--- a/pkgs/by-name/jo/joplin-desktop/release-data.json
+++ b/pkgs/by-name/jo/joplin-desktop/release-data.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.6.15",
-  "hash": "sha256-uCF0nsHZowb9SuqBNni8/MWjGv9JyAUJs/gQprEoGjU=",
+  "version": "3.6.16",
+  "hash": "sha256-0W6xNcEMXIs8XsoY6NqSud9D5fEmc5GKFC8Uo6CEtec=",
   "plugins": {
     "io.github.jackgruber.backup": {
       "name": "joplin-plugin-backup",


### PR DESCRIPTION
Changes in Joplin [v3.6.16](https://github.com/laurent22/joplin/releases/tag/v3.6.16):
- Support syncing with Joplin v3.7

Closes #551039

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
