### PR TITLE
influxdb3: Fix the wrong server type header

### DIFF
--- a/pkgs/by-name/in/influxdb3/package.nix
+++ b/pkgs/by-name/in/influxdb3/package.nix
@@ -9,7 +9,7 @@
   makeWrapper,
   nix-update-script,
 }:
-rustPlatform.buildRustPackage (finalAttrs: {
+rustPlatform.buildRustPackage {
   pname = "influxdb3";
   version = "3.8.3";
   src = fetchFromGitHub {
@@ -33,6 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env = {
+    INFLUXDB3_BUILD_VERSION = "Core";
     GIT_HASH = "000000000000000000000000000000000000000000000000000";
     GIT_HASH_SHORT = "0000000";
     PYO3_PYTHON = lib.getExe python3;
@@ -42,8 +43,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # We provide GIT_HASH and GIT_HASH_SHORT ourselves
     rm influxdb3_process/build.rs
   '';
-
-  env.INFLUXDB3_BUILD_VERSION = finalAttrs.version;
 
   buildNoDefaultFeatures = true;
   buildFeatures = [
@@ -84,4 +83,4 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [ oddlama ];
     mainProgram = "influxdb3";
   };
-})
+}


### PR DESCRIPTION
Fixes #556328

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
