### PR TITLE
deltachat-desktop: 2.59.0 -> 2.59.1

### DIFF
--- a/pkgs/by-name/de/deltachat-desktop/package.nix
+++ b/pkgs/by-name/de/deltachat-desktop/package.nix
@@ -38,21 +38,21 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "deltachat-desktop";
-  version = "2.59.0";
+  version = "2.59.1";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "deltachat";
     repo = "deltachat-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Qr9QCH62Hd41rihaxB4nYwa68qiB4HDxx2333DkRkvA=";
+    hash = "sha256-FXm4dMWzaEcKbYlHKCXXV1pPLjBEtQR1IwvZ9SgqK7E=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 4;
-    hash = "sha256-RApYXI5k/CQGe/6K9vGWqP+C125xqNMEqjiE4W42TMc=";
+    hash = "sha256-mLGMntAXEiHptL7JLpu4eYdTHB0eY3yDX9KMt3PD2JA=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/de/deltachat-desktop/package.nix
+++ b/pkgs/by-name/de/deltachat-desktop/package.nix
@@ -4,7 +4,6 @@
   electron_42,
   fetchFromGitHub,
   deltachat-rpc-server,
-  deltachat-tauri,
   makeDesktopItem,
   makeWrapper,
   nodejs,
@@ -150,7 +149,6 @@ stdenv.mkDerivation (finalAttrs: {
     version = testers.testVersion {
       package = deltachat-desktop;
     };
-    inherit deltachat-tauri;
   };
 
   meta = {

--- a/pkgs/by-name/de/deltachat-tauri/package.nix
+++ b/pkgs/by-name/de/deltachat-tauri/package.nix
@@ -2,13 +2,11 @@
   apple-sdk_14,
   cargo-tauri,
   darwin,
-  deltachat-desktop,
   fetchFromGitHub,
   fetchPnpmDeps,
   gst_all_1,
   lib,
   libayatana-appindicator,
-  makeWrapper,
   nodejs,
   openssl,
   perl,
@@ -18,7 +16,6 @@
   python3,
   rustPlatform,
   stdenv,
-  versionCheckHook,
   webkitgtk_4_1,
   wrapGAppsHook4,
 }:
@@ -28,14 +25,25 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "deltachat-tauri";
-  inherit (deltachat-desktop)
-    version
-    src
-    pnpmDeps
-    ;
+  version = "2.59.0-unstable-2026-08-15";
   __structuredAttrs = true;
 
+  src = fetchFromGitHub {
+    owner = "deltachat";
+    repo = "deltachat-tauri";
+    rev = "ea854b4799578d7291e4dc9d6b76ddb5a001d2f0";
+    fetchSubmodules = true;
+    hash = "sha256-EdtSrr/5QKzBFhocCdFyAUFYHhuQUEUzMyw/fjgsIIg=";
+  };
+
   cargoHash = "sha256-Z3uZ+IARmCZbJiIotYjdQRzYZFplRwE3xO0Yb0tLbcE=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-IzMl6dZ8r8CH0eELOzHuFYVuzhQTdSS4NvYFOp7jHIs=";
+  };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
@@ -73,24 +81,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
       apple-sdk_14
     ];
 
-  buildAndTestSubdir = "packages/target-tauri";
-
   env = {
-    VERSION_INFO_GIT_REF = finalAttrs.src.tag;
+    VERSION_INFO_GIT_REF = finalAttrs.src.rev;
   };
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     install -Dm 444 images/tray/deltachat.svg "$out/share/icons/hicolor/scalable/apps/deltachat-tauri.svg"
   '';
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-
   meta = {
-    changelog = "https://github.com/deltachat/deltachat-desktop/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    broken = true; # Error Found version mismatched Tauri packages.
     description = "Email-based instant messaging for Desktop";
-    homepage = "https://github.com/deltachat/deltachat-desktop";
+    homepage = "https://github.com/deltachat/deltachat-tauri";
     license = lib.licenses.gpl3Plus;
     mainProgram = "deltachat-tauri";
     maintainers = [ lib.maintainers.dotlambda ];


### PR DESCRIPTION
Diff: https://github.com/deltachat/deltachat-desktop/compare/v2.59.0...v2.59.1

Changelog: https://github.com/deltachat/deltachat-desktop/blob/v2.59.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
