### PR TITLE
ghc: add LoongArch64 NCG support for 9.14+

### DIFF
--- a/pkgs/development/compilers/ghc/common-have-ncg.nix
+++ b/pkgs/development/compilers/ghc/common-have-ncg.nix
@@ -12,3 +12,4 @@ stdenv.targetPlatform.isx86
 || (lib.versionAtLeast version "9.2" && stdenv.targetPlatform.isAarch64)
 || (lib.versionAtLeast version "9.6" && stdenv.targetPlatform.isGhcjs)
 || (lib.versionAtLeast version "9.12" && stdenv.targetPlatform.isRiscV64)
+|| (lib.versionAtLeast version "9.14" && stdenv.targetPlatform.isLoongArch64)


### PR DESCRIPTION
GHC gains NCG support for loongarch64-linux since 9.14: https://downloads.haskell.org/ghc/9.14.1/docs/users_guide/9.14.1-notes.html

This commit came from @darkyzhou and I think it's worth upstreaming here. In particular, we already have the RISC-V bits even before GHC works there in Nixpkgs, so why not do the same for LoongArch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
