### PR TITLE
linuxPackages.evdi: 1.14.15 -> 1.15.0

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -7,7 +7,6 @@
   libdrm,
   python3,
 }:
-
 let
   python3WithLibs = python3.withPackages (
     ps: with ps; [
@@ -17,19 +16,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "evdi";
-  version = "1.14.15";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = "evdi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tms+UNws+oBmwLvDFaDSIa/bUdSpK+CADodbsip3tRg=";
+    hash = "sha256-CXF7PvmrPjjNoWXbWxEkFE/Sw4bO6YqDplPwF/OxhB0=";
   };
 
-  prePatch = ''
-    substituteInPlace module/Makefile \
-      --replace-fail '/etc/os-release' '/dev/null'
-  '';
+  patches = [
+    # Fix feature probes on kernels with allocation profiling enabled.
+    # Upstream: https://github.com/DisplayLink/evdi/pull/592
+    ./fix-conftest-probes.patch
+  ];
 
   env.CFLAGS = toString [
     "-Wno-error"

--- a/pkgs/os-specific/linux/evdi/fix-conftest-probes.patch
+++ b/pkgs/os-specific/linux/evdi/fix-conftest-probes.patch
@@ -1,0 +1,10 @@
+--- a/module/conftest.sh
++++ b/module/conftest.sh
+@@ -32,6 +32,7 @@
+ 	done
+ }
+ CFLAGS=$(requote "$@")
++CFLAGS="$CFLAGS '-DKBUILD_MODNAME=\"conftest\"' '-DKBUILD_BASENAME=\"conftest\"'"
+ 
+ WORKDIR="$(mktemp -d)"
+ trap 'rm -rf "$WORKDIR"' EXIT


### PR DESCRIPTION
Update EVDI from 1.14.15 to 1.15.0.

EVDI 1.15.0 introduces feature probes and preliminary support for Linux 7.2. It also removes the distribution detection for which Nixpkgs previously substituted `/etc/os-release`.

The new probes still fail on kernels with allocation profiling enabled because they are compiled without `KBUILD_MODNAME`. This produces a false-negative `kzalloc_obj` result and causes the module build to fail. Vendor the fix proposed in https://github.com/DisplayLink/evdi/pull/592 while that PR remains open.

Resolves #554981.
Closes #516848.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

I verified the build against Linux 7.2 and 6.18.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
