### PR TITLE
cloudcompare: 2.13.2 -> 2.13.2-unstable-2026-08-21

### DIFF
--- a/nixos/tests/vlm-screenshot-question.nix
+++ b/nixos/tests/vlm-screenshot-question.nix
@@ -60,7 +60,7 @@ let
         vlm_start = time.time()
         result = subprocess.run(
             [
-                "${lib.getExe llama-cpp}",
+                "${lib.getExe' llama-cpp "llama-cli"}",
                 "--single-turn", "--no-display-prompt", "--log-verbosity", "0", "--jinja",
                 "--simple-io",  # disables the spinner whose backspace chars would corrupt captured output
                 "--reasoning", "off", "--temp", "0",

--- a/nixos/tests/vlm-screenshot-question.nix
+++ b/nixos/tests/vlm-screenshot-question.nix
@@ -54,7 +54,8 @@ let
             "Start your output with [output-start]."
             f" {question}"
             " Explain what you see, and your judgment."
-            " Then answer that question with exactly YES or NO, followed by [output-end]."
+            " On the final line, output exactly YES or NO."
+            " Then immediately output [output-end] with nothing else after it."
         )
 
         vlm_start = time.time()

--- a/pkgs/by-name/cl/cloudcompare/package.nix
+++ b/pkgs/by-name/cl/cloudcompare/package.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "cloudcompare";
   version = "2.13.2-unstable-2026-08-21";
 
+  scriptDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "CloudCompare";
     repo = "CloudCompare";

--- a/pkgs/by-name/cl/cloudcompare/package.nix
+++ b/pkgs/by-name/cl/cloudcompare/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   makeDesktopItem,
   copyDesktopItems,
   cmake,
@@ -15,39 +14,35 @@
   laszip,
   mpfr,
   pcl,
-  libsForQt5,
+  qt6Packages,
   nixosTests,
   onetbb,
   xercesc,
   wrapGAppsHook3,
+  pkg-config,
+  libusb1,
+  hidapi,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cloudcompare";
-  version = "2.13.2";
+  version = "2.13.2-unstable-2026-08-21";
 
   src = fetchFromGitHub {
     owner = "CloudCompare";
     repo = "CloudCompare";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-a/0lf3Mt5ZpLFRM8jAoqZer8pY1ROgPRY4dPt34Bk3E=";
+    rev = "be1fdb0fd05ec42d6922d7f18b22aab71c168ad6";
+    hash = "sha256-dlB3d6AE8R5SjjVUHvYv3D4FjlOnEHHLoDexejwUp6U=";
     fetchSubmodules = true;
   };
 
-  patches = [
-    # https://github.com/CloudCompare/CloudCompare/pull/2208
-    (fetchpatch2 {
-      url = "https://github.com/CloudCompare/CloudCompare/commit/8e1c0562a7c19fd26ccd0c23bb05fb7c36980e0c.patch?full_index=1";
-      hash = "sha256-DARxLiRjcBJEo63o92ujjxBU42Y8CY2c7px8Y9UD5A4=";
-    })
-  ];
-
   nativeBuildInputs = [
     cmake
-    eigen # header-only
-    wrapGAppsHook3
     copyDesktopItems
-    libsForQt5.wrapQtAppsHook
+    eigen # header-only
+    pkg-config
+    qt6Packages.wrapQtAppsHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -57,12 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
     gdal
     gmp
     laszip
+    libusb1 # required together with hidapi for 3D-mouse support
     mpfr
-    pcl
-    libsForQt5.qtbase
-    libsForQt5.qtsvg
-    libsForQt5.qttools
     onetbb
+    pcl
+    qt6Packages.qtbase
+    qt6Packages.qtsvg
+    qt6Packages.qttools
     xercesc
   ];
 
@@ -123,7 +119,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   # fix file dialogs crashing on non-NixOS (and avoid double wrapping)
   preFixup = ''
-    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    qtWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ hidapi ]}
+    )
   '';
 
   desktopItems = [


### PR DESCRIPTION
Fix build and update package

```
cloudcompare> /build/source/qCC/ccRasterizeTool.cpp: In static member function 'static bool ccRasterizeTool::ExportGeoTiff(const QString&, const ExportBands&, ccRasterGrid::EmptyCellFillOption, const ccRasterGrid&, const ccBBox&, unsigned char, double, ccGenericPointCloud*, int)':
cloudcompare> /build/source/qCC/ccRasterizeTool.cpp:1326:53: error: invalid conversion from 'CSLConstList' {aka 'const char* const*'} to 'char**' [-fpermissive]
cloudcompare>  1326 |         char** papszMetadata = poDriver->GetMetadata();
cloudcompare>       |                                ~~~~~~~~~~~~~~~~~~~~~^~
cloudcompare>       |                                                     |
cloudcompare>       |                                                     CSLConstList {aka const char* const*}
cloudcompare> /build/source/qCC/ccRasterizeTool.cpp: In member function 'void ccRasterizeTool::generateASCIIMatrix() const':
```
switch to qt6 and fix test

Changes: https://github.com/CloudCompare/CloudCompare/compare/49dbbb662f296c7780aae717897c85b3cb3764ed...be1fdb0fd05ec42d6922d7f18b22aab71c168ad6

Fixes https://github.com/NixOS/nixpkgs/issues/553490

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
