### PR TITLE
init dmemcg booster at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20005,6 +20005,11 @@
     githubId = 72071763;
     name = "Yusup Urazaev";
   };
+  name-tar-xz = {
+    github = "name-tar-xz";
+    githubId = 54463026;
+    name = "name-tar-xz";
+  };
   namore = {
     email = "namor@hemio.de";
     github = "namore";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -106,6 +106,8 @@
 
 - [kvrocks_exporter](https://github.com/RocksLabs/kvrocks_exporter), a Prometheus exporter for Kvrocks metrics. Available as [services.prometheus.exporters.kvrocks](#opt-services.prometheus.exporters.kvrocks.enable).
 
+- [dmemcg-booster](https://gitlab.steamos.cloud/holo/dmemcg-booster), a Service for enabling and controlling dmem cgroup limits for boosting foreground games. Available as [services.dmemcg-booster](#opt-services.dmemcg-booster.enable).
+
 - [Umbriel](https://docs.noctalia.dev/umbriel/), a Wayland compositor built on wlroots and SceneFX. Available as [programs.umbriel](#opt-programs.umbriel.enable).
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -664,6 +664,7 @@
   ./services/games/archisteamfarm.nix
   ./services/games/armagetronad.nix
   ./services/games/crossfire-server.nix
+  ./services/games/dmemcg-booster.nix
   ./services/games/factorio.nix
   ./services/games/freeciv.nix
   ./services/games/mchprs.nix

--- a/nixos/modules/services/games/dmemcg-booster.nix
+++ b/nixos/modules/services/games/dmemcg-booster.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.dmemcg-booster;
+in
+{
+  options.services.dmemcg-booster = {
+    enable = lib.mkEnableOption "Service for enabling and controlling dmem cgroup limits for boosting foreground games";
+    package = lib.mkPackageOption pkgs "dmemcg-booster" { };
+    type = lib.mkOption {
+      default = "system";
+      description = "Whether to use the dmemcg-booster system service or user service";
+      type = lib.types.enum [
+        "system"
+        "user"
+      ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd = {
+      packages = [ cfg.package ];
+      services = lib.mkIf (cfg.type == "system") {
+        dmemcg-booster-system.wantedBy = [ "multi-user.target" ];
+      };
+      user.services = lib.mkIf (cfg.type == "user") {
+        dmemcg-booster-user.wantedBy = [ "graphical-session-pre.target" ];
+      };
+    };
+  };
+
+  meta = { inherit (pkgs.dmemcg-booster.meta) maintainers; };
+}

--- a/pkgs/by-name/dm/dmemcg-booster/package.nix
+++ b/pkgs/by-name/dm/dmemcg-booster/package.nix
@@ -1,0 +1,50 @@
+{
+  rustPlatform,
+  fetchFromGitLab,
+  dbus,
+  pkg-config,
+  nix-update-script,
+  lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dmemcg-booster";
+  version = "0.1.3";
+  cargoHash = "sha256-NHK4734Jvi4RJieGn0RjYU0PzQFqaE4exHG77dmukig=";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.steamos.cloud";
+    owner = "holo";
+    repo = "dmemcg-booster";
+    tag = finalAttrs.version;
+    hash = "sha256-JDT+JKxgaETinIHiP0Pqb7fPNrvcI6AQu90nmoA/YuI=";
+  };
+
+  __structuredAttrs = true;
+
+  env.PKG_CONFIG_PATH = "${dbus.dev}/lib/pkgconfig";
+  nativeBuildInputs = [ pkg-config ];
+
+  installPhase = ''
+    install -Dm755 target/x86_64-unknown-linux-gnu/release/dmemcg-booster "$out/bin/dmemcg-booster"
+
+    # Set up systemd services
+    install -Dm644 dmemcg-booster-system.service "$out/lib/systemd/system/dmemcg-booster-system.service"
+    install -Dm644 dmemcg-booster-user.service "$out/lib/systemd/user/dmemcg-booster-user.service"
+  '';
+  fixupPhase = ''
+    substituteInPlace $out/lib/systemd/system/dmemcg-booster-system.service \
+      --replace-fail "/usr/bin/dmemcg-booster" "$out/bin/dmemcg-booster"
+    substituteInPlace $out/lib/systemd/user/dmemcg-booster-user.service \
+      --replace-fail "/usr/bin/dmemcg-booster" "$out/bin/dmemcg-booster"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "dmemcg-booster";
+    description = "Service for enabling and controlling dmem cgroup limits for boosting foreground games";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ name-tar-xz ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
