### PR TITLE
nixos/{label,bootspec,/systemd-boot}: Allow setting the boot label

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -248,6 +248,8 @@
 
 - `boot.loader.systemd-boot` gained support for [Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/) via the new [`boot.loader.systemd-boot.bootCounting`](#opt-boot.loader.systemd-boot.bootCounting.enable) options, allowing automatic detection of and recovery from bad NixOS generations. As part of this change, boot loader entries on the ESP/XBOOTLDR partition are now named `nixos-<content-hash>.conf` instead of `nixos-generation-<n>.conf`; existing entries are migrated automatically on the next `nixos-rebuild boot`/`switch`.
 
+- The label of the boot entry can now be customized with new option `system.nixos.bootEntryLabel`. Previously, the option `system.nixos.label` only allowed to configure the "version part" of the boot entry label.  This new option allows more control.
+
 - `services.nginx` gained a [`lua`](#opt-services.nginx.lua.enable) option to enable Lua scripting via OpenResty's lua-nginx-module on a stock nginx, configuring `lua_package_path`/`lua_package_cpath` from the packages listed in [`services.nginx.lua.extraPackages`](#opt-services.nginx.lua.extraPackages). Use this to add Lua to a regular nginx; for the full OpenResty platform (libraries that rely on its bundled lualib, such as `lua-resty-openidc`), set `services.nginx.package` to `pkgs.openresty` instead — the option configures the Lua search path for it too.
 
 - `services.nginx.virtualHosts.<name>.locations.<name>` gained a new `useGrpcErrorPages` option. If enabled, it sets up error pages that are valid gRPC messages. This is useful if you proxy gRPC and want to emit errors from nginx, for example when adding authentication on top.

--- a/nixos/modules/misc/label.nix
+++ b/nixos/modules/misc/label.nix
@@ -7,6 +7,49 @@ in
 
   options.system = {
 
+    nixos.bootEntryLabel = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        Display label of the boot menu entry.
+
+        If you only want to modify the version part of the boot entry label
+        use {option}`system.nixos.label` instead.
+
+        In the label the string `{generation}` is replaced by the generation
+        number and `{build_date}` is replaced by the date the configuration
+        was built.  (Since Nix expressions are pure, these cannot be filled
+        in by Nix like the kernel version.)
+
+        The default entry label is
+        ```
+        Generation {generation} ''${config.system.nixos.distroName} ''${config.system.nixos.codeName} ''${config.system.nixos.label} (Linux ''${config.boot.kernelPackages.kernel.modDirVersion}), built on {build_date}
+        ```
+        and looks like
+        ```
+        Generation 1234 NixOS Emu 16.03.1160.f2d4ee1 (Linux 28.12.69), built on 2016-03-14
+        ```
+
+        Can be overridden by setting {env}`NIXOS_BOOT_ENTRY_LABEL`.
+
+        Useful for not loosing track of configurations built from different
+        nixos branches/revisions, e.g.:
+
+        ```
+        #!/bin/sh
+        today=`date +%Y%m%d`
+        branch=`(cd nixpkgs ; git branch 2>/dev/null | sed -n '/^\* / { s|^\* ||; p; }')`
+        revision=`(cd nixpkgs ; git rev-parse HEAD)`
+        export NIXOS_BOOT_ENTRY_LABEL="{generation}. NixOS $today.$branch-''${revision:0:7}"
+        nixos-rebuild switch
+        ```
+
+        Note: Only used by boot loaders which follow the Bootspec RFC
+        [RFC 0125].
+
+        [RFC 0125]: https://github.com/NixOS/rfcs/blob/master/rfcs/0125-bootspec.md
+      '';
+    };
+
     nixos.label = lib.mkOption {
       type = lib.types.strMatching "[a-zA-Z0-9:_\\.-]*";
       description = ''
@@ -14,7 +57,8 @@ in
         outputs and boot labels.
 
         If you ever wanted to influence the labels in your GRUB menu,
-        this is the option for you.
+        this is the option for you.  For more control over the label
+        use option {option}`system.nixos.bootEntryLabel`.
 
         It can only contain letters, numbers and the following symbols:
         `:`, `_`, `.` and `-`.
@@ -72,6 +116,8 @@ in
         )
       )
     );
+    system.nixos.bootEntryLabel = lib.mkDefault (
+      lib.maybeEnv "NIXOS_BOOT_ENTRY_LABEL" "Generation {generation} ${config.system.nixos.distroName} ${config.system.nixos.codeName} ${config.system.nixos.label} (Linux ${config.boot.kernelPackages.kernel.modDirVersion}), built on {build_date}"
+    );
   };
-
 }

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -26,7 +26,7 @@ let
             // {
               "org.nixos.bootspec.v1" = {
                 system = config.boot.kernelPackages.stdenv.hostPlatform.system;
-                label = "${config.system.nixos.distroName} ${config.system.nixos.codeName} ${config.system.nixos.label} (Linux ${config.boot.kernelPackages.kernel.modDirVersion})";
+                label = config.system.nixos.bootEntryLabel;
               }
               // lib.optionalAttrs config.boot.kernel.enable {
                 kernel = "${config.boot.kernelPackages.kernel}/${config.system.boot.loader.kernelFile}";

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -410,7 +410,9 @@ def boot_file(
         profile=" [" + profile + "]" if profile else "",
         specialisation=" (%s)" % specialisation if specialisation else "",
     )
-    description = f"Generation {generation} {bootspec.label}, built on {build_date}"
+    description = bootspec.label.replace("{generation}", str(generation)).replace(
+        "{build_date}", build_date
+    )
     boot_entry = (
         [
             f"title {title}",


### PR DESCRIPTION
The option `system.nixos.label` only allowed to configure the "version part" of the boot entry label.

Add a new option `system.nixos.bootEntryLabel` which allows to configure the boot entry label.  Thus, boot labels like
```
Gen 1234 (2016-03-14): NixOS Emu 16.03.1160.f2d4ee1
```
are now possible.

The new option allows arbitrary strings (the [UAPI] spec defines it as UTF-8 string).  The name of the option `bootEntryLabel`, the environment variable name (`NIXOS_BOOT_ENTRY_LABEL`)  and its location (is `boot.something.` better?) is up to debate.

The boot label contains to bits of information, the generation number and the build date, which cannot be interpolated by the nix expression as their values are impure.  Provide placeholders `{generation}` and `{build_date}`, which get replace by their values when the boot entry is generated. The exact names of the replacements can also be bikeshedded. I adopted the names of `systemd-boot-builder.py`

The current implementation uses the "label" entry of the bootspec RFC [RFC 0125] to store the `bootEntryLabel` value.  Thus, only systemd-boot is supported as other boot loaders have not yet implemented the bootspec RFC.

I've chosen to add a new option `system.nixos.bootEntryLabel` over altering the behaviour of `system.nixos.label` as this is a backwards compatible change.
If we replace the effect of `system.nixos.label` so that it behaves like the `system.nixos.bootEntryLabel`, then this would require an intervention for people who have set `system.nixos.label`, i.e. a breaking change. If you find that a breaking change is acceptable to avoid the introduction of a new option, let me now and I'll update the implementation.

Closes: https://github.com/NixOS/nixpkgs/issues/555461
and partially https://github.com/NixOS/nixpkgs/issues/402584
The latter asks to change the beginning of the menu, which the "title" for systemd-boot.  This pull request changes the "version" entry (which NixOS (ab)uses as label).

[RFC 0125]: https://github.com/NixOS/rfcs/blob/master/rfcs/0125-bootspec.md
[UAPI] https://uapi-group.org/specifications/specs/boot_loader_specification/#type-1-boot-loader-specification-entries

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Booted machine with changed label
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
