### PR TITLE
python3Packages.typer: 0.25.1 -> 0.27.1

### DIFF
--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -9,9 +9,6 @@
 
   # dependencies
   annotated-doc,
-  click,
-
-  # optional-dependencies
   rich,
   shellingham,
 
@@ -24,21 +21,29 @@
 
 buildPythonPackage rec {
   pname = "typer";
-  version = "0.25.1";
+  version = "0.27.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fastapi";
     repo = "typer";
     tag = version;
-    hash = "sha256-HIvXseuR7zUXFuTWzntDfHhAp8BcFjxo35gn0i4+03w=";
+    hash = "sha256-6I7MxBmSu8kX+eYO5fJSRJgN+UzfR1scIkm6pBfUb5k=";
   };
 
   postPatch = ''
     for f in $(find tests -type f -print); do
       # replace `sys.executable -m coverage run` with `sys.executable`
       sed -z -i 's/"-m",\n\?\s*"coverage",\n\?\s*"run",//g' "$f"
+      sed -i 's/-m coverage run//g' "$f"
     done
+    # These are already included in the PYTHONPATH.
+    # Overriding PYTHONPATH breaks the tests when executed by Nix
+    # ("No module named 'typer'" error) because it's used to find `typer` too.
+    substituteInPlace tests/test_tutorial/test_subcommands/test_tutorial001.py \
+      --replace-fail 'env["PYTHONPATH"] = ":".join(list(tutorial001_py310.__path__))' ""
+    substituteInPlace tests/test_tutorial/test_subcommands/test_tutorial003.py \
+      --replace-fail 'env["PYTHONPATH"] = ":".join(list(tutorial003_py310.__path__))' ""
   '';
 
   env.TIANGOLO_BUILD_PACKAGE = "typer";
@@ -47,7 +52,6 @@ buildPythonPackage rec {
 
   dependencies = [
     annotated-doc
-    click
     rich
     shellingham
   ];
@@ -61,23 +65,10 @@ buildPythonPackage rec {
     procps
   ];
 
-  disabledTestPaths = [
-    # Test CLI commands
-    "tests/test_tutorial/"
-  ];
-
-  disabledTests = [
-    "test_scripts"
-    # Likely related to https://github.com/sarugaku/shellingham/issues/35
-    # fails also on Linux
-    "test_show_completion"
-    "test_install_completion"
-    # AssertionError
-    "test_typo_suggestion_disabled"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-    "test_install_completion"
-  ];
+  preCheck = ''
+    # Fix "No module named 'tests'" error in tests/test_types_file.py::test_binary_stderr
+    export PYTHONPATH="$PWD:$PYTHONPATH"
+  '';
 
   pythonImportsCheck = [ "typer" ];
 


### PR DESCRIPTION
Unbreaks `typer`.

Diff: https://github.com/fastapi/typer/compare/0.25.1...0.27.1

Changelog: https://github.com/tiangolo/typer/releases/tag/0.27.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
