### PR TITLE
zvm: modernize, bump

### DIFF
--- a/pkgs/by-name/zv/zvm/package.nix
+++ b/pkgs/by-name/zv/zvm/package.nix
@@ -10,6 +10,8 @@ buildGoModule (finalAttrs: {
   pname = "zvm";
   version = "0.8.27";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "tristanisham";
     repo = "zvm";
@@ -23,6 +25,10 @@ buildGoModule (finalAttrs: {
     substituteInPlace cli/meta/version.go \
       --replace-fail 'VERSION = "v0.8.25"' 'VERSION = "v${finalAttrs.version}"'
   '';
+
+  ldflags = [
+    "-s"
+  ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/zv/zvm/package.nix
+++ b/pkgs/by-name/zv/zvm/package.nix
@@ -2,36 +2,51 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  installShellFiles,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
   nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "zvm";
-  version = "0.8.27";
+  version = "0.9.1";
 
   __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "tristanisham";
     repo = "zvm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NDkvTghdqabfzzXSyxYHZj67u+upY0WfLOAO5DWAZ3s=";
+    hash = "sha256-J6LDlXkTAdHvtQZimVJ3EPgAzSCvSnVSy+eZe3OwhPg=";
   };
 
-  vendorHash = "sha256-kJrCUxzbpyxEUF9UQeAI28tWKA+T7zT1DBI1wf3pjjM=";
-
-  postPatch = ''
-    substituteInPlace cli/meta/version.go \
-      --replace-fail 'VERSION = "v0.8.25"' 'VERSION = "v${finalAttrs.version}"'
-  '';
+  vendorHash = "sha256-ouRaZ/mrB84e0T2aGJwYPsLoB3a1/kk7WS5rlKBfImU=";
 
   ldflags = [
     "-s"
+    "-X 'main.BuildUpgradeMessage=This package is maintained in Nixpkgs'"
   ];
 
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    installManPage man/*.1
+  '';
+
   doInstallCheck = true;
-  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
- **zvm: modernize**
- **zvm: 0.8.27 -> 0.9.1**
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
