### PR TITLE
fzf-git-sh: add unwrapped variant

### DIFF
--- a/pkgs/by-name/fz/fzf-git-sh-unwrapped/package.nix
+++ b/pkgs/by-name/fz/fzf-git-sh-unwrapped/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  bash,
+  fetchFromGitHub,
+  fish,
+  unstableGitUpdater,
+  writeShellScriptBin,
+  zsh,
+}:
+
+let
+  batProbe = writeShellScriptBin "bat" ''
+    echo bat-from-path
+  '';
+  fzfProbe = writeShellScriptBin "fzf" ''
+    echo fzf-from-path
+  '';
+  bashProbe = writeShellScriptBin "bash" ''
+    if [ "$1" != "$EXPECTED_FZF_GIT_SH" ]; then
+      echo "unexpected fzf-git.sh path: $1" >&2
+      exit 1
+    fi
+    exec ${bash}/bin/bash "$@"
+  '';
+in
+stdenv.mkDerivation {
+  pname = "fzf-git-sh-unwrapped";
+  version = "0-unstable-2026-08-06";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "junegunn";
+    repo = "fzf-git.sh";
+    rev = "d5b0a5dcd1e073b8bfca45338d5dfad3e5642471";
+    hash = "sha256-j7co9UjWdSMC7Ojyhuz2bIALrucF94o+irF4pJ6hgG4=";
+  };
+
+  dontBuild = true;
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D fzf-git.sh $out/share/fzf-git-sh/fzf-git.sh
+    install -D fzf-git.fish $out/share/fzf-git-sh/fzf-git.fish
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    bash
+    batProbe
+    fish
+    fzfProbe
+    zsh
+  ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cmp fzf-git.sh $out/share/fzf-git-sh/fzf-git.sh
+    cmp fzf-git.fish $out/share/fzf-git-sh/fzf-git.fish
+
+    export HOME=$(mktemp -d)
+
+    ${bash}/bin/bash --noprofile --norc -c '
+      source "$out/share/fzf-git-sh/fzf-git.sh" --run list_bindings >/dev/null
+      test "$__fzf_git" = "$out/share/fzf-git-sh/fzf-git.sh"
+      test "$(eval "$(__fzf_git_cat)" </dev/null)" = bat-from-path
+      test "$(_fzf_git_fzf)" = fzf-from-path
+      ${bash}/bin/bash "$__fzf_git" --run list_bindings | grep -Fq "CTRL-G CTRL-F for Files"
+    '
+
+    ${zsh}/bin/zsh -fc '
+      source "$out/share/fzf-git-sh/fzf-git.sh" --run list_bindings >/dev/null
+      test "$__fzf_git" = "$out/share/fzf-git-sh/fzf-git.sh"
+      test "$(_fzf_git_fzf)" = fzf-from-path
+      ${bash}/bin/bash "$__fzf_git" --run list_bindings | grep -Fq "CTRL-G CTRL-F for Files"
+    '
+
+    EXPECTED_FZF_GIT_SH="$out/share/fzf-git-sh/fzf-git.sh" \
+      PATH=${bashProbe}/bin:$PATH \
+      ${fish}/bin/fish --no-config -c '
+        source "$out/share/fzf-git-sh/fzf-git.fish"
+        __fzf_git_sh list_bindings | string match --quiet "*CTRL-G CTRL-F for Files*"
+      '
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/junegunn/fzf-git.sh";
+    description = "Bash, zsh and fish key bindings for Git objects, powered by fzf";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ deejayem ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/fz/fzf-git-sh/package.nix
+++ b/pkgs/by-name/fz/fzf-git-sh/package.nix
@@ -1,12 +1,11 @@
 {
-  stdenv,
-  lib,
   bash,
   bat,
   coreutils,
-  fetchFromGitHub,
   findutils,
+  fish,
   fzf,
+  fzf-git-sh-unwrapped,
   gawk,
   git,
   gnugrep,
@@ -14,23 +13,10 @@
   util-linux,
   xdg-utils,
   zsh,
-  fish,
-  unstableGitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+fzf-git-sh-unwrapped.overrideAttrs (previousAttrs: {
   pname = "fzf-git-sh";
-  version = "0-unstable-2026-08-06";
-
-  src = fetchFromGitHub {
-    owner = "junegunn";
-    repo = "fzf-git.sh";
-    rev = "d5b0a5dcd1e073b8bfca45338d5dfad3e5642471";
-    hash = "sha256-j7co9UjWdSMC7Ojyhuz2bIALrucF94o+irF4pJ6hgG4=";
-  };
-
-  dontBuild = true;
-  doInstallCheck = true;
 
   postPatch = ''
     sed -i \
@@ -49,35 +35,39 @@ stdenv.mkDerivation rec {
       -e "s,\bxdg-open\b,${xdg-utils}/bin/xdg-open," \
       -e "s,\bzsh\b,${zsh}/bin/zsh," \
       -e "/display-message\|fzf-git-\$o-widget\|\burl=\|\$remote_url =~ /!s,\bgit\b,${git}/bin/git,g" \
-      -e "s,__fzf_git=.*BASH_SOURCE.*,__fzf_git=$out/share/${pname}/fzf-git.sh," \
+      -e "s,__fzf_git=.*BASH_SOURCE.*,__fzf_git=$out/share/fzf-git-sh/fzf-git.sh," \
       -e "/__fzf_git=.*readlink.*/d" \
       fzf-git.sh
 
     sed -i \
       -e "s,\bbash\b,${bash}/bin/bash," \
-      -e "s,\''$fzf_git_sh_path\b,$out/share/${pname}," \
+      -e "s,\''$fzf_git_sh_path\b,$out/share/fzf-git-sh," \
       fzf-git.fish
   '';
 
-  installPhase = ''
-    install -D fzf-git.sh $out/share/${pname}/fzf-git.sh
-    install -D fzf-git.fish $out/share/${pname}/fzf-git.fish
-  '';
-
-  # Smoke test
   installCheckPhase = ''
     export HOME=$(mktemp -d)
-    ${bash}/bin/bash -c "source $out/share/${pname}/fzf-git.sh"
-    ${fish}/bin/fish -c "source $out/share/${pname}/fzf-git.fish"
+
+    ${bash}/bin/bash --noprofile --norc -c '
+      source "$out/share/fzf-git-sh/fzf-git.sh" --run list_bindings >/dev/null
+      test "$__fzf_git" = "$out/share/fzf-git-sh/fzf-git.sh"
+      ${bash}/bin/bash "$__fzf_git" --run list_bindings | ${gnugrep}/bin/grep -Fq "CTRL-G CTRL-F for Files"
+    '
+
+    ${zsh}/bin/zsh -fc '
+      source "$out/share/fzf-git-sh/fzf-git.sh" --run list_bindings >/dev/null
+      test "$__fzf_git" = "$out/share/fzf-git-sh/fzf-git.sh"
+      ${bash}/bin/bash "$__fzf_git" --run list_bindings | ${gnugrep}/bin/grep -Fq "CTRL-G CTRL-F for Files"
+    '
+
+    ${fish}/bin/fish --no-config -c "source $out/share/fzf-git-sh/fzf-git.fish"
+
+    ${gnugrep}/bin/grep -Fq '${fzf}/bin/fzf' $out/share/fzf-git-sh/fzf-git.sh
+    ${gnugrep}/bin/grep -Fq '${bat}/bin/bat' $out/share/fzf-git-sh/fzf-git.sh
+    ${gnugrep}/bin/grep -Fq "__fzf_git=$out/share/fzf-git-sh/fzf-git.sh" $out/share/fzf-git-sh/fzf-git.sh
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
-
-  meta = {
-    homepage = "https://github.com/junegunn/fzf-git.sh";
-    description = "Bash, zsh and fish key bindings for Git objects, powered by fzf";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ deejayem ];
-    platforms = lib.platforms.all;
+  passthru = previousAttrs.passthru // {
+    unwrapped = fzf-git-sh-unwrapped;
   };
-}
+})


### PR DESCRIPTION
Add `fzf-git-sh-unwrapped`, which installs upstream's Bash/Zsh and Fish plugins unchanged so runtime commands such as `fzf` and `bat` are resolved from `PATH`.

Refactor the existing `fzf-git-sh` package to derive from the unwrapped package while retaining its absolute store substitutions, output layout, and runtime closure. The wrapped package also exposes `passthru.unwrapped`.

This addresses the sourcing concern raised in [#521555](https://github.com/NixOS/nixpkgs/issues/521555):

- Bash and Zsh checks source the installed plugin, verify its self-resolved path, and re-enter the installed script.
- The Fish check resolves the sibling `fzf-git.sh` path, delegates through Bash, and exercises `--run list_bindings`.
- PATH-only test doubles exercise `fzf` and `bat` resolution.
- The unwrapped output has no references to nixpkgs `fzf` or `bat` and the existing wrapped output retains both.

Automation disclosure: Codex (GPT-5) assisted with implementation, testing, and drafting this PR. I reviewed and edited myself

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
