### PR TITLE
gsmlib: fix version, license; modernize

### DIFF
--- a/pkgs/by-name/gs/gsmlib/package.nix
+++ b/pkgs/by-name/gs/gsmlib/package.nix
@@ -6,13 +6,16 @@
 }:
 stdenv.mkDerivation {
   pname = "gsmlib";
-  version = "unstable-2017-10-06";
+  version = "0-unstable-2017-10-06";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "x-logLT";
     repo = "gsmlib";
     rev = "4f794b14450132f81673f7d3570c5a859aecf7ae";
-    sha256 = "16v8aj914ac1ipf14a867ljib3gy7fhzd9ypxnsg9l0zi8mm3ml5";
+    hash = "sha256-hdZRK4of0PS07den9qE7/o0VJT0GKRLcjYEpEpJUaJs=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -25,7 +28,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Library to access GSM mobile phones through GSM modems";
     homepage = "https://github.com/x-logLT/gsmlib";
-    license = lib.licenses.lgpl2;
+    license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.misuzu ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- #541820
  - [pinned commit](https://github.com/x-logLT/gsmlib/commit/4f794b14450132f81673f7d3570c5a859aecf7ae)
  - [tags](https://github.com/x-logLT/gsmlib/tags)
- The license change was based on most of the files having [headers like this](https://github.com/x-logLT/gsmlib/blob/4f794b14450132f81673f7d3570c5a859aecf7ae/intl/intl-exports.c#L5-L8)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
