### PR TITLE
protobuf_36: init at 36.0

### DIFF
--- a/pkgs/development/libraries/protobuf/36.nix
+++ b/pkgs/development/libraries/protobuf/36.nix
@@ -1,0 +1,9 @@
+{ callPackage, ... }@args:
+
+callPackage ./generic.nix (
+  {
+    version = "36.0";
+    hash = "sha256-VGXFfqLm7IEJ9MQpMYhdVW5qPZbrYZ6q+0Y1TqQkjks=";
+  }
+  // args
+)

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -79,13 +79,14 @@ stdenv.mkDerivation (finalAttrs: {
       # https://github.com/protocolbuffers/protobuf/pull/25683
       ./fix-upb-packed-enum-be.patch
     ]
-    ++ lib.optionals (lib.versionAtLeast version "34") [
+    ++ lib.optionals ((lib.versionAtLeast version "34") && (lib.versionOlder version "36")) [
       # upb linker-array fix for newer toolchains (notably GCC 15):
       # `UPB_linkarr_internal_empty_upb_AllExts` can conflict with extension
       # entries in `linkarr_upb_AllExts` during test builds.
       # Context: https://github.com/protocolbuffers/protobuf/issues/21021
       ./fix-upb-linkarr-sentinel-init.patch
-
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "34") [
       # Fix BoolKeys test on big-endian
       # https://github.com/protocolbuffers/protobuf/pull/25862
       ./fix-BoolKeys-test-on-be.patch
@@ -106,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     # Keep the sentinel macro non-retained for GCC 15+ to match generated
     # extension objects in linker arrays and avoid section type conflicts.
-    + lib.optionalString (lib.versionAtLeast version "34") ''
+    + lib.optionalString ((lib.versionAtLeast version "34") && (lib.versionOlder version "36")) ''
       substituteInPlace upb/port/def.inc \
         --replace-fail \
           '#define UPB_LINKARR_SENTINEL UPB_RETAIN __attribute__((weak, used))' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6430,6 +6430,7 @@ with pkgs;
 
   inherit
     ({
+      protobuf_36 = callPackage ../development/libraries/protobuf/36.nix { };
       protobuf_35 = callPackage ../development/libraries/protobuf/35.nix { };
       protobuf_34 = callPackage ../development/libraries/protobuf/34.nix { };
       protobuf_33 = callPackage ../development/libraries/protobuf/33.nix { };
@@ -6449,6 +6450,7 @@ with pkgs;
         abseil-cpp = abseil-cpp_202103;
       };
     })
+    protobuf_36
     protobuf_35
     protobuf_34
     protobuf_33


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Changelog: https://github.com/protocolbuffers/protobuf/releases/tag/v36.0
Diff: https://github.com/protocolbuffers/protobuf/compare/v35.1...v36.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
