### PR TITLE
generate-ipv6-address: init at 0.1

### DIFF
--- a/pkgs/by-name/ge/generate-ipv6-address/package.nix
+++ b/pkgs/by-name/ge/generate-ipv6-address/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "generate-ipv6-address";
+  version = "0.1";
+
+  src = fetchurl {
+    url = "https://www.irif.fr/~jch/software/files/generate-ipv6-address-0.1.tar.gz";
+    hash = "sha256-4TVtJF1fiR+jm3lqii3u/aqJ8IEw3JejeHOMpe2aIPo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = {
+    description = "Utility to generate IPv6 addresses according to RFC 4193";
+    mainProgram = "generate-ipv6-address";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dvn0 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added a package for a simple utility that generates IPv6 addresses based on RFC 4193.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
