### PR TITLE
tcl: fix cross compilation from Darwin

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -48,6 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "/usr/lib/zoneinfo" "" \
       --replace "/usr/local/etc/zoneinfo" ""
   ''
+  + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    substituteInPlace unix/configure unix/configure.in \
+      --replace-fail '`uname -s`' '${stdenv.hostPlatform.uname.system}'
+  ''
   # A shared Cygwin build tries to configure the windows build system
   # to separately build these DLLs so it can load them later. That's
   # not gonna work for us --- in Nixpkgs this would need to be a
@@ -114,7 +118,13 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags =
     lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       # TODO make this unconditional
-      "tcl_cv_sys_version=${stdenv.hostPlatform.uname.system}"
+      # tcl_cv_sys_version is intended to be set to `$(uname -s)-$(uname -r)`.
+      "tcl_cv_sys_version=${
+        lib.concatStringsSep "-" [
+          stdenv.hostPlatform.uname.system
+          (lib.optionalString (stdenv.hostPlatform.uname.release != null) stdenv.hostPlatform.uname.release)
+        ]
+      }"
     ]
     ++ lib.optionals (lib.versionOlder version "9.0") [
       # Unlike the two `versionOlder` gates below, this one is real: enabled


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
