### PR TITLE
python3Packages.textual-fastdatatable: 0.17.1 -> 0.19.0 , sqlit-tui: 1.6.0 -> 1.6.1, harlequin: relax textual-fastdatatable

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -32,6 +32,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "click"
     "questionary"
     "tomlkit"
+    "textual-fastdatatable"
   ];
   dependencies =
     with python3Packages;

--- a/pkgs/by-name/sq/sqlit-tui/package.nix
+++ b/pkgs/by-name/sq/sqlit-tui/package.nix
@@ -8,7 +8,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "sqlit-tui";
-  version = "1.6.0";
+  version = "1.6.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -16,7 +16,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "Maxteabag";
     repo = "sqlit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LAWlUnRa+i+XQN8Sl7ri4i0UGjyqV7MTz1X+XgNDAcI=";
+    hash = "sha256-xKlL6Q32v7lD9RCwlkJidYmtwXqNiXLf9W57c7hxjFI=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/development/python-modules/textual-fastdatatable/default.nix
+++ b/pkgs/development/python-modules/textual-fastdatatable/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "textual-fastdatatable";
-  version = "0.17.1";
+  version = "0.19.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -30,7 +30,7 @@ buildPythonPackage (finalAttrs: {
     owner = "tconbeer";
     repo = "textual-fastdatatable";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-no2iLZmlQKSWLzHE9w5c6VRpHEQpPmVzrnBSvrwhgPI=";
+    hash = "sha256-o+lM682bLwhirNMOJ4AXzdgaA1ggysBkWFnDqTOj1s0=";
   };
 
   build-system = [ hatchling ];


### PR DESCRIPTION
Fixing https://github.com/NixOS/nixpkgs/pull/555919

Textual fastdatatable updated to 0.19.0 was breaking both harlequin and sqlit-tui.
Relaxing the python dep on harlequin seems to work fine.  
For sqlit-tui, updating to latest version 1.6.1 works.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
