### PR TITLE
pkgs.formats: fix importing toPretty from lib.generators

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -24,7 +24,6 @@ let
     singleton
     strings
     toJSON
-    toPretty
     types
     versionAtLeast
     warn
@@ -39,6 +38,7 @@ let
     toLua
     mkLuaInline
     toPlist
+    toPretty
     ;
 
   inherit (lib.types)


### PR DESCRIPTION
Under a given edge case, the code in nixConf of formats.nix will fail incorrectly while rendering a pretty abort msg because lib.toPretty does not exist. This fixes this, inheriting toPretty from lib.generators. Then under the given edge case, nixConf fails correctly with a pretty abort msg.

The edge case is playing with in nixos/modules/config/nix.nix with the type of nix.settings s.t. a value not supported by nixConf gets accepted as a value inside `nix.settings`.

A quick way to reproduce this edge case is by appending to the option declaration of `nix.settings.substituters`

```nix
apply = v: { };
```

then evaluting any nixos config, e.g.:
```sh
nix build .#nixosTests.systemd-journal-upload
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
