### PR TITLE
openterface-qt: 0.5.28 -> 0.5.30, change udev rules

### DIFF
--- a/pkgs/by-name/op/openterface-qt/package.nix
+++ b/pkgs/by-name/op/openterface-qt/package.nix
@@ -4,7 +4,6 @@
   makeDesktopItem,
   copyDesktopItems,
   fetchFromGitHub,
-  writeText,
   qt6,
   libusb1,
 
@@ -14,18 +13,6 @@
   pkg-config,
   ffmpeg,
 }:
-let
-  # Based on upstream instructions: https://github.com/TechxArtisanStudio/Openterface_QT#for-linux-users
-  udevRules = writeText "60-openterface.rules" ''
-    # Serial to HID converter for keyboard/mouse control.
-    # ID 1a86:7523 QinHeng Electronics CH340 serial converter
-    KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", TAG+="uaccess"
-
-    # "hidraw" device for accessing the host-target toggleable USB port.
-    # ID 534d:2109 MacroSilicon Openterface
-    KERNEL=="hidraw*", ATTRS{idVendor}=="534d", ATTRS{idProduct}=="2109", TAG+="uaccess"
-  '';
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openterface-qt";
   version = "0.5.30";
@@ -63,12 +50,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/bin
     cp ./openterfaceQT $out/bin/
     mkdir -p $out/share/pixmaps
     cp ./images/icon_256.png $out/share/pixmaps/openterface-qt.png
     mkdir -p $out/etc/udev/rules.d
-    cp ${udevRules} $out/etc/udev/rules.d/60-openterface.rules
+
+    # Install the udev rules from the packaging/archlinux until this issue is resolved:
+    # https://github.com/TechxArtisanStudio/Openterface_QT/issues/606
+    install -Dm644 packaging/archlinux/openterfaceqt-udev.rules $out/etc/udev/rules.d/51-openterface.rules
+
     runHook postInstall
   '';
 

--- a/pkgs/by-name/op/openterface-qt/package.nix
+++ b/pkgs/by-name/op/openterface-qt/package.nix
@@ -28,13 +28,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openterface-qt";
-  version = "0.5.28";
+  version = "0.5.30";
 
   src = fetchFromGitHub {
     owner = "TechxArtisanStudio";
     repo = "Openterface_QT";
     tag = "${finalAttrs.version}";
-    hash = "sha256-MHmTG/9b/BZFPcIBtCrZrQe4uFQ/tttbQMZUpDCwRuc=";
+    hash = "sha256-7ZgdAEQXy9QS7hRzrHOQEuimllRQ4w+u1/3DWXB3jUc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- update to 0.5.30
- Switch to installing udev rules directly from upstream's `packaging/archlinux/openterfaceqt-udev.rules` instead of a hand-written inline rule, and rename the installed file to `51-openterface.rules`.

Need testing with hardware

If testing is successful, this package needs to be backported.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
