### PR TITLE
eddie: 2.24.6 -> 2.26.2

### DIFF
--- a/pkgs/by-name/ed/eddie/package.nix
+++ b/pkgs/by-name/ed/eddie/package.nix
@@ -29,25 +29,26 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "eddie";
-  version = "2.24.6";
+  version = "2.26.2";
 
   src = fetchFromGitHub {
     owner = "AirVPN";
     repo = "Eddie";
-    tag = finalAttrs.version;
-    hash = "sha256-XSLxjF2k9cw+cx6KzFIQHtjDWqLT2V49KRw+oIyxM5M=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-G3geXoZAd8gf6HnKboadDL/QLlO9d4fd0rNEnViobhY=";
   };
 
   patches = [
     ./dont-set-rpath-in-eddie-tray.patch
     ./remove-the-postbuild-from-the-project-file.patch
+    ./remove-impure-integrity-check.patch
   ];
 
-  projectFile = [ "src/App.CLI.Linux/App.CLI.Linux.net8.csproj" ];
+  projectFile = [ "src/App.CLI.Linux/App.CLI.Linux.net10.csproj" ];
   nugetDeps = ./deps.json;
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
 
   nativeBuildInputs = [
     gcc
@@ -142,9 +143,7 @@ buildDotnetModule (finalAttrs: {
     homepage = "https://eddie.website";
     license = lib.licenses.gpl3Plus;
     mainProgram = "eddie-ui";
-    maintainers = with lib.maintainers; [
-      ryand56
-    ];
+    maintainers = [ lib.maintainers.ryand56 ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ed/eddie/remove-impure-integrity-check.patch
+++ b/pkgs/by-name/ed/eddie/remove-impure-integrity-check.patch
@@ -1,0 +1,20 @@
+diff --git a/src/Lib.CLI.Elevated/src/ibase.cpp b/src/Lib.CLI.Elevated/src/ibase.cpp
+index 3f002048cf..c1814cd2af 100644
+--- a/src/Lib.CLI.Elevated/src/ibase.cpp
++++ b/src/Lib.CLI.Elevated/src/ibase.cpp
+@@ -427,15 +427,6 @@
+ 						if (clientProcessId != GetSpotClientPid())
+ 							ThrowException("Client not allowed: Spot mode, client PID mismatch");
+ 					}
+-
+-#if defined(Debug) || defined(_DEBUG)
+-#else
+-					if (true)
+-					{
+-						if (IntegrityCheckFileKnown(clientProcessPath) == false)
+-							ThrowException("Client not allowed: Integrity check failed ");
+-					}
+-#endif
+ 				}
+ 
+ 				ReplyPID(GetCurrentProcessId());

--- a/pkgs/by-name/ed/eddie/remove-the-postbuild-from-the-project-file.patch
+++ b/pkgs/by-name/ed/eddie/remove-the-postbuild-from-the-project-file.patch
@@ -1,19 +1,10 @@
-From bfe8a4e0d75b97cf646818bfba52dfdbc3c4274c Mon Sep 17 00:00:00 2001
-From: Pavel Sobolev <contact@paveloom.dev>
-Date: Fri, 6 Dec 2024 22:42:40 +0300
-Subject: [PATCH 1/2] Remove the postbuild from the project file.
-
----
- src/App.CLI.Linux/App.CLI.Linux.net8.csproj | 5 -----
- 1 file changed, 5 deletions(-)
-
-diff --git a/src/App.CLI.Linux/App.CLI.Linux.net8.csproj b/src/App.CLI.Linux/App.CLI.Linux.net8.csproj
+diff --git a/src/App.CLI.Linux/App.CLI.Linux.net10.csproj b/src/App.CLI.Linux/App.CLI.Linux.net10.csproj
 index 8d53d36..b4b3822 100644
---- a/src/App.CLI.Linux/App.CLI.Linux.net8.csproj
-+++ b/src/App.CLI.Linux/App.CLI.Linux.net8.csproj
+--- a/src/App.CLI.Linux/App.CLI.Linux.net10.csproj
++++ b/src/App.CLI.Linux/App.CLI.Linux.net10.csproj
 @@ -50,9 +50,4 @@
- 		<ProjectReference Include="..\Lib.Core\Lib.Core.net8.csproj" />
- 		<ProjectReference Include="..\Lib.Platform.Linux\Lib.Platform.Linux.net8.csproj" />
+ 		<ProjectReference Include="..\Lib.Core\Lib.Core.net10.csproj" />
+ 		<ProjectReference Include="..\Lib.Platform.Linux\Lib.Platform.Linux.net10.csproj" />
  	</ItemGroup>
 -
 -	<Target Name="LinuxPostBuild" AfterTargets="PostBuildEvent">		


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
