### PR TITLE
keymapper: 5.3.1 -> 5.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1948,6 +1948,12 @@
     githubId = 51257127;
     name = "anntnzrb";
   };
+  anntoin = {
+    email = "anntoin@gmail.com";
+    github = "Anntoin";
+    githubId = 3289027;
+    name = "Anntóin Wilkinson";
+  };
   anoa = {
     matrix = "@andrewm:amorgan.xyz";
     email = "andrew@amorgan.xyz";

--- a/pkgs/by-name/ke/keymapper/package.nix
+++ b/pkgs/by-name/ke/keymapper/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "keymapper";
-  version = "5.3.1";
+  version = "5.7.0";
 
   src = fetchFromGitHub {
     owner = "houmain";
     repo = "keymapper";
     tag = finalAttrs.version;
-    hash = "sha256-YKfKgsrjDrskLEoYCSRMYco7+7E/sgXFAMEwwm7rs7w=";
+    hash = "sha256-w6QZlpONbJRY0PxbL1FyDMqG/y5DA7SzDbwobvpGB7o=";
   };
 
   # all the following must be in nativeBuildInputs
@@ -47,8 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/houmain/keymapper";
     license = lib.licenses.gpl3Only;
     mainProgram = "keymapper";
-    maintainers = [
-    ];
+    maintainers = with lib.maintainers; [ anntoin ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
## Description

Update keymapper from 5.3.1 to 5.7.0. Add anntoin as maintainer.

> **Note:** PR #542364 (5.3.1 → 5.6.0) was merged but hasn't propagated to `master` yet. This PR supersedes it and goes straight to 5.7.0, which includes the IPC socket fd leak fix (#388). The maintainer entry is included in case it hasn't landed yet — if it has, it's a no-op.

Changelog: https://github.com/houmain/keymapper/blob/5.7.0/CHANGELOG.md

Notable changes across 5.3.2 → 5.7.0:
- **5.7.0**: IPC socket fd leak fix (`FD_CLOEXEC` via `set_close_on_exec`) preventing "Binding control port failed" errors after restart ([#388](https://github.com/houmain/keymapper/pull/388)); Karabiner-Elements coexistence ([#376](https://github.com/houmain/keymapper/issues/376)); timeout after key release in input expressions
- **5.6.0**: Timeouts in input expressions with `?` prefix ([#372](https://github.com/houmain/keymapper/issues/372)); tray menu sync fix on Linux ([#370](https://github.com/houmain/keymapper/issues/370))
- **5.5.1**: xwayland detection robustness, tray icon fixes, keymapperd reconnection fix
- **5.5.0**: Mouse support on macOS ([#228](https://github.com/houmain/keymapper/issues/228)); `keymapperctl --type-stdin` ([#356](https://github.com/houmain/keymapper/issues/356)); action limit raised to 1024
- **5.4.2**: `keymapperctl --wait` timeout fix ([#355](https://github.com/houmain/keymapper/issues/355))
- **5.4.1**: `Any` expression fix, empty string comparison fixes
- **5.4.0**: (see changelog)
- **5.3.2**: Concurrent output fix, empty strings in context filters

## Checklist

- [x] Tested using sandboxing
- [x] Built on platform(s): x86_64-linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Tested compilation of all pkgs that depend on this change using `nixpkgs-review`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Meets Nixpkgs contribution standards

## nixpkgs-review

```
1 package built:
keymapper
```

No broken dependents (keymapper is a leaf package).

## Additional notes

- `nix-build -A keymapper` succeeds
- All three binaries (`keymapper`, `keymapperctl`, `keymapperd`) execute correctly
- `nix fmt` passes clean
- No existing NixOS tests for this package