### PR TITLE
nix-easy-search: init at v1.0.0

### DIFF
--- a/pkgs/by-name/ni/nix-easy-search/package.nix
+++ b/pkgs/by-name/ni/nix-easy-search/package.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "nix-easy-search";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Sh0rtRound-wq";
+    repo = "NixEasySearch";
+    rev = "v${version}";
+    hash = "sha256-LvWXZlTUVVJpcjKdVDojyuw246RgOm9dDh9LgWAT49I=";
+  };
+
+  vendorHash = null;
+
+  postInstall = ''
+    mv $out/bin/nix-easy-search $out/bin/nes
+  '';
+
+  meta = {
+    description = "Fast NixOS package search CLI with clean output";
+    homepage = "https://github.com/Sh0rtRound-wq/NixEasySearch";
+    license = lib.licenses.mit;
+    mainProgram = "nes";
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Adds nix-easy-search, a fast NixOS package search CLI that queries the official package index directly and displays clean, human-readable output. The command is `nes`.

- Zero external dependencies (pure stdlib Go)
- Caches package index locally at ~/.cache/nes/

Usage: nes [flags] <term>
  -channel string
    	Channel: unstable, 25.05, 24.11 (default "unstable")
  -json
    	Output JSON
  -n int
    	Max results (default 50)
  -offline
    	Skip update check
  -update
    	Force re-download of package index