### PR TITLE
libosinfo, osinfo-db: Replace pagure links with upstream

### DIFF
--- a/pkgs/by-name/li/libosinfo/package.nix
+++ b/pkgs/by-name/li/libosinfo/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.12.0";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/libosinfo/libosinfo-${finalAttrs.version}.tar.xz";
+    url = "https://gitlab.com/api/v4/projects/libosinfo%2Flibosinfo/packages/generic/release-assets/v${finalAttrs.version}/libosinfo-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-rYVX7OJnk9pD0m3lZePWjOLua/uNARO3zH3+B/a/xrY=";
   };
 

--- a/pkgs/by-name/os/osinfo-db-tools/package.nix
+++ b/pkgs/by-name/os/osinfo-db-tools/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.12.0";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/libosinfo/osinfo-db-tools-${finalAttrs.version}.tar.xz";
+    url = "https://gitlab.com/api/v4/projects/libosinfo%2Fosinfo-db-tools/packages/generic/release-assets/v${finalAttrs.version}/osinfo-db-tools-${finalAttrs.version}.tar.xz";
     hash = "sha256-8zFfZ10Ydw8l3qjtBLILj8gO+wD2DDfuXoFfnDd25/M=";
   };
 


### PR DESCRIPTION
Release tarballs on `releases.pagure.org` were 404ing, the Pagure Project has been sunset, so replace the URLs with releases by the libosinfo project.

I have checked that the new URLs produce tarballs with the same hash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].