### PR TITLE
openhome: init at 1.15.2

### DIFF
--- a/pkgs/by-name/op/openhome/package.nix
+++ b/pkgs/by-name/op/openhome/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  cargo-tauri,
+  nodejs_24,
+  pnpm_11,
+  pnpmConfigHook,
+  pkg-config,
+  lld,
+  wasm-pack,
+  wrapGAppsHook3,
+  webkitgtk_4_1,
+  openssl,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "openhome";
+  version = "1.15.2";
+
+  src = fetchFromGitHub {
+    owner = "andrewbenington";
+    repo = "OpenHome";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oFEVQrwyUpob/IhfCgzYgbEMy10zP/I3c/pbkWl1B7Y=";
+  };
+
+  cargoHash = "sha256-/99xHv/5A5l2sGAhmR2qz62HqTNRpX9G0jzL0E8scLg=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-RDSbvjbageRZBUmmFrG5qT4azz8ctloANQvjoZrvydo=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs_24
+    pnpm_11
+    pnpmConfigHook
+    pkg-config
+    lld
+    wasm-pack
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    openssl
+    webkitgtk_4_1
+  ];
+
+  cargoRoot = ".";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for moving Pokémon between game saves";
+    homepage = "https://github.com/andrewbenington/OpenHome";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ evanp ];
+    mainProgram = "OpenHome";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
