### PR TITLE
python3Packages.firecrawl-py: 2.8.0 -> 4.38.0

### DIFF
--- a/pkgs/development/python-modules/firecrawl-py/default.nix
+++ b/pkgs/development/python-modules/firecrawl-py/default.nix
@@ -14,14 +14,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "firecrawl-py";
-  version = "2.8.0";
+  version = "4.38.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mendableai";
     repo = "firecrawl";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-7dB3jdp5jkRiNx63C5sjs3t85fuz5vzurfvYY5jWQyU=";
+    # The Python SDK version is decoupled from the firecrawl monorepo tags.
+    tag = "v2.11.226";
+    hash = "sha256-htBM3ywHDMSnJhtbPyQOWLkUtSGSWMIPHpNQ7PNA3Bo=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/apps/python-sdk";


### PR DESCRIPTION
Update to the latest version so it can be used as dependency for https://github.com/numtide/llm-agents.nix

Note that there was a change in versioning. The package version changed to 4 to match the mono repo, while the SDK version was only lifted to 2.11. See comment in code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
