### PR TITLE
dopamine: 3.0.7 -> 3.0.9

### DIFF
--- a/pkgs/by-name/do/dopamine/package.nix
+++ b/pkgs/by-name/do/dopamine/package.nix
@@ -10,7 +10,7 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "dopamine";
-  version = "3.0.7";
+  version = "3.0.9";
 
   # needed to upgrade better-sqlite3 in npmConfigHook
   src = applyPatches {
@@ -18,7 +18,7 @@ buildNpmPackage (finalAttrs: {
       owner = "digimezzo";
       repo = "dopamine";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-zYuf5BIQaxTqHBXWX1PLghGR5WmwtnSxTYrNosVFebc=";
+      hash = "sha256-2I/xGuBFGtSCKWaM5J574tk1c1yxgCo1fnJr/uGPq2c=";
     };
     patches = [
       # register-scheme contains install scripts, but has no lockfile
@@ -32,7 +32,7 @@ buildNpmPackage (finalAttrs: {
     ];
   };
 
-  npmDepsHash = "sha256-m5y8TmOUAUf2IE87b73hFe2vj/uRAqFGgfuy3vkUX/s=";
+  npmDepsHash = "sha256-LaHqS36bMN/kkb6+3GpmTOTAEaEMH3yy04jM3OfR+1k=";
 
   nativeBuildInputs = [
     (python3.withPackages (ps: with ps; [ distutils ]))


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Manual update due to r-ryantm failing.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
