### PR TITLE
fetchit-nzuum: init at 0-unstable-2026-08-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -873,6 +873,12 @@
     githubId = 1141462;
     name = "Vladyslav Pekker";
   };
+  agnab = {
+    name = "AGNAB";
+    github = "AGNAB712";
+    githubId = 133778639;
+    email = "agnab712@gmail.com";
+  };
   agustinmista = {
     email = "agustin@mista.me";
     github = "agustinmista";

--- a/pkgs/by-name/fe/fetchit-nzuum/package.nix
+++ b/pkgs/by-name/fe/fetchit-nzuum/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  fetchFromCodeberg,
+  pkg-config,
+  lua5_4,
+  vulkan-tools,
+  pciutils,
+  mesa-demos,
+  makeWrapper,
+  lib,
+  gnugrep,
+}:
+
+stdenv.mkDerivation {
+  pname = "fetchit";
+  version = "0-unstable-2026-08-12";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Minimal system info fetcher written in C and configurable in lua";
+    homepage = "https://codeberg.org/nzuum/fetchit";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ agnab ];
+    platforms = lib.platforms.linux;
+    mainProgram = "fetchit";
+  };
+
+  src = fetchFromCodeberg {
+    owner = "nzuum";
+    repo = "fetchit";
+    rev = "da3f5cf58fb2807cf3ae2f2cf4cd65c18e685bd7";
+    hash = "sha256-gT+zfJjFxgZcXlCR3crD4QuZlrb5Z9psvdUtAYUTHEo=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+  buildInputs = [
+    lua5_4
+  ];
+
+  installFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/fetchit \
+      --set PATH ${
+        lib.makeBinPath [
+          vulkan-tools
+          pciutils
+          mesa-demos
+          gnugrep
+        ]
+      }
+  '';
+}


### PR DESCRIPTION
Adds fetchit-nzuum, a minimal system information fetcher written in C with Lua configuration

Upstream: https://codeberg.org/nzuum/fetchit

The nzuum suffix is used to avoid naming conflict with the existing [fetchit](https://github.com/NixOS/nixpkgs/blob/nixos-26.05/pkgs/by-name/fe/fetchit/package.nix#L70) package

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]
  - [ ] [Package tests] at `passthru.tests`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module
  - [ ] Module update: when the change is significant
- [x] Fits https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md, [pkgs/README.md], [maintainers/README.md] and other READMEs
- [x] Follows the [automation/AI policy]

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md