### PR TITLE
redis, valkey: migrate to runTest, simplify

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1501,7 +1501,10 @@ in
   readeck = runTest ./readeck.nix;
   realm = runTest ./realm.nix;
   rebuilderd = runTest ./rebuilderd.nix;
-  redis = handleTest ./redis.nix { };
+  redis = import ./redis.nix {
+    inherit pkgs runTest;
+    inherit (pkgs) lib;
+  };
   redlib = runTest ./redlib.nix;
   redmine = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./redmine.nix { };
   refind = runTest ./refind.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1501,9 +1501,9 @@ in
   readeck = runTest ./readeck.nix;
   realm = runTest ./realm.nix;
   rebuilderd = runTest ./rebuilderd.nix;
-  redis = import ./redis.nix {
-    inherit pkgs runTest;
-    inherit (pkgs) lib;
+  redis = runTest {
+    imports = [ ./redis.nix ];
+    _module.args.package = pkgs.redis;
   };
   redlib = runTest ./redlib.nix;
   redmine = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./redmine.nix { };
@@ -1867,6 +1867,10 @@ in
   utmp = runTest ./utmp.nix;
   uwsgi = runTest ./uwsgi.nix;
   v2ray = runTest ./v2ray.nix;
+  valkey = runTest {
+    imports = [ ./redis.nix ];
+    _module.args.package = pkgs.valkey;
+  };
   varnish80 = runTest {
     imports = [ ./varnish.nix ];
     _module.args.package = pkgs.varnish80;

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -1,12 +1,9 @@
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../../.. { inherit system config; },
-
-  lib ? pkgs.lib,
+  pkgs,
+  lib,
+  runTest,
 }:
 let
-  makeTest = import ./make-test-python.nix;
   mkTestName =
     pkg: "${pkg.pname}_${builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor pkg.version)}";
   redisPackages = {
@@ -17,7 +14,7 @@ let
       package,
       name ? mkTestName package,
     }:
-    makeTest {
+    runTest {
       inherit name;
       meta.maintainers = lib.teams.redis.members;
 

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -1,81 +1,73 @@
 {
   pkgs,
   lib,
-  runTest,
+  package,
+  ...
 }:
 let
   mkTestName =
     pkg: "${pkg.pname}_${builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor pkg.version)}";
-  redisPackages = {
-    inherit (pkgs) redis valkey;
-  };
-  makeRedisTest =
-    {
-      package,
-      name ? mkTestName package,
-    }:
-    runTest {
-      inherit name;
-      meta.maintainers = lib.teams.redis.members;
-
-      nodes = {
-        machine =
-          { lib, ... }:
-
-          {
-            services = {
-              redis = {
-                inherit package;
-                servers."".enable = true;
-                servers."test".enable = true;
-              };
-            };
-
-            users.users = lib.listToAttrs (
-              map
-                (
-                  suffix:
-                  lib.nameValuePair "member${suffix}" {
-                    createHome = false;
-                    description = "A member of the redis${suffix} group";
-                    isNormalUser = true;
-                    extraGroups = [ "redis${suffix}" ];
-                  }
-                )
-                [
-                  ""
-                  "-test"
-                ]
-            );
-          };
-      };
-
-      testScript =
-        { nodes, ... }:
-        let
-          inherit (nodes.machine.services) redis;
-        in
-        ''
-          start_all()
-          machine.wait_for_unit("redis")
-          machine.wait_for_unit("redis-test")
-
-          # The unnamed Redis server still opens a port for backward-compatibility
-          machine.wait_for_open_port(6379)
-
-          machine.wait_for_file("${redis.servers."".unixSocket}")
-          machine.wait_for_file("${redis.servers."test".unixSocket}")
-
-          # The unix socket is accessible to the redis group
-          machine.succeed('su member -c "${pkgs.redis}/bin/redis-cli ping | grep PONG"')
-          machine.succeed('su member-test -c "${pkgs.redis}/bin/redis-cli ping | grep PONG"')
-
-          machine.succeed("${pkgs.redis}/bin/redis-cli ping | grep PONG")
-          machine.succeed("${pkgs.redis}/bin/redis-cli -s ${redis.servers."".unixSocket} ping | grep PONG")
-          machine.succeed("${pkgs.redis}/bin/redis-cli -s ${
-            redis.servers."test".unixSocket
-          } ping | grep PONG")
-        '';
-    };
 in
-lib.mapAttrs (_: package: makeRedisTest { inherit package; }) redisPackages
+{
+  name = mkTestName package;
+  meta.maintainers = lib.teams.redis.members;
+
+  nodes = {
+    machine =
+      { lib, ... }:
+
+      {
+        services = {
+          redis = {
+            inherit package;
+            servers."".enable = true;
+            servers."test".enable = true;
+          };
+        };
+
+        users.users = lib.listToAttrs (
+          map
+            (
+              suffix:
+              lib.nameValuePair "member${suffix}" {
+                createHome = false;
+                description = "A member of the redis${suffix} group";
+                isNormalUser = true;
+                extraGroups = [ "redis${suffix}" ];
+              }
+            )
+            [
+              ""
+              "-test"
+            ]
+        );
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      inherit (nodes.machine.services) redis;
+    in
+    ''
+      start_all()
+      machine.wait_for_unit("redis")
+      machine.wait_for_unit("redis-test")
+
+      # The unnamed Redis server still opens a port for backward-compatibility
+      machine.wait_for_open_port(6379)
+
+      machine.wait_for_file("${redis.servers."".unixSocket}")
+      machine.wait_for_file("${redis.servers."test".unixSocket}")
+
+      # The unix socket is accessible to the redis group
+      machine.succeed('su member -c "${pkgs.redis}/bin/redis-cli ping | grep PONG"')
+      machine.succeed('su member-test -c "${pkgs.redis}/bin/redis-cli ping | grep PONG"')
+
+      machine.succeed("${pkgs.redis}/bin/redis-cli ping | grep PONG")
+      machine.succeed("${pkgs.redis}/bin/redis-cli -s ${redis.servers."".unixSocket} ping | grep PONG")
+      machine.succeed("${pkgs.redis}/bin/redis-cli -s ${
+        redis.servers."test".unixSocket
+      } ping | grep PONG")
+    '';
+}

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
-      redis = nixosTests.redis;
+      redis = nixosTests.valkey;
       unitTests = finalAttrs.finalPackage.overrideAttrs { doCheck = true; };
       valkey-python = python3Packages.valkey;
     };


### PR DESCRIPTION
- **nixosTests.redis: migrate to runTest**
- **redis, valkey: simplify nixosTests.redis, make more general**

Inspo from: https://github.com/NixOS/nixpkgs/pull/486325
0 rebuilds for either!

part of https://github.com/NixOS/nixpkgs/issues/386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
