### PR TITLE
sdroxide: init at 1.5.0

### DIFF
--- a/pkgs/by-name/sd/sdroxide/package.nix
+++ b/pkgs/by-name/sd/sdroxide/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchurl,
   rustPlatform,
   pkgconf,
   alsa-lib,
@@ -15,6 +16,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-obVqYyrZRzKpt2/LU0T6XPg8wa6GdegLy3NykAHCHl0=";
   };
+
+  # HACK: the deep_filter crate include_bytes! from its workspace
+  #  (but outside its directory) which fetchCargoVendor cannot handle
+  prePatch = let
+    model = fetchurl {
+      url = "https://github.com/Rikorose/DeepFilterNet/raw/978576aa8400552a4ce9730838c635aa30db5e61/models/DeepFilterNet3_onnx.tar.gz";
+      hash = "sha256-yU2R9wkRAByUbg+rtKqa3DcEX0WgO1YAjLDIJEy2NhY=";
+    };
+  in ''
+    mkdir ../sdroxide-1.5.0-vendor/source-git-0/models
+    ln -s ${model} ../sdroxide-1.5.0-vendor/source-git-0/models/DeepFilterNet3_onnx.tar.gz
+  '';
 
   cargoHash = "sha256-RChkuoXZ/Ex45P+D+9t2ZQ2JPM3O06DpkFyrSCOe/9s=";
 

--- a/pkgs/by-name/sd/sdroxide/package.nix
+++ b/pkgs/by-name/sd/sdroxide/package.nix
@@ -19,15 +19,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # HACK: the deep_filter crate include_bytes! from its workspace
   #  (but outside its directory) which fetchCargoVendor cannot handle
-  prePatch = let
-    model = fetchurl {
-      url = "https://github.com/Rikorose/DeepFilterNet/raw/978576aa8400552a4ce9730838c635aa30db5e61/models/DeepFilterNet3_onnx.tar.gz";
-      hash = "sha256-yU2R9wkRAByUbg+rtKqa3DcEX0WgO1YAjLDIJEy2NhY=";
-    };
-  in ''
-    mkdir ../sdroxide-1.5.0-vendor/source-git-0/models
-    ln -s ${model} ../sdroxide-1.5.0-vendor/source-git-0/models/DeepFilterNet3_onnx.tar.gz
-  '';
+  prePatch =
+    let
+      model = fetchurl {
+        url = "https://github.com/Rikorose/DeepFilterNet/raw/978576aa8400552a4ce9730838c635aa30db5e61/models/DeepFilterNet3_onnx.tar.gz";
+        hash = "sha256-yU2R9wkRAByUbg+rtKqa3DcEX0WgO1YAjLDIJEy2NhY=";
+      };
+    in
+    ''
+      mkdir ../sdroxide-1.5.0-vendor/source-git-0/models
+      ln -s ${model} ../sdroxide-1.5.0-vendor/source-git-0/models/DeepFilterNet3_onnx.tar.gz
+    '';
 
   cargoHash = "sha256-RChkuoXZ/Ex45P+D+9t2ZQ2JPM3O06DpkFyrSCOe/9s=";
 

--- a/pkgs/by-name/sd/sdroxide/package.nix
+++ b/pkgs/by-name/sd/sdroxide/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "A native SDR client for many radios, written in Rust, with native and web remote UI";
-    homepage = "https://github.com/dividebysandwich/sdroxide";
+    homepage = "https://sdroxide.com/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       nicoo

--- a/pkgs/by-name/sd/sdroxide/package.nix
+++ b/pkgs/by-name/sd/sdroxide/package.nix
@@ -7,16 +7,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sdroxide";
-  version = "1.4.3";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "dividebysandwich";
     repo = "sdroxide";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9agV8Y6Vk7CFacm8o6sPJXW23OP+5Ze7kK38QHLmOiU=";
+    hash = "sha256-obVqYyrZRzKpt2/LU0T6XPg8wa6GdegLy3NykAHCHl0=";
   };
 
-  cargoHash = "sha256-u662PZWoIWdMEfUXiViKu+vs2fagCSZ12P2RYXSx2K4=";
+  cargoHash = "sha256-RChkuoXZ/Ex45P+D+9t2ZQ2JPM3O06DpkFyrSCOe/9s=";
 
   __structuredAttrs = true;
   buildInputs = [ alsa-lib ];

--- a/pkgs/by-name/sd/sdroxide/package.nix
+++ b/pkgs/by-name/sd/sdroxide/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkgconf,
+  alsa-lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sdroxide";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "dividebysandwich";
+    repo = "sdroxide";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9agV8Y6Vk7CFacm8o6sPJXW23OP+5Ze7kK38QHLmOiU=";
+  };
+
+  buildInputs = [ alsa-lib ];
+  nativeBuildInputs = [ pkgconf ];
+
+  cargoHash = "sha256-u662PZWoIWdMEfUXiViKu+vs2fagCSZ12P2RYXSx2K4=";
+
+  meta = {
+    description = "A native SDR client for many radios, written in Rust, with native and web remote UI";
+    homepage = "https://github.com/dividebysandwich/sdroxide";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      nicoo
+    ];
+  };
+})

--- a/pkgs/by-name/sd/sdroxide/package.nix
+++ b/pkgs/by-name/sd/sdroxide/package.nix
@@ -16,10 +16,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-9agV8Y6Vk7CFacm8o6sPJXW23OP+5Ze7kK38QHLmOiU=";
   };
 
+  cargoHash = "sha256-u662PZWoIWdMEfUXiViKu+vs2fagCSZ12P2RYXSx2K4=";
+
+  __structuredAttrs = true;
   buildInputs = [ alsa-lib ];
   nativeBuildInputs = [ pkgconf ];
-
-  cargoHash = "sha256-u662PZWoIWdMEfUXiViKu+vs2fagCSZ12P2RYXSx2K4=";
 
   meta = {
     description = "A native SDR client for many radios, written in Rust, with native and web remote UI";


### PR DESCRIPTION
Initial packaging of [sdroxide]; requested by @Rua.

[sdroxide]: https://github.com/dividebysandwich/sdroxide/

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
