### PR TITLE
nixos/vellum: fix missing attribute on empty settings

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10764,6 +10764,12 @@
     githubId = 7385287;
     name = "Lana Black";
   };
+  greyxp1 = {
+    email = "greyxp2@proton.me";
+    github = "greyxp1";
+    githubId = 120752906;
+    name = "Grey";
+  };
   grgi = {
     name = "Gregor Giesen";
     email = "gregor@giesen.net";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -94,7 +94,7 @@
 
 - [Krill](https://nlnetlabs.nl/projects/krill/about), RPKI CA and Publication Server written in Rust. Available as [services.krill](#opt-services.krill.enable).
 
-- [vellum](https://github.com/greyxp1/vellum) is a live screen annotation overlay for Wayland. Available as [programs.vellum](#opt-programs.vellum.enable).
+- [vellum](https://github.com/greyxp1/vellum) is a live screen annotation overlay for Wayland. Available as [services.vellum](#opt-services.vellum.enable).
 
 - [stash-clipboard](https://github.com/NotAShelf/stash), a Wayland clipboard "manager" with fast persistent history and multi-media support. Available as [services.stash-clipboard](#opt-services.stash-clipboard.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -353,7 +353,6 @@
   ./programs/udevil.nix
   ./programs/upki.nix
   ./programs/usbtop.nix
-  ./programs/vellum.nix
   ./programs/vim.nix
   ./programs/virt-manager.nix
   ./programs/vivid.nix
@@ -1658,6 +1657,7 @@
   ./services/video/wivrn.nix
   ./services/wayland/cage.nix
   ./services/wayland/hypridle.nix
+  ./services/wayland/vellum.nix
   ./services/web-apps/actual.nix
   ./services/web-apps/agorakit.nix
   ./services/web-apps/akkoma.nix

--- a/nixos/modules/programs/vellum.nix
+++ b/nixos/modules/programs/vellum.nix
@@ -67,7 +67,7 @@ in
       after = [ "graphical-session.target" ];
       partOf = [ "graphical-session.target" ];
       wantedBy = [ "graphical-session.target" ];
-      restartTriggers = [ config.environment.etc."xdg/vellum/config.toml".source ];
+      restartTriggers = [ "/etc/xdg/vellum/config.toml" ];
       serviceConfig = {
         ExecStart = "${getExe cfg.package} ${cfg.extraOptions}";
         Restart = "on-failure";

--- a/nixos/modules/services/wayland/vellum.nix
+++ b/nixos/modules/services/wayland/vellum.nix
@@ -6,22 +6,20 @@
 }:
 
 let
-  cfg = config.programs.vellum;
+  cfg = config.services.vellum;
 
   inherit (lib)
     getExe
-    literalExpression
     mkEnableOption
     mkIf
     mkOption
     mkPackageOption
     ;
-  inherit (lib.types) separatedString;
 
   toml = pkgs.formats.toml { };
 in
 {
-  options.programs.vellum = {
+  options.services.vellum = {
     enable = mkEnableOption "vellum, a live screen annotation overlay for Wayland";
 
     package = mkPackageOption pkgs "vellum" { };
@@ -33,23 +31,20 @@ in
         Configuration options for vellum.
         See available options at <https://github.com/greyxp1/vellum/blob/master/docs/configuration.md>.
       '';
-      example = literalExpression ''
-        {
-          default_tool = "arrow";
-          remember_last_tool = false;
-          feedback_duration_ms = 250;
-        }
-      '';
-    };
-
-    extraOptions = mkOption {
-      type = separatedString " ";
-      default = "";
-      description = ''
-        Extra command-line options to pass to
-        the {command}`vellum` daemon.
-      '';
-      example = "--force-backend vulkan";
+      example = {
+        default_tool = "arrow";
+        remember_last_tool = false;
+        default_fill_shapes = true;
+        feedback_duration_ms = 250;
+        tools.pen.opacity = 0.75;
+        palette = [
+          "#FF6B6B"
+          "#FFD93D"
+          "#6BCB77"
+          "#4D96FF"
+          "#845EC2"
+        ];
+      };
     };
   };
 
@@ -69,7 +64,7 @@ in
       wantedBy = [ "graphical-session.target" ];
       restartTriggers = [ "/etc/xdg/vellum/config.toml" ];
       serviceConfig = {
-        ExecStart = "${getExe cfg.package} ${cfg.extraOptions}";
+        ExecStart = getExe cfg.package;
         Restart = "on-failure";
       };
     };

--- a/nixos/modules/services/wayland/vellum.nix
+++ b/nixos/modules/services/wayland/vellum.nix
@@ -71,6 +71,9 @@ in
   };
 
   meta = {
-    maintainers = with lib.maintainers; [ poz ];
+    maintainers = with lib.maintainers; [
+      greyxp1
+      poz
+    ];
   };
 }

--- a/pkgs/by-name/ve/vellum/package.nix
+++ b/pkgs/by-name/ve/vellum/package.nix
@@ -2,7 +2,6 @@
   fetchFromGitHub,
   installShellFiles,
   lib,
-  libGL,
   libxkbcommon,
   makeBinaryWrapper,
   pkg-config,
@@ -14,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "vellum";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "greyxp1";
     repo = "vellum";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uWGaCeENwaqg2+wbtfgpDAjxIsJbgUcMnvSPauwjcBI=";
+    hash = "sha256-tIPQ0uFnklgb39i0bS0Rz1jXJlVF6dz5jxMMxSyH+aA=";
   };
 
-  cargoHash = "sha256-quZW6jkGzvRHNgkJQS4entJyXeYftBOV89hKaFfQCDw=";
+  cargoHash = "sha256-uycCEO07mrucAxbgsePcUjy0qyRSDJQqGftHZ6ujWMg=";
 
   __structuredAttrs = true;
 
@@ -45,7 +44,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapProgram $out/bin/vellum \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
-          libGL
           vulkan-loader
           wayland
         ]

--- a/pkgs/by-name/ve/vellum/package.nix
+++ b/pkgs/by-name/ve/vellum/package.nix
@@ -64,7 +64,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
         isc
         mit
       ];
-    maintainers = with lib.maintainers; [ poz ];
+    maintainers = with lib.maintainers; [
+      greyxp1
+      poz
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "vellum";
   };


### PR DESCRIPTION
genuinely how did I miss this

```
       error: attribute '"xdg/vellum/config.toml"' missing
       at /nix/store/6z7xnswwnq9dw8vvi7gb9cj3szdgasf6-source/nixos/modules/programs/vellum.nix:70:50:
           69|       wantedBy = [ "graphical-session.target" ];
           70|       restartTriggers = [ config.environment.etc."xdg/vellum/config.toml".source ];
             |                                                  ^
           71|       serviceConfig = {
```

until this gets merged use the following if you wanna use this module with an empty config:

```nix
inputs.nixpkgs-vellum-module-fix.url = "github:imnotpoz/nixpkgs/vellum-module-fix";
```

```nix
{
  disabledModules = [ "programs/vellum.nix" ];

  imports = [ "${inputs.nixpkgs-vellum-module-fix}/nixos/modules/programs/vellum.nix" ];

  programs.vellum.enable = true;
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
