### PR TITLE
gnubg: use gtk3, modernize

### DIFF
--- a/pkgs/by-name/gn/gnubg/package.nix
+++ b/pkgs/by-name/gn/gnubg/package.nix
@@ -6,10 +6,11 @@
   flex,
   glib,
   python3,
-  gtk2,
+  gtk3,
   readline,
   copyDesktopItems,
   makeDesktopItem,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,17 +28,18 @@ stdenv.mkDerivation rec {
     python3
     flex
     glib
+    wrapGAppsHook3
   ];
 
   buildInputs = [
-    gtk2
+    gtk3
     readline
   ];
 
   strictDeps = true;
 
   configureFlags = [
-    "--with-gtk"
+    "--with-gtk3"
     "--with--board3d"
   ];
 

--- a/pkgs/by-name/gn/gnubg/package.nix
+++ b/pkgs/by-name/gn/gnubg/package.nix
@@ -13,12 +13,12 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnubg";
   version = "1.08.003";
 
   src = fetchurl {
-    url = "mirror://gnu/gnubg/gnubg-release-${version}-sources.tar.gz";
+    url = "mirror://gnu/gnubg/gnubg-release-${finalAttrs.version}-sources.tar.gz";
     hash = "sha256-b32WmxPP/3hvupD/jMXl1WS5f08Kppr+Tzg48YxEWXk=";
   };
 
@@ -46,11 +46,11 @@ stdenv.mkDerivation rec {
   desktopItems = [
     (makeDesktopItem {
       desktopName = "GNU Backgammon";
-      name = pname;
+      name = "gnubg";
       genericName = "Backgammon";
-      comment = meta.description;
-      exec = pname;
-      icon = pname;
+      comment = "World class backgammon application";
+      exec = "gnubg";
+      icon = "gnubg";
       categories = [
         "Game"
         "GTK"
@@ -65,4 +65,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Part of #410814 
Only very minor testing to figure out the schema problem
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
