### PR TITLE
testers.*PkgConfig*: make output a bash comment

### DIFF
--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -56,7 +56,7 @@ runCommand testName
           } pkg-config module $moduleName exists at version $moduleVersion != $version (drv version)"
           ((versionMismatch+=1))
         fi
-        printf '%s\t%s\n' "$moduleName" "$version" >> "$out"
+        printf '# %s\t%s\n' "$moduleName" "$version" >> "$out"
       else
         echo "❌ pkg-config module $moduleName was not found"
         ((notFound+=1))

--- a/pkgs/build-support/testers/testMetaPkgConfig/tester.nix
+++ b/pkgs/build-support/testers/testMetaPkgConfig/tester.nix
@@ -14,5 +14,5 @@ runCommand "check-meta-pkg-config-modules-for-${package.name}"
     dependsOn = testers.hasPkgConfigModules { inherit package; };
   }
   ''
-    echo "found all of ${toString package.meta.pkgConfigModules}" > "$out"
+    echo "# found all of ${toString package.meta.pkgConfigModules}" > "$out"
   ''


### PR DESCRIPTION
This package's output is a single file and is treated as a setup hook in activatePackage in stdenv, which means it's [sourced as a bash file](https://github.com/NixOS/nixpkgs/commit/b23dbb1a5dffbfa3abb47fcd0f1579ac2e6f29fc) as a convenience when you try to build something like

```
pkgs.mkShell { packages = [ pkgs.ncurses pkgs.ncurses.tests.pkg-config ]; }
```

This will throw an error on

```
/nix/store/...-check-meta-pkg-config-modules-for-ncurses-6.6: line 1: found: command not found
```

Loading a tester derivation in a mkShell maybe doesn't make much sense, but it's what happens under the hood when I tried to run `nixpkgs-review --package ncurses --package ncurses.tests.pkg-config`, which I think is a legitimate command / use case. This blocks getting into the review shell and posting a result to GitHub.

Slightly tweaking the output of the tester so that it is "valid bash code" can fix this use case.

Edit/addition: `testers.hasPkgConfigModules` has the same problem and possible solution, which I've added here. `nix-build -A tests.testers.hasPkgConfigModules` builds.

Alternatively, we could think about a more general solution? `tests.fetchurl` have similar problems, but there the offending file that is sourced is a binary file so we can't comment out the contents.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
