### PR TITLE
freebsd: don't assume packages will build for platforms other than freebsd by default

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/pkgs/arp.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/arp.nix
@@ -7,6 +7,5 @@ mkDerivation {
   path = "usr.sbin/arp";
   buildInputs = [ libxo ];
 
-  meta.platforms = lib.platforms.freebsd;
   meta.mainProgram = "arp";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/bsdfan.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/bsdfan.nix
@@ -33,7 +33,6 @@ mkDerivation {
 
   meta = {
     description = "A simple FreeBSD fan control utility for thinkpads";
-    platforms = lib.platforms.freebsd;
     mainProgram = "bsdfan";
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/csu.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/csu.nix
@@ -32,5 +32,4 @@ mkDerivation {
   ];
   buildInputs = [ include ];
   MK_TESTS = "no";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/devd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/devd.nix
@@ -48,6 +48,5 @@ mkDerivation {
     make $makeFlags installconfig
   '';
 
-  meta.platforms = lib.platforms.freebsd;
   meta.mainProgram = "devd";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/dmesg.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/dmesg.nix
@@ -2,5 +2,4 @@
 mkDerivation {
   path = "sbin/dmesg";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -58,7 +58,6 @@ mkDerivation rec {
 
   meta = {
     description = "GPU firmware for FreeBSD drm-kmod";
-    platforms = lib.platforms.freebsd;
     license =
       lib.optional withAmd lib.licenses.unfreeRedistributableFirmware
       # Intel license prohibits modification. this will wrap firmware files in an ELF

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
@@ -74,7 +74,6 @@ mkDerivation rec {
 
   meta = {
     description = "Linux drm driver, ported to FreeBSD";
-    platforms = lib.platforms.freebsd;
     license = with lib.licenses; [
       bsd2
       gpl2Only

--- a/pkgs/os-specific/bsd/freebsd/pkgs/fsck.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/fsck.nix
@@ -3,5 +3,4 @@ mkDerivation {
   path = "sbin/fsck";
   extraPaths = [ "sbin/mount" ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/fsck_ffs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/fsck_ffs.nix
@@ -9,5 +9,4 @@ mkDerivation {
 
   buildInputs = [ libufs ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/fsck_msdosfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/fsck_msdosfs.nix
@@ -10,5 +10,4 @@ mkDerivation {
     "-Wno-unterminated-string-initialization"
   ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/fstat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/fstat.nix
@@ -12,5 +12,4 @@ mkDerivation {
   ];
 
   meta.mainProgram = "fstat";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/growfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/growfs.nix
@@ -24,5 +24,4 @@ mkDerivation {
   MK_TESTS = "no";
 
   meta.mainProgram = "growfs";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/include/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/include/package.nix
@@ -45,5 +45,4 @@ mkDerivation {
 
   MK_HESIOD = "yes";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/init.nix
@@ -10,7 +10,6 @@ mkDerivation {
 
   meta = {
     broken = !stdenv.hostPlatform.isStatic;
-    platforms = lib.platforms.freebsd;
     mainProgram = "init";
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/package.nix
@@ -49,7 +49,6 @@ mkDerivation rec {
 
   meta = {
     description = "Intel Wifi Firmware for FreeBSD";
-    platforms = lib.platforms.freebsd;
     license = linux-firmware.meta.license;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/jail.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/jail.nix
@@ -16,5 +16,4 @@ mkDerivation {
   ];
   MK_TESTS = "no";
   meta.mainProgram = "jail";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/jexec.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/jexec.nix
@@ -9,5 +9,4 @@ mkDerivation {
     libjail
   ];
   meta.mainProgram = "jexec";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/jls.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/jls.nix
@@ -11,5 +11,4 @@ mkDerivation {
     libxo
   ];
   meta.mainProgram = "jls";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kbdmap.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kbdmap.nix
@@ -17,5 +17,4 @@ mkDerivation {
   ];
 
   meta.mainProgram = "kbdmap";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldconfig.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldconfig.nix
@@ -2,5 +2,4 @@
 mkDerivation {
   path = "sbin/kldconfig";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldload.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldload.nix
@@ -2,5 +2,4 @@
 mkDerivation {
   path = "sbin/kldload";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldstat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldstat.nix
@@ -2,5 +2,4 @@
 mkDerivation {
   path = "sbin/kldstat";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldunload.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldunload.nix
@@ -2,5 +2,4 @@
 mkDerivation {
   path = "sbin/kldunload";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ldd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ldd.nix
@@ -14,5 +14,4 @@ mkDerivation {
     NIX_CFLAGS_COMPILE = "-D_RTLD_PATH=${lib.getLib stdenv.cc.libc}/libexec/ld-elf.so.1";
   };
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcam.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcam.nix
@@ -13,5 +13,4 @@ mkDerivation {
     libsbuf
   ];
   MK_TESTS = "no";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libctf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libctf.nix
@@ -42,5 +42,4 @@ mkDerivation {
 
   alwaysKeepStatic = true;
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libdevdctl.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libdevdctl.nix
@@ -13,5 +13,4 @@ mkDerivation {
 
   env.NIX_CFLAGS_COMPILE = "-std=c++23 -Wno-nullability-completeness";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libdevinfo.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libdevinfo.nix
@@ -11,5 +11,4 @@ mkDerivation {
     "debug"
   ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnetgraph.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnetgraph.nix
@@ -11,5 +11,4 @@ mkDerivation {
     "debug"
   ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libproc.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libproc.nix
@@ -30,5 +30,4 @@ mkDerivation {
 
   MK_TESTS = "no";
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/librtld-db.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/librtld-db.nix
@@ -21,5 +21,4 @@ mkDerivation {
     libprocstat
   ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libsysinfo.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libsysinfo.nix
@@ -51,6 +51,5 @@ mkDerivation rec {
     homepage = "https://github.com/bsdimp/libsysinfo";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ rhelmot ];
-    platforms = lib.platforms.freebsd;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libusb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libusb.nix
@@ -15,5 +15,4 @@ mkDerivation {
     mv $out/data/pkgconfig $out/lib/pkgconfig
   '';
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libusbhid.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libusbhid.nix
@@ -11,5 +11,4 @@ mkDerivation {
     "debug"
   ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libzfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libzfs.nix
@@ -80,7 +80,6 @@ mkDerivation {
   MK_TESTS = "no";
 
   meta = {
-    platforms = lib.platforms.freebsd;
     license = lib.licenses.cddl;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -113,7 +113,6 @@ lib.makeOverridable (
           rhelmot
           artemist
         ];
-        platforms = lib.platforms.unix;
         license = lib.licenses.bsd2;
       }
       // attrs.meta or { };

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mount.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mount.nix
@@ -11,5 +11,4 @@ mkDerivation {
     libxo
   ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mount_msdosfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mount_msdosfs.nix
@@ -8,5 +8,4 @@ mkDerivation {
   extraPaths = [ "sbin/mount" ];
   buildInputs = [ libkiconv ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mount_nullfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mount_nullfs.nix
@@ -6,5 +6,4 @@ mkDerivation {
   path = "sbin/mount_nullfs";
   extraPaths = [ "sbin/mount" ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/netstat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/netstat.nix
@@ -18,6 +18,5 @@ mkDerivation {
     libnetgraph
   ];
 
-  meta.platforms = lib.platforms.freebsd;
   meta.mainProgram = "netstat";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/passwd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/passwd.nix
@@ -20,6 +20,5 @@ mkDerivation {
     sed -E -i -e '/BINOWN|BINMODE|PRECIOUSPROG/d' $BSDSRCDIR/usr.bin/passwd/Makefile
   '';
 
-  meta.platforms = lib.platforms.freebsd;
   meta.mainProgram = "passwd";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/pciconf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/pciconf.nix
@@ -28,6 +28,5 @@ mkDerivation {
     cp "${pciutils}/share/pci.ids" "$out/share/pci.ids"
   '';
 
-  meta.platforms = lib.platforms.freebsd;
   meta.mainProgram = "pciconf";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/ping.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/ping.nix
@@ -20,5 +20,4 @@ mkDerivation {
   MK_TESTS = "no";
   clangFixup = true;
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/procstat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/procstat.nix
@@ -19,6 +19,5 @@ mkDerivation {
 
   MK_TESTS = "no";
 
-  meta.platforms = lib.platforms.freebsd;
   meta.mainProgram = "procstat";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/stand-efi.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/stand-efi.nix
@@ -67,5 +67,4 @@ mkDerivation {
     cp -r $BSDSRCDIR/stand/defaults $out/bin/defaults
   '';
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/su.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/su.nix
@@ -23,5 +23,4 @@ mkDerivation {
   '';
 
   meta.mainProgram = "su";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
@@ -156,6 +156,5 @@ mkDerivation rec {
 
   meta = {
     description = "FreeBSD kernel and modules";
-    platforms = lib.platforms.freebsd;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/syslogd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/syslogd.nix
@@ -29,7 +29,6 @@ mkDerivation {
   meta = {
     description = "FreeBSD syslog daemon";
     maintainers = with lib.maintainers; [ artemist ];
-    platforms = lib.platforms.freebsd;
     license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/tip.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/tip.nix
@@ -14,6 +14,5 @@ mkDerivation {
     "debug"
   ];
 
-  meta.platforms = lib.platforms.freebsd;
   meta.mainProgram = "tip";
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/umount.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/umount.nix
@@ -15,5 +15,4 @@ mkDerivation {
     "debug"
   ];
 
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/usbconfig.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/usbconfig.nix
@@ -17,5 +17,4 @@ mkDerivation {
   ];
 
   meta.mainProgram = "usbconfig";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/v4l-compat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/v4l-compat.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Video4Linux header files for FreeBSD";
     maintainers = [ lib.maintainers.rhelmot ];
-    platforms = lib.platforms.freebsd;
     license = lib.licenses.gpl2Only;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/vidcontrol.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/vidcontrol.nix
@@ -6,5 +6,4 @@ mkDerivation {
   path = "usr.sbin/vidcontrol";
 
   meta.mainProgram = "vidcontrol";
-  meta.platforms = lib.platforms.freebsd;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/zfs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/zfs.nix
@@ -40,7 +40,6 @@ mkDerivation {
   ];
 
   meta = {
-    platforms = lib.platforms.freebsd;
     license = with lib.licenses; [
       cddl
       bsd2

--- a/pkgs/os-specific/bsd/freebsd/pkgs/zfsd.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/zfsd.nix
@@ -33,7 +33,6 @@ mkDerivation {
 
   meta = {
     mainProgram = "zfsd";
-    platforms = lib.platforms.freebsd;
     license = with lib.licenses; [
       cddl
       bsd2


### PR DESCRIPTION
#550620 fixed some configuration errors and surfaced an assumption that has been baked in since the initial commit of the freebsd subtree, that the default `meta.platforms` should be `lib.platforms.unix`. This is obviously not a useful default and adds a lot of failing linux and darwin builds to hydra. This commit changes the default to `lib.platforms.freebsd` to fix this.

I tested this commit by building freebsd.{sys,bin,zfs,drm-kmod,devfs} cross from x86_64-linux to x86_64-freebsd, since the primary purpose of tools from the freebsd tree building for other platforms is to run at cross-build-time.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
