### PR TITLE
{anewer, artem, lazycli}: adopt; modernize derivation; update

### DIFF
--- a/pkgs/by-name/an/anewer/package.nix
+++ b/pkgs/by-name/an/anewer/package.nix
@@ -22,6 +22,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "anewer";
     homepage = "https://github.com/ysf/anewer";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tomasrivera ];
   };
 })

--- a/pkgs/by-name/an/anewer/package.nix
+++ b/pkgs/by-name/an/anewer/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -16,6 +17,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-ojgm5LTOOhnGS7tUD1UUktviivp68u0c06gIJNhEO1E=";
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Append lines from stdin to a file if they don't already exist in the file";

--- a/pkgs/by-name/an/anewer/package.nix
+++ b/pkgs/by-name/an/anewer/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -21,6 +22,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Append lines from stdin to a file if they don't already exist in the file";

--- a/pkgs/by-name/an/anewer/package.nix
+++ b/pkgs/by-name/an/anewer/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "anewer";
-  version = "0.1.6";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "ysf";
     repo = "anewer";
-    tag = finalAttrs.version;
-    sha256 = "181mi674354bddnq894yyq587w7skjh35vn61i41vfi6lqz5dy3d";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FyK0AvwGAFmxswrf42ZBzYCZdZ7X0goQRCUpqFOTD9o=";
   };
 
-  cargoHash = "sha256-ojgm5LTOOhnGS7tUD1UUktviivp68u0c06gIJNhEO1E=";
+  cargoHash = "sha256-7qOfGHS9WPsdBUOjWztkIrkr+krfw84aEf9+5fvmhXM=";
 
   doInstallCheck = true;
 

--- a/pkgs/by-name/ar/artem/package.nix
+++ b/pkgs/by-name/ar/artem/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/finefindus/artem";
     changelog = "https://github.com/finefindus/artem/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tomasrivera ];
     mainProgram = "artem";
   };
 })

--- a/pkgs/by-name/ar/artem/package.nix
+++ b/pkgs/by-name/ar/artem/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "finefindus";
     repo = "artem";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-C3Co+hXstVN/WADIpzqr7f3muAgQL0Zbnz6VI1XNo4U=";
   };
 

--- a/pkgs/by-name/ar/artem/package.nix
+++ b/pkgs/by-name/ar/artem/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Small CLI program to convert images to ASCII art";
     homepage = "https://github.com/finefindus/artem";
-    changelog = "https://github.com/finefindus/artem/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/finefindus/artem/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = [ ];
     mainProgram = "artem";

--- a/pkgs/by-name/la/lazycli/package.nix
+++ b/pkgs/by-name/la/lazycli/package.nix
@@ -6,21 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lazycli";
-  version = "0.1.15";
+  version = "0.1.15-unstable-2022-11-15";
 
   src = fetchFromGitHub {
     owner = "jesseduffield";
     repo = "lazycli";
-    rev = "v${finalAttrs.version}";
-    sha256 = "1qq167hc7pp9l0m40ysphfljakmm8hjjnhpldvb0kbc825h0z8z5";
+    rev = "40c32e74b406152404375e58dbef4036d3ab3197";
+    hash = "sha256-k/iPcxVuLZhveVkFaeMMLASHCB+Ccrxr8mwPNqfknvQ=";
   };
 
-  cargoHash = "sha256-L6qY1yu+8L7DajX//Yov0KgI2bR8yipSzbZC2c+LZZs=";
-
-  checkFlags = [
-    # currently broken: https://github.com/jesseduffield/lazycli/pull/20
-    "--skip=command::test_run_command_fail"
-  ];
+  cargoHash = "sha256-DSff1jJ+0W7+Ul+3D2DVe0XTKObyuJ0APU5UbrfHSFA=";
 
   meta = {
     description = "Tool to static turn CLI commands into TUIs";

--- a/pkgs/by-name/la/lazycli/package.nix
+++ b/pkgs/by-name/la/lazycli/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Tool to static turn CLI commands into TUIs";
     homepage = "https://github.com/jesseduffield/lazycli";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tomasrivera ];
     mainProgram = "lazycli";
   };
 })


### PR DESCRIPTION
Part of #458096

No AI/Automation was used for this PR
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
