### PR TITLE
alsa-utils: fix cross-compiled shebangs

### DIFF
--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -5,6 +5,7 @@
   fetchurl,
   alsa-lib,
   alsa-plugins,
+  bashNonInteractive,
   gettext,
   makeWrapper,
   pkg-config,
@@ -45,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
   buildInputs = [
+    bashNonInteractive
     alsa-lib
     ncurses
     libsamplerate


### PR DESCRIPTION
before:
```
$ head -n1 $(nix-build -A pkgsCross.aarch64-multiplatform.alsa-utils)/bin/.alsa-info-wrapped
#!/bin/bash
```

and the resulting `alsa-info` would fail when invoked: "/bin/bash: bad interpreter: No such file or directory"

after:
```
$ head -n1 $(nix-build -A pkgsCross.aarch64-multiplatform.alsa-utils)/bin/.alsa-info-wrapped
#!/nix/store/p6mqrxz3wl8fvqcqqf498nyp88lv8687-bash-aarch64-unknown-linux-gnu-5.3p15/bin/bash
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
