### PR TITLE
t3code: bake T3 Connect public identifiers into the web client

### DIFF
--- a/pkgs/by-name/t3/t3code/package.nix
+++ b/pkgs/by-name/t3/t3code/package.nix
@@ -1,8 +1,11 @@
 {
   lib,
   callPackage,
+  stdenv,
   symlinkJoin,
   makeBinaryWrapper,
+  desktop-file-utils,
+  xdg-utils,
   enableAzureDevOps ? false,
   azure-cli,
   azure-cli-extensions,
@@ -62,6 +65,15 @@ let
       "--set-default"
       "T3CODE_RESOURCE_MONITOR_PATH"
       (lib.getExe t3code-resource-monitor)
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath [
+        desktop-file-utils
+        xdg-utils
+      ])
     ];
 
 in
@@ -75,11 +87,15 @@ symlinkJoin {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  postBuild = lib.optionalString (wrapperArgs != [ ]) ''
-    for program in "$out/bin"/*; do
-      wrapProgram "$program" ${lib.escapeShellArgs wrapperArgs}
-    done
-  '';
+  postBuild =
+    lib.optionalString (wrapperArgs != [ ]) ''
+      for program in "$out/bin"/*; do
+        wrapProgram "$program" ${lib.escapeShellArgs wrapperArgs}
+      done
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      wrapProgram "$out/bin/t3code-desktop" --set T3CODE_DESKTOP_EXECUTABLE "$out/bin/t3code-desktop"
+    '';
 
   passthru = {
     unwrapped = t3code-unwrapped;

--- a/pkgs/by-name/t3/t3code/unwrapped.nix
+++ b/pkgs/by-name/t3/t3code/unwrapped.nix
@@ -1,6 +1,7 @@
 {
   cctools,
   copyDesktopItems,
+  desktop-file-utils,
   electron_41,
   fetchFromGitHub,
   installShellFiles,
@@ -15,6 +16,7 @@
   stdenv,
   writeDarwinBundle,
   xcbuild,
+  xdg-utils,
   fetchPnpmDeps,
   pnpm_11,
   pnpmConfigHook,
@@ -154,7 +156,13 @@ stdenv.mkDerivation (
 
       makeWrapper ${lib.getExe electron} "$out"/bin/t3code-desktop \
         --add-flags "$out"/libexec/t3code/apps/desktop \
-        --inherit-argv0
+        --inherit-argv0 \
+        ${lib.optionalString stdenv.hostPlatform.isLinux ''--set T3CODE_DESKTOP_EXECUTABLE "$out/bin/t3code-desktop" --prefix PATH : "${
+          lib.makeBinPath [
+            desktop-file-utils
+            xdg-utils
+          ]
+        }"''}
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       # node-pty tries to chmod this helper at runtime, but the Nix store is

--- a/pkgs/by-name/t3/t3code/unwrapped.nix
+++ b/pkgs/by-name/t3/t3code/unwrapped.nix
@@ -52,6 +52,13 @@ stdenv.mkDerivation (
       substituteInPlace apps/web/vite.config.ts \
         --replace-fail 'const host = explicitHost || "localhost";' \
                        'const host = explicitHost || "127.0.0.1";'
+      # Bake the T3 Connect public identifiers (Clerk publishable key/JWT
+      # template, OAuth client ID, relay URL). The bundled web client gates
+      # every cloud feature on these via `import.meta.env`, so official
+      # release builds ship them. This is upstream's own suggested
+      # source-build setup (`cp .env.example .env`); the file holds public
+      # identifiers, not secrets.
+      cp .env.example .env
     '';
 
     nativeBuildInputs = [
@@ -193,6 +200,10 @@ stdenv.mkDerivation (
         icon = "t3code";
         startupWMClass = "t3code";
         categories = [ "Development" ];
+        # Claimed here because the app's runtime registration is gated on
+        # `app.isPackaged`, which never holds under the Nix Electron
+        # wrapper; without it the Clerk OAuth redirect never reaches the app.
+        mimeTypes = [ "x-scheme-handler/t3code" ];
       })
     ];
 


### PR DESCRIPTION
The bundled T3 Connect cloud UI (sign-in, relay discovery, environment picker) renders nothing in the packaged client because its configuration is compiled empty. The web client gates every cloud feature on build-time constants (`import.meta.env.VITE_CLERK_PUBLISHABLE_KEY`, `VITE_CLERK_JWT_TEMPLATE`, `VITE_T3CODE_RELAY_URL`), which the monorepo env loader projects from the canonical `T3CODE_*` names found in repo-root `.env`. Runtime environment variables cannot fix this for a packaged browser bundle — the gating happens at build time.

This PR sets the four public identifiers (Clerk publishable key, JWT template name, CLI OAuth client ID, relay URL) as build-time `env` so the derivation matches official upstream release builds. These values are published upstream in [`.env.example`](https://github.com/pingdotgg/t3code/blob/v0.0.33/.env.example), which describes them as "the same public identifiers baked into official release builds, not secrets"; see also [`docs/internals/t3-connect.md`](https://github.com/pingdotgg/t3code/blob/v0.0.33/docs/internals/t3-connect.md).

cc @iamanaws @qweered

Note for reviewers: #555814 touches the same file; this is a 12-line additive change and trivially rebasable if that merges first.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

---

Addendum to "Tested basic functionality": built `t3code.unwrapped` with this change and verified the resulting store output contains the identifiers where they matter:

- `apps/server/dist/client/assets/index-*.js` contains the publishable key, `t3-relay`, and `relay.t3.codes` (client gating now passes)
- `apps/server/dist/bin.mjs` contains the publishable key and OAuth client ID

One known limitation: sign-in from non-`app.t3.codes` origins goes through Clerk components; if the production Clerk instance restricts allowed origins, that flow could still fail. Upstream ships the same bundle in its desktop releases, so parity with official builds remains the correct target.
