### PR TITLE
ggh: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/by-name/gg/ggh/package.nix
+++ b/pkgs/by-name/gg/ggh/package.nix
@@ -7,22 +7,27 @@
 
 buildGoModule (finalAttrs: {
   pname = "ggh";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "byawitz";
     repo = "ggh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-itNx/AcLUQCH99ZCOXiXPWNg3mx+UhHepidqmzPY8Oc=";
+    hash = "sha256-IjiRz6ierqqjRZB4XBQYwohasx7ByAs7aPt1i2Tv5Eo=";
   };
 
-  vendorHash = "sha256-WPPjpxCD3WA3E7lx5+DPvG31p8djera5xRn980eaJT8=";
+  vendorHash = "sha256-TVe6Yd3dOmrrcTIEGWnXRG+nCAyE/ygCv/M23ZXXzB4=";
 
   ldflags = [
     "-s"
     "-w"
     "-X main.version=v${finalAttrs.version}"
   ];
+
+  # Test requires a HOME dir
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Bump `ggh` from 0.14.0 to 0.15.0

Added `preCheck` to add TMP Home dir for needed for existing test

Background:
A `Home` dir is needed for to test `save(s)` fn that calls another fn `getFileLocation()` that itself calls `os.UserHomeDir()`
See:
https://github.com/byawitz/ggh/blob/v0.1.5/internal/settings/settings.go#L32-L41

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
