### PR TITLE
rsync: skip sandbox-incompatible Darwin tests

### DIFF
--- a/pkgs/by-name/rs/rsync/package.nix
+++ b/pkgs/by-name/rs/rsync/package.nix
@@ -126,6 +126,12 @@ stdenv.mkDerivation (finalAttrs: {
           "variety-symlink-traversal"
           "variety"
         ]
+        # The Darwin sandbox drops set-id bits, and Python's os.getgroups()
+        # reports account groups that may not be usable by this process.
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          "chmod-setid"
+          "daemon-groupmap-wild"
+        ]
         # This test assumes that every Linux libc provides glibc malloc stats.
         ++ lib.optional stdenv.hostPlatform.isMusl "misc-coverage"
         # These require a native compiler and dynamic interposition.


### PR DESCRIPTION
Skip `chmod-setid` and `daemon-groupmap-wild` on Darwin because they assume set-id and supplementary-group behavior unavailable in the Nix Darwin build sandbox. This unblocks the current `staging-next` cycle after repeated failures in [Hydra build 343034394](https://hydra.nixos.org/build/343034394).

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
