### PR TITLE
libcap_ng: 0.9.3 -> 0.9.5

### DIFF
--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcap-ng";
-  version = "0.9.3";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "stevegrubb";
     repo = "libcap-ng";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-anuPOBWp4Hlpo+m6kYlSd2v7H3P7LQ9brZdq1lo7Po4=";
+    hash = "sha256-HYVbPoFSlkmNuL5EsEQVAekE4fwidgL+biTBBS1BdPM=";
   };
 
   # NEWS needs to exist or else the build fails

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -58,6 +58,20 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [
+    # cap_audit is deliberately not enabled here.
+    # First, it'd create a cyclic dependency on audit, which we want to avoid.
+    # Second, it requires a vmlinux.h for utils/cap-audit/cap_audit.bpf.c
+    # The vmlinux.h header can either be generated from the running kernel of the build system
+    # (which does not work on cross with a non-linux build machine, and is never reproducible),
+    # or it can be supplied to configure by path (necessitating a dependency on a specific linux kernel).
+    # A compromise could be introducing a cap_audit package as part of linuxPackages set,
+    # but the cost on CI would not be insignificant due to that being built once per kernel.
+    # All current options are bad in their own way, so this stays disabled until we have a proper
+    # solution for vmlinux.h to not rebuild the world, or provably a user requiring this.
+    # "--enable-cap-audit"
+    # "--with-vmlinux-h=provided"
+    # "--with-vmlinux-h-path="
+
     (lib.withFeature withPython "python")
     "--with-capability_header='${linuxHeaders}/include/linux/capability.h'" # required to link bindings
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
