### PR TITLE
python3Packages: fix makeWrapperArgs

### DIFF
--- a/pkgs/development/python-modules/dnf-plugins-core/default.nix
+++ b/pkgs/development/python-modules/dnf-plugins-core/default.nix
@@ -117,7 +117,10 @@ buildPythonPackage rec {
     done
   '';
 
-  makeWrapperArgs = [ ''--add-flags "--setopt=pluginpath=$out/${python.sitePackages}/dnf-plugins"'' ];
+  makeWrapperArgs = [
+    "--add-flags"
+    "--setopt=pluginpath=$out/${python.sitePackages}/dnf-plugins"
+  ];
 
   meta = {
     description = "Core plugins to use with DNF package manager";

--- a/pkgs/development/python-modules/gprof2dot/default.nix
+++ b/pkgs/development/python-modules/gprof2dot/default.nix
@@ -18,7 +18,12 @@ buildPythonPackage rec {
     hash = "sha256-kX/DCXO/qwm1iF44gG7aBSUpG4Vf2Aer0zwrtq4YNHo=";
   };
 
-  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ graphviz ]}" ];
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ graphviz ])
+  ];
 
   # Needed so dot is on path of the test script
   nativeCheckInputs = [ graphviz ];

--- a/pkgs/development/python-modules/luigi/default.nix
+++ b/pkgs/development/python-modules/luigi/default.nix
@@ -46,8 +46,8 @@ buildPythonPackage (finalAttrs: {
   makeWrapperArgs = [
     "--prefix"
     "PYTHONPATH"
-    "."
     ":"
+    "."
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pynitrokey/default.nix
+++ b/pkgs/development/python-modules/pynitrokey/default.nix
@@ -71,7 +71,8 @@ buildPythonPackage {
   # It is only usable from the wrapped bin/nitropy
   makeWrapperArgs = [
     "--set"
-    "LIBNK_PATH ${lib.makeLibraryPath [ libnitrokey ]}"
+    "LIBNK_PATH"
+    (lib.makeLibraryPath [ libnitrokey ])
   ];
 
   pythonImportsCheck = [ "pynitrokey" ];

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -125,7 +125,11 @@ buildPythonPackage (finalAttrs: {
   '';
 
   # Set env variable explicitly for Darwin, but allow overriding when invoking directly
-  makeWrapperArgs = [ "--set-default FONTCONFIG_FILE ${finalAttrs.env.FONTCONFIG_FILE}" ];
+  makeWrapperArgs = [
+    "--set-default"
+    "FONTCONFIG_FILE"
+    finalAttrs.env.FONTCONFIG_FILE
+  ];
 
   pythonImportsCheck = [ "weasyprint" ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
