### PR TITLE
vscode-extensions.quarto.quarto: init at 1.135.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3890,6 +3890,8 @@ let
         };
       };
 
+      quarto.quarto = callPackage ./quarto.quarto { };
+
       quicktype.quicktype = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "quicktype";

--- a/pkgs/applications/editors/vscode/extensions/quarto.quarto/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/quarto.quarto/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "quarto";
+    publisher = "quarto";
+    version = "1.135.0";
+    hash = "sha256-KxdiW/WFQN7nCZhhB7wntChcv+VV3E8d5FfArCt+0KQ=";
+  };
+  meta = {
+    changelog = "https://marketplace.visualstudio.com/items/quarto.quarto/changelog";
+    description = "Visual Studio Code extension for the Quarto scientific and technical publishing system";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=quarto.quarto";
+    homepage = "https://github.com/quarto-dev/quarto/tree/main/apps/vscode";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ maj0e ];
+  };
+}


### PR DESCRIPTION
Release: https://marketplace.visualstudio.com/items/quarto.quarto/changelog

This PR adds the quarto.quarto VSCode extension.

I used this extension for quite some time in my personal nixos config via `vscode-utils.extensionsFromVscodeMarketplace` and figured, that upstreaming it would not be much more effort.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
