### PR TITLE
nixos/test-driver: catch QMP disconnect while waiting

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -10,6 +10,7 @@
   junit-xml,
   ptpython,
   pydantic,
+  pytestCheckHook,
   python,
   ovmfvartool,
   remote-pdb,
@@ -77,11 +78,12 @@ buildPythonApplication {
   doCheck = true;
 
   nativeCheckInputs = [
+    pytestCheckHook
     ruff
     ty
   ];
 
-  checkPhase = ''
+  preCheck = ''
     echo -e "\x1b[32m## run ty\x1b[0m"
     ty check --error-on-warning test_driver extract-docstrings.py
     echo -e "\x1b[32m## run ruff check\x1b[0m"

--- a/nixos/lib/test-driver/src/test_driver/machine/qmp.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/qmp.py
@@ -4,6 +4,7 @@ import logging
 import os
 import select
 import socket
+import time
 from collections.abc import Iterator
 from pathlib import Path
 from queue import Queue
@@ -60,14 +61,17 @@ class QMPSession:
             if self.read_pending_messages():
                 continue
 
-            select.select([self.sock], [], [])
-
-            if self.sock.recv(1, socket.MSG_PEEK) == b"":
-                raise ConnectionError(
-                    "QMP connection closed while waiting for a response"
-                )
+            self._wait_for_socket_data()
 
         return self.results.get()
+
+    def _wait_for_socket_data(self, timeout: float | None = None) -> None:
+        readable, _, _ = select.select([self.sock], [], [], timeout)
+        if not readable:
+            raise TimeoutError
+
+        if self.sock.recv(1, socket.MSG_PEEK) == b"":
+            raise ConnectionError("QMP connection closed while waiting for data")
 
     def read_pending_messages(self) -> bool:
         line = self.reader.readline()
@@ -90,10 +94,18 @@ class QMPSession:
     def wait_for_event(
         self, timeout: dt.timedelta = dt.timedelta(seconds=10)
     ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout.total_seconds()
         while self.pending_events.empty():
-            self.read_pending_messages()
+            if self.read_pending_messages():
+                continue
 
-        return self.pending_events.get(timeout=timeout.total_seconds())
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError
+
+            self._wait_for_socket_data(remaining)
+
+        return self.pending_events.get_nowait()
 
     def events(
         self, timeout: dt.timedelta = dt.timedelta(seconds=10)

--- a/nixos/lib/test-driver/src/test_driver/machine/qmp.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/qmp.py
@@ -2,6 +2,7 @@ import datetime as dt
 import json
 import logging
 import os
+import select
 import socket
 from collections.abc import Iterator
 from pathlib import Path
@@ -56,13 +57,22 @@ class QMPSession:
     def _wait_for_new_result(self) -> dict[str, str]:
         assert self.results.empty(), "Results set is not empty, missed results!"
         while self.results.empty():
-            self.read_pending_messages()
+            if self.read_pending_messages():
+                continue
+
+            select.select([self.sock], [], [])
+
+            if self.sock.recv(1, socket.MSG_PEEK) == b"":
+                raise ConnectionError(
+                    "QMP connection closed while waiting for a response"
+                )
+
         return self.results.get()
 
-    def read_pending_messages(self) -> None:
+    def read_pending_messages(self) -> bool:
         line = self.reader.readline()
         if not line:
-            return
+            return False
         evt_or_result = json.loads(line)
         logger.debug(f"Received a message: {evt_or_result}")
 
@@ -74,6 +84,8 @@ class QMPSession:
             self.pending_events.put(evt_or_result)
         else:
             raise QMPAPIError(evt_or_result)
+
+        return True
 
     def wait_for_event(
         self, timeout: dt.timedelta = dt.timedelta(seconds=10)

--- a/nixos/lib/test-driver/src/tests/machine/test_qmp.py
+++ b/nixos/lib/test-driver/src/tests/machine/test_qmp.py
@@ -106,3 +106,41 @@ def test_queues_event_received_before_command_result(
     thread.join(timeout=1)
     assert not thread.is_alive()
     assert list(session.events()) == [event]
+
+
+def test_reports_connection_closed_before_greeting() -> None:
+    client_sock, server_sock = socket.socketpair()
+    server_sock.close()
+
+    try:
+        with pytest.raises(
+            ConnectionError,
+            match="QMP connection closed while waiting for a response",
+        ):
+            QMPSession(client_sock)
+    finally:
+        client_sock.close()
+
+
+def test_reports_connection_closed_while_waiting_for_result(
+    qmp_session: tuple[QMPSession, QMPServer],
+) -> None:
+    session, server = qmp_session
+    requests: Queue[dict[str, Any]] = Queue()
+
+    def disconnect() -> None:
+        requests.put(server.receive())
+        server.close()
+
+    thread = threading.Thread(target=disconnect)
+    thread.start()
+
+    with pytest.raises(
+        ConnectionError,
+        match="QMP connection closed while waiting for a response",
+    ):
+        session.send("query-status")
+
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert requests.get_nowait() == {"execute": "query-status"}

--- a/nixos/lib/test-driver/src/tests/machine/test_qmp.py
+++ b/nixos/lib/test-driver/src/tests/machine/test_qmp.py
@@ -1,0 +1,108 @@
+import json
+import socket
+import threading
+from collections.abc import Iterator
+from queue import Queue
+from typing import Any
+
+import pytest
+
+from test_driver.machine.qmp import QMPSession
+
+QMP_GREETING = {
+    "QMP": {
+        "version": {
+            "qemu": {"major": 11, "minor": 1, "micro": 0},
+            "package": "",
+        },
+        "capabilities": [],
+    }
+}
+
+
+class QMPServer:
+    def __init__(self, sock: socket.socket) -> None:
+        self.sock = sock
+        self.reader = sock.makefile("r")
+
+    def send(self, message: dict[str, Any]) -> None:
+        self.sock.sendall(f"{json.dumps(message)}\n".encode())
+
+    def receive(self) -> dict[str, Any]:
+        return json.loads(self.reader.readline())
+
+    def close(self) -> None:
+        self.reader.close()
+        self.sock.close()
+
+
+def respond_once(
+    server: QMPServer, responses: list[dict[str, Any]]
+) -> tuple[threading.Thread, Queue[dict[str, Any]]]:
+    requests: Queue[dict[str, Any]] = Queue()
+
+    def respond() -> None:
+        requests.put(server.receive())
+        for response in responses:
+            server.send(response)
+
+    thread = threading.Thread(target=respond)
+    thread.start()
+    return thread, requests
+
+
+@pytest.fixture
+def qmp_session() -> Iterator[tuple[QMPSession, QMPServer]]:
+    client_sock, server_sock = socket.socketpair()
+    server = QMPServer(server_sock)
+    server.send(QMP_GREETING)
+    thread, requests = respond_once(server, [{"return": {}}])
+    session = QMPSession(client_sock)
+
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert requests.get_nowait() == {"execute": "qmp_capabilities"}
+
+    try:
+        yield session, server
+    finally:
+        session.reader.close()
+        session.writer.close()
+        session.close()
+        server.close()
+
+
+@pytest.mark.usefixtures("qmp_session")
+def test_negotiates_qmp_capabilities() -> None:
+    pass
+
+
+def test_sends_command_with_arguments(
+    qmp_session: tuple[QMPSession, QMPServer],
+) -> None:
+    session, server = qmp_session
+    thread, requests = respond_once(server, [{"return": {"status": "running"}}])
+
+    result = session.send("query-status", {"verbose": "true"})
+
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert requests.get_nowait() == {
+        "execute": "query-status",
+        "arguments": {"verbose": "true"},
+    }
+    assert result == {"return": {"status": "running"}}
+
+
+def test_queues_event_received_before_command_result(
+    qmp_session: tuple[QMPSession, QMPServer],
+) -> None:
+    session, server = qmp_session
+    event = {"event": "RESET", "data": {"guest": True}}
+    thread, _ = respond_once(server, [event, {"return": {}}])
+
+    assert session.send("system_reset") == {"return": {}}
+
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert list(session.events()) == [event]

--- a/nixos/lib/test-driver/src/tests/machine/test_qmp.py
+++ b/nixos/lib/test-driver/src/tests/machine/test_qmp.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 import socket
 import threading
@@ -115,7 +116,7 @@ def test_reports_connection_closed_before_greeting() -> None:
     try:
         with pytest.raises(
             ConnectionError,
-            match="QMP connection closed while waiting for a response",
+            match="QMP connection closed",
         ):
             QMPSession(client_sock)
     finally:
@@ -137,10 +138,40 @@ def test_reports_connection_closed_while_waiting_for_result(
 
     with pytest.raises(
         ConnectionError,
-        match="QMP connection closed while waiting for a response",
+        match="QMP connection closed",
     ):
         session.send("query-status")
 
     thread.join(timeout=1)
     assert not thread.is_alive()
     assert requests.get_nowait() == {"execute": "query-status"}
+
+
+def test_reports_connection_closed_while_waiting_for_event(
+    qmp_session: tuple[QMPSession, QMPServer],
+) -> None:
+    session, server = qmp_session
+    errors: Queue[BaseException] = Queue()
+
+    def wait_for_event() -> None:
+        try:
+            session.wait_for_event()
+        except BaseException as error:
+            errors.put(error)
+
+    server.close()
+    thread = threading.Thread(target=wait_for_event, daemon=True)
+    thread.start()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive(), "wait_for_event did not detect the disconnect"
+    assert isinstance(errors.get_nowait(), ConnectionError)
+
+
+def test_waiting_for_event_times_out(
+    qmp_session: tuple[QMPSession, QMPServer],
+) -> None:
+    session, _ = qmp_session
+
+    with pytest.raises(TimeoutError):
+        session.wait_for_event(dt.timedelta(milliseconds=10))


### PR DESCRIPTION
There's a bug in qemu driver on darwin with qemu 11.1 that ~~currently makes~~ made all
nixos tests hang. It happens because qemu exits but QMPSession doesn't detect
it; instead it spins forever until the test times out. (The fix for this is:
https://github.com/NixOS/nixpkgs/pull/555928)

Anyway, this bug above also revealed that we have a bug in the test driver too
in how it (mis)handles QMP disconnects while waiting for command result.

Instead of spinning forever while waiting for a result from QMP (that will
never arrive because qemu crashed), we should check whether the socket is EOF
(by peeking into it).

This series also includes a fix for a similar issue in event wait.

It also adds first unit tests for qmp.py, including for the newly found bugs.

Commits:
- **nixos/test-driver: add QMP unit tests**
- **nixos/test-driver: detect QMP disconnects while waiting for responses**
- **nixos/test-driver: terminate QMP event waits on timeout and disconnect**

---

How to test:

Before the changes, any NixOS test executed on darwin hangs. With it:

```
$ nix build --file . nixosTests.whisparr -L
vm-test-run-whisparr> Machine state will be reset. To keep it, pass --keep-machine-state
vm-test-run-whisparr> start all VLans
vm-test-run-whisparr> (finished: start all VLans, in 0.01 seconds)
vm-test-run-whisparr> Test will time out and terminate in 3600.0 seconds
vm-test-run-whisparr> run the VM test script
vm-test-run-whisparr> additionally exposed symbols:
vm-test-run-whisparr>     machine,
vm-test-run-whisparr>     vlan1,
vm-test-run-whisparr>     start_all, test_script, machines, machines_qemu, machines_nspawn, vlans, driver, log, os, create_machine, subtest, run_tests, join_all, retry, serial_stdout_off, serial_stdout_on, polling_condition, BaseMachine, QemuMachine, NspawnMachine, t, debug, dump_machine_ssh
vm-test-run-whisparr> machine: waiting for unit whisparr.service
vm-test-run-whisparr> machine: waiting for the VM to finish booting
vm-test-run-whisparr> machine: starting vm
vm-test-run-whisparr> cleanup
vm-test-run-whisparr> (finished: cleanup, in 0.00 seconds)
vm-test-run-whisparr> Traceback (most recent call last):
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/bin/.nixos-test-driver-wrapped", line 9, in <module>
vm-test-run-whisparr>     sys.exit(main())
vm-test-run-whisparr>              ~~~~^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/__init__.py", line 194, in main
vm-test-run-whisparr>     driver.run_tests()
vm-test-run-whisparr>     ~~~~~~~~~~~~~~~~^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/driver.py", line 437, in run_tests
vm-test-run-whisparr>     self.test_script()
vm-test-run-whisparr>     ~~~~~~~~~~~~~~~~^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/driver.py", line 395, in test_script
vm-test-run-whisparr>     exec(self.tests, symbols, None)
vm-test-run-whisparr>     ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
vm-test-run-whisparr>   File "<string>", line 1, in <module>
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 405, in wait_for_unit
vm-test-run-whisparr>     retry(check_active, as_timedelta(timeout))
vm-test-run-whisparr>     ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 141, in retry
vm-test-run-whisparr>     if fn(False):
vm-test-run-whisparr>        ~~^^^^^^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 386, in check_active
vm-test-run-whisparr>     state = self.get_unit_property(unit, "ActiveState", user)
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 441, in get_unit_property
vm-test-run-whisparr>     status, lines = self.systemctl(
vm-test-run-whisparr>                     ~~~~~~~~~~~~~~^
vm-test-run-whisparr>         f'--no-pager show "{unit}" --property="{property}"',
vm-test-run-whisparr>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vm-test-run-whisparr>         user,
vm-test-run-whisparr>         ^^^^^
vm-test-run-whisparr>     )
vm-test-run-whisparr>     ^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 370, in systemctl
vm-test-run-whisparr>     return self.execute(f"systemctl {q}")
vm-test-run-whisparr>            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 722, in execute
vm-test-run-whisparr>     return self._execute(
vm-test-run-whisparr>            ~~~~~~~~~~~~~^
vm-test-run-whisparr>         command=command,
vm-test-run-whisparr>         ^^^^^^^^^^^^^^^^
vm-test-run-whisparr>     ...<2 lines>...
vm-test-run-whisparr>         timeout=as_timedelta(timeout) if timeout is not None else None,
vm-test-run-whisparr>         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
vm-test-run-whisparr>     )
vm-test-run-whisparr>     ^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 983, in _execute
vm-test-run-whisparr>     self.connect()
vm-test-run-whisparr>     ~~~~~~~~~~~~^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 1158, in connect
vm-test-run-whisparr>     self.start()
vm-test-run-whisparr>     ~~~~~~~~~~^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/__init__.py", line 1408, in start
vm-test-run-whisparr>     self.qmp_client = QMPSession.from_path(self.qmp_path)
vm-test-run-whisparr>                       ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/qmp.py", line 53, in from_path
vm-test-run-whisparr>     return cls(sock)
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/qmp.py", line 47, in __init__
vm-test-run-whisparr>     self.send("qmp_capabilities")
vm-test-run-whisparr>     ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/qmp.py", line 127, in send
vm-test-run-whisparr>     return self._wait_for_new_result()
vm-test-run-whisparr>            ~~~~~~~~~~~~~~~~~~~~~~~~~^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/qmp.py", line 64, in _wait_for_new_result
vm-test-run-whisparr>     self._wait_for_socket_data()
vm-test-run-whisparr>     ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
vm-test-run-whisparr>   File "/nix/store/7bv9dh3svcrl7fzhv31ziw79nbvlg6ay-nixos-test-driver-1.1/lib/python3.14/site-packages/test_driver/machine/qmp.py", line 74, in _wait_for_socket_data
vm-test-run-whisparr>     raise ConnectionError("QMP connection closed while waiting for data")
vm-test-run-whisparr> ConnectionError: QMP connection closed while waiting for data
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
