### PR TITLE
 nixos/tests/gitea: lots of clean up, reduce resource usage a lot

### DIFF
--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -30,10 +30,9 @@ let
     type:
     lib.nameValuePair type (runTest {
       name = "${pkgs.gitea.pname}-${type}";
-      meta.maintainers = with lib.maintainers; [
-        aanderse
-        kolaente
-      ];
+      meta = {
+        inherit (pkgs.gitea.meta) maintainers;
+      };
 
       nodes = {
         server =

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -5,8 +5,6 @@
   ...
 }:
 
-with lib;
-
 let
   ## gpg --faked-system-time='20230301T010000!' --quick-generate-key snakeoil ed25519 sign
   signingPrivateKey = ''
@@ -30,9 +28,9 @@ let
   ];
   makeGiteaTest =
     type:
-    nameValuePair type (runTest {
+    lib.nameValuePair type (runTest {
       name = "${pkgs.gitea.pname}-${type}";
-      meta.maintainers = with maintainers; [
+      meta.maintainers = with lib.maintainers; [
         aanderse
         kolaente
       ];
@@ -186,4 +184,4 @@ let
     });
 in
 
-listToAttrs (map makeGiteaTest supportedDbTypes)
+lib.listToAttrs (map makeGiteaTest supportedDbTypes)

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -74,12 +74,7 @@ let
               };
             };
           };
-        client1 =
-          { pkgs, ... }:
-          {
-            environment.systemPackages = [ pkgs.git ];
-          };
-        client2 =
+        client =
           { pkgs, ... }:
           {
             environment.systemPackages = [ pkgs.git ];
@@ -99,17 +94,17 @@ let
 
           start_all()
 
-          client1.succeed("mkdir /tmp/repo")
-          client1.succeed("mkdir -p $HOME/.ssh")
-          client1.succeed(f"cat {PRIVK} > $HOME/.ssh/privk")
-          client1.succeed("chmod 0400 $HOME/.ssh/privk")
-          client1.succeed("git -C /tmp/repo init")
-          client1.succeed("echo hello world > /tmp/repo/testfile")
-          client1.succeed("git -C /tmp/repo add .")
-          client1.succeed("git config --global user.email test@localhost")
-          client1.succeed("git config --global user.name test")
-          client1.succeed("git -C /tmp/repo commit -m 'Initial import'")
-          client1.succeed(f"git -C /tmp/repo remote add origin {REPO}")
+          client.succeed("mkdir /tmp/repo")
+          client.succeed("mkdir -p $HOME/.ssh")
+          client.succeed(f"cat {PRIVK} > $HOME/.ssh/privk")
+          client.succeed("chmod 0400 $HOME/.ssh/privk")
+          client.succeed("git -C /tmp/repo init")
+          client.succeed("echo hello world > /tmp/repo/testfile")
+          client.succeed("git -C /tmp/repo add .")
+          client.succeed("git config --global user.email test@localhost")
+          client.succeed("git config --global user.name test")
+          client.succeed("git -C /tmp/repo commit -m 'Initial import'")
+          client.succeed(f"git -C /tmp/repo remote add origin {REPO}")
 
           server.wait_for_unit("gitea.service")
           server.wait_for_open_port(3000)
@@ -152,15 +147,12 @@ let
               + ' -d \'{"key":"${snakeOilPublicKey}","read_only":true,"title":"SSH"}\'''
           )
 
-          client1.succeed(
+          client.succeed(
               f"GIT_SSH_COMMAND='{GIT_SSH_COMMAND}' git -C /tmp/repo push origin master"
           )
 
-          client2.succeed("mkdir -p $HOME/.ssh")
-          client2.succeed(f"cat {PRIVK} > $HOME/.ssh/privk")
-          client2.succeed("chmod 0400 $HOME/.ssh/privk")
-          client2.succeed(f"GIT_SSH_COMMAND='{GIT_SSH_COMMAND}' git clone {REPO}")
-          client2.succeed('test "$(cat repo/testfile | xargs echo -n)" = "hello world"')
+          client.succeed(f"GIT_SSH_COMMAND='{GIT_SSH_COMMAND}' git clone {REPO} repo2")
+          client.succeed('test "$(cat repo2/testfile | xargs echo -n)" = "hello world"')
 
           server.wait_until_succeeds(
               'test "$(curl http://localhost:3000/api/v1/repos/test/repo/commits '

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -39,7 +39,7 @@ let
 
       nodes = {
         server =
-          { config, pkgs, ... }:
+          { pkgs, ... }:
           {
             virtualisation.memorySize = 2047;
             services.gitea = {
@@ -47,10 +47,12 @@ let
               database = { inherit type; };
               package = pkgs.gitea;
               metricsTokenFile = (pkgs.writeText "metrics_secret" "fakesecret").outPath;
-              settings.service.DISABLE_REGISTRATION = true;
-              settings."repository.signing".SIGNING_KEY = signingPrivateKeyId;
-              settings.actions.ENABLED = true;
-              settings.metrics.ENABLED = true;
+              settings = {
+                "repository.signing".SIGNING_KEY = signingPrivateKeyId;
+                actions.ENABLED = true;
+                metrics.ENABLED = true;
+                service.DISABLE_REGISTRATION = true;
+              };
             };
             environment.systemPackages = [
               pkgs.gitea
@@ -75,12 +77,12 @@ let
             };
           };
         client1 =
-          { config, pkgs, ... }:
+          { pkgs, ... }:
           {
             environment.systemPackages = [ pkgs.git ];
           };
         client2 =
-          { config, pkgs, ... }:
+          { pkgs, ... }:
           {
             environment.systemPackages = [ pkgs.git ];
           };
@@ -92,7 +94,7 @@ let
           inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
           serverSystem = nodes.server.system.build.toplevel;
         in
-        ''
+        /* python */ ''
           GIT_SSH_COMMAND = "ssh -i $HOME/.ssh/privk -o StrictHostKeyChecking=no"
           REPO = "gitea@server:test/repo"
           PRIVK = "${snakeOilPrivateKey}"

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -40,29 +40,21 @@ let
           { pkgs, ... }:
           {
             virtualisation.memorySize = 2047;
-            services.gitea = {
-              enable = true;
-              database = { inherit type; };
-              package = pkgs.gitea;
-              metricsTokenFile = (pkgs.writeText "metrics_secret" "fakesecret").outPath;
-              settings = {
-                "repository.signing".SIGNING_KEY = signingPrivateKeyId;
-                actions.ENABLED = true;
-                metrics.ENABLED = true;
-                service.DISABLE_REGISTRATION = true;
+            services = {
+              gitea = {
+                enable = true;
+                database = { inherit type; };
+                package = pkgs.gitea;
+                metricsTokenFile = (pkgs.writeText "metrics_secret" "fakesecret").outPath;
+                settings = {
+                  "repository.signing".SIGNING_KEY = signingPrivateKeyId;
+                  actions.ENABLED = true;
+                  metrics.ENABLED = true;
+                  service.DISABLE_REGISTRATION = true;
+                };
               };
-            };
-            environment.systemPackages = [
-              pkgs.gitea
-              pkgs.gnupg
-              pkgs.jq
-            ];
-            services.openssh.enable = true;
 
-            specialisation.runner = {
-              inheritParentConfig = true;
-
-              configuration.services.gitea-actions-runner.instances."test" = {
+              gitea-actions-runner.instances."test" = {
                 enable = true;
                 name = "ci";
                 url = "http://localhost:3000";
@@ -72,7 +64,14 @@ let
                 ];
                 tokenFile = "/var/lib/gitea/runner_token";
               };
+
+              openssh.enable = true;
             };
+            environment.systemPackages = [
+              pkgs.gitea
+              pkgs.gnupg
+              pkgs.jq
+            ];
           };
         client =
           { pkgs, ... }:
@@ -82,10 +81,8 @@ let
       };
 
       testScript =
-        { nodes, ... }:
         let
           inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
-          serverSystem = nodes.server.system.build.toplevel;
         in
         /* python */ ''
           GIT_SSH_COMMAND = "ssh -i $HOME/.ssh/privk -o StrictHostKeyChecking=no"
@@ -169,7 +166,6 @@ let
               server.succeed(
                   "su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/gitea/runner_token"
               )
-              server.succeed("${serverSystem}/specialisation/runner/bin/switch-to-configuration test")
               server.wait_for_unit("gitea-runner-test.service")
               server.succeed("journalctl -o cat -u gitea-runner-test.service | grep -q 'Runner registered successfully'")
         '';


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
