### PR TITLE
zfs_2_3: 2.3.8 -> 2.3.9, zfs_2_4: 2.4.3 -> 2.4.4

### DIFF
--- a/pkgs/os-specific/linux/zfs/2_3.nix
+++ b/pkgs/os-specific/linux/zfs/2_3.nix
@@ -3,7 +3,6 @@
   lib,
   nixosTests,
   stdenv,
-  fetchpatch,
   ...
 }@args:
 
@@ -13,10 +12,10 @@ callPackage ./generic.nix args {
   kernelModuleAttribute = "zfs_2_3";
 
   kernelMinSupportedMajorMinor = "4.18";
-  kernelMaxSupportedMajorMinor = "7.0";
+  kernelMaxSupportedMajorMinor = "7.2";
 
   # this package should point to the latest release.
-  version = "2.3.8";
+  version = "2.3.9";
 
   tests = {
     inherit (nixosTests.zfs) series_2_3;
@@ -30,5 +29,5 @@ callPackage ./generic.nix args {
     amarshall
   ];
 
-  hash = "sha256-qNBInNRpWrmImcermSHC0emYmnnjNvxWj3QnGtA6SUg=";
+  hash = "sha256-JQc9JOJLrqKUqFowg+Bs2d2YWQXBjTqCCelL5JpnvyQ=";
 }

--- a/pkgs/os-specific/linux/zfs/2_4.nix
+++ b/pkgs/os-specific/linux/zfs/2_4.nix
@@ -3,7 +3,6 @@
   lib,
   nixosTests,
   stdenv,
-  fetchpatch,
   ...
 }@args:
 
@@ -13,26 +12,13 @@ callPackage ./generic.nix args {
   kernelModuleAttribute = "zfs_2_4";
 
   kernelMinSupportedMajorMinor = "4.18";
-  kernelMaxSupportedMajorMinor = "7.0";
+  kernelMaxSupportedMajorMinor = "7.2";
 
   # this package should point to the latest release.
-  version = "2.4.3";
+  version = "2.4.4";
 
   # if adding a patch here, check if it also needs to be applied to zfs_unstable
-  extraPatches = [
-    # https://github.com/openzfs/zfs/issues/18366
-    # dedup data corruption fix unreleased as of OpenZFS 2.4.3
-    (fetchpatch {
-      url = "https://github.com/openzfs/zfs/commit/6fb72fda0f60d9efb591e320f83f78b19ec451cc.patch?full_index=1";
-      hash = "sha256-UuSVmO61Ux5S3F+JAtRnHyeVS4EFobDTKBuD5s8PI+k=";
-    })
-    # backport kernel memory corruption fix
-    # https://github.com/openzfs/zfs/issues/18787
-    (fetchpatch {
-      url = "https://github.com/openzfs/zfs/commit/223b8bc446851e5e796e5446ac24d03bbf468f43.patch?full_index=1";
-      hash = "sha256-I29A+NLYLzy7cMC8FQpBdSYbjFu/kscgTW8mAauPVf4=";
-    })
-  ];
+  extraPatches = [ ];
 
   tests = {
     inherit (nixosTests.zfs) series_2_4;
@@ -46,5 +32,5 @@ callPackage ./generic.nix args {
     amarshall
   ];
 
-  hash = "sha256-I1wLbstr0cFiGsyynP9kJ9ATRp/2b+fnnsdz0up+IzM=";
+  hash = "sha256-ZgfHTPsNoeDq6GKP4Xiti7Keis3vIZLDaTGQjgCItIc=";
 }

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -1,7 +1,6 @@
 {
   callPackage,
   nixosTests,
-  fetchpatch,
   ...
 }@args:
 
@@ -11,36 +10,23 @@ callPackage ./generic.nix args {
   kernelModuleAttribute = "zfs_unstable";
 
   kernelMinSupportedMajorMinor = "4.18";
-  kernelMaxSupportedMajorMinor = "7.0";
+  kernelMaxSupportedMajorMinor = "7.2";
 
   # this package should point to a version / git revision compatible with the latest kernel release
   # IMPORTANT: Always use a tagged release candidate or commits from the
   # zfs-<version>-staging branch, because this is tested by the OpenZFS
   # maintainers.
-  version = "2.4.3";
+  version = "2.4.4";
   # rev = "";
 
   # if adding a patch here, check if it also needs to be applied to the stable branches
-  extraPatches = [
-    # https://github.com/openzfs/zfs/issues/18366
-    # dedup data corruption fix unreleased as of OpenZFS 2.4.3
-    (fetchpatch {
-      url = "https://github.com/openzfs/zfs/commit/6fb72fda0f60d9efb591e320f83f78b19ec451cc.patch?full_index=1";
-      hash = "sha256-UuSVmO61Ux5S3F+JAtRnHyeVS4EFobDTKBuD5s8PI+k=";
-    })
-    # backport kernel memory corruption fix
-    # https://github.com/openzfs/zfs/issues/18787
-    (fetchpatch {
-      url = "https://github.com/openzfs/zfs/commit/223b8bc446851e5e796e5446ac24d03bbf468f43.patch?full_index=1";
-      hash = "sha256-I29A+NLYLzy7cMC8FQpBdSYbjFu/kscgTW8mAauPVf4=";
-    })
-  ];
+  extraPatches = [ ];
 
   tests = {
     inherit (nixosTests.zfs) unstable;
   };
 
-  hash = "sha256-I1wLbstr0cFiGsyynP9kJ9ATRp/2b+fnnsdz0up+IzM=";
+  hash = "sha256-ZgfHTPsNoeDq6GKP4Xiti7Keis3vIZLDaTGQjgCItIc=";
 
   extraLongDescription = ''
     This is "unstable" ZFS, and will usually be a pre-release version of ZFS.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~Tags were pushed a couple of hours ago but doesn't have github releases yet.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
