### PR TITLE
seednaut: init at v0.1.1

### DIFF
--- a/pkgs/by-name/se/seednaut/package.nix
+++ b/pkgs/by-name/se/seednaut/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "seednaut";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Baltram";
+    repo = "seednaut";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wyMOZQPJPSqLl4tzC5NELoe81aJZSOurifi62v1+jcQ=";
+  };
+
+  cargoHash = "sha256-1GZ7ZoiGKEQGN2AQFcz/YXpcqg3iYLRSzl2GfTmGk8g=";
+
+  meta = {
+    description = "Inspect, verify and extract files from Seedvault Android backups";
+    longDescription = ''
+      A command-line and terminal UI utility for Seedvault, the backup
+      mechanism integrated by Android distributions such as CalyxOS,
+      GrapheneOS, iodéOS, LineageOS and /e/OS. It works fully offline and
+      supports the current backup formats (v2 app backup, v0 file backup),
+      allowing backups to be verified, explored and extracted off-device.
+    '';
+    homepage = "https://github.com/Baltram/seednaut";
+    changelog = "https://github.com/Baltram/seednaut/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    mainProgram = "seednaut";
+    maintainers = with lib.maintainers; [ _6543 ];
+  };
+})


### PR DESCRIPTION
package https://github.com/Baltram/seednaut

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


NOTE: claude helped with description so it should not contain mispells :D