### PR TITLE
gershwin-textedit: init at 4-unstable-2026-07-07

### DIFF
--- a/pkgs/by-name/ge/gershwin-textedit/package.nix
+++ b/pkgs/by-name/ge/gershwin-textedit/package.nix
@@ -1,0 +1,40 @@
+{
+  clangStdenv,
+  fetchFromGitHub,
+  gnustep-back,
+  lib,
+  wrapGNUstepAppsHook,
+}:
+
+clangStdenv.mkDerivation {
+  strictDeps = true;
+  __structuredAttrs = true;
+  name = "gershwin-textedit";
+  version = "4-unstable-2026-07-07";
+
+  src = fetchFromGitHub {
+    owner = "gershwin-desktop";
+    repo = "gershwin-textedit";
+    rev = "f77e874b3bed709267885cdd24aeeb8711a407b0";
+    hash = "sha256-b4a/ywmwzXjmi4Y8RaDaPZlHXt5pa/4VqUw8Izt8N38=";
+  };
+
+  nativeBuildInputs = [
+    wrapGNUstepAppsHook
+  ];
+
+  buildInputs = [
+    gnustep-back
+  ];
+
+  meta = {
+    homepage = "https://github.com/gershwin-desktop/gershwin-textedit";
+    description = "The text editor for Gershwin Desktop";
+    license = lib.licenses.mit;
+    mainProgram = "TextEdit";
+    maintainers = with lib.maintainers; [
+      OulipianSummer
+    ];
+  };
+  platforms = lib.platforms.linux;
+}


### PR DESCRIPTION
This PR introduces a component of the [Gershwin Desktop ](https://github.com/gershwin-desktop) called [TextEdit](https://github.com/gershwin-desktop/gershwin-textedit/tree/main). TextEdit is itself a fork of the NextStep program by the same name with some compatibility enhancement for GNUStep / Gershwin.

It is a GNUStep / X11 application that uses some of the build scripts and hooks already available in nixpkgs and thus has decent compatibility with an existing GNUStep environment.

This PR was not created or supervised with the use of AI tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
