### PR TITLE
paper-design: init at 0.5.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5912,6 +5912,12 @@
     githubId = 1222362;
     name = "Matías Lang";
   };
+  crisautomata = {
+    email = "camnm.youthplus@gmail.com";
+    github = "CrisAutomata";
+    githubId = 132472609;
+    name = "Nguyen (Cris) Manh Cam";
+  };
   criyle = {
     email = "i+nixos@goj.ac";
     name = "Yang Gao";

--- a/pkgs/by-name/pa/paper-design/package.nix
+++ b/pkgs/by-name/pa/paper-design/package.nix
@@ -1,0 +1,77 @@
+{
+  appimageTools,
+  asar,
+  common-updater-scripts,
+  curl,
+  fetchurl,
+  gnused,
+  lib,
+  writeShellApplication,
+}:
+
+let
+  pname = "paper-design";
+  version = "0.5.5";
+
+  # The public download link always redirects to the newest build, so
+  # pin ToDesktop's real per-build URL instead. Its build id isn't
+  # derivable from the version, so updateScript replaces the whole URL.
+  src = fetchurl {
+    url = "https://download.todesktop.com/2601167vjw8xe/paper-desktop-0.5.5-build-2608248vduqftg0-x86_64.AppImage";
+    hash = "sha256-Lrfs5NPbJpF7taUigNg8sICX774tVwF7MkJqNQR4iLw=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+
+    # Get rid of the autoupdater
+    postExtract = ''
+      ${lib.getExe asar} extract $out/resources/app.asar app
+      sed -i 's/async isUpdateAvailable.*/async isUpdateAvailable(updateInfo) { return false;/g' app/node_modules/electron-updater/out/AppUpdater.js
+      ${lib.getExe asar} pack app $out/resources/app.asar
+    '';
+  };
+in
+(appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/paper-desktop.desktop $out/share/applications/paper-design.desktop
+    install -Dm444 ${appimageContents}/paper-desktop.png $out/share/icons/hicolor/1024x1024/apps/paper-design.png
+    substituteInPlace $out/share/applications/paper-design.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=paper-design %U' \
+      --replace-fail 'Icon=paper-desktop' 'Icon=paper-design'
+  '';
+
+  passthru.updateScript = writeShellApplication {
+    name = "update-paper-design";
+    runtimeInputs = [
+      common-updater-scripts
+      curl
+      gnused
+    ];
+    text = ''
+      feed="$(curl -sf https://download.todesktop.com/2601167vjw8xe/latest-linux.yml)"
+      version="$(echo "$feed" | sed -n 's/^version: *//p')"
+      path="$(echo "$feed" | sed -n 's/^path: *//p')"
+      update-source-version paper-design "$version" "" \
+        "https://download.todesktop.com/2601167vjw8xe/$path"
+    '';
+  };
+
+  meta = {
+    description = "Native desktop client for a browser-based collaborative design tool";
+    homepage = "https://paper.design";
+    changelog = "https://paper.design/build-log";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ crisautomata ];
+    mainProgram = "paper-design";
+    platforms = [ "x86_64-linux" ];
+  };
+}).overrideAttrs
+  {
+    # wrapType2 extracts `src` itself for the runtime contents, ignoring
+    # appimageContents above, so the autoupdater patch never took effect
+    # without this override.
+    contents = appimageContents;
+  }


### PR DESCRIPTION
Add Paper Desktop, the native Electron client for Paper a real-time collaborative design tool. Paper also offers an official MCP server for AI-agent access to canvases. Distributed upstream only as a Linux AppImage; this package wraps it with appimageTools and disables the built-in auto-updater so nixpkgs manages updates instead. 
Paper also offers an official MCP server for AI-agent access to canvases 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
