### PR TITLE
epkowa: disable pipefail for rpm2cpio|cpio install phases

### DIFF
--- a/pkgs/by-name/ep/epkowa/plugins.nix
+++ b/pkgs/by-name/ep/epkowa/plugins.nix
@@ -11,6 +11,13 @@
 }:
 
 # adding a plugin for another printer shouldn't be too difficult, but you need the firmware to test...
+#
+# Each installPhase below runs `rpm2cpio X | cpio -idmv`. Under stdenv's
+# `pipefail`, cpio exiting on the complete archive can kill rpm2cpio with
+# SIGPIPE (exit 141), so each pipe runs in a subshell with `set +o pipefail`
+# (scoped so later phases keep pipefail). cpio's own exit status still fails
+# on truncated archives. Same fix as in pkgs/build-support/vm/default.nix.
+# See NixOS/nixpkgs#541364.
 {
   v330 = stdenv.mkDerivation rec {
     name = "iscan-v330-bundle";
@@ -35,7 +42,8 @@
     ];
 
     installPhase = ''
-      ${rpm}/bin/rpm2cpio plugins/esci-interpreter-perfection-v330-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio plugins/esci-interpreter-perfection-v330-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out{,/share,/lib}
       cp -r ./usr/share/{iscan-data,esci}/ $out/share/
       cp -r ./usr/lib64/esci $out/lib
@@ -70,7 +78,8 @@
 
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-perfection-v370-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-perfection-v370-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
 
 
       mkdir -p $out/share $out/lib
@@ -107,7 +116,8 @@
     };
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-perfection-v550-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-perfection-v550-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -141,7 +151,8 @@
     };
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-gt-x820-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-gt-x820-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -175,7 +186,8 @@
     };
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-gt-x770-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-gt-x770-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -207,7 +219,8 @@
     };
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio esci-interpreter-gt-f720-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio esci-interpreter-gt-f720-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -242,8 +255,9 @@
     };
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio esci-interpreter-gt-s80-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
-      ${rpm}/bin/rpm2cpio iscan-plugin-esdip-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio esci-interpreter-gt-s80-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+        ${rpm}/bin/rpm2cpio iscan-plugin-esdip-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -283,7 +297,8 @@
 
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-gt-s600-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-gt-s600-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -320,7 +335,8 @@
 
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-gt-s650-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-gt-s650-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -358,7 +374,8 @@
 
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-gt-x750-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-gt-x750-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -395,7 +412,8 @@
 
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-plugin-gt-1500-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-plugin-gt-1500-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -431,7 +449,8 @@
     ];
 
     installPhase = ''
-      ${rpm}/bin/rpm2cpio plugins/iscan-plugin-ds-30-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio plugins/iscan-plugin-ds-30-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
       mkdir $out
       cp -r usr/share $out
       cp -r usr/lib64 $out/lib
@@ -466,7 +485,8 @@
     };
     installPhase = ''
       cd plugins
-      ${rpm}/bin/rpm2cpio iscan-network-nt-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      ( set +o pipefail; ${rpm}/bin/rpm2cpio iscan-network-nt-*.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      )
 
       mkdir $out
       cp -r usr/share $out


### PR DESCRIPTION
The `epkowa` plugin derivations extract Epson rpms via `rpm2cpio X | cpio -idmv`. Under stdenv's `pipefail`, cpio closes the pipe as soon as it has the complete archive, so rpm2cpio can then be killed by SIGPIPE — turning a harmless race into a hard build failure (exit 141) that flakes `nixos-rebuild` and CI (see #541364).

Each `installPhase` now starts with `set +o pipefail`. cpio is the last command in the pipe, so its own exit status still gates correctness without pipefail (it returns non-zero on truncated archives), so a broken package can never be shipped. This mirrors the same fix already applied to the identical `rpm2cpio|cpio` pipe in `pkgs/build-support/vm/default.nix`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Disclosure

This change was drafted with the assistance of an LLM coding agent (deepseek-v4-flash, via the `pi` agent), reviewed and verified by the author before submission. Verification used `nixpkgs-review pr 556059 --no-shell` (built `epkowa` on x86_64-linux) and the PR CI checks.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test