### PR TITLE
jool: 4.1.14 -> 4.1.15

### DIFF
--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -71,6 +71,7 @@ in
         ];
       };
 
+      boot.kernelPackages = pkgs.linuxPackages_latest;
       networking.jool.enable = true;
       networking.jool.siit.default.global.pool6 = "fd::/96";
     };
@@ -191,6 +192,7 @@ in
         ];
       };
 
+      boot.kernelPackages = pkgs.linuxPackages_latest;
       networking.jool.enable = true;
       networking.jool.nat64.default = {
         bib = [
@@ -206,17 +208,17 @@ in
           {
             protocol = "TCP";
             prefix = "203.0.113.1/32";
-            "port range" = "40001-65535";
+            "port range" = "20000-29999";
           }
           {
             protocol = "UDP";
             prefix = "203.0.113.1/32";
-            "port range" = "40001-65535";
+            "port range" = "20000-29999";
           }
           {
             protocol = "ICMP";
             prefix = "203.0.113.1/32";
-            "port range" = "40001-65535";
+            "port range" = "20000-29999";
           }
           # Ports for static BIB entries
           {

--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -19,10 +19,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = sourceAttrs.src;
 
-  patches = lib.optionals (lib.versionAtLeast kernel.version "6.18.0") [
+  patches = lib.optionals (lib.versionAtLeast kernel.version "7.2") [
+    # https://github.com/NICMx/Jool/pull/456
     (fetchpatch {
-      url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/3.23-stable/community/jool-modules-lts/kernel-6.18.patch";
-      hash = "sha256-EtV95YaOzPU3e/8NQvUtAH/RWiV16djeKrnvSgYybCQ=";
+      url = "https://github.com/NICMx/Jool/commit/47a8c7426f08e50505e69eef7ff607a04fbab52e.diff";
+      hash = "sha256-EcfBwFKOSFQOBWl8s5Pa2/RJg9lH1ziGzvV4ap2505M=";
     })
   ];
 

--- a/pkgs/os-specific/linux/jool/source.nix
+++ b/pkgs/os-specific/linux/jool/source.nix
@@ -1,11 +1,11 @@
 { fetchFromGitHub }:
 
 rec {
-  version = "4.1.14";
+  version = "4.1.15";
   src = fetchFromGitHub {
     owner = "NICMx";
     repo = "Jool";
     tag = "v${version}";
-    hash = "sha256-fAs289FFdUnddkikm4ceA9d/w1qqqaWuPXmAiq3cIA8=";
+    hash = "sha256-I+cgxOONq8LZWlpVaqXW+MmEKts/dQAr7Hs8uC6N8/w=";
   };
 }


### PR DESCRIPTION
## Things done

Fixes build with Linux 7.2. Also fixes the test as the new version checks if the outgoing ports for nat are shared with the system for other purposes.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
