### PR TITLE
scanservjs: 3.1.0 -> 3.3.0

### DIFF
--- a/pkgs/by-name/sc/scanservjs/package.nix
+++ b/pkgs/by-name/sc/scanservjs/package.nix
@@ -1,31 +1,56 @@
 {
   lib,
   fetchFromGitHub,
+  fetchNpmDeps,
   buildNpmPackage,
   nodejs,
+  npmHooks,
   nixosTests,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "scanservjs";
-  version = "3.1.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "sbs20";
     repo = "scanservjs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VfFahIyn2MIW4E0sMCpqdduP7F0U7t4a5c1fwpQl7Dc=";
+    hash = "sha256-UyNSEjwqL+DHTJWgJ6lrNXfPuNJv2H3rUtpRqdNeEkg=";
   };
 
-  npmDepsHash = "sha256-VB4z7PCOUzhSbSbxLj/47oppMdTvd2lT7WZKDqd+jfo=";
+  appServerNpmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-app-server-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/app-server";
+    hash = "sha256-zp8gguoc+OdSABCOKUzLMuKIrnuYVX39kCD8b7ZTIgQ=";
+  };
+
+  appUiNpmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-app-ui-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/app-ui";
+    hash = "sha256-/30JnlN66N3pWQHHxeGG6k0nW3miFfiYlb3Snx2BP6E=";
+  };
+
+  npmDepsHash = "sha256-BNYRDVGC7wFdv7VKARZee2ea1QcLSX3iwoCGGcsVtag=";
 
   patches = [
     ./nix-compatibility.patch
   ];
 
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+  ];
+
+  preConfigure = ''
+    npmRoot=app-server npmDeps=${finalAttrs.appServerNpmDeps} npmConfigHook
+    npmRoot=app-ui npmDeps=${finalAttrs.appUiNpmDeps} npmConfigHook
+  '';
+
   postBuild = ''
     # Install runtime dependencies
-    npm install \
+    npm_config_cache=${finalAttrs.appServerNpmDeps} npm install \
       --prefix ./dist \
       --offline \
       --production \


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
