### PR TITLE
simplepkg: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1165,6 +1165,11 @@
     githubId = 43479487;
     name = "Titouan Biteau";
   };
+  void01n = {
+  name = "void01";
+  github = "void01n";
+  githubId = 253173115;
+};
   albertchae = {
     github = "albertchae";
     githubId = 217050;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1165,11 +1165,6 @@
     githubId = 43479487;
     name = "Titouan Biteau";
   };
-  void01n = {
-  name = "void01";
-  github = "void01n";
-  githubId = 253173115;
-};
   albertchae = {
     github = "albertchae";
     githubId = 217050;
@@ -30410,6 +30405,11 @@
     githubId = 412749;
     name = "Volker Diels-Grabsch";
     keys = [ { fingerprint = "A7E6 9C4F 69DC 5D6C FC84  EE34 A29F BD51 5F89 90AF"; } ];
+  };
+  void01n = {
+    github = "void01n";
+    githubId = 253173115;
+    name = "void01";
   };
   voidless = {
     email = "julius.schmitt@yahoo.de";

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -17,6 +17,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-eYQ7szXFhI8azEz86OL3OjkLbdHtZgADRuZ1A+Gu6/E=";
   };
+  strictDeps = true;
+  __structuredAttrs = true;
   dontBuild = true;
   dontConfigure = true;
   nativeBuildInputs = [ makeWrapper ];
@@ -27,10 +29,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp pkg-import.fish $out/share/fish/vendor_functions.d/
 
     mkdir -p $out/bin
-    cat > $out/bin/pkg <<'EOF'
+    cat > $out/bin/pkg <<'INNEREOF'
 #!/usr/bin/env bash
 exec fish -c 'pkg $argv' -- "$@"
-EOF
+INNEREOF
     chmod +x $out/bin/pkg
     wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish ]}
 

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -5,38 +5,42 @@
   nix,
   git,
   sqlite,
+  fish,
+  makeWrapper,
 }:
-
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "simplepkg";
   version = "0.1.0";
-
   src = fetchFromGitHub {
     owner = "void01n";
     repo = "simple-pkg";
     tag = "v${finalAttrs.version}";
     hash = "sha256-eYQ7szXFhI8azEz86OL3OjkLbdHtZgADRuZ1A+Gu6/E=";
   };
-
   dontBuild = true;
   dontConfigure = true;
-
+  nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
     runHook preInstall
-
     mkdir -p $out/share/fish/vendor_functions.d
     cp pkg.fish $out/share/fish/vendor_functions.d/
     cp pkg-import.fish $out/share/fish/vendor_functions.d/
 
+    mkdir -p $out/bin
+    cat > $out/bin/pkg <<'EOF'
+#!/usr/bin/env bash
+exec fish -c 'pkg $argv' -- "$@"
+EOF
+    chmod +x $out/bin/pkg
+    wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish ]}
+
     runHook postInstall
   '';
-
   propagatedBuildInputs = [
     nix
     git
     sqlite
   ];
-
   meta = {
     description = "Declarative-feeling pkg manager for NixOS packages.nix";
     homepage = "https://github.com/void01n/simple-pkg";

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -23,20 +23,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontConfigure = true;
   nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/fish/vendor_functions.d
-    cp pkg.fish $out/share/fish/vendor_functions.d/
-    cp pkg-import.fish $out/share/fish/vendor_functions.d/
+        runHook preInstall
+        mkdir -p $out/share/fish/vendor_functions.d
+        cp pkg.fish $out/share/fish/vendor_functions.d/
+        cp pkg-import.fish $out/share/fish/vendor_functions.d/
 
-    mkdir -p $out/bin
-    cat > $out/bin/pkg <<'INNEREOF'
-#!/usr/bin/env bash
-exec fish -c 'pkg $argv' -- "$@"
-INNEREOF
-    chmod +x $out/bin/pkg
-    wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish ]}
+        mkdir -p $out/bin
+        cat > $out/bin/pkg <<'INNEREOF'
+    #!/usr/bin/env bash
+    exec fish -c 'pkg $argv' -- "$@"
+    INNEREOF
+        chmod +x $out/bin/pkg
+        wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish ]}
 
-    runHook postInstall
+        runHook postInstall
   '';
   propagatedBuildInputs = [
     nix

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -37,7 +37,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
     cp ${pkgWrapper}/bin/pkg $out/bin/pkg
     chmod +x $out/bin/pkg
-    wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish nix git sqlite ]}
+    wrapProgram $out/bin/pkg --prefix PATH : ${
+      lib.makeBinPath [
+        fish
+        nix
+        git
+        sqlite
+      ]
+    }
 
     runHook postInstall
   '';

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -7,7 +7,13 @@
   sqlite,
   fish,
   makeWrapper,
+  writeShellScriptBin,
 }:
+let
+  pkgWrapper = writeShellScriptBin "pkg" ''
+    exec fish -c 'pkg $argv' -- "$@"
+  '';
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "simplepkg";
   version = "0.1.0";
@@ -23,20 +29,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontConfigure = true;
   nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
-        runHook preInstall
-        mkdir -p $out/share/fish/vendor_functions.d
-        cp pkg.fish $out/share/fish/vendor_functions.d/
-        cp pkg-import.fish $out/share/fish/vendor_functions.d/
+    runHook preInstall
+    mkdir -p $out/share/fish/vendor_functions.d
+    cp pkg.fish $out/share/fish/vendor_functions.d/
+    cp pkg-import.fish $out/share/fish/vendor_functions.d/
 
-        mkdir -p $out/bin
-        cat > $out/bin/pkg <<'INNEREOF'
-    #!/usr/bin/env bash
-    exec fish -c 'pkg $argv' -- "$@"
-    INNEREOF
-        chmod +x $out/bin/pkg
-        wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish ]}
+    mkdir -p $out/bin
+    cp ${pkgWrapper}/bin/pkg $out/bin/pkg
+    chmod +x $out/bin/pkg
+    wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish ]}
 
-        runHook postInstall
+    runHook postInstall
   '';
   propagatedBuildInputs = [
     nix
@@ -45,7 +48,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
   meta = {
     description = "Declarative-feeling pkg manager for NixOS packages.nix";
-    homepage = "https://github.com/void01n/simple-pkg";
+    homepage = "https://github.com/void01n/simple-pkg";\;
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     mainProgram = "pkg";

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nix,
+  git,
+  sqlite,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "simplepkg";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "void01n";
+    repo = "simple-pkg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eYQ7szXFhI8azEz86OL3OjkLbdHtZgADRuZ1A+Gu6/E="; # nix build will report the correct value on first attempt
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fish/vendor_functions.d
+    cp pkg.fish $out/share/fish/vendor_functions.d/
+    cp pkg-import.fish $out/share/fish/vendor_functions.d/
+
+    runHook postInstall
+  '';
+
+  propagatedBuildInputs = [
+    nix
+    git
+    sqlite
+  ];
+
+  meta = {
+    description = "Declarative-feeling pkg manager for NixOS packages.nix";
+    homepage = "https://github.com/void01n/simplepkg";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "pkg";
+    maintainers = with lib.maintainers; [ void01n ];
+  };
+})

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -48,7 +48,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
   meta = {
     description = "Declarative-feeling pkg manager for NixOS packages.nix";
-    homepage = "https://github.com/void01n/simple-pkg";\;
+    homepage = "https://github.com/void01n/simple-pkg";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     mainProgram = "pkg";

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
     cp ${pkgWrapper}/bin/pkg $out/bin/pkg
     chmod +x $out/bin/pkg
-    wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish ]}
+    wrapProgram $out/bin/pkg --prefix PATH : ${lib.makeBinPath [ fish nix git sqlite ]}
 
     runHook postInstall
   '';

--- a/pkgs/by-name/si/simplepkg/package.nix
+++ b/pkgs/by-name/si/simplepkg/package.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "void01n";
     repo = "simple-pkg";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eYQ7szXFhI8azEz86OL3OjkLbdHtZgADRuZ1A+Gu6/E="; # nix build will report the correct value on first attempt
+    hash = "sha256-eYQ7szXFhI8azEz86OL3OjkLbdHtZgADRuZ1A+Gu6/E=";
   };
 
   dontBuild = true;
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Declarative-feeling pkg manager for NixOS packages.nix";
-    homepage = "https://github.com/void01n/simplepkg";
+    homepage = "https://github.com/void01n/simple-pkg";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     mainProgram = "pkg";


### PR DESCRIPTION
Adds `simplepkg`, a small fish-based declarative package manager wrapper around
`/etc/nixos/packages.nix`. Source: https://github.com/void01n/simple-pkg (tag v0.1.0).

## Things done

- [x] Built on platform: x86_64-linux
- [ ] aarch64-linux
- [ ] aarch64-darwin
- [ ] Tested via NixOS test(s)
- [ ] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files in `./result/bin/` — ran `pkg list`
      against a real `packages.nix` and confirmed correct output
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md

---

**AI assistance disclosure:** Some parts of `package.nix` and the
`maintainer-list.nix` entry were drafted with assistance from Claude (Anthropic,
Claude Sonnet 5) — commits carry `Assisted-by:` trailers accordingly. I reviewed
the derivation logic, ran the build locally (`nix build .#simplepkg`), resolved
the correct source hash, and manually tested the resulting binary's basic
functionality before submitting.