### PR TITLE
kustomize-lint: modernize

### DIFF
--- a/pkgs/by-name/ku/kustomize-lint/package.nix
+++ b/pkgs/by-name/ku/kustomize-lint/package.nix
@@ -2,18 +2,17 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  kustomize-lint,
-  testers,
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "kustomize-lint";
   version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "groq";
     repo = "kustomize-lint";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-zVtF66A7w0RtEzZ9MNA4dqgxQUtpiUqcmnjslm4NxaE=";
   };
 
@@ -23,20 +22,17 @@ buildGoModule rec {
 
   ldflags = [
     "-s"
-    "-w"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = kustomize-lint;
-    command = "kustomize-lint --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Linter for Kustomize configuration files";
     homepage = "https://github.com/groq/kustomize-lint";
-    changelog = "https://github.com/groq/kustomize-lint/releases/tag/v${version}";
+    changelog = "https://github.com/groq/kustomize-lint/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ matanyall ];
     mainProgram = "kustomize-lint";
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
