### PR TITLE
dbc-parser-cpp: init at 0.5.0

### DIFF
--- a/pkgs/by-name/db/dbc-parser-cpp/0001-fix-pkg-config-file.patch
+++ b/pkgs/by-name/db/dbc-parser-cpp/0001-fix-pkg-config-file.patch
@@ -1,0 +1,12 @@
+--- a/dbc.pc.in
++++ b/dbc.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @PROJECT_NAME@
+ Description: @CPACK_PACKAGE_DESCRIPTION_SUMMARY@

--- a/pkgs/by-name/db/dbc-parser-cpp/0002-fix-testcase-aarch64.patch
+++ b/pkgs/by-name/db/dbc-parser-cpp/0002-fix-testcase-aarch64.patch
@@ -1,0 +1,29 @@
+--- a/test/test_parse_message.cpp
++++ b/test/test_parse_message.cpp
+@@ -50,7 +50,7 @@ TEST_CASE("Parse Message Big Number not aligned little endian") {
+ 		CHECK(refData.size() == 7);
+ 		CHECK(out_values.size() == refData.size());
+ 		for (size_t i = 0; i < refData.size(); i++) {
+-			CHECK(out_values.at(i) == refData.at(i));
++			CHECK(out_values.at(i) == Catch::Approx(refData.at(i)).margin(1e-9));
+ 		}
+ 	}
+ 
+@@ -61,7 +61,7 @@ TEST_CASE("Parse Message Big Number not aligned little endian") {
+ 		CHECK(refData.size() == 7);
+ 		CHECK(out_values.size() == refData.size());
+ 		for (size_t i = 0; i < refData.size(); i++) {
+-			CHECK(out_values.at(i) == refData.at(i));
++			CHECK(out_values.at(i) == Catch::Approx(refData.at(i)).margin(1e-9));
+ 		}
+ 	}
+ 
+@@ -72,7 +72,7 @@ TEST_CASE("Parse Message Big Number not aligned little endian") {
+ 		CHECK(refData.size() == 7);
+ 		CHECK(out_values.size() == refData.size());
+ 		for (size_t i = 0; i < refData.size(); i++) {
+-			CHECK(out_values.at(i) == refData.at(i));
++			CHECK(out_values.at(i) == Catch::Approx(refData.at(i)).margin(1e-9));
+ 		}
+ 	}
+ }

--- a/pkgs/by-name/db/dbc-parser-cpp/package.nix
+++ b/pkgs/by-name/db/dbc-parser-cpp/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  fast-float,
+  catch2_3,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dbc-parser-cpp";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "LinuxDevon";
+    repo = "dbc_parser_cpp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oyC7NihrlYvoR3CH07FeZcXfQ1JH2Ymsb7ocgim4dZ8=";
+  };
+
+  patches = [
+    # Submitted upstream:  https://github.com/LinuxDevon/dbc_parser_cpp/pull/37
+    # Remove when upstream merges the PR
+    ./0001-fix-pkg-config-file.patch
+  ]
+  # Submitted upstream: https://github.com/LinuxDevon/dbc_parser_cpp/pull/36
+  # Remove when upstream merges the PR
+  ++ lib.optional stdenv.hostPlatform.isAarch64 ./0002-fix-testcase-aarch64.patch;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    fast-float
+  ];
+
+  checkInputs = [
+    catch2_3
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "DBC_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    # Cmake test file doesn't check for system installed Catch2 and directly uses FetchContent to download Catch2
+    (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
+  ];
+
+  doCheck = true;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "DBC file parsing library written in C++";
+    homepage = "https://github.com/LinuxDevon/dbc_parser_cpp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      AhmedAmr
+    ];
+    teams = with lib.teams; [ ngi ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the dbc-parser-cpp library (A DBC file parsing library written in C++).
this is used in combination with `vector-blf` to add blf log file support to Labplot

This package is a dependency of KDE Labplot and is being packaged as part of the work to bring Labplot into nixpkgs / NGI Forge.

Homepage: https://github.com/LinuxDevon/dbc_parser_cpp

This work is done as part of Summer of Nix 2026.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
