### PR TITLE
python3Packages.skia-pathops: cleanup

### DIFF
--- a/pkgs/development/python-modules/skia-pathops/default.nix
+++ b/pkgs/development/python-modules/skia-pathops/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     hash = "sha256-S22EWfb0ppKCyyb8oMK7CzIcxYqb+cxleaUqOR7cAxk=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isLoongArch64 [
+  patches = [
     (fetchpatch2 {
       url = "https://salsa.debian.org/fonts-team/libskia/-/raw/6574ca599eab076a9cd5b8667f81aef0f67b3eeb/debian/patches/loong-build";
       stripLen = 1;

--- a/pkgs/development/python-modules/skia-pathops/default.nix
+++ b/pkgs/development/python-modules/skia-pathops/default.nix
@@ -37,16 +37,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "build_cmd = [sys.executable, build_skia_py, build_dir]" \
+      --replace-fail "build_cmd = [sys.executable, build_skia_py, build_dir]" \
         'build_cmd = [sys.executable, build_skia_py, "--no-fetch-gn", "--no-virtualenv", "--gn-path", "${gn}/bin/gn", build_dir]'
-  ''
-  + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
-    substituteInPlace src/cpp/skia-builder/skia/gn/skia/BUILD.gn \
-      --replace "-march=armv7-a" "-march=armv8-a" \
-      --replace "-mfpu=neon" "" \
-      --replace "-mthumb" ""
-    substituteInPlace src/cpp/skia-builder/skia/src/core/SkOpts.cpp \
-      --replace "defined(SK_CPU_ARM64)" "0"
   '';
 
   build-system = [


### PR DESCRIPTION
This PR makes patches unconditional and cleans up postPatch. I've tested on master, but the commits need to go to staging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
