### PR TITLE
vim: 9.2.0782 -> 9.2.0995

### DIFF
--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -4,7 +4,7 @@
   stdenv,
 }:
 rec {
-  version = "9.2.0782";
+  version = "9.2.0995";
 
   outputs = [
     "out"
@@ -15,7 +15,7 @@ rec {
     owner = "vim";
     repo = "vim";
     rev = "v${version}";
-    hash = "sha256-D4IyDgl1JdmumDzO0uMg2LhoSnFUeqhcMJ6ImC17wzs=";
+    hash = "sha256-NkiyjBLpjCdBXkh39npnwV79wDrND8ERtTGMPaCBQd4=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Updates Vim to 9.2.0995, fixing CVE-2026-73070 through CVE-2026-73078.

Upstream changes: https://github.com/vim/vim/compare/v9.2.0782...v9.2.0995

Upstream security advisories: [CVE-2026-73070](https://github.com/vim/vim/security/advisories/GHSA-49m8-wwxj-mr69), [CVE-2026-73071](https://github.com/vim/vim/security/advisories/GHSA-69ch-22ch-r887), [CVE-2026-73072](https://github.com/vim/vim/security/advisories/GHSA-9jqx-hgpr-6v64), [CVE-2026-73073](https://github.com/vim/vim/security/advisories/GHSA-cx73-phcg-3j5g), [CVE-2026-73074](https://github.com/vim/vim/security/advisories/GHSA-hm4g-pjfx-m27j), [CVE-2026-73075](https://github.com/vim/vim/security/advisories/GHSA-pmvp-6rcj-98p4), [CVE-2026-73076](https://github.com/vim/vim/security/advisories/GHSA-r22p-fhw4-84p2), [CVE-2026-73077](https://github.com/vim/vim/security/advisories/GHSA-r5v6-q6j8-8qw2), [CVE-2026-73078](https://github.com/vim/vim/security/advisories/GHSA-rcr7-f3wr-22r2)

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
