### PR TITLE
terminal-notifier: 2.0.0 -> 3.0.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -157,6 +157,8 @@
 
 - `vimacs` has been removed, as it has not been maintained in 10 years and was built for an old version of vim (6.0).
 
+- `terminal-notifier` was updated to version 3.0.0 which adds native support for Apple silicon. See the "[Differences from version 2](https://github.com/julienXX/terminal-notifier#differences-from-version-2)" for more details.
+
 - The deprecated `appimageTools.extractType1`, `appimageTools.extractType2`, and `appimageTools.wrapType1` aliases now emit warnings. Use `appimageTools.extract` and `appimageTools.wrapType2` instead.
 
 - netbox plugins have been moved from the python3Packages to the netboxPlugins package set.

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -5,17 +5,18 @@
   makeBinaryWrapper,
   stdenv,
   xcbuildHook,
+  rcodesign,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "terminal-notifier";
-  version = "2.0.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "julienXX";
     repo = "terminal-notifier";
     tag = finalAttrs.version;
-    hash = "sha256-Hd9cI3R2nQK2deBb5CBYz4DTHAEcO4vzqtA5qZwa1Ao=";
+    hash = "sha256-FONOQGbJYn2ixuuIv1dbO3SH580eZucI1yh8JFhTgaU=";
   };
 
   __structuredAttrs = true;
@@ -44,6 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
       $out/bin/terminal-notifier
 
     runHook postInstall
+  '';
+
+  # Notifications require that the app bundle be codesigned (beyond the linker-signing that happens automatically for the executable)
+  postFixup = ''
+    ${lib.getExe rcodesign} sign "$out/Applications/terminal-notifier.app"
   '';
 
   meta = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
