### PR TITLE
nixos/widevine-cdm: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -376,6 +376,7 @@
   ./programs/wayland/wayvnc.nix
   ./programs/weylus.nix
   ./programs/whois.nix
+  ./programs/widevine-cdm.nix
   ./programs/winbox.nix
   ./programs/wireshark.nix
   ./programs/wshowkeys.nix

--- a/nixos/modules/programs/widevine-cdm.nix
+++ b/nixos/modules/programs/widevine-cdm.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.widevine-cdm;
+
+  # `chromium` and `ungoogled-chromium` are patched via their native
+  # `enableWideVine` flag. Every other fork is patched by copying the CDM next
+  # to its real executable
+  wrapBrowser =
+    browser:
+    let
+      pname = lib.getName browser;
+      binaryName = browser.meta.mainProgram or pname;
+    in
+    if pname == "chromium" || pname == "ungoogled-chromium" then
+      browser.override { enableWideVine = true; }
+    else
+      browser.overrideAttrs (old: {
+        postInstall = (old.postInstall or "") + ''
+          exe=$(find "$out" -type f -name '${lib.escapeShellArg binaryName}' -executable -not -path '*/bin/*' | head -n1)
+          if [ -n "$exe" ]; then
+            dir=$(dirname "$exe")
+          else
+            dir="$out"
+          fi
+          mkdir -p "$dir"
+          cp -a "${pkgs.widevine-cdm}/share/google/chrome/WidevineCdm" "$dir/WidevineCdm"
+        '';
+      });
+in
+{
+  options.programs.widevine-cdm = {
+    enable = lib.mkEnableOption "Widevine CDM support in Chromium-family browsers";
+
+    browsers = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          pkgs.chromium
+          pkgs.ungoogled-chromium
+        ]
+      '';
+      description = ''
+        Chromium-family browsers to patch with the Widevine CDM.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = map wrapBrowser cfg.browsers;
+  };
+}


### PR DESCRIPTION
Add a module that patches Chromium-family browsers with the Widevine CDM. This allows users to easily access Widevine on packages without `enableWideVine` (such as the various unofficial Helium packages)

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
