### PR TITLE
icm: 0.10.53 -> 0.10.61

### DIFF
--- a/pkgs/by-name/ic/icm/package.nix
+++ b/pkgs/by-name/ic/icm/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitHub,
+  git,
+  makeBinaryWrapper,
   pkg-config,
   openssl,
   nix-update-script,
@@ -12,19 +13,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "icm";
-  version = "0.10.53";
+  version = "0.10.61";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "rtk-ai";
     repo = "icm";
     tag = "icm-v${finalAttrs.version}";
-    hash = "sha256-fx7RPt32Vuy0j+Ab9VtqXoJ/+Ql5h4ORNPYwARlll0U=";
+    hash = "sha256-dIZxq29umqRt81g0Y7RY90oAgf+ockrKfwPvFd8k8tU=";
   };
 
-  cargoHash = "sha256-5xlgEjQWPQEtLDzP403lFIEa2dvdsX6HujWMmCiFnD8=";
+  cargoHash = "sha256-1YZ1GYnRxxbXXIG7d0+Nd8z2MhL8JQuuLexWNCmA+Ic=";
 
   nativeBuildInputs = [
+    makeBinaryWrapper
     pkg-config
   ];
 
@@ -36,11 +38,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Build the HTTP dashboard
   buildFeatures = [ "web" ];
 
+  # The project-detection tests shell out to `git` (init, worktree add, ...)
+  nativeCheckInputs = [
+    git
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/icm \
+      --suffix PATH : ${lib.makeBinPath [ git ]}
+  '';
   env = {
     # Use system OpenSSL instead of vendoring it
     OPENSSL_NO_VENDOR = "1";
-    # Point ort (ONNX Runtime bindings) at the system library
-    ORT_STRATEGY = "system";
     ORT_LIB_LOCATION = "${lib.getLib onnxruntime}/lib";
   };
 
@@ -59,10 +68,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Permanent memory system for AI agents with MCP integration";
     homepage = "https://github.com/rtk-ai/icm";
+    changelog = "https://github.com/rtk-ai/icm/releases/tag/icm-v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jpds ];
     mainProgram = "icm";
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
+    badPlatforms = lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
## Things done

update icm

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
