### PR TITLE
kubeshark: modernize

### DIFF
--- a/pkgs/by-name/ku/kubeshark/package.nix
+++ b/pkgs/by-name/ku/kubeshark/package.nix
@@ -4,14 +4,15 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  testers,
-  kubeshark,
+  versionCheckHook,
   nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "kubeshark";
   version = "53.4.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "kubeshark";
@@ -28,7 +29,6 @@ buildGoModule (finalAttrs: {
     in
     [
       "-s"
-      "-w"
       "-X ${t}/misc.GitCommitHash=${finalAttrs.src.tag}"
       "-X ${t}/misc.Branch=master"
       "-X ${t}/misc.BuildTimestamp=0"
@@ -37,11 +37,6 @@ buildGoModule (finalAttrs: {
     ];
 
   nativeBuildInputs = [ installShellFiles ];
-
-  checkPhase = ''
-    go test ./...
-  '';
-  doCheck = true;
 
   # Tests bind loopback sockets via httptest.
   __darwinAllowLocalNetworking = true;
@@ -53,14 +48,11 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/kubeshark completion zsh)
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = kubeshark;
-      command = "kubeshark version";
-      inherit (finalAttrs) version;
-    };
-    updateScript = nix-update-script { };
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/kubeshark/kubeshark/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
