### PR TITLE
formats.nixConf: clarify & refactor list support

### DIFF
--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -60,36 +60,17 @@ let
     systemFeatures = "system-features";
   };
 
-  semanticConfType =
-    with types;
-    let
-      confAtom =
-        nullOr (oneOf [
-          bool
-          int
-          float
-          str
-          path
-          package
-        ])
-        // {
-          description = "Nix config atom (null, bool, int, float, str, path or package)";
-        };
-    in
-    attrsOf (either confAtom (listOf confAtom));
+  nixConfFormat = pkgs.formats.nixConf {
+    inherit (cfg)
+      package
+      checkAllErrors
+      checkConfig
+      extraOptions
+      ;
+    inherit (nixPackage) version;
+  };
 
-  nixConf =
-    (pkgs.formats.nixConf {
-      inherit (cfg)
-        package
-        checkAllErrors
-        checkConfig
-        extraOptions
-        ;
-      inherit (nixPackage) version;
-    }).generate
-      "nix.conf"
-      cfg.settings;
+  nixConf = nixConfFormat.generate "nix.conf" cfg.settings;
 
   makeNixBuildUser = nr: {
     name = "nixbld${toString nr}";
@@ -210,7 +191,7 @@ in
 
       settings = mkOption {
         type = types.submodule {
-          freeformType = semanticConfType;
+          freeformType = nixConfFormat.type;
 
           options = {
             max-jobs = mkOption {

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -843,6 +843,8 @@ optionalAttrs allowAliases aliases
       lib.mkRaw = mkLuaInline;
     };
 
+  # cannot handle list values not using "space" as a separator
+  # those should be handled in the declarations of nix.settings.*
   nixConf =
     {
       package,
@@ -865,12 +867,13 @@ optionalAttrs allowAliases aliases
             str
             path
             types.package
-          ]);
+          ]) // {
+            description = "Nix config atom (null, bool, int, float, string, path or package)";
+          };
         in
-        attrsOf atomType;
+        attrsOf (either atomType (listOf atomType));
       generate =
         let
-          # note that list type has been omitted here as the separator varies, see `nix.settings.*`
           mkValueString =
             v:
             if v == null then
@@ -888,7 +891,7 @@ optionalAttrs allowAliases aliases
             else if isString v then
               v
             else if strings.isConvertibleWithToString v then
-              toString v
+              toString v # also handles list values, concats with space
             else
               abort "The nix conf value: ${toPretty { } v} can not be encoded";
 

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -1090,6 +1090,10 @@ runBuildTests {
       auto-optimise-store = true;
       cores = 0;
       store = "auto";
+      substituters = [
+        "https://alpha.example"
+        "https://beta.example"
+      ];
     };
     # note that null type is hard to test here,
     # as it involves a trailing space our formatter will remove here
@@ -1100,6 +1104,7 @@ runBuildTests {
       auto-optimise-store = true
       cores = 0
       store = auto
+      substituters = https://alpha.example https://beta.example
 
       ignore-try = false
     '';


### PR DESCRIPTION
I started working on this PR after reading this comment from the original PR #440438 which states that:

https://github.com/NixOS/nixpkgs/blob/6a67cb2c6aae565f5fc9b5a43f6d0802a1260e7f/pkgs/pkgs-lib/formats.nix#L873

While not being completely wrong (see e.g. [`builders`](https://nix.dev/manual/nix/2.33/command-ref/conf-file.html#conf-builders)), the comment is not correct in terms of the implementation of nixConf. The comment suggests looking into the `nix.settings.*` options, but in the whole `nixos/modules/config/nix.nix` file there is no indication of a special handling for list values. Instead, list values are currently "silently" handled by `isConvertibleWithToString` & `toString`.

This commit makes this silent behavior more explicit by updating the comments on nixConf & extending its type to allow lists as well.

And as then the type from nixConf now looked similar to the semanticConfType of the nix module, I removed semanticConfType in favor of nixConf.type, moving the human-friendly type description to nixConf to reduce further code duplication.

I decided for making the list support of nixConf explicit because:
- removing the list support would require more changes in the current implementation, therefore might be backwards-incompatible
- most Nix options with list type support space as separator, so this is a sane fallback
- special behavior for certain options can still be implemented in the module system of `nix.settings` if required (or replaced by an alternative like `nix.buildMachines`)

@KiaraGrouwstra in case I missed something interpreting your comment in your PR, feel free to comment

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
