### PR TITLE
ix: init at 0-unstable-2026-08-20

### DIFF
--- a/pkgs/by-name/ix/ix/package.nix
+++ b/pkgs/by-name/ix/ix/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+let
+  version = "0-unstable-2026-08-20";
+
+  throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
+
+  # ix.dev publishes the CLI as self-contained binaries (static-pie on
+  # Linux) at content-addressed URLs: the sha256 digest of the binary is
+  # the URL path segment, so a release can never mutate an existing URL
+  # and every pinned revision stays fetchable. Digests come from
+  # https://ix.dev/cli/manifest.json (see update.sh).
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://ix.dev/cli/linux-x86_64/sha256/5754ccfe1eb074c6984dfa503a40372c52fc7d787513898d2062538e79677d43/ix";
+      hash = "sha256-V1TM/h6wdMaYTfpQOkA3LFL8fXh1E4mNIGJTjnlnfUM=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://ix.dev/cli/linux-arm64/sha256/125a8bf7e21fef5d72c55f1e7859e5e75ea4fdeef5092c03da09bb87a2205d9c/ix";
+      hash = "sha256-ElqL9+If711yxV8eeFnl516k/e71CSwD2gm7h6IgXZw=";
+    };
+
+    aarch64-darwin = fetchurl {
+      url = "https://ix.dev/cli/darwin-arm64/sha256/fb1685a1a0dd5fb189cf5670a7d87e5e6dda30fe293da22cae82b58dd500d87c/ix";
+      hash = "sha256-+xaFoaDdX7GJz1Zwp9h+Xm3aMP4pPaIsroK1jdUA2Hw=";
+    };
+  };
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ix";
+  inherit version;
+
+  src = srcs.${stdenvNoCC.hostPlatform.system} or throwSystem;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/ix
+
+    runHook postInstall
+  '';
+
+  # Upstream versions builds by date, so versionCheckHook cannot match the
+  # full version string; check the build date instead.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/ix --version | grep -F "${lib.removePrefix "0-unstable-" finalAttrs.version}"
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Boot and manage ix.dev virtual machines";
+    homepage = "https://ix.dev";
+    downloadPage = "https://ix.dev/cli/manifest.json";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = [ lib.maintainers.andrewgazelka ];
+    mainProgram = "ix";
+    platforms = builtins.attrNames srcs;
+  };
+})

--- a/pkgs/by-name/ix/ix/update.sh
+++ b/pkgs/by-name/ix/ix/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+# shellcheck shell=bash
+#!nix-shell -i bash -p bash curl gnused jq nix
+
+set -euo pipefail
+
+packageNix="$(dirname "$0")/package.nix"
+
+manifest=$(curl -fsSL https://ix.dev/cli/manifest.json)
+date=$(jq -r '."channel-version"' <<< "$manifest" | cut -d T -f 1)
+latestVersion="0-unstable-$date"
+
+currentVersion=$(nix-instantiate --eval --raw -E "with import ./. {}; ix.version")
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "package is up-to-date: $currentVersion"
+    exit 0
+fi
+
+declare -A platforms=(
+    [x86_64-linux]=linux-x86_64
+    [aarch64-linux]=linux-arm64
+    [aarch64-darwin]=darwin-arm64
+)
+
+sed -i -E "s|(version = \")[^\"]+|\1$latestVersion|" "$packageNix"
+for system in "${!platforms[@]}"; do
+    platform=${platforms[$system]}
+    digest=$(jq -er ".\"$platform\"" <<< "$manifest")
+    sri=$(nix hash convert --hash-algo sha256 --to sri "$digest")
+    sed -i -E "s|(cli/$platform/sha256/)[0-9a-f]{64}|\1$digest|" "$packageNix"
+    sed -i -E "\|cli/$platform/|,\|hash = | s|(hash = \")[^\"]+|\1$sri|" "$packageNix"
+done


### PR DESCRIPTION
Adds the `ix` CLI (https://ix.dev): boot and manage ix VMs.

Upstream distributes the CLI only as self-contained prebuilt binaries (static-pie on Linux) published at content-addressed URLs — the binary's sha256 digest is the URL path segment (digests listed in https://ix.dev/cli/manifest.json), so a release never mutates an existing URL and pinned nixpkgs revisions stay fetchable indefinitely. Upstream has no versioned releases; builds are date-stamped (`ix --version` → `ix 2026-08-20T16:49:03Z (a4ef7254bb)`), hence the `0-unstable-YYYY-MM-DD` version scheme, with an update script that reads the manifest.

I am the upstream author/owner of ix.dev; fetching/redistributing these binaries is permitted. `license = unfree` since no source is published.

**AI disclosure (per the automation/AI policy):** the package and this PR text were written with Claude Code 2.1.228 (Anthropic Claude Fable 5) under my direction; I reviewed the contribution before submission. The commit carries the `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux (evaluates; not built — no hardware at hand)
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`ix --version` runs in `installCheckPhase` and was run manually on both built platforms; update script tested in both directions.)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
