### PR TITLE
obs-studio: fix NVENC probe driver lookup

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -233,6 +233,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = lib.concatStrings [
     (lib.optionalString stdenv.hostPlatform.isLinux ''
+      addDriverRunpath $out/bin/.obs-nvenc-test-wrapped
       addDriverRunpath $out/lib/lib*.so
       addDriverRunpath $out/lib/obs-plugins/*.so
     '')


### PR DESCRIPTION
`obs-nvenc-test` is wrapped after installation, so the executable that loads
`libnvidia-encode.so.1` does not receive the driver RUNPATH already added to
OBS libraries and plugins. Apply the same hook to the wrapped probe.

Built the default package on x86_64-linux. With `LD_LIBRARY_PATH` unset, the
real probe on a Quadro RTX 3000 reports `nvenc_supported=true`, with H.264 and
HEVC supported and AV1 correctly unsupported on Turing.

Assisted by OpenAI Codex (GPT-5.6-sol).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
