### PR TITLE
python3Packages.{numpy,scipy}: {2.5.(1 -> 2),1.18.(0 -> 1)}

### DIFF
--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -148,8 +148,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
-    # Tries to import numpy.distutils.msvccompiler, removed in setuptools 74.0
-    "test_api_importable"
   ]
   ++ lib.optionals (pythonAtLeast "3.13") [
     # https://github.com/numpy/numpy/issues/26713

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -42,7 +42,7 @@ assert blas.isILP64 == lapack.isILP64;
 
 buildPythonPackage (finalAttrs: {
   pname = "numpy";
-  version = "2.5.1";
+  version = "2.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -50,7 +50,7 @@ buildPythonPackage (finalAttrs: {
     repo = "numpy";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-IriSrnGAZHvJ7m97s12BydNQZDZunCVtRgj/iSgw5Vc=";
+    hash = "sha256-ydxCnoWsWc+1z1GT0BGq1APdUGlDx6fTMFNcJZdH+JM=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -149,10 +149,6 @@ buildPythonPackage (finalAttrs: {
 
   disabledTests = [
   ]
-  ++ lib.optionals (pythonAtLeast "3.13") [
-    # https://github.com/numpy/numpy/issues/26713
-    "test_iter_refcount"
-  ]
   ++ lib.optionals stdenv.hostPlatform.isAarch32 [
     # https://github.com/numpy/numpy/issues/24548
     "test_impossible_feature_enable" # AssertionError: Failed to generate error

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -44,14 +44,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "scipy";
-  version = "1.18.0";
+  version = "1.18.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scipy";
     repo = "scipy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qVTFWYZ9krhZNYLyuZTfiS7UYmMZL40GFqod84l+VHI=";
+    hash = "sha256-gVHCO4+DmZ6Jg+zenfIY90v1/De1qbPYecoT+amQKJ0=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Built dependent `python3Packages` (@ `x86_64-linux`):
  - [x] `pandas`
  - [x] `astropy`
  - [x] `numba`
  - [ ] `sage` - dependencies between Numpy and it fail to build
  - [ ] `xarray` - same as `sage`
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test