### PR TITLE
Frigate/multiprocessing socket fix

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -802,5 +802,10 @@ in
         ProtectProc = "invisible";
       };
     };
+
+    systemd.tmpfiles.settings."frigate" = {
+      # prevent gc of multiprocessing forkserver socket due to default systemd tmpfiles rules
+      "/tmp/systemd-private-%b-${config.systemd.services.frigate.name}-*/tmp/pymp-*".x = { };
+    };
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
tldr: systemd-tempfiles deletes python multiprocessing sockets

```
Jul 03 10:09:08 smart-home frigate[1474]: Exception in thread frigate_watchdog:
Jul 03 10:09:08 smart-home frigate[1474]: Traceback (most recent call last):
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     self.run()
Jul 03 10:09:08 smart-home frigate[1474]:     ~~~~~~~~^^
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/kf8098dcmhr5g4fiwn7xj486i6zksllz-frigate>
Jul 03 10:09:08 smart-home frigate[1474]:     detector.start_or_restart()
Jul 03 10:09:08 smart-home frigate[1474]:     ~~~~~~~~~~~~~~~~~~~~~~~~~^^
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/kf8098dcmhr5g4fiwn7xj486i6zksllz-frigate>
Jul 03 10:09:08 smart-home frigate[1474]:     self.detect_process.start()
Jul 03 10:09:08 smart-home frigate[1474]:     ~~~~~~~~~~~~~~~~~~~~~~~~~^^
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/kf8098dcmhr5g4fiwn7xj486i6zksllz-frigate>
Jul 03 10:09:08 smart-home frigate[1474]:     super().start(*args, **kwargs)
Jul 03 10:09:08 smart-home frigate[1474]:     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     self._popen = self._Popen(self)
Jul 03 10:09:08 smart-home frigate[1474]:                   ~~~~~~~~~~~^^^^^^
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     return _default_context.get_context().Process._Popen(pr>
Jul 03 10:09:08 smart-home frigate[1474]:            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^>
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     return Popen(process_obj)
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     super().__init__(process_obj)
Jul 03 10:09:08 smart-home frigate[1474]:     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     self._launch(process_obj)
Jul 03 10:09:08 smart-home frigate[1474]:     ~~~~~~~~~~~~^^^^^^^^^^^^^
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     self.sentinel, w = forkserver.connect_to_new_process(se>
Jul 03 10:09:08 smart-home frigate[1474]:                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^>
Jul 03 10:09:08 smart-home frigate[1474]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3>
Jul 03 10:09:08 smart-home frigate[1474]:     client.connect(self._forkserver_address)
Jul 03 10:09:08 smart-home frigate[1474]:     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 03 10:09:08 smart-home frigate[1474]: FileNotFoundError: [Errno 2] No such file or directory
```

Frigate uses pythons multiprocessing module to manage its detector subprocesses [(multiprocessing.py).](https://github.com/blakeblackshear/frigate/blob/master/frigate/service_manager/multiprocessing.py#L45) . These are created in the PrivateTmp [(frigate.nix)](https://github.com/NixOS/nixpkgs/blob/e346eca2be4bd6d2953c7ced3d72bbf377296988/nixos/modules/services/video/frigate.nix#L789) [(util.py)](https://github.com/python/cpython/blob/f74cdf80a120649e4c353430da8cbd1305c00993/Lib/multiprocessing/util.py#L215-L228). 

systemd tempfile rules:
```
[b@smart-home:~]$ systemd-tmpfiles --cat-config
...
# /etc/tmpfiles.d/systemd-tmp.conf
x /tmp/systemd-private-%b-*
X /tmp/systemd-private-%b-*/tmp
...
# /etc/tmpfiles.d/tmp.conf
q /tmp 1777 root root 10d
...
```

Every ten days the sockets under /tmp/systemd-private-%b-*/tmp get deleted.
The fix is to add a more specific rule to prevent it.

With the fix:
```
[b@smart-home:~]$ sudo SYSTEMD_LOG_LEVEL=debug systemd-tmpfiles --clean --dry-run 2>&1 | grep /tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate
[sudo] password for b:
Running clean action for entry x /tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate.service-*/tmp/pymp-*
Cleanup threshold for directory "/tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate.service-qkT19m/tmp" is Wed 2026-08-12 17:29:08.694361 CEST; age-by: abcmABM
Ignoring "/tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate.service-qkT19m/tmp/pymp-dnedcdnc": a separate glob exists.
Ignoring "/tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate.service-qkT19m/tmp/pymp-fd2ojjyt": a separate glob exists.
Ignoring "/tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate.service-qkT19m": a separate glob exists.
Cleanup threshold for directory "/var/tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate.service-cIS9z9/tmp" is Thu 2026-07-23 17:29:08.694938 CEST; age-by: abcmABM
Ignoring "/var/tmp/systemd-private-e6dd7f6b4d334262a5036ecc2a5cc16a-frigate.service-cIS9z9": a separate glob exists.
```

Regression was introduced in https://github.com/blakeblackshear/frigate/pull/18682, which was merged into frigate 0.17.0. It was introduced into nixpkgs in https://github.com/NixOS/nixpkgs/commit/816af80754cc55981ba6b6a1c154026f870b48fb

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
