### PR TITLE
home-assistant: 2026.8.2 -> 2026.8.3

### DIFF
--- a/pkgs/development/python-modules/aiowebostv/default.nix
+++ b/pkgs/development/python-modules/aiowebostv/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "aiowebostv";
-  version = "0.9.1";
+  version = "0.9.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = "aiowebostv";
     tag = "v${version}";
-    hash = "sha256-rHbGKJrEl/Rot7sW8KFK/a2bOF+XWfYbLlUs/1bqf2U=";
+    hash = "sha256-Bswq/8PvKUTSbOklJBJ/hKsEQyd+s1ZVDsKCbRN1Bc4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/ical/default.nix
+++ b/pkgs/development/python-modules/ical/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "ical";
-  version = "14.1.0";
+  version = "14.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "allenporter";
     repo = "ical";
     tag = finalAttrs.version;
-    hash = "sha256-YbYZbgSEqfQP4VQ/g25o+NbCBLU0dxA0laoeP7c54Fw=";
+    hash = "sha256-Rl/tEOG+n7MCd/kHmoluBS4YI8+Jd4pxgvmUyp9eOag=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/msmart-ng/default.nix
+++ b/pkgs/development/python-modules/msmart-ng/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "msmart-ng";
-  version = "2026.7.0";
+  version = "2026.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mill1000";
     repo = "midea-msmart";
     tag = version;
-    hash = "sha256-OW5++yd+o2KqaFWTo/RiLjK1HO2l9WSDxkiX3lYtaUs=";
+    hash = "sha256-UbRL42jQk3A8VYe/eLj3XNTFPhyVjBMzB/lTNs0tyRM=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/msmart-ng/default.nix
+++ b/pkgs/development/python-modules/msmart-ng/default.nix
@@ -51,7 +51,6 @@ buildPythonPackage rec {
     mainProgram = "msmart-ng";
     maintainers = with lib.maintainers; [
       hexa
-      emilylange
     ];
   };
 }

--- a/pkgs/development/python-modules/nsapi/default.nix
+++ b/pkgs/development/python-modules/nsapi/default.nix
@@ -2,26 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pyprojectVersionPatchHook,
   pytz,
   setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "nsapi";
-  version = "3.2.1";
+  version = "3.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aquatix";
     repo = "ns-api";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eZT6DU68wcEYyoFejECuluzit9MDA269zaKVFWpSuc8=";
+    hash = "sha256-Buhc0643WeX/4ZU/RkzNWiFjfEAJUtNL6uJ98unTnCg=";
   };
 
   build-system = [ setuptools ];
-
-  nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
   dependencies = [ pytz ];
 

--- a/pkgs/development/python-modules/pyenphase/default.nix
+++ b/pkgs/development/python-modules/pyenphase/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyenphase";
-  version = "3.2.2";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyenphase";
     repo = "pyenphase";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-K23i3/BEZx9VCxlwue1g4nS7hz4ckJL6FIZqdFaTtAQ=";
+    hash = "sha256-fMfQApK8e6Oi81H7tMJZOsAPr4EoRrkP6gdKexg6jVg=";
   };
 
   pythonRelaxDeps = [ "tenacity" ];

--- a/pkgs/development/python-modules/reolink-aio/default.nix
+++ b/pkgs/development/python-modules/reolink-aio/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "reolink-aio";
-  version = "0.21.8";
+  version = "0.21.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "starkillerOG";
     repo = "reolink_aio";
     tag = finalAttrs.version;
-    hash = "sha256-b4VmYHrSf1NBiWI09IWdQQWrm9kMJlm2ScUaG08MC38=";
+    hash = "sha256-t1mmmHhh5J9i28ISVbZp8PbRQTXv8YUcAVl6ZtSCF1o=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/volvocarsapi/default.nix
+++ b/pkgs/development/python-modules/volvocarsapi/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "volvocarsapi";
-  version = "0.4.3";
+  version = "0.4.4";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "thomasddn";
     repo = "volvo-cars-api";
     tag = "v${version}";
-    hash = "sha256-GC2vktTFWh4z/sO+2hhsVKInSl5GQCtzq4q0YtfkfKg=";
+    hash = "sha256-8ASR7IE84Hrv+u4ORULMTSgBnn7TMIKwzFKiKWhQLIg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.8.2";
+  version = "2026.8.3";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
@@ -10,13 +10,13 @@
 buildHomeAssistantComponent rec {
   owner = "mill1000";
   domain = "midea_ac";
-  version = "2026.7.2";
+  version = "2026.8.2";
 
   src = fetchFromGitHub {
     owner = "mill1000";
     repo = "midea-ac-py";
     tag = version;
-    hash = "sha256-ErQDCU17qJ3hO7PBawNEn8mj/Gt9kWns6PV5T9OFYqw=";
+    hash = "sha256-FFSp89d1NDtKmVgt9fI3fFWPL0Xm9h1Kqxl8Rvof6R8=";
   };
 
   dependencies = [ msmart-ng ];

--- a/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
@@ -33,7 +33,6 @@ buildHomeAssistantComponent rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       hexa
-      emilylange
     ];
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -270,7 +270,7 @@ let
   extraBuildInputs = extraPackages python3Packages;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.8.2";
+  hassVersion = "2026.8.3";
 
 in
 python3Packages.buildPythonApplication rec {
@@ -291,13 +291,13 @@ python3Packages.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-u8vXAsO1jQpUpvqSRuYMOR8eY0Oqk7T4A/aRneE88Qg=";
+    hash = "sha256-bM4YYwV4MNKnVe+1Gzh2DIY2LE2IvGexP/F0RR0R7Y0=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-ImLh7LxH/p08y2kPmfFxdp+vUgFyCLf/Zsnbv79w990=";
+    hash = "sha256-f1zG2rBz4hKJ0lhMqk25Xp5INWgs6bEisF7vEQV7UPg=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.356";
+  version = "0.13.357";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-NBGHtEtk3JGqG0VES3UhZ4WLfamDS4EPsLAhYZdl0n4=";
+    hash = "sha256-FnkR+AhTPIznIdr7bOYLd6IHsoHz2nV855gYwgvrfXU=";
   };
 
   patches = [

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.8.2";
+  version = "2026.8.3";
   pyproject = true;
 
   disabled = python.version != home-assistant.python3Packages.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-cLGvesBrD76vrkG46PnCaadSTLVUZmz0zTBJep15QjM=";
+    hash = "sha256-2dpEUiNBPyQltkZM9slKkZpbWyxC2f4dzpLJCHeKJ4I=";
   };
 
   build-system = [


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2026.8.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
