### PR TITLE
pdf-cli: 2.0 -> 3.0

### DIFF
--- a/pkgs/by-name/pd/pdf-cli/package.nix
+++ b/pkgs/by-name/pd/pdf-cli/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "pdf-cli";
-  version = "2.0";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "Yujonpradhananga";
     repo = "pdf-cli";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-TvfSauT9UWjQjkzQtepEVyxm/LaiCANmxMtVmjiw8kI=";
+    rev = "v.3.0";
+    hash = "sha256-9LXnRHh1afusg4YmVqZam6efJnrW4Bxx02xbArsGIxM=";
   };
 
   vendorHash = "sha256-LCIv135ywuq494hZbrKdbqkGPSsSlSkVQ9hCE8i7www=";


### PR DESCRIPTION
Update pdf-cli from 2.0 to 3.0.

Major changes:
- New UI built with Bubble Tea
- Significant performance improvements 
  - Two-tier LRU render cache (in-memory + persistent disk)
  - Background prefetching of neighboring pages
  - Native Kitty graphics transmission (bypasses go-termimg)
  - Zero-cost geometry queries for aspect ratios
  - Faster PNG encoding (BestSpeed)
  - Optimized dark mode rendering (LUT fast path)
  - HiDPI supersampling with memory safety caps

Changelog: https://github.com/Yujonpradhananga/pdf-cli/releases/tag/v.3.0