### PR TITLE
minimal-bootstrap.stage0-posix: support riscv64-linux up to M2-Planet

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/hex0.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/hex0.nix
@@ -14,6 +14,7 @@ let
       "AArch64" = "sha256-XTPsoKeI6wTZAF0UwEJPzuHelWOJe//wXg4HYO0dEJo=";
       "AMD64" = "sha256-DCzZduYrix9yOeJoem/Jhz/WDzAss7UWwjZbkXJq6Ms=";
       "x86" = "sha256-DFmSpy4EYoKBSuPQRqtTsUfIUjlg794PnMrEg5stOFY=";
+      "riscv64" = "sha256-BMgaiXD8bnxOTHal4RlmYKItuWUcDIwSrRuPVAnm/BE=";
     }
     .${stage0Arch} or (throw "Unsupported system: ${hostPlatform.system}");
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools-boot.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/mescc-tools-boot.nix
@@ -132,8 +132,19 @@ rec {
   # Phase-4 Build cc_arch from M0 #
   ################################
 
+  cc_arch_src =
+    if hostPlatform.isRiscV then
+      # See e.g. https://github.com/oriansj/stage0-posix-riscv64/blob/4688bc66bdfd00efd5964350c9d76bdb90a0f72e/mescc-tools-mini-kaem.kaem#L54
+      run "cc_arch_riscv_c" catm [
+        out
+        "${src}/${stage0Arch}/${m2libcArch}_defs.M1"
+        "${src}/${stage0Arch}/cc_${m2libcArch}.M1"
+      ]
+    else
+      "${src}/${stage0Arch}/cc_${m2libcArch}.M1";
+
   cc_arch-0_hex2 = run "cc_arch-0.hex2" M0 [
-    "${src}/${stage0Arch}/cc_${m2libcArch}.M1"
+    "${cc_arch_src}"
     out
   ];
   cc_arch-1_hex2 = run "cc_arch-1.hex2" catm [

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/platforms.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/platforms.nix
@@ -10,6 +10,7 @@ rec {
     "aarch64-linux"
     "i686-linux"
     "x86_64-linux"
+    "riscv64-linux"
   ];
 
   # system arch as used within the stage0 project
@@ -18,6 +19,7 @@ rec {
       "aarch64-linux" = "AArch64";
       "i686-linux" = "x86";
       "x86_64-linux" = "AMD64";
+      "riscv64-linux" = "riscv64";
     }
     .${hostPlatform.system} or (throw "Unsupported system: ${hostPlatform.system}");
 
@@ -33,6 +35,7 @@ rec {
       "aarch64-linux" = "0x00600000";
       "i686-linux" = "0x08048000";
       "x86_64-linux" = "0x00600000";
+      "riscv64-linux" = "0x00600000";
     }
     .${hostPlatform.system} or (throw "Unsupported system: ${hostPlatform.system}");
 }


### PR DESCRIPTION
Support building up to M2-Planet in stage0-posix on RISC-V platforms.
This does not add support for riscv64-linux in the full bootstrap chain for now.
riscv32-linux requires adding `signal.h` to the include list for tools built within stage0-posix, which would trigger a world rebuild.
It should trigger 0 rebuilds on non-RISC-V platforms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  * Tested M2-Planet.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
