### PR TITLE
sm64ap: init at 0-unstable-2026-07-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19723,6 +19723,13 @@
     githubId = 9636071;
     name = "Myrl Hex";
   };
+  mysaa = {
+    name = "Samy Avrillon";
+    email = "mysaa@hadoly.fr";
+    github = "MysaaJava";
+    githubId = 33335046;
+    keys = [ { fingerprint = "8803 52F5 FD83 DF24 F414  13CC 4E77 7255 80DA 73CE"; } ];
+  };
   MysteryBlokHed = {
     name = "Adam Thompson-Sharpe";
     email = "nix@adamts.me";

--- a/pkgs/by-name/ap/apcpp/package.nix
+++ b/pkgs/by-name/ap/apcpp/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  ixwebsocket,
+  openssl,
+  cmake,
+  jsoncpp,
+  zlib,
+}:
+stdenv.mkDerivation {
+  pname = "apcpp";
+  version = "0-unstable-2026-08-25";
+
+  src = fetchFromGitHub {
+    owner = "N00byKing";
+    repo = "APCpp";
+    rev = "172f683d4306b4fa209949419993198f87d881ed";
+    hash = "sha256-kcVZQlKl6DVWKkOxnduv+XezISYP1q8YKkClS/rmn1M=";
+  };
+
+  patches = [
+    ./use-system-ixwebsocket.patch
+  ];
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    ixwebsocket
+    zlib
+    jsoncpp
+    openssl
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/N00byKing/APCpp";
+    description = "C++ Library for Clients interfacing with the Archipelago Multi-Game Randomizer";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ mysaa ];
+  };
+}

--- a/pkgs/by-name/ap/apcpp/use-system-ixwebsocket.patch
+++ b/pkgs/by-name/ap/apcpp/use-system-ixwebsocket.patch
@@ -1,0 +1,24 @@
+--- x/CMakeLists.txt	2026-08-14 01:11:31.296420655 +0200
++++ y/CMakeLists.txt	2026-08-20 17:43:39.082357025 +0200
+@@ -63,10 +63,17 @@
+     add_library(ZLIB::ZLIB ALIAS zlibstatic)
+ endif (MINGW OR NOT ZLIB_FOUND)
+ 
+-set(IXWEBSOCKET_INSTALL OFF CACHE BOOL "" FORCE)
+-add_subdirectory(IXWebSocket)
+-include_directories(IXWebSocket)
+-target_link_libraries(APCpp ixwebsocket)
++# Attempt finding system version of IxWebSocket
++find_package(PkgConfig)
++if (PKGCONFIG_FOUND AND (NOT MINGW))
++    pkg_check_modules(IXWEBSOCKET ixwebsocket)
++    if (IXWEBSOCKET_FOUND)
++        include_directories(${IXWEBSOCKET_INCLUDE_DIRS})
++        target_link_libraries(APCpp ${IXWEBSOCKET_LDFLAGS})
++    endif(IXWEBSOCKET_FOUND)
++endif(PKGCONFIG_FOUND AND (NOT MINGW))
++
++target_link_libraries(APCpp)
+ 
+ if (MINGW)
+     target_link_libraries(APCpp -static -static-libstdc++ -static-libgcc)

--- a/pkgs/by-name/ix/ixwebsocket/package.nix
+++ b/pkgs/by-name/ix/ixwebsocket/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  openssl,
+  cmake,
+  zlib,
+  useTLS ? true,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ixwebsocket";
+  version = "12.0.1";
+  src = fetchFromGitHub {
+    owner = "machinezone";
+    repo = "IXWebSocket";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2QWIpLVIs2vGuMEhewDyihYdDQBz7SsOtfZ6pE67j2Q=";
+  };
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+  ]
+  ++ lib.optional useTLS (lib.cmakeBool "USE_TLS" true);
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    zlib
+  ]
+  ++ lib.optional useTLS openssl;
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/machinezone/IXWebSocket";
+    description = "C++ library for WebSocket client and server development";
+    longDescription = ''
+      IXWebSocket is a C++ library for WebSocket client and server development. It has minimal dependencies (no boost), is very simple to use and support everything you'll likely need for websocket dev (SSL, deflate compression, compiles on most platforms, etc...).
+    '';
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ mysaa ];
+  };
+})

--- a/pkgs/by-name/sm/sm64ap/fix-makefile.patch
+++ b/pkgs/by-name/sm/sm64ap/fix-makefile.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index fe65e47..b26b770 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1038,12 +1038,18 @@ ifeq ($(GCC_MAJORVERSION_BELOW15),1)
+   CMAKE_CFLAGS:=""
+ endif
+ 
++ifeq ($(DISCORDRPC),1)
++	LDFLAGS += -L$(DISCORDRPC_LD_PATH) -ldiscord-rpc
++endif
++LDFLAGS += -L$(APCPP_LD_PATH) -lAPCpp
++LDFLAGS += $(shell pkg-config --libs sdl2 ixwebsocket zlib)
++
++
+ $(APCPP_LIB): lib/APCpp/Archipelago.cpp lib/APCpp/Archipelago.h
+ 	cd lib/APCpp && mkdir -p build && cd build && CXX=$(CXX) cmake .. $(CMAKE_WIN_BUILD_FLAG) -DMBEDTLS_FATAL_WARNINGS=OFF -DCMAKE_C_FLAGS=$(CMAKE_CFLAGS) && CXX=$(CXX) cmake --build .
+ 
+-$(EXE): $(O_FILES) $(MIO0_FILES:.mio0=.o) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES) $(if $(RPC_LIBS),$(BUILD_DIR)/$(RPC_LIBS),) $(APCPP_LIB)
+-	$(LD) $(LDFLAGS_STATIC) -L $(BUILD_DIR) -o $@ $(O_FILES) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES) $(LDFLAGS) $(APCPP_LIB) -Wl,-rpath,.
+-	cp $(APCPP_LIB) $(BUILD_DIR)
++$(EXE): $(O_FILES) $(MIO0_FILES:.mio0=.o) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES)
++	$(LD) $(LDFLAGS_STATIC) -L $(BUILD_DIR) -o $@ $(O_FILES) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES) $(LDFLAGS) -Wl,-rpath,.
+ 
+ .PHONY: all clean distclean default diff test load libultra res
+ .PRECIOUS: $(BUILD_DIR)/bin/%.elf $(SOUND_BIN_DIR)/%.ctl $(SOUND_BIN_DIR)/%.tbl $(SOUND_SAMPLE_TABLES) $(SOUND_BIN_DIR)/%.s $(BUILD_DIR)/%

--- a/pkgs/by-name/sm/sm64ap/package.nix
+++ b/pkgs/by-name/sm/sm64ap/package.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  python3,
+  pkg-config,
+  audiofile,
+  SDL2,
+  libGL,
+  openssl,
+  hexdump,
+  cmake,
+  apcpp,
+  zlib,
+  ixwebsocket,
+  sm64baserom,
+  discord-rpc,
+  region ? "us",
+  _60fps ? true,
+  extended-moveset ? false,
+  nonstop ? false,
+  bettercamera ? true,
+  with-discord-rpc ? true,
+  fix-textures ? true,
+  no-drawing-distance ? true,
+}:
+let
+  baseRom = (sm64baserom.override { inherit region; }).romPath;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sm64ap";
+  version = "0-unstable-2026-07-27";
+
+  src = fetchFromGitHub {
+    owner = "N00byKing";
+    repo = "sm64ex";
+    rev = "d73bce2e046a87d3ce1e4ae5fb1979fb290cc684";
+    hash = "sha256-wCUfHSSGDn40/NGl1FuBBlqNVPn1HLSkx/VEIi/bna8=";
+  };
+
+  patches = [
+    ./fix-makefile.patch
+  ]
+  ++ lib.optionals _60fps [
+    (fetchpatch {
+      name = "60fps_ex.patch";
+      url = "file://${finalAttrs.src}/enhancements/60fps_ex.patch";
+      hash = "sha256-2V7WcZ8zG8Ef0bHmXVz2iaR48XRRDjTvynC4RPxMkcA=";
+    })
+  ]
+  ++ lib.optionals extended-moveset [
+    (fetchpatch {
+      name = "Extended.Moveset.v1.03b.sm64ex_archipelago.patch";
+      url = "file://${finalAttrs.src}/enhancements/Extended.Moveset.v1.03b.sm64ex_archipelago.patch";
+      hash = "sha256-kvsVZu5sXRJpya2BcnJOA+sgORBL3jK6YiZf/Gt3LlA=";
+    })
+  ]
+  ++ lib.optionals nonstop [
+    (fetchpatch {
+      name = "nonstop_mode_always_enabled.patch";
+      url = "file://${finalAttrs.src}/enhancements/nonstop_mode_always_enabled.patch";
+      hash = "sha256-s9V8UeIcjNyczfNPmgawgCmKJUkdCItSEr1cQ3ZyX/Q=";
+    })
+  ];
+
+  dontConfigure = true;
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    python3
+    pkg-config
+    hexdump
+    cmake
+  ];
+
+  buildInputs = [
+    apcpp
+    ixwebsocket
+    zlib
+    audiofile
+    SDL2
+    libGL
+    openssl
+  ]
+  ++ lib.optionals with-discord-rpc [ discord-rpc ];
+
+  makeFlags = [
+    "VERSION=${region}"
+  ]
+  ++ lib.optionals bettercamera [ "BETTERCAMERA=1" ]
+  ++ lib.optionals no-drawing-distance [ "NODRAWINGDISTANCE=1" ]
+  ++ lib.optionals fix-textures [ "TEXTURE_FIX=1" ]
+  ++ lib.optionals with-discord-rpc [ "DISCORDRPC=1" ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "OSX_BUILD=1" ];
+
+  env = {
+    DISCORDRPC_LD_PATH = "${discord-rpc}/lib";
+    APCPP_LD_PATH = "${apcpp}/lib";
+  };
+
+  # We remove dependency of the git-submodule apcpp
+  postPatch = ''
+    patchShebangs extract_assets.py
+  '';
+
+  preBuild = ''
+    ln -s ${baseRom} ./baserom.${region}.z64
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp build/${region}_pc/sm64.${region}.f3dex2e $out/bin/sm64ex
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/N00byKing/sm64ex/tree/archipelago";
+    description = "Fork of sm64ex adding a link to archipelago";
+    longDescription = ''
+      Note that you must supply a baserom yourself from which to extract assets.
+      If you are not using a US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
+    '';
+    mainProgram = "sm64ex";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      mysaa
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
This pr adds three packages:
- sm64ap, a fork of sm64ex with support for archipelago
- which depends on apcpp, a library for archipelago programs
- which depends on ixwebsocket, a cpp library for web sockets

(i don't know if i should do multiple pr for every one of my commits, or if i should merge them. Tests have been conducted after each commit)

Closes #554833 

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].