### PR TITLE
gershwin-eau-theme: init at 0-unstable-2026-07-18

### DIFF
--- a/pkgs/by-name/ge/gershwin-eau-theme/package.nix
+++ b/pkgs/by-name/ge/gershwin-eau-theme/package.nix
@@ -1,0 +1,43 @@
+{
+  clangStdenv,
+  fetchFromGitHub,
+  gnustep-back,
+  lib,
+  libx11,
+  swift-corelibs-libdispatch,
+  wrapGNUstepAppsHook,
+}:
+
+clangStdenv.mkDerivation {
+  strictDeps = true;
+  __structuredAttrs = true;
+  pname = "gershwin-eau-theme";
+  name = "gershwin-eau-theme";
+  version = "0-unstable-2026-07-18";
+
+  src = fetchFromGitHub {
+    owner = "gershwin-desktop";
+    repo = "gershwin-eau-theme";
+    rev = "1551c7e6fe86858ebe09cee3ee0fa8d92b1cc9da";
+    hash = "sha256-AkPkjVvK2ARPGMK4k7EgaHksO5+68Tsc8uUKI+PfZtQ=";
+  };
+
+  nativeBuildInputs = [
+    wrapGNUstepAppsHook
+  ];
+
+  buildInputs = [
+    gnustep-back
+    libx11
+    swift-corelibs-libdispatch
+  ];
+
+  meta = {
+    homepage = "https://github.com/gershwin-desktop/gershwin-eau-theme";
+    description = "The default theme for the Gershwin Desktop";
+    maintainers = with lib.maintainers; [
+      OulipianSummer
+    ];
+  };
+  platforms = lib.platforms.linux;
+}


### PR DESCRIPTION
This is a port of the default theme for the [Gershwin Desktop](https://github.com/gershwin-desktop), called [Eau](https://github.com/gershwin-desktop/gershwin-eau-theme).  It is effectively a theme for GNUstep environments and apps.

This PR was not made with the help of AI tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
