### PR TITLE
[26.05] atomgit-cli: init at 0.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25524,6 +25524,12 @@
     name = "Nikolay Korotkiy";
     keys = [ { fingerprint = "ADF4 C13D 0E36 1240 BD01  9B51 D1DE 6D7F 6936 63A5"; } ];
   };
+  silicalet = {
+    name = "Mr. why";
+    email = "silicalet@outlook.com";
+    github = "silicalet";
+    githubId = 188071249;
+  };
   silky = {
     name = "Noon van der Silk";
     email = "noonsilk+nixpkgs@gmail.com";

--- a/pkgs/by-name/at/atomgit-cli/package.nix
+++ b/pkgs/by-name/at/atomgit-cli/package.nix
@@ -1,10 +1,12 @@
 {
+  _experimental-update-script-combinators,
   lib,
   stdenv,
   buildGoModule,
   fetchgit,
   gitMinimal,
   gitUpdater,
+  nix-update-script,
   makeWrapper,
   versionCheckHook,
   writableTmpDirAsHomeHook,
@@ -15,15 +17,15 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "atomgit-cli";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchgit {
     url = "https://atomgit.com/hust-open-atom-club/atomgit-cli.git";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SyOGkxDgkfQUeaHp6F+FhTLqWYCWvG7RVqVw1wfE1Uw=";
+    hash = "sha256-E1T093LkccgLPPNs5OokxY5tw4HEMmRy+ulaROnuSCE=";
   };
 
-  vendorHash = "sha256-gkVSHoo7BWMy/vSKq2+sgm/TAhC4WYl04OXfG6INrG4=";
+  vendorHash = "sha256-YuAY+CBO+YAMEfrJuUJ/EMnmR9pfRkL+qMhOr1LPKck=";
 
   subPackages = [ "cmd/ag" ];
 
@@ -42,7 +44,10 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    (gitUpdater { rev-prefix = "v"; }).command
+    (nix-update-script { extraArgs = [ "--version=skip" ]; })
+  ];
 
   postFixup = ''
     wrapProgram $out/bin/ag \

--- a/pkgs/by-name/at/atomgit-cli/package.nix
+++ b/pkgs/by-name/at/atomgit-cli/package.nix
@@ -14,12 +14,12 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "atomgit-cli";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchgit {
     url = "https://atomgit.com/hust-open-atom-club/atomgit-cli.git";
-    rev = "11f1ff216053bf47c0a3baaed6698c9222f1ce77";
-    hash = "sha256-ZvQ8S0f1jUfN48UE/U+JnTTrtoWYZfwhDPDBbKKLlC0=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-LBkozdOmNs3SbyUrwgim0pw4v3Irg44hH2lAsRdRpWk=";
   };
 
   vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
@@ -36,7 +36,7 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.Version=v${finalAttrs.version}"
     "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.Commit=${finalAttrs.src.rev}"
-    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.BuildDate=2026-07-13T07:53:45Z"
+    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.BuildDate=2026-07-18T16:40:02Z"
   ];
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/at/atomgit-cli/package.nix
+++ b/pkgs/by-name/at/atomgit-cli/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   fetchgit,
   gitMinimal,
+  gitUpdater,
   makeWrapper,
   versionCheckHook,
   writableTmpDirAsHomeHook,
@@ -14,15 +15,15 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "atomgit-cli";
-  version = "0.6.0";
+  version = "0.7.1";
 
   src = fetchgit {
     url = "https://atomgit.com/hust-open-atom-club/atomgit-cli.git";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LBkozdOmNs3SbyUrwgim0pw4v3Irg44hH2lAsRdRpWk=";
+    hash = "sha256-SyOGkxDgkfQUeaHp6F+FhTLqWYCWvG7RVqVw1wfE1Uw=";
   };
 
-  vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
+  vendorHash = "sha256-gkVSHoo7BWMy/vSKq2+sgm/TAhC4WYl04OXfG6INrG4=";
 
   subPackages = [ "cmd/ag" ];
 
@@ -41,6 +42,8 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
   postFixup = ''
     wrapProgram $out/bin/ag \
       --prefix PATH : ${
@@ -49,6 +52,7 @@ buildGoModule (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [
+    gitMinimal
     versionCheckHook
     writableTmpDirAsHomeHook
   ];

--- a/pkgs/by-name/at/atomgit-cli/package.nix
+++ b/pkgs/by-name/at/atomgit-cli/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchgit,
+  gitMinimal,
+  makeWrapper,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  xdg-utils,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "atomgit-cli";
+  version = "0.5.0";
+
+  src = fetchgit {
+    url = "https://atomgit.com/hust-open-atom-club/atomgit-cli.git";
+    rev = "11f1ff216053bf47c0a3baaed6698c9222f1ce77";
+    hash = "sha256-ZvQ8S0f1jUfN48UE/U+JnTTrtoWYZfwhDPDBbKKLlC0=";
+  };
+
+  vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
+
+  subPackages = [ "cmd/ag" ];
+
+  preCheck = ''
+    # Test all packages, not only cmd/ag.
+    unset subPackages
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.Version=v${finalAttrs.version}"
+    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.Commit=${finalAttrs.src.rev}"
+    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.BuildDate=2026-07-13T07:53:45Z"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/ag \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [ gitMinimal ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ]
+        )
+      }
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Command-line interface for AtomGit";
+    homepage = "https://atomgit.com/hust-open-atom-club/atomgit-cli";
+    changelog = "https://atomgit.com/hust-open-atom-club/atomgit-cli/tags/v${finalAttrs.version}";
+    license = lib.licenses.mulan-psl2;
+    mainProgram = "ag";
+    maintainers = [ lib.maintainers.silicalet ];
+  };
+})

--- a/pkgs/by-name/at/atomgit-cli/package.nix
+++ b/pkgs/by-name/at/atomgit-cli/package.nix
@@ -11,6 +11,8 @@
 }:
 
 buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "atomgit-cli";
   version = "0.5.0";
 
@@ -42,9 +44,7 @@ buildGoModule (finalAttrs: {
   postFixup = ''
     wrapProgram $out/bin/ag \
       --prefix PATH : ${
-        lib.makeBinPath (
-          [ gitMinimal ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ]
-        )
+        lib.makeBinPath ([ gitMinimal ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ])
       }
   '';
 


### PR DESCRIPTION
Backport the complete AtomGit CLI package history to the supported 26.05 release branch, resulting in version 0.7.2.

Backports:

- #542103
- #543404
- #550697
- #554628

All six commits were cherry-picked from `master` with `-x`, in their original order. This is suitable for the release branch because new packages and backwards-compatible package updates are explicitly accepted by the release policy. The resulting diff adds the original maintainer entry and `pkgs/by-name/at/atomgit-cli/package.nix`.

## Automation/AI disclosure

OpenAI Codex (GPT-5) was used to research the backport and automation/AI policies, perform the cherry-picks, draft this pull request description, and run and interpret the checks listed below. The pull request is intentionally submitted as a draft so the responsible human contributor can review the complete contribution before marking it ready.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Additional checks:

- `git diff --check upstream/release-26.05...HEAD`
- `nixfmt --check pkgs/by-name/at/atomgit-cli/package.nix`
- `nix-instantiate --eval -A atomgit-cli.version`
- `nix-build --option substituters https://cache.nixos.org -A atomgit-cli --no-out-link`
- `nixpkgs-review pr 555775 --eval local --no-shell -p atomgit-cli` (1 package built)
- `ag version` reports `v0.7.2`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
