### PR TITLE
umbriel, xdg-desktop-portal-umbriel, nixos/umbriel: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -100,6 +100,8 @@
 
 - [kvrocks_exporter](https://github.com/RocksLabs/kvrocks_exporter), a Prometheus exporter for Kvrocks metrics. Available as [services.prometheus.exporters.kvrocks](#opt-services.prometheus.exporters.kvrocks.enable).
 
+- [Umbriel](https://docs.noctalia.dev/umbriel/), a Wayland compositor built on wlroots and SceneFX. Available as [programs.umbriel](#opt-programs.umbriel.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -371,6 +371,7 @@
   ./programs/wayland/pinnacle.nix
   ./programs/wayland/river.nix
   ./programs/wayland/sway.nix
+  ./programs/wayland/umbriel.nix
   ./programs/wayland/uwsm.nix
   ./programs/wayland/waybar.nix
   ./programs/wayland/wayfire.nix

--- a/nixos/modules/programs/wayland/umbriel.nix
+++ b/nixos/modules/programs/wayland/umbriel.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.umbriel;
+in
+{
+  options.programs.umbriel = {
+    enable = lib.mkEnableOption "Umbriel, a Wayland compositor built on wlroots and SceneFX";
+    package = lib.mkPackageOption pkgs "umbriel" { };
+    portalPackage = lib.mkPackageOption pkgs "xdg-desktop-portal-umbriel" { };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
+        services.displayManager.sessionPackages = [ cfg.package ];
+        systemd.packages = [ cfg.package ];
+
+        systemd.user.services.umbriel = {
+          restartIfChanged = false;
+          enableDefaultPath = false;
+        };
+
+        xdg.portal = {
+          enable = lib.mkDefault true;
+          extraPortals = [ cfg.portalPackage ];
+          configPackages = [ cfg.portalPackage ];
+        };
+      }
+
+      (import ./wayland-session.nix {
+        inherit lib pkgs;
+        enableXWayland = false;
+        enableWlrPortal = false;
+      })
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [
+    samiser
+    pyrox0
+  ];
+}

--- a/pkgs/by-name/um/umbriel/package.nix
+++ b/pkgs/by-name/um/umbriel/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  wayland,
+  wayland-protocols,
+  wlroots_0_20,
+  libxkbcommon,
+  libinput,
+  pixman,
+  cairo,
+  pango,
+  libGL,
+  libdrm,
+  libgbm,
+  libxcb,
+  libxcb-wm,
+  lcms2,
+  jemalloc,
+  tomlplusplus,
+  nlohmann_json,
+  xwayland-satellite,
+  makeBinaryWrapper,
+  versionCheckHook,
+  unstableGitUpdater,
+}:
+stdenv.mkDerivation {
+  pname = "umbriel";
+  version = "0-unstable-2026-08-23";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "umbriel";
+    # No tagged releases yet
+    rev = "8650637f6fdb3cb78022a4560f5f34861439dbad";
+    fetchSubmodules = true;
+    hash = "sha256-WSTWPuF6KkSaO+zudERJCuga4BQzIH/RJdpvpkLVH4Q=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    wayland-scanner
+    wlroots_0_20
+    libxkbcommon
+    libinput
+    pixman
+    tomlplusplus
+    libGL
+    nlohmann_json
+    libdrm
+    libgbm
+    libxcb
+    libxcb-wm
+    lcms2
+    jemalloc
+    cairo
+    pango
+  ];
+
+  mesonBuildType = "release";
+
+  mesonInstallFlags = [ "--skip-subprojects" ];
+
+  postInstall = ''
+    if [ -f "$out/share/wayland-sessions/umbriel.desktop" ]; then
+      substituteInPlace "$out/share/wayland-sessions/umbriel.desktop" \
+        --replace-fail 'Exec=start-umbriel' "Exec=$out/bin/start-umbriel"
+    fi
+    wrapProgram $out/bin/umbriel \
+      --prefix PATH : ${lib.makeBinPath [ xwayland-satellite ]}
+  '';
+
+  doCheck = true;
+
+  # Set up to version check below, but currently it's untagged so the version doesn't match.
+  # On first release, set this to true make the version check run.
+  doInstallCheck = false;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    providedSessions = [ "umbriel" ];
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = {
+    description = "Wayland compositor built on wlroots and SceneFX";
+    homepage = "https://docs.noctalia.dev/umbriel/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "umbriel";
+    maintainers = with lib.maintainers; [
+      pyrox0
+      samiser
+    ];
+  };
+}

--- a/pkgs/by-name/xd/xdg-desktop-portal-umbriel/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-umbriel/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  wayland,
+  wayland-protocols,
+  sdbus-cpp_2,
+  systemd,
+  pipewire,
+  libdrm,
+  libgbm,
+  cairo,
+  tomlplusplus,
+  nlohmann_json,
+  gtk4,
+  unstableGitUpdater,
+}:
+stdenv.mkDerivation {
+  pname = "xdg-desktop-portal-umbriel";
+  version = "0-unstable-2026-08-23";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "xdg-desktop-portal-umbriel";
+    # No tagged releases yet
+    rev = "c8a9a223d48e6c62652f3f3cfaaa0f50aca39146";
+    hash = "sha256-jQFZRDnoaa0EvB9b55J1eYyfwCfD9LO2bwT1NVNbUME=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    sdbus-cpp_2
+    systemd
+    pipewire
+    libdrm
+    libgbm
+    cairo
+    tomlplusplus
+    nlohmann_json
+    gtk4
+  ];
+
+  mesonBuildType = "release";
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/noctalia-dev/xdg-desktop-portal-umbriel";
+    description = "xdg-desktop-portal backend for the Umbriel compositor";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      pyrox0
+      samiser
+    ];
+  };
+}


### PR DESCRIPTION
Adds umbriel(https://github.com/noctalia-dev/umbriel) along with its associated xdg desktop portal(https://github.com/noctalia-dev/xdg-desktop-portal-umbriel), and a module to set up the session with the portal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
