### PR TITLE
nixos/ente: add and respect services.ente.api.settings.http.port option

### DIFF
--- a/nixos/modules/services/web-apps/ente.nix
+++ b/nixos/modules/services/web-apps/ente.nix
@@ -145,6 +145,14 @@ in
               };
             };
 
+            http = {
+              port = mkOption {
+                type = types.port;
+                default = 8080;
+                description = "The HTTP port for the museum API service.";
+              };
+            };
+
             db = {
               host = mkOption {
                 type = types.str;
@@ -286,7 +294,7 @@ in
       services.nginx = mkIf cfgApi.nginx.enable {
         enable = true;
         upstreams.museum = {
-          servers."localhost:8080" = { };
+          servers."localhost:${toString cfgApi.settings.http.port}" = { };
           extraConfig = ''
             zone museum 64k;
             keepalive 20;


### PR DESCRIPTION
Hi,
this allows binding to a port other than the default (somewhat crowded..) port 8080. It was already possible to set this option, but `api.nginx.enable` would still point to `:8080` previously.

Thanks!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
