### PR TITLE
python3Packages.python.withPackages: respect package set overrides

### DIFF
--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -210,7 +210,13 @@ in
   inherit toPythonModule toPythonApplication;
   inherit mkPythonMetaPackage mkPythonEditablePackage;
 
-  python = toPythonModule python;
+  python = toPythonModule python // {
+    pkgs = self;
+    withPackages = import ./with-packages.nix {
+      inherit (python) buildEnv;
+      pythonPackages = self;
+    };
+  };
 
   # Don't take pythonPackages from "global" pkgs scope to avoid mixing python versions.
   pythonPackages = self;

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -216,7 +216,13 @@ let
             myPackages = python.pkgs.overrideScope extension;
           in
           assert myPackages.foobar == myPackages.numpy;
-          myPackages.python.withPackages (ps: with ps; [ foobar ]);
+          assert myPackages.python.pkgs.foobar == myPackages.numpy;
+          myPackages.python.withPackages (
+            ps: with ps; [
+              foobar
+              ps.python.pkgs.foobar
+            ]
+          );
         #
         # Have to skip prebuilt python as it's not present in top-level
         # `pkgs` as an attribute.

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -211,10 +211,12 @@ let
           in
           assert myPython.pkgs.foobar == myPython.pkgs.numpy;
           myPython.withPackages (ps: with ps; [ foobar ]);
-        # overrideScope is broken currently
-        # test-overrideScope = let
-        #  myPackages = python.pkgs.overrideScope extension;
-        # in assert myPackages.foobar == myPackages.numpy; myPackages.python.withPackages(ps: with ps; [ foobar ]);
+        test-overrideScope =
+          let
+            myPackages = python.pkgs.overrideScope extension;
+          in
+          assert myPackages.foobar == myPackages.numpy;
+          myPackages.python.withPackages (ps: with ps; [ foobar ]);
         #
         # Have to skip prebuilt python as it's not present in top-level
         # `pkgs` as an attribute.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

might be better to put `withPackages` in the package set, but this is a much easier change for now

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
