### PR TITLE
minikube: let the kubectl package win $out/bin/kubectl

### DIFF
--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  kubectl,
   pkg-config,
   which,
   libvirt,
@@ -114,6 +115,10 @@ buildGoModule (finalAttrs: {
     description = "Tool that makes it easy to run Kubernetes locally";
     mainProgram = "minikube";
     license = lib.licenses.asl20;
+    # installPhase symlinks $out/bin/kubectl to minikube, which acts as kubectl when
+    # argv[0] says so. That collides with the kubectl package, and anyone installing
+    # both alongside each other wants the real kubectl to win.
+    priority = (kubectl.meta.priority or lib.meta.defaultPriority) + 1;
     maintainers = with lib.maintainers; [
       vdemeester
       atkinschang


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/551845.

`minikube`'s `installPhase` symlinks `$out/bin/kubectl` to the minikube binary, which acts as
kubectl when `argv[0]` says so ([main.go#L80](https://github.com/kubernetes/minikube/blob/v1.38.1/cmd/minikube/main.go#L80)),
as the minikube handbook suggests. That path collides with the `kubectl` package, so installing both
into one `buildEnv` (`environment.systemPackages`, `home.packages`, `nix profile`) aborts the build.
Installing both is a normal thing to want: `kubectl` is the standalone tool, and minikube's copy
exists only for `minikube kubectl`.

`buildEnv` already resolves this class of conflict. `builder.pl` skips a colliding path from the
lower-priority package and only aborts when the two priorities are equal, so putting minikube one
step below `kubectl` makes the real `kubectl` win, while someone who installs minikube alone still
gets its `bin/kubectl`. `inetutils` uses the same relative form against `util-linux`.

An alternative is a `withKubectl` argument, as the issue suggests. It is more code and it leaves the
collision in place by default, so this seemed like the smaller fix. Happy to switch if the
maintainers prefer the explicit knob.

`meta`-only, so there is no rebuild: `nix-instantiate -A minikube` produces
`8fr016vv5vgakw936py80x97z8yd6vm1-minikube-1.38.1.drv` both at the base commit and at the tip of
this branch.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

### Verification

Before, on nixpkgs unstable (this is the reporter's failure, reproduced):

```
$ nix-build -E 'with import <nixpkgs> {}; buildEnv { name = "t"; paths = [ kubectl minikube ]; }'
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  `/nix/store/...-minikube-1.38.1/bin/kubectl' and
  `/nix/store/...-kubectl-1.36.3/bin/kubectl'
```

After, same nixpkgs revision, same store paths for both packages. Control first, with only the
`meta.priority` line reverted:

```
$ nix-build -E 'with import ./. {}; buildEnv { name = "control"; paths = [ kubectl minikube ]; }'
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  `/nix/store/ds2mizymkan1g0kn88i3sndc14p7mria-minikube-1.38.1/bin/kubectl' and
  `/nix/store/87yqi8l6g2387fjhsvrhwaxggvjychq0-kubectl-1.36.3/bin/kubectl'
```

With the line in place:

```
$ nix-build -E 'with import ./. {}; buildEnv { name = "after"; paths = [ kubectl minikube ]; }'
created 10 symlinks in user environment
/nix/store/v9z11fs6y3njg9j6h3jb1fdk760vcd40-kubectl-minikube-after

$ ls -l result/bin/
kubectl  -> /nix/store/87yqi8l6g2387fjhsvrhwaxggvjychq0-kubectl-1.36.3/bin/kubectl
minikube -> /nix/store/ds2mizymkan1g0kn88i3sndc14p7mria-minikube-1.38.1/bin/minikube

$ result/bin/kubectl version --client | head -1
Client Version: v1.36.3
$ result/bin/minikube version | head -1
minikube version: v1.38.1
```

Order does not matter: `paths = [ minikube kubectl ]` builds too and resolves `bin/kubectl` to the
same real kubectl, because `builder.pl` handles both the overwrite and the skip direction.

And minikube on its own is unchanged, so the handbook's kubectl behaviour survives:

```
$ nix-build -E 'with import ./. {}; buildEnv { name = "alone"; paths = [ minikube ]; }'
$ ls -l result/bin/
kubectl -> minikube
minikube
$ result/bin/kubectl version --client | head -1
Client Version: v1.35.1
```

**Automation disclosure**, separate from the commit trailer as the policy requires: this pull
request's change and this summary were prepared with Claude Code (claude-opus-5). I reviewed the
diff and reproduced the runs above myself before submitting, and I am the person accountable for it.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
