### PR TITLE
introspectme: init at 0.0.2

### DIFF
--- a/pkgs/by-name/in/introspectme/package.nix
+++ b/pkgs/by-name/in/introspectme/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  zstd,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "introspectme";
+  version = "0.0.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "bountyyfi";
+    repo = "IntrospectMe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PQSfIbcY3vgJhi2OcG6wqFH6xiWcBylJhr1kWdlr0go=";
+  };
+
+  cargoHash = "sha256-UAcIwBrHuU7AbLXoSCwpT7cetioVNboG2rpDMPbnvR8=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    zstd
+  ];
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for introspecting and analyzing GraphQL field suggestion errors";
+    homepage = "https://github.com/bountyyfi/IntrospectMe";
+    changelog = "https://github.com/bountyyfi/IntrospectMe/releases/tag/${finalAttrs.src.tag}";
+    # SOURCE-AVAILABLE LICENSE, Version 0.0.1 - Effective February 15, 2026
+    # https://github.com/bountyyfi/IntrospectMe/blob/main/LICENSE
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "introspectme";
+  };
+})


### PR DESCRIPTION
Tool for introspecting and analyzing GraphQL field suggestion errors

https://github.com/bountyyfi/IntrospectMe

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
