### PR TITLE
bisq2: 2.1.11 -> 2.1.12

### DIFF
--- a/pkgs/by-name/bi/bisq2/package.nix
+++ b/pkgs/by-name/bi/bisq2/package.nix
@@ -26,7 +26,7 @@
 }:
 
 let
-  version = "2.1.11";
+  version = "2.1.12";
 
   jdk = zulu25.override { enableJavaFX = true; };
 
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   # nixpkgs-update: no auto update
   src = fetchurl {
     url = "https://github.com/bisq-network/bisq2/releases/download/v${version}/Bisq-${version}.deb";
-    hash = "sha256-Ts0u1Rapgfz/z17U3VSN17/rdACr/KOGmiZjWnGJmcw=";
+    hash = "sha256-oLNvCc52lkp/efh7ehnV/0JjkY5+oKv0A2Dj0xtBK7Y=";
 
     # Verify the upstream Debian package prior to extraction.
     # See https://bisq.wiki/Bisq_2#Installation
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   signature = fetchurl {
     url = "https://github.com/bisq-network/bisq2/releases/download/v${version}/Bisq-${version}.deb.asc";
-    hash = "sha256-/+HDj28uOFQwkrrzKfcQW0T5/qTIeB30Zd10EjeGhlU=";
+    hash = "sha256-dydNfzk8EMUPGP9W6GI5H0iZA+SCP9PHw+RbWCmMlTM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates `bisq2` to v2.1.12, an important security release from upstream fixing vulnerabilities identified during Bisq's recent security audit: reputation privacy/integrity, bonded-role validation, and Bisq 1 bridge reliability.

Changelog: https://github.com/bisq-network/bisq2/releases/tag/v2.1.12

No packaging-level breaking changes; only the `version` and the `.deb`/`.deb.asc` hashes changed. The GPG signature on the new `.deb` was manually verified against Bisq's known signing keys (good signature from Alejandro García) before updating the hashes.

> **Disclosure:** This PR's code changes and description were produced with assistance from Claude Code (Anthropic, model `claude-sonnet-5`), reviewed, built, and tested by the submitter before opening this PR, per the [automation/AI policy].

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
