### PR TITLE
ctags-lsp: 0.10.2 -> 0.11.0

### DIFF
--- a/pkgs/by-name/ct/ctags-lsp/package.nix
+++ b/pkgs/by-name/ct/ctags-lsp/package.nix
@@ -11,17 +11,18 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "ctags-lsp";
-  version = "0.10.2";
+  version = "0.11.0";
   vendorHash = null;
 
   src = fetchFromGitHub {
     owner = "netmute";
     repo = "ctags-lsp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8cknVcXIuV7mmRMm87jn2l3qrfaY3CGzCZ0VW5Vb9xk=";
+    hash = "sha256-9VKXdffK46gl7MLN1kpSpQRIoJzu4nTS9C1r//qsOuo=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
+  nativeCheckInputs = [ universal-ctags ];
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Bump `ctags-lsp` from 0.10.2 to 0.11.0

Added `nativeCheckInputs` to include `universal-ctags` needed for the following tests:
>       TestInitializeLSPRequest
>       TestInitializeRootSelection
>       TestDidOpenSetsRootURIFromMarker
>       TestDidOpenRootlessWithoutMarker
>       TestDidOpenRootlessOutsideWorkspace
>       TestScanWorkspaceExplicitTagfile

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
