### PR TITLE
captive-browser: set meta.mainProgram, update source to codeberg

### DIFF
--- a/pkgs/by-name/ca/captive-browser/package.nix
+++ b/pkgs/by-name/ca/captive-browser/package.nix
@@ -24,6 +24,7 @@ buildGoModule (finalAttrs: {
   ];
 
   meta = {
+    mainProgram = "captive-browser";
     description = "Dedicated Chrome instance to log into captive portals without messing with DNS settings";
     homepage = "https://blog.filippo.io/captive-browser";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ca/captive-browser/package.nix
+++ b/pkgs/by-name/ca/captive-browser/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   buildGoModule,
 }:
 
@@ -8,8 +8,8 @@ buildGoModule (finalAttrs: {
   pname = "captive-browser";
   version = "0-unstable-2025-11-05";
 
-  src = fetchFromGitHub {
-    owner = "pacoorozco";
+  src = fetchFromCodeberg {
+    owner = "pakus";
     repo = "captive-browser";
     rev = "ca6f74e132ecf298c87936d4c946fd551aefbbf7";
     sha256 = "sha256-wojx28GFg9whfkNxUbOVDVNHp8M7SLsmRBTP/Jh8nLQ=";


### PR DESCRIPTION
Project moved to codeberg in https://github.com/pacoorozco/captive-browser/pull/7. other than that, latest commit and hash remain the same at the new source (without the move commit)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
