### PR TITLE
nixosTests.gitea: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -694,7 +694,10 @@ in
   ghostunnel = runTest ./ghostunnel.nix;
   ghostunnel-modular = runTest ./ghostunnel-modular.nix;
   gitdaemon = runTest ./gitdaemon.nix;
-  gitea = handleTest ./gitea.nix { giteaPackage = pkgs.gitea; };
+  gitea = import ./gitea.nix {
+    inherit pkgs runTest;
+    inherit (pkgs) lib;
+  };
   github-runner = runTest ./github-runner.nix;
   gitlab = import ./gitlab {
     inherit runTest;

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -1,12 +1,11 @@
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  giteaPackage ? pkgs.gitea,
-  pkgs ? import ../.. { inherit system config; },
+  pkgs,
+  lib,
+  runTest,
+  ...
 }:
 
-with import ../lib/testing-python.nix { inherit system pkgs; };
-with pkgs.lib;
+with lib;
 
 let
   ## gpg --faked-system-time='20230301T010000!' --quick-generate-key snakeoil ed25519 sign
@@ -31,8 +30,8 @@ let
   ];
   makeGiteaTest =
     type:
-    nameValuePair type (makeTest {
-      name = "${giteaPackage.pname}-${type}";
+    nameValuePair type (runTest {
+      name = "${pkgs.gitea.pname}-${type}";
       meta.maintainers = with maintainers; [
         aanderse
         kolaente
@@ -46,7 +45,7 @@ let
             services.gitea = {
               enable = true;
               database = { inherit type; };
-              package = giteaPackage;
+              package = pkgs.gitea;
               metricsTokenFile = (pkgs.writeText "metrics_secret" "fakesecret").outPath;
               settings.service.DISABLE_REGISTRATION = true;
               settings."repository.signing".SIGNING_KEY = signingPrivateKeyId;
@@ -54,7 +53,7 @@ let
               settings.metrics.ENABLED = true;
             };
             environment.systemPackages = [
-              giteaPackage
+              pkgs.gitea
               pkgs.gnupg
               pkgs.jq
             ];


### PR DESCRIPTION
0 test rebuilds too, nice!

Part of https://github.com/NixOS/nixpkgs/issues/386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
