### PR TITLE
cpak: init at 2.12.7

### DIFF
--- a/pkgs/by-name/cp/cpak/package.nix
+++ b/pkgs/by-name/cp/cpak/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "cpak";
+  version = "2.12.7";
+
+  src = fetchFromGitHub {
+    owner = "Containerpak";
+    repo = "cpak";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bISKyH1+Yr1EBzZYIK0xpe0jmBiWtCnByz4Ng01QJCI=";
+  };
+
+  vendorHash = "sha256-cgqb2AY06Ru+JJIK7vyaLSPyjJqiLvNytvSQCgDOASc=";
+
+  subPackages = [
+    "."
+    "cmd/cpak-storaged"
+    "cmd/cpak-sign"
+  ];
+
+  tags = [ "cpak_ui_builtin" ];
+
+  __structuredAttrs = true;
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.selfUpdateMode=disabled"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Decentralized, portable, low-overhead containerized application format for Linux";
+    homepage = "https://cpak.it";
+    changelog = "https://github.com/Containerpak/cpak/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "cpak";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[Cpak](https://cpak.it)

A fast, decentralized, portable, powerful and low-memory footprint package format for Linux.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
