### PR TITLE
finetune: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7232,6 +7232,12 @@
     github = "DimitarNestorov";
     githubId = 8790386;
   };
+  dinckelman = {
+    name = "Ivan Sosnov";
+    email = "ivanmsosnov@gmail.com";
+    github = "dinckelman";
+    githubId = 12545914;
+  };
   diogomdp = {
     email = "me@diogodp.dev";
     github = "diogomdp";

--- a/pkgs/by-name/fi/finetune/package.nix
+++ b/pkgs/by-name/fi/finetune/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "finetune";
+  version = "1.9.0";
+
+  src = fetchurl {
+    name = "FineTune.dmg";
+    url = "https://github.com/ronitsingh10/FineTune/releases/download/v${finalAttrs.version}/FineTune.dmg";
+    hash = "sha256-K4r5PA8b4YcNSQ/+Pope8uF7yDv0jPxbS4N5GGHN8i4=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = "FineTune.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R . "$out/Applications/FineTune.app"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Per-app volume control, multi-device output, audio routing, and 10-band EQ";
+    homepage = "https://github.com/ronitsingh10/FineTune";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
+      dinckelman
+    ];
+    platforms = [
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds the FineTune package for aarch64-darwin, adds myself as maintainer.

FineTune is a menu bar widget for per-app volume control. OSS alternative to SoundSource.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
