### PR TITLE
google-cloud-sdk: 579.0.0 -> 581.0.0

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/components.json
+++ b/pkgs/by-name/go/google-cloud-sdk/components.json
@@ -5,7 +5,7 @@
         "checksum": "73eeb0b0222c8c72ce1cbba3c2ca787d7d89eabc5226463fd59a404f76280138",
         "contents_checksum": "a0096c5a5f0a315397d46a44d19b63f26bca1607a833260032e1efa03d44c9a7",
         "size": 761,
-        "source": "components/google-cloud-sdk-alpha-20260731054104.tar.gz",
+        "source": "components/google-cloud-sdk-alpha-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -23,8 +23,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "2026.07.31"
+        "build_number": 20260814074256,
+        "version_string": "2026.08.14"
       }
     },
     {
@@ -1138,7 +1138,7 @@
         "checksum": "0034138f7ee8d13690dae0a1443a09ecbdae1e45497360c14dabd2c57a79c8a2",
         "contents_checksum": "eee82cd34806ce26487960b9cf1705786ccf975d34390b179f7b89307dc51044",
         "size": 758,
-        "source": "components/google-cloud-sdk-beta-20260731054104.tar.gz",
+        "source": "components/google-cloud-sdk-beta-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1156,8 +1156,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "2026.07.31"
+        "build_number": 20260814074256,
+        "version_string": "2026.08.14"
       }
     },
     {
@@ -1481,10 +1481,10 @@
     },
     {
       "data": {
-        "checksum": "ea5d5573c5f273c69031b1f861ce3579434b7a4b37a53f81b558f1b0e6fea3d7",
-        "contents_checksum": "30706c8fc569a3578eefceb01b78b0b5a67fd72d1c016f269abc264834baa0e4",
-        "size": 1973753,
-        "source": "components/google-cloud-sdk-bq-20260724054717.tar.gz",
+        "checksum": "954a92fb0c34dfc607295a230ef126e84ebae0e0827a5ba2424d2622ce3535d6",
+        "contents_checksum": "16f1ebfc39679cfb5e3e3a7f24de0bf9da8f9ba21e86fb90de9244bdd905821b",
+        "size": 2286040,
+        "source": "components/google-cloud-sdk-bq-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1504,8 +1504,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20260724054717,
-        "version_string": "2.1.36"
+        "build_number": 20260814074256,
+        "version_string": "2.1.37"
       }
     },
     {
@@ -1610,15 +1610,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.25.3"
+        "version_string": "1.25.4"
       }
     },
     {
       "data": {
-        "checksum": "79590ed52dbd03a247b69e11dd40c625ce16354b2a5d88de100f14f364e57bdb",
-        "contents_checksum": "762286f63aafe7d3b43863f7d81743ba77110c74b9dad7419e85ed58a06f162a",
-        "size": 20845895,
-        "source": "components/google-cloud-sdk-cbt-darwin-arm-20260717053915.tar.gz",
+        "checksum": "d6b7eee546c9f44de0c02018144539ebb7b739934bd477efe4ce14061a6d1fb6",
+        "contents_checksum": "105a55d37d626676b5b1351d9432d41dbc2c13327b44a2e965d4dd9a093cd389",
+        "size": 22101844,
+        "source": "components/google-cloud-sdk-cbt-darwin-arm-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1643,8 +1643,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260717053915,
-        "version_string": "1.25.3"
+        "build_number": 20260814074256,
+        "version_string": "1.25.4"
       }
     },
     {
@@ -1683,10 +1683,10 @@
     },
     {
       "data": {
-        "checksum": "af846f78a8906d2f63c4da1449dd147c7805820bb30b6f1bd0437c5cab048a1f",
-        "contents_checksum": "a2b6581c530da0dad6e3d330b24f7b0d703e99915a91d829dd2893f7d4974d86",
-        "size": 22038894,
-        "source": "components/google-cloud-sdk-cbt-darwin-x86_64-20260717053915.tar.gz",
+        "checksum": "23ae91edc498b4e407ab529e1efa942870f32dac3923c1f830a41005b4fabfa9",
+        "contents_checksum": "dac40b2a5f61ce95a93fddc7495a483731c82e8c3e015854440f16aafc41f182",
+        "size": 23354874,
+        "source": "components/google-cloud-sdk-cbt-darwin-x86_64-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1711,16 +1711,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260717053915,
-        "version_string": "1.25.3"
+        "build_number": 20260814074256,
+        "version_string": "1.25.4"
       }
     },
     {
       "data": {
-        "checksum": "051264f5559ecb4b0135f95935b55a221978b24382febd1ec4e68512c0ffd442",
-        "contents_checksum": "2e8f90e00370f41597de5f6c5759a889866d112022b3e0d950a29b1ee6d63777",
-        "size": 19276042,
-        "source": "components/google-cloud-sdk-cbt-linux-arm-20260717053915.tar.gz",
+        "checksum": "e4ba5ebc32e9c3eff8de39374a7ed4f85138eca034a2fdc4ea662fc3383e32ec",
+        "contents_checksum": "db962cb6a3b04fe90c5552204c4db88f97c1ea13d8fd4bbbe610b453d8a32164",
+        "size": 20420640,
+        "source": "components/google-cloud-sdk-cbt-linux-arm-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1745,16 +1745,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260717053915,
-        "version_string": "1.25.3"
+        "build_number": 20260814074256,
+        "version_string": "1.25.4"
       }
     },
     {
       "data": {
-        "checksum": "6145eabb4c63f4dacd65b93b44cc53890496ab4c9cb1e6b12c1a4539bc86a2eb",
-        "contents_checksum": "58b86989036f07e3716686667fed972dea38af44f8aa417adccbbb0c8feff8d5",
-        "size": 19901952,
-        "source": "components/google-cloud-sdk-cbt-linux-x86-20260717053915.tar.gz",
+        "checksum": "79d91403cb2018a35a017a9258faec0377336ce1248d04673b365f73ce8bcf47",
+        "contents_checksum": "bef43c1e95fb7b881037c853822efc198bccaee65bdbcaee9a27516b744c896c",
+        "size": 21141620,
+        "source": "components/google-cloud-sdk-cbt-linux-x86-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1779,16 +1779,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260717053915,
-        "version_string": "1.25.3"
+        "build_number": 20260814074256,
+        "version_string": "1.25.4"
       }
     },
     {
       "data": {
-        "checksum": "482bee238a7aade205fd1a3f88ac8ca7e41df6b829c34f53bd265c3d24b309f9",
-        "contents_checksum": "c300acced8b8f1d22f649a86ea7179d15b6a4f6d508a96cf15be6cea60c7cc4f",
-        "size": 20909709,
-        "source": "components/google-cloud-sdk-cbt-linux-x86_64-20260717053915.tar.gz",
+        "checksum": "bf72f5f6f2c8649594e45ea3c0a8578934e1b937d36a8ff89c1677169b4b3f22",
+        "contents_checksum": "c616e30c3986cce5e434a317bef33f2d4acf83328e1b04663fa09562ec0fffea",
+        "size": 22132663,
+        "source": "components/google-cloud-sdk-cbt-linux-x86_64-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1813,16 +1813,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260717053915,
-        "version_string": "1.25.3"
+        "build_number": 20260814074256,
+        "version_string": "1.25.4"
       }
     },
     {
       "data": {
-        "checksum": "83b3187fed8cc589426d96d007d85e4c77119600d29c6ac9ce2aa1f8d9a62a4d",
-        "contents_checksum": "06031024289140c23288dc37ebdc66e2b1929ca384bfd9a4fbdff447e01dec6d",
-        "size": 20363797,
-        "source": "components/google-cloud-sdk-cbt-windows-x86-20260717053915.tar.gz",
+        "checksum": "11f15c7b7f13b51cb1505451eae37215e40caad709c248f3eed7771d15b2b99a",
+        "contents_checksum": "839b6d9391827353c2469f0f12a38cc777bfd9a6c7661acfba1d1c66823e78c0",
+        "size": 21644226,
+        "source": "components/google-cloud-sdk-cbt-windows-x86-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1847,16 +1847,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260717053915,
-        "version_string": "1.25.3"
+        "build_number": 20260814074256,
+        "version_string": "1.25.4"
       }
     },
     {
       "data": {
-        "checksum": "aed38eeebcb8eca2fea6200a434b1b555c175a81eac720da1da127c64eaf22d6",
-        "contents_checksum": "268ac7799d48ec6c2dc6c3034890a3b98f9ee3185764f371180272c4d8897852",
-        "size": 21160864,
-        "source": "components/google-cloud-sdk-cbt-windows-x86_64-20260717053915.tar.gz",
+        "checksum": "1e682e75f4f4fe9c3f7ca1831ed63b24db8f29db26cff0a987bbceea22e2d373",
+        "contents_checksum": "61c764c9feec805d679d1c8d56abc36b9bdd6c9b90ea958ef0d4a167e73a5c0f",
+        "size": 22388510,
+        "source": "components/google-cloud-sdk-cbt-windows-x86_64-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1881,8 +1881,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260717053915,
-        "version_string": "1.25.3"
+        "build_number": 20260814074256,
+        "version_string": "1.25.4"
       }
     },
     {
@@ -2301,15 +2301,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.5.55"
+        "version_string": "1.5.56"
       }
     },
     {
       "data": {
-        "checksum": "2b33301e10787e62c622435ef9de0ee0082d6c79955f845a755d80116291dd9b",
-        "contents_checksum": "a0a68fd62c1dcb243f16964a8cba368032252b6747a049b160663ca6a278c9e8",
-        "size": 51210457,
-        "source": "components/google-cloud-sdk-cloud-spanner-emulator-linux-x86_64-20260710150251.tar.gz",
+        "checksum": "2249fc658438d2434c1cf7f0e444107cfc24ce1b894bcdad3e8a7dc947fe62dd",
+        "contents_checksum": "517267de89b3f20d3fda91b1385f7b3b9a76d3920d9ad597edfb4d76749264ff",
+        "size": 52345394,
+        "source": "components/google-cloud-sdk-cloud-spanner-emulator-linux-x86_64-20260807154943.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2335,8 +2335,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260710150251,
-        "version_string": "1.5.55"
+        "build_number": 20260807154943,
+        "version_string": "1.5.56"
       }
     },
     {
@@ -3095,10 +3095,10 @@
     },
     {
       "data": {
-        "checksum": "ec505a00a8ccfba34e53d85f7302f9586a84eb17fe72525c60622606e1136aa4",
-        "contents_checksum": "726076916a36597072facad59103328324da73522ba20511cfeebea0f9ddc0ce",
-        "size": 27916650,
-        "source": "components/google-cloud-sdk-core-20260731054104.tar.gz",
+        "checksum": "645f514aede6e7c6d43d758c2464fc78b1d66d98d3dbbe63fa0e64d9370403a9",
+        "contents_checksum": "2b465549bd6ecb6dad4941fefd5e090d967b858daed22342955da03a7c9d9857",
+        "size": 28132031,
+        "source": "components/google-cloud-sdk-core-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3119,8 +3119,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "2026.07.31"
+        "build_number": 20260814074256,
+        "version_string": "2026.08.14"
       }
     },
     {
@@ -3497,15 +3497,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "0.3.19"
+        "version_string": "0.3.20"
       }
     },
     {
       "data": {
-        "checksum": "ed43d9c16d8763a42a980d8f62076c862463abdc7237492939bb569ef6fb92dd",
-        "contents_checksum": "043140a7d0fad390591d6e8a7768e910c447dbecf8b57c5b92abfa0fc5e030f9",
-        "size": 15336065,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-arm-20260731054104.tar.gz",
+        "checksum": "2f9947d3be36a47d3f690140111ca79c15391dbc670b120715693e0d5bcea0ed",
+        "contents_checksum": "1e67b289d8f07d3ff5ff3c90babc5ef72e6b3ccf3a18fac4a2d48c485d8b9500",
+        "size": 15337430,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-arm-20260807154943.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3530,16 +3530,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "0.3.19"
+        "build_number": 20260807154943,
+        "version_string": "0.3.20"
       }
     },
     {
       "data": {
-        "checksum": "cd2c825b1615fc97ccd632478694c010db608dce2f63e3cada4e66d255c27103",
-        "contents_checksum": "74a89013ab0da2e08a8d9ab5871212689bddc7583a66c60c54c704d15867c75d",
-        "size": 16297514,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-x86_64-20260731054104.tar.gz",
+        "checksum": "fa41da2478182e5b9f8f3b2679a3c65f8952eaaa8626b27d0727996b0f54dab0",
+        "contents_checksum": "f6d226c963d112a3e5a186d3fa2377cf9274c510cc1b9ec19393e841ea0fa13d",
+        "size": 16296666,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-x86_64-20260807154943.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3564,16 +3564,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "0.3.19"
+        "build_number": 20260807154943,
+        "version_string": "0.3.20"
       }
     },
     {
       "data": {
-        "checksum": "f8d7c5c09a436aff61918517824e5fcf1f10e82d46fe3898c8b915794f5bfa1d",
-        "contents_checksum": "e0a058d5ffd0ce65a6129bc37db8f1fec56e0f9e08e4b14c021a896bd0b84698",
-        "size": 18436186,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-linux-x86_64-20260731054104.tar.gz",
+        "checksum": "e346f92235ea867e1e1a2f7ef8ef2b9907f0e7e2a35dbcfc87b7eba6c908c5b0",
+        "contents_checksum": "68e57165e4453f13810109a554115feee1ab925b4481ce383fd5f85dac31a9ce",
+        "size": 18436193,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-linux-x86_64-20260807154943.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3598,16 +3598,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "0.3.19"
+        "build_number": 20260807154943,
+        "version_string": "0.3.20"
       }
     },
     {
       "data": {
-        "checksum": "d731c7710da2820cffc2b4cb7314f5218b2f4ac7c30fb341980df44a3ef13f81",
-        "contents_checksum": "e54a67c367628edf8d3efcb8669c0d738718dfb0c20bb1df929123852f25675d",
-        "size": 13416873,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-windows-x86_64-20260731054104.tar.gz",
+        "checksum": "b267dff0f17e28deffd96db80a6e844533c296f41092e45409e5192814ea000e",
+        "contents_checksum": "14bcdfa9a15b2fad5ee3d70439c5ff6b528f3f1fd5f1f2288f9373d3fc1103eb",
+        "size": 13416970,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-windows-x86_64-20260807154943.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3632,8 +3632,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "0.3.19"
+        "build_number": 20260807154943,
+        "version_string": "0.3.20"
       }
     },
     {
@@ -4359,10 +4359,10 @@
     },
     {
       "data": {
-        "checksum": "2648f2f8064a17b0d97236aa67aad62a4e503cf87f0c6d1117a03a4e9065e9b1",
-        "contents_checksum": "36383a100c64ae6002aa3fdd37eb8b0941d35fda6c48d2634be7c1a3aa18a0df",
-        "size": 10483823,
-        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20260731054104.tar.gz",
+        "checksum": "2c7a22f1d75b6a85fc6e44e28cca3fa8f6aa8a8c81e14e1ec3b7abebbb5dc9af",
+        "contents_checksum": "cd4beff93d45489198de5857881aec8009e50e437aa87d7a6b5d10b58d2ec305",
+        "size": 10535456,
+        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4388,7 +4388,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
+        "build_number": 20260814074256,
         "version_string": ""
       }
     },
@@ -4827,15 +4827,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.20.892"
+        "version_string": "1.20.8107"
       }
     },
     {
       "data": {
-        "checksum": "8b1d96997ba8a4e13043d362f6ff77c6515b9cf905237fcf6be363a950d219a4",
-        "contents_checksum": "3ebdd0a114596a3a470a48e6a6461db02099adeb53e79288c5d12748e6157a0a",
-        "size": 27723752,
-        "source": "components/google-cloud-sdk-istioctl-darwin-arm-20260710150251.tar.gz",
+        "checksum": "35825fe23b15d7604b617218fed998c96b87ca3c413b0cfe8717cc96966d5b8e",
+        "contents_checksum": "c000d3b1e6cbb45d3fc0cd236a3807b696e00b0c1c77a645ae928a4f834bd690",
+        "size": 27751763,
+        "source": "components/google-cloud-sdk-istioctl-darwin-arm-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4860,16 +4860,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260710150251,
-        "version_string": "1.20.892"
+        "build_number": 20260814074256,
+        "version_string": "1.20.8107"
       }
     },
     {
       "data": {
-        "checksum": "10a72bfbf62eace1c22d752ce77189b01769f472e29629c592f22b1eaf1d0468",
-        "contents_checksum": "943e43953d21092e26c42a8d2eb930e9716505ecc1bbc338b1e5ddd3e11e43fb",
-        "size": 29776478,
-        "source": "components/google-cloud-sdk-istioctl-darwin-x86_64-20260710150251.tar.gz",
+        "checksum": "96a17744595b780d72b3745aec5ff1f32fee3aab4d015306137ec7a4b080fa73",
+        "contents_checksum": "cf37e1eddb2000ce464ae7448703dff00a4ee14c9b9312cac4cea91c138d6490",
+        "size": 29803999,
+        "source": "components/google-cloud-sdk-istioctl-darwin-x86_64-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4894,16 +4894,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260710150251,
-        "version_string": "1.20.892"
+        "build_number": 20260814074256,
+        "version_string": "1.20.8107"
       }
     },
     {
       "data": {
-        "checksum": "b239adc3ce63ea6c4e3d016085f43774d85331d0bd891084984e19fe6a03df74",
-        "contents_checksum": "6ab5c4bcedb178abe3783876491d527e7c524ff258c4419a16f6a34f3a756035",
-        "size": 25874544,
-        "source": "components/google-cloud-sdk-istioctl-linux-arm-20260710150251.tar.gz",
+        "checksum": "991e4ea71e26eeeed8fc7a9b3d962d44f1a8b508a57282110d43264b89625cdb",
+        "contents_checksum": "c5fecdcd9b526b54f5b0f5cf88a874967a7819272f6e3153016b203ce4d65418",
+        "size": 25901981,
+        "source": "components/google-cloud-sdk-istioctl-linux-arm-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4928,16 +4928,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260710150251,
-        "version_string": "1.20.892"
+        "build_number": 20260814074256,
+        "version_string": "1.20.8107"
       }
     },
     {
       "data": {
-        "checksum": "173078820da7f599c95b681933da7a5358f5aa9ef97a372f2dd9403e6a3d1ddf",
-        "contents_checksum": "c7328be1e3b6780074d609bdc48cf98bf19df7be3d46d29c696aa65e5a3f87a7",
-        "size": 28710833,
-        "source": "components/google-cloud-sdk-istioctl-linux-x86_64-20260710150251.tar.gz",
+        "checksum": "65e9bdd42333dca6f6ff87fe456f5c7b4d6b07476278cdfbc76fc44d997dc248",
+        "contents_checksum": "f337697c75f563559dcbb8b9766cb82f8d94883a6159f8b8d490e96619abd8f2",
+        "size": 28742918,
+        "source": "components/google-cloud-sdk-istioctl-linux-x86_64-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4962,8 +4962,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20260710150251,
-        "version_string": "1.20.892"
+        "build_number": 20260814074256,
+        "version_string": "1.20.8107"
       }
     },
     {
@@ -6720,7 +6720,7 @@
         "checksum": "f135e5f6dd331d28f3ebf299208dbe1993838ad4f2d9d87cbde365a6b760c66c",
         "contents_checksum": "c4caf1dd1ca46b5fb9d759606c18619ffaafff9315db4037ade8b3b628f6312b",
         "size": 782,
-        "source": "components/google-cloud-sdk-preview-20260731054104.tar.gz",
+        "source": "components/google-cloud-sdk-preview-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6738,16 +6738,16 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "2026.07.31"
+        "build_number": 20260814074256,
+        "version_string": "2026.08.14"
       }
     },
     {
       "data": {
-        "checksum": "ce429db6453c95aee8d801cfa27486f9aca691be5b176f80223be0126280ba96",
-        "contents_checksum": "c54cc6153aa7694f9cb91c95961e9637a9c0f207f4671145cf718189af4f4abd",
-        "size": 53000366,
-        "source": "components/google-cloud-sdk-pubsub-emulator-20260710150251.tar.gz",
+        "checksum": "4d88c9a67c3f34f2669e9461db0ca067d406f6240881e04d00840f2da3e1fe4e",
+        "contents_checksum": "cfe5515690b9e0638c597a6f1476f6b27a8095c9f6f2c887384420dd9b16d116",
+        "size": 53008490,
+        "source": "components/google-cloud-sdk-pubsub-emulator-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6765,8 +6765,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20260710150251,
-        "version_string": "0.8.34"
+        "build_number": 20260814074256,
+        "version_string": "0.8.35"
       }
     },
     {
@@ -7985,10 +7985,10 @@
     },
     {
       "data": {
-        "checksum": "79a897b67c84d3e91b276075aa5231290dfd5c65017f5c01f83bc4d053ffa220",
-        "contents_checksum": "3545ecf221daa4ce972b11b88cb6ae55e8c0d92e43c01350bf45d48551a025dd",
-        "size": 64010748,
-        "source": "components/google-cloud-sdk-tests-20260731054104.tar.gz",
+        "checksum": "0db579165ba1ee59f46b7772298b070a47f775d57e45ec414260445a5d917426",
+        "contents_checksum": "f530583ef6822009960bdc9e0fa9973081838876815f3142faa9c8f5f7309cfa",
+        "size": 102176840,
+        "source": "components/google-cloud-sdk-tests-20260814074256.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -8006,8 +8006,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20260731054104,
-        "version_string": "2026.07.31"
+        "build_number": 20260814074256,
+        "version_string": "2026.08.14"
       }
     },
     {
@@ -8160,11 +8160,11 @@
   ],
   "post_processing_command": "components post-process",
   "release_notes_url": "RELEASE_NOTES",
-  "revision": 20260731054104,
+  "revision": 20260814074256,
   "schema_version": {
     "no_update": false,
     "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz",
     "version": 3
   },
-  "version": "579.0.0"
+  "version": "581.0.0"
 }

--- a/pkgs/by-name/go/google-cloud-sdk/data.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/data.nix
@@ -1,23 +1,23 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "579.0.0";
+  version = "581.0.0";
   googleCloudSdkPkgs = {
     x86_64-linux = {
-      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-579.0.0-linux-x86_64.tar.gz";
-      sha256 = "1mqns1dkngv41hk9cr41pjcy1315sz9bq79ghq4sqw7ybyaapa3b";
+      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-581.0.0-linux-x86_64.tar.gz";
+      sha256 = "14gvc7c0cha7v7jv4bkisc0m3q018kr989agi7hma4xgqmdwzrij";
     };
     aarch64-linux = {
-      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-579.0.0-linux-arm.tar.gz";
-      sha256 = "0nrp4nycn221a6nrjmkb2rbm1rfcyq9as3alx4qxlhacl9cv327p";
+      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-581.0.0-linux-arm.tar.gz";
+      sha256 = "1l00qdriqnnzdbd134v565p3ii50fx133wca5am6qf04yqnwbpyd";
     };
     aarch64-darwin = {
-      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-579.0.0-darwin-arm.tar.gz";
-      sha256 = "1bbcl9f312bl2bng46vsnqg238prl1129wg7bij2rzmikvmmhdvq";
+      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-581.0.0-darwin-arm.tar.gz";
+      sha256 = "1pabqk9nk2gfmzgp1kfw9qv3v2qk1asxsg5qzyyyn0n353y7jnsx";
     };
     i686-linux = {
-      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-579.0.0-linux-x86.tar.gz";
-      sha256 = "1csy7l94f4xj5n3gpss1r6dfpr2cx3gvsfgfvhzrs2b48yjk39kc";
+      url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-581.0.0-linux-x86.tar.gz";
+      sha256 = "06lihs49m98mznzr9j6v03pfcqnjf5qvwrqwdr3wzas9kch56qyf";
     };
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
