### PR TITLE
rosec: 0.0.28 -> 0.0.34

### DIFF
--- a/pkgs/by-name/ro/rosec-bitwarden-pm/package.nix
+++ b/pkgs/by-name/ro/rosec-bitwarden-pm/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: rec {
 
   sourceRoot = "${src.name}/rosec-bitwarden-pm";
 
-  cargoHash = "sha256-hNeCZPclwz2WMKnHsECBL0TduqkWsYhadEfsw54lGBg=";
+  cargoHash = "sha256-TAP1G0QJGg3w0lKCUHTsfVvwON7nSlcM4jhtIB+WByQ=";
 
   env.RUSTFLAGS = "-C linker=wasm-ld";
   nativeBuildInputs = [ lld ];

--- a/pkgs/by-name/ro/rosec-bitwarden-sm/package.nix
+++ b/pkgs/by-name/ro/rosec-bitwarden-sm/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: rec {
 
   sourceRoot = "${src.name}/rosec-bitwarden-sm";
 
-  cargoHash = "sha256-E4xxxK+7LEyYh7QtLnN8bHYwb2I9DQ7t4Inxbu72Fq4=";
+  cargoHash = "sha256-JeTUX/ZUtOrnpYPChdS7EP96rirrPlMajO/ptxonN7w=";
 
   env.RUSTFLAGS = "-C linker=wasm-ld";
   nativeBuildInputs = [ lld ];

--- a/pkgs/by-name/ro/rosec-gnome-keyring/package.nix
+++ b/pkgs/by-name/ro/rosec-gnome-keyring/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: rec {
 
   sourceRoot = "${src.name}/rosec-gnome-keyring";
 
-  cargoHash = "sha256-gkbD1N4veXhETwc5uzL/eq7a6naGq6suqJOAp53suFI=";
+  cargoHash = "sha256-DaEdT/E4blOM/wFwuZoEuquwMgcSmTKlHT5CtSsqJ3g=";
 
   env.RUSTFLAGS = "-C linker=wasm-ld";
   nativeBuildInputs = [ lld ];

--- a/pkgs/by-name/ro/rosec/package.nix
+++ b/pkgs/by-name/ro/rosec/package.nix
@@ -22,7 +22,7 @@ symlinkJoin (
       owner = "jmylchreest";
       repo = "rosec";
       tag = "v${version}";
-      hash = "sha256-qs6WjgiK2AFhGlbsl85fEmVaWr/aw5pOIaKw68rsLZ0=";
+      hash = "sha256-dlHOzUW/kH9SS/mPl+VvEetCzOY/L2qEpoYLJTCWR90=";
     };
 
     rosecPam = stdenv.mkDerivation {
@@ -48,7 +48,7 @@ symlinkJoin (
       pname = "rosec-unwrapped";
       inherit version src;
 
-      cargoHash = "sha256-kE3qpdQGvXtjlospxSeoyPIUNyioLq5Ao5y94yIsjMs=";
+      cargoHash = "sha256-X1LEL8/ntKkdRQLU+XBJ7oaDhNph2WAeVWVJ2KnzVzA=";
 
       nativeBuildInputs = [
         autoPatchelfHook
@@ -66,6 +66,8 @@ symlinkJoin (
 
       preCheck = ''
         export $(dbus-launch --config-file=${dbus}/share/dbus-1/session.conf)
+        # rosec-vault sidecar tests require writable xdg data directory
+        export XDG_DATA_HOME=$TMPDIR/xdg-data
       '';
 
       postInstall = ''
@@ -85,7 +87,7 @@ symlinkJoin (
   in
   {
     pname = "rosec";
-    version = "0.0.28";
+    version = "0.0.34";
 
     paths = [
       rosecCore


### PR DESCRIPTION
rosec 0.0.28 -> 0.0.34, a version bump using `nix-shell maintainers/scripts/update.nix`. The companion packages `rosec-bitwarden-pm`, `rosec-bitwarden-sm` and `rosec-gnome-keyring` inherit `version` and `src` from `rosec`, so their hashes are updated in the same commit.

Includes a minor fix to make new cargo tests work.

Changelog: https://github.com/jmylchreest/rosec/releases/tag/v0.0.34

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
