### PR TITLE
textadept: update qt5 -> qt6

### DIFF
--- a/pkgs/by-name/te/textadept/package.nix
+++ b/pkgs/by-name/te/textadept/package.nix
@@ -5,7 +5,7 @@
   fetchurl,
   cmake,
   withQt ? true,
-  libsForQt5,
+  qt6,
   withCurses ? false,
   ncurses,
 }:
@@ -20,9 +20,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-vpBmDcnaHdpYZIfcy482G4NGor+64Dh1tzryb8JJ+c8=";
   };
 
-  nativeBuildInputs = [ cmake ] ++ lib.optionals withQt [ libsForQt5.wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ lib.optionals withQt [
+    qt6.wrapQtAppsHook
+  ];
 
-  buildInputs = lib.optionals withQt [ libsForQt5.qtbase ] ++ lib.optionals withCurses ncurses;
+  buildInputs =
+    lib.optionals withQt [
+      qt6.qtbase
+      qt6.qt5compat
+    ]
+    ++ lib.optionals withCurses ncurses;
 
   cmakeFlags =
     lib.optional withQt [ "-DQT=ON" ]
@@ -51,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
       raskin
       mirrexagon
       arcuru
+      mikecm
     ];
     platforms = lib.platforms.linux;
     mainProgram = "textadept";


### PR DESCRIPTION
Textadept is a fast, minimalist, and remarkably extensible cross-platform text editor for programmers.
See [Textadept](https://orbitalquark.github.io/textadept/)
This change is to upgrade from qt5 to qt6, which has a number of benefits one of which is to be able to control the menu font size.
This issue relates to issue https://github.com/NixOS/nixpkgs/issues/551424

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
