### PR TITLE
treewide: fix typos

### DIFF
--- a/doc/interoperability/cyclonedx.md
+++ b/doc/interoperability/cyclonedx.md
@@ -39,7 +39,7 @@ The `nix:narinfo` properties should be accompanied by a `nix:store_path` propert
 | `nix:narinfo:system`      | The hardware and software platform on which this component is produced. |
 | `nix:narinfo:sig`         | Signatures claiming that this component is what it claims to be. |
 | `nix:narinfo:ca`          | Content address of this store object's file system object, used to compute its store path. |
-| `nix:narinfo:references`  | A whitespace separated array of store paths that this component references. |
+| `nix:narinfo:references`  | A whitespace-separated array of store paths that this component references. |
 
 ### `nix:fod` {#sec-interop.cylonedx-fod}
 

--- a/nixos/modules/services/cluster/hadoop/hbase.nix
+++ b/nixos/modules/services/cluster/hadoop/hbase.nix
@@ -167,7 +167,7 @@ in
       zookeeperQuorum = lib.mkOption {
         description = ''
           This option will set "hbase.zookeeper.quorum" in hbase-site.xml.
-          Comma separated list of servers in the ZooKeeper ensemble.
+          Comma-separated list of servers in the ZooKeeper ensemble.
         '';
         type = with lib.types; nullOr commas;
         example = "zk1.internal,zk2.internal,zk3.internal";

--- a/nixos/modules/services/networking/supplicant.nix
+++ b/nixos/modules/services/networking/supplicant.nix
@@ -226,7 +226,7 @@ in
         The value of this option is an attribute set. Each attribute configures a
         {command}`wpa_supplicant` service, where the attribute name specifies
         the name of the interface that {command}`wpa_supplicant` operates on.
-        The attribute name can be a space separated list of interfaces.
+        The attribute name can be a space-separated list of interfaces.
         The attribute names `WLAN`, `LAN` and `DBUS`
         have a special meaning. `WLAN` and `LAN` are
         configurations for universal {command}`wpa_supplicant` service that is

--- a/nixos/modules/services/networking/vsftpd.nix
+++ b/nixos/modules/services/networking/vsftpd.nix
@@ -168,7 +168,7 @@ in
         default = pkgs.writeText "userlist" (concatMapStrings (x: "${x}\n") cfg.userlist);
         defaultText = literalExpression ''pkgs.writeText "userlist" (concatMapStrings (x: "''${x}\n") cfg.userlist)'';
         description = ''
-          Newline separated list of names to be allowed/denied if {option}`userlistEnable`
+          Newline-separated list of names to be allowed/denied if {option}`userlistEnable`
           is `true`. Meaning see {option}`userlistDeny`.
 
           The default is a file containing the users from {option}`userlist`.

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -360,7 +360,7 @@ in
           default = null;
           type = lib.types.nullOr lib.types.str;
           description = ''
-            A ; seperated array of 8 colors in the format RRGGBB:
+            A semicolon-separated array of 8 colors in the format RRGGBB:
             black, red, green, brown, blue, magenta, cyan, and gray.
           '';
         };
@@ -369,7 +369,7 @@ in
           default = null;
           type = lib.types.nullOr lib.types.str;
           description = ''
-            A ; seperated array of 8 colors in the format RRGGBB:
+            A semicolon-separated array of 8 colors in the format RRGGBB:
             dark gray, bright red, bright green, yellow, bright blue, bright magenta, bright cyan, and white.
           '';
         };

--- a/pkgs/applications/misc/inochi2d/default.nix
+++ b/pkgs/applications/misc/inochi2d/default.nix
@@ -36,7 +36,7 @@ in
     patches = [
       # Upstream asks that we change the bug tracker URL to not point to the upstream bug tracker
       (replaceVars ./support-url.patch {
-        assignees = "TomaSajt"; # should be a comma separated list of the github usernames of the maintainers
+        assignees = "TomaSajt"; # should be a comma-separated list of the github usernames of the maintainers
       })
       # Change how duplicate locales differentiate themselves (the store paths were too long)
       ./translations.patch

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -322,7 +322,7 @@ lib.extendMkDerivation {
               getGoDirs() {
                 local -r type="$1"
 
-                # Support structuredAttrs, they are not space seperated
+                # Support structuredAttrs, they are not space separated
                 local -a subPackagesArray
                 concatTo subPackagesArray subPackages
 

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -322,7 +322,7 @@ lib.extendMkDerivation {
               getGoDirs() {
                 local -r type="$1"
 
-                # Support strucuredAttrs, they are not space seperated
+                # Support structuredAttrs, they are not space seperated
                 local -a subPackagesArray
                 concatTo subPackagesArray subPackages
 

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -531,7 +531,7 @@ effectiveStdenv.mkDerivation {
 
     # OpenCV respects at least three variables:
     # -DCUDA_GENERATION takes a single arch name, e.g. Volta
-    # -DCUDA_ARCH_BIN takes a semi-colon separated list of real arches, e.g. "8.0;8.6"
+    # -DCUDA_ARCH_BIN takes a semicolon-separated list of real arches, e.g. "8.0;8.6"
     # -DCUDA_ARCH_PTX takes the virtual arch, e.g. "8.6"
     (cmakeFeature "CUDA_ARCH_BIN" cmakeCudaArchitecturesString)
     (cmakeFeature "CUDA_ARCH_PTX" (last cudaCapabilities))


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixed a number of typos in code comments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
