### PR TITLE
nixos/netbird: export the whole preStart environment

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -6,6 +6,7 @@
 }:
 let
   inherit (lib)
+    attrNames
     attrValues
     concatLists
     concatStringsSep
@@ -807,7 +808,8 @@ in
                 ]
               )
             }:$PATH"
-            export ${toShellVars client.environment}
+            ${toShellVars client.environment}
+            export ${concatStringsSep " " (attrNames client.environment)}
 
             # merge /etc/${client.dir.baseName}/config.d' into "$NB_CONFIG"
             {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/543380.

With `systemd.enableStrictShellChecks = true`, any `services.netbird.clients.<name>` fails to
evaluate its unit script, and the failure propagates all the way up to `system.build.toplevel`:

```
NB_WIREGUARD_PORT=51820
^---------------^ SC2034 (warning): NB_WIREGUARD_PORT appears unused. Verify use (or export if used externally).
error: Cannot build '/nix/store/...-unit-script-netbird-nb_test-pre-start.drv'.
```

The cause is at `nixos/modules/services/networking/netbird.nix:810`:

```nix
export ${toShellVars client.environment}
```

`toShellVars` emits one assignment per line, so `export` binds to the first line only and the other
seven variables are plain assignments:

```
$ printf 'export FIRST=1\nSECOND=2\nTHIRD=3\nenv | grep -E "^(FIRST|SECOND|THIRD)="\n' | bash
FIRST=1
```

That explains the exact shape of the shellcheck output: every variable is reported except
`NB_CONFIG`, which is both alphabetically first (so it got the `export`) and the only one the script
actually reads. So this is not only a lint failure. The module intends to export eight variables and
exports one.

The fix keeps `toShellVars` and its quoting and exports the names afterwards. `set -o allexport`
around the block, which `radicle/ci-broker.nix` uses for the same job, does not work here:
`shellcheck` does not model it and still reports SC2034 for every variable. `netbird.nix:810` is the
only place in the tree with this `export ${toShellVars ...}` shape.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]: `nixosTests.netbird` passes.
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- NixOS Release Notes
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

### Verification

A throwaway config with strict checks on and one client, building only the unit rather than a whole
`toplevel`:

```nix
systemd.enableStrictShellChecks = true;
services.netbird.clients.nb_test.port = 51820;
```

Before, on the base commit:

```
$ nix-build -E '... config.systemd.units."netbird-nb_test.service".unit'
SC2034 (warning): NB_DAEMON_ADDR appears unused. ...   (and 6 more, NB_CONFIG not among them)
error: Cannot build '/nix/store/...-unit-netbird-nb_test.service.drv'.
```

After, same config:

```
$ nix-build -E '... config.systemd.units."netbird-nb_test.service".unit'
/nix/store/8hq1ppkm00jrs8557nk5rbm1rxs49n6r-unit-netbird-nb_test.service
```

and the generated script now exports all eight:

```bash
NB_CONFIG=/var/lib/netbird-nb_test/config.json
NB_DAEMON_ADDR=unix:///var/run/netbird-nb_test/sock
NB_INTERFACE_NAME=nb-nb_test
NB_LOG_FILE=console
NB_LOG_LEVEL=info
NB_SERVICE=netbird-nb_test
NB_STATE_DIR=/var/lib/netbird-nb_test
NB_WIREGUARD_PORT=51820
export NB_CONFIG NB_DAEMON_ADDR NB_INTERFACE_NAME NB_LOG_FILE NB_LOG_LEVEL NB_SERVICE NB_STATE_DIR NB_WIREGUARD_PORT
```

`nix-build -A nixosTests.netbird` passes on this branch, so the `preStart` still does its config.d
merge in a real VM for both the default and the `custom` client:

```
node: must succeed: netbird-custom status |& grep -C20 Disconnected
test script finished in 8.07s
/nix/store/jjilrkzmzr3m21lrzzc3mslgjbc2fin1-vm-test-run-netbird
```

Note that the existing test cannot catch the regression this fixes, because
`systemd.enableStrictShellChecks` defaults to `false` and the test does not set it. I left the test
alone rather than turning strict checks on there, since that would gate the netbird test on every
other unit script in the VM.

**Automation disclosure**, separate from the commit trailer as the policy requires: this pull
request's change and this summary were prepared with Claude Code (claude-opus-5). I reviewed the
diff and reproduced the runs above myself before submitting, and I am the person accountable for it.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
