### PR TITLE
gogcli: 0.36.0 -> 0.37.0

### DIFF
--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -1,19 +1,19 @@
 {
   lib,
-  buildGoModule,
+  buildGo127Module,
   fetchFromGitHub,
   testers,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "gogcli";
-  version = "0.36.0";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
     owner = "openclaw";
     repo = "gogcli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7XfjpAzUHH1VUJzgllKa/4GvQZhTCX8TePTXRB+oJRE=";
+    hash = "sha256-UQa9Z7zv2IuH7GL1udNee2F+uB2BAZA5a0/2XtFcBWg=";
   };
 
   vendorHash = "sha256-+Nbuwok3dY/82gUDKeGgrC0F1ZqXSW8IpV6Q1yzIPvo=";


### PR DESCRIPTION
Updates gogcli from 0.36.0 to 0.37.0.

- Diff: https://github.com/openclaw/gogcli/compare/v0.36.0...v0.37.0
- Changelog: https://github.com/openclaw/gogcli/blob/v0.37.0/CHANGELOG.md#v0370---2026-08-14

This release fixes duplicate sanitized Gmail output and adds read-only Connected
Sheets discovery and bounded data-source-table reads. Upstream now requires Go
>= 1.26.6, so the package switches to `buildGo127Module`.

cc @macalinao @kirillrdy

Verified on `x86_64-linux` using Go 1.27.0 from current `master`:

- `nix build --no-link --print-out-paths .#gogcli`;
- `nix build --no-link --print-out-paths .#gogcli.tests.version`;
- executed the binary and confirmed its version, tag, and build-date metadata.

Verified on `aarch64-linux` under binfmt emulation using the same toolchain:

- `nix build --no-link --print-out-paths .#legacyPackages.aarch64-linux.gogcli`;
- `nix build --no-link --print-out-paths .#legacyPackages.aarch64-linux.gogcli.tests.version`;
- confirmed the resulting binary is an ARM aarch64 ELF executable;
- executed the binary and confirmed its version, tag, and build-date metadata.

Installed-system testing passed with the final package built by Go 1.27.0 for
both configured underwrap-backed accounts:

- confirmed the active system closure contains the expected package and Go
  compiler version;
- confirmed wrapper version, tag, and build-date metadata;
- validated stored authentication;
- ran bounded, read-only Gmail, Calendar, and Drive smoke tests;
- verified the v0.37.0 sanitized Gmail JSON regression: the default form emitted
  one `message` envelope and `--results-only` emitted the direct sanitized
  message, without raw payload or unsubscribe fields;
- ran bounded Connected Sheets data-source and table discovery against one
  spreadsheet per account.

`nixpkgs-review rev HEAD -b master -p gogcli --no-shell --print-result`
passed at commit `c4b2e8b5c4abd35ffa26607f4763fdaef5e166f1`; one package
(`gogcli`) was rebuilt successfully against freshly fetched `master`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (under binfmt emulation)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation/AI disclosure

The routine version and hash update was produced with `nix-update`. The upstream
change review, toolchain compatibility diagnosis, validation plan, and this pull
request summary were prepared with assistance from pi
(`openai-codex/gpt-5.6-sol`). I reviewed the changes and test results.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
