### PR TITLE
usbguard-tui: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2024,6 +2024,11 @@
     githubId = 29845794;
     name = "Duncan Russell";
   };
+  anotherhadi = {
+    github = "anotherhadi";
+    githubId = 112569860;
+    name = "Hadi";
+  };
   anpin = {
     email = "pavel@anpin.fyi";
     github = "anpin";

--- a/pkgs/by-name/us/usbguard-tui/package.nix
+++ b/pkgs/by-name/us/usbguard-tui/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "usbguard-tui";
+  version = "1.3.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "anotherhadi";
+    repo = "usbguard-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z72ZQ1jYFK9itc93fBVQUQJbx2Iw4K1l1k3GCbUO8AU=";
+  };
+
+  vendorHash = "sha256-O9DG0pxRKt8VwpZdyvoQ4wsfEbsh5npmwocmtcm2IfA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Terminal UI for managing USB devices via usbguard, with keybindings & mouse support";
+    homepage = "https://github.com/anotherhadi/usbguard-tui";
+    changelog = "https://github.com/anotherhadi/usbguard-tui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anotherhadi ];
+    mainProgram = "usbguard-tui";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds usbguard-tui, a TUI for managing USB devices via usbguard.
I'm the upstream author: https://github.com/anotherhadi/usbguard-tui

Assisted-by: Claude Code: package.nix drafted with AI assistance, reviewed and build-tested locally by me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
