### PR TITLE
ddcci-driver: Fix build for kernel 7.2

### DIFF
--- a/pkgs/os-specific/linux/ddcci/0001-Use-sysfs_emit-and-field-width-specifier.patch
+++ b/pkgs/os-specific/linux/ddcci/0001-Use-sysfs_emit-and-field-width-specifier.patch
@@ -1,0 +1,285 @@
+From 9510aa4aebf32678884f55ae251e54012a354ed1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alice=20=E2=9C=A8=F0=9F=8C=99=20Luna?= <alice@liquidnya.dev>
+Date: Sat, 22 Aug 2026 16:26:42 +0200
+Subject: [PATCH] Use sysfs_emit and field width specifier '*'
+
+This fixes the build due to strncpy being removed from the kernel 7.2
+and also makes the code more readable,
+since the handling of buffer overflows id done by sysfs_emit.
+
+Note that the documentation about reading attributes says:
+
+> New implementations of show() methods should only use sysfs_emit()
+> or sysfs_emit_at() when formatting the value to be returned to user space.
+
+See: https://docs.kernel.org/filesystems/sysfs.html#reading-writing-attribute-data
+from kernel 7.2.0, last revised 16 August 2011.
+
+This change also uses the field width specifier '*' for add_uevent_var calls.
+---
+ ddcci/ddcci.c | 153 +++++++++++++++++---------------------------------
+ 1 file changed, 50 insertions(+), 103 deletions(-)
+
+diff --git a/ddcci/ddcci.c b/ddcci/ddcci.c
+index 6b41eab..76a1cd3 100644
+--- a/ddcci/ddcci.c
++++ b/ddcci/ddcci.c
+@@ -735,154 +735,101 @@ static ssize_t ddcci_attr_capabilities_show(struct device *dev,
+ 					    char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+-	size_t len;
+ 
+ 	if (likely(device != NULL)) {
+-		len = device->capabilities_len;
+-		if (unlikely(len > PAGE_SIZE))
+-			len = PAGE_SIZE;
+-		if (len == 0) {
+-			ret = len;
+-		} else {
+-			memcpy(buf, device->capabilities, len);
+-			if (likely(len < PAGE_SIZE)) {
+-				buf[len] = '\n';
+-				ret = len+1;
+-			}
+-		}
+-	}
++		if (device->capabilities_len == 0)
++			return 0;
+ 
+-	return ret;
++		return sysfs_emit(buf, "%.*s\n", (int)device->capabilities_len, device->capabilities);
++	}
++	return -ENOENT;
+ }
+ 
+ static ssize_t ddcci_attr_prot_show(struct device *dev,
+ 				    struct device_attribute *attr, char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+-	size_t len;
+ 
+ 	if (likely(device != NULL)) {
+-		len = strnlen(device->prot, sizeof(device->prot));
+-		strncpy(buf, device->prot, PAGE_SIZE);
+-		if (len == 0) {
+-			ret = len;
+-		} else if (likely(len < PAGE_SIZE)) {
+-			buf[len] = '\n';
+-			ret = len+1;
+-		} else {
+-			ret = PAGE_SIZE;
+-		}
++		if (device->prot[0] == '\0')
++			return 0;
++
++		return sysfs_emit(buf, "%.*s\n", (int)sizeof(device->prot), device->prot);
+ 	}
+-	return ret;
++	return -ENOENT;
+ }
+ 
+ static ssize_t ddcci_attr_type_show(struct device *dev,
+ 				    struct device_attribute *attr, char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+-	size_t len;
+ 
+ 	if (likely(device != NULL)) {
+-		len = strnlen(device->type, sizeof(device->type));
+-		strncpy(buf, device->type, PAGE_SIZE);
+-		if (len == 0) {
+-			ret = len;
+-		} else if (likely(len < PAGE_SIZE)) {
+-			buf[len] = '\n';
+-			ret = len+1;
+-		} else {
+-			ret = PAGE_SIZE;
+-		}
++		if (device->type[0] == '\0')
++			return 0;
++
++		return sysfs_emit(buf, "%.*s\n", (int)sizeof(device->type), device->type);
+ 	}
+-	return ret;
++	return -ENOENT;
+ }
+ 
+ static ssize_t ddcci_attr_model_show(struct device *dev,
+ 				     struct device_attribute *attr, char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+-	size_t len;
+ 
+ 	if (likely(device != NULL)) {
+-		len = strnlen(device->model, sizeof(device->model));
+-		strncpy(buf, device->model, PAGE_SIZE);
+-		if (len == 0) {
+-			ret = len;
+-		} else if (likely(len < PAGE_SIZE)) {
+-			buf[len] = '\n';
+-			ret = len+1;
+-		} else {
+-			ret = PAGE_SIZE;
+-		}
++		if (device->model[0] == '\0')
++			return 0;
++
++		return sysfs_emit(buf, "%.*s\n", (int)sizeof(device->model), device->model);
+ 	}
+-	return ret;
++	return -ENOENT;
+ }
+ 
+ static ssize_t ddcci_attr_vendor_show(struct device *dev,
+ 				      struct device_attribute *attr, char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+-	size_t len;
+ 
+ 	if (likely(device != NULL)) {
+-		len = strnlen(device->vendor, sizeof(device->vendor));
+-		strncpy(buf, device->vendor, PAGE_SIZE);
+-		if (len == 0) {
+-			ret = len;
+-		} else if (likely(len < PAGE_SIZE)) {
+-			buf[len] = '\n';
+-			ret = len+1;
+-		} else {
+-			ret = PAGE_SIZE;
+-		}
++		if (device->vendor[0] == '\0')
++			return 0;
++
++		return sysfs_emit(buf, "%.*s\n", (int)sizeof(device->vendor), device->vendor);
+ 	}
+-	return ret;
++	return -ENOENT;
+ }
+ 
+ static ssize_t ddcci_attr_module_show(struct device *dev,
+ 				      struct device_attribute *attr, char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+-	size_t len;
+ 
+ 	if (likely(device != NULL)) {
+-		len = strnlen(device->module, sizeof(device->module));
+-		strncpy(buf, device->module, PAGE_SIZE);
+-		if (len == 0) {
+-			ret = len;
+-		} else if (likely(len < PAGE_SIZE)) {
+-			buf[len] = '\n';
+-			ret = len+1;
+-		} else {
+-			ret = PAGE_SIZE;
+-		}
++		if (device->module[0] == '\0')
++			return 0;
++
++		return sysfs_emit(buf, "%.*s\n", (int)sizeof(device->module), device->module);
+ 	}
+-	return ret;
++	return -ENOENT;
+ }
+ 
+ static ssize_t ddcci_attr_serial_show(struct device *dev,
+ 				      struct device_attribute *attr, char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+ 
+ 	if (likely(device != NULL))
+-		ret = scnprintf(buf, PAGE_SIZE, "%d\n", device->device_number);
++		return sysfs_emit(buf, "%d\n", device->device_number);
+ 
+-	return ret;
++	return -ENOENT;
+ }
+ 
+ static ssize_t ddcci_attr_modalias_show(struct device *dev,
+ 				      struct device_attribute *attr, char *buf)
+ {
+ 	struct ddcci_device *device = ddcci_verify_device(dev);
+-	ssize_t ret = -ENOENT;
+ 	char model[ARRAY_SIZE(device->model)];
+ 	char vendor[ARRAY_SIZE(device->model)];
+ 	char module[ARRAY_SIZE(device->model)];
+@@ -895,16 +842,16 @@ static ssize_t ddcci_attr_modalias_show(struct device *dev,
+ 		ddcci_modalias_clean(vendor, sizeof(vendor), '_');
+ 		ddcci_modalias_clean(module, sizeof(module), '_');
+ 
+-		ret = scnprintf(buf, PAGE_SIZE, "%s%s-%s-%s-%s-%s\n",
++		return sysfs_emit(buf, "%s%.*s-%.*s-%.*s-%.*s-%.*s\n",
+ 			DDCCI_MODULE_PREFIX,
+-			device->prot,
+-			device->type,
+-			model,
+-			vendor,
+-			module
++			(int)sizeof(device->prot), device->prot,
++			(int)sizeof(device->type), device->type,
++			(int)sizeof(model), model,
++			(int)sizeof(vendor), vendor,
++			(int)sizeof(module), module
+ 		);
+ 	}
+-	return ret;
++	return -ENOENT;
+ }
+ 
+ static DEVICE_ATTR(capabilities, S_IRUGO, ddcci_attr_capabilities_show, NULL);
+@@ -945,33 +892,33 @@ static int ddcci_device_uevent(CSTRUCT device *dev, struct kobj_uevent_env *env)
+ 	ddcci_modalias_clean(vendor, sizeof(vendor), '_');
+ 	ddcci_modalias_clean(module, sizeof(module), '_');
+ 
+-	if (add_uevent_var(env, "MODALIAS=%s%s-%s-%s-%s-%s",
++	if (add_uevent_var(env, "MODALIAS=%s%.*s-%.*s-%.*s-%.*s-%.*s",
+ 			   DDCCI_MODULE_PREFIX,
+-			   device->prot,
+-			   device->type,
+-			   model,
+-			   vendor,
+-			   module
++			   (int)sizeof(device->prot), device->prot,
++			   (int)sizeof(device->type), device->type,
++			   (int)sizeof(model), model,
++			   (int)sizeof(vendor), vendor,
++			   (int)sizeof(module), module
+ 		))
+ 		return -ENOMEM;
+ 
+ 	if (device->prot[0])
+-		if (add_uevent_var(env, "DDCCI_PROT=%s", device->prot))
++		if (add_uevent_var(env, "DDCCI_PROT=%.*s", (int)sizeof(device->prot), device->prot))
+ 			return -ENOMEM;
+ 
+ 	if (device->type[0])
+-		if (add_uevent_var(env, "DDCCI_TYPE=%s", device->type))
++		if (add_uevent_var(env, "DDCCI_TYPE=%.*s", (int)sizeof(device->type), device->type))
+ 			return -ENOMEM;
+ 
+ 	if (device->model[0])
+-		if (add_uevent_var(env, "DDCCI_MODEL=%s", device->model))
++		if (add_uevent_var(env, "DDCCI_MODEL=%.*s", (int)sizeof(device->model), device->model))
+ 			return -ENOMEM;
+ 
+ 	if (device->vendor[0]) {
+-		if (add_uevent_var(env, "DDCCI_VENDOR=%s", device->vendor))
++		if (add_uevent_var(env, "DDCCI_VENDOR=%.*s", (int)sizeof(device->vendor), device->vendor))
+ 			return -ENOMEM;
+ 
+-		if (add_uevent_var(env, "DDCCI_MODULE=%s", device->module))
++		if (add_uevent_var(env, "DDCCI_MODULE=%.*s", (int)sizeof(device->module), device->module))
+ 			return -ENOMEM;
+ 
+ 		if (add_uevent_var(env, "DDCCI_UNIQ=%d", device->device_number))
+-- 
+2.54.0
+

--- a/pkgs/os-specific/linux/ddcci/default.nix
+++ b/pkgs/os-specific/linux/ddcci/default.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec {
       --replace depmod \#
   '';
 
+  patches = [
+    ./0001-Use-sysfs_emit-and-field-width-specifier.patch
+  ];
+
   makeFlags = kernelModuleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "KVER=${kernel.modDirVersion}"


### PR DESCRIPTION
This PR fixes #554041.
The linux kernel 7.2 removes the `strncpy` function, but the `ddcci-driver` uses that function and so the build fails for the linux kernel 7.2.
See: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1a3746ccbb0a97bed3c06ccde6b880013b1dddc1

I created my own merge request to the upstream `ddcci-driver-linux`, because I was checking if the implementation of an already existing upstream merge request was correct: <https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux/-/merge_requests/20>
The implementation for the `db5d6b87b2c85ff91a4470c50a4da99534d9917c` revision should be correct.

However, I was reading through the kernel documentation to figure out if the patch is correct and saw that the function `sysfs_emit exists`, which simplifies the code.
So I created my own patch: <https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux/-/merge_requests/21>

Note that the kernel documentation about reading attributes says:

> New implementations of show() methods should only use sysfs_emit() or sysfs_emit_at() when formatting the value to be returned to user space.

See: <https://docs.kernel.org/filesystems/sysfs.html#reading-writing-attribute-data> from kernel 7.2.0, last revised 16 August 2011.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Tests

I have tested this patch on NixOS 26.05 (revision a9e6d84f9c2f9012f5fe7d964a7851352300e61a):

```nix
{ pkgs, ... }: {
  config.boot.kernelPackages = pkgs.linuxPackages_latest.extend (
    _final: prev: {
      ddcci-driver = prev.ddcci-driver.overrideAttrs (oldAttrs: {
        patches = [
          (pkgs.fetchpatch {
            name = "Use-sysfs_emit-and-field-width-specifier.patch";
            url = "https://gitlab.com/liquidnya/ddcci-driver-linux/-/commit/9510aa4aebf32678884f55ae251e54012a354ed1.patch";
            hash = "sha256-s12ers7nPFaHOB+8/S8t3dtdoR6slukkfNPdghgftNs=";
          })
        ] ++ (oldAttrs.patches or []);
      });
    }
  );
}
```

Then I used the following commands:

```bash
$ echo 'ddcci 0x37' | sudo tee /sys/bus/i2c/devices/i2c-9/new_device
ddcci 0x37
$ cat /sys/bus/ddcci/devices/ddcci9/capabilities | xxd
00000000: 2870 726f 7428 6d6f 6e69 746f 7229 7479  (prot(monitor)ty
00000010: 7065 284c 4344 296d 6f64 656c 2843 3237  pe(LCD)model(C27
00000020: 4731 2963 6d64 7328 3031 2030 3220 3033  G1)cmds(01 02 03
00000030: 2030 3720 3043 2045 3320 4633 2976 6370   07 0C E3 F3)vcp
00000040: 2830 3220 3034 2030 3520 3038 2030 4320  (02 04 05 08 0C
00000050: 3130 2031 3220 3134 2830 3120 3035 2030  10 12 14(01 05 0
00000060: 3620 3038 2030 4229 2031 3620 3138 2031  6 08 0B) 16 18 1
00000070: 4120 3532 2036 3028 3031 2030 4620 3131  A 52 60(01 0F 11
00000080: 2031 3229 2038 3628 3031 2030 3220 3035   12) 86(01 02 05
00000090: 2030 4220 3043 2030 4420 3045 2030 4620   0B 0C 0D 0E 0F
000000a0: 3130 2031 3120 3132 2031 3329 2041 4320  10 11 12 13) AC
000000b0: 4145 2042 3220 4236 2043 3620 4338 2043  AE B2 B6 C6 C8 C
000000c0: 4120 4343 2830 3120 3032 2030 3320 3034  A CC(01 02 03 04
000000d0: 2030 3520 3036 2030 3720 3039 2030 4120   05 06 07 09 0A
000000e0: 3042 2030 4420 3045 2031 3220 3134 2031  0B 0D 0E 12 14 1
000000f0: 3620 3145 2920 4436 2830 3120 3034 2030  6 1E) D6(01 04 0
00000100: 3529 2044 4328 3030 2030 4220 3043 2030  5) DC(00 0B 0C 0
00000110: 4420 3045 2030 4620 3130 2920 4446 2045  D 0E 0F 10) DF E
00000120: 4420 4646 296d 7377 6871 6c28 3129 6173  D FF)mswhql(1)as
00000130: 7365 745f 6565 7028 3430 296d 6363 735f  set_eep(40)mccs_
00000140: 7665 7228 322e 3229 290a                 ver(2.2)).
cat /sys/bus/ddcci/devices/ddcci9/idProt | xxd
00000000: 6d6f 6e69 746f 720a                      monitor.
cat /sys/bus/ddcci/devices/ddcci9/idType | xxd
00000000: 4c43 440a                                LCD.
$ cat /sys/bus/ddcci/devices/ddcci9/idModel | xxd
00000000: 4332 3747 310a                           C27G1.
$ cat /sys/bus/ddcci/devices/ddcci9/idVendor | xxd
$ cat /sys/bus/ddcci/devices/ddcci9/idModule | xxd
$ cat /sys/bus/ddcci/devices/ddcci9/idSerial | xxd
00000000: 300a                                     0.
$ cat /sys/bus/ddcci/devices/ddcci9/modalias | xxd
00000000: 6464 6363 693a 6d6f 6e69 746f 722d 4c43  ddcci:monitor-LC
00000010: 442d 4332 3747 312d 2d0a                 D-C27G1--.
```

You can see how the newline `\n` (0a) is added to the output only if the value is not empty (same behavior as before).
I also checked that the code in `ddcci_device_uevent` still works by running:

```bash
$ udevadm monitor --kernel --property
```

And while that is running use:

```bash
$ sudo modprobe -r ddcci-backlight
$ sudo modprobe -r ddcci
$ sudo modprobe ddcci
```

Then `udevadm` is outputting the following:

```
KERNEL[3679.026868] add      /bus/ddcci (bus)
ACTION=add
DEVPATH=/bus/ddcci
SUBSYSTEM=bus
SEQNUM=5909

KERNEL[3680.341049] add      /devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0/drm/card1/card1-DP-1/i2c-9/9-0037/ddcci9 (ddcci)
ACTION=add
DEVPATH=/devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0/drm/card1/card1-DP-1/i2c-9/9-0037/ddcci9
SUBSYSTEM=ddcci
DEVNAME=/dev/bus/ddcci/9/display
DEVTYPE=ddcci-device
MODALIAS=ddcci:monitor-LCD-C27G1--
DDCCI_PROT=monitor
DDCCI_TYPE=LCD
DDCCI_MODEL=C27G1
SEQNUM=5910
MAJOR=242
MINOR=0
```

The properties are set correctly.

## Alternative Solution

Consider not using my patch, and instead using the trivial patch <https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux/-/merge_requests/20/diffs> instead or just using the following in `prePatch`:

```
substituteInPlace ./ddcci/ddcci.c \
      --replace 'strncpy(buf' 'strscpy(buf'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

I have not used any LLM tools for this PR and the upstream merge request.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

ddcci-driver maintainers: @kiike