### PR TITLE
ocamlPackages.kapla: init at 0.4.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1293,6 +1293,7 @@
   ./services/networking/jitsi-videobridge.nix
   ./services/networking/jool.nix
   ./services/networking/jotta-cli.nix
+  ./services/networking/kapla.nix
   ./services/networking/kea.nix
   ./services/networking/keepalived/default.nix
   ./services/networking/keybase.nix

--- a/nixos/modules/services/networking/kapla.nix
+++ b/nixos/modules/services/networking/kapla.nix
@@ -1,0 +1,134 @@
+{
+  pkgs,
+  lib,
+  config,
+  utils,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkOption
+    mkIf
+    optionalAttrs
+    optionals
+    types
+    ;
+  cfg = config.services.kapla;
+in
+{
+  meta = {
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+    teams = [ lib.teams.ngi ];
+  };
+
+  options = {
+    services.kapla = {
+      enable = mkEnableOption "Kapla storage and transport service";
+
+      package = mkOption {
+        description = "Package to use for Kapla.";
+        default = pkgs.ocamlPackages.kapla;
+        defaultText = "pkgs.ocamlPackages.kapla";
+        type = types.package;
+      };
+
+      openFirewall = mkEnableOption "Open the UDP ports for CoAP peers to connect";
+
+      user = mkOption {
+        description = "User the kapla binary should execute under.";
+        type = types.str;
+        default = "kapla";
+        example = "kapla";
+      };
+
+      group = mkOption {
+        description = "Group required to access the kapla socket";
+        type = types.str;
+        default = "kapla";
+        example = "kapla";
+      };
+
+      erisSocket = {
+        path = mkOption {
+          description = "The socket to listen for eris connections on.";
+          type = types.str;
+          default = "/var/lib/kapla/eris.sock";
+          example = "/var/lib/kapla/eris.sock";
+        };
+        setSessionVariable = (mkEnableOption "Expose the eris socket in ERIS_UNIX_SOCKET") // {
+          default = true;
+        };
+      };
+
+      dataDirectory = mkOption {
+        description = "Directory where the ERIS blocks are stored.";
+        type = types.str;
+        default = "/var/lib/kapla";
+        example = "/var/lib/kapla";
+      };
+
+      stateDirectory = mkOption {
+        description = "Directory for kapla's socket and lock files.";
+        type = types.str;
+        default = "/var/lib/kapla";
+        example = "/var/lib/kapla";
+      };
+
+      extraArgs = mkOption {
+        description = "Extra arguments to pass to `kapla serve`.";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users = optionalAttrs (cfg.user == "kapla") {
+      kapla = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = optionalAttrs (cfg.group == "kapla") {
+      kapla = { };
+    };
+
+    networking.firewall.allowedUDPPorts = optionals cfg.openFirewall [
+      5683
+    ];
+
+    environment = {
+      systemPackages = [ cfg.package ];
+      sessionVariables = mkIf cfg.erisSocket.setSessionVariable {
+        ERIS_UNIX_SOCKET = cfg.erisSocket.path;
+      };
+    };
+
+    systemd.services.kapla = {
+      description = "Kapla";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = utils.escapeSystemdExecArgs (
+          [
+            "${getExe cfg.package}"
+            "serve"
+            "--socket=${cfg.erisSocket.path}"
+            "--data=${cfg.dataDirectory}"
+            "--state=${cfg.stateDirectory}"
+          ]
+          ++ cfg.extraArgs
+        );
+        Type = "simple";
+        Restart = "on-failure";
+        StateDirectory = "kapla";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -900,6 +900,7 @@ in
   kanboard = runTest ./web-apps/kanboard.nix;
   kanidm = runTest ./kanidm.nix;
   kanidm-provisioning = runTest ./kanidm-provisioning.nix;
+  kapla = runTest ./kapla.nix;
   karakeep = runTest ./web-apps/karakeep.nix;
   karma = runTest ./karma.nix;
   kavita = runTest ./kavita.nix;

--- a/nixos/tests/kapla.nix
+++ b/nixos/tests/kapla.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+{
+  name = "kapla";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.kapla = {
+        enable = true;
+        group = "users";
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("kapla.service")
+
+    resource = machine.succeed('echo "Hello world!" | kapla encode -')
+    assert "Hello world!" in machine.succeed(f"kapla decode {resource.strip()}")
+  '';
+
+  meta = {
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+    teams = [ lib.teams.ngi ];
+  };
+}

--- a/pkgs/development/ocaml-modules/base32/default.nix
+++ b/pkgs/development/ocaml-modules/base32/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromCodeberg,
+  nix-update-script,
+  alcotest,
+  qcheck,
+  qcheck-alcotest,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "base32";
+  version = "1.0.0";
+
+  src = fetchFromCodeberg {
+    owner = "pukkamustard";
+    repo = "ocaml-base32";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YREcrUF2EdNjO+8W4rNbELh+yH5DlLFsbeiEbtmjijE=";
+  };
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+    qcheck
+    qcheck-alcotest
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Base32 for Ocaml";
+    homepage = "https://codeberg.org/pukkamustard/ocaml-base32";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+  };
+})

--- a/pkgs/development/ocaml-modules/cborl/default.nix
+++ b/pkgs/development/ocaml-modules/cborl/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromCodeberg,
+  nix-update-script,
+  fmt,
+  zarith,
+  alcotest,
+  qcheck,
+  qcheck-alcotest,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "cborl";
+  version = "0.1.0";
+
+  minimalOCamlVersion = "4.14";
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "openEngiadina";
+    repo = "ocaml-cborl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MXSZgab1gMTyQKKi+odvM0yJQc2pa0Fw0p1fLJAefJU=";
+  };
+
+  propagatedBuildInputs = [
+    fmt
+    zarith
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+    qcheck
+    qcheck-alcotest
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Implementation of the Concise Binary Object Representation (CBOR) as specified by RFC 8949 for OCaml";
+    homepage = "https://codeberg.org/openengiadina/ocaml-cborl";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+  };
+})

--- a/pkgs/development/ocaml-modules/eris/default.nix
+++ b/pkgs/development/ocaml-modules/eris/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromCodeberg,
+  unstableGitUpdater,
+  zig,
+  ctypes,
+  fmt,
+  base32,
+  monocypher,
+  js_of_ocaml,
+  crunch,
+  lwt,
+  cborl,
+  benchmark,
+  bos,
+  decoders-yojson,
+  alcotest,
+  qcheck,
+  qcheck-alcotest,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "eris";
+  version = "1.0.0-unstable-2026-03-11";
+
+  minimalOCamlVersion = "4.14";
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "eris";
+    repo = "ocaml-eris";
+    rev = "ced19e6054b4fcf546930a9ecee06055908c0b73";
+    hash = "sha256-Yng7liiDS3Pupr9c4J5vNIyomxwjPLn2GJHIO12rIWc=";
+  };
+
+  dunePackages = [
+    "eris"
+    "eris-lwt"
+    "eris_cbor"
+  ];
+
+  nativeBuildInputs = [
+    zig
+    crunch
+  ];
+
+  propagatedBuildInputs = [
+    ctypes
+    fmt
+    base32
+    monocypher
+    js_of_ocaml
+    lwt
+    cborl
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    benchmark
+    bos
+    decoders-yojson
+    alcotest
+    qcheck
+    qcheck-alcotest
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
+
+  meta = {
+    description = "OCaml implementation of the Encoding for Robust Immutable Storage (ERIS)";
+    homepage = "https://codeberg.org/eris/ocaml-eris";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+    teams = [ lib.teams.ngi ];
+  };
+})

--- a/pkgs/development/ocaml-modules/kapla/add-rresult-dependency.patch
+++ b/pkgs/development/ocaml-modules/kapla/add-rresult-dependency.patch
@@ -1,0 +1,12 @@
+diff --git a/bin/dune b/bin/dune
+index 1c1e128..c3b53f8 100644
+--- a/bin/dune
++++ b/bin/dune
+@@ -7,6 +7,7 @@
+   kapla_fs
+   kapla_sqlite
+   cmdliner
++  rresult
+   miou
+   logs
+   logs.fmt

--- a/pkgs/development/ocaml-modules/kapla/default.nix
+++ b/pkgs/development/ocaml-modules/kapla/default.nix
@@ -3,6 +3,7 @@
   buildDunePackage,
   fetchFromCodeberg,
   nix-update-script,
+  nixosTests,
   cmdliner,
   bytesrw,
   fmt,
@@ -70,7 +71,12 @@ buildDunePackage (finalAttrs: {
     csexp
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) kapla;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "ERIS block storage and transport";

--- a/pkgs/development/ocaml-modules/kapla/default.nix
+++ b/pkgs/development/ocaml-modules/kapla/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromCodeberg,
+  nix-update-script,
+  cmdliner,
+  bytesrw,
+  fmt,
+  eris,
+  base32,
+  psq,
+  lru,
+  miou,
+  sqlite3,
+  astring,
+  fpath,
+  rresult,
+  bos,
+  logs,
+  uuidm,
+  ptime,
+  htmlit,
+  zarith,
+  csexp,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "kapla";
+  version = "0.4.0";
+
+  src = fetchFromCodeberg {
+    owner = "eris";
+    repo = "kapla";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xnPBv/20dH+fyNK6J/qJyyFTizhWfvbl6nUA8JzTRco=";
+  };
+
+  patches = [
+    # Replace with fetchpatch when https://codeberg.org/eris/kapla/pulls/2 is merged
+    ./add-rresult-dependency.patch
+  ];
+
+  postPatch = ''
+    rm -rf vendor
+  '';
+
+  nativeBuildInputs = [
+    cmdliner
+  ];
+
+  buildInputs = [
+    cmdliner
+    fmt
+    bytesrw
+    eris
+    base32
+    psq
+    lru
+    miou
+    sqlite3
+    astring
+    fpath
+    rresult
+    bos
+    logs
+    uuidm
+    ptime
+    htmlit
+    zarith
+    csexp
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ERIS block storage and transport";
+    homepage = "https://codeberg.org/eris/kapla";
+    mainProgram = "kapla";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+    teams = [ lib.teams.ngi ];
+  };
+})

--- a/pkgs/development/ocaml-modules/monocypher/default.nix
+++ b/pkgs/development/ocaml-modules/monocypher/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromCodeberg,
+  nix-update-script,
+  alcotest,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "monocypher";
+  version = "0.3.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "eris";
+    repo = "ocaml-monocypher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rUHiYQlopW0Dzz3nZIU0S+DqiLsjTofaItvPPuhfFs4=";
+  };
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "OCaml bindings to the Monocypher crytographic library";
+    homepage = "https://codeberg.org/eris/ocaml-monocypher/";
+    license = lib.licenses.OR [
+      lib.licenses.bsd2
+      lib.licenses.cc0
+    ];
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -113,6 +113,8 @@ let
           inherit (pkgs.llvmPackages) llvm;
         };
 
+        base32 = callPackage ../development/ocaml-modules/base32 { };
+
         base64 = callPackage ../development/ocaml-modules/base64 { };
 
         batteries = callPackage ../development/ocaml-modules/batteries { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -251,6 +251,8 @@ let
 
         cbor = callPackage ../development/ocaml-modules/cbor { };
 
+        cborl = callPackage ../development/ocaml-modules/cborl { };
+
         cfstream = callPackage ../development/ocaml-modules/cfstream { };
 
         checkseum = callPackage ../development/ocaml-modules/checkseum { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1063,6 +1063,8 @@ let
           cmdliner = cmdliner_1;
         };
 
+        kapla = callPackage ../development/ocaml-modules/kapla { };
+
         kcas = callPackage ../development/ocaml-modules/kcas { };
 
         kdf = callPackage ../development/ocaml-modules/kdf { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -606,6 +606,8 @@ let
 
         eqaf-cstruct = callPackage ../development/ocaml-modules/eqaf/cstruct.nix { };
 
+        eris = callPackage ../development/ocaml-modules/eris { };
+
         erm_xml = callPackage ../development/ocaml-modules/erm_xml { };
 
         erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1389,6 +1389,8 @@ let
 
         mmap = callPackage ../development/ocaml-modules/mmap { };
 
+        monocypher = callPackage ../development/ocaml-modules/monocypher { };
+
         monolith = callPackage ../development/ocaml-modules/monolith { };
 
         mopsa = callPackage ../development/ocaml-modules/mopsa {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

An ERIS-based server, with tools to migrate data in from sql databases and more. See https://codeberg.org/eris/kapla.

Note that unlike the other ERIS packages removed in #439158, these packages are made by a different maintainer, with history before the ban occurred, so hopefully there is little risk of the tags being change out from under us.

Closes: https://github.com/ngi-nix/projects/issues/2237

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
