### PR TITLE
buildEnv: enable strictDeps

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -97,6 +97,8 @@ lib.makeOverridable (
         # Explicitly opt in: builder.pl reads all configuration from file $ENV["NIX_ATTRS_JSON_FILE"].
         __structuredAttrs = true;
 
+        strictDeps = true;
+
         inherit
           extraOutputsToInstall
           manifest

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -144,7 +144,7 @@ lib.makeOverridable (
         allowSubstitutes = derivationArgs.allowSubstitutes or false;
 
         buildCommand = ''
-          ${buildPackages.perl}/bin/perl -w ${builder}
+          ${buildPackages.perl.interpreter} -w ${builder}
           eval "$postBuild"
         '';
 

--- a/pkgs/test/buildenv.nix
+++ b/pkgs/test/buildenv.nix
@@ -337,6 +337,27 @@ let
     };
   };
 
+  tests-strictDeps = {
+    testStrictDepsExplicitlyFalse = {
+      expr =
+        (buildEnv {
+          name = "test-env";
+          paths = [ ];
+        }).strictDeps;
+      expected = true;
+    };
+
+    testStrictDepsCantBeOverriddenViaDerivationArgs = {
+      expr =
+        (buildEnv {
+          name = "test-env";
+          paths = [ ];
+          derivationArgs.strictDeps = false;
+        }).strictDeps;
+      expected = true;
+    };
+  };
+
   tests =
     tests-name
     // tests-passthru-paths
@@ -344,11 +365,13 @@ let
     // tests-overrideAttrs
     // tests-passthru-merging
     // tests-derivationArgs
-    // tests-structuredAttrs;
+    // tests-structuredAttrs
+    // tests-strictDeps;
 in
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
+  strictDeps = true;
   name = "test-buildenv";
   passthru = {
     inherit tests buildTests;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
