### PR TITLE
temporal_capi: introduce a `dev` output, enable `__structuredAttrs`

### DIFF
--- a/pkgs/by-name/te/temporal_capi/package.nix
+++ b/pkgs/by-name/te/temporal_capi/package.nix
@@ -20,6 +20,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-nKE5n/ingB/+sEPJvpUQVsjCn+4/EPpcfZAM91CCZDE=";
   };
 
+  __structuredAttrs = true;
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   cargoHash = "sha256-sE4I1TW6XEgdqcPL0kRHQ+usb1UYIvbf8ujpJHu4LXo=";
 
   postPatch = ''
@@ -79,7 +85,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    FLAGS=$(PKG_CONFIG_PATH="$out/lib/pkgconfig" pkg-config --cflags --libs temporal_capi)
+    FLAGS=$(PKG_CONFIG_PATH="$dev/lib/pkgconfig" pkg-config --cflags --libs temporal_capi)
     cc $FLAGS temporal_capi/tests/c/simple.c -o c_test
     ./c_test
     c++ $FLAGS temporal_capi/tests/cpp/simple.cpp -o cpp_test


### PR DESCRIPTION
On macOS it makes the out output goes from 2.5MiB down to 1.5MiB, that's 40% decrease, seems worth it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
