### PR TITLE
qt5.qtserialport: replace systemd dependency with udev (systemdLibs)

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtserialport.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtserialport.nix
@@ -3,11 +3,11 @@
   stdenv,
   lib,
   qtbase,
-  systemd,
+  udev,
 }:
 
 qtModule {
   pname = "qtserialport";
   propagatedBuildInputs = [ qtbase ];
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux "-DNIXPKGS_LIBUDEV=\"${lib.getLib systemd}/lib/libudev\"";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux "-DNIXPKGS_LIBUDEV=\"${udev}/lib/libudev\"";
 }

--- a/pkgs/development/libraries/qt-5/modules/qtserialport.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtserialport.nix
@@ -4,10 +4,11 @@
   lib,
   qtbase,
   udev,
+  udevSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 qtModule {
   pname = "qtserialport";
   propagatedBuildInputs = [ qtbase ];
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux "-DNIXPKGS_LIBUDEV=\"${udev}/lib/libudev\"";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString udevSupport "-DNIXPKGS_LIBUDEV=\"${udev}/lib/libudev\"";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtserialport.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtserialport.nix
@@ -4,11 +4,12 @@
   lib,
   qtbase,
   udev,
+  udevSupport ? stdenv.hostPlatform.isLinux,
   pkg-config,
 }:
 
 qtModule {
   pname = "qtserialport";
   nativeBuildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ qtbase ] ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
+  propagatedBuildInputs = [ qtbase ] ++ lib.optionals udevSupport [ udev ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

i decided to replace with the `udev` alias of `systemdLibs` instead of `systemdLibs` directory for consistency with `qt6Packages.qtserialport`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
