### PR TITLE
breaktimer: bump electron to v42

### DIFF
--- a/pkgs/by-name/br/breaktimer/package.nix
+++ b/pkgs/by-name/br/breaktimer/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildNpmPackage,
   copyDesktopItems,
-  electron_41,
+  electron_42,
   fetchFromGitHub,
   jq,
   makeDesktopItem,
@@ -13,18 +13,18 @@
 }:
 
 let
-  electron = electron_41;
+  electron = electron_42;
   nodejs = nodejs_24;
   description = "Cross-platform desktop app for managing periodic breaks";
 in
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "breaktimer";
   version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "tom-james-watson";
     repo = "breaktimer-app";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-STDb6+brlVk/ZPUbw3cQOpe2r03WlFKEBgVLqJrsrHI=";
   };
 
@@ -124,10 +124,10 @@ buildNpmPackage rec {
   meta = {
     inherit description;
     homepage = "https://github.com/tom-james-watson/breaktimer-app";
-    changelog = "https://github.com/tom-james-watson/breaktimer-app/releases/tag/v${version}";
+    changelog = "https://github.com/tom-james-watson/breaktimer-app/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ proitheus ];
     mainProgram = "breaktimer";
     platforms = electron.meta.platforms;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Work towards #555100 
- rewrite with `finalAttrs`
- update electron to v42
- Tested basic functionality

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
