### PR TITLE
libgit2: add linking exception

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -715,6 +715,11 @@ lib.mapAttrs mkLicense (
       url = "https://geant4.web.cern.ch/geant4/license/LICENSE.html";
     };
 
+    gccException20 = {
+      spdxId = "GCC-exception-2.0";
+      fullName = "GCC Runtime Library exception 2.0";
+    };
+
     gccException31 = {
       spdxId = "GCC-exception-3.1";
       fullName = "GCC Runtime Library exception 3.1";

--- a/pkgs/by-name/li/libgit2/package.nix
+++ b/pkgs/by-name/li/libgit2/package.nix
@@ -111,6 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://libgit2.org/";
     license = with lib.licenses; WITH gpl2Only gccException20;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/li/libgit2/package.nix
+++ b/pkgs/by-name/li/libgit2/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Linkable library implementation of Git that you can use in your application";
     mainProgram = "git2";
     homepage = "https://libgit2.org/";
-    license = lib.licenses.gpl2Only;
+    license = with lib.licenses; WITH gpl2Only gccException20;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };


### PR DESCRIPTION
libgit2's license includes a very permissive GPLv2 exception that covers both static and dynamic linking.
This PR adds that to `meta.license`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
