### PR TITLE
gnuradioPackages.fosphor: fix version, modernize

### DIFF
--- a/pkgs/development/gnuradio-modules/fosphor/default.nix
+++ b/pkgs/development/gnuradio-modules/fosphor/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   mkDerivation,
-  fetchgit,
+  fetchFromGitea,
   gnuradio,
   cmake,
   pkg-config,
@@ -26,13 +26,17 @@
 
 mkDerivation {
   pname = "gr-fosphor";
-  version = "unstable-2024-03-23";
+  version = "0-unstable-2024-03-23";
 
-  # It is a gitea instance, but its archive service doesn't work very well so
-  # we can't use it.
-  src = fetchgit {
-    url = "https://gitea.osmocom.org/sdr/gr-fosphor.git";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "gitea.osmocom.org";
+    owner = "sdr";
+    repo = "gr-fosphor";
     rev = "74d54fc0b3ec9aeb7033686526c5e766f36eaf24";
+    forceFetchGit = true;
     hash = "sha256-FBmH4DmKATl0FPFU7T30OrYYmxlSTTLm1SZpt0o1qkw=";
   };
   disabled = gnuradioOlder "3.9" || gnuradioAtLeast "3.11";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- #541820
  - [pinned commit](https://gitea.osmocom.org/sdr/gr-fosphor/commit/74d54fc0b3ec9aeb7033686526c5e766f36eaf24)
  - [tags](https://gitea.osmocom.org/sdr/gr-fosphor/tags)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
