### PR TITLE
nixos/lib/qemu-common.nix: pin qemu machine to virt-11.0 on darwin

### DIFF
--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -49,7 +49,9 @@ rec {
       };
       otherHostGuestMatrix = {
         aarch64-darwin = {
-          aarch64-linux = "${qemuPkg}/bin/qemu-system-aarch64 -machine virt,gic-version=2,accel=${accel "hvf"} -cpu max";
+          # Pin virt-11.0 to avoid gic-version=3 that works on MacOS 15+ only.
+          # FIXME: Revert to `virt` after minimal supported macos is 15+.
+          aarch64-linux = "${qemuPkg}/bin/qemu-system-aarch64 -machine virt-11.0,accel=${accel "hvf"} -cpu max";
         };
       };
 


### PR DESCRIPTION
In qemu 11.1, vGIC was enabled by default for `virt-11.1` machine type:

https://gitlab.com/qemu-project/qemu/-/commit/37863fff59e0b2c71989f2de906a52935f11ce7b

On modern MacOS versions (15+), it makes gic-version=2 invalid: only
version 3 is allowed:

https://gitlab.com/qemu-project/qemu/-/blob/v11.1.0/hw/arm/virt.c#L2717-2724

Because of this, darwin qemu driver broke after qemu 11.1 adoption. When
a VM is started, it exits with: `HVF does not support GICv2 emulation`.

(NixOS test driver just hangs at `machine: starting vm` until timeout
because the driver swallows the error... Probably something to improve.)

We could bump `gic-version` to 3, which would work. But this has a
similar risk of being bitten by changed defaults in future qemu
versions.

We could remove `gic-version` and stick to default `virt` config (which
is 3 in qemu 11.1), which would also work, and has the benefit of not
hardcoding a setting.

Regardless, gic-version=3 means we no longer support MacOS versions
below 15. Officially, nixpkgs still supports them, and while there are
plans and aspirations to move the minimal version to 15+ in 26.11, it's
not done until it's actually done.

Hence, this patch pins the machine version to `virt-11.0` and sticks to
software irq implementation. It may be not as optimal as vGIC but it
works everywhere.

While not required, this patch also removes the hardcoded gic-version
and lets qemu pick the right setting that matches the machine. This will
come handy when we move back to default `virt`.

---

How to reproduce the issue: just run any nixos qemu test on darwin and see that it hangs:

```
>  nom build --file . nixosTests.whisparr
[...]
vm-test-run-whisparr> building '/nix/store/q4skw5rlmx641nj8g22spzf0z6a853mm-vm-test-run-whisparr.drv'
vm-test-run-whisparr> Machine state will be reset. To keep it, pass --keep-machine-state
vm-test-run-whisparr> start all VLans
vm-test-run-whisparr> (finished: start all VLans, in 0.01 seconds)
vm-test-run-whisparr> Test will time out and terminate in 3600.0 seconds
vm-test-run-whisparr> run the VM test script
vm-test-run-whisparr> additionally exposed symbols:
vm-test-run-whisparr>     machine,
vm-test-run-whisparr>     vlan1,
vm-test-run-whisparr>     start_all, test_script, machines, machines_qemu, machines_nspawn, vlans, driver, log, os, create_machine, subtest, run_tests, join_all, retry, serial_stdout_off, serial_stdout_on, polling_condition, BaseMachine, QemuMachine, NspawnMachine, t, debug, dump_machine_ssh
vm-test-run-whisparr> machine: waiting for unit whisparr.service
vm-test-run-whisparr> machine: waiting for the VM to finish booting
vm-test-run-whisparr> machine: starting vm
```

It eventually times out, after an hour.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
