### PR TITLE
gershwin-terminal: init at 0-unstable-2026-07-12

### DIFF
--- a/pkgs/by-name/ge/gershwin-terminal/package.nix
+++ b/pkgs/by-name/ge/gershwin-terminal/package.nix
@@ -1,0 +1,46 @@
+{
+  clangStdenv,
+  fetchFromGitHub,
+  gnustep-back,
+  lib,
+  libx11,
+  wrapGNUstepAppsHook,
+}:
+
+clangStdenv.mkDerivation {
+  strictDeps = true;
+  __structuredAttrs = true;
+  pname = "gershwin-terminal";
+  version = "0-unstable-2026-07-12";
+
+  src = fetchFromGitHub {
+    owner = "gershwin-desktop";
+    repo = "gershwin-terminal";
+    rev = "e52b9bc8401f9e28f322001dce8e2d45632bdedd";
+    hash = "sha256-NqYSfCH93M0Gx9hdqWOkG3u9TxgG6TToe9OKZkAd/cI=";
+  };
+
+  patches = [
+    ./patches/TerminalViewGNU.patch
+  ];
+
+  nativeBuildInputs = [
+    wrapGNUstepAppsHook
+  ];
+
+  buildInputs = [
+    libx11
+    gnustep-back
+  ];
+
+  meta = {
+    homepage = "https://github.com/gershwin-desktop/gershwin-terminal";
+    description = "The terminal emulator for Gershwin Desktop";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "Terminal";
+    maintainers = with lib.maintainers; [
+      OulipianSummer
+    ];
+  };
+  platforms = lib.platforms.linux;
+}

--- a/pkgs/by-name/ge/gershwin-terminal/patches/TerminalViewGNU.patch
+++ b/pkgs/by-name/ge/gershwin-terminal/patches/TerminalViewGNU.patch
@@ -1,0 +1,15 @@
+diff --git a/TerminalView.m b/TerminalView.m
+index ce6ee16..522d4b9 100644
+--- a/TerminalView.m
++++ b/TerminalView.m
+@@ -44,9 +44,6 @@
+ #  include <termios.h>
+ #  include <util.h>
+ #  include <sys/ioctl.h>
+-#elif defined (__GNU__)
+-#else
+-#  include <termio.h>
+ #endif
+ 
+ #include <sys/time.h>
+


### PR DESCRIPTION
This is a port of [Gershwin Terminal](github.com/gershwin-desktop/gershwin-terminal) from the [Gershwin Desktop](github.com/gershwin-desktop) project.

It's a GNUStep / X11 compatible terminal emulator with some good integration into existing GNUStep environments.

This PR was not created with the help or supervision of any AI tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
