### PR TITLE
geoclue2: add [ip] source

### DIFF
--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -141,6 +141,35 @@ in
         '';
       };
 
+      enableIP = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable IP source.
+        '';
+      };
+
+      ipMethod = lib.mkOption {
+        type = lib.types.enum [
+          "ichnaea"
+          "gmaps"
+          "reallyfreegeoip"
+        ];
+        default = "ichnaea";
+        description = ''
+          Method (backend) to use for IP location.
+        '';
+      };
+
+      ipAccuracy = lib.mkOption {
+        type = lib.types.nullOr lib.types.float;
+        default = 30000.0;
+        description = ''
+          Value with which to hardcode as, or override, the accuracy in the
+          GeoIP service response.
+        '';
+      };
+
       enableStatic = lib.mkOption {
         type = lib.types.bool;
         default = false;
@@ -277,6 +306,7 @@ in
       enableModemGPS = lib.mkIf cfg.enableStatic false;
       enableNmea = lib.mkIf cfg.enableStatic false;
       enableWifi = lib.mkIf cfg.enableStatic false;
+      enableIP = lib.mkIf cfg.enableStatic false;
       staticLatitude = lib.mkDefault config.location.latitude;
       staticLongitude = lib.mkDefault config.location.longitude;
     };
@@ -352,6 +382,14 @@ in
           submit-data = lib.boolToString cfg.submitData;
           submission-url = cfg.submissionUrl;
           submission-nick = cfg.submissionNick;
+        };
+        ip = {
+          enable = cfg.enableIP;
+        }
+        // lib.optionalAttrs cfg.enableIP {
+          method = cfg.ipMethod;
+          url = cfg.geoProviderUrl;
+          accuracy = lib.mkIf (cfg.ipAccuracy != null) cfg.ipAccuracy;
         };
         static-source = {
           enable = cfg.enableStatic;


### PR DESCRIPTION
adds the `[ip]` source to `services.geoclue2`, along with corresponding module options.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
