### PR TITLE
python3Packages.holoviews: 1.22.1 -> 1.23.1

### DIFF
--- a/pkgs/development/python-modules/holoviews/default.nix
+++ b/pkgs/development/python-modules/holoviews/default.nix
@@ -17,21 +17,22 @@
   pyviz-comms,
 
   # tests
-  pytestCheckHook,
-  pytest-asyncio,
   flaky,
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "holoviews";
-  version = "1.22.1";
+  version = "1.23.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "holoviz";
     repo = "holoviews";
-    tag = "v${version}";
-    hash = "sha256-rZZQgM8gchWTsgA47BVWblzWiWMuHK2vAZD/1Z8BHAk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+s7AzER7ipiqjiZL9vmno16MmhSK8Sz9LYLQ2cxNM6Y=";
   };
 
   postPatch = ''
@@ -54,13 +55,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    pytest-asyncio
     flaky
-  ];
-
-  pytestFlags = [
-    "-Wignore::FutureWarning"
+    pytest-asyncio
+    pytestCheckHook
   ];
 
   disabledTests = [
@@ -87,10 +84,10 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python data analysis and visualization seamless and simple";
-    changelog = "https://github.com/holoviz/holoviews/releases/tag/${src.tag}";
+    changelog = "https://github.com/holoviz/holoviews/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "holoviews";
     homepage = "https://www.holoviews.org/";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/hvplot/default.nix
+++ b/pkgs/development/python-modules/hvplot/default.nix
@@ -25,15 +25,16 @@
   plotly,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hvplot";
   version = "0.12.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "holoviz";
     repo = "hvplot";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hJ9lgpM3AVyDeFxobUKDNYO39NKEejSDywOgnHPEm2c=";
   };
 
@@ -94,8 +95,8 @@ buildPythonPackage rec {
   meta = {
     description = "High-level plotting API for the PyData ecosystem built on HoloViews";
     homepage = "https://hvplot.pyviz.org";
-    changelog = "https://github.com/holoviz/hvplot/releases/tag/${src.tag}";
+    changelog = "https://github.com/holoviz/hvplot/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ locnide ];
   };
-}
+})

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -1,66 +1,74 @@
 {
   lib,
-  stdenv,
-  platformdirs,
-  bokeh,
   buildPythonPackage,
-  dask,
-  entrypoints,
   fetchFromGitHub,
-  fsspec,
-  hvplot,
-  intake-parquet,
-  jinja2,
-  msgpack,
-  msgpack-numpy,
-  pandas,
-  panel,
-  pyarrow,
-  pytestCheckHook,
-  python-snappy,
-  pythonAtLeast,
-  pyyaml,
-  networkx,
-  requests,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  dask,
+  entrypoints,
+  fsspec,
+  jinja2,
+  msgpack,
+  networkx,
+  pandas,
+  platformdirs,
+  pyyaml,
+
+  # optional-dependencies
+  # server:
+  msgpack-numpy,
+  python-snappy,
   tornado,
+  # dataframe:
+  pyarrow,
+  # plot
+  hvplot,
+  bokeh,
+  panel,
+  # remote:
+  requests,
+
+  # tests
+  addBinToPathHook,
+  intake-parquet,
+  pytestCheckHook,
+  pythonAtLeast,
+  writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "intake";
   version = "2.0.9";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "intake";
     repo = "intake";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-DiALGrJP4vLWygzZprjYCFM+TYtMS7NVM3+MTyjzcs0=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
-    platformdirs
+  dependencies = [
     dask
     entrypoints
     fsspec
-    msgpack
     jinja2
-    pandas
-    pyyaml
+    msgpack
     networkx
+    pandas
+    platformdirs
+    pyyaml
   ];
-
-  nativeCheckInputs = [
-    intake-parquet
-    pytestCheckHook
-  ]
-  ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     server = [
@@ -80,12 +88,13 @@ buildPythonPackage rec {
     remote = [ requests ];
   };
 
-  __darwinAllowLocalNetworking = true;
-
-  preCheck = ''
-    export HOME=$(mktemp -d);
-    export PATH="$PATH:$out/bin";
-  '';
+  nativeCheckInputs = [
+    addBinToPathHook
+    intake-parquet
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   disabledTestPaths = [
     # Missing plusins
@@ -132,11 +141,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "intake" ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "Data load and catalog system";
     homepage = "https://github.com/ContinuumIO/intake";
-    changelog = "https://github.com/intake/intake/blob/${version}/docs/source/changelog.rst";
+    changelog = "https://github.com/intake/intake/blob/${finalAttrs.src.rev}/docs/source/changelog.rst";
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.holoviews: 1.22.1 -> 1.23.1** ([Diff](https://github.com/holoviz/holoviews/compare/v1.22.1...v1.23.1), [Changelog](https://github.com/holoviz/holoviews/releases/tag/v1.23.1))
- **python3Packages.hvplot: cleanup**
- **python3Packages.intake: cleanup**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
