### PR TITLE
raddebugger: init at v0.9.28-alpha

### DIFF
--- a/pkgs/by-name/ra/raddebugger/package.nix
+++ b/pkgs/by-name/ra/raddebugger/package.nix
@@ -1,0 +1,120 @@
+{
+  clang,
+  clangStdenv,
+  copyDesktopItems,
+  egl-wayland,
+  fetchFromGitHub,
+  freetype,
+  lib,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxi,
+  libxinerama,
+  makeDesktopItem,
+  makeWrapper,
+  mesa,
+  pkg-config,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "raddebugger";
+  version = "0.9.28-alpha";
+
+  src = fetchFromGitHub {
+    owner = "EpicGames";
+    repo = "raddebugger";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-hTX52/x1RauIaYlpv/+pPYqh68Xi7TKE7bibGkFGy3I=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    clang
+    copyDesktopItems
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    egl-wayland
+    freetype
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxi
+    libxinerama
+    mesa
+  ];
+
+  postPatch = ''
+    patchShebangs build.sh
+
+    substituteInPlace build.sh \
+      --replace-fail 'git_hash=$(git describe --always --dirty)' 'git_hash="v${finalAttrs.version}"' \
+      --replace-fail 'git_hash_full=$(git rev-parse HEAD)' 'git_hash_full="v${finalAttrs.version}"'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./build.sh raddbg release clang no_meta=0
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp build/raddbg $out/bin/
+
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    cp data/logo.png $out/share/icons/hicolor/256x256/apps/raddbg.png
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/raddbg \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          egl-wayland
+          libGL
+          libx11
+          libxext
+          mesa
+        ]
+      }"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "raddbg";
+      desktopName = "RAD Debugger";
+      genericName = "Debugger";
+      comment = "A native, user-mode, multi-process, graphical debugger";
+      exec = "raddbg %U";
+      icon = "raddbg";
+      categories = [
+        "Development"
+        "Debugger"
+      ];
+      terminal = false;
+      startupNotify = true;
+    })
+  ];
+
+  meta = with lib; {
+    description = "A native, user-mode, multi-process, graphical debugger.";
+    homepage = "https://github.com/EpicGames/raddebugger";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "raddbg";
+    maintainers = with lib.maintainers; [ atomicptr ];
+  };
+})


### PR DESCRIPTION
## Things done

Add raddebugger v0.9.28-alpha - Changelog: https://github.com/EpicGames/raddebugger/releases/tag/v0.9.28-alpha

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
