### PR TITLE
python3Packages.expiring-dict: disable flaky tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/expiring-dict/default.nix
+++ b/pkgs/development/python-modules/expiring-dict/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   setuptools,
@@ -25,6 +26,15 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "expiring_dict" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Flaky real-time assertions: https://github.com/dparker2/py-expiring-dict/issues/5
+    "test_class_ttl"
+    "test_set_ttl"
+    "test_class_ttl_twice"
+    "test_class_reset_ttl_with_reinsert"
+    "test_class_ttl_reinsert_after_delete"
+  ];
 
   meta = {
     description = "Python dict with TTL support for auto-expiring caches";


### PR DESCRIPTION
Disable the five timing-based `expiring-dict` tests on Darwin while retaining the full test suite on other platforms and the three deterministic tests on Darwin.

All five tests use real-time sleeps around 10 ms TTLs. Each failed at least once across repeated local builds, and retrying failures five times was insufficient. Upstream previously identified the test design as flaky in https://github.com/dparker2/py-expiring-dict/issues/5. Upstream PR that would make this test disablement moot: https://github.com/dparker2/py-expiring-dict/pull/9

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/tree/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/tree/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

Verification:

- `nix-build -A python313Packages.expiring-dict --check --no-out-link`
- `nix-build -A python314Packages.expiring-dict --check --no-out-link`
- `nix-build -A unifi-protect-backup --no-out-link`

Assisted-by: Codex (GPT-5). I reviewed the PR myself and made updates as needed.
