### PR TITLE
moon: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/by-name/mo/moon/package.nix
+++ b/pkgs/by-name/mo/moon/package.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moon";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = fetchFromGitHub {
     owner = "moonrepo";
     repo = "moon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HR9C76TBmxLElZzNC/+Eyt61T2HYn6ElOGG50Oj3Eng=";
+    hash = "sha256-tDJjEpQBCo6rpAJBITuxkzXWa0B/k10ZbWR/I7e+KAw=";
   };
 
-  cargoHash = "sha256-6SgCcaPLQ6pj7bJU6iBV8mk8EsulCpFDL+26ip6TSgY=";
+  cargoHash = "sha256-j80p+Lfpa17gPPmEzJOpQz2vmI73AodxEUiZt31x9To=";
 
   env = {
     RUSTFLAGS = "-C strip=symbols";


### PR DESCRIPTION
Routine version bump of `moon` from 2.5.2 to 2.5.3.

Changelog: https://github.com/moonrepo/moon/releases/tag/v2.5.3

Only `version`, `src.hash` and `cargoHash` change; the derivation is otherwise untouched. Patch release — Bun/Go toolchain handling upstream, plus one fix for tag-scoped task dependencies.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Details on the boxes above:

- `nix build -f . moon` on x86_64-linux succeeded. The package sets `doInstallCheck` with `versionCheckHook`, so the build itself asserts the version:

  ```
  Successfully managed to find version 2.5.3 in the output of the command /nix/store/93gb5mfixid7fspd82dw28sx07w6k2av-moon-2.5.3/bin/moon --version
  moon 2.5.3
  ```

- Both installed binaries run: `moon --version` → `moon 2.5.3`, `moonx --version` → `moon-exec 2.5.3`.

- `nixpkgs-review pr 555987` on x86_64-linux, against merge commit `f25af00` (this branch `3f9f96f` merged into master `fecff82`):

  ```
  --------- Report for 'x86_64-linux' ---------
  1 package built:
  moon
  ```

  `moon` is a leaf package, so it is the only rebuild. The merge commit evaluates to the same derivation as the standalone build above (`nixpkgs-review` resolved `moon-2.5.3.drv` from the local store rather than recompiling), so nothing in `stdenv`/`rustPlatform` has drifted under this package.

- The branch is based on the previously merged `moon: 2.4.6 -> 2.5.2` commit (`1d0bb91`, an ancestor of master), so the diff against master is these three lines and nothing else. `pkgs/by-name/mo/moon/package.nix` is byte-identical between that commit and current master, so there is nothing to rebase around.

## Automation/AI disclosure

Per the [automation/AI policy], this contribution was assisted with Claude Code (Claude Opus 5), disclosed in the commit via an `Assisted-by:` trailer. The three-line diff and the build output above were reviewed by me before submission, and I take responsibility for the change. This summary is likewise assisted. The hashes were derived without `nix-update` this time: `nix-prefetch-url --unpack` plus `nix hash convert` for `src.hash`, and a `lib.fakeHash` round-trip on `moon.cargoDeps` for `cargoHash`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md

