### PR TITLE
kdePackages.kio-snapshot: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11708,6 +11708,12 @@
     github = "I-Al-Istannen";
     githubId = 20284688;
   };
+  i-love-lean = {
+    name = "i-love-lean";
+    github = "i-love-lean";
+    githubId = 170473930;
+    email = "nixpkgs@unnamed.website";
+  };
   i01011001 = {
     email = "yugen.m7@gmail.com";
     github = "i01011001";

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -78,6 +78,7 @@ let
         kio-extras-kf5 = self.callPackage ./misc/kio-extras-kf5 { };
         kio-fuse = self.callPackage ./misc/kio-fuse { };
         kio-s3 = self.callPackage ./misc/kio-s3 { };
+        kio-snapshot = self.callPackage ./misc/kio-snapshot { };
         klevernotes = self.callPackage ./misc/klevernotes { };
         ktextaddons = self.callPackage ./misc/ktextaddons { };
         kup = self.callPackage ./misc/kup { };

--- a/pkgs/kde/misc/kio-snapshot/default.nix
+++ b/pkgs/kde/misc/kio-snapshot/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  mkKdeDerivation,
+  fetchurl,
+  pkg-config,
+  btrfs-progs,
+}:
+mkKdeDerivation rec {
+  pname = "kio-snapshot";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/kio-snapshot/kio-snapshot-${version}.tar.xz";
+    hash = "sha256-RxPQxgsYa+8LwPmSCTyLriRz03gIro1zF5qyVxzop9I=";
+  };
+
+  extraNativeBuildInputs = [ pkg-config ];
+
+  extraBuildInputs = [ btrfs-progs ];
+
+  meta = {
+    license = lib.licenses.lgpl2Plus;
+    maintainers = [ lib.maintainers.i-love-lean ];
+  };
+}


### PR DESCRIPTION
kio-snapshot is a [new KDE package that provides Btrfs snapshot integration](https://bharadwajraju.com/posts/btrfs-snapshots-in-kde/).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
