### PR TITLE
deja-vu: init at 0.18.0

### DIFF
--- a/pkgs/by-name/de/deja-vu/package.nix
+++ b/pkgs/by-name/de/deja-vu/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  stdenv,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "deja-vu";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "vshulcz";
+    repo = "deja-vu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-h6YSQdbs5t49CeYbuI7QKtbrbVzYVZwtQDmN39bnINo=";
+  };
+
+  # No third-party dependencies: the module has no go.sum.
+  vendorHash = null;
+
+  subPackages = [ "cmd/deja" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd deja \
+      --bash <($out/bin/deja completion bash) \
+      --fish <($out/bin/deja completion fish) \
+      --zsh <($out/bin/deja completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local searchable memory over the session histories coding agents already write";
+    longDescription = ''
+      deja indexes the session transcripts that coding agents write to disk —
+      Claude Code, Codex, Cursor, opencode, Zed and others — including sessions
+      from before it was installed, and searches them from the command line or
+      through an MCP server the agents can call.
+
+      Indexing and search are local: BM25 over the transcripts, no model and no
+      embeddings, and credentials are redacted as the index is built.
+    '';
+    homepage = "https://github.com/vshulcz/deja-vu";
+    changelog = "https://github.com/vshulcz/deja-vu/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "deja";
+  };
+})


### PR DESCRIPTION
deja indexes the session transcripts coding agents write to disk — Claude Code, Codex, Cursor, opencode, Zed and others, including sessions from before it was installed — and searches them from the command line or through an MCP server the agents can call. BM25 over local files, no model and no embeddings, credentials redacted as the index is built.

Homepage: https://github.com/vshulcz/deja-vu

Notes for review:

- The module has no third-party dependencies, so `vendorHash = null`.
- The source hash was produced by serialising the tag's tree to a NAR and taking its SHA-256, since I have no nix on this machine. The method was validated first by reproducing the hash nixpkgs already states for `gocryptfs` 2.6.1 from its own tag, so it should match what ofborg computes. If it does not, say so and I will fix it rather than guess again.
- `maintainers` is empty deliberately; happy to add an entry if the upstream author wants to be listed.
