### PR TITLE
chroncal: init at 0.7.12

### DIFF
--- a/pkgs/by-name/ch/chroncal/package.nix
+++ b/pkgs/by-name/ch/chroncal/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  stdenv,
+}:
+buildGoModule (finalAttrs: {
+  pname = "chroncal";
+  version = "0.7.12";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "DouglasdeMoura";
+    repo = "chroncal";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N3VHM5b06UNKBMGEi3txlm/XY+sq3ic+nCEAzugz+zs=";
+  };
+
+  vendorHash = "sha256-kkorYX/WY/IHCAZExfkUVBxb8wl9kae8CWd+WVD9Q8k=";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook # multiple tests need a writable $HOME for the database
+  ];
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  doCheck = stdenv.hostPlatform.isLinux; # some tests need local networking and some doesn't use correctly writableTmpDirAsHomeHook
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-first calendar, todo, and journal manager with iCalendar support and CalDAV sync";
+    homepage = "https://github.com/DouglasdeMoura/chroncal";
+    changelog = "https://github.com/DouglasdeMoura/chroncal/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ tomasrivera ];
+    mainProgram = "chroncal";
+  };
+})


### PR DESCRIPTION
No AI/Automation was used for this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
