### PR TITLE
discourse: add riscv64-linux support

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -1045,6 +1045,17 @@ in
     buildFlags = [ "--with-ssh" ];
   };
 
+  rbtrace = attrs: {
+    dontBuild = false;
+    postPatch = ''
+      tar -xzf ext/src/msgpack-1.1.0.tar.gz -C ext/src
+    '';
+    preConfigure = ''
+      tar -czf ext/src/msgpack-1.1.0.tar.gz -C ext/src msgpack-1.1.0
+      rm -r ext/src/msgpack-1.1.0
+    '';
+  };
+
   sassc = attrs: {
     nativeBuildInputs = [ rake ];
     dontBuild = false;

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -182,6 +182,7 @@ let
       # these hashes are auto-updated by update.py
       dart-x64-hash = "sha256-2rnqNeEr8PFMuFa4IhutxxXui1dCw3XQVqCV5ZwsUR8=";
       dart-arm64-hash = "sha256-8sgc9IaeWSRnURFtMuSOqnKACkDc5WynmLIboYWwoSM=";
+      dart-riscv64-hash = "sha256-9amKnAuuAQcKTQT2DGnl9r64g7ATY9GCvZUvY9pzEIM=";
     in
     bundlerEnv rec {
       name = "discourse-ruby-env-${version}";
@@ -190,7 +191,12 @@ let
       gemset = import (gemdir + "/gemset.nix") src;
       passthru = {
         # these MUST be passthru'd for update.py to function correctly (to update dart-dart-x64-hash and dart-arm64-hash)
-        inherit dart-x64-hash dart-arm64-hash gemset;
+        inherit
+          dart-x64-hash
+          dart-arm64-hash
+          dart-riscv64-hash
+          gemset
+          ;
       };
       gemConfig = defaultGemConfig // {
         mini_racer = attrs: {
@@ -310,6 +316,8 @@ let
                   "linux-x64"
                 else if stdenv.system == "aarch64-linux" then
                   "linux-arm64"
+                else if stdenv.system == "riscv64-linux" then
+                  "linux-riscv64"
                 else
                   "unsupported-system-triple-download-will-fail";
               hash =
@@ -317,6 +325,8 @@ let
                   dart-x64-hash
                 else if stdenv.system == "aarch64-linux" then
                   dart-arm64-hash
+                else if stdenv.system == "riscv64-linux" then
+                  dart-riscv64-hash
                 else
                   "unsupported-system";
             in
@@ -592,6 +602,7 @@ let
       platforms = [
         "x86_64-linux"
         "aarch64-linux"
+        "riscv64-linux"
       ];
       maintainers = with lib.maintainers; [
         leona

--- a/pkgs/servers/web-apps/discourse/update.py
+++ b/pkgs/servers/web-apps/discourse/update.py
@@ -279,7 +279,7 @@ def update(rev):
     # update the sass-embedded override
     # must run *after* the gemfile update!
     dart_sass_ver = _nix_eval('discourse.rubyEnv.gemset.sass-embedded.version')
-    for platform in ["x64", "arm64"]:
+    for platform in ["x64", "arm64", "riscv64"]:
         prev_hash = _nix_eval(f'discourse.rubyEnv.dart-{platform}-hash')
         new_hash = subprocess.check_output([
             "nurl",


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
