### PR TITLE
python3Packages.{pyimg4,smart-meter-texas}: fix against asn1 3.x by adding asn1_2

### DIFF
--- a/pkgs/development/python-modules/asn1/2.nix
+++ b/pkgs/development/python-modules/asn1/2.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "asn1";
+  version = "2.8.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "andrivet";
+    repo = "python-asn1";
+    tag = "v${version}";
+    hash = "sha256-DLKfdQzYLhfaIEPPymTzRqj3+L/fsm5Jh8kqud/ezfw=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = [ "enum-compat" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  enabledTestPaths = [ "tests/test_asn1.py" ];
+
+  pythonImportsCheck = [ "asn1" ];
+
+  meta = {
+    description = "Python ASN.1 encoder and decoder";
+    longDescription = ''
+      Kept for consumers that cannot use asn1 3.x, where Decoder.read() returns
+      recursively decoded values for constructed tags instead of the raw contents.
+    '';
+    homepage = "https://github.com/andrivet/python-asn1";
+    changelog = "https://github.com/andrivet/python-asn1/blob/${src.tag}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pyimg4/default.nix
+++ b/pkgs/development/python-modules/pyimg4/default.nix
@@ -1,6 +1,6 @@
 {
   apple-compress,
-  asn1,
+  asn1_2,
   buildPythonPackage,
   click,
   fetchFromGitHub,
@@ -37,7 +37,8 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    asn1
+    # upstream pins asn1<3.0.0: https://github.com/m1stadev/PyIMG4/pull/59
+    asn1_2
     click
     pycryptodome
     pylzss
@@ -66,8 +67,6 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    # https://github.com/m1stadev/PyIMG4/pull/59
-    broken = lib.versionAtLeast asn1.version "3";
     changelog = "https://github.com/m1stadev/PyIMG4/releases/tag/${src.tag}";
     description = "Python library/CLI tool for parsing Apple's Image4 format";
     homepage = "https://github.com/m1stadev/PyIMG4";

--- a/pkgs/development/python-modules/smart-meter-texas/default.nix
+++ b/pkgs/development/python-modules/smart-meter-texas/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   aiohttp,
-  asn1,
+  asn1_2,
   python-dateutil,
   setuptools,
   tenacity,
@@ -30,7 +30,9 @@ buildPythonPackage rec {
 
   dependencies = [
     aiohttp
-    asn1
+    # _find_ca_issuers_uri() recurses with enter()/leave() and loops on eof(),
+    # which is only container-relative in asn1 2.x
+    asn1_2
     python-dateutil
     tenacity
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1399,6 +1399,8 @@ self: super: with self; {
 
   asn1 = callPackage ../development/python-modules/asn1 { };
 
+  asn1_2 = callPackage ../development/python-modules/asn1/2.nix { };
+
   asn1ate = callPackage ../development/python-modules/asn1ate { };
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };


### PR DESCRIPTION
`python3Packages.pyimg4` has been marked broken since ef300f432152, which set `broken = lib.versionAtLeast asn1.version "3"`. Since `asn1` is at 3.3.0, the guard always fires and takes `ipsw-parser` and `pymobiledevice3` down with it:

```
$ nix shell nixpkgs#python3Packages.pymobiledevice3
error: Refusing to evaluate package 'python3.14-pyimg4-0.8.8' ... because it has problems:
       - broken: This package is broken.
note: trace involved the following derivations:
       derivation 'python3.14-pymobiledevice3-7.7.0'
       derivation 'python3.14-ipsw-parser-1.5.0'
```

The pin is not stale metadata. With the constraint relaxed and `broken` dropped, 5 of 7 tests fail against asn1 3.3.0:

```
FAILED tests/test_im4m.py::test_im4m  - asn1.core.Error: Expecting bytes or a subclass of io.RawIOBase or BufferedI...
FAILED tests/test_im4r.py::test_read  - asn1.core.Error: Expecting bytes or a subclass of io.RawIOBase or BufferedI...
FAILED tests/test_img4.py::test_read  - pyimg4.errors.UnexpectedTagError: Expected tag of type IA5String, got Print...
```

python-asn1 3.0 changed `Decoder.read()` to recursively decode constructed elements into nested lists instead of returning their raw content octets, which is what `parser.py` re-parses and re-emits throughout. It also changed `Encoder.write(..., Types.Constructed)` to iterate the value rather than emit pre-encoded octets verbatim, so pre-encoded DER silently becomes one Integer per byte. Upstream declined the port in [m1stadev/PyIMG4#59](https://github.com/m1stadev/PyIMG4/pull/59) ("Version 3.0.0 is technically much better, but pyimg4 should be refactored around it first to support it") and has not released since v0.8.8 in April 2025.

So this adds `asn1_2` at 2.8.0, the last 2.x, and builds `pyimg4` against it, following the existing convention for versioned Python attributes (`cython_0`, `chardet_5`, `django_5`). `asn1` stays at 3.3.0 as the default. No `pythonRelaxDeps` entry is needed, since 2.8.0 satisfies upstream's `asn1>=2.7.0,<3.0.0` directly.

`smart-meter-texas` is the only other Nixpkgs consumer of `python3Packages.asn1`, and it is broken on 3.x for the same root cause: `_find_ca_issuers_uri()` recurses through `Decoder.enter()`/`leave()` while looping on `Decoder.eof()`, which 3.0 made relative to the whole input instead of the entered container. On a two-entry `authorityInfoAccess` (the common OCSP-then-caIssuers layout) it raises `AttributeError: 'NoneType' object has no attribute 'typ'` on 3.3.0 and returns the URI on 2.8.0. It goes unnoticed because upstream ships no tests and `get_ca_issuers_uri()` swallows the exception. The third commit moves it to `asn1_2` too; details and the reproduction are in a comment below.

That leaves `asn1` at 3.3.0 with no in-tree consumer, so downgrading it outright and dropping `asn1_2` would be a smaller diff and breaks nothing in the tree. I avoided that because it would silently hand 2.x to out-of-tree users who asked for the current release. Glad to switch if you prefer it.

I have also proposed the actual port upstream in [m1stadev/PyIMG4#63](https://github.com/m1stadev/PyIMG4/pull/63). Once that lands and is released, `pyimg4` can move back to `asn1` and `asn1_2` can be dropped. Happy to go the other way instead and patch `pyimg4` with that diff here if maintainers prefer not to carry a second `asn1`.

### Verification

```
nix-build -A python3Packages.pyimg4           # 7 passed, 5 deselected
nix-build -A python3Packages.ipsw-parser      # ok
nix-build -A python3Packages.pymobiledevice3  # 56 passed, 113 deselected, 1 xfailed
nix-build -A python3Packages.asn1_2           # upstream tests/test_asn1.py pass
nix-instantiate -A python3Packages.{asn1_2,pyimg4,ipsw-parser,ldap3} \
                -A python312Packages.pyimg4 -A python313Packages.asn1_2
```

`nix-store -qR` on the `pymobiledevice3` output contains `python3.14-asn1-2.8.0` and no 3.3.0, so there is no module collision in the closure.

The affected set is closed and was built in full by hand: `asn1_2` is new and only `pyimg4` consumes it, `pyimg4`'s only reverse dependency is `ipsw-parser`, whose only reverse dependency is `pymobiledevice3`, which nothing else in tree depends on. All four are built above. `nixpkgs-review pr 555937` has since confirmed exactly that set: 8 packages built (`asn1_2`, `pyimg4`, `ipsw-parser`, `pymobiledevice3` on python313 and python314), 0 failures. Report posted as a comment below.

### Automation/AI disclosure

Per [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy): both commits carry an `Assisted-by: Claude Code (claude-opus-5)` trailer, and this pull request summary was likewise drafted with that tooling. I have reviewed the diff and the reasoning, and verified the outcome independently by building every affected package and inspecting the runtime closure, as listed above.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
