### PR TITLE
python3Packages.nltk: 3.10.0 -> 3.10.3

### DIFF
--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -24,22 +24,26 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "nltk";
-  version = "3.10.0";
+  version = "3.10.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nltk";
     repo = "nltk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1iflqb3cOyaviW3IostFCuJtZ9KBZI0n9dfKfqqbcO0=";
+    hash = "sha256-PaMW9QNV+++Gz+OoG7m2VFn6L3vkG/Mg9ZLx9KlN19U=";
   };
 
   postPatch = ''
-    # In the nix store we trust
+    # NLTK's immutable-root model does not include the Nix store. Trust it for
+    # data roots and read-only symlinks produced by nltk-data-dir.
     substituteInPlace nltk/pathsec.py \
       --replace-fail 'if not (target == scoped_root or target.is_relative_to(scoped_root)):' \
                      'if not (target == scoped_root or target.is_relative_to(scoped_root) or target.is_relative_to("/nix/store")):' \
-      --replace-fail ' "/usr/share/nltk_data", ' ' "/usr/share/nltk_data", "/nix/store", '
+      --replace-fail 'candidate_locs = ["~/nltk_data", "/usr/share/nltk_data"]' \
+                     'candidate_locs = ["~/nltk_data", "/usr/share/nltk_data", "/nix/store"]' \
+      --replace-fail 'if ENFORCE and os.name == "posix":' \
+                     'if ENFORCE and os.name == "posix" and not (_is_readonly_mode(mode) and Path(os.path.abspath(raw_path)).is_relative_to("/nix/store")):'
   '';
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Updates NLTK to 3.10.3, fixing [CVE-2026-72818](https://www.cve.org/CVERecord?id=CVE-2026-72818) as tracked in [security suggestion #28202](https://tracker.security.nixos.org/suggestions/by-id/28202/).

[Upstream changes](https://redirect.github.com/nltk/nltk/compare/v3.10.0...v3.10.3)

Stable backport: `release-26.05` still has NLTK 3.9.4, so this change requires a separate manual backport including the preceding 3.10.0 update.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
