### PR TITLE
stack-pr: init at 0.1.7

### DIFF
--- a/pkgs/by-name/st/stack-pr/package.nix
+++ b/pkgs/by-name/st/stack-pr/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  fetchFromGitHub,
+  gh,
+  git,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "stack-pr";
+  version = "0.1.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "modular";
+    repo = "stack-pr";
+    tag = finalAttrs.version;
+    hash = "sha256-bOzSUE0bRMV6mskFjEJ0hDOnS7YpCrEpREf8ASXJkdU=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = with python3Packages; [ pdm-backend ];
+
+  dependencies = lib.optionals (python3Packages.pythonOlder "3.13") [
+    python3Packages.typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    git
+  ]
+  ++ (with python3Packages; [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ]);
+
+  preCheck = ''
+    git init
+    git config user.email "nix-build@example.invalid"
+    git config user.name "Nix build"
+    git commit --allow-empty -m "Initialize test repository"
+  '';
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      gh
+      git
+    ])
+  ];
+
+  pythonImportsCheck = [ "stack_pr" ];
+
+  meta = {
+    description = "CLI for working with stacked GitHub pull requests";
+    homepage = "https://github.com/modular/stack-pr";
+    changelog = "https://github.com/modular/stack-pr/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ evanwporter ];
+    mainProgram = "stack-pr";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds stack-pr (https://github.com/modular/stack-pr) to nixpkgs. I'm aware github now has support for stacks prs, but I prefer this implementation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
