### PR TITLE
obs-studio-plugins.obs-move-transition: Fix deprecation errors

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-move-transition.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-move-transition.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   obs-studio,
 }:
@@ -16,6 +17,13 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-YA66qSCchZbA5TowOqn1FNvAtPzxREIChVJleoaImxk=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/exeldro/obs-move-transition/commit/06311ee01d7f436a67b9ca562c41e3bba4f4770f.patch";
+      hash = "sha256-lIV8MBQ17Cue0tDI0vS3P+juj367bpEAFXeo47x7vws=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ obs-studio ];


### PR DESCRIPTION
Add patch to fix deprecations in obs-studio 32.2.1. This can be reverted when the next release of obs-move-transition is cut.

The latest version of obs-studio breaks compilation for obs-move-transition. This has already been fixed upstream, but hasn't been released yet.

This patch adds the commit which fixes the compilation failure as a stop-gap until the new release is cut.

https://github.com/exeldro/obs-move-transition/commit/06311ee01d7f436a67b9ca562c41e3bba4f4770f

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
