### PR TITLE
once: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6749,6 +6749,12 @@
     github = "MadelineBaggins";
     githubId = 57464835;
   };
+  declarative-dale = {
+    name = "Dale Morgan";
+    email = "uptapped@protonmail.ch";
+    github = "declarative-dale";
+    githubId = 52590374;
+  };
   deeengan = {
     github = "deeengan";
     githubId = 87693324;

--- a/pkgs/by-name/on/once/package.nix
+++ b/pkgs/by-name/on/once/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "once";
+  version = "0.4.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "closure-labs";
+    repo = "once";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W/yA/0+USGRfJLwzmR8daaD0wF6LuEOXblnO7Itlv+U=";
+  };
+
+  cargoHash = "sha256-k+xAuO8VWHDCMCsVD9jeZEq9RQYH3HLpJDfoSoUXD1Y=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Recognize accepted Nix build-trace realizations";
+    homepage = "https://github.com/closure-labs/once";
+    changelog = "https://github.com/closure-labs/once/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ declarative-dale ];
+    mainProgram = "once";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds [Once](https://github.com/closure-labs/once), an experimental CLI that recognizes accepted Nix 2.35+ build-trace realizations. The package uses the upstream v0.4.0 tag, runs the Rust test suite, verifies `once --version`, and includes an update script.

This draft also adds `declarative-dale` as the package maintainer.

## Automation/AI disclosure

OpenAI Codex using GPT-5 assisted with the package expression, commit message, and this PR summary. The same assistant ran `nixfmt`, derived both fixed-output hashes from Nix mismatch verification, built the package against the exact Nixpkgs master base, ran all 31 upstream Rust tests, and verified `once 0.4.0`. The commit includes the required `Assisted-by:` trailer. This remains a draft pending responsible human review.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.
- [x] Follows the Automation/AI policy through commit and PR disclosure; human accountability review is pending while this PR is a draft.