### PR TITLE
python3Packages.ntlk: fix build in Darwin sandbox

### DIFF
--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -118,6 +118,8 @@ buildPythonPackage (finalAttrs: {
     dataDir = pkgs.callPackage ./data-dir.nix { };
   };
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     changelog = "https://github.com/nltk/nltk/blob/${finalAttrs.src.tag}/ChangeLog";
     description = "Natural Language Processing ToolKit";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes use of loopback in tests during darwin build with sandbox enabled:

```python
__________________ test_ssrf_dns_rebinding_blocked_at_connect __________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1148e4520>

    def test_ssrf_dns_rebinding_blocked_at_connect(monkeypatch):
        """A hostname that resolves to a public IP at validation time but to a
        loopback IP at connect time (DNS rebinding) must still be blocked: the
        connection is pinned to the validated resolution.  Regression test for the
        validate-vs-connect DNS re-resolution TOCTOU in pathsec.urlopen.
        """
        import threading
        from http.server import BaseHTTPRequestHandler, HTTPServer

        SECRET = b"LOOPBACK-ONLY-SECRET"

        class _Handler(BaseHTTPRequestHandler):
            def do_GET(self):
                self.send_response(200)
                self.end_headers()
                self.wfile.write(SECRET)

            def log_message(self, *args):
                pass

>       srv = HTTPServer(("127.0.0.1", 0), _Handler)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

nltk/test/unit/test_pathsec.py:308:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/kmq6qdcg0yq6r4awf02dgq003n42r6zk-python3-3.14.7/lib/python3.14/socketserver.py:457: in __init__
    self.server_bind()
/nix/store/kmq6qdcg0yq6r4awf02dgq003n42r6zk-python3-3.14.7/lib/python3.14/http/server.py:148: in server_bind
    socketserver.TCPServer.server_bind(self)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <http.server.HTTPServer object at 0x11279b0e0>

    def server_bind(self):
        """Called by constructor to bind the socket.

        May be overridden.

        """
        if self.allow_reuse_address and hasattr(socket, "SO_REUSEADDR"):
            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        # Since Linux 6.12.9, SO_REUSEPORT is not allowed
        # on other address families than AF_INET/AF_INET6.
        if (
            self.allow_reuse_port and hasattr(socket, "SO_REUSEPORT")
            and self.address_family in (socket.AF_INET, socket.AF_INET6)
        ):
            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
>       self.socket.bind(self.server_address)
E       PermissionError: [Errno 1] Operation not permitted

/nix/store/kmq6qdcg0yq6r4awf02dgq003n42r6zk-python3-3.14.7/lib/python3.14/socketserver.py:478: PermissionError
```

Caught while working on #553128

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
