### PR TITLE
pnpmConfigHook: strip pnpm install state from outputs

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -377,7 +377,7 @@ In case you are patching `package.json` or `pnpm-lock.yaml`, make sure to pass `
 
 #### pnpmConfigHook {#javascript-pnpm-pnpmConfigHook}
 
-`pnpmConfigHook` supports adding additional `pnpm install` flags via `pnpmInstallFlags` which can be set to a Nix string array:
+`pnpmConfigHook` supports adding additional `pnpm install` flags via `pnpmInstallFlags`:
 
 ```nix
 {
@@ -391,25 +391,16 @@ In case you are patching `package.json` or `pnpm-lock.yaml`, make sure to pass `
 }
 ```
 
-If needed, set `dontPnpmConfigure = true;` to fully disable `pnpmConfigHook` without removing it from inputs manually.
+If you need to disable `pnpmConfigHook`, set `dontPnpmConfigure = true;`.
 
-Installing `node_modules` into an output would make a package unreproducible, because pnpm records install state inside it.
-Specifically, `.modules.yaml` stores where the pnpm store was (a temporary directory during a Nix build) and when it was written; `.pnpm-workspace-state-v1.json` stores a validation timestamp:
+By default, `pnpmConfigHook` deletes all instances of `.modules.yaml` and `.pnpm-workspace-state-v1.json` (these contain a build timestamp and path, either of which prevents a reproducible build).
 
-```console
-$ grep -E 'storeDir|prunedAt' result/lib/tsx/node_modules/.modules.yaml
-  "prunedAt": "Fri, 10 Jul 2026 13:19:13 GMT",
-  "storeDir": "/build/tmp.U0hlwviO2V/v10",
-```
+You can set `dontPnpmStripInstallState = true;` to keep the state files.
 
-`pnpmConfigHook` deletes every file with either name from every output after `fixupPhase`, and once more after `installCheckPhase`, because a check that runs pnpm writes them again.
-Packages no longer need to delete the files after their own `pnpm prune`.
-A deletion made before `pnpm prune` is different: pnpm reads `.modules.yaml` to decide how to prune, so those deletions stay in the package.
-Set `dontPnpmStripInstallState = true;` to keep the state files; `dontPnpmConfigure = true;` also disables this cleanup along with the rest of the hook.
+::: {.note}
+When using `makeWrapper` to call `pnpm run`:
 
-A package that starts its program through a `pnpm run` wrapper at runtime, like `misskey`, needs its wrapper adjusted.
-Since version 11, pnpm checks at startup whether `node_modules` is up to date and reinstalls the dependencies if not.
-In a built output the check cannot pass, and the attempted reinstall fails against the read-only Nix store.
+Since version 11, pnpm checks at startup whether `node_modules` is up to date and reinstalls dependencies if not.
 Point pnpm at a writable store directory and disable the check:
 
 ```nix
@@ -427,6 +418,7 @@ Point pnpm at a writable store directory and disable the check:
   '';
 }
 ```
+:::
 
 #### Dealing with `sourceRoot` {#javascript-pnpm-sourceRoot}
 

--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -375,6 +375,8 @@ Use a pinned version of pnpm (for example `pnpm_9` or `pnpm_10`) to increase rep
 
 In case you are patching `package.json` or `pnpm-lock.yaml`, make sure to pass `finalAttrs.patches` to the function as well (i.e., `inherit (finalAttrs) patches`).
 
+#### pnpmConfigHook {#javascript-pnpm-pnpmConfigHook}
+
 `pnpmConfigHook` supports adding additional `pnpm install` flags via `pnpmInstallFlags` which can be set to a Nix string array:
 
 ```nix
@@ -390,6 +392,41 @@ In case you are patching `package.json` or `pnpm-lock.yaml`, make sure to pass `
 ```
 
 If needed, set `dontPnpmConfigure = true;` to fully disable `pnpmConfigHook` without removing it from inputs manually.
+
+Installing `node_modules` into an output would make a package unreproducible, because pnpm records install state inside it.
+Specifically, `.modules.yaml` stores where the pnpm store was (a temporary directory during a Nix build) and when it was written; `.pnpm-workspace-state-v1.json` stores a validation timestamp:
+
+```console
+$ grep -E 'storeDir|prunedAt' result/lib/tsx/node_modules/.modules.yaml
+  "prunedAt": "Fri, 10 Jul 2026 13:19:13 GMT",
+  "storeDir": "/build/tmp.U0hlwviO2V/v10",
+```
+
+`pnpmConfigHook` deletes every file with either name from every output after `fixupPhase`, and once more after `installCheckPhase`, because a check that runs pnpm writes them again.
+Packages no longer need to delete the files after their own `pnpm prune`.
+A deletion made before `pnpm prune` is different: pnpm reads `.modules.yaml` to decide how to prune, so those deletions stay in the package.
+Set `dontPnpmStripInstallState = true;` to keep the state files; `dontPnpmConfigure = true;` also disables this cleanup along with the rest of the hook.
+
+A package that starts its program through a `pnpm run` wrapper at runtime, like `misskey`, needs its wrapper adjusted.
+Since version 11, pnpm checks at startup whether `node_modules` is up to date and reinstalls the dependencies if not.
+In a built output the check cannot pass, and the attempted reinstall fails against the read-only Nix store.
+Point pnpm at a writable store directory and disable the check:
+
+```nix
+{
+  # ...
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    makeWrapper ${lib.getExe pnpm} $out/bin/foo \
+      --chdir $out/share/foo \
+      --add-flag "--config.store-dir=/tmp/pnpm-store" \
+      --add-flag "--config.verify-deps-before-run=false" \
+      --add-flag run \
+      --add-flag start
+  '';
+}
+```
 
 #### Dealing with `sourceRoot` {#javascript-pnpm-sourceRoot}
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -3837,6 +3837,9 @@
   "javascript-pnpm": [
     "index.html#javascript-pnpm"
   ],
+  "javascript-pnpm-pnpmConfigHook": [
+    "index.html#javascript-pnpm-pnpmConfigHook"
+  ],
   "javascript-pnpm-sourceRoot": [
     "index.html#javascript-pnpm-sourceRoot"
   ],

--- a/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
+++ b/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
@@ -122,11 +122,13 @@ if [ -z "${dontPnpmConfigure-}" ]; then
   postConfigureHooks+=(pnpmConfigHook)
 fi
 
+# This does not replace deletions of .modules.yaml made before a package's
+# own `pnpm prune`: pnpm reads that file to decide how to prune.
 pnpmStripInstallState() {
     local output
     for output in $(getAllOutputNames); do
         [ -e "${!output}" ] || continue
-        # Delete impure files. Contains references to build dir and wall clock timestamp.
+        # Delete impure files. Contains references to build dir and a timestamp.
         find "${!output}" \
             \( -name .modules.yaml -o -name .pnpm-workspace-state-v1.json \) \
             -delete

--- a/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
+++ b/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
@@ -121,3 +121,20 @@ pnpmConfigHook() {
 if [ -z "${dontPnpmConfigure-}" ]; then
   postConfigureHooks+=(pnpmConfigHook)
 fi
+
+pnpmStripInstallState() {
+    local output
+    for output in $(getAllOutputNames); do
+        [ -e "${!output}" ] || continue
+        # Delete impure files. Contains references to build dir and wall clock timestamp.
+        find "${!output}" \
+            \( -name .modules.yaml -o -name .pnpm-workspace-state-v1.json \) \
+            -delete
+    done
+}
+
+if [ -z "${dontPnpmConfigure-}" ] && [ -z "${dontPnpmStripInstallState-}" ]; then
+  postFixupHooks+=(pnpmStripInstallState)
+  # pnpm might be called during installCheckPhase. Cleanup here afterwards as well
+  postInstallCheckHooks+=(pnpmStripInstallState)
+fi

--- a/pkgs/by-name/ba/bash-language-server/package.nix
+++ b/pkgs/by-name/ba/bash-language-server/package.nix
@@ -57,9 +57,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules server/node_modules -xtype l -delete
-
-    # remove non-deterministic files
-    rm node_modules/.modules.yaml
   '';
 
   installPhase = ''

--- a/pkgs/by-name/co/concurrently/package.nix
+++ b/pkgs/by-name/co/concurrently/package.nix
@@ -53,9 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules -xtype l -delete
-
-    # remove non-deterministic files
-    rm node_modules/{.modules.yaml,.pnpm-workspace-state-v1.json}
   '';
 
   installPhase = ''

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -39,14 +39,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     pnpm
   ];
 
-  # remove unnecessary and non-deterministic files
+  # remove unnecessary files
   preInstall = ''
     CI=true pnpm --ignore-scripts --prod prune
     find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules -xtype l -delete
-
-    rm node_modules/.modules.yaml
   '';
 
   installPhase = ''

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -56,9 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     rm node_modules/.modules.yaml
     CI=true pnpm prune --prod --ignore-scripts
     find -type f \( -name "*.d.ts" -o -name "*.map" \) -exec rm -rf {} +
-
-    # remove non-deterministic files
-    rm node_modules/.modules.yaml
   '';
 
   # Upstream scripts uses `pnpm run prod` which is equivalent to

--- a/pkgs/by-name/fi/firecrawl-cli/package.nix
+++ b/pkgs/by-name/fi/firecrawl-cli/package.nix
@@ -68,8 +68,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules -xtype l -delete
-    # - remove non-deterministic files
-    rm node_modules/{.modules.yaml,.pnpm-workspace-state-v1.json}
     # - copy over node modules
     cp -r dist node_modules $out/lib/firecrawl-cli
     cp package.json $out/lib/firecrawl-cli

--- a/pkgs/by-name/fi/firecrawl-mcp/package.nix
+++ b/pkgs/by-name/fi/firecrawl-mcp/package.nix
@@ -61,8 +61,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules -xtype l -delete
-    # - remove non-deterministic files
-    rm node_modules/{.modules.yaml,.pnpm-workspace-state-v1.json}
     # - copy over node modules
     cp -r dist node_modules $out/lib/firecrawl-mcp
     cp package.json $out/lib/firecrawl-mcp

--- a/pkgs/by-name/tu/turborepo-remote-cache/package.nix
+++ b/pkgs/by-name/tu/turborepo-remote-cache/package.nix
@@ -54,8 +54,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Clean up broken symlinks left behind by `pnpm prune`
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules -xtype l -delete
-     # Remove non-deterministic files
-    rm node_modules/.modules.yaml
     runHook postBuild
   '';
 

--- a/pkgs/by-name/vu/vue-language-server/package.nix
+++ b/pkgs/by-name/vu/vue-language-server/package.nix
@@ -62,9 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules packages/language-server/node_modules -xtype l -delete
-
-    # remove non-deterministic files
-    rm node_modules/.modules.yaml node_modules/.pnpm-workspace-state-v1.json
   '';
 
   installPhase = ''


### PR DESCRIPTION
TL;DR: pnpm's install state — `node_modules/.modules.yaml` and `.pnpm-workspace-state-v1.json` — embeds a `mktemp` store path and wall-clock timestamps, so every `pnpmConfigHook` consumer that puts `node_modules` in its output is irreproducible. This strips both files from every output during fixup, replacing eight per-package workarounds.

The strip runs in `postFixupHooks` over every output, and again in `postInstallCheckHooks` because `installCheckPhase` runs after fixup; `dontPnpmStripInstallState` opts out of just the strip, and `dontPnpmConfigure` still disables the whole hook as the manual documents.

376 rebuilds on linux, 272 on darwin, so this targets `master`. The hook reaches all ~225 `pnpmConfigHook` consumers, so output paths change well beyond the eight packages edited here.

<details>
<summary>Reproducibility check on <code>emmet-language-server</code></summary>

At the merge base:

```console
$ nix build --rebuild github:NixOS/nixpkgs/6d408bf200fa5e1b97751fdeb6466f1bed697dbe#emmet-language-server
error: derivation '/nix/store/kyda389pkzywcmnp61zz3biw72p2dh8k-emmet-language-server-2.8.0.drv' may not be deterministic: output "/nix/store/01i4kvz0wq2bfpbx19wdi6nmlc6mgrgh-emmet-language-server-2.8.0" differs
```

With this branch, `nix build --rebuild` exits 0.

`nixpkgs-review` 3.9.0 on this head built 373 of 379 packages on x86_64-linux; the five failures are not caused by this change, per the review comment.

</details>

This PR summary and the manual addition were written in part with Claude Code (Claude Opus 5, `claude-opus-5`; Claude Fable 5, `claude-fable-5`); the commits have `Assisted-by:` trailers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



