### PR TITLE
thermald: patch error on non-mobile platforms

### DIFF
--- a/pkgs/by-name/th/thermald/package.nix
+++ b/pkgs/by-name/th/thermald/package.nix
@@ -7,6 +7,7 @@
   docbook_xml_dtd_412,
   docbook-xsl-nons,
   fetchFromGitHub,
+  fetchpatch,
   gtk-doc,
   libevdev,
   libtool,
@@ -32,6 +33,20 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-pppza3HVKl27K/dM4G5h9095N9Fw4a/7FZD95/2Llu8=";
   };
+
+  patches = [
+    # Fix "[ERR]Non mobile platform, exiting.." issue.
+    # https://github.com/intel/thermal_daemon/issues/589
+    # (Will be included in the next release).
+    #
+    # NOTES:
+    # - https://github.com/NixOS/nixos-hardware/issues/208
+    (fetchpatch {
+      name = "demote-fatal-error-to-warning-for-non-mobile-platform.patch";
+      url = "https://github.com/panchoh/thermal_daemon/commit/7f2a5d09010c1ffa9ce53c4fe0e673bcc504ea67.patch";
+      hash = "sha256-XQM6OfIg/2SZxhxB/NrCUEiWxBl/AtI4Y/jdcXBVoJM=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoconf


### PR DESCRIPTION
See https://github.com/intel/thermal_daemon/issues/589

This adds the backport of the commit that fixes it on the master branch:

https://github.com/intel/thermal_daemon/commit/de4821ce559a2041f6a5d574aeca278df340e379


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
