### PR TITLE
python3Packages.aioquic: fix build in Darwin sandbox

### DIFF
--- a/pkgs/development/python-modules/aioquic/default.nix
+++ b/pkgs/development/python-modules/aioquic/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   certifi,
   cryptography,
@@ -35,6 +36,11 @@ buildPythonPackage rec {
   buildInputs = [ openssl ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # QUIC needs UDP/multicast not available in sandbox.
+    "test_connect_and_serve_ipv4"
+  ];
 
   pythonImportsCheck = [ "aioquic" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Disable failing test during darwin build with sandbox enabled:

```python
    async with connect(host, port, configuration=configuration, **kwargs) as client:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/kmq6qdcg0yq6r4awf02dgq003n42r6zk-python3-3.14.7/lib/python3.14/contextlib.py:214: in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
/nix/store/crrh9mkdcjhyfqhpvmgkdcwa3zvl1sg9-python3.14-aioquic-1.3.0/lib/python3.14/site-packages/aioquic/asyncio/client.py:93: in connect
    await protocol.wait_connected()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <aioquic.asyncio.protocol.QuicConnectionProtocol object at 0x10c2f9940>

    async def wait_connected(self) -> None:
        """
        Wait for the TLS handshake to complete.
        """
        assert self._connected_waiter is None, "already awaiting connected"
        if not self._connected:
            self._connected_waiter = self._loop.create_future()
>           await asyncio.shield(self._connected_waiter)
E           ConnectionError

/nix/store/crrh9mkdcjhyfqhpvmgkdcwa3zvl1sg9-python3.14-aioquic-1.3.0/lib/python3.14/site-packages/aioquic/asyncio/protocol.py:146: ConnectionError
=========================== short test summary info ============================
FAILED tests/test_asyncio.py::HighLevelTest::test_connect_and_serve_ipv4 - ConnectionError
=================== 1 failed, 469 passed in 90.25s (0:01:30) ===================
```

Caught while working on #553128

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
