### PR TITLE
nautilus-admin-gtk4: init at 1.2.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27917,6 +27917,12 @@
     githubId = 245573;
     name = "Dmitry Kalinkin";
   };
+  verantor = {
+    email = "verantor@protonmail.com";
+    github = "Verantor";
+    githubId = 56546640;
+    name = "Verantor";
+  };
   versality = {
     email = "artyom@pertsovsky.com";
     github = "versality";

--- a/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
+++ b/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gettext,
+  glib,
+  nautilus,
+  nautilus-python,
+  python3,
+  gedit,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nautilus-admin";
+  version = "1.2.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MacTavishAO";
+    repo = "nautilus-admin-gtk4";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-UJe9gbMm2Dt4JVJ7GI7DX4+3W5W4WZP4JcJ5iN3e3G4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    nautilus
+    nautilus-python
+    python3
+    gedit
+  ];
+
+  postPatch = ''
+    sed -i 's/cmake_minimum_required(VERSION [0-9.]*)/cmake_minimum_required(VERSION 3.5)/' CMakeLists.txt
+
+    substituteInPlace CMakeLists.txt \
+      --replace "DESTINATION /usr/share" "DESTINATION share"
+  '';
+
+  cmakeFlags = [
+    "-DNAUTILUS_PATH=${nautilus}/bin/nautilus"
+    "-DGEDIT_PATH=${gedit}/bin/gedit"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
+  meta = with lib; {
+    description = "Extension for Nautilus to do administrative operations";
+    homepage = "https://github.com/MacTavishAO/nautilus-admin-gtk4";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ verantor ];
+  };
+})


### PR DESCRIPTION
added nautilus-admin-gtk4 to nixpkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
