### PR TITLE
music-assistant: disable another test on aarch64-linux

### DIFF
--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -236,14 +236,10 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     "tests/providers/zvuk_music"
     # mocking music_assistant.providers.airplay.pairing.AirPlayPairing does not work
     "tests/providers/airplay/test_player.py::test_start_pairing__pin_decision"
-  ];
-
-  disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # RuntimeError: failed to initialize QNNPACK
-    "test_beat_detection"
-    "test_extended_analysis_fields"
-    "test_finalize_returns_audio_analysis_data"
-    "test_finalize_returns_none_on_early_exit"
+    "tests/providers/smart_fades/test_provider.py"
   ];
 
   pythonImportsCheck = [ "music_assistant" ];


### PR DESCRIPTION
fix:
```python

==================================== ERRORS ====================================
____ ERROR at setup of test_digital_silence_yields_finite_spectral_centroid ____

mass_mock = <Mock id='140723235080912'>
manifest_mock = <Mock id='140723235089984'>
config_mock = <Mock id='140723235090320'>

    @pytest.fixture
    async def provider(mass_mock: Mock, manifest_mock: Mock, config_mock: Mock) -> SmartFadesProvider:
        """Return a SmartFadesProvider with mocked MA but real Beat This model."""
        prov = SmartFadesProvider(mass_mock, manifest_mock, config_mock, set())
>       await prov.handle_async_init()

tests/providers/smart_fades/test_provider.py:116:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
music_assistant/providers/smart_fades/provider.py:90: in handle_async_init
    ) = await asyncio.to_thread(self._initialize_models)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/3inr3nxzqarhb9rh1z7s2s20j8c0395h-python3-3.14.7/lib/python3.14/asyncio/threads.py:26: in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/3inr3nxzqarhb9rh1z7s2s20j8c0395h-python3-3.14.7/lib/python3.14/concurrent/futures/thread.py:86: in run
    result = ctx.run(self.task)
             ^^^^^^^^^^^^^^^^^^
/nix/store/3inr3nxzqarhb9rh1z7s2s20j8c0395h-python3-3.14.7/lib/python3.14/concurrent/futures/thread.py:73: in run
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
music_assistant/providers/smart_fades/provider.py:101: in _initialize_models
    beat_this_model.model = torch.ao.quantization.quantize_dynamic(  # type: ignore[no-untyped-call]
/nix/store/3inr3nxzqarhb9rh1z7s2s20j8c0395h-python3-3.14.7/lib/python3.14/_py_warnings.py:800: in wrapper
    return arg(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:570: in quantize_dynamic
    convert(model, mapping, inplace=True)
/nix/store/3inr3nxzqarhb9rh1z7s2s20j8c0395h-python3-3.14.7/lib/python3.14/_py_warnings.py:800: in wrapper
    return arg(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:669: in convert
    _convert(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:726: in _convert
    _convert(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:726: in _convert
    _convert(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:726: in _convert
    _convert(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:726: in _convert
    _convert(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:726: in _convert
    _convert(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:734: in _convert
    reassign[name] = swap_module(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:779: in swap_module
    new_mod = qmod.from_float(
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/nn/quantized/dynamic/modules/linear.py:149: in from_float
    qlinear = cls(mod.in_features, mod.out_features, dtype=dtype)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/nn/quantized/dynamic/modules/linear.py:43: in __init__
    super().__init__(in_features, out_features, bias_, dtype=dtype)
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/nn/quantized/modules/linear.py:170: in __init__
    self._packed_params = LinearPackedParams(dtype)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/nn/quantized/modules/linear.py:30: in __init__
    self.set_weight_bias(wq, None)  # type: ignore[possibly-undefined]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/nn/quantized/modules/linear.py:35: in set_weight_bias
    self._packed_params = torch.ops.quantized.linear_prepack(weight, bias)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <OpOverloadPacket(op='quantized.linear_prepack')>
args = (tensor([[0.]], size=(1, 1), dtype=torch.qint8,
       quantization_scheme=torch.per_tensor_affine, scale=1.0, zero_point=0), None)
kwargs = {}

    def __call__(self, /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
        # overloading __call__ to ensure torch.ops.foo.bar()
        # is still callable from JIT
        # We save the function ptr as the `op` attribute on
        # OpOverloadPacket to access it here.

        # Directly calling OverloadPacket goes into C++, which will check
        # the schema and cause an error for torchbind op when inputs consist of FakeScriptObject so we
        # intercept it here and call TorchBindOpverload instead.
        if self._has_torchbind_op_overload and _must_dispatch_in_python(args, kwargs):
            # pyrefly: ignore [bad-argument-type]
            return _call_overload_packet_from_python(self, *args, **kwargs)
>       return self._op(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
E       RuntimeError: failed to initialize QNNPACK

/nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/_ops.py:1275: RuntimeError
------------------------------ Captured log setup ------------------------------
DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
DEBUG    music_assistant.smart_fades:provider.py:232 Log level configured to GLOBAL
=============================== warnings summary ===============================
../../nix/store/rw8kag1ahwi3dplr40s03n9l34mrcc1s-python3.14-numba-0.66.0/lib/python3.14/site-packages/numba/np/npdatetime_helpers.py:29
  /nix/store/rw8kag1ahwi3dplr40s03n9l34mrcc1s-python3.14-numba-0.66.0/lib/python3.14/site-packages/numba/np/npdatetime_helpers.py:29: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
    NAT = np.timedelta64('nat').astype(np.int64)

tests/providers/smart_fades/test_provider.py::test_digital_silence_yields_finite_spectral_centroid
  /build/source/music_assistant/providers/smart_fades/provider.py:101: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10.
  For migrations of users:
  1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead
  2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e)
  3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e)
  see https://github.com/pytorch/ao/issues/2259 for more details
    beat_this_model.model = torch.ao.quantization.quantize_dynamic(  # type: ignore[no-untyped-call]

tests/providers/smart_fades/test_provider.py::test_digital_silence_yields_finite_spectral_centroid
  /nix/store/c15xhd1avq66j3r5pzq80s4b84j0cy0g-python3.14-torch-2.12.0/lib/python3.14/site-packages/torch/ao/quantization/quantize.py:570: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10.
  For migrations of users:
  1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead
  2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e)
  3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e)
  see https://github.com/pytorch/ao/issues/2259 for more details
    convert(model, mapping, inplace=True)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------- snapshot report summary ----------------------------
47 snapshots passed.
=========================== short test summary info ============================
ERROR tests/providers/smart_fades/test_provider.py::test_digital_silence_yields_finite_spectral_centroid - RuntimeError: failed to initialize QNNPACK
= 3216 passed, 7 skipped, 6 deselected, 3 warnings, 1 error in 557.60s (0:09:17) =
```


And now: `===== 3216 passed, 7 skipped, 7 deselected, 1 warning in 563.60s (0:09:23) =====`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
