### PR TITLE
nfs-utils: replace systemd dependency with systemdMinimal

### DIFF
--- a/pkgs/by-name/nf/nfs-utils/package.nix
+++ b/pkgs/by-name/nf/nfs-utils/package.nix
@@ -15,7 +15,7 @@
   libuuid,
   keyutils,
   lvm2,
-  systemd,
+  systemdMinimal,
   coreutils,
   python3,
   buildPackages,
@@ -32,7 +32,7 @@
 
 let
   statdPath = lib.makeBinPath [
-    systemd
+    systemdMinimal
     util-linux
     coreutils
   ];

--- a/pkgs/by-name/nf/nfs-utils/package.nix
+++ b/pkgs/by-name/nf/nfs-utils/package.nix
@@ -28,14 +28,19 @@
   udevCheckHook,
   enablePython ? true,
   enableLdap ? true,
+  enableSystemd ? true,
 }:
 
 let
-  statdPath = lib.makeBinPath [
-    systemdMinimal
-    util-linux
-    coreutils
-  ];
+  statdPath = lib.makeBinPath (
+    [
+      util-linux
+      coreutils
+    ]
+    ++ lib.optionals enableSystemd [
+      systemdMinimal
+    ]
+  );
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -96,11 +101,16 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-svcgss"
     "--with-statedir=/var/lib/nfs"
     "--with-krb5=${lib.getLib libkrb5}"
-    "--with-systemd=${placeholder "out"}/etc/systemd/system"
     "--enable-libmount-mount"
     "--with-pluginpath=${placeholder "lib"}/lib/libnfsidmap" # this installs libnfsidmap
     "--with-rpcgen=${buildPackages.rpcsvc-proto}/bin/rpcgen"
     "--with-modprobedir=${placeholder "out"}/etc/modprobe.d"
+    (
+      if enableSystemd then
+        "--with-systemd=${placeholder "out"}/etc/systemd/system"
+      else
+        "--without-systemd"
+    )
   ]
   ++ lib.optional enableLdap "--enable-ldap";
 
@@ -139,6 +149,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [
     "sbindir=$(out)/bin"
+  ]
+  ++ lib.optionals enableSystemd [
     "generator_dir=$(out)/etc/systemd/system-generators"
   ];
 
@@ -153,20 +165,23 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
     "libexec"
     "bin"
+  ]
+  ++ lib.optionals enableSystemd [
     "etc/systemd/system-generators"
   ];
 
-  postInstall = ''
-    # Not used on NixOS
-    sed -i \
-      -e "s,/sbin/modprobe,${kmod}/bin/modprobe,g" \
-      -e "s,/usr/sbin,$out/bin,g" \
-      $out/etc/systemd/system/*
-  ''
-  + lib.optionalString (!enablePython) ''
-    # Remove all scripts that require python (currently mountstats and nfsiostat)
-    grep -l /usr/bin/python $out/bin/* | xargs -I {} rm -v {}
-  '';
+  postInstall =
+    lib.optionalString enableSystemd ''
+      # Not used on NixOS
+      sed -i \
+        -e "s,/sbin/modprobe,${kmod}/bin/modprobe,g" \
+        -e "s,/usr/sbin,$out/bin,g" \
+        $out/etc/systemd/system/*
+    ''
+    + lib.optionalString (!enablePython) ''
+      # Remove all scripts that require python (currently mountstats and nfsiostat)
+      grep -l /usr/bin/python $out/bin/* | xargs -I {} rm -v {}
+    '';
 
   # One test fails on mips.
   # doCheck = !stdenv.hostPlatform.isMips;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
