### PR TITLE
lsdisplay: init at 0.2.5; lsgpus: init at 0.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10846,6 +10846,11 @@
     githubId = 4753752;
     name = "guttermonk";
   };
+  guy-marc-aprin = {
+    github = "AGuyMarc";
+    githubId = 281480315;
+    name = "Guy-Marc Aprin";
+  };
   guylamar2006 = {
     name = "guylamar2006";
     github = "guylamar2006";

--- a/pkgs/by-name/ls/lsdisplay/package.nix
+++ b/pkgs/by-name/ls/lsdisplay/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "lsdisplay";
+  version = "0.2.5";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-UhYJkrL5gr+8nCGmV9PfJzCCm7AqLhKKdo/2HVc2o1c=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  # Script Python 3 autonome, aucune dependance d'execution.
+  pythonImportsCheck = [ "lsdisplay" ];
+
+  # Tests unittest embarques : ils s'auto-invoquent (--help/--version) et
+  # mockent le reste, donc ils tournent sans serveur X.
+  checkPhase = ''
+    runHook preCheck
+    python -m unittest discover -s tests -v
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "List connected displays — like lsusb/lspci but for screens";
+    homepage = "https://github.com/AGuyMarc/lsdisplay";
+    changelog = "https://github.com/AGuyMarc/lsdisplay/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "lsdisplay";
+    maintainers = with lib.maintainers; [ guy-marc-aprin ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/ls/lsgpus/package.nix
+++ b/pkgs/by-name/ls/lsgpus/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "lsgpus";
+  version = "0.2.6";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-8IRbkhu3CbbjONFOo2wLI0dubWBcKA8E1knUBmpZvgE=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  # Le module importe s'appelle "lsgpu" ; le binaire installe est "lsgpus"
+  # (le nom "lsgpu" est deja pris par /usr/bin/lsgpu d'igt-gpu-tools).
+  pythonImportsCheck = [ "lsgpu" ];
+
+  # Tests unittest embarques : ils s'auto-invoquent (--help/--version) et
+  # mockent le reste, donc ils tournent sans GPU ni nvidia-smi/rocm-smi.
+  checkPhase = ''
+    runHook preCheck
+    python -m unittest discover -s tests -v
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "List GPUs with details — like lscpu/lsusb but for graphics cards";
+    homepage = "https://github.com/AGuyMarc/lsgpu";
+    changelog = "https://github.com/AGuyMarc/lsgpu/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "lsgpus";
+    maintainers = with lib.maintainers; [ guy-marc-aprin ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds two small, self-contained CLI utilities by the same author (me, Guy-Marc Aprin, the maintainer):

- **lsdisplay** — lists connected displays (EDID make/model/serial, resolution,
  refresh rate, ASCII layout diagram). Works on X11 (`xrandr`) and Wayland
  (`kscreen-doctor`, `wlr-randr`), speaks `--json`. Like `lsusb`/`lspci`, but for
  screens.
- **lsgpus** — lists GPUs (vendor, model, driver, NVIDIA/AMD stats when available,
  monitor↔GPU mapping via EDID, a real-time `--watch` view). Like `lscpu`, but for
  graphics cards.

Both are single-file, pure-Python 3 programs with **no runtime dependencies** — they
only read external tools (`xrandr`, `nvidia-smi`, `rocm-smi`, sysfs…) when those are
present. They are already published on PyPI, Debian, Fedora (COPR), openSUSE (OBS) and
the AUR.

**Packaging notes**
- `buildPythonApplication` + `fetchPypi` (immutable sdists).
- For `lsgpus` the importable module is `lsgpu`, while the installed binary is `lsgpus`
  (the `lsgpu` name is already taken by `igt-gpu-tools`).
- The embedded `unittest` suite runs at build time; it is headless-safe (it self-invokes
  `--help`/`--version` and mocks the rest — no X server or GPU required).
- No man page: it is not shipped in the PyPI sdist. It can be added later via
  `fetchFromGitHub` if preferred.

> I don't currently have a Nix environment on my machine, so I could not run a local
> `nix-build` / `nixpkgs-review`. The derivations are trivial pure-Python apps; I'm
> relying on ofborg to evaluate and build, and I'll gladly iterate on any review feedback.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`?
- [ ] Tested, as applicable:
  - [ ] `nixpkgs-review` (no local Nix — see note above; relying on ofborg)
  - [x] Upstream test suite passes; packages already build on PyPI/Debian/Fedora/openSUSE/AUR
- [ ] Tested basic functionality of all binary files (in `./result/bin/`)
- [x] Added the packages under `pkgs/by-name/ls/` (auto-discovered)
- [x] Added myself to `maintainers/maintainer-list.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
