### PR TITLE
rsname: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22741,6 +22741,12 @@
     name = "Kevin Mullins";
     keys = [ { fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A"; } ];
   };
+  poacher = {
+    email = "poacherGoneWild@proton.me";
+    github = "poach3r";
+    githubId = 58641438;
+    name = "Henry Matonis";
+  };
   podium868909 = {
     email = "89096245@proton.me";
     github = "podium868909";

--- a/pkgs/by-name/rs/rsname/package.nix
+++ b/pkgs/by-name/rs/rsname/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchFromCodeberg,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rsname";
+  version = "1.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "poacher";
+    repo = "rsname";
+    rev = "611c610ef8bf18ede56b772779f6848788b647e4";
+    hash = "sha256-8KJSBZP6H9GL9aQn3IpuY2WKRu/jlBplBGO1Xg2gE/8=";
+  };
+
+  cargoHash = "sha256-ZvzCDwptWye4jQBBAGCn3x8u1/wf5KEj+jmRDVSS0iY=";
+
+  meta = {
+    description = "Rename files on the command line";
+    homepage = "https://codeberg.org/poacher/rsname";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ poacher ];
+    mainProgram = "rn";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
This initializes the [rsname](https://codeberg.org/poacher/rsname) project at version 1.1.0 and adds me as a maintainer.
 
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [] [Package tests] at `passthru.tests`.
  - [] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
