### PR TITLE
lima: find virtiofsd for `mountType: virtiofs` on Linux

### DIFF
--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -5,6 +5,8 @@
   callPackage,
   installShellFiles,
   qemu,
+  symlinkJoin,
+  virtiofsd,
   darwin,
   makeWrapper,
   nix-update-script,
@@ -22,6 +24,22 @@
 
 let
   source = callPackage ./source.nix { };
+
+  # lima looks for virtiofsd through QEMU's vhost-user descriptor directory
+  # (<qemu-prefix>/share/qemu/vhost-user), which it derives from the path of the
+  # qemu-system-* binary it resolved. virtiofsd therefore has to share a prefix
+  # with qemu, or `mountType: virtiofs` fails with "failed to locate virtiofsd".
+  qemuWithVirtiofsd =
+    if stdenv.hostPlatform.isLinux then
+      symlinkJoin {
+        name = "qemu-with-virtiofsd";
+        paths = [
+          qemu
+          virtiofsd
+        ];
+      }
+    else
+      qemu;
 in
 buildGoModule (finalAttrs: {
   pname = "lima" + lib.optionalString withAdditionalGuestAgents "-full";
@@ -69,7 +87,7 @@ buildGoModule (finalAttrs: {
     mkdir -p $out
     cp -r _output/* $out
     wrapProgram $out/bin/limactl \
-      --prefix PATH : ${lib.makeBinPath [ qemu ]}
+      --prefix PATH : ${lib.makeBinPath [ qemuWithVirtiofsd ]}
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd limactl \


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/555161.

`limactl` with `mountType: virtiofs` dies at instance start with `failed to locate virtiofsd`, even
when `virtiofsd` is installed system-wide.

Lima does not look for `virtiofsd` on `PATH` and does not hardcode a path to it. `FindVirtiofsd`
resolves `qemu-system-*` through `PATH`, walks up to that prefix, and scans
`<prefix>/share/qemu/vhost-user/*.json` for a descriptor whose `type` is `fs`
([qemu.go#L1039](https://github.com/lima-vm/lima/blob/v2.2.0/pkg/driver/qemu/qemu.go#L1039)).
Our `virtiofsd` package already installs exactly that descriptor, rewritten to point at its own
`$out/bin/virtiofsd`, but it lands under the `virtiofsd` prefix, while `limactl`'s wrapper only
puts `qemu` on `PATH`. The two prefixes never meet, so the scan only ever sees QEMU's own
`50-qemu-gpu.json` and gives up.

Giving the wrapper a `symlinkJoin` of `qemu` and `virtiofsd` puts the descriptor under the prefix
lima already scans. No source patching, and the `binary` the descriptor names is still virtiofsd's
own store path, so the join is used for discovery only.

Linux only: `virtiofsd` is `platforms = linux`, and on Darwin lima implements `virtiofs` through
Virtualization.framework instead.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] 24.11 Release Notes (or backporting 24.05 and 24.11 Release notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Verification

Both runs on NixOS 26.11, x86_64-linux, `/dev/kvm` present, same instance
(`limactl create --name=vfs --set '.mountType="virtiofs"' template:alpine`, Alpine 3.23.4).

Before (`lima` from the unstable channel, 2.2.0):

```
[hostagent] Using system firmware (`/nix/store/...-qemu-11.0.3/share/qemu/edk2-x86_64-code.fd`)
FATA exiting, status={Running:false Degraded:false Exiting:true ...}
# ha.stderr.log
Checking vhost directory /nix/store/...-qemu-11.0.3/share/qemu/vhost-user
Checking vhost vhostCfg 50-qemu-gpu.json
Checking vhost directory /usr/share/qemu/vhost-user
Failed to list vhost directory: open /usr/share/qemu/vhost-user: no such file or directory
failed to locate virtiofsd
```

After (this branch):

```
INFO[0000] [hostagent] Using system firmware (`/nix/store/...-qemu-with-virtiofsd/share/qemu/edk2-x86_64-code.fd`)
DEBU[0000] virtiofsd-0[stderr]: [INFO  virtiofsd] Waiting for vhost-user socket connection...
DEBU[0000] virtiofsd-0[stderr]: [INFO  virtiofsd] Client connected, servicing requests
INFO[0093] [hostagent] READY. Run `limactl shell vfs` to open the shell.

$ limactl shell vfs -- mount | grep virtiofs
lima-3159a065bb009ad6 on /home/ravi type virtiofs (ro,relatime)

$ echo probe > ~/.lima-vfs-probe
$ limactl shell vfs -- sh -c 'cat /home/ravi/.lima-vfs-probe; touch /home/ravi/should-fail'
probe
touch: /home/ravi/should-fail: Read-only file system
```

The guest reads the host file through the virtiofs mount, and the mount honours `writable: false`,
so the descriptor is not merely found, the backend actually serves the share.

The joined prefix, for reference:

```
$ ls -l /nix/store/...-qemu-with-virtiofsd/share/qemu/vhost-user/
50-qemu-gpu.json  -> /nix/store/...-qemu-11.1.0/share/qemu/vhost-user/50-qemu-gpu.json
50-virtiofsd.json -> /nix/store/...-virtiofsd-1.14.0/share/qemu/vhost-user/50-virtiofsd.json
```

**Automation disclosure**, separate from the commit trailer as the policy requires: this pull
request's change and this summary were prepared with Claude Code (claude-opus-5). I reviewed the
diff and reproduced the before/after runs above myself before submitting, and I am the person
accountable for it.
