### PR TITLE
pipe-viewer: move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/pi/pipe-viewer/package.nix
+++ b/pkgs/by-name/pi/pipe-viewer/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   perl,
-  buildPerlModule,
   makeWrapper,
   wrapGAppsHook3,
   withGtk3 ? false,
@@ -11,8 +10,7 @@
   wget,
   xdg-utils,
   yt-dlp,
-  TestPod,
-  Gtk3,
+  perlPackages,
 }:
 let
   perlEnv = perl.withPackages (
@@ -43,7 +41,7 @@ let
     ]
   );
 in
-buildPerlModule rec {
+perlPackages.buildPerlModule rec {
   pname = "pipe-viewer";
   version = "0.5.8";
 
@@ -60,7 +58,7 @@ buildPerlModule rec {
     perlEnv
   ]
   # Can't be in perlEnv for wrapGAppsHook3 to work correctly
-  ++ lib.optional withGtk3 Gtk3;
+  ++ lib.optional withGtk3 perlPackages.Gtk3;
 
   # Not supported by buildPerlModule
   # and the Perl code fails anyway
@@ -72,7 +70,7 @@ buildPerlModule rec {
   '';
 
   nativeCheckInputs = [
-    TestPod
+    perlPackages.TestPod
   ];
 
   dontWrapGApps = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8669,7 +8669,7 @@ with pkgs;
 
   gimpPlugins = recurseIntoAttrs (callPackage ../applications/graphics/gimp/plugins { });
 
-  gtk-pipe-viewer = perlPackages.callPackage ../applications/video/pipe-viewer { withGtk3 = true; };
+  gtk-pipe-viewer = pipe-viewer.override { withGtk3 = true; };
 
   jetbrains = (
     recurseIntoAttrs (
@@ -8980,8 +8980,6 @@ with pkgs;
   pijuice = with python3Packages; toPythonApplication pijuice;
 
   pinegrow6 = pinegrow.override { pinegrowVersion = "6"; };
-
-  pipe-viewer = perlPackages.callPackage ../applications/video/pipe-viewer { };
 
   pleroma-bot = python3Packages.callPackage ../development/python-modules/pleroma-bot { };
 


### PR DESCRIPTION
Partially supersedes #543552, while leaving the controversial part of migrating gtk-pipe-viewer there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
