### PR TITLE
llama-cpp: 10408 -> 0.2.0

### DIFF
--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -4,7 +4,6 @@
   cmake,
   fetchFromGitHub,
   installShellFiles,
-  nix-update-script,
   stdenv,
 
   config,
@@ -46,6 +45,8 @@
 }:
 
 let
+  buildNumber = "10566";
+
   # It's necessary to consistently use backendStdenv when building with CUDA support,
   # otherwise we get libstdc++ errors downstream.
   # cuda imposes an upper bound on the gcc version
@@ -80,7 +81,7 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp";
-  version = "10408";
+  version = "0.2.0";
 
   outputs = [
     "out"
@@ -90,8 +91,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ggml-org";
     repo = "llama.cpp";
-    tag = "b${finalAttrs.version}";
-    hash = "sha256-b01kyCjcrAJ4zFPNRM2GU/9TR5y1mi7WIJDNYrhSJZo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6cK5BMCCEUWL+590+WbrRInH3eEnsZ/S5m71IIBgDsA=";
     leaveDotGit = true;
     postFetch = ''
       git -C "$out" rev-parse --short HEAD > $out/COMMIT
@@ -137,7 +138,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     prependToVar cmakeFlags "-DLLAMA_BUILD_COMMIT:STRING=$(cat COMMIT)"
     pushd ${finalAttrs.npmRoot}
-    LLAMA_BUILD_NUMBER=${finalAttrs.version} npm run build
+    LLAMA_BUILD_NUMBER=${buildNumber} npm run build
     popd
   '';
 
@@ -146,6 +147,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "LLAMA_BUILD_EXAMPLES" false)
     (cmakeBool "LLAMA_BUILD_SERVER" true)
     (cmakeBool "LLAMA_BUILD_TESTS" (finalAttrs.finalPackage.doCheck or false))
+    (cmakeBool "LLAMA_BUILD_IS_DEV" false)
     (cmakeBool "LLAMA_OPENSSL" true)
     (cmakeBool "BUILD_SHARED_LIBS" true)
     (cmakeBool "GGML_BLAS" blasSupport)
@@ -155,7 +157,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "GGML_METAL" metalSupport)
     (cmakeBool "GGML_RPC" rpcSupport)
     (cmakeBool "GGML_VULKAN" vulkanSupport)
-    (cmakeFeature "LLAMA_BUILD_NUMBER" finalAttrs.version)
+    (cmakeFeature "LLAMA_BUILD_NUMBER" buildNumber)
   ]
   ++ optionals cpuArchDynamicDispatch [
     # Build all CPU backend variants for runtime dynamic dispatch.
@@ -196,13 +198,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   doCheck = false;
 
   passthru = {
-    updateScript = nix-update-script {
-      attrPath = "llama-cpp";
-      extraArgs = [
-        "--version-regex"
-        "b(.*)"
-      ];
-    };
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/ll/llama-cpp/update.sh
+++ b/pkgs/by-name/ll/llama-cpp/update.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils gitMinimal gnused nix-update
+# shellcheck shell=bash
+
+set -euo pipefail
+
+repo_url="https://github.com/ggml-org/llama.cpp.git"
+
+version="$({
+  git ls-remote --refs --tags "$repo_url" 'refs/tags/v*' \
+    | sed -nE 's|^[^[:space:]]+[[:space:]]+refs/tags/v([0-9]+\.[0-9]+\.[0-9]+)$|\1|p' \
+    | sort -V \
+    | tail -n1
+})"
+
+if [[ -z "$version" ]]; then
+  echo "Failed to find the latest semantic version tag" >&2
+  exit 1
+fi
+
+tag_refs="$(
+  git ls-remote --tags "$repo_url" \
+    "refs/tags/v$version" "refs/tags/v$version^{}" 'refs/tags/b*'
+)"
+release_commit="$(
+  awk -v ref="refs/tags/v$version^{}" '$2 == ref { print $1 }' <<<"$tag_refs"
+)"
+if [[ -z "$release_commit" ]]; then
+  release_commit="$(
+    awk -v ref="refs/tags/v$version" '$2 == ref { print $1 }' <<<"$tag_refs"
+  )"
+fi
+build_number="$({
+  awk -v commit="$release_commit" '
+    $1 == commit && $2 ~ /^refs\/tags\/b[0-9]+(\^\{\})?$/ {
+      sub(/^refs\/tags\/b/, "", $2)
+      sub(/\^\{\}$/, "", $2)
+      print $2
+    }
+  ' <<<"$tag_refs" | sort -n | tail -n1
+})"
+
+if [[ -z "$release_commit" || -z "$build_number" ]]; then
+  echo "Failed to find the build number for v$version" >&2
+  exit 1
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+nix-update "${UPDATE_NIX_ATTR_PATH:-llama-cpp}" --version "$version"
+sed -i -E \
+  's|(buildNumber = ")[0-9]+(";)|\1'"$build_number"'\2|' \
+  pkgs/by-name/ll/llama-cpp/package.nix


### PR DESCRIPTION
Switch to the new semantic version release scheme that is recommended by
upstream for downstream distributions.

We still have to embed the build number (bXXXX) that corresponds the
semantic version because llama.cpp exposes it in a few places in API
(e.g. llama_build_number) and webui. This unfortunately complicates the
update script a bit because we have to calculate the bXXXX version.

Note: The update script also has to extract git tags directly instead of
nix-update because the latter returns only a few top "releases", which
are overwhelmed by per-commit bXXXX "releases" - so it fails to find a
matching version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
