### PR TITLE
nixos/test-driver: coerced testScript merging

### DIFF
--- a/nixos/lib/testing/testScript.nix
+++ b/nixos/lib/testing/testScript.nix
@@ -7,20 +7,15 @@ testModuleArgs@{
   ...
 }:
 let
-  inherit (lib) mkOption types;
-  inherit (types) either lines functionTo;
+  inherit (lib) mkOption types const;
+  inherit (types) coercedTo lines functionTo;
 in
 {
   options = {
     testScript = mkOption {
-      type = either lines (functionTo lines);
-      apply =
-        v:
-        if lib.isFunction v then
-          # Only pass args the testScript function expects.
-          args: v (builtins.intersectAttrs (lib.functionArgs v) args)
-        else
-          v;
+      type = coercedTo lines const (functionTo lines);
+      # Only pass args the testScript function expects.
+      apply = v: args: v (builtins.intersectAttrs (lib.functionArgs v) args);
       description = ''
         A series of python declarations and statements that you write to perform
         the test.
@@ -50,23 +45,19 @@ in
     withoutTestScriptReferences.includeTestScriptReferences = false;
     withoutTestScriptReferences.testScript = lib.mkForce "testscript omitted";
 
-    testScriptString =
-      if lib.isFunction config.testScript then
-        config.testScript {
-          nodes = lib.mapAttrs (
-            k: v:
-            if v.virtualisation.useNixStoreImage then
-              # prevent infinite recursion when testScript would
-              # reference v's toplevel
-              config.withoutTestScriptReferences.nodesCompat.${k}
-            else
-              # reuse memoized config
-              v
-          ) config.nodesCompat;
-          containers = config.containers;
-        }
-      else
-        config.testScript;
+    testScriptString = config.testScript {
+      nodes = lib.mapAttrs (
+        k: v:
+        if v.virtualisation.useNixStoreImage then
+          # prevent infinite recursion when testScript would
+          # reference v's toplevel
+          config.withoutTestScriptReferences.nodesCompat.${k}
+        else
+          # reuse memoized config
+          v
+      ) config.nodesCompat;
+      containers = config.containers;
+    };
 
     nodeDefaults =
       { config, name, ... }:


### PR DESCRIPTION
This PR allows NixOS test scripts to use `lines` and `functionTo lines` within the same evaluation, whereas before all definitions had to be the same type. Just a small ergonomics improvement IMO, and also an slight overall simplification of the `testScript.nix` module.

cc @roberth @aszlig this is a follow-up to [nixos/test-driver: Use types.lines for testScript](https://github.com/NixOS/nixpkgs/pull/552059#top)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
