### PR TITLE
trilinos: 16.1.0 -> 17.2.0

### DIFF
--- a/pkgs/by-name/tr/trilinos/package.nix
+++ b/pkgs/by-name/tr/trilinos/package.nix
@@ -13,7 +13,7 @@
   withMPI ? false,
 }:
 
-# NOTE: Not all packages are enabled.  We specifically enable the ones
+# NOTE: Not all packages are enabled. We specifically enable the ones
 # required to build Xyce. If the need comes, we can enable more of them.
 
 let
@@ -43,6 +43,7 @@ let
     -DTrilinos_ENABLE_Sacado=ON
     -DTrilinos_ENABLE_Stokhos=ON
     -DTrilinos_ENABLE_Kokkos=ON
+    -DTrilinos_ENABLE_ShyLU_NodeTacho=ON
     -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF
     -DTrilinos_ENABLE_CXX11=ON
     -DTPL_ENABLE_AMD=ON
@@ -60,14 +61,17 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "trilinos";
-  version = "16.1.0";
+  version = "17.2.0";
 
   src = fetchFromGitHub {
     owner = "trilinos";
     repo = "Trilinos";
     tag = "trilinos-release-${lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
-    hash = "sha256-9Yn79kt7JHS30lc+qImSbLOU3Cdb87S3xmlm3v9G1uo=";
+    hash = "sha256-S05iv5f4BiQ4P5tlJcOSSDYiWyKsRy0Q15SGncuZDCw=";
   };
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     cmake
@@ -108,7 +112,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://trilinos.org";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fbeffa ];
+    maintainers = with lib.maintainers; [
+      fbeffa
+      evanwporter
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/tr/trilinos_16/package.nix
+++ b/pkgs/by-name/tr/trilinos_16/package.nix
@@ -1,0 +1,120 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  blas,
+  boost,
+  cmake,
+  gfortran,
+  lapack,
+  mpi,
+  suitesparse,
+  swig,
+  withMPI ? false,
+}:
+
+# NOTE: Not all packages are enabled. We specifically enable the ones
+# required to build Xyce. If the need comes, we can enable more of them.
+
+let
+  flagsBase = ''
+    -G "Unix Makefiles"
+    -DBUILD_SHARED_LIBS=ON
+    -DCMAKE_CXX_FLAGS="-O3 -fPIC"
+    -DCMAKE_C_FLAGS="-O3 -fPIC"
+    -DCMAKE_Fortran_FLAGS="-O3 -fPIC"
+    -DTrilinos_ENABLE_NOX=ON
+    -DNOX_ENABLE_LOCA=ON
+    -DTrilinos_ENABLE_EpetraExt=ON
+    -DEpetraExt_BUILD_BTF=ON
+    -DEpetraExt_BUILD_EXPERIMENTAL=ON
+    -DEpetraExt_BUILD_GRAPH_REORDERINGS=ON
+    -DTrilinos_ENABLE_TrilinosCouplings=ON
+    -DTrilinos_ENABLE_Ifpack=ON
+    -DTrilinos_ENABLE_AztecOO=ON
+    -DTrilinos_ENABLE_Belos=ON
+    -DTrilinos_ENABLE_Teuchos=ON
+    -DTeuchos_ENABLE_COMPLEX=ON
+    -DTrilinos_ENABLE_Amesos=ON
+    -DAmesos_ENABLE_KLU=ON
+    -DTrilinos_ENABLE_Amesos2=ON
+    -DAmesos2_ENABLE_KLU2=ON
+    -DAmesos2_ENABLE_Basker=ON
+    -DTrilinos_ENABLE_Sacado=ON
+    -DTrilinos_ENABLE_Stokhos=ON
+    -DTrilinos_ENABLE_Kokkos=ON
+    -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF
+    -DTrilinos_ENABLE_CXX11=ON
+    -DTPL_ENABLE_AMD=ON
+    -DTPL_ENABLE_BLAS=ON
+    -DTPL_ENABLE_LAPACK=ON
+  '';
+  flagsParallel = ''
+    -DCMAKE_C_COMPILER=mpicc
+    -DCMAKE_CXX_COMPILER=mpic++
+    -DCMAKE_Fortran_COMPILER=mpif77
+    -DTrilinos_ENABLE_Isorropia=ON
+    -DTrilinos_ENABLE_Zoltan=ON
+    -DTPL_ENABLE_MPI=ON
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "trilinos";
+  version = "16.1.0";
+
+  src = fetchFromGitHub {
+    owner = "trilinos";
+    repo = "Trilinos";
+    tag = "trilinos-release-${lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
+    hash = "sha256-9Yn79kt7JHS30lc+qImSbLOU3Cdb87S3xmlm3v9G1uo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    swig
+  ];
+
+  buildInputs = [
+    blas
+    boost
+    lapack
+    suitesparse
+  ]
+  ++ lib.optionals withMPI [ mpi ];
+
+  preConfigure =
+    if withMPI then
+      ''
+        cmakeFlagsArray+=(${flagsBase} ${flagsParallel})
+      ''
+    else
+      ''
+        cmakeFlagsArray+=(${flagsBase})
+      '';
+
+  passthru = {
+    inherit withMPI;
+  };
+
+  meta = {
+    description = "Engineering and scientific problems algorithms";
+    mainProgram = "nvcc_wrapper";
+    longDescription = ''
+      The Trilinos Project is an effort to develop algorithms and enabling
+      technologies within an object-oriented software framework for the
+      solution of large-scale, complex multi-physics engineering and scientific
+      problems.
+    '';
+    homepage = "https://trilinos.org";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      fbeffa
+      evanwporter
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/xy/xyce/package.nix
+++ b/pkgs/by-name/xy/xyce/package.nix
@@ -15,7 +15,7 @@
   libtool_2,
   mpi,
   suitesparse,
-  trilinos,
+  trilinos_16,
   withMPI ? false,
   # for doc
   texliveMedium,
@@ -29,7 +29,7 @@
   enableTests ? true,
 }:
 
-assert withMPI -> trilinos.withMPI;
+assert withMPI -> trilinos_16.withMPI;
 
 let
   version = "7.10.0";
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     fftw
     lapack
     suitesparse
-    trilinos
+    trilinos_16
   ]
   ++ lib.optionals withMPI [ mpi ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10357,7 +10357,7 @@ with pkgs;
 
   xyce-parallel = callPackage ../by-name/xy/xyce/package.nix {
     withMPI = true;
-    trilinos = trilinos-mpi;
+    trilinos_16 = trilinos_16-mpi;
   };
 
   ### SCIENCE / MATH

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10156,6 +10156,8 @@ with pkgs;
 
   trilinos-mpi = trilinos.override { withMPI = true; };
 
+  trilinos_16-mpi = trilinos_16.override { withMPI = true; };
+
   wolfram-for-jupyter-kernel = callPackage ../applications/editors/jupyter-kernels/wolfram { };
 
   ### SCIENCE/MOLECULAR-DYNAMICS


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This bumps the trilinos version. In addition to maintain backward compatibility with `xyce` a new package `trilinos_16` was created. I also added the tacho package (a sparse cholesky solver), which I need for my own purposes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
