### PR TITLE
nixos/toxvpn: run as non-root, nixos/tests/toxvpn: init 

### DIFF
--- a/nixos/modules/services/networking/toxvpn.nix
+++ b/nixos/modules/services/networking/toxvpn.nix
@@ -59,6 +59,11 @@ with lib;
         KillMode = "process";
         Restart = "on-success";
         Type = "notify";
+        User = "toxvpn";
+        Group = "toxvpn";
+        # Creates a tun device, which needs CAP_NET_ADMIN.
+        AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
       };
 
       restartIfChanged = false; # Likely to be used for remote admin

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1793,6 +1793,7 @@ in
   tmate-ssh-server = runTest ./tmate-ssh-server.nix;
   tomcat = runTest ./tomcat.nix;
   tor = runTest ./tor.nix;
+  toxvpn = runTest ./toxvpn.nix;
   tpm-ek = handleTest ./tpm-ek { };
   tpm2 = import ./tpm2 { inherit runTest; };
   traccar = runTest ./traccar.nix;

--- a/nixos/tests/toxvpn.nix
+++ b/nixos/tests/toxvpn.nix
@@ -1,0 +1,70 @@
+{ lib, ... }:
+let
+  mkNode =
+    localip:
+    {
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      virtualisation.vlans = [ 1 ];
+      services.toxvpn = {
+        enable = true;
+        inherit localip;
+      };
+      networking.firewall.allowedUDPPorts = [ config.services.toxvpn.port ];
+      networking.firewall.allowedTCPPorts = [ 8000 ];
+      environment.systemPackages = [ pkgs.socat ];
+    };
+in
+{
+  name = "toxvpn";
+
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  containers.alice = mkNode "10.0.0.1";
+  containers.bob = mkNode "10.0.0.2";
+
+  testScript =
+    { containers, ... }:
+    let
+      aliceIp = containers.alice.services.toxvpn.localip;
+      bobIp = containers.bob.services.toxvpn.localip;
+    in
+    ''
+      import re
+
+      start_all()
+      alice.wait_for_unit("toxvpn.service")
+      bob.wait_for_unit("toxvpn.service")
+
+      with subtest("Whitelist each other"):
+          alice_status = alice.succeed('socat TEXT:"status\\n" UNIX-CONNECT:/run/toxvpn/control')
+          bob_status = bob.succeed('socat TEXT:"status\\n" UNIX-CONNECT:/run/toxvpn/control')
+
+          alice_id_match = re.search(r"my id is ([0-9a-f]+)", alice_status)
+          bob_id_match = re.search(r"my id is ([0-9a-f]+)", bob_status)
+          assert alice_id_match
+          assert bob_id_match
+
+          alice.succeed(f'socat TEXT:"whitelist {bob_id_match.group(1)}\\n" UNIX-CONNECT:/run/toxvpn/control')
+          bob.succeed(f'socat TEXT:"whitelist {alice_id_match.group(1)}\\n" UNIX-CONNECT:/run/toxvpn/control')
+
+      with subtest("Connect to each other"):
+          alice.wait_until_succeeds('socat TEXT:"list\\n" UNIX-CONNECT:/run/toxvpn/control | grep -q bob')
+          bob.wait_until_succeeds('socat TEXT:"list\\n" UNIX-CONNECT:/run/toxvpn/control | grep -q alice')
+
+          alice.succeed("ping -c 1 ${bobIp}")
+          bob.succeed("ping -c 1 ${aliceIp}")
+
+      with subtest("Send messages to each other"):
+          alice.execute("(socat TCP-LISTEN:8000 OPEN:/tmp/received,creat &) >&2")
+          bob.execute("(socat TCP-LISTEN:8000 OPEN:/tmp/received,creat &) >&2")
+
+          bob.wait_until_succeeds('socat TEXT:"hi\\n" TCP:${aliceIp}:8000')
+          alice.wait_until_succeeds("grep -q hi /tmp/received")
+          alice.wait_until_succeeds('socat TEXT:"hi\\n" TCP:${bobIp}:8000')
+          bob.wait_until_succeeds("grep -q hi /tmp/received")
+    '';
+}

--- a/pkgs/by-name/to/toxvpn/package.nix
+++ b/pkgs/by-name/to/toxvpn/package.nix
@@ -9,6 +9,7 @@
   libcap,
   zeromq,
   systemd,
+  nixosTests,
 }:
 
 stdenv.mkDerivation {
@@ -46,6 +47,8 @@ stdenv.mkDerivation {
 
   installCheckPhase = "$out/bin/toxvpn -h";
   doInstallCheck = true;
+
+  passthru.tests.nixos = nixosTests.toxvpn;
 
   meta = {
     description = "Powerful tool that allows one to make tunneled point to point connections over Tox";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes breakage introduced in #481639, as well as adding a nixos test to assert that it works as expected.

@cleverca22 could you verify that there are no other required caps that I have missed?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
