### PR TITLE
{banjo,mariokart64,starfox64,zelda64}recomp: fix clobber

### DIFF
--- a/pkgs/by-name/ba/banjorecomp/package.nix
+++ b/pkgs/by-name/ba/banjorecomp/package.nix
@@ -115,11 +115,9 @@ llvmPackages_21.stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     installBin BanjoRecompiled
-    install -Dm644 -t $out/share ../recompcontrollerdb.txt
+    install -Dm644 -t $out/share/banjorecomp ../recompcontrollerdb.txt
     install -Dm644 ../icons/app.png $out/share/icons/hicolor/512x512/apps/BanjoRecompiled.png
-    cp -r ../assets $out/share/
-    ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
-    ln -s $out/share/assets $out/bin/assets
+    cp -r ../assets $out/share/banjorecomp/
 
     install -Dm644 -t $out/share/licenses/banjorecomp ../COPYING
     install -Dm644 -t $out/share/licenses/banjorecomp/N64ModernRuntime ../lib/N64ModernRuntime/COPYING
@@ -134,9 +132,8 @@ llvmPackages_21.stdenv.mkDerivation (finalAttrs: {
      )
   '';
 
-  # The game will segfault when not run from the same directory as the binary.
   postFixup = ''
-    wrapProgram $out/bin/BanjoRecompiled --chdir "$out/bin/"
+    wrapProgram $out/bin/BanjoRecompiled --chdir "$out/share/banjorecomp"
   '';
 
   meta = {

--- a/pkgs/by-name/ma/mariokart64recomp/package.nix
+++ b/pkgs/by-name/ma/mariokart64recomp/package.nix
@@ -115,12 +115,10 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     installBin MarioKart64Recompiled
-    install -Dm644 -t $out/share ../recompcontrollerdb.txt
+    install -Dm644 -t $out/share/mariokart64recomp ../recompcontrollerdb.txt
     install -Dm644 ../icons/512.png $out/share/icons/hicolor/512x512/apps/MarioKart64Recompiled.png
     install -Dm644 ../flatpak/io.github.mariokart64recomp.mariokart64recomp.desktop $out/share/applications/MarioKart64Recompiled.desktop
-    cp -r ../assets $out/share/
-    ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
-    ln -s $out/share/assets $out/bin/assets
+    cp -r ../assets $out/share/mariokart64recomp/
 
     install -Dm644 -t $out/share/licenses/mariokart64recompiled ../COPYING
     install -Dm644 -t $out/share/licenses/mariokart64recompiled/N64ModernRuntime ../lib/N64ModernRuntime/COPYING
@@ -137,9 +135,8 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
      )
   '';
 
-  # The game will segfault when not run from the same directory as the binary.
   postFixup = ''
-    wrapProgram $out/bin/MarioKart64Recompiled --chdir "$out/bin/"
+    wrapProgram $out/bin/MarioKart64Recompiled --chdir "$out/share/mariokart64recomp"
   '';
 
   meta = {

--- a/pkgs/by-name/st/starfox64recomp/package.nix
+++ b/pkgs/by-name/st/starfox64recomp/package.nix
@@ -124,11 +124,9 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     installBin Starfox64Recompiled
-    install -Dm644 -t $out/share ../recompcontrollerdb.txt
+    install -Dm644 -t $out/share/starfox64recomp ../recompcontrollerdb.txt
     install -Dm644 ../icons/512.png $out/share/icons/hicolor/512x512/apps/Starfox64Recompiled.png
-    cp -r ../assets $out/share/
-    ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
-    ln -s $out/share/assets $out/bin/assets
+    cp -r ../assets $out/share/starfox64recomp/
 
     install -Dm644 -t $out/share/licenses/starfox64recompiled/N64ModernRuntime ../lib/N64ModernRuntime/COPYING
     install -Dm644 -t $out/share/licenses/starfox64recompiled/RmlUi ../lib/RmlUi/LICENSE.txt
@@ -144,9 +142,8 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
      )
   '';
 
-  # The game will segfault when not run from the same directory as the binary.
   postFixup = ''
-    wrapProgram $out/bin/Starfox64Recompiled --chdir "$out/bin/"
+    wrapProgram $out/bin/Starfox64Recompiled --chdir "$out/share/starfox64recomp"
   '';
 
   meta = {

--- a/pkgs/by-name/ze/zelda64recomp/package.nix
+++ b/pkgs/by-name/ze/zelda64recomp/package.nix
@@ -115,11 +115,9 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     installBin Zelda64Recompiled
-    install -Dm644 -t $out/share ../recompcontrollerdb.txt
+    install -Dm644 -t $out/share/zelda64recomp ../recompcontrollerdb.txt
     install -Dm644 ../icons/512.png $out/share/icons/hicolor/scalable/apps/zelda64recomp.png
-    cp -r ../assets $out/share/
-    ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
-    ln -s $out/share/assets $out/bin/assets
+    cp -r ../assets $out/share/zelda64recomp/
 
     install -Dm644 -t $out/share/licenses/zelda64recomp ../COPYING
     install -Dm644 -t $out/share/licenses/zelda64recomp/N64ModernRuntime ../lib/N64ModernRuntime/COPYING
@@ -136,12 +134,11 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
      )
   '';
 
-  # This is needed as Zelda64Recompiled will segfault when not run from the same
-  # directory as the binary. It also used to exit when run without X11. Recent rt64
-  # updates enabled wayland support, but leave the option to disable this on the
-  # application level if desired.
+  # This is needed as Zelda64Recompiled used to exit when run without X11.
+  # Recent rt64 updates enabled wayland support, but leave the option to disable
+  # this on the application level if desired.
   postFixup = ''
-    wrapProgram $out/bin/Zelda64Recompiled --chdir "$out/bin/" \
+    wrapProgram $out/bin/Zelda64Recompiled --chdir "$out/share/zelda64recomp" \
         ${lib.optionalString forceX11 "--set SDL_VIDEODRIVER x11"}
   '';
 


### PR DESCRIPTION
- Fixes the clobber when simultaneously adding these packages to the system closure.
- Seems to work fine doing this, so removed the comment about segfaults

Did not thoroughly test everything, but I haven't noticed anything broken.

Before:
<img width="295" height="300" alt="image" src="https://github.com/user-attachments/assets/27c144fd-dd59-4f2f-b49f-775085d82c30" />

After:
<img width="291" height="269" alt="image" src="https://github.com/user-attachments/assets/17aff9d0-dfbf-4f52-8a92-08190732c159" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
