### PR TITLE
beamPackages.expert: 0.1.8 -> 0.1.9

### DIFF
--- a/pkgs/development/beam-modules/expert/default.nix
+++ b/pkgs/development/beam-modules/expert/default.nix
@@ -1,43 +1,27 @@
 {
-  _experimental-update-script-combinators,
   erlang,
   fetchFromGitHub,
   fetchMixDeps,
-  gnused,
   lib,
   mixRelease,
-  nix-update-script,
-  nurl,
+  nix-update,
   writeShellApplication,
 }:
-let
-  version = "0.1.8";
+
+mixRelease (finalAttrs: {
+  pname = "expert";
+  version = "0.1.9";
 
   src = fetchFromGitHub {
     owner = "expert-lsp";
     repo = "expert";
-    tag = "v${version}";
-    hash = "sha256-2dZ3ve1ksdI1atjA6mxipwPYOr0yEZeKWhteSfMeL48=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TcYSO+CY4ZC4uC6k5OhKFKwv70preoILHAan3KZlUqQ=";
   };
-
-  engineDeps = fetchMixDeps {
-    pname = "mix-deps-expert-engine";
-
-    inherit src version;
-    hash = "sha256-evYg/yRk6ymV75kuWpY0pFODWWopozjnFHUa9MOFN/A=";
-
-    preConfigure = ''
-      cd apps/engine
-    '';
-  };
-in
-mixRelease rec {
-  pname = "expert";
-  inherit src version;
 
   mixFodDeps = fetchMixDeps {
-    pname = "mix-deps-${pname}";
-    inherit src version;
+    pname = "mix-deps-${finalAttrs.pname}";
+    inherit (finalAttrs) src version;
     hash = "sha256-N2krs4NNWytrN3K8lR5IGGroXVNuBzjks6IoD9D1rPM=";
 
     preConfigure = ''
@@ -47,8 +31,19 @@ mixRelease rec {
 
   mixReleaseName = "plain";
 
+  engineDeps = fetchMixDeps {
+    pname = "mix-deps-expert-engine";
+
+    inherit (finalAttrs) src version;
+    hash = "sha256-evYg/yRk6ymV75kuWpY0pFODWWopozjnFHUa9MOFN/A=";
+
+    preConfigure = ''
+      cd apps/engine
+    '';
+  };
+
   preConfigure = ''
-    ln -sv ${engineDeps} apps/engine/deps
+    ln -sv ${finalAttrs.engineDeps} apps/engine/deps
 
     cd apps/expert
   '';
@@ -62,30 +57,19 @@ mixRelease rec {
   removeCookie = false;
 
   passthru = {
-    inherit engineDeps;
-
-    updateScript = _experimental-update-script-combinators.sequence [
-      (nix-update-script { })
-      (lib.getExe (writeShellApplication {
-        name = "expert-update-engine";
-        runtimeInputs = [
-          gnused
-          nurl
-        ];
-        text = ''
-          nixpkgs="$(git rev-parse --show-toplevel)"
-          engineHashOld=${engineDeps.hash}
-          engineHashNew=$(nurl -e "(import $nixpkgs/. { }).$UPDATE_NIX_ATTR_PATH.engineDeps")
-          echo "$UPDATE_NIX_ATTR_PATH.engineDeps.hash" >&2
-          sed -i "s|$engineHashOld|$engineHashNew|" "$nixpkgs"/pkgs/development/beam-modules/expert/default.nix
-        '';
-      }))
-    ];
+    updateScript = lib.getExe (writeShellApplication {
+      name = "expert-update-script";
+      runtimeInputs = [ nix-update ];
+      text = ''
+        nix-update beamPackages.expert
+        nix-update beamPackages.expert.engineDeps
+      '';
+    });
   };
 
   meta = {
     homepage = "https://github.com/expert-lsp/expert";
-    changelog = "https://github.com/expert-lsp/expert/blob/v0.1.1/CHANGELOG.md";
+    changelog = "https://github.com/expert-lsp/expert/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Official Elixir Language Server Protocol implementation";
     longDescription = ''
       Expert is the official language server implementation for the Elixir programming language.
@@ -95,4 +79,4 @@ mixRelease rec {
     mainProgram = "expert";
     teams = [ lib.teams.beam ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/expert-lsp/expert/blob/v0.1.9/CHANGELOG.md

Nice to have `finalAttrs` pattern now. :)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
