### PR TITLE
nixos/pdns-recursor: add api.enable to start the built-in webserver

### DIFF
--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -94,6 +94,13 @@ in
       '';
     };
 
+    api.enable = mkEnableOption ''
+      the built-in webserver. It serves the REST API (which additionally needs
+      an API key set via {option}`services.pdns-recursor.settings.webservice.api_key`)
+      and, at `/metrics`, statistics in Prometheus format. Without this the
+      `api.address`, `api.port` and `api.allowFrom` options have no effect, as
+      the webserver stays disabled'';
+
     api.address = mkOption {
       type = types.str;
       default = "0.0.0.0";
@@ -222,6 +229,7 @@ in
       };
 
       webservice = mkDefaultAttrs {
+        webserver = cfg.api.enable;
         address = cfg.api.address;
         port = cfg.api.port;
         allow_from = cfg.api.allowFrom;

--- a/nixos/tests/pdns-recursor.nix
+++ b/nixos/tests/pdns-recursor.nix
@@ -6,7 +6,9 @@
 
   nodes.server = {
     services.pdns-recursor.enable = true;
+    services.pdns-recursor.api.enable = true;
     services.pdns-recursor.exportHosts = true;
+    services.pdns-recursor.settings.webservice.api_key = "supersecret";
     networking.hosts."192.0.2.1" = [ "example.com" ];
   };
 
@@ -17,5 +19,13 @@
 
     with subtest("can resolve names"):
       assert "192.0.2.1" in server.succeed("host example.com localhost")
+
+    with subtest("api is working"):
+      server.wait_for_open_port(8082)
+      server.succeed("curl -f -H 'X-API-Key: supersecret' http://localhost:8082/api/v1/servers")
+      server.fail("curl -f http://localhost:8082/api/v1/servers")
+
+    with subtest("metrics are exported"):
+      assert "pdns_recursor_" in server.succeed("curl -f -H 'X-API-Key: supersecret' http://localhost:8082/metrics")
   '';
 }


### PR DESCRIPTION
## Motivation

Add an `api.enable` option that starts the recursor's built-in webserver (which serves the REST API and Prometheus `/metrics`). Currently `api.address`, `api.port` and `api.allowFrom` are inert: the module renders `webservice.{address,port,allow_from}` but never `webservice.webserver`, so the webserver never starts.

## Behaviour

- `api.enable` defaults to `false`, so **existing configurations are unchanged** (the webserver was already effectively off).
- Setting `services.pdns-recursor.api.enable = true;` starts the built-in webserver on `api.address:api.port`, gated by `api.allowFrom`, serving the REST API (which additionally needs an API key via `settings.webservice.api_key`) and Prometheus metrics at `/metrics`.
- `webserver` is set through the module's existing `mkDefaultAttrs` (i.e. `mkDefault`), so `settings.webservice.webserver` can still override it.

## Testing

Evaluated the module through `nixos/lib/eval-config.nix`:

| `api.enable` | resulting `settings.webservice.webserver` |
|---|---|
| `true` | `true` |
| unset (default) | `false` |

Also verified on a live host that the recursor's webserver then serves `/metrics`. Syntax checked with `nix-instantiate --parse`.

## Things done

- [x] Evaluated the NixOS module change (no package rebuilds; option addition only).
- [ ] Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxing enabled in `nix.conf`?
- [ ] Tested via one or more NixOS test(s) — existing `nixosTests.pdns-recursor` still applies; no new behaviour to test (default is unchanged).
- [ ] Tested compilation of all packages that depend on this change using `nixpkgs-review`.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`).
- [ ] Added a release notes entry — not needed: additive, backwards-compatible option (default off).
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).