### PR TITLE
tests.pkg-config: remove all tests that depend on gtk2 libraries

### DIFF
--- a/pkgs/top-level/pkg-config/pkg-config-data.json
+++ b/pkgs/top-level/pkg-config/pkg-config-data.json
@@ -209,11 +209,6 @@
         "freetype"
       ]
     },
-    "gdk-2.0": {
-      "attrPath": [
-        "gtk2"
-      ]
-    },
     "gdk-3.0": {
       "attrPath": [
         "gtk3"
@@ -222,11 +217,6 @@
     "gdk-pixbuf-2.0": {
       "attrPath": [
         "gdk-pixbuf"
-      ]
-    },
-    "gdk-x11-2.0": {
-      "attrPath": [
-        "gtk2-x11"
       ]
     },
     "gdk-x11-3.0": {
@@ -314,19 +304,9 @@
         "glib"
       ]
     },
-    "gtk+-2.0": {
-      "attrPath": [
-        "gtk2"
-      ]
-    },
     "gtk+-3.0": {
       "attrPath": [
         "gtk3"
-      ]
-    },
-    "gtk+-x11-2.0": {
-      "attrPath": [
-        "gtk2-x11"
       ]
     },
     "gtksourceview-3.0": {


### PR DESCRIPTION
Part of #410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
