### PR TITLE
[Backport staging-26.05] darwin.libffi: fix crashes loading the trampoline dylib on macOS 27

### DIFF
--- a/pkgs/os-specific/darwin/by-name/li/libffi/package.nix
+++ b/pkgs/os-specific/darwin/by-name/li/libffi/package.nix
@@ -3,6 +3,9 @@
   autoreconfHook,
   dejagnu,
   mkAppleDerivation,
+  runCommand,
+  dyld,
+  python3,
   stdenv,
   testers,
   texinfo,
@@ -11,6 +14,10 @@
   # dejagnu also requires tcl which can't be built statically at the moment
   doCheck ? !(stdenv.hostPlatform.isStatic),
 }:
+
+let
+  python3-with-macholib = python3.withPackages (pkgs: [ pkgs.macholib ]);
+in
 
 mkAppleDerivation (finalAttrs: {
   releaseName = "libffi";
@@ -96,6 +103,32 @@ mkAppleDerivation (finalAttrs: {
       pkg-config = testers.hasPkgConfigModules {
         package = finalAttrs.finalPackage;
       };
+      # Done as a passthru test to avoid pulling dyld into the Darwin bootstrap just for `dyld_info`.
+      # `dyld_info` is needed because `check-trampolines-dylib.py` does not check chained fixups.
+      check-trampolines-dylib =
+        runCommand "check-trampolines-dylib"
+          {
+            inherit (finalAttrs) src version;
+
+            nativeBuildInputs = [
+              dyld
+              python3-with-macholib
+            ];
+            buildInputs = [ finalAttrs.finalPackage ];
+
+            meta = {
+              description = "Test whether the libffi trampoline was built correctly and works on Darwin.";
+              inherit (finalAttrs.meta) license platforms;
+            };
+          }
+          ''
+            runPhase unpackPhase
+            trampolineDylib=${lib.escapeShellArg (lib.getLib finalAttrs.finalPackage)}/lib/libffi-trampolines.dylib
+            patchShebangs check-trampolines-dylib.py
+            ./check-trampolines-dylib.py "$trampolineDylib"
+            dyld_info -fixups "$trampolineDylib" | grep -v "chained fixups, seg_count exceeds number of segments"
+            touch "$out"
+          '';
     };
   };
 

--- a/pkgs/os-specific/darwin/by-name/li/libffi/package.nix
+++ b/pkgs/os-specific/darwin/by-name/li/libffi/package.nix
@@ -70,7 +70,7 @@ mkAppleDerivation (finalAttrs: {
   '';
 
   postBuild = lib.optionalString stdenv.hostPlatform.isAarch64 ''
-    $CC -Os -Wl,-allowable_client,! -Wl,-not_for_dyld_shared_cache -Wl,-no_compact_unwind \
+    $CC -Os -Wl,-allowable_client,! -Wl,-not_for_dyld_shared_cache -Wl,-no_compact_unwind -Wl,-no_fixup_chains \
       src/aarch64/trampoline.S -dynamiclib -o libffi-trampolines.dylib \
       -Iinclude -Ibuild -Ibuild/include \
       -install_name "$out/lib/libffi-trampoline.dylib" -Wl,-compatibility_version,1 -Wl,-current_version,1


### PR DESCRIPTION
Backport of #541990 to `staging-26.05`, as requested in https://github.com/NixOS/nixpkgs/pull/541990#issuecomment-5394120029.

The dylib was apparently built with invalid chained fixups. This hasn’t been a problem in the past, but dyld under macOS 27 is apparently stricter now about which binaries it will load. Binaries using the trampolines crash under macOS 27. Disabling them fixes those crashes.

Original author: @reckenrode.

Fixes #541367 on the 26.05 release branch.

Cherry-picked commits:
- `darwin.libffi: check that the trampoline dylib is built correctly`
- `darwin.libffi: disable linking with chained fixups`

Conflict resolution: on this branch `postBuild` is wrapped in `lib.optionalString stdenv.hostPlatform.isAarch64`, so `-Wl,-no_fixup_chains` was applied inside that guard rather than to the unconditional `postBuild` upstream had.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
