### PR TITLE
skyscraper: fix build with enableXdg = true

### DIFF
--- a/pkgs/by-name/sk/skyscraper/package.nix
+++ b/pkgs/by-name/sk/skyscraper/package.nix
@@ -40,9 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  postPatch = lib.optionalString enableXdg ''
-    substituteInPlace skyscraper.pro --replace-fail "#DEFINES+=XDG" "DEFINES+=XDG"
-  '';
+  # skyscraper.pro carries the define as a commented-out line, so it is set on
+  # the qmake command line rather than by uncommenting: upstream respaced that
+  # comment in 3.20.3, which silently broke the substitution this used to do.
+  qmakeFlags = lib.optional enableXdg "DEFINES+=XDG";
 
   postInstall = ''
     installShellCompletion --cmd Skyscraper \


### PR DESCRIPTION
`skyscraper.pro` carries the XDG define as a commented-out line, and the package uncommented it with an exact `--replace-fail` on `"#DEFINES+=XDG"`. Upstream respaced that comment to `#DEFINES += XDG` in 3.20.3, so since then every `enableXdg = true` build has failed in `patchPhase`:

```
substituteStream() in derivation skyscraper-3.20.4:
ERROR: pattern \#DEFINES+=XDG doesn't match anything in file 'skyscraper.pro'
```

`enableXdg` defaults to `false`, so no CI job builds that path and the breakage went unnoticed through two releases.

This sets the define on the qmake command line instead of editing the comment, so the package no longer depends on how upstream formats that line.

Verified both ways on x86_64-linux:

- `skyscraper.override { enableXdg = true; }` builds, and the banner from `Skyscraper --version` shows the `(XDG)` marker that `src/strtools.cpp` emits under `#ifdef XDG`.
- The default build still builds and shows no marker.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

---

**Automation disclosure.** The commit and this pull request summary were produced with Claude Code (Claude Opus 5); the commit carries an `Assisted-by:` trailer accordingly.

I also have to disclose a policy violation on my side: this PR was originally opened by that tool on my behalf **before I had reviewed it**, which does not meet the Accountability requirement, and its first revision used a fabricated version of the PR template and falsely ticked the `nixpkgs-review` box. I have since reviewed the diff and the reasoning myself and stand behind them, and this description has been corrected to the real template with accurate checkboxes. Apologies for the noise — if maintainers would rather this be resubmitted cleanly, or closed, I am happy to do either.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
