### PR TITLE
gpupad: 3.4.1 -> 4.3.0,spirv-reflect: init at 1.4.357.0,directxtex: init at may2026,directxmath: init at jun2026

### DIFF
--- a/pkgs/by-name/di/directxmath/package.nix
+++ b/pkgs/by-name/di/directxmath/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  pkgsBuildBuild,
+}:
+
+let
+  releaseYear = "2026";
+  releaseMonth = "jun";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "directxmath";
+  version = "${releaseMonth}${releaseYear}";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "DirectXMath";
+    tag = finalAttrs.version;
+    hash = "sha256-iKUCtMDZklxLcNqaP0hNRfqhyd049xXZB0iF6D6DoWM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  # DirectXMath includes `<sal.h>`, which only exists in the Windows
+  # SDK.  Non-Windows consumers need a shim on the include path, so we
+  # ship the mingw-w64 CRT copy.
+  # See <https://github.com/microsoft/DirectXMath#compiler-support>
+  postInstall = with pkgsBuildBuild.pkgsCross.mingwW64.windows; ''
+    install --mode=644 \
+      ${mingw_w64_headers}/include/{sal,concurrencysal}.h \
+      --target-directory="$out/include"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "All inline SIMD C++ linear algebra library";
+    homepage = "https://github.com/microsoft/DirectXMath";
+    changelog = "https://github.com/microsoft/DirectXMath/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/di/directxtex/0001-cmake-fallback-for-directx-headers.patch
+++ b/pkgs/by-name/di/directxtex/0001-cmake-fallback-for-directx-headers.patch
@@ -1,0 +1,17 @@
+diff -ruN a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2026-08-22 01:52:44.644347661 -0700
++++ b/CMakeLists.txt	2026-08-22 02:09:56.617878659 -0700
+@@ -384,7 +384,12 @@
+     find_package(directxmath CONFIG REQUIRED)
+     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+ 
+-    find_package(directx-headers CONFIG REQUIRED)
++    find_package(directx-headers CONFIG QUIET)
++    if(NOT TARGET Microsoft::DirectX-Headers)
++        find_package(PkgConfig REQUIRED)
++        pkg_check_modules(DirectX-Headers REQUIRED IMPORTED_TARGET DirectX-Headers)
++        add_library(Microsoft::DirectX-Headers ALIAS PkgConfig::DirectX-Headers)
++    endif()
+     target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectX-Headers)
+     target_compile_definitions(${PROJECT_NAME} PUBLIC USING_DIRECTX_HEADERS)
+ else()

--- a/pkgs/by-name/di/directxtex/package.nix
+++ b/pkgs/by-name/di/directxtex/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  directx-headers,
+  directxmath,
+  pkg-config,
+}:
+
+let
+  releaseYear = "2026";
+  releaseMonth = "may";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "directxtex";
+  version = "${releaseMonth}${releaseYear}";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "DirectXTex";
+    tag = finalAttrs.version;
+    hash = "sha256-2JqaAbZXOBIZ2oRQGnpAhuoCiZ4OaqNPYnYRkTll9IA=";
+  };
+
+  patches = [ ./0001-cmake-fallback-for-directx-headers.patch ];
+
+  buildInputs = [
+    directx-headers
+    directxmath
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "DirectXTex texture processing library";
+    homepage = "https://github.com/microsoft/DirectXTex";
+    changelog = "https://github.com/microsoft/DirectXTex/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/gp/gpupad/package.nix
+++ b/pkgs/by-name/gp/gpupad/package.nix
@@ -5,25 +5,64 @@
   cmake,
   nix-update-script,
 
+  directx-headers,
+  directxmath,
+  directxtex,
+  getopt,
   glslang,
   imath,
+  kissfft,
   ktx-tools,
+  nlohmann_json,
   openimageio,
+  pipewire,
   qt6Packages,
   spdlog,
   spirv-cross,
+  spirv-headers,
+  spirv-reflect,
+  spirv-tools,
+  vulkan-headers,
+  vulkan-loader,
   vulkan-memory-allocator,
 }:
 
+let
+  ktx-src =
+    (stdenv.mkDerivation {
+      name = "ktx-src";
+      src = ktx-tools.src.overrideAttrs (old: {
+        fetchSubmodules = true;
+        hash = "sha256-vxQ6QVsUeKFM8W5TS4TWZasWKXbXbxsbf72nKpVwBFE=";
+      });
+
+      nativeBuildInputs = [ getopt ];
+      dontBuild = true;
+      installPhase = ''
+        runHook preInstall
+
+        # Generate `version.h` files that ktx's cmake version.cmake
+        # would otherwise try to regenerate inside the read-only
+        # store output
+        patchShebangs .
+        for obj in tools/ktx lib/src; do
+          ./scripts/mkversion -v v0.0.0-noversion -o version.h "$obj"
+        done
+        cp --recursive . "$out"
+
+        runHook postInstall
+      '';
+    }).out;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpupad";
-  version = "3.4.1";
+  version = "4.3.0";
 
   src = fetchFromGitHub {
     owner = "houmain";
     repo = "gpupad";
     tag = finalAttrs.version;
-    hash = "sha256-8kDJRZPDzZA6ofaXWQ55VZfuXdOHvTCssoe64qgNrbU=";
+    hash = "sha256-xqkheFFnWkuFkcA3EAFUzvJAOlrqijWfNlGucMQ6gkI=";
     fetchSubmodules = true;
   };
 
@@ -37,14 +76,35 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     glslang
     imath # needed for openimageio
-    ktx-tools
+    nlohmann_json
     openimageio
     qt6Packages.qtbase
     qt6Packages.qtdeclarative
     qt6Packages.qtmultimedia
     spdlog
-    spirv-cross
-    vulkan-memory-allocator
+    spirv-headers
+    spirv-tools
+    vulkan-headers
+    vulkan-loader
+  ];
+
+  cmakeFlags = [
+    "-DVERSION=${finalAttrs.version}"
+    "-DGPUPAD_NLOHMANN_JSON_FIND_PACKAGE=ON"
+    "-DFETCHCONTENT_SOURCE_DIR_KTXSOFTWARE=${ktx-src}"
+    "-DFETCHCONTENT_SOURCE_DIR_DIRECTX-HEADERS=${directx-headers.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_DIRECTXMATH=${directxmath.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_DIRECTXTEX=${directxtex.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_KISSFFT=${kissfft.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_SPIRV-CROSS=${spirv-cross.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_SPIRV-REFLECT=${spirv-reflect.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_VULKAN-MEMORY-ALLOCATOR=${vulkan-memory-allocator.src}"
+  ];
+
+  # qtmultimedia's ffmpeg backend dlopens libpipewire-0.3 at runtime,
+  # so it is not kept in the shrunk RPATH
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ pipewire ]}"
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/gp/gpupad/package.nix
+++ b/pkgs/by-name/gp/gpupad/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  nix-update-script,
 
   glslang,
   imath,
@@ -45,6 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
     spirv-cross
     vulkan-memory-allocator
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Flexible GLSL and HLSL shader editor and IDE";

--- a/pkgs/by-name/sp/spirv-reflect/package.nix
+++ b/pkgs/by-name/sp/spirv-reflect/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spirv-reflect";
+  version = "1.4.357.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "SPIRV-Reflect";
+    tag = "vulkan-sdk-${finalAttrs.version}";
+    hash = "sha256-RLT6NQg+4GPPX67FEVu3sOOsyFqB+Ol/ZoD5M8N+dEM=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Reflection API for SPIR-V shader bytecode in Vulkan applications";
+    homepage = "https://github.com/KhronosGroup/SPIRV-Reflect";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "spirv-reflect";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Resolves; #554813

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
