### PR TITLE
[Backport release-26.05] udp514-journal: new package and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -759,6 +759,7 @@
   ./services/logging/syslog-ng.nix
   ./services/logging/syslogd.nix
   ./services/logging/SystemdJournal2Gelf.nix
+  ./services/logging/udp514-journal.nix
   ./services/logging/ulogd.nix
   ./services/logging/vector.nix
   ./services/mail/automx2.nix

--- a/nixos/modules/services/logging/udp514-journal.nix
+++ b/nixos/modules/services/logging/udp514-journal.nix
@@ -1,0 +1,95 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.udp514-journal;
+  description = "Forward syslog from network (udp/514) to journal";
+in
+{
+  options = {
+    services.udp514-journal = {
+      enable = lib.mkEnableOption "the udp514-journal systemd socket/service";
+
+      openFirewall = lib.mkEnableOption "" // {
+        description = "Whether to open the port in the firewall.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 514;
+        description = "Port to listen on";
+      };
+
+      package = lib.mkPackageOption pkgs "udp514-journal" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.sockets.udp514-journal = {
+      enable = true;
+      name = "udp514-journal.socket";
+      inherit description;
+      listenDatagrams = [ (builtins.toString cfg.port) ];
+      wantedBy = [ "sockets.target" ];
+    };
+
+    systemd.services.udp514-journal = {
+      enable = true;
+      name = "udp514-journal.service";
+      inherit description;
+      requires = [
+        "systemd-journald.socket"
+        "udp514-journal.socket"
+      ];
+      serviceConfig = {
+        Type = "notify";
+        Restart = "always";
+        ExecStart = "${cfg.package}/bin/udp514-journal";
+        DynamicUser = "on";
+        CapabilityBoundingSet = "";
+        AmbientCapabilities = "";
+        ProtectSystem = "strict";
+        ProtectHome = "on";
+        PrivateDevices = "on";
+        PrivateTmp = true;
+        PrivateUsers = "self";
+        PrivateNetwork = "on";
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = "on";
+        ProtectControlGroups = "strict";
+        ProtectProc = "noaccess";
+        ProcSubset = "pid";
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        MemoryMax = "5M";
+        UMask = "0077";
+      };
+      confinement = {
+        enable = true;
+        binSh = null;
+      };
+    };
+
+    networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ usovalx ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1756,6 +1756,7 @@ in
   ucarp = runTest ./ucarp.nix;
   udisks2 = runTest ./udisks2.nix;
   udp-over-tcp = runTest ./udp-over-tcp.nix;
+  udp514-journal = runTest ./udp514-journal.nix;
   ulogd = runTest ./ulogd/ulogd.nix;
   umami = runTest ./web-apps/umami.nix;
   umurmur = runTest ./umurmur.nix;

--- a/nixos/tests/udp514-journal.nix
+++ b/nixos/tests/udp514-journal.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  name = "udp514-journal";
+  meta.maintainers = with lib.maintainers; [ usovalx ];
+
+  containers.machine = {
+    services.udp514-journal.enable = true;
+    environment.systemPackages = [ pkgs.netcat ];
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("udp514-journal.socket");
+
+    # send a test log entry via UDP, RFC 5424 format
+    machine.execute('echo "<34>1 2026-08-01T00:24:15.123+01:00 router01 - testing" | nc -w1 -u localhost 514')
+
+    machine.wait_until_succeeds('journalctl -u udp514-journal --grep "router01 - testing"', timeout = 60)
+  '';
+}

--- a/pkgs/by-name/ud/udp514-journal/package.nix
+++ b/pkgs/by-name/ud/udp514-journal/package.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  systemdLibs,
+  pkg-config,
+  discount
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "udp514-journal";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "eworm-de";
+    repo = "udp514-journal";
+    tag = finalAttrs.version;
+    hash = "sha256-ufxxeW2G6C/DEzVgVVrQjUsI4tDvaqi5VrXZIr2Eh7Y=";
+  };
+
+  buildInputs = [
+    systemdLibs
+  ];
+  nativeBuildInputs = [
+    pkg-config
+    discount
+  ];
+
+  # brute-force patching - remove /usr/ from install paths
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "$(DESTDIR)/usr/" "$(DESTDIR)/"
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+  installTargets = [
+    "install-bin"
+    "install-doc"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = with lib; {
+    description = "Forward syslog from network (udp/514) to journal";
+    homepage = "https://github.com/eworm-de/udp514-journal";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ usovalx ];
+  };
+})

--- a/pkgs/by-name/ud/udp514-journal/package.nix
+++ b/pkgs/by-name/ud/udp514-journal/package.nix
@@ -4,7 +4,8 @@
   fetchFromGitHub,
   systemdLibs,
   pkg-config,
-  discount
+  discount,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
   __structuredAttrs = true;
+
+  passthru.tests.nixos = nixosTests.udp514-journal;
 
   meta = with lib; {
     description = "Forward syslog from network (udp/514) to journal";


### PR DESCRIPTION
Add new package and corresponding NixOS module.
Simple daemon for writing remote syslog-style logs (e.g. from the router) to journal.

Creating backport PR by hand due conflict (in the release notes)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
