### PR TITLE
pdfsam-basic: 5.4.1 -> 6.0.5

### DIFF
--- a/pkgs/by-name/pd/pdfsam-basic/package.nix
+++ b/pkgs/by-name/pd/pdfsam-basic/package.nix
@@ -1,13 +1,18 @@
 {
   lib,
+  stdenv,
+  symlinkJoin,
   maven,
   makeDesktopItem,
   fetchFromGitHub,
-  temurin-jre-bin-21,
-  temurin-bin-21,
+  jdk25,
+  jre25_minimal,
+  openjfx25,
+  xmlstarlet,
   glib,
   libxxf86vm,
   libxtst,
+  libx11,
   gtk3,
   libGL,
 
@@ -18,23 +23,136 @@
 }:
 
 let
-  mavenOurJdk = maven.override {
-    jdk_headless = temurin-jre-bin-21;
+  # The JavaFX modules pdfsam-basic jlinks in, and the plain JDK modules it
+  # adds alongside them (taken from pdfsam-basic/pom.xml's jlink execution).
+  javafxModules = [
+    "javafx.base"
+    "javafx.graphics"
+    "javafx.controls"
+    "javafx.media"
+  ];
+  jdkModules = [
+    "java.base"
+    "java.logging"
+    "java.naming"
+    "java.sql"
+    "java.desktop"
+    "java.xml"
+    "java.management"
+    "jdk.unsupported"
+    "java.prefs"
+    "jdk.localedata"
+  ];
+
+  # Upstream builds their linux-x64 tarball with BellSoft's Liberica
+  # "jdk+fx" distribution, whose jmods directory bundles JavaFX modules.
+  # nixpkgs' openjfx doesn't provide prebuilt jmods (only exploded module
+  # classes without a compiled module-info.class), so we build our own
+  # jmods for the JavaFX modules pdfsam-basic needs, compiling openjfx's
+  # own module-info.java sources against its classes and bundling in the
+  # native libraries and legal notices. Laid out under lib/openjdk/jmods
+  # like jdk25 itself, so it can be merged with it below.
+  javafxJmods = stdenv.mkDerivation {
+    pname = "openjfx-jmods";
+    inherit (openjfx25) version;
+
+    dontUnpack = true;
+    nativeBuildInputs = [ jdk25 ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      mkdir -p $out/lib/openjdk/jmods
+      staging=$TMPDIR/staging
+    ''
+    + lib.pipe javafxModules [
+      (map (mod: ''
+        mkdir -p "$staging/${mod}"
+        cp -r ${openjfx25}/modules/${mod}/. "$staging/${mod}/"
+        javac \
+          --module-path "$staging" \
+          -d "$staging/${mod}" \
+          ${openjfx25}/modules_src/${mod}/module-info.java
+        jmodArgs=(--class-path "$staging/${mod}")
+        if [ -d "${openjfx25}/modules_libs/${mod}" ]; then
+          jmodArgs+=(--libs "${openjfx25}/modules_libs/${mod}")
+        fi
+        if [ -d "${openjfx25}/modules_legal/${mod}" ]; then
+          jmodArgs+=(--legal-notices "${openjfx25}/modules_legal/${mod}")
+        fi
+        jmod create "''${jmodArgs[@]}" "$out/lib/openjdk/jmods/${mod}.jmod"
+      ''))
+      (lib.concatStringsSep "\n")
+    ]
+    + ''
+      runHook postBuild
+    '';
+
+    dontInstall = true;
+  };
+
+  # jdk25 with javafxJmods' jmods merged into the same lib/openjdk/jmods
+  # directory, so it can be dropped straight into jre_minimal's `jdk`
+  # argument below (jre.nix jlinks from `${jdk}/lib/openjdk/jmods` alone).
+  jdk25WithJavafx = symlinkJoin {
+    inherit (jdk25) pname version;
+    paths = [
+      jdk25
+      javafxJmods
+    ];
+  };
+
+  # A minimal JRE, containing exactly the modules pdfsam-basic uses
+  # (JavaFX included), so we don't need a full external JDK/JRE just to
+  # run the app.
+  jre = jre25_minimal.override {
+    jdk = jdk25WithJavafx;
+    modules = jdkModules ++ javafxModules;
   };
 in
-mavenOurJdk.buildMavenPackage rec {
+maven.buildMavenPackage rec {
   pname = "pdfsam-basic";
-  version = "5.4.1";
+  version = "6.0.5";
 
   src = fetchFromGitHub {
     owner = "torakiki";
     repo = "pdfsam";
     rev = "v${version}";
-    hash = "sha256-9IzYnWYE0OD1b4xybl3NdaBvVSw6C4+1ORUnrotqSuc=";
+    hash = "sha256-RbCZ7HQvb2FN5JxsdZvjFeMTt/N2qJE9iK7vGezSuD8=";
   };
 
   mvnParameters = "-Drelease -Dmaven.test.skip";
-  mvnHash = "sha256-Y/wz/XuzDpT7qnk/pRBkv6PeI0GmqKXh54gqb7cWHHw=";
+  mvnHash = "sha256-l8ns++RTK69AV2dq8EFPOzhfzhcgYQlF/OUZ0IZ7QII=";
+
+  # fix for:
+  #
+  #   date 1980-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+  env.SOURCE_DATE_EPOCH = 315532802; # 1980-01-01T00:00:02Z
+  mvnFetchExtraArgs.env = {
+    inherit (env) SOURCE_DATE_EPOCH;
+  };
+
+  # pdfsam-parent's pom.xml only activates the maven-toolchains-plugin (which
+  # would require a toolchains.xml we don't provide) when the JDK running
+  # Maven is older than 25. Running Maven itself with a JDK 25 avoids that,
+  # and is also required since the project now compiles with
+  # `-release 25`. We use nixpkgs' own from-source jdk25 rather than
+  # temurin-bin-25: the latter ships without a jmods directory, and its
+  # jlink relies on a JDK 25 "self-hosting" feature (building a runtime
+  # image directly off the currently running JDK's own linked image)
+  # that SHA-512-checksums resource files like man pages against their
+  # expected path, which fails since nixpkgs relocates them to
+  # $out/share/man instead of $out/man.
+  mvnJdk = jdk25;
+
+  # Point pdfsam-basic's own jlink invocation (which upstream assumes runs
+  # with a JDK that bundles JavaFX as jmods) at the merged jmods dir above.
+  postPatch = ''
+    xmlstarlet ed --inplace -N x=http://maven.apache.org/POM/4.0.0 \
+      -i '//x:argument[text()="--add-modules"]' -t elem -n argument -v '--module-path' \
+      -i '//x:argument[text()="--add-modules"]' -t elem -n argument -v '${jdk25WithJavafx}/lib/openjdk/jmods' \
+      pdfsam-basic/pom.xml
+  '';
 
   buildInputs = [
     glib
@@ -44,7 +162,8 @@ mavenOurJdk.buildMavenPackage rec {
   nativeBuildInputs = [
     # Used as the main java implementation. Also the build relies upon jlink
     # which is included in this package.
-    temurin-bin-21
+    jdk25
+    xmlstarlet
     gettext
     wrapGAppsHook3
     copyDesktopItems
@@ -59,12 +178,13 @@ mavenOurJdk.buildMavenPackage rec {
     mv $out/lib/pdfsam-basic-${version}-linux-x64 $out/lib/pdfsam-basic
     # Based upon upstream's default $out/lib/pdfsam-basic/bin/pdfsam.sh file,
     # but with Nix specific dynamically loaded libraries
-    makeWrapper ${temurin-jre-bin-21}/bin/java $out/bin/pdfsam-basic \
+    makeWrapper ${jre}/bin/java $out/bin/pdfsam-basic \
       "''${gappsWrapperArgs[@]}" \
       --prefix LD_LIBRARY_PATH : "${
         lib.makeLibraryPath [
           libxxf86vm
           libxtst
+          libx11
           gtk3
           libGL
         ]

--- a/pkgs/by-name/pd/pdfsam-basic/package.nix
+++ b/pkgs/by-name/pd/pdfsam-basic/package.nix
@@ -117,7 +117,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "torakiki";
     repo = "pdfsam";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-RbCZ7HQvb2FN5JxsdZvjFeMTt/N2qJE9iK7vGezSuD8=";
   };
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test