### PR TITLE
home-assistant-custom-components.ha_mcp_tools: Install Python module via Nix instead of UV

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/disable-update-entity.patch
+++ b/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/disable-update-entity.patch
@@ -1,0 +1,12 @@
+--- a/custom_components/ha_mcp_tools/update.py	2026-08-13 12:08:27
++++ b/custom_components/ha_mcp_tools/update.py	2026-08-13 12:08:30
+@@ -65,8 +65,7 @@
+     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+ ) -> None:
+     """Add the single server-package update entity for this config entry."""
+-    coordinator: ServerVersionCoordinator = hass.data[DOMAIN][DATA_UPDATE_COORDINATOR]
+-    async_add_entities([ServerUpdateEntity(coordinator, entry)])
++    return
+
+
+ class ServerUpdateEntity(CoordinatorEntity[ServerVersionCoordinator], UpdateEntity):

--- a/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   buildHomeAssistantComponent,
   ha-mcp,
   nix-update-script,
@@ -12,6 +11,7 @@ buildHomeAssistantComponent {
   inherit (ha-mcp.src) owner;
 
   dependencies = [
+    ha-mcp
     ruamel-yaml
   ];
 
@@ -21,6 +21,11 @@ buildHomeAssistantComponent {
       "--version-regex=^v([0-9]+\\.[0-9]+\\.[0-9]+)$"
     ];
   };
+
+  patches = [
+    ./skip-uv-install.patch
+    ./disable-update-entity.patch
+  ];
 
   meta = {
     inherit (ha-mcp.meta)

--- a/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/skip-uv-install.patch
+++ b/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/skip-uv-install.patch
@@ -1,0 +1,13 @@
+--- a/custom_components/ha_mcp_tools/embedded_server.py	2026-08-13 12:08:27
++++ b/custom_components/ha_mcp_tools/embedded_server.py	2026-08-13 12:08:30
+@@ -695,6 +695,10 @@
+         Never imports ``ha_mcp`` in this (main) process — that happens only inside
+         the worker thread.
+         """
++        installed_version = await self._hass.async_add_executor_job(_installed_ha_mcp_version)
++        if installed_version is not None and _is_compatible_embedded_version(installed_version):
++            _LOGGER.info("HA-MCP package %s already satisfied in environment; skipping uv install", installed_version)
++            return installed_version
+         await self._async_wait_for_pending_install()
+
+         stored_spec = self._entry.data.get(DATA_LAST_PIP_SPEC)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

HA-MCP refused to start on my system in its current form, with an error message about not being able to install the HA-MCP Python module using UV.

Adding this module to the custom component's dependencies explicitly and patching the `_async_ensure_package` function (https://github.com/homeassistant-ai/ha-mcp/blob/master/custom_components/ha_mcp_tools/embedded_server.py#L676) to bail out if the required version is already available makes it work.

While this behavior is necessary on NixOS, it may also be beneficial for other systems, so I will also open a PR for this upstream.

This PR also contains one additional patch that removes the auto update entity that prompts the user to install an update, since this is not possible in a Nix-managed setup anyway.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
