### PR TITLE
stylelint-language-server: init at 1.1.1

### DIFF
--- a/pkgs/by-name/st/stylelint-language-server/package.nix
+++ b/pkgs/by-name/st/stylelint-language-server/package.nix
@@ -1,0 +1,87 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  nodejs,
+  runCommand,
+  stylelint-language-server,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "stylelint-language-server";
+  version = "1.1.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stylelint";
+    repo = "vscode-stylelint";
+    tag = "@stylelint/language-server@${finalAttrs.version}";
+    hash = "sha256-QRFc//mG7e0G7A7ZmwQzakU7RvegTPaJ6pGzvan2mwQ=";
+  };
+
+  npmWorkspace = "packages/language-server";
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-+h7+c4zrS3UlssAYvcovkHEsyfJsBXruZFAEDv1Xro0=";
+
+  npmInstallFlags = [
+    "--workspace=packages/language-server"
+    "--include-workspace-root=false"
+  ];
+
+  npmPruneFlags = [
+    "--workspace=packages/language-server"
+    "--include-workspace-root=false"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    npm prune --omit=dev --workspace=packages/language-server --include-workspace-root=false
+
+    mkdir -p $out/bin $out/lib/stylelint-language-server/packages
+    cp -r node_modules $out/lib/stylelint-language-server
+    cp -r packages/language-server $out/lib/stylelint-language-server/packages
+
+    makeWrapper ${nodejs}/bin/node $out/bin/stylelint-language-server \
+      --add-flags "$out/lib/stylelint-language-server/packages/language-server/bin/stylelint-language-server.mjs"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--use-github-releases"
+        "--version-regex"
+        "@stylelint/language-server@(.*)"
+      ];
+    };
+
+    tests.smoke = runCommand "stylelint-language-server-smoke-test" { } ''
+      INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":"file:///tmp","workspaceFolders":[{"uri":"file:///tmp","name":"test"}],"capabilities":{}}}'
+      CONTENT_LENGTH=''${#INIT_REQUEST}
+
+      RESPONSE=$(
+        {
+          printf "Content-Length: %d\\r\\n\\r\\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST"
+          sleep 1
+        } | timeout 3 ${lib.getExe stylelint-language-server} --stdio 2>&1 | head -c 1000
+      ) || true
+
+      echo "$RESPONSE" | grep -q '"capabilities"'
+      touch $out
+    '';
+  };
+
+  meta = {
+    description = "Official Stylelint language server";
+    homepage = "https://github.com/stylelint/vscode-stylelint";
+    license = lib.licenses.mit;
+    mainProgram = "stylelint-language-server";
+    maintainers = with lib.maintainers; [ tyceherrman ];
+  };
+})


### PR DESCRIPTION
Packages the official [`@stylelint/language-server`](https://github.com/stylelint/vscode-stylelint/tree/main/packages/language-server) [1.1.1 release](https://github.com/stylelint/vscode-stylelint/releases/tag/%40stylelint/language-server%401.1.1) as the independent `stylelint-language-server` package and executable.

The package includes a `passthru.tests.smoke` check that sends an LSP `initialize` request over stdio and requires a response containing `capabilities`.

Verified with:

- `nix-build --no-out-link -A stylelint-language-server`
- `nix-build --no-out-link -A stylelint-language-server.tests.smoke`
- An environment containing both `stylelint-lsp` and `stylelint-language-server`, with both executables present
- `nix-shell --run treefmt`

Automation disclosure: OpenAI Codex (GPT-5) assisted with implementation, testing, review, and drafting this PR description. I reviewed and edited as needed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
