### PR TITLE
wasmedge: 0.16.3 -> 0.17.1, modernize, add ilkecan to maintainers

### DIFF
--- a/pkgs/by-name/wa/wasmedge/package.nix
+++ b/pkgs/by-name/wa/wasmedge/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications";
     changelog = "https://github.com/WasmEdge/WasmEdge/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ilkecan ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/wa/wasmedge/package.nix
+++ b/pkgs/by-name/wa/wasmedge/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   llvmPackages_19,
   boost,
   cmake,
@@ -24,14 +25,26 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wasmedge";
-  version = "0.16.3";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "WasmEdge";
     repo = "WasmEdge";
     rev = finalAttrs.version;
-    sha256 = "sha256-Z6SnTKLW1nBa9gCSDO3d+CmwfWpGRAb2D9ZCoqqqMjk=";
+    hash = "sha256-+Z9mhIoRc8iJoCPafbkX3lB9nQAysKB5gjLmq8AUk/I=";
   };
+
+  patches = [
+    # fmt 12.2's uint128 fallback does not support unary complement. PR #4936
+    # was merged into WasmEdge's main development history on June 5, but the
+    # 0.17.1 release was cut from a separate release line that diverged from
+    # that history on May 18. The fix was not cherry-picked into that release
+    # line.
+    (fetchpatch {
+      url = "https://github.com/WasmEdge/WasmEdge/commit/41a01b6b4f40defbac0dd551663c542cdcf9ae76.patch";
+      hash = "sha256-g8EOz/dldPN7oM9+IKfwGCqMQgD8FnsT2w2WsyLdR60=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/wa/wasmedge/package.nix
+++ b/pkgs/by-name/wa/wasmedge/package.nix
@@ -1,26 +1,18 @@
 {
   lib,
-  fetchFromGitHub,
-  fetchpatch,
-  llvmPackages_19,
   boost,
   cmake,
-  spdlog,
-  libxml2,
+  fetchFromGitHub,
+  fetchpatch,
   libffi,
+  libxml2,
+  llvmPackages,
+  spdlog,
   testers,
+  nix-update-script,
 }:
 
 let
-  # The supported version is found in the changelog, the documentation does indicate a minimum version but not a maximum.
-  # The project is also using a `flake.nix` so we can retrieve the used llvm version with:
-  #
-  # ```shell
-  # nix eval --inputs-from .# nixpkgs#llvmPackages.libllvm.version
-  # ```
-  #
-  # > Where `.#` is the flake path were the repo `wasmedge` was cloned at the expected version.
-  llvmPackages = llvmPackages_19;
   stdenv = llvmPackages.stdenv;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -30,9 +22,12 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "WasmEdge";
     repo = "WasmEdge";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-+Z9mhIoRc8iJoCPafbkX3lB9nQAysKB5gjLmq8AUk/I=";
   };
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   patches = [
     # fmt 12.2's uint128 fallback does not support unary complement. PR #4936
@@ -48,21 +43,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    llvmPackages.lld
+    llvmPackages.bintools
   ];
 
   buildInputs = [
     boost
-    spdlog
-    llvmPackages.llvm
-    libxml2
     libffi
+    libxml2
+    llvmPackages.lld
+    llvmPackages.llvm
+    spdlog
   ];
 
-  cmakeFlags = [
-    "-DWASMEDGE_BUILD_TESTS=OFF" # Tests are downloaded using git
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "-DWASMEDGE_FORCE_DISABLE_LTO=ON"
   ];
 
@@ -70,16 +63,20 @@ stdenv.mkDerivation (finalAttrs: {
     echo -n $version > VERSION
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
     };
+    updateScript = nix-update-script { };
   };
 
   meta = {
     homepage = "https://wasmedge.org/";
-    license = lib.licenses.asl20;
     description = "Lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications";
+    changelog = "https://github.com/WasmEdge/WasmEdge/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
     maintainers = [ ];
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes the `wasmedge` build failure (https://github.com/NixOS/nixpkgs/pull/521839) on master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
