### PR TITLE
qmapshack: add aarch64-darwin support

### DIFF
--- a/pkgs/by-name/qm/qmapshack/package.nix
+++ b/pkgs/by-name/qm/qmapshack/package.nix
@@ -11,6 +11,36 @@
   routino,
 }:
 
+let
+  qtwebengine =
+    if stdenv.hostPlatform.isDarwin then
+      qt6.qtwebengine.overrideAttrs (oldAttrs: {
+        # Remove when these Darwin fixes are included in qtwebengine:
+        # https://github.com/NixOS/nixpkgs/pull/515997
+        # https://github.com/NixOS/nixpkgs/pull/520445
+        # https://github.com/NixOS/nixpkgs/pull/547302
+        postPatch = oldAttrs.postPatch + ''
+          substituteInPlace cmake/QtToolchainHelpers.cmake \
+            --replace-fail 'clang_base_path="''${QWELibClang_BASE_PATH}"' 'clang_base_path="${stdenv.cc}"'
+          substituteInPlace cmake/QtConfigureHelpers.cmake \
+            --replace-fail 'message(STATUS "Checking for Metal Toolchain")' 'message(STATUS "Checking for Metal Toolchain")
+              set(TEST_metal_toolchain TRUE PARENT_SCOPE)
+              return()'
+          substituteInPlace src/core/configure/BUILD.root.gn.in src/pdf/configure/BUILD.root.gn.in \
+            --replace-fail 'lflags_remove = "(--sysroot=)(\\.\\./.*\\S*?)" # ignore sysroot with realative path' \
+              'lflags_remove = "(--sysroot=|-isysroot )\\.\\./\\S+" # ignore sysroot with relative path'
+          substituteInPlace src/core/configure/BUILD.root.gn.in \
+            --replace-fail '  shared_library("convert_dict") {
+              rsp_types = [ "objects", "archives", "libs", "ldir", "lflags" ]' \
+              '  shared_library("convert_dict") {
+              rsp_types = [ "objects", "archives", "libs", "ldir", "lflags" ]
+              lflags_remove = "(--sysroot=|-isysroot )\\.\\./\\S+" # ignore sysroot with relative path'
+        '';
+        cmakeFlags = oldAttrs.cmakeFlags ++ [ "-DCMAKE_OSX_DEPLOYMENT_TARGET=12.0" ];
+      })
+    else
+      qt6.qtwebengine;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "qmapshack";
   version = "1.20.3";
@@ -33,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     gdal
     proj
     routino
-    qt6.qtwebengine
+    qtwebengine
     qt6Packages.quazip
   ];
 
@@ -41,7 +71,43 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "ALGLIB_INCLUDE_DIRS" "${alglib}/include/alglib")
     (lib.cmakeFeature "ALGLIB_LIBRARIES" "alglib3")
     (lib.cmakeFeature "ROUTINO_XML_PATH" "${routino}/share/routino")
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeFeature "QT_DEV_PATH" "${qt6.qtbase.dev}")
+    (lib.cmakeFeature "ROUTINO_DEV_PATH" "${routino}")
+    (lib.cmakeFeature "QuaZip-Qt6_DIR" "${qt6Packages.quazip.dev}/lib/cmake/QuaZip-Qt6-${qt6Packages.quazip.version}")
+    (lib.cmakeFeature "PROJ_DEV_PATH" "${proj}")
+    (lib.cmakeFeature "GDAL_DEV_PATH" "${gdal}")
   ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    for app in QMapShack QMapTool; do
+      contents="$out/Applications/$app.app/Contents"
+      mkdir -p "$contents/MacOS" "$contents/Resources/help" "$contents/Resources/translations"
+      ln -s ${gdal}/share/gdal "$contents/Resources/gdal"
+      ln -s ${gdal}/lib/gdalplugins "$contents/Resources/gdalplugins"
+      ln -s ${proj}/share/proj "$contents/Resources/proj"
+      ln -s ${routino}/share/routino "$contents/Resources/routino"
+      ln -s "$out/bin" "$contents/Tools"
+
+      cp "$src"/MacOSX/resources/*.qss "$contents/Resources/"
+      cp "$src"/src/qmapshack/doc/QMSHelp.qch "$src"/src/qmapshack/doc/QMSHelp.qhc "$contents/Resources/help/"
+      cp "$src"/src/qmaptool/doc/QMTHelp.qch "$src"/src/qmaptool/doc/QMTHelp.qhc "$contents/Resources/help/"
+      cp src/qmapshack/*.qm src/qmaptool/*.qm src/qmt_rgb2pct/*.qm "$contents/Resources/translations/"
+      cp ${qt6.qttranslations}/translations/qtbase_*.qm "$contents/Resources/translations/"
+      install -Dm444 "$src/MacOSX/resources/$app.icns" "$contents/Resources/$app.icns"
+      substitute "$src/MacOSX/resources/Info.plist" "$contents/Info.plist" \
+        --replace-fail QMapShack "$app" \
+        --replace-fail APP_VERSION ${finalAttrs.version} \
+        --replace-fail BUNDLE_VERSION ${finalAttrs.version} \
+        --replace-fail PACKAGES_PATH "$out"
+    done
+
+    mv "$out/bin/qmapshack" "$out/Applications/QMapShack.app/Contents/MacOS/QMapShack"
+    mv "$out/bin/qmaptool" "$out/Applications/QMapTool.app/Contents/MacOS/QMapTool"
+    ln -s "$out/Applications/QMapShack.app/Contents/MacOS/QMapShack" "$out/bin/qmapshack"
+    ln -s "$out/Applications/QMapTool.app/Contents/MacOS/QMapTool" "$out/bin/qmaptool"
+  '';
 
   qtWrapperArgs = [
     "--suffix PATH : ${
@@ -61,6 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
       dotlambda
       sikmir
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
The Darwin build needs explicit CMake dependency paths and complete app bundles containing its runtime resources. Qt WebEngine also requires several pending Darwin fixes and a macOS 12 deployment target to build successfully.

Carry the Qt WebEngine workarounds locally until the corresponding Nixpkgs changes land:

https://github.com/NixOS/nixpkgs/pull/515997
https://github.com/NixOS/nixpkgs/pull/520445
https://github.com/NixOS/nixpkgs/pull/547302

Assisted-by: OpenCode (OpenAI GPT-5.6 Sol)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
