### PR TITLE
Revert "scx.rustscheds: 1.1.2 -> 1.1.3"

### DIFF
--- a/nixos/tests/scx/default.nix
+++ b/nixos/tests/scx/default.nix
@@ -20,7 +20,6 @@
       flow.configuration.services.scx.scheduler = "scx_flow";
       forge.configuration.services.scx.scheduler = "scx_forge";
       lavd.configuration.services.scx.scheduler = "scx_lavd";
-      mlfq.configuration.services.scx.scheduler = "scx_mlfq";
       p2dq.configuration.services.scx.scheduler = "scx_p2dq";
       pandemonium.configuration.services.scx.scheduler = "scx_pandemonium";
       rlfifo.configuration.services.scx.scheduler = "scx_rlfifo";
@@ -41,7 +40,6 @@
       "flow",
       "forge",
       "lavd",
-      "mlfq",
       "p2dq",
       "pandemonium",
       "rlfifo",

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -15,16 +15,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scx_rustscheds";
-  version = "1.1.3";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "sched-ext";
     repo = "scx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LK0go5blWgCtDpS5xm9BQc7C2NvbfrW+Jp66ImIThxA=";
+    hash = "sha256-igrmrfimVOEJnFxMr9ghN6lAHwEBSFLLVrB2MQ72PXI=";
   };
 
-  cargoHash = "sha256-vEsbpor52DEUpYO5OubFPMzRltO5kUXjqAoO/9hsKXc=";
+  cargoHash = "sha256-CTEVdvw6aG/fFas2Fk3x9o4Sp2k3lHO/OLwUM8t9UjE=";
 
   nativeBuildInputs = [
     pkg-config
@@ -95,7 +95,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "scx_lavd"
     "scx_layered"
     "scx_mitosis"
-    "scx_mlfq"
     "scx_p2dq"
     "scx_pandemonium"
     "scx_rlfifo"


### PR DESCRIPTION
Reverts NixOS/nixpkgs#554706

`scx_lavd` is broken. See

- #555996
- https://github.com/sched-ext/scx/issues/3750