### PR TITLE
intel-graphics-compiler: fix patch applying for opencl-clang

### DIFF
--- a/pkgs/by-name/in/intel-graphics-compiler/package.nix
+++ b/pkgs/by-name/in/intel-graphics-compiler/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     # The build system only applies patches when the sources are in a Git repository.
     git -C llvm-project init
     git -C llvm-project add .
-    git -C llvm-project -c user.name=nixbld -c user.email= commit -m stub
+    git -C llvm-project -c user.name=nixbld -c user.email= commit -m stub >/dev/null
 
     substituteInPlace llvm-project/llvm/projects/opencl-clang/cmake/modules/CMakeFunctions.cmake \
       --replace-fail 'COMMAND ''${GIT_EXECUTABLE} am --3way --keep-non-patch --ignore-whitespace -C0 ' \

--- a/pkgs/by-name/in/intel-graphics-compiler/package.nix
+++ b/pkgs/by-name/in/intel-graphics-compiler/package.nix
@@ -92,14 +92,26 @@ stdenv.mkDerivation rec {
     chmod +x igc/IGC/Scripts/igc_create_linker_script.sh
     patchShebangs --build igc/IGC/Scripts/igc_create_linker_script.sh
 
-    # The build system only applies patches when the sources are in a Git repository.
-    git -C llvm-project init
-    git -C llvm-project add .
-    git -C llvm-project -c user.name=nixbld -c user.email= commit -m stub >/dev/null
+    # Their slapdash CMake code checks the exit code of "git rev-parse" whether patches must be applied.
+    # Since we do not have a full git repo and cannot clone one due to reproducibility issues,
+    # git exits with 128 which is in newer versions of opencl-clang logged as a STATUS, but does not abort either.
+    # We could hack around this, but since we are certain we want the patches (eg for CL3.1), we just shortcircuit the condition.
+    substituteInPlace llvm-project/llvm/projects/opencl-clang/cmake/modules/CMakeFunctions.cmake \
+      --replace-fail "if(patches_needed EQUAL 1)" "if(TRUE)"
 
+    # "git am" wants to check the git history if the commit is already applied, but we do not have that.
+    # "git apply" works very similar, but without a git history and supports the same options unlike patch.
     substituteInPlace llvm-project/llvm/projects/opencl-clang/cmake/modules/CMakeFunctions.cmake \
       --replace-fail 'COMMAND ''${GIT_EXECUTABLE} am --3way --keep-non-patch --ignore-whitespace -C0 ' \
                      'COMMAND ''${GIT_EXECUTABLE} apply --3way --ignore-whitespace -C0 '
+
+    # The build system only applies patches when the sources are in a Git repository.
+    export HOME=$(mktemp -d)
+    git config --global user.email ""
+    git config --global user.name nixbld
+    git -C llvm-project init
+    git -C llvm-project add .
+    git -C llvm-project commit -m stub >/dev/null
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
