### PR TITLE
bun: 1.3.13 -> 1.4.2 with resolution of downstream package failures

### DIFF
--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -87,7 +87,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     dontFixup = true;
 
-    outputHash = "sha256-phvOKUOqXwqNvZ6njyEf6CTBlDTP8CmSglmaUWqDXqI=";
+    outputHash = "sha256-MaqiNcD2unlMDPtt2vuNDa+kGXY61Hv93SuyW/+s4XM=";
     outputHashMode = "recursive";
   };
 

--- a/pkgs/by-name/bu/bun/package.nix
+++ b/pkgs/by-name/bu/bun/package.nix
@@ -17,7 +17,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  version = "1.3.13";
+  version = "1.4.2";
   pname = "bun";
 
   src =
@@ -69,15 +69,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sources = {
       "aarch64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-darwin-aarch64.zip";
-        hash = "sha256-VGfj9l26Umuf6pjwzOBO+vwMY+Fpcz7Ce4dqOtMtoZA=";
+        hash = "sha256-kJh6OhbX21VtiGrD1VHnttPt8KHPQ6yu1iLoZ2vh0S8=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-linux-aarch64.zip";
-        hash = "sha256-cLrkGzkIsKEg4eWMXIrzDnSvrjuNEbDT/djnh937SyI=";
+        hash = "sha256-VDKLvC2cjgyfiSxUTWbFeoO4QTnjSQnl7oF1jxrI/ac=";
       };
       "x86_64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-linux-x64-baseline.zip";
-        hash = "sha256-nYokKSpwaAkCBdqsCloiP19pc29Sh+N7+I07QDHtx1A=";
+        hash = "sha256-xngEDxT+BEDrg503y9DOTAUaMtpygGrJfeamqra/co8=";
       };
     };
     updateScript = writeShellScript "update-bun" ''

--- a/pkgs/by-name/cy/cyberstrike/package.nix
+++ b/pkgs/by-name/cy/cyberstrike/package.nix
@@ -174,5 +174,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cyberstrike";
+    # Maintainers have never tested on other platforms, and the package breaks on aarch64-linux and aarch64-darwin in practice
+    platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/by-name/ki/kilo/package.nix
+++ b/pkgs/by-name/ki/kilo/package.nix
@@ -191,5 +191,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       "x86_64-linux"
       "aarch64-darwin"
     ];
+    # Has been broken on all platforms for over a month: https://github.com/NixOS/nixpkgs/issues/542516. Maintainer is irresponsive, mark broken to prevent blocking upstream updates.
+    broken = true;
   };
 })

--- a/pkgs/by-name/om/omp/package.nix
+++ b/pkgs/by-name/om/omp/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Prevents breaking symlinks in node_modules
     dontFixup = true;
 
-    outputHash = "sha256-wqfKptBYo7GENPQLz3BfZ/m9i5lhng6yYjWbz7L6NNw=";
+    outputHash = "sha256-d6ygla6moNBSB6tB8tfQ35lrpB65IJRiMGqaTpw++gc=";
     outputHashMode = "recursive";
   };
 

--- a/pkgs/by-name/ze/zerobyte/package.nix
+++ b/pkgs/by-name/ze/zerobyte/package.nix
@@ -68,7 +68,7 @@ let
       # Required, otherwise the fixed-output derivation references store paths.
       dontFixup = true;
 
-      outputHash = "sha256-4fMmwxknyj2jwDyooT3WAzHXW2J5uxi6LsHdOoFte0k=";
+      outputHash = "sha256-GHLJ04D+f7uzWhFDxWVP++XGF2tPziMcfYrgaz2oQL8=";
       outputHashAlgo = "sha256";
       outputHashMode = "recursive";
     };


### PR DESCRIPTION
Updates Bun to 1.4.2:

- https://bun.com/blog/bun-v1.3.14
- https://bun.com/blog/bun-v1.4.0
- https://bun.com/blog/bun-v1.4.1
- https://bun.com/blog/bun-v1.4.2

Downstream failures resolved:

- `kilo`: has been broken since July: https://github.com/NixOS/nixpkgs/issues/542516; failure unrelated with Bun update; original maintainer is unresponsive; marked as broken
- `cyberstrike`: original maintainers have only tested on `x86_64-linux` throughout its lifetime; breaks on all other platforms in practice; unrelated with Bun update; limited platform to `x86_64-linux` only
- `anytype`: Bun update changes `node_modules` installation to default to `pnpm`-style isolated linker, which changes `node_modules` shape and causes its FOD hash mismatch. This is a development-time behavioral change that doesn't impact building or runtime. Hash can be safely updated.
- `zerobyte`: same as `anytype`.
- `omp`: same as `anytype`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests] (not applicable).
  - [ ] [Package tests] at `passthru.tests` (none of the touched packages have passthru tests).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. (not applicable)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (not major)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module. (not applicable)
  - [ ] Module update: when the change is significant. (not applicable)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
