### PR TITLE
python3Packages.stemming: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/stemming/default.nix
+++ b/pkgs/development/python-modules/stemming/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 }:
 let
   pname = "stemming";
@@ -9,7 +10,7 @@ let
 in
 buildPythonPackage {
   inherit version pname;
-  format = "setuptools";
+  pyproject = true;
 
   # Pypi source package doesn't contain tests
   src = fetchFromGitHub {
@@ -18,6 +19,8 @@ buildPythonPackage {
     rev = "477d0e354e79843f5ec241ba3603bcb5b843c3c4";
     hash = "sha256-wnmBCbxnCZ9mN1J7sLcN7OynMcvqgAnhEgpAwW2/xz4=";
   };
+
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "stemming" ];
 

--- a/pkgs/development/python-modules/stemming/default.nix
+++ b/pkgs/development/python-modules/stemming/default.nix
@@ -4,15 +4,11 @@
   fetchFromGitHub,
   setuptools,
 }:
-let
+buildPythonPackage {
   pname = "stemming";
   version = "1.0.1";
-in
-buildPythonPackage {
-  inherit version pname;
   pyproject = true;
 
-  # Pypi source package doesn't contain tests
   src = fetchFromGitHub {
     owner = "nmstoker";
     repo = "stemming";
@@ -23,6 +19,8 @@ buildPythonPackage {
   build-system = [ setuptools ];
 
   pythonImportsCheck = [ "stemming" ];
+
+  doCheck = false; # source doesn't contain tests
 
   meta = {
     description = "Python implementations of various stemming algorithms";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
