### PR TITLE
mactahoe-icon-theme: init at 2026-07-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11306,6 +11306,12 @@
     githubId = 69494718;
     name = "Herschenglime";
   };
+  hesprs = {
+    email = "hesprs@outlook.com";
+    github = "hesprs";
+    githubId = 190185753;
+    name = "Hēsperus";
+  };
   hexa = {
     email = "hexa@darmstadt.ccc.de";
     matrix = "@hexa:lossy.network";

--- a/pkgs/by-name/ma/mactahoe-icon-theme/package.nix
+++ b/pkgs/by-name/ma/mactahoe-icon-theme/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gtk3,
+  hicolor-icon-theme,
+  jdupes,
+  boldPanelIcons ? false,
+  themeVariants ? [ ],
+}:
+
+let
+  pname = "mactahoe-icon-theme";
+in
+lib.checkListOfEnum "${pname}: theme variants"
+  [
+    "default"
+    "blue"
+    "purple"
+    "green"
+    "red"
+    "orange"
+    "yellow"
+    "grey"
+    "nord"
+    "all"
+  ]
+  themeVariants
+
+  stdenvNoCC.mkDerivation
+  rec {
+    inherit pname;
+    version = "2026-07-07";
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "vinceliuice";
+      repo = "MacTahoe-icon-theme";
+      tag = "${version}";
+      hash = "sha256-CXZn4r1B+eB2Uv00vutFGQjOKJIia/I5RkPOBAAJKYA=";
+    };
+
+    nativeBuildInputs = [
+      gtk3
+      jdupes
+    ];
+
+    buildInputs = [ hicolor-icon-theme ];
+
+    # These fixup steps are slow and unnecessary
+    dontPatchELF = true;
+    dontRewriteSymlinks = true;
+    dontDropIconThemeCache = true;
+
+    postPatch = ''
+      patchShebangs install.sh
+
+      # Fix upstream symlink, whose relative target is invalid after installation.
+      rm links/status/symbolic/globe-symbolic.svg
+      ln -s ../../places/symbolic/network-workgroup-symbolic.svg \
+        links/status/symbolic/globe-symbolic.svg
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      ./install.sh --dest $out/share/icons \
+        --name MacTahoe \
+        --theme ${toString themeVariants} \
+        ${lib.optionalString boldPanelIcons "--bold"}
+
+      jdupes --link-soft --recurse $out/share
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "MacOS Tahoe style icon theme for Linux desktops";
+      homepage = "https://github.com/vinceliuice/MacTahoe-icon-theme";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [ hesprs ];
+    };
+  }


### PR DESCRIPTION
Added `mactahoe-icon-theme` package by vinceliuice: https://github.com/vinceliuice/MacTahoe-icon-theme.

Added `hesprs` to maintainers list and set the maintainer of `mactahoe-icon-theme` to hesprs.

Packaging used template [`whitesur-icon-theme`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/wh/whitesur-icon-theme/package.nix#L79). Fixed a symlink issue in source release.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
