### PR TITLE
python3Packages.caido-sdk-client: 0.2.0 -> 0.3.1, python3Packages.caido-schema-proxy: 0.57.1 -> 0.58.0

### DIFF
--- a/pkgs/development/python-modules/caido-schema-proxy/default.nix
+++ b/pkgs/development/python-modules/caido-schema-proxy/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "caido-schema-proxy";
-  version = "0.57.1";
+  version = "0.58.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -16,7 +16,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchPypi {
     pname = "caido_schema_proxy";
     inherit (finalAttrs) version;
-    hash = "sha256-gIElEhHnMDfz6hu0UTOtTiYaB/ZnfeBCskEWTM9419M=";
+    hash = "sha256-1vGmDivVqx3XN1CUR/XwgYTG/mwI6Zny0Nv8AKUpOa4=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/caido-sdk-client/default.nix
+++ b/pkgs/development/python-modules/caido-sdk-client/default.nix
@@ -6,6 +6,7 @@
   gql,
   nix-update-script,
   pydantic,
+  semver,
   uv-build,
   pytestCheckHook,
   pytest-asyncio,
@@ -13,7 +14,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "caido-sdk-client";
-  version = "0.2.0";
+  version = "0.3.1";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -21,7 +22,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchPypi {
     pname = "caido_sdk_client";
     inherit (finalAttrs) version;
-    hash = "sha256-OZiP4Hs/qcaa29SWYttmDXcH1g2SRRCbFiPe+Xs5usg=";
+    hash = "sha256-9jvd49QePhboxtHDDyWcumliNLX8n2bfOjNjcZWLKDs=";
   };
 
   postPatch = ''
@@ -35,6 +36,7 @@ buildPythonPackage (finalAttrs: {
     caido-server-auth
     gql
     pydantic
+    semver
   ]
   ++ gql.optional-dependencies.aiohttp
   ++ gql.optional-dependencies.websockets;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
