### PR TITLE
aioquic: fix build in Darwin sandbox

### DIFF
--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -6,8 +6,8 @@
   versionCheckHook,
 }:
 let
-  version = "1.1.13";
-  buildId = "6068529322131456";
+  version = "1.1.19";
+  buildId = "4894004681244672";
   wholeVersion = "${version}-${buildId}";
 
   throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
@@ -15,15 +15,15 @@ let
   sourceData = {
     x86_64-linux = fetchurl {
       url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/linux-x64/cli_linux_x64.tar.gz";
-      hash = "sha256-6X92AldCzlcWQ4ON2t2jEFNsqwIX4YAbpUh6cRz8/uY=";
+      hash = "sha256-oCEyp8bGR+8K1IPsvnZ2Ga32tmClWJy6XJN7DIOQm5c=";
     };
     aarch64-linux = fetchurl {
       url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/linux-arm/cli_linux_arm64.tar.gz";
-      hash = "sha256-CcNHggD96vwkVl8s09HPlMIv3ayzWVEFK1YwVv7EFR4=";
+      hash = "sha256-Fb2ZWewMCLy/7pSzdvAr2LVS3PF6U5vNIQpEP7gkQ8s=";
     };
     aarch64-darwin = fetchurl {
       url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/darwin-arm/cli_mac_arm64.tar.gz";
-      hash = "sha256-ZkgCqzy6zU1XaxDJvdYPEs6JKDBeNFFHw22Rhbugkps=";
+      hash = "sha256-rXLa9rJV2W5IZP5r0vP6QHD7TFVIRc6vHWOZ2PEJLkU=";
     };
   };
 in

--- a/pkgs/by-name/ba/basalt/package.nix
+++ b/pkgs/by-name/ba/basalt/package.nix
@@ -9,6 +9,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "basalt";
   version = "0.12.7";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "erikjuhani";
     repo = "basalt";

--- a/pkgs/by-name/bu/bulk_extractor/package.nix
+++ b/pkgs/by-name/bu/bulk_extractor/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bulk_extractor";
-  version = "2.1.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "simsong";
     repo = "bulk_extractor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Jj/amXESFBu/ZaiIRlDKmtWTBVQ2TEvOM2jBYP3y1L8=";
+    hash = "sha256-Ed+KUImSMVVZEKLKl90YkGruwD8xtevgyozCj44bHic=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/ca/cargo-binstall/package.nix
+++ b/pkgs/by-name/ca/cargo-binstall/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-binstall";
-  version = "1.21.1";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "cargo-bins";
     repo = "cargo-binstall";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7YXdKK6P6LSf/DGDL6jroR3VVqAD4uGUOGJS/dZbcvw=";
+    hash = "sha256-9MxfariJbdol0nPB2fdWpDDrRL6LrBX994FFiKiD45E=";
   };
 
-  cargoHash = "sha256-iUYTFtx0KBi4qgJNyuIAGcTCbS4KMyBbTIgR3nDiNAI=";
+  cargoHash = "sha256-42m6TkdsyZm5i/ME8wneJYWmbWICX/Is/S/lqSkx5nw=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ch/chsrc/package.nix
+++ b/pkgs/by-name/ch/chsrc/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "chsrc";
-  version = "0.2.6";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "RubyMetric";
     repo = "chsrc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7vG/E1AtT/SqYI5VvE4bO3KWB867z5BHpo3vCL1M4jI=";
+    hash = "sha256-8GSsxFrZSQkJvJVsBTlCQFY5a2tG92CZVCWameRBEVY=";
   };
 
   nativeBuildInputs = [ texinfo ];

--- a/pkgs/by-name/cl/cliamp/package.nix
+++ b/pkgs/by-name/cl/cliamp/package.nix
@@ -12,6 +12,7 @@
   ffmpeg,
   flac,
   yt-dlp,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -26,6 +27,13 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = "sha256-WYyv0w5KFA15axb+NA9tClfc1H4Znj8kI2boR8XziXg=";
+
+  ldflags = [
+    "-s"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/co/commons-logging/package.nix
+++ b/pkgs/by-name/co/commons-logging/package.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "commons-logging";
-  version = "1.3.6";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "mirror://apache/commons/logging/binaries/commons-logging-${finalAttrs.version}-bin.tar.gz";
-    sha256 = "sha256-7+wHpv5x63E2u4KEStKz17DIOfqokYzwp/Q1/tBOBxE=";
+    sha256 = "sha256-CEOFR0SEtbEULR0RWVc7dC6FUOZ/eTForuo5tabGn20=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/co/container2wasm/package.nix
+++ b/pkgs/by-name/co/container2wasm/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "container2wasm";
-  version = "0.8.3";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "container2wasm";
     repo = "container2wasm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cE/cKMMslu4GGVV3aRcdsu7cTdsVABZLs8GX6ihgW38=";
+    hash = "sha256-vmEof0mcvBau/eYtUj5DzzZm5QgkM3G6TsG8doLju78=";
   };
 
-  vendorHash = "sha256-vKvQyrdmtPAjcaXU374eYPll5+Samo+zbaiMjOtGp7I=";
+  vendorHash = "sha256-Lg8gvbnyEcrwDGPiHrB7NR4waB2/yqyQbZsp/pQK0jc=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ed/editres/package.nix
+++ b/pkgs/by-name/ed/editres/package.nix
@@ -17,7 +17,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "editres";
-  version = "1.0.9";
+  version = "1.1.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "app";
     repo = "editres";
     tag = "editres-${finalAttrs.version}";
-    hash = "sha256-fdp6j8zS8mtzHpG9js9c8iIt1vsKsqGG9MdkpLh8UB0=";
+    hash = "sha256-JDRa3IVHw44SQ+eYICoTlhVY0+9q+Bul8zQ/zTU9QiY=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/fu/fuse-emulator/package.nix
+++ b/pkgs/by-name/fu/fuse-emulator/package.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fuse-emulator";
-  version = "1.9.0";
+  version = "1.9.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/fuse-emulator/fuse-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-NGGMQZ4hXhauRYTyJ+iZ5OVb4d25D7AzgMkQrBbKs4o=";
+    hash = "sha256-WBW0IlbU3ShYHVnzzuwz/Nc2t6aK/gMrHmW6cU+1VkI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gl/gl3w/package.nix
+++ b/pkgs/by-name/gl/gl3w/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation {
   pname = "gl3w";
-  version = "0-unstable-2025-11-07";
+  version = "0-unstable-2026-08-17";
 
   src = fetchFromGitHub {
     owner = "skaslev";
     repo = "gl3w";
-    rev = "d5ba9340cdeb9154323817f5c87e5a5c377fdef7";
-    hash = "sha256-IAI0Ep2s79UT2d8davHnUp65SvE5mubwqVg6ym1Agw4=";
+    rev = "372e391702acac616e0fd32e3eaccf19d58b9626";
+    hash = "sha256-CQZ12557ruFkuoKFyaFja6rEgzqRtbVAupHYfM2J4XQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/go/go-sct/package.nix
+++ b/pkgs/by-name/go/go-sct/package.nix
@@ -9,7 +9,9 @@
 
 buildGoModule {
   pname = "go-sct";
-  version = "unstable-2022-01-32";
+  version = "1.0-unstable-2022-01-31";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "d4l3k";

--- a/pkgs/by-name/ja/jacoco/package.nix
+++ b/pkgs/by-name/ja/jacoco/package.nix
@@ -8,12 +8,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jacoco";
-  version = "0.8.14";
+  version = "0.8.15";
 
   src = fetchzip {
     url = "https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/${finalAttrs.version}/jacoco-${finalAttrs.version}.zip";
     stripRoot = false;
-    sha256 = "sha256-ysqPAxZK/mcnGiqqqTzfCOCyAcvMMvymFrSme6rFCJE=";
+    hash = "sha256-9B+IkVEWs1hfcI6CSfTIm1EvsuRKiXpHjQfAPGkkqxE=";
   };
 
   outputs = [

--- a/pkgs/by-name/ki/kitex/package.nix
+++ b/pkgs/by-name/ki/kitex/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "kitex";
-  version = "0.16.2";
+  version = "0.16.3";
 
   src = fetchFromGitHub {
     owner = "cloudwego";
     repo = "kitex";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RlKdOpe1VhSLPBghBDcC+pi4sodwrNg4vNMGe9A9uYM=";
+    hash = "sha256-zikltrh2H1EzzZWIELleyOz7A1twvNECSJUlSGZWQMU=";
   };
 
   vendorHash = "sha256-aKZvMS6dm8EqZgelZ4eCgM7dAob99rEJSURX/Lz2UyU=";

--- a/pkgs/by-name/la/labwc/package.nix
+++ b/pkgs/by-name/la/labwc/package.nix
@@ -31,13 +31,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "labwc";
-  version = "0.20.1";
+  version = "0.20.2";
 
   src = fetchFromGitHub {
     owner = "labwc";
     repo = "labwc";
     tag = finalAttrs.version;
-    hash = "sha256-1LINOZsdN5btT0VQvUwYXbSjuKdQdbkaI062OYAJSiE=";
+    hash = "sha256-gKix9UW4np6fMoMZgHN9G4opwbPkT6ax5G5ZWQCzYio=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/lp/lprobe/package.nix
+++ b/pkgs/by-name/lp/lprobe/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "lprobe";
-  version = "0.1.9";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "fivexl";
     repo = "lprobe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eR4WJD0Wa1+erwrmZBfH3wD1iSjH9s33nxaO+6bwMGE=";
+    hash = "sha256-JDZgjtXfWte4+rTNv4o7pKc4SnqLZkmh3NvEd5X4yGM=";
   };
 
-  vendorHash = "sha256-kA4vXOOaQicjaoQeQest1NPAXXK4hmMXz2uFo4QGWO8=";
+  vendorHash = "sha256-r5qKJ3Pd99yyBf4Eugz21UXO8IamutomdEy3aCor+sI=";
 
   buildInputs = [
     libpcap

--- a/pkgs/by-name/ne/necesse-server/package.nix
+++ b/pkgs/by-name/ne/necesse-server/package.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "1.3.2-24574169";
+  version = "1.3.2-24650233";
   urlVersion = lib.replaceStrings [ "." ] [ "-" ] version;
 
 in
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchzip {
     url = "https://necesse.pwn.sh/server/necesse-server-linux64-${urlVersion}.zip";
-    hash = "sha256-WJY9cTtkZcL55khatPesG1asS06tUnazzP0bp80cfu8=";
+    hash = "sha256-csFBev2t0i49GbD/oiIP2h7081ZFRdnlXVZh+2dabBs=";
   };
 
   # removing packaged jre since we use our own

--- a/pkgs/by-name/op/opengrok/package.nix
+++ b/pkgs/by-name/op/opengrok/package.nix
@@ -8,12 +8,12 @@
 
 stdenv.mkDerivation rec {
   pname = "opengrok";
-  version = "1.14.15";
+  version = "1.14.16";
 
   # binary distribution
   src = fetchurl {
     url = "https://github.com/oracle/opengrok/releases/download/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-+XRXwVyVpPjDhUPIriECQBntK4hZ1w2GKvf0NPnUwTU=";
+    hash = "sha256-ZZNTkPaPJzH9dInzb4qdEQSnSzU13LMW3B6JIO/N2RA=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/pg/pg_checksums/package.nix
+++ b/pkgs/by-name/pg/pg_checksums/package.nix
@@ -9,13 +9,13 @@
 
 clangStdenv.mkDerivation rec {
   pname = "pg_checksums";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "credativ";
     repo = "pg_checksums";
     rev = version;
-    sha256 = "sha256-iPgiiOxj3EDK7uf0D94oZSGz3RQbK3yEvdKNCW2Q1N0=";
+    sha256 = "sha256-CXWJroUkp6g1g0T5skx8P5rZyv1Pvzb/DQ7ezuDNi7s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/qu/quickjs-ng/package.nix
+++ b/pkgs/by-name/qu/quickjs-ng/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quickjs-ng";
-  version = "0.16.1";
+  version = "0.16.2";
 
   src = fetchFromGitHub {
     owner = "quickjs-ng";
     repo = "quickjs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qTBRR38axE6CtShUBaaLjytszKRzo/8eyARw9JRJBAA=";
+    hash = "sha256-r4aO+ItSogpFeYRPfAditJsit5qN8J5LU+xGPhKhgwA=";
   };
 
   outputs = [

--- a/pkgs/by-name/ss/ssh-vault/package.nix
+++ b/pkgs/by-name/ss/ssh-vault/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ssh-vault";
-  version = "1.3.2";
+  version = "1.3.4";
 
   src = fetchFromGitHub {
     owner = "ssh-vault";
     repo = "ssh-vault";
     tag = finalAttrs.version;
-    hash = "sha256-JwCW4IcA1B6A+ax+mITVfbrT/Od+y9NtDezE+KjbHlE=";
+    hash = "sha256-4DBsJoEVxsonBgeQ6zMIo5JMiz+mfesUqj0q40114F8=";
   };
 
-  cargoHash = "sha256-aXnFmpxAjX6dLzzNXTJP7iBnuVjGNGcmwia7PNOkeTg=";
+  cargoHash = "sha256-1BXjVX+Je6KFjw3c0dWeL80s2vvoXRJBI5gY14XWA4A=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/th/thruster/package.nix
+++ b/pkgs/by-name/th/thruster/package.nix
@@ -7,13 +7,13 @@
 
 buildGo126Module (finalAttrs: {
   pname = "thruster";
-  version = "0.1.23";
+  version = "0.1.25";
 
   src = fetchFromGitHub {
     owner = "basecamp";
     repo = "thruster";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-R7JutM3tWkkkRsxxNgHIoz7VdYIfXNTmmvhSh8YHFuM=";
+    hash = "sha256-cwAYWl8MnrR3z8OLI12DgFgBj+7muJagayzC6sX+g30=";
   };
 
   vendorHash = "sha256-V9KAr+/r5SGNSBamD3U7bvBiiXn5GTmopSxiNmFL6lQ=";

--- a/pkgs/by-name/un/unimatrix/package.nix
+++ b/pkgs/by-name/un/unimatrix/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "unimatrix";
-  version = "0-unstable-2023-04-25";
+  version = "0-unstable-2026-05-20";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "will8211";
     repo = "unimatrix";
-    rev = "65793c237553bf657af2f2248d2a2dc84169f5c4";
-    hash = "sha256-fiaVEc0rtZarUQlUwe1V817qWRx4LnUyRD/j2vWX5NM=";
+    rev = "dff519f972103f91384f360f270614184de8aa92";
+    hash = "sha256-g5/Hrk/coq8d7pNwE5juMQhxYSZBXwlGbqikiI9eGvg=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/xp/xpr/package.nix
+++ b/pkgs/by-name/xp/xpr/package.nix
@@ -12,7 +12,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xpr";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "app";
     repo = "xpr";
     tag = "xpr-${finalAttrs.version}";
-    hash = "sha256-q8WcQSzlAwbdIcXWyQjjHmvuqYa4k2e7O+VhShwBDUE=";
+    hash = "sha256-KAWQyVIkqa1zOVNjUAQl4zCqctNwaDLPO+LWE0QoIDk=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/yo/yoshimi/package.nix
+++ b/pkgs/by-name/yo/yoshimi/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "yoshimi";
-  version = "2.3.6.4";
+  version = "2.3.6.5";
 
   src = fetchFromGitHub {
     owner = "Yoshimi";
     repo = "yoshimi";
     tag = finalAttrs.version;
-    hash = "sha256-zFEbrACwJxfohcHTrJFxw6fHSJT/vYGuIlGyTcqo6Hk=";
+    hash = "sha256-ZlabEfDt/94kXPI1DbkykdFGfqf0csH/Cad3OBtyUf0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";

--- a/pkgs/development/python-modules/aioquic/default.nix
+++ b/pkgs/development/python-modules/aioquic/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   certifi,
   cryptography,
@@ -35,6 +36,11 @@ buildPythonPackage rec {
   buildInputs = [ openssl ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # QUIC needs UDP/multicast not available in sandbox.
+    "test_connect_and_serve_ipv4"
+  ];
 
   pythonImportsCheck = [ "aioquic" ];
 

--- a/pkgs/development/python-modules/cramjam/default.nix
+++ b/pkgs/development/python-modules/cramjam/default.nix
@@ -21,12 +21,12 @@ buildPythonPackage (finalAttrs: {
     owner = "milesgranger";
     repo = "cramjam";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vGT57ou9nnCVCw8LR+w+5MV54EqwT2R+ww9acRQk8Lc=";
+    hash = "sha256-Sjb1YBFJ26or4RiTA1G0UmVD6tyi9hNwBrde7E/WOes=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname src version;
-    hash = "sha256-evXYLbv+GwSBUJBb0upjQTFtMPdQbKka8KfJltMUmDs=";
+    hash = "sha256-wTheNASf8G4i8cTLPcreBM1+Kl/VvR+jyliiSC+KMpY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/cramjam/default.nix
+++ b/pkgs/development/python-modules/cramjam/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage (finalAttrs: {
   pname = "cramjam";
   version = "2.12.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "milesgranger";

--- a/pkgs/development/python-modules/holoviews/default.nix
+++ b/pkgs/development/python-modules/holoviews/default.nix
@@ -17,21 +17,22 @@
   pyviz-comms,
 
   # tests
-  pytestCheckHook,
-  pytest-asyncio,
   flaky,
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "holoviews";
-  version = "1.22.1";
+  version = "1.23.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "holoviz";
     repo = "holoviews";
-    tag = "v${version}";
-    hash = "sha256-rZZQgM8gchWTsgA47BVWblzWiWMuHK2vAZD/1Z8BHAk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+s7AzER7ipiqjiZL9vmno16MmhSK8Sz9LYLQ2cxNM6Y=";
   };
 
   postPatch = ''
@@ -54,13 +55,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    pytest-asyncio
     flaky
-  ];
-
-  pytestFlags = [
-    "-Wignore::FutureWarning"
+    pytest-asyncio
+    pytestCheckHook
   ];
 
   disabledTests = [
@@ -87,10 +84,10 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python data analysis and visualization seamless and simple";
-    changelog = "https://github.com/holoviz/holoviews/releases/tag/${src.tag}";
+    changelog = "https://github.com/holoviz/holoviews/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "holoviews";
     homepage = "https://www.holoviews.org/";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/hvplot/default.nix
+++ b/pkgs/development/python-modules/hvplot/default.nix
@@ -25,15 +25,16 @@
   plotly,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hvplot";
   version = "0.12.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "holoviz";
     repo = "hvplot";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hJ9lgpM3AVyDeFxobUKDNYO39NKEejSDywOgnHPEm2c=";
   };
 
@@ -94,8 +95,8 @@ buildPythonPackage rec {
   meta = {
     description = "High-level plotting API for the PyData ecosystem built on HoloViews";
     homepage = "https://hvplot.pyviz.org";
-    changelog = "https://github.com/holoviz/hvplot/releases/tag/${src.tag}";
+    changelog = "https://github.com/holoviz/hvplot/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ locnide ];
   };
-}
+})

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -1,66 +1,74 @@
 {
   lib,
-  stdenv,
-  platformdirs,
-  bokeh,
   buildPythonPackage,
-  dask,
-  entrypoints,
   fetchFromGitHub,
-  fsspec,
-  hvplot,
-  intake-parquet,
-  jinja2,
-  msgpack,
-  msgpack-numpy,
-  pandas,
-  panel,
-  pyarrow,
-  pytestCheckHook,
-  python-snappy,
-  pythonAtLeast,
-  pyyaml,
-  networkx,
-  requests,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  dask,
+  entrypoints,
+  fsspec,
+  jinja2,
+  msgpack,
+  networkx,
+  pandas,
+  platformdirs,
+  pyyaml,
+
+  # optional-dependencies
+  # server:
+  msgpack-numpy,
+  python-snappy,
   tornado,
+  # dataframe:
+  pyarrow,
+  # plot
+  hvplot,
+  bokeh,
+  panel,
+  # remote:
+  requests,
+
+  # tests
+  addBinToPathHook,
+  intake-parquet,
+  pytestCheckHook,
+  pythonAtLeast,
+  writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "intake";
   version = "2.0.9";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "intake";
     repo = "intake";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-DiALGrJP4vLWygzZprjYCFM+TYtMS7NVM3+MTyjzcs0=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
-    platformdirs
+  dependencies = [
     dask
     entrypoints
     fsspec
-    msgpack
     jinja2
-    pandas
-    pyyaml
+    msgpack
     networkx
+    pandas
+    platformdirs
+    pyyaml
   ];
-
-  nativeCheckInputs = [
-    intake-parquet
-    pytestCheckHook
-  ]
-  ++ lib.concatAttrValues optional-dependencies;
 
   optional-dependencies = {
     server = [
@@ -80,12 +88,13 @@ buildPythonPackage rec {
     remote = [ requests ];
   };
 
-  __darwinAllowLocalNetworking = true;
-
-  preCheck = ''
-    export HOME=$(mktemp -d);
-    export PATH="$PATH:$out/bin";
-  '';
+  nativeCheckInputs = [
+    addBinToPathHook
+    intake-parquet
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   disabledTestPaths = [
     # Missing plusins
@@ -132,11 +141,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "intake" ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "Data load and catalog system";
     homepage = "https://github.com/ContinuumIO/intake";
-    changelog = "https://github.com/intake/intake/blob/${version}/docs/source/changelog.rst";
+    changelog = "https://github.com/intake/intake/blob/${finalAttrs.src.rev}/docs/source/changelog.rst";
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Disable failing test during darwin build with sandbox enabled:

```python
    async with connect(host, port, configuration=configuration, **kwargs) as client:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/kmq6qdcg0yq6r4awf02dgq003n42r6zk-python3-3.14.7/lib/python3.14/contextlib.py:214: in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
/nix/store/crrh9mkdcjhyfqhpvmgkdcwa3zvl1sg9-python3.14-aioquic-1.3.0/lib/python3.14/site-packages/aioquic/asyncio/client.py:93: in connect
    await protocol.wait_connected()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <aioquic.asyncio.protocol.QuicConnectionProtocol object at 0x10c2f9940>

    async def wait_connected(self) -> None:
        """
        Wait for the TLS handshake to complete.
        """
        assert self._connected_waiter is None, "already awaiting connected"
        if not self._connected:
            self._connected_waiter = self._loop.create_future()
>           await asyncio.shield(self._connected_waiter)
E           ConnectionError

/nix/store/crrh9mkdcjhyfqhpvmgkdcwa3zvl1sg9-python3.14-aioquic-1.3.0/lib/python3.14/site-packages/aioquic/asyncio/protocol.py:146: ConnectionError
=========================== short test summary info ============================
FAILED tests/test_asyncio.py::HighLevelTest::test_connect_and_serve_ipv4 - ConnectionError
=================== 1 failed, 469 passed in 90.25s (0:01:30) ===================
```

Caught while working on #553128

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
