### PR TITLE
libse{linux,pol}: fix cross compilation from Darwin

### DIFF
--- a/pkgs/by-name/li/libselinux/package.nix
+++ b/pkgs/by-name/li/libselinux/package.nix
@@ -92,7 +92,12 @@ stdenv.mkDerivation (finalAttrs: {
     "PYTHON=${python3.pythonOnBuildForHost.interpreter}"
     "PYTHONLIBDIR=$(py)/${python3.sitePackages}"
     "PYTHON_SETUP_ARGS=--no-build-isolation"
-  ];
+  ]
+  ++
+    lib.optionals (stdenv.buildPlatform.parsed.kernel.name != stdenv.hostPlatform.parsed.kernel.name)
+      [
+        "OS=${if stdenv.hostPlatform.isDarwin then "Darwin" else "Linux"}"
+      ];
 
   preInstall = lib.optionalString enablePython ''
     mkdir -p $py/${python3.sitePackages}/selinux

--- a/pkgs/by-name/li/libsepol/package.nix
+++ b/pkgs/by-name/li/libsepol/package.nix
@@ -35,7 +35,12 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isStatic [
     "DISABLE_SHARED=y"
-  ];
+  ]
+  ++
+    lib.optionals (stdenv.buildPlatform.parsed.kernel.name != stdenv.hostPlatform.parsed.kernel.name)
+      [
+        "OS=${if stdenv.hostPlatform.isDarwin then "Darwin" else "Linux"}"
+      ];
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 


### PR DESCRIPTION
OS overrides `uname` based detection of target platform that doesn't
work when building darwin -> linux.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
