### PR TITLE
skia: fix loongarch64-linux build

### DIFF
--- a/pkgs/by-name/sk/skia/package.nix
+++ b/pkgs/by-name/sk/skia/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchgit,
+  fetchpatch2,
   expat,
   fontconfig,
   freetype,
@@ -38,6 +39,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "ee20d565acb08dece4a32e3f209cdd41119015ca";
     hash = "sha256-0LiFK/8873gei70iVhNGRlcFeGIp7tjDEfxTBz1LYv8=";
   };
+
+  patches = [
+    # A tiny patch to fix build errors on loongarch64-linux using GCC (Clang works fine).
+    # https://skia-review.googlesource.com/c/skia/+/1199836
+    (fetchpatch2 {
+      url = "https://salsa.debian.org/fonts-team/libskia/-/raw/6574ca599eab076a9cd5b8667f81aef0f67b3eeb/debian/patches/loong-build";
+      hash = "sha256-6dUCQixmll2K8fqRGwhay7ee8gvdRq1NJjUHBHxIFvo=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace BUILD.gn \
@@ -84,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
           "i686" = "x86";
           "arm" = "arm";
           "aarch64" = "arm64";
+          "loongarch64" = "loong64";
         }
         .${stdenv.hostPlatform.parsed.cpu.name};
     in
@@ -168,7 +179,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://skia.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fgaz ];
-    platforms = with lib.platforms; arm ++ aarch64 ++ x86 ++ x86_64;
+    platforms = with lib.platforms; arm ++ aarch64 ++ x86 ++ x86_64 ++ loongarch64;
     pkgConfigModules = [ "skia" ];
   };
 })


### PR DESCRIPTION
Debian already has a skia patch for loongarch64-linux, so I just fetch the tiny patch from there.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
