### PR TITLE
gpauth: drop binary-eater as a maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3694,13 +3694,6 @@
     githubId = 185443;
     name = "Alexey Lebedeff";
   };
-  binary-eater = {
-    email = "sergeantsagara@protonmail.com";
-    github = "Binary-Eater";
-    githubId = 10691440;
-    name = "Rahul Rameshbabu";
-    keys = [ { fingerprint = "678A 8DF1 D9F2 B51B 7110  BE53 FF24 7B3E 5411 387B"; } ];
-  };
   binarycat = {
     email = "binarycat@envs.net";
     github = "lolbinarycat";

--- a/pkgs/by-name/gp/gpauth/package.nix
+++ b/pkgs/by-name/gp/gpauth/package.nix
@@ -58,7 +58,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/${finalAttrs.src.owner}/${finalAttrs.src.repo}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      binary-eater
       booxter
       m1dugh
     ];


### PR DESCRIPTION
I am no longer using nixpkgs nor actively participating in reviews. This is a
good opportunity for me to step aside from the gpauth and gpclient packages
since we have good maintainers for the packages.