### PR TITLE
ftxui: 6.1.9 → 7.0.3, json-tui: 1.4.1 → 1.4.2

### DIFF
--- a/pkgs/by-name/ft/ftxui/package.nix
+++ b/pkgs/by-name/ft/ftxui/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
 
   cmake,
-  doxygen,
   gbenchmark,
   graphviz,
   gtest,
@@ -12,21 +11,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ftxui";
-  version = "6.1.9";
+  version = "7.0.3";
 
   src = fetchFromGitHub {
     owner = "ArthurSonzogni";
     repo = "ftxui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-plJxTLhOhUyuay5uYv4KLK9UTmM2vsoda+iDXVa4b+k=";
+    hash = "sha256-hKdmzraAgKwvOGQXpglD9lm0465j92AAn2MhS9ZM4jA=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
     cmake
-    doxygen
-    graphviz
   ];
 
   checkInputs = [
@@ -37,8 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   cmakeFlags = [
-    (lib.cmakeBool "FTXUI_BUILD_EXAMPLES" false)
-    (lib.cmakeBool "FTXUI_BUILD_DOCS" true)
     (lib.cmakeBool "FTXUI_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 

--- a/pkgs/by-name/js/json-tui/package.nix
+++ b/pkgs/by-name/js/json-tui/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchpatch2,
   fetchFromGitHub,
 
   cmake,
@@ -16,22 +15,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "json-tui";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "ArthurSonzogni";
     repo = "json-tui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qS2EbCxH8sUUJMu5hwm1+Nu6SsJRfLReX56YSd1RZU4=";
+    hash = "sha256-PXiTlTwF/qL/Nq1PSf8PHgKa0MD6QrA0tSWiFfm93Gk=";
   };
-
-  patches = [
-    # fixes tests - https://github.com/ArthurSonzogni/json-tui/pull/37
-    (fetchpatch2 {
-      url = "https://github.com/ArthurSonzogni/json-tui/commit/645060a016c1e1ca84b9e1dc638a926415aaa5fe.patch?full_index=1";
-      hash = "sha256-8AZEZgU8HHyaasb/7LegSwRAMo1iyonv3XUY284nYKg=";
-    })
-  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
* https://github.com/ArthurSonzogni/FTXUI/compare/v6.1.9...v7.0.3
* https://github.com/ArthurSonzogni/json-tui/compare/v1.4.1...v1.4.2

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
