### PR TITLE
fastmcp-remote: init at 3.4.7

### DIFF
--- a/pkgs/by-name/fa/fastmcp-remote/package.nix
+++ b/pkgs/by-name/fa/fastmcp-remote/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  python3Packages,
+  writableTmpDirAsHomeHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "fastmcp-remote";
+  inherit (python3Packages.fastmcp) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/fastmcp_remote";
+  pyproject = true;
+
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
+  build-system = with python3Packages; [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = lib.flatten (
+    with python3Packages;
+    [
+      fastmcp-slim
+      fastmcp-slim.optional-dependencies.client
+      fastmcp-slim.optional-dependencies.server
+    ]
+  );
+
+  nativeCheckInputs = with python3Packages; [
+    inline-snapshot
+    opentelemetry-sdk
+    pytest-asyncio
+    pytest-env
+    pytestCheckHook
+    pytest-timeout
+    writableTmpDirAsHomeHook
+  ];
+
+  pytestFlags = [
+    "-pno:cacheprovider"
+    "../tests/cli/test_fastmcp_remote.py"
+  ];
+
+  preCheck = ''
+    export FASTMCP_REMOTE_CONFIG_DIR="$TMPDIR/fastmcp-remote-config"
+    mkdir -p "$FASTMCP_REMOTE_CONFIG_DIR"
+  '';
+
+  pythonImportsCheck = [ "fastmcp_remote" ];
+
+  postInstallCheck = ''
+    $out/bin/fastmcp-remote --help >/dev/null
+  '';
+
+  meta = {
+    description = "Python stdio bridge for remote MCP servers, powered by FastMCP";
+    homepage = "https://gofastmcp.com";
+    changelog = "https://github.com/PrefectHQ/fastmcp/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.tyceherrman ];
+    mainProgram = "fastmcp-remote";
+  };
+})


### PR DESCRIPTION
Adds [`fastmcp-remote`](https://github.com/PrefectHQ/fastmcp/blob/v3.4.7/docs/clients/fastmcp-remote.mdx) 3.4.7 as a top-level application. It bridges a remote HTTP or SSE MCP server to a local stdio MCP process.

The package follows the existing `python3Packages.fastmcp` version and source, builds the `fastmcp_remote` subproject, and includes the `fastmcp-slim` client and server optional dependency closures required by upstream.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

This pull request description was drafted with OpenAI Codex (GPT-5). I reviewed and edited as needed.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
