### PR TITLE
gpwn-toolkit: init at 0.1.0-unstable-2026-08-20

### DIFF
--- a/pkgs/by-name/gp/gpwn-toolkit/package.nix
+++ b/pkgs/by-name/gp/gpwn-toolkit/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  perl,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gpwn-toolkit";
+  version = "0.1.0-unstable-2026-08-20";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gpwn-org";
+    repo = "gpwn-toolkit";
+    rev = "a5a03958097d54f7e91b9c39393a4bb7d2bc88ba";
+    hash = "sha256-xe8glMrzS7xpx+xQStxJIl5vxvsVvj1cHSx1QWx2sHk=";
+  };
+
+  cargoHash = "sha256-bPBOYLpQ97kzcOJe9jl2lP6lhDcj/HscWquYbhdDNSU=";
+
+  nativeBuildInputs = [ perl ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Collection of libraries and a TUI to test fiber GPON deployments";
+    homepage = "https://github.com/gpwn-org/gpwn-toolkit";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ felbinger ];
+    mainProgram = "gpwn-tui";
+  };
+})


### PR DESCRIPTION
#81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
