### PR TITLE
python3Packages.shiboken6: don't propagate shiboken6-generator

### DIFF
--- a/pkgs/by-name/cu/cutter/package.nix
+++ b/pkgs/by-name/cu/cutter/package.nix
@@ -32,6 +32,7 @@ let
       cmake
       pkg-config
       python3
+      python3.pkgs.shiboken6-generator
       qt6.wrapQtAppsHook
     ];
 

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -8,6 +8,7 @@
   pythonImportsCheckHook,
   moveBuildTree,
   shiboken6,
+  shiboken6-generator,
   llvmPackages,
   symlinkJoin,
 }:
@@ -91,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     python
     pythonImportsCheckHook
+    shiboken6-generator
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
 

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -21,14 +21,11 @@ stdenv'.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     python.pkgs.ninja
+    shiboken6-generator
     (python.pythonOnBuildForHost.withPackages (ps: [
       ps.packaging
       ps.setuptools
     ]))
-  ];
-
-  propagatedNativeBuildInputs = [
-    shiboken6-generator
   ];
 
   buildInputs = [

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -116,6 +116,7 @@ let
     ]
     ++ lib.optionals hasPythonBindings [
       python3Packages.shiboken6
+      python3Packages.shiboken6-generator
       (python3.withPackages (ps: [
         ps.build
         ps.setuptools


### PR DESCRIPTION
Measured on a PySide6 application, dropping the propagation removes 17 paths and 1.72 GiB, 813 MiB of which is clang-21.1.8-lib alone.

The generator is now depended on directly by the packages that run it to generate bindings: pyside6 and the KDE python bindings. pyside6-qtads already did this.

freecad needs no change. Its FindShiboken6.cmake only falls back to the generator's include directory when find_package(Shiboken6 CONFIG) fails, which is the pip layout where the headers ship in the generator wheel. nixpkgs' shiboken6 installs Shiboken6Config.cmake and all 41 headers, and exports them through Shiboken6::libshiboken, so the fallback is never reached. freecad never invokes the generator binary either.

Assisted-by: claude-code with claude-opus-5[1m]-high


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
