### PR TITLE
age-plugin-keystore: init at 1.2.0

### DIFF
--- a/pkgs/by-name/ag/age-plugin-keystore/package.nix
+++ b/pkgs/by-name/ag/age-plugin-keystore/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "age-plugin-keystore";
+  version = "1.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "arouene";
+    repo = "age-plugin-keystore";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-op9gJPfYSwaLyq6UpnKtu7MqBVtPMPnJBvZTibqG+p8=";
+  };
+
+  vendorHash = "sha256-+RwWLDqnSOv5/lBa89jbWQq+BcFHxP5to5/zVfYt1fs=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  env = {
+    CGO_ENABLED = "0";
+  };
+
+  # Tests need dbus and a secret service
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Age plugin that stores X25519 or PQ Hybrid private keys in Linux Keyrings using the Secret Service D-Bus API";
+    homepage = "https://github.com/arouene/age-plugin-keystore";
+    changelog = "https://github.com/arouene/age-plugin-keystore/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marie ];
+    mainProgram = "age-plugin-keystore";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/arouene/age-plugin-keystore

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
