### PR TITLE
gplates: 2.5.0-dev3 -> 2.6.0-unstable-2026-08-18

### DIFF
--- a/pkgs/by-name/gp/gplates/package.nix
+++ b/pkgs/by-name/gp/gplates/package.nix
@@ -16,7 +16,8 @@
   mpfr,
   proj,
   python3,
-  libsForQt5,
+  qt6Packages,
+  gtk3,
 }:
 
 let
@@ -35,20 +36,24 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gplates";
-  version = "2.5.0-dev3";
+  version = "2.6.0-47";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "GPlates";
     repo = "GPlates";
-    rev = "e3ec5a4ee58147d21d8b42050c4c7e78f861f21c";
-    hash = "sha256-/y+fozK6DvoVuS1I1ZdWtRwy+M/XRFyLDWHcUFu2++M=";
+    tag = "GPlates-${finalAttrs.version}";
+    hash = "sha256-sKhOMZm5ctXTxq0sLw1iDaqxf76yw4iFEorQ8jupGHk=";
   };
 
   nativeBuildInputs = [
     cmake
     doxygen
     graphviz
-    libsForQt5.wrapQtAppsHook
+    python
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -57,15 +62,24 @@ stdenv.mkDerivation (finalAttrs: {
     gdal
     glew
     gmp
+    gtk3
     libGL
     libGLU
     libsm
     mpfr
     proj
     python
-    libsForQt5.qtxmlpatterns
-    libsForQt5.qwt
+    qt6Packages.qt5compat
+    qt6Packages.qwt
   ];
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --set PYTHONHOME "${python}"
+      --set PYTHONPATH "${python}/${python.sitePackages}"
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+    )
+  '';
 
   meta = {
     description = "Desktop software for the interactive visualisation of plate-tectonics";


### PR DESCRIPTION
Fix broken build:

```
gplates> [ 25%] Building CXX object src/CMakeFiles/gplates-lib.dir/file-io/GmapReader.cc.o
gplates> /build/source/src/file-io/GdalRasterWriter.cc: In function 'bool {anonymous}::does_driver_support_creation(const char*)':
gplates> /build/source/src/file-io/GdalRasterWriter.cc:104:61: error: invalid conversion from 'CSLConstList' {aka 'const char* const*'} to 'char**' [-fpermissive]
gplates>   104 |                 char **driver_metadata = driver->GetMetadata();
gplates>       |                                          ~~~~~~~~~~~~~~~~~~~^~
gplates>       |                                                             |
gplates>       |                                                             CSLConstList {aka const char* const*}
gplates> /build/source/src/file-io/GdalRasterWriter.cc: In function 'std::vector<GPlatesPropertyValues::RasterType::Type> {anonymous}::get_supported_band_types(const char*)':
gplates> /build/source/src/file-io/GdalRasterWriter.cc:138:61: error: invalid conversion from 'CSLConstList' {aka 'const char* const*'} to 'char**' [-fpermissive]
gplates>   138 |                 char **driver_metadata = driver->GetMetadata();
gplates>       |                                          ~~~~~~~~~~~~~~~~~~~^~
gplates>       |                                                             |
gplates>       |                                                             CSLConstList {aka const char* const*}
gplates> /build/source/src/file-io/GdalRasterWriter.cc: In constructor 'GPlatesFileIO::GDALRasterWriter::GDALRasterWriter(const QString&, const GPlatesFileIO::RasterWriter::FormatInfo&, unsigned int, unsigned int, unsigned int, GPlatesPropertyValues::RasterType::Type, bool)':
gplates> /build/source/src/file-io/GdalRasterWriter.cc:440:65: error: invalid conversion from 'CSLConstList' {aka 'const char* const*'} to 'char**' [-fpermissive]
gplates>   440 |         char **file_driver_metadata = d_file_driver->GetMetadata();
gplates>       |                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
gplates>       |                                                                 |
gplates>       |                                                                 CSLConstList {aka const char* const*}
gplates> make[2]: *** [src/CMakeFiles/gplates-lib.dir/build.make:3507: src/CMakeFiles/gplates-lib.dir/file-io/GdalRasterWriter.cc.o] Error 1
gplates> make[2]: *** Waiting for unfinished jobs....
gplates> make[1]: *** [CMakeFiles/Makefile2:600: src/CMakeFiles/gplates-lib.dir/all] Error 2
gplates> make: *** [Makefile:156: all] Error 2
```
and switch from qt5 to qt6.

Changes https://github.com/GPlates/GPlates/compare/e3ec5a4ee58147d21d8b42050c4c7e78f861f21c...3c3f1a7c8faaecf8e3bb9991b998b41052beda50

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
