### PR TITLE
silverbullet: 2.9.0 -> 2.10.0

### DIFF
--- a/nixos/modules/services/web-apps/silverbullet.nix
+++ b/nixos/modules/services/web-apps/silverbullet.nix
@@ -83,7 +83,7 @@ in
       extraArgs = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         default = [ ];
-        example = [ "--db /path/to/silverbullet.db" ];
+        example = [ "--single" ];
         description = "Extra arguments passed to silverbullet.";
       };
     };

--- a/nixos/tests/silverbullet.nix
+++ b/nixos/tests/silverbullet.nix
@@ -46,8 +46,8 @@
       SPACEDIR = "${nodes.configured.services.silverbullet.spaceDir}"
       configured.wait_for_unit("silverbullet.service")
       configured.wait_for_open_port(PORT)
-      assert int(configured.succeed(f"curl --max-time 5 -s -o /dev/null -w '%{{http_code}}' -XPUT -d 'test' --fail http://{ADDRESS}:{PORT}/test.md -H'Authorization: Bearer test'")) == 200
-      assert int(configured.fail(f"curl --max-time 5 -s -o /dev/null -w '%{{http_code}}' -XPUT -d 'test' --fail http://{ADDRESS}:{PORT}/test.md -H'Authorization: Bearer wrong'")) == 401
+      assert int(configured.succeed(f"curl --max-time 5 -s -o /dev/null -w '%{{http_code}}' -XPUT -d 'test' --fail http://{ADDRESS}:{PORT}/.fs/test.md -H'Authorization: Bearer test'")) == 200
+      assert int(configured.fail(f"curl --max-time 5 -s -o /dev/null -w '%{{http_code}}' -XPUT -d 'test' --fail http://{ADDRESS}:{PORT}/.fs/test.md -H'Authorization: Bearer wrong'")) == 401
       configured.succeed(f"test -d '{SPACEDIR}'")
     '';
 }

--- a/pkgs/by-name/si/silverbullet/override-version.patch
+++ b/pkgs/by-name/si/silverbullet/override-version.patch
@@ -1,15 +1,17 @@
-diff --git a/build/build_plugs.ts b/build/build_plugs.ts
-index e72beaaa..e0660eef 100644
---- a/build/build_plugs.ts
-+++ b/build/build_plugs.ts
-@@ -42,41 +42,15 @@ export async function buildPlugsAndLibraries(options?: {
-
+diff --git a/build/version.ts b/build/version.ts
+index 0b1a2159..1234abcd 100644
+--- a/build/version.ts
++++ b/build/version.ts
+@@ -31,51 +31,15 @@
+  */
  export function updateVersionFile(): Promise<void> {
    return new Promise<void>((resolve, reject) => {
 -    const gitProcess = spawn("git", ["describe", "--tags", "--long"], {
 -      stdio: ["ignore", "pipe", "pipe"],
 -    });
--
++    const versionFilePath = "./version.json";
++    const versionContent = `${JSON.stringify({ version: "@version@" })}\n`;
+ 
 -    let stdout = "";
 -
 -    gitProcess.stdout?.on("data", (data) => {
@@ -24,16 +26,26 @@ index e72beaaa..e0660eef 100644
 -        commitVersion = `${version}-${process.env.GITHUB_SHA || "unknown"}`;
 -      }
 -
--      const versionFilePath = "./public_version.ts";
--      // Write version to file with date in YYYY-MM-DDTHH-MM-SSZ format attached to the version
--      const versionContent = `export const publicVersion = "${commitVersion}-${new Date()
+-      // Keep the existing string when it was minted for this same commit, so
+-      // repeated builds stay byte-identical (see the note above).
+-      if (isForCommit(await readVersionFile(), commitVersion)) {
+-        resolve();
+-        return;
+-      }
+-
+-      // Attach the build date in YYYY-MM-DDTHH-MM-SSZ format to the version.
+-      const publicVersion = `${commitVersion}-${new Date()
 -        .toISOString()
 -        .split(".")[0]
 -        .replaceAll(":", "-")
--        .concat("Z")}";`;
+-        .concat("Z")}`;
 -
 -      try {
--        await writeFile(versionFilePath, versionContent, "utf-8");
+-        await writeFile(
+-          "./version.json",
+-          `${JSON.stringify({ version: publicVersion })}\n`,
+-          "utf-8",
+-        );
 -        resolve();
 -      } catch (err) {
 -        reject(err);
@@ -41,9 +53,6 @@ index e72beaaa..e0660eef 100644
 -    });
 -
 -    gitProcess.on("error", reject);
-+    const versionFilePath = "./public_version.ts";
-+    const versionContent = `export const publicVersion = "@version@";`;
-+
 +    try {
 +      writeFile(versionFilePath, versionContent, "utf-8");
 +      resolve();
@@ -52,4 +61,4 @@ index e72beaaa..e0660eef 100644
 +    }
    });
  }
-
+ 

--- a/pkgs/by-name/si/silverbullet/package.nix
+++ b/pkgs/by-name/si/silverbullet/package.nix
@@ -2,44 +2,45 @@
   lib,
   fetchFromGitHub,
   buildNpmPackage,
-  buildGoModule,
+  rustPlatform,
   replaceVars,
+  versionCheckHook,
 }:
 
-buildGoModule (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "silverbullet";
-  version = "2.9.0";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "silverbulletmd";
     repo = "silverbullet";
     rev = finalAttrs.version;
-    hash = "sha256-XQ0OKkiQrrmwmdGXk3dcim/2qosenF3EG2lkglQQ/iY=";
+    hash = "sha256-tcn0NrABLnX22OWJ3PzYJ5xbTLyNH5p6JtJ6CujkpQQ=";
   };
 
-  vendorHash = "sha256-8zZlhVptJq8y3k2DBghJ0lPNcIcaZYkrxN67b6dNBPs=";
+  cargoHash = "sha256-M/bX9oj76kmXGkCzvBJZMeI7/4UJ+yvz84KrysyPOLA=";
 
-  subPackages = [ "." ];
+  cargoBuildFlags = [
+    "-p"
+    "silverbullet"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   frontend = buildNpmPackage {
     pname = "silverbullet-frontend";
     inherit (finalAttrs) version src;
 
-    npmDepsHash = "sha256-Twcv3I3scF09onJQdYsc1zOFzMFPOEyPF7VPYa7LBko=";
+    npmDepsHash = "sha256-We3K4jZGcC5Q1WBgEOKDKhn8M83srNLP3C36WCOX5Qs=";
 
     patches = [
-      (replaceVars ./override-public-version.patch { inherit (finalAttrs) version; })
+      (replaceVars ./override-version.patch { inherit (finalAttrs) version; })
     ];
-
-    postBuild = ''
-      npm run build:plug-compile
-    '';
 
     installPhase = ''
       runHook preInstall
 
       mkdir -p $out
-      cp -r client_bundle public_version.ts $out/
+      cp -r client_bundle version.json $out/
 
       runHook postInstall
     '';
@@ -47,21 +48,17 @@ buildGoModule (finalAttrs: {
 
   preBuild = ''
     cp -r ${finalAttrs.frontend}/client_bundle .
-    cp ${finalAttrs.frontend}/public_version.ts .
+    cp ${finalAttrs.frontend}/version.json .
   '';
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 "$GOPATH/bin/silverbullet" $out/bin/silverbullet
-
-    runHook postInstall
-  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
 
   passthru.updateScript = ./update.sh;
 
   meta = {
-    changelog = "https://github.com/silverbulletmd/silverbullet/blob/${finalAttrs.version}/website/CHANGELOG.md";
+    changelog = "https://github.com/silverbulletmd/silverbullet/blob/${finalAttrs.version}/docs/CHANGELOG.md";
     description = "Open-source, self-hosted, offline-capable Personal Knowledge Management (PKM) web application";
     homepage = "https://silverbullet.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/si/silverbullet/update.sh
+++ b/pkgs/by-name/si/silverbullet/update.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 
 nix-update silverbullet --src-only --override-filename
 update-source-version silverbullet --source-key=frontend.npmDeps --ignore-same-version
-update-source-version silverbullet --source-key=goModules --ignore-same-version
+update-source-version silverbullet --source-key=cargoDeps.vendorStaging --ignore-same-version


### PR DESCRIPTION
https://github.com/silverbulletmd/silverbullet/blob/2.10.0/docs/CHANGELOG.md
Upstream migrated from go to rust.
This instroduces the concept of multi instances but when migrating from an old version it will auto-detect if the silverbullet "space" is not empty and run in single mode automatically.

This follows up after #550873 was closed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
