### PR TITLE
[26.05]: appium-inspector: 2026.5.1 -> 2026.7.1, update to electron v43

### DIFF
--- a/pkgs/by-name/ap/appium-inspector/package.nix
+++ b/pkgs/by-name/ap/appium-inspector/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildNpmPackage,
   copyDesktopItems,
-  electron_41,
+  electron_43,
   fetchFromGitHub,
   makeDesktopItem,
   makeWrapper,
@@ -14,18 +14,17 @@
 }:
 
 let
-  electron = electron_41;
-  version = "2026.7.1";
+  electron = electron_43;
 in
 
 buildNpmPackage (finalAttrs: {
   pname = "appium-inspector";
-  inherit version;
+  version = "2026.7.1";
 
   src = fetchFromGitHub {
     owner = "appium";
     repo = "appium-inspector";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7pxXlY/aifrg4cuGZSgxONF+RPL8P7JcZ6Gobqv2nz4=";
   };
 
@@ -102,7 +101,7 @@ buildNpmPackage (finalAttrs: {
   meta = {
     description = "GUI inspector for the appium UI automation tool";
     homepage = "https://appium.github.io/appium-inspector";
-    changelog = "https://github.com/appium/appium-inspector/releases/tag/v${version}";
+    changelog = "https://github.com/appium/appium-inspector/releases/tag/v${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     mainProgram = "appium-inspector";
     maintainers = with lib.maintainers; [ marie ];

--- a/pkgs/by-name/ap/appium-inspector/package.nix
+++ b/pkgs/by-name/ap/appium-inspector/package.nix
@@ -15,7 +15,7 @@
 
 let
   electron = electron_41;
-  version = "2026.5.1";
+  version = "2026.7.1";
 in
 
 buildNpmPackage (finalAttrs: {
@@ -26,10 +26,10 @@ buildNpmPackage (finalAttrs: {
     owner = "appium";
     repo = "appium-inspector";
     tag = "v${version}";
-    hash = "sha256-SJlTTVTZ/zGIK7Nf35cZ62tdhevXC95MsbiQJCLiVtk=";
+    hash = "sha256-7pxXlY/aifrg4cuGZSgxONF+RPL8P7JcZ6Gobqv2nz4=";
   };
 
-  npmDepsHash = "sha256-2rjgKS1mIrjOg+YXuMaqKyEQt0utLA4DGxOs0oI4BaQ=";
+  npmDepsHash = "sha256-W9FWIHhtS2d9xBpIEGB8sWmDfcdyphL+0eCk1+8pu2s=";
   npmFlags = [ "--ignore-scripts" ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Manual backport of https://github.com/NixOS/nixpkgs/pull/547366 and https://github.com/NixOS/nixpkgs/pull/555467

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
