### PR TITLE
go-check: fix version, use structuredAttrs

### DIFF
--- a/pkgs/by-name/go/go-check/package.nix
+++ b/pkgs/by-name/go/go-check/package.nix
@@ -4,19 +4,20 @@
   fetchFromGitLab,
 }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "check";
-  version = "unstable-2018-12-24";
-  rev = "ccaba434e62accd51209476ad093810bd27ec150";
+  version = "0-unstable-2018-12-24";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitLab {
     owner = "opennota";
     repo = "check";
-    inherit rev;
+    rev = "ccaba434e62accd51209476ad093810bd27ec150";
     hash = "sha256-u8U/62LZEn1ffwdGsUCGam4HAk7b2LetomCLZzHuuas=";
   };
 
-  vendorHash = "sha256-DyysiVYFpncmyCzlHIOEtWlCMpm90AC3gdItI9WinSo=";
+  vendorHash = "sha256-XgYRw077ry+ZJSuelXH2imYjfTxW+i7nVZ3DurL5UPU=";
 
   meta = {
     description = "Set of utilities for checking Go sources";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- #541820
  - [pinned commit](https://gitlab.com/opennota/check/-/commit/ccaba434e62accd51209476ad093810bd27ec150)
  - [tags](https://gitlab.com/opennota/check/-/tags)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
