### PR TITLE
frogatto: fix invalid unstable version scheme

### DIFF
--- a/pkgs/by-name/fr/frogatto/data.nix
+++ b/pkgs/by-name/fr/frogatto/data.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "frogatto-data";
-  version = "unstable-2023-02-27";
+  version = "1.3.1-unstable-2023-02-27";
 
   src = fetchFromGitHub {
     owner = "frogatto";

--- a/pkgs/by-name/fr/frogatto/engine.nix
+++ b/pkgs/by-name/fr/frogatto/engine.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation {
   pname = "anura-engine";
-  version = "unstable-2023-02-27";
+  version = "0-unstable-2023-02-27";
 
   src = fetchFromGitHub {
     owner = "anura-engine";


### PR DESCRIPTION
As part of https://github.com/NixOS/nixpkgs/issues/541820

Both the game, and the engine seem to have a 4.0.0 version, but it was made 2023-04-17, when the version we're using is older, so 0 it is.

Those releases are:
- https://github.com/frogatto/frogatto/releases/tag/4.0.0
- https://github.com/anura-engine/anura/releases/tag/v4.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
