### PR TITLE
zennotes-desktop: 2.36.0 -> 2.39.0

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.38.0";
-  npmDepsHash = "sha256-MM7Nxs3vUYrp9CBcJbKNjOZy9qEO7nWRfGMBqgfPbHQ=";
+  version = "2.39.0";
+  npmDepsHash = "sha256-AawgTAl0goPI3mkIyHEuV7E4AYR33HNL6bFwqN+yASo=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KLKXdsyiqX308qbM3zGuZOMmGi3UBjO8rYZ9Dcvz+bg=";
+    hash = "sha256-H+cD9Qhgg8BGTXBHI28WZPP40Gk+dMzCnbm2sK8kxqM=";
   };
 
   npmWorkspace = "apps/desktop";

--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.36.0";
-  npmDepsHash = "sha256-5Zc9jzhF5vL8Aj0K91gRdF6zL1Czsxp7ClsohDkvY68=";
+  version = "2.38.0";
+  npmDepsHash = "sha256-MM7Nxs3vUYrp9CBcJbKNjOZy9qEO7nWRfGMBqgfPbHQ=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2Eoi8NAQ5AlysCLMQejLWjKgM1c2WyLUK3Et+Ye5hT4=";
+    hash = "sha256-KLKXdsyiqX308qbM3zGuZOMmGi3UBjO8rYZ9Dcvz+bg=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update `zennotes-desktop` to v2.39.0.

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.39.0

Verification:

- The source and npm fixed-output hashes were computed by the upstream Nix update workflow using `nix-prefetch-github` and `prefetch-npm-deps` (ZenNotes/zennotes run 33186724606).
- That workflow built the upstream desktop and server Nix packages successfully on x86_64-linux, and the upstream `nix-build` workflow rebuilt them from the committed hashes on the release commit (run 33187098191).
- The package diff was reviewed against current nixpkgs master and retains Electron 42; only `version`, `npmDepsHash`, and the source `hash` change.
- The exact nixpkgs package was not built locally because Nix is unavailable on the release host; this PR relies on nixpkgs CI for that final package build.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: Claude Code (Anthropic) assisted with the version and hash update and with drafting this PR description. The three-line package diff was reviewed directly, and the hashes were independently produced and build-verified by ZenNotes' deterministic Nix workflows linked above.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests