### PR TITLE
fasd: reinit at 2.0.0

### DIFF
--- a/pkgs/by-name/fa/fasd/package.nix
+++ b/pkgs/by-name/fa/fasd/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "fasd";
+  version = "unstable-2016-08-11";
+
+  src = fetchFromGitHub {
+    owner = "clvv";
+    repo = "fasd";
+    rev = "90b531a5daaa545c74c7d98974b54cbdb92659fc";
+    sha256 = "0i22qmhq3indpvwbxz7c472rdyp8grag55x7iyjz8gmyn8gxjc11";
+  };
+
+  installPhase = ''
+    PREFIX=$out make install
+  '';
+
+  meta = {
+    homepage = "https://github.com/clvv/fasd";
+    description = "Quick command-line access to files and directories for POSIX shells";
+    license = lib.licenses.mit;
+
+    longDescription = ''
+      Fasd is a command-line productivity booster.
+      Fasd offers quick access to files and directories for POSIX shells. It is
+      inspired by tools like autojump, z and v. Fasd keeps track of files and
+      directories you have accessed, so that you can quickly reference them in the
+      command line.
+    '';
+
+    platforms = lib.platforms.all;
+    maintainers = [ ];
+    mainProgram = "fasd";
+  };
+}

--- a/pkgs/by-name/fa/fasd/package.nix
+++ b/pkgs/by-name/fa/fasd/package.nix
@@ -4,23 +4,24 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fasd";
-  version = "unstable-2016-08-11";
+  version = "2.0.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "clvv";
+    owner = "whjvenyl";
     repo = "fasd";
-    rev = "90b531a5daaa545c74c7d98974b54cbdb92659fc";
-    sha256 = "0i22qmhq3indpvwbxz7c472rdyp8grag55x7iyjz8gmyn8gxjc11";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XLlS+EsjTCI5oTdHuIwiNEXiEgaO6lLgA25bm55sve0=";
   };
 
-  installPhase = ''
-    PREFIX=$out make install
-  '';
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = {
-    homepage = "https://github.com/clvv/fasd";
+    homepage = "https://github.com/whjvenyl/fasd";
     description = "Quick command-line access to files and directories for POSIX shells";
     license = lib.licenses.mit;
 
@@ -33,7 +34,7 @@ stdenv.mkDerivation {
     '';
 
     platforms = lib.platforms.all;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ bcc32 ];
     mainProgram = "fasd";
   };
-}
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -796,7 +796,6 @@ mapAliases {
   fabs = throw "'fabs' has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
   falcon = throw "'falcon' has been removed as it is unmaintained and depends on pcre, which is deprecated"; # Added 2026-06-16
   fancontrol-gui = throw "'fancontrol-gui' has been removed due to outdated KF5 dependencies"; # Added 2026-05-01
-  fasd = throw "'fasd' has been removed because it was archived upstream"; # Added 2026-08-15
   fast-cli = throw "'fast-cli' has been removed because it was unmaintainable in nixpkgs"; # Added 2025-11-17
   fastfetchMinimal = warnAlias "'fastfetchMinimal' has been renamed to 'fastfetch-unwrapped'" fastfetch-unwrapped; # Added 2026-05-18
   fastJson = warnAlias "'fastJson' has been renamed to 'libfastjson'" libfastjson; # Added 2026-02-08


### PR DESCRIPTION
#553114 dropped fasd because its repo was archived.

This PR restores the package and switches to an actively maintained
fork.  It also updates the package to a newer version than before.

## Changes

Primarily, some config variables were added and some defaults changed.

- The default fasd data file now respects the XDG Base Directory
  specification, and lives at `$XDG_CACHE_HOME/fasd` or
  `$HOME/.cache/fasd` if `$XDG_CACHE_HOME` is not set.  It previously
  lived at `$HOME/.fasd`.  There is no automatic migration.

- The default fasd config file also moved from `$HOME/.fasdrc` to
  `$XDG_CONFIG_HOME/fasd/config` (plus fallbacks).  The old rc file is
  still read as a final fallback.

Two new config variables:

- `$_FASD_RESOLVE_SYMLINKS`: Set this option to 1 if you want fasd to
  resolve symbolic links. This is useful to prevent duplicates in the
  entry list. Defaults to 0.

- `$_FASD_NOCASE`: If set to any non-empty string, fasd will ignore
  case when matching.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test