### PR TITLE
desync: 1.0.4 -> 1.1.0

### DIFF
--- a/pkgs/by-name/de/desync/package.nix
+++ b/pkgs/by-name/de/desync/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "desync";
-  version = "1.0.4";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "folbricht";
     repo = "desync";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/ojucBo+UOr5WFahVMSz7xJ84dzenwuotZk+5QqODls=";
+    hash = "sha256-ViwNE+8fmYbAMPFd8yiWXDLbaenkgri9PBe92M0Se5U=";
   };
 
-  vendorHash = "sha256-PU2EbYei6X/fmA/POaFI6flAZYb2WcBA10E9+rS651U=";
+  vendorHash = "sha256-dAFci7GXe1fPPABIG1dngEyGqC5TKa90fyQPYSbJJrk=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -41,6 +41,8 @@ buildGoModule (finalAttrs: {
         "TestUnTarDirMTime" # xattr.list: operation not supported
         "TestUnTarIntoReadOnlyDir" # xattr.list: operation not supported
         "TestUnTarNoSamePermissionsOverReadOnlyTree" # xattr.list: operation not supported
+        "TestUnTarReadOnlyDir" # xattr.list: operation not supported
+        "TestUnTarReadOnlyDirNoSamePermissions" # xattr.list: operation not supported
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         "TestS3StoreGetChunk/fail" # sendfile is not permitted in Darwin sandbox


### PR DESCRIPTION
* https://github.com/folbricht/desync/releases/tag/v1.1.0
* Disabled tests failed in https://nixpkgs-update-logs.nix-community.org/desync/2026-08-23.log
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
