### PR TITLE
lib.escapeShellArg: handle paths

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1190,7 +1190,9 @@ rec {
 
   /**
     Quote `string` to be used safely within the Bourne shell if it has any
-    special characters.
+    special characters. Prior to escaping, if `string` is a path literal, copy
+    it into the store; otherwise, coerce `string` to a string via `toString` if
+    it is not one.
 
     # Inputs
 
@@ -1200,7 +1202,7 @@ rec {
     # Type
 
     ```
-    escapeShellArg :: String -> String
+    escapeShellArg :: a -> String
     ```
 
     # Examples
@@ -1217,7 +1219,14 @@ rec {
   escapeShellArg =
     arg:
     let
-      string = toString arg;
+      string =
+        # Even a store path can need escaping; as an extreme example, though
+        # it is deeply unwise, a store path prefix can contain any non-null
+        # character.
+        # If a path has a store path prefix but is not itself a store path, we
+        # still want to copy it into a fresh store object, so as not to take a
+        # dependency on the entire original source.
+        if isPath arg && !isStorePath arg then "${arg}" else toString arg;
     in
     if match "[[:alnum:],._+:@%/-]+" string == null then
       "'${replaceString "'" "'\\''" string}'"

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -154,6 +154,8 @@ let
     builder = "builder";
     system = "system";
   };
+
+  aPathLiteral = ./misc.nix;
 in
 
 runTests {
@@ -988,7 +990,7 @@ runTests {
           outPath = "/drv";
           foo = "ignored attribute";
         };
-        path = /path;
+        path = aPathLiteral;
         stringable = {
           __toString = _: "hello toString";
           bar = "ignored attribute";
@@ -1002,7 +1004,7 @@ runTests {
       possibly newlines
       ')
       drv=/drv
-      path=/path
+      path=${aPathLiteral}
       stringable='hello toString'
     '';
   };

--- a/lib/tests/strings.sh
+++ b/lib/tests/strings.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Tests lib/strings.nix
+# Run:
+# [nixpkgs]$ lib/tests/strings.sh
+# or:
+# [nixpkgs]$ nix-build lib/tests/release.nix
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+# Use
+#     || die
+die() {
+  echo >&2 "test case failed: " "$@"
+  exit 1
+}
+
+if test -n "${TEST_LIB:-}"; then
+  nixpkgs="$(dirname "$TEST_LIB")"
+else
+  nixpkgs="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.."; pwd)"
+fi
+export NIX_PATH=nixpkgs=$nixpkgs
+
+work="$(mktemp -d)"
+clean_up() {
+  rm -rf "$work"
+}
+trap clean_up EXIT
+cd "$work"
+
+expectSuccess() {
+    local expr=$1
+    local expectedResultRegex=$2
+    if ! result=$(nix-instantiate --eval --strict --json \
+        --expr "with (import <nixpkgs/lib>).strings; $expr" 2>/dev/null); then
+        die "$expr failed to evaluate, but it was expected to succeed"
+    fi
+    if [[ ! "$result" =~ $expectedResultRegex ]]; then
+        die "$expr == $result, but $expectedResultRegex was expected"
+    fi
+}
+
+expectFailure() {
+    local expr=$1
+    local expectedErrorRegex=$2
+    if result=$(nix-instantiate --eval --strict --json 2>"$work/stderr" \
+        --expr "with (import <nixpkgs/lib>).strings; $expr"); then
+        die "$expr evaluated successfully to $result, but it was expected to fail"
+    fi
+    if [[ ! "$(<"$work/stderr")" =~ $expectedErrorRegex ]]; then
+        die "Error was $(<"$work/stderr"), but $expectedErrorRegex was expected"
+    fi
+}
+
+expectFailure 'escapeShellArg /does-not-exist' "error: path '/does-not-exist' does not exist"
+
+# Without this, there would be no need to escape the path.
+export NIX_STORE_DIR="$work/store with spaces"
+mkdir -p $NIX_STORE_DIR
+
+# Check that escaping happens even with paths.
+expectSuccess "escapeShellArg $nixpkgs/lib/tests/strings.sh" "'$NIX_STORE_DIR/.*'"
+# Check that store paths are not recopied into the store.
+expectSuccess "escapeShellArg (/. + replaceString \"'\" \"\" $result)" "$result"
+
+export -n NIX_STORE_DIR
+
+echo >&2 tests ok

--- a/lib/tests/test-with-nix.nix
+++ b/lib/tests/test-with-nix.nix
@@ -66,6 +66,9 @@ pkgs.runCommand "nixpkgs-lib-tests-nix-${nix.version}"
     echo "Running lib/tests/network.sh"
     TEST_LIB=$PWD/lib bash lib/tests/network.sh
 
+    echo "Running lib/tests/strings.sh"
+    TEST_LIB=$PWD/lib bash lib/tests/strings.sh
+
     echo "Running lib/fileset/tests.sh"
     TEST_LIB=$PWD/lib bash lib/fileset/tests.sh
 


### PR DESCRIPTION
Path values should be copied into the store if they're going to be used in a shell script. In other words, `"my-command ${arg}"` and `"my-command ${lib.escapeShellArg arg}"` should always do the same thing if `arg` is a path; it should not be the case that the first is safe and the second results in an out-of-store reference.

Hat tip to @tejing1, who put this bee in my bonnet in https://discourse.nixos.org/t/refrencing-files-with-path-to-foo-am-i-holding-it-wrong/79360.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
