### PR TITLE
dotmatch: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7401,6 +7401,11 @@
     githubId = 699961;
     name = "Dmytro Kyrychuk";
   };
+  dnncha = {
+    github = "dnncha";
+    githubId = 5190258;
+    name = "Donncha O'Toole";
+  };
   dnr = {
     email = "dnr@dnr.im";
     github = "dnr";

--- a/pkgs/by-name/do/dotmatch/package.nix
+++ b/pkgs/by-name/do/dotmatch/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+  zlib,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "dotmatch";
+  version = "0.2.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-xEGqr7aynbUVYNP8aMUqitAe0PCBWKiVRMHZNm8S/Og=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [ python3Packages.tomli ];
+
+  buildInputs = [ zlib ];
+
+  pythonImportsCheck = [
+    "assaycode"
+    "dotmatch"
+    "quickdna"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  postInstallCheck = ''
+    test "$($out/bin/dotmatch dist ACGT AGGT)" = 1
+  '';
+
+  meta = {
+    description = "Known-target short-DNA assignment from FASTQ";
+    homepage = "https://github.com/dnncha/dotmatch";
+    license = lib.licenses.asl20;
+    mainProgram = "dotmatch";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ dnncha ];
+  };
+})


### PR DESCRIPTION
## Summary

- Add DotMatch 0.2.2 as a Python application for deterministic known-target short-DNA assignment.
- Build from the published PyPI source distribution with a pinned hash.
- Include the native C library/CLI build and the Python entry points (`dotmatch`, `assaycode`, and `quickdna`).
- Restrict the package to Linux and Darwin, matching upstream support.

## Validation

- Published PyPI sdist SHA256 verified against the release metadata.
- DotMatch 0.2.2 clean sdist installation and CLI smoke tests pass outside Nix.
- `pythonImportsCheck` and an install-check phase exercise the packaged Python modules and `dotmatch dist ACGT AGGT`.
- I could not run `nix-build` locally because this host does not have Nix installed; ofborg/Hydra should be treated as the authoritative Nix build validation.

This is a new package, not a claim of Nixpkgs adoption or user count.
