### PR TITLE
flakeguard: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21000,6 +21000,11 @@
     githubId = 2946283;
     name = "Brian Cohen";
   };
+  notzorua = {
+    github = "notzorua";
+    githubId = 248946345;
+    name = "rem";
+  };
   nouritsu = {
     name = "Aneesh Bhave";
     email = "aneesh1701@gmail.com";

--- a/pkgs/by-name/fl/flakeguard/package.nix
+++ b/pkgs/by-name/fl/flakeguard/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "flakeguard";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "notzorua";
+    repo = "flakeguard";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AjVWBJz6MFldg5XHlUqGLlslSR5N75UKckmy9FySTSE=";
+  };
+
+  vendorHash = null;
+
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Detect ownership changes of the accounts a flake executes code from";
+    longDescription = ''
+      A flake input such as `github:someone/tool` means that every build
+      downloads and runs code from an account somebody else controls. A typical
+      configuration accumulates dozens of these once transitive inputs are
+      counted.
+
+      GitHub releases an account name when its owner renames, and anyone can
+      then claim it and publish a repository under the old path. This is called
+      repojacking. The lock file's narHash protects the pinned revision, but not
+      the moment somebody updates the input.
+
+      flakeguard reads flake.lock and reports inputs whose repository is gone,
+      moved, archived, stale, or - the case it exists for - whose account was
+      created after the commit the lock file pins, which means the name changed
+      hands. Depth varies by forge: GitHub needs no credentials, GitLab needs a
+      token for the account checks, SourceHut and plain git are limited to
+      reachability and staleness.
+    '';
+    homepage = "https://github.com/notzorua/flakeguard";
+    changelog = "https://github.com/notzorua/flakeguard/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ notzorua ];
+    mainProgram = "flakeguard";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds flakeguard, which checks whether the accounts a flake executes code from have changed hands.

Every flake input means Nix downloads and runs code from a repository somebody else controls, and a typical configuration accumulates dozens once transitive inputs are counted. GitHub releases an account name when its owner renames, and anyone can claim it afterwards; this is called repojacking, and the protections against it have been bypassed repeatedly.

The lock file's narHash protects the pinned revision, but not the moment the input is updated. flakeguard reads flake.lock and reports inputs whose repository is gone, moved, archived or stale, and inputs whose account was created after the commit being pinned, which means the name changed hands.

Depth varies by forge and the README documents the gaps: GitHub needs no credentials, GitLab needs a token for the account checks, SourceHut and plain git support reachability and staleness only.

Upstream: https://github.com/notzorua/flakeguard

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test