### PR TITLE
nixos/systemd-boot: add package override config

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -45,7 +45,7 @@ let
 
       inherit (pkgs) python3;
 
-      systemd = config.systemd.package;
+      systemd = cfg.package;
 
       nix = config.nix.package.out;
 
@@ -173,6 +173,44 @@ in
         Whether to enable the systemd-boot (formerly gummiboot) EFI boot manager.
         For more information about systemd-boot:
         <https://www.freedesktop.org/wiki/Software/systemd/systemd-boot/>
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      example = literalExpression ''
+        let
+          systemd = config.systemd.package;
+          disabledAllWith = lib.pipe systemd.override [
+            lib.functionArgs
+            builtins.attrNames
+            (builtins.filter (name: lib.hasPrefix "with" name))
+            lib.genAttrs
+          ] (_: false);
+        in
+        (systemd.override (
+          # disable all with* function arguments like withTimesyncd etc.
+          disabledAllWith
+          // {
+            # and re-enable bootloader arguments to just build the bootloader
+            withEfi = true;
+            withBootloader = true;
+          }
+        )).overrideAttrs
+          (old: {
+            # change the colors of the bootloader
+            mesonFlags = (old.mesonFlags or [ ]) ++ [
+              "-Defi-color-normal=black,lightgray"
+              "-Defi-color-entry=black,lightgray"
+              "-Defi-color-highlight=green,lightgray"
+              "-Defi-color-edit=black,lightgray"
+            ];
+          });
+      '';
+      default = config.systemd.package;
+      defaultText = literalExpression "config.systemd.package";
+      description = ''
+        The systemd package to use containing the systemd-boot (formerly gummiboot) EFI boot manager.
       '';
     };
 


### PR DESCRIPTION
This allows overriding the systemd-boot package.

## Motivation

When wanting to change the foreground and background colors of the text used by systemd-boot, one has to set compile time configuration in the systemd package.
Since the systemd-boot package can not be overridden, overriding `config.systemd.package` instead rebuilds a lot of packages and it takes a long time.

See: https://github.com/systemd/systemd/pull/30059#issuecomment-3700525087

I have implemented setting the colors as as configuration instead and created a pull request upstream (<https://github.com/systemd/systemd/pull/41608>).
Until that is accepted, overriding the colors during build time is very feasible and does not take long to compile on my machine if only the boot-loader is recompiled.

The motivation of that PR is:

> This PR has been created for the following use-cases:
>
>   - An easier way for users to change the colors of the bootloader without having to recompile systemd. See https://github.com/systemd/systemd/pull/30059 for an abandoned attempt at this.
>   - Being able to change the colors can help for accessibility reasons. Some people (including myself sometimes) see white text on black background blurry (sometimes referred to as ghosting). This can be a result of astigmatism, dry or damaged eyes.

## Implementation

This introduces the following new option:

- `boot.loader.systemd-boot.package`
  which defaults to `config.systemd.package` and is therefore not a breaking change.

The option contains an example value:

```nix
{ lib, config, ... }: {
  config.boot.loader.systemd-boot.package =
    let
      systemd = config.systemd.package;
      disabledAllWith = lib.pipe systemd.override [
        lib.functionArgs
        builtins.attrNames
        (builtins.filter (name: lib.hasPrefix "with" name))
        lib.genAttrs
      ] (_: false);
    in
    (systemd.override (
      # disable all with* function arguments like withTimesyncd etc.
      disabledAllWith
      // {
        # and re-enable bootloader arguments to just build the bootloader
        withEfi = true;
        withBootloader = true;
      }
    )).overrideAttrs
      (old: {
        # change the colors of the bootloader
        mesonFlags = (old.mesonFlags or [ ]) ++ [
          "-Defi-color-normal=black,lightgray"
          "-Defi-color-entry=black,lightgray"
          "-Defi-color-highlight=green,lightgray"
          "-Defi-color-edit=black,lightgray"
        ];
      });
}
```

I tested that example value on my PC using NixOS 25.06 (revision a9e6d84f9c2f9012f5fe7d964a7851352300e61a) and this commit cherry-picked and it works and the bootloader shows a menu with white-ish background, green text for the selected entries and black text for the entries that are not selected.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Open Questions

Does this change cause the `Module update: when the change is significant.` checkbox to be checked?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
