### PR TITLE
openscreen: 1.4.0 -> 1.5.0, bump electron to 42

### DIFF
--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -7,13 +7,16 @@
   makeWrapper,
   makeDesktopItem,
   xcbuild,
-  electron_41,
+  electron_42,
   nodejs_22,
   nix-update-script,
   fetchgit,
+  vips,
+  glib,
+  pkg-config,
 }:
 let
-  electron = electron_41;
+  electron = electron_42;
   nodejs = nodejs_22;
 
   # download model
@@ -45,8 +48,15 @@ buildNpmPackage (finalAttrs: {
     makeWrapper
     copyDesktopItems
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+    pkg-config
     xcbuild
+  ];
+
+  # Fix darwin build
+  buildInputs = lib.optionals (stdenv.hostPlatform.isDarwin) [
+    vips
+    glib
   ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";

--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -7,28 +7,37 @@
   makeWrapper,
   makeDesktopItem,
   xcbuild,
-  electron_41,
+  electron_42,
   nodejs_22,
   nix-update-script,
+  fetchgit,
 }:
 let
-  electron = electron_41;
+  electron = electron_42;
   nodejs = nodejs_22;
+
+  # download model
+  xenovaWhisperTiny = fetchgit {
+    url = "https://huggingface.co/Xenova/whisper-tiny";
+    fetchLFS = true;
+    hash = "sha256-6v4CMUeFFLrN80gb7OxVv8EHIWg61Xx2khRjzhHvAnQ=";
+  };
+
 in
 buildNpmPackage (finalAttrs: {
   inherit nodejs;
 
   pname = "openscreen";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "siddharthvaddem";
     repo = "openscreen";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZBWDQVYDXJ/IQGhlmscmCOMjpl03kVIdMoJXOW8OjUI=";
+    hash = "sha256-csGCSYfqhQaswn/qdFeX3wZsAYlwU7V30n90HJrKslY=";
   };
 
-  npmDepsHash = "sha256-SMAYgOwlZg9+/KZBUhVviOxEdMeL3Z2YdC8Hx8Q/ioY=";
+  npmDepsHash = "sha256-lx38H0qG5IrjQRekLG2N+x90Zq/emPfbxOo/qDSn7iE=";
 
   npmRebuildFlags = [ "--ignore-scripts" ]; # Prevent running `node-gyp build`
 
@@ -42,6 +51,25 @@ buildNpmPackage (finalAttrs: {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
+  configurePhase = ''
+    runHook preConfigure
+
+    # Copy manually model files
+    mkdir -p caption-assets/models/Xenova/whisper-tiny
+    for el in config.json generation_config.json preprocessor_config.json tokenizer.json tokenizer_config.json \
+      added_tokens.json special_tokens_map.json normalizer.json merges.txt vocab.json quantize_config.json \
+      onnx/encoder_model_quantized.onnx onnx/decoder_model_merged_quantized.onnx; do
+
+        install -Dm644 "${xenovaWhisperTiny}/$el" "caption-assets/models/Xenova/whisper-tiny/$el"
+    done
+
+    # Disable download in script
+    substituteInPlace scripts/fetch-caption-model.mjs \
+      --replace-fail 'await download(`''${HF_BASE}/''${rel}`, path.join(modelDir, rel));' '/* skip */'
+
+    runHook postConfigure
+  '';
+
   buildPhase = ''
     runHook preBuild
 
@@ -52,6 +80,7 @@ buildNpmPackage (finalAttrs: {
       # electronDist needs to be modifiable on Darwin
       cp -r ${electron.dist} electron-dist
       chmod -R u+w electron-dist
+
 
       # Disable code signing during build on macOS.
       # https://www.electron.build/code-signing-mac.html#how-to-disable-code-signing-during-the-build-process-on-macos

--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -7,13 +7,13 @@
   makeWrapper,
   makeDesktopItem,
   xcbuild,
-  electron_42,
+  electron_41,
   nodejs_22,
   nix-update-script,
   fetchgit,
 }:
 let
-  electron = electron_42;
+  electron = electron_41;
   nodejs = nodejs_22;
 
   # download model


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Work towards: #555100

Update to the latest (and likely final) upstream release, as the
upstream repository has been archived on GitHub and development
has stopped: https://github.com/siddharthvaddem/openscreen

A community fork by EtienneLescot is available at
https://github.com/getopenscreen/openscreen, which could be used
as a replacement for this package in the future if it needs to be
removed or migrated.

## Things done
- update to last version
- fix model download

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
