### PR TITLE
Add argotlunar

### DIFF
--- a/pkgs/by-name/ar/argotlunar/package.nix
+++ b/pkgs/by-name/ar/argotlunar/package.nix
@@ -13,6 +13,8 @@
 }:
 
 stdenv.mkDerivation {
+  __structuredAttrs = true;
+
   pname = "argotlunar";
   version = "unstable-2026-08-16";
 
@@ -21,7 +23,7 @@ stdenv.mkDerivation {
     repo = "argotlunar";
     rev = "2440c12f02826bd6e563f7287a232997bc1f0313";
     hash = "sha256-pyZV7fzwISAWZzs5A3L2nDJBjoDi1WXongRFCs9F4hg=";
-   };
+  };
 
   strictDeps = true;
 
@@ -54,7 +56,7 @@ stdenv.mkDerivation {
     install -Dm755 build/*.so -t "$out/lib/vst"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Argotlunar VST granulizer with modern fixes";
     homepage = "https://github.com/mourednik/argotlunar";
     license = lib.licenses.gpl2;

--- a/pkgs/by-name/ar/argotlunar/package.nix
+++ b/pkgs/by-name/ar/argotlunar/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  alsa-lib,
+  freetype,
+  libxcomposite,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrender,
+  vst2-sdk,
+}:
+
+stdenv.mkDerivation {
+  pname = "argotlunar";
+  version = "unstable-2026-08-16";
+
+  src = fetchFromGitHub {
+    owner = "smootswag";
+    repo = "argotlunar";
+    rev = "2440c12f02826bd6e563f7287a232997bc1f0313";
+    hash = "sha256-pyZV7fzwISAWZzs5A3L2nDJBjoDi1WXongRFCs9F4hg=";
+   };
+
+  strictDeps = true;
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    libxcomposite
+    libxcursor
+    libxext
+    libxinerama
+    libxrender
+    vst2-sdk
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-fno-strict-aliasing"
+    "-Wno-error=packed"
+    "-I${vst2-sdk}"
+    "-DJUCE_USE_VSTSDK_2_4=1"
+    "-DJUCE_FORCE_USE_LEGACY_COMPATIBILITY=1"
+    "-DJUCE_PLUGINHOST_VST=1"
+    "-DJUCE_MODAL_LOOPS_PERMITTED=1"
+  ];
+
+  preBuild = ''
+    cd Builds/Linux
+  '';
+
+  installPhase = ''
+    install -Dm755 build/*.so -t "$out/lib/vst"
+  '';
+
+  meta = with lib; {
+    description = "Argotlunar VST granulizer with modern fixes";
+    homepage = "https://github.com/mourednik/argotlunar";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Argotlunar is a VST2 granulizer for music production. I originally planned to use nix patches but since certain small errors prevent compilation on modern toolchains and the original project has been abandoned for 5 years, I opted to maintain the fixes in a fork instead, the fork only contains necessary tweaks to enable compilation and prevent graphical errors.

The VST was tested with the DAW renoise.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
