### PR TITLE
rocqPackages.{mathcomp-word,ITree}: enable for recent versions of Rocq

### DIFF
--- a/pkgs/development/rocq-modules/ITree/default.nix
+++ b/pkgs/development/rocq-modules/ITree/default.nix
@@ -17,7 +17,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.version [
-      (case (range "8.14" "9.1") "5.2.1")
+      (case (range "8.14" "9.2") "5.2.1")
       (case (isEq "8.13") "5.2.0+20241009")
       (case (range "8.10" "8.16") "4.0.0")
     ] null;

--- a/pkgs/development/rocq-modules/mathcomp-word/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-word/default.nix
@@ -73,7 +73,7 @@ mkCoqDerivation {
     lib.switch
       [ coq.coq-version mathcomp.version ]
       [
-        (case (range "8.16" "9.1") (isGe "2.0") "3.5")
+        (case (range "8.16" "9.3") (isGe "2.0") "3.5")
         (case (range "8.12" "8.20") (range "1.12" "1.19") "2.4")
       ]
       null;


### PR DESCRIPTION
Tested: https://github.com/rocq-community/coq-nix-toolbox/pull/501

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
