### PR TITLE
auto-patchelf,autoPatchelfHook: sort library walks for determinism

### DIFF
--- a/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
@@ -144,7 +144,10 @@ def osabi_are_compatible(wanted: str, got: str) -> bool:
 
 def glob(path: Path, pattern: str, recursive: bool) -> Iterator[Path]:
     if path.is_dir():
-        return path.rglob(pattern) if recursive else path.glob(pattern)
+        # Sort siblings: readdir order is not reproducible.
+        return iter(sorted(
+            path.rglob(pattern) if recursive else path.glob(pattern),
+            key=lambda p: (p.parent.parts, p.name)))
     else:
         # path.glob won't return anything if the path is not a directory.
         # We extend that behavior by matching the file name against the pattern.

--- a/pkgs/by-name/au/autoPatchelfHook/auto-patchelf.sh
+++ b/pkgs/by-name/au/autoPatchelfHook/auto-patchelf.sh
@@ -28,13 +28,14 @@ addAutoPatchelfSearchPath() {
         esac
     done
 
+    # Sort in the C locale. find's order is not reproducible.
     local dir=
     while IFS= read -r -d '' dir; do
         extraAutoPatchelfLibs+=("$dir")
     done <  <(find "$@" "${findOpts[@]}" \! -type d \
             \( -name '*.so' -o -name '*.so.*' \) -print0 \
             | sed -z 's#/[^/]*$##' \
-            | uniq -z
+            | LC_ALL=C sort -z -u
         )
 }
 


### PR DESCRIPTION
`auto-patchelf` can bind a binary to either of two libraries sharing a soname depending on the order the filesystem returns directory entries, so the same derivation does not always produce the same RPATH. This sorts the two walks that decide it.

Sorting buys reproducibility, not correctness — where the sorted winner is the wrong library, that remains a packaging problem. 48997 rebuilds on linux, 14 on darwin, so this targets `staging`.

This pull request summary was written with Claude Code (Claude Opus 5, `claude-opus-5`; Claude Fable 5, `claude-fable-5`); the commit has an `Assisted-by:` trailer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


