### PR TITLE
nixosTests.hitch: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -799,7 +799,7 @@ in
     systemdStage1 = true;
   };
   hister = runTest ./hister.nix;
-  hitch = handleTest ./hitch { };
+  hitch = runTest ./hitch;
   hledger-web = runTest ./hledger-web.nix;
   hockeypuck = runTest ./hockeypuck.nix;
   holo-daemon-modular-service = runTest ./holo-daemon-modular.nix;

--- a/nixos/tests/hitch/default.nix
+++ b/nixos/tests/hitch/default.nix
@@ -1,36 +1,34 @@
-import ../make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "hitch";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ jflanglois ];
-    };
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        environment.systemPackages = [ pkgs.curl ];
-        services.hitch = {
-          enable = true;
-          backend = "[127.0.0.1]:80";
-          pem-files = [
-            ./example.pem
-          ];
-        };
-
-        services.httpd = {
-          enable = true;
-          virtualHosts.localhost.documentRoot = ./example;
-          adminAddr = "noone@testing.nowhere";
-        };
+{ pkgs, ... }:
+{
+  name = "hitch";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ jflanglois ];
+  };
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.curl ];
+      services.hitch = {
+        enable = true;
+        backend = "[127.0.0.1]:80";
+        pem-files = [
+          ./example.pem
+        ];
       };
 
-    testScript = ''
-      start_all()
+      services.httpd = {
+        enable = true;
+        virtualHosts.localhost.documentRoot = ./example;
+        adminAddr = "noone@testing.nowhere";
+      };
+    };
 
-      machine.wait_for_unit("multi-user.target")
-      machine.wait_for_unit("hitch.service")
-      machine.wait_for_open_port(443)
-      assert "We are all good!" in machine.succeed("curl -fk https://localhost:443/index.txt")
-    '';
-  }
-)
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("hitch.service")
+    machine.wait_for_open_port(443)
+    assert "We are all good!" in machine.succeed("curl -fk https://localhost:443/index.txt")
+  '';
+}


### PR DESCRIPTION
Signed-off-by: Ethan Carter Edwards <ethan@ethancedwards.com>

0 rebuilds

part of https://github.com/NixOS/nixpkgs/issues/386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
