### PR TITLE
gershwin-system: init at 0-unstable-2026-08-19

### DIFF
--- a/pkgs/by-name/ge/gershwin-system/package.nix
+++ b/pkgs/by-name/ge/gershwin-system/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "gershwin-system";
+  version = "0-unstable-2026-08-19";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gershwin-desktop";
+    repo = "gershwin-system";
+    rev = "a29ac743fea4388d580467e1998d7bf4c06b1de2";
+    hash = "sha256-T/1iGevtrkIfoUVDu645UTujd+lhUxOuGiYfCYlaCYw=";
+  };
+
+  dontBuild = true;
+
+  env.DESTDIR = placeholder "out";
+
+  meta = {
+    homepage = "https://github.com/gershwin-desktop/gershwin-system";
+    description = "Gershwin Desktop configuration defaults and scaffolding files";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      OulipianSummer
+    ];
+  };
+  platforms = lib.platforms.linux;
+}


### PR DESCRIPTION
This PR introduces the[ gershwin-system](https://github.com/gershwin-desktop/gershwin-system) package from the [Gershwin Desktop](https://github.com/gershwin-desktop) project.

The repo itself is a simple shell script that places some system resources and config files (that otherwise belong nowhere else in the Gershwin ecosystem) into a globally accessible location. This package simply places all of those resources in the nix store in a place where Gershwin and GNUstep expect to find them.

This PR was authored and produced without the use of AI tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
