### PR TITLE
zoomer: init at 0.0.1

### DIFF
--- a/pkgs/by-name/zo/zoomer/lock.json
+++ b/pkgs/by-name/zo/zoomer/lock.json
@@ -1,0 +1,28 @@
+{
+  "depends": [
+    {
+      "method": "fetchzip",
+      "packages": [
+        "x11"
+      ],
+      "path": "/nix/store/8qaywzr8nzsiddjba77nhf75hzmxx0d9-source",
+      "ref": "1.2",
+      "rev": "29aca5e519ebf5d833f63a6a2769e62ec7bfb83a",
+      "sha256": "16npqgmi2qawjxaddj9ax15rfpdc7sqc37i2r5vg23lyr6znq4wc",
+      "srcDir": "",
+      "url": "https://github.com/nim-lang/x11/archive/29aca5e519ebf5d833f63a6a2769e62ec7bfb83a.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "opengl"
+      ],
+      "path": "/nix/store/dvv6cgzl9xmax5rmjxnp5wrr08ibvjaw-source",
+      "ref": "1.2.9",
+      "rev": "8e2e098f82dc5eefd874488c37b5830233cd18f4",
+      "sha256": "01csz5bl4jiv7jx76k7izgknl7k73y2i9hd9s6brlhfqhq7cqxmz",
+      "srcDir": "src",
+      "url": "https://github.com/nim-lang/opengl/archive/8e2e098f82dc5eefd874488c37b5830233cd18f4.tar.gz"
+    }
+  ]
+}

--- a/pkgs/by-name/zo/zoomer/package.nix
+++ b/pkgs/by-name/zo/zoomer/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildNimPackage,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  wayland,
+  wayland-protocols,
+  libGL,
+  grim,
+  nix-update-script,
+}:
+
+buildNimPackage (finalAttrs: {
+  pname = "zoomer";
+  version = "0.0.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "cxinu";
+    repo = "zoomer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oYDTvqUDw1UwzINQl32xQEUN8anZs3TbJ5qHvgC1k6k=";
+  };
+
+  lockFile = ./lock.json;
+
+  nimbleFile = "boomer.nimble";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libGL
+  ];
+
+  nimFlags = [ "-d:wayland" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/boomer \
+      --prefix PATH : ${lib.makeBinPath [ grim ]}
+    ln -s boomer $out/bin/zoomer
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Boomer but for Zoomers, zooming application for Linux with Wayland support";
+    homepage = "https://github.com/cxinu/zoomer";
+    changelog = "https://github.com/cxinu/zoomer/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.lnk3 ];
+    mainProgram = "boomer";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
