### PR TITLE
nixos/wireguard: assert peer names are valid systemd credential names under networkd

### DIFF
--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -227,6 +227,10 @@ in
             assertion = peer.dynamicEndpointRefreshRestartSeconds == null;
             message = "networking.wireguard.interfaces.${name}.peers[].dynamicEndpointRefreshRestartSeconds cannot be used with networkd.";
           }
+          {
+            assertion = builtins.match "[ -.0-9;-~]*" peer.name != null;
+            message = "networking.wireguard.interfaces.${name}.peers[].name value \"${peer.name}\" is not a valid systemd credential name when using networkd.";
+          }
         ])
       )
     );


### PR DESCRIPTION
`networking.wireguard.interfaces.<name>.peers[].name` is embedded into a systemd credential ID (`wireguard-<iface>-<name>-preshared-key`, passed via LoadCredential=) whenever the peer has a presharedKeyFile and `networking.wireguard.useNetworkd` is enabled.
This PR adds an assertion, alongside the existing networkd-only peer assertions in wireguard-networkd.nix, that fails evaluation with a clear message when a peer name contains a non-printable/non-ASCII character, /, or :. Otherwise, a peer name violating this currently breaks the generated credential silently instead of failing at eval time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
