### PR TITLE
qownnotes-tui: init at 0.6.0

### DIFF
--- a/pkgs/by-name/qo/qownnotes-tui/package.nix
+++ b/pkgs/by-name/qo/qownnotes-tui/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "qownnotes-tui";
+  version = "0.6.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "qownnotes";
+    repo = "qownnotes-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TqqqXpUYWIkcQVMHxapCveASmMHYjCHchmYUEDZg7qY=";
+  };
+
+  cargoHash = "sha256-fjSHZ2Xg1uv5Nl1oBBTE+5YsD749ITHUZG8grqrnNDU=";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd qownnotes-tui \
+      --bash <($out/bin/qownnotes-tui --generate-completion bash) \
+      --fish <($out/bin/qownnotes-tui --generate-completion fish) \
+      --zsh <($out/bin/qownnotes-tui --generate-completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Keyboard-first terminal browser for QOwnNotes-compatible note folders";
+    homepage = "https://github.com/qownnotes/qownnotes-tui";
+    changelog = "https://github.com/qownnotes/qownnotes-tui/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pbek ];
+    mainProgram = "qownnotes-tui";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds a package for https://github.com/qownnotes/qownnotes-tui.

`qownnotes-tui` is a keyboard-first terminal browser and editor for local,
[QOwnNotes](https://www.qownnotes.org/)-compatible Markdown note folders.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
