### PR TITLE
beamPackages: add extend throw to guide users

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -91,6 +91,11 @@ makeScopeWithSplicing' {
 
     }
     // lib.optionalAttrs config.allowAliases {
+      extend = throw ''
+        'beamPackages.extend' has been replaced by 'beamPackages.overrideScope'
+
+        See examples at https://nixos.org/manual/nixpkgs/unstable/#sec-beam
+      ''; # added 2026-08-24
       webdriver = throw "'beamPackages.webdriver' has been removed."; # added 2026-07-29
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The docs are not actually updated yet, but we should guide external users. Maybe they will get updated before this gets out.

```
nix-repl> beam29Packages.extend (_: prev: { elixir = prev.elixir_1_20; })
error:
       … while evaluating the attribute 'extend'
         at /home/adam/git/nixpkgs/pkgs/development/beam-modules/default.nix:94:7:
           93|     // lib.optionalAttrs config.allowAliases {
           94|       extend = throw ''
             |       ^
           95|         'beamPackages.extend' has been replaced by 'beamPackages.overrideScope'

       … while calling the 'throw' builtin
         at /home/adam/git/nixpkgs/pkgs/development/beam-modules/default.nix:94:16:
           93|     // lib.optionalAttrs config.allowAliases {
           94|       extend = throw ''
             |                ^
           95|         'beamPackages.extend' has been replaced by 'beamPackages.overrideScope'

       error: 'beamPackages.extend' has been replaced by 'beamPackages.overrideScope'

       See examples at https://nixos.org/manual/nixpkgs/unstable/#sec-beam

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
