### PR TITLE
rolespec: 20161104 -> 0.3.2

### DIFF
--- a/pkgs/by-name/ro/rolespec/package.nix
+++ b/pkgs/by-name/ro/rolespec/package.nix
@@ -5,15 +5,15 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rolespec";
-  version = "20161104";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "nickjj";
     repo = "rolespec";
-    rev = "d9ee530cd709168882059776c482fc37f46cb743";
-    sha256 = "1jkidw6aqr0zfqwmcvlpi9qa140z2pxcfsd43xm5ikx6jcwjdrzl";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-9t7aDfRYb5zJ+POnhx0BmsTVyWGRJwEzcsbJhdOvOBU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -46,7 +46,10 @@ stdenv.mkDerivation {
     '';
     downloadPage = "https://github.com/nickjj/rolespec";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.dochang ];
+    maintainers = [
+      lib.maintainers.dochang
+      lib.maintainers.lukas-sgx
+    ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
