### PR TITLE
nixos/modemmanager: fix missing awk and xxd in FCC unlock script PATH

### DIFF
--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -64,10 +64,15 @@ in
 
     systemd.services.ModemManager = {
       aliases = [ "dbus-org.freedesktop.ModemManager1.service" ];
-      path = lib.optionals (cfg.fccUnlockScripts != [ ]) [
-        pkgs.libqmi
-        pkgs.libmbim
-      ];
+      path = lib.optionals (cfg.fccUnlockScripts != [ ]) (
+        with pkgs;
+        [
+          gawk
+          libmbim
+          libqmi
+          xxd
+        ]
+      );
     };
 
     /*


### PR DESCRIPTION
The FCC unlock scripts use a few helpers not automatically included with systemd, which we need to set up the service path for. Two of the scripts that come from upstream use awk and xxd, which were missing in the list. That made the script mistakenly yield an empty response, which ultimately makes the unlock fail.

As of today, this fix covers the MediaTek T700, sold e.g. with the ThinkPad X1 Yoga Gen 8 as Fibocom FM350-GL.

## Related

Affected unlock scripts upstream: ([linux-mobile-broadband/ModemManager](https://github.com/linux-mobile-broadband/ModemManager))

- [data/dispatcher-fcc-unlock/14c3](https://github.com/linux-mobile-broadband/ModemManager/blob/main/data/dispatcher-fcc-unlock/14c3) (currently included in nixpkgs)
- [data/dispatcher-fcc-unlock/8086:7360](https://github.com/linux-mobile-broadband/ModemManager/blob/main/data/dispatcher-fcc-unlock/8086:7360) (upcoming, not yet included here)