### PR TITLE
proxyauth: 0.8.0 -> 1.0.3

### DIFF
--- a/pkgs/by-name/pr/proxyauth/package.nix
+++ b/pkgs/by-name/pr/proxyauth/package.nix
@@ -5,24 +5,26 @@
   pkg-config,
   openssl,
   nettle,
+  libmysqlclient,
+  libpq,
+  cacert,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "proxyauth";
-  version = "0.8.0";
+  version = "1.0.3";
 
   src = fetchFromForgejo {
     domain = "git.proxyauth.app";
     owner = "ProxyAuth";
     repo = "ProxyAuth";
-    rev = "13b353e4a8b34fc1736c834cfcaa9afe06e8abf8";
-    # Tags were not replicated from GitHub to git.proxyauth.app
-    hash = "sha256-cVjD91tBCGyslLsYUSP1Gy7KuMQZDVxQXU7fQkWeWyM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hdLkDM1xNqQnaTKcBDRzLCc0hocHiIwLNPxIEU2MYIE=";
   };
 
-  cargoHash = "sha256-YhFOh60D014Tb/Gi3u+tpmXbaaIFIB5HU4X8rhWPV40=";
+  cargoHash = "sha256-IwIOlo5OyjvQBhgUZiRJy7fiNQshMgMHcl9MA6ju1h8=";
 
   nativeBuildInputs = [
     pkg-config
@@ -31,10 +33,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     openssl
     nettle
+    libmysqlclient
+    libpq
   ];
 
   __structuredAttrs = true;
   strictDeps = true;
+
+  nativeCheckInputs = [
+    cacert
+  ];
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Diff : https://git.proxyauth.app/ProxyAuth/ProxyAuth/compare/v1.0.0...v1.0.3
Changelog : https://git.proxyauth.app/ProxyAuth/ProxyAuth/releases/tag/v1.0.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
