### PR TITLE
tmux: fix darwin build

### DIFF
--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -8,6 +8,7 @@
   ncurses,
   pkg-config,
   runCommand,
+  jemalloc,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
   systemdLibs,
   # broken on i686-linux https://github.com/tmux/tmux/issues/4597
@@ -49,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
     libevent
   ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ jemalloc ]
   ++ lib.optionals withSystemd [ systemdLibs ]
   ++ lib.optionals withUtf8proc [ utf8proc ]
   ++ lib.optionals withUtempter [ libutempter ];
@@ -57,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
   ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "--enable-jemalloc" ]
   ++ lib.optionals withSystemd [ "--enable-systemd" ]
   ++ lib.optionals withSixel [ "--enable-sixel" ]
   ++ lib.optionals withUtempter [ "--enable-utempter" ]


### PR DESCRIPTION
> https://raw.githubusercontent.com/tmux/tmux/3.7c/CHANGES
> Build with jemalloc on macOS to avoid what appears to be a bug in calloc

https://hydra.nixos.org/build/342974360/step/1/log
```
configure: 	   macOS calloc(3) appears not to correctly
configure: 	   zero allocations in some circumstances;
configure: 	   to avoid this, configuring with
configure: 	   --enable-jemalloc is recommended. To build
configure: 	   without anyway, use --disable-jemalloc
configure: 
configure: error: must give --enable-jemalloc or --disable-jemalloc
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
