### PR TITLE
libs-av: init at 0-unstable-2026-07-27

### DIFF
--- a/pkgs/by-name/li/libs-av/package.nix
+++ b/pkgs/by-name/li/libs-av/package.nix
@@ -1,0 +1,54 @@
+{
+  clangStdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  gnustep-make,
+  gnustep-back,
+  gnustep-base,
+  lib,
+  withGershwinPatches ? false,
+  wrapGNUstepAppsHook,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pname = "libs-av";
+  version = "0-unstable-2026-07-27";
+
+  src = fetchFromGitHub {
+    owner = "gnustep";
+    repo = "libs-av";
+    rev = "26566e25043ffc354364a9a5ff2c69252f81d404";
+    hash = "sha256-vy8zhSxsZ+G/sCPu0yTtLLb+lgbLPMW3xXq7sXFhyRo=";
+  };
+
+  nativeBuildInputs = [
+    wrapGNUstepAppsHook
+    gnustep-make
+    gnustep-base
+  ];
+
+  buildInputs = [
+    gnustep-back
+  ];
+
+  patches = lib.optionals withGershwinPatches [
+    (fetchpatch {
+      name = "metadata.patch";
+      url = "https://raw.githubusercontent.com/gershwin-desktop/gershwin-developer/81bd1c3269819bc889701ec3674b7def892db5be/Library/Patches/libs-av-metadata.patch";
+      sha256 = "sha256-SUEJGQGy/eSNzuWgX+uEwBMn5GvfzWJZA1XhW7xjkh8=";
+    })
+  ];
+
+  meta = {
+    homepage = "https://github.com/gnustep/libs-av";
+    description = "A GNUstep implementation of the AVFoundation library, based on FFmpeg";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      OulipianSummer
+    ];
+  };
+  platforms = lib.platforms.linux;
+})


### PR DESCRIPTION
This packages [libs-av](https://github.com/gnustep/libs-av) by the GNUStep project. It is a GNUstep implementation of the AVFoundation library, based on FFmpeg (libavformat/libavcodec/libavutil) for media I/O and FluidSynth for MIDI playback.

I'm working on porting Gershwin packages into nixpkgs, and this is one of the dependencies that tools like the workspace manager require.

This PR was not created with the help of any AI tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
