### PR TITLE
nixos/mixing-station: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -56,6 +56,8 @@
 
 - [feishin](https://github.com/jeffvli/feishin), a modern self-hosted music player. Available as [services.feishin](#opt-services.feishin.enable).
 
+- [Mixing Station](https://mixingstation.app), a remote control app for digital audio mixers. Available as [programs.mixing-station](#opt-programs.mixing-station.enable). The module can open the firewall for mixer discovery and metering, and register an OpenSnitch rule for the app's outbound traffic.
+
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -273,6 +273,7 @@
   ./programs/mininet.nix
   ./programs/minipro.nix
   ./programs/miriway.nix
+  ./programs/mixing-station.nix
   ./programs/moonlight-qt.nix
   ./programs/mosh.nix
   ./programs/mouse-actions.nix

--- a/nixos/modules/programs/mixing-station.nix
+++ b/nixos/modules/programs/mixing-station.nix
@@ -1,0 +1,190 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.mixing-station;
+
+  isIPv6 = lib.hasInfix ":";
+  groups4 = lib.filter (group: !isIPv6 group) cfg.multicastGroups;
+  groups6 = lib.filter isIPv6 cfg.multicastGroups;
+
+  nftSet = items: "{ ${lib.concatStringsSep ", " items} }";
+  udpSportSet = nftSet (map toString cfg.mixerUdpPorts);
+  tcpDportSet = nftSet (map toString cfg.listenTcpPorts);
+  ipv4GroupSet = nftSet groups4;
+  ipv6GroupSet = nftSet groups6;
+
+  # `null` stands for "match on any interface".
+  interfaces = if cfg.firewallInterfaces == [ ] then [ null ] else cfg.firewallInterfaces;
+  perInterface = mkRules: lib.concatStringsSep "\n" (lib.concatMap mkRules interfaces);
+
+  nftRules = perInterface (
+    iface:
+    let
+      inIface = lib.optionalString (iface != null) ''iifname "${iface}" '';
+    in
+    lib.optional (cfg.mixerUdpPorts != [ ]) "${inIface}udp sport ${udpSportSet} accept"
+    ++ lib.optional (cfg.listenTcpPorts != [ ]) "${inIface}tcp dport ${tcpDportSet} accept"
+    ++ lib.optional (groups4 != [ ]) "${inIface}meta l4proto udp ip daddr ${ipv4GroupSet} accept"
+    ++ lib.optional (groups6 != [ ]) "${inIface}meta l4proto udp ip6 daddr ${ipv6GroupSet} accept"
+  );
+
+  iptablesRules = perInterface (
+    iface:
+    let
+      inIface = lib.optionalString (iface != null) "-i ${iface} ";
+      accept = binary: match: "${binary} -A nixos-fw ${inIface}${match} -j nixos-fw-accept";
+    in
+    map (port: accept "ip46tables" "-p udp --sport ${toString port}") cfg.mixerUdpPorts
+    ++ map (port: accept "ip46tables" "-p tcp --dport ${toString port}") cfg.listenTcpPorts
+    ++ map (group: accept "iptables -w" "-p udp -d ${group}") groups4
+    ++ lib.optionals config.networking.enableIPv6 (
+      map (group: accept "ip6tables -w" "-p udp -d ${group}") groups6
+    )
+  );
+in
+{
+  options.programs.mixing-station = {
+    enable = lib.mkEnableOption "Mixing Station, a remote control app for digital audio mixers";
+
+    package = lib.mkPackageOption pkgs "mixing-station" { };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to accept the inbound traffic Mixing Station depends on.
+
+        Answers to a connection the app opened itself are already accepted by
+        connection tracking. This option covers the traffic that is not:
+        discovery (the app broadcasts a request and the mixer answers from its
+        own service port to a local port the app picked at random), multicast
+        metering, and mixers that connect back to the app instead of accepting
+        a connection from it.
+
+        Set {option}`programs.mixing-station.firewallInterfaces` to confine
+        these rules to the network the mixer is on. Mixing Station's own REST
+        and OSC API ports are not covered; open those with
+        {option}`networking.firewall.allowedTCPPorts` and
+        {option}`networking.firewall.allowedUDPPorts`.
+      '';
+    };
+
+    firewallInterfaces = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "enp3s0" ];
+      description = ''
+        Interfaces the rules added by
+        {option}`programs.mixing-station.openFirewall` are restricted to. The
+        empty list applies them to every interface.
+      '';
+    };
+
+    mixerUdpPorts = lib.mkOption {
+      type = lib.types.listOf lib.types.port;
+      default = [
+        2222 # Behringer Wing
+        2223 # Behringer Wing
+        3804 # HiQNet (Soundcraft Si/Vi)
+        5353 # mDNS
+        8000 # Soundcraft Ui and other OSC based devices
+        10023 # Behringer X32/M32
+        10024 # Behringer XAir, Midas MR
+        47809 # PreSonus Universal Control discovery
+        50240 # Yamaha metering
+        50272 # Yamaha metering
+        50368 # Yamaha metering
+      ];
+      description = ''
+        UDP ports the mixers themselves listen on.
+
+        These are matched as the *source* port of inbound packets. Mixing
+        Station binds its own local port dynamically, so a rule on the
+        destination port could not describe this traffic.
+      '';
+    };
+
+    listenTcpPorts = lib.mkOption {
+      type = lib.types.listOf lib.types.port;
+      default = [
+        3804 # HiQNet: the mixer connects to the app, not the other way round
+      ];
+      description = ''
+        TCP ports on this host that mixers connect back to.
+      '';
+    };
+
+    multicastGroups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "224.0.0.251" # mDNS
+        "ff02::fb" # mDNS
+        "239.192.0.164" # Yamaha metering
+      ];
+      description = ''
+        Multicast groups Mixing Station joins. Inbound UDP addressed to these
+        groups is accepted on any port, because the app binds a dynamic local
+        port for them as well.
+      '';
+    };
+
+    openSnitchRule = lib.mkOption {
+      type = lib.types.bool;
+      default = config.services.opensnitch.enable;
+      defaultText = lib.literalExpression "config.services.opensnitch.enable";
+      description = ''
+        Whether to add an OpenSnitch rule that permits every outbound
+        connection made by Mixing Station.
+
+        Without it OpenSnitch asks about each connection, which is impractical
+        here: the destination port depends on the mixer, discovery uses
+        broadcasts, and the app keeps opening new flows while it runs. The rule
+        matches on the store path of
+        {option}`programs.mixing-station.package`, so it does not cover other
+        Java programs.
+
+        Note that OpenSnitch only filters outbound connections. Inbound traffic
+        is handled by {option}`programs.mixing-station.openFirewall`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = lib.optional cfg.openSnitchRule {
+      assertion = config.services.opensnitch.enable;
+      message = "programs.mixing-station.openSnitchRule requires services.opensnitch.enable.";
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    services.opensnitch.rules = lib.mkIf cfg.openSnitchRule {
+      mixing-station = {
+        name = "mixing-station";
+        description = "Allow all outbound traffic of Mixing Station";
+        enabled = true;
+        # Wins over broader deny rules.
+        precedence = true;
+        action = "allow";
+        duration = "always";
+        operator = {
+          type = "regexp";
+          sensitive = false;
+          operand = "process.command";
+          data = lib.escapeRegex "${cfg.package}/";
+        };
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      extraCommands = lib.optionalString (!config.networking.nftables.enable) iptablesRules;
+      extraInputRules = lib.optionalString config.networking.nftables.enable nftRules;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ korny666 ];
+}


### PR DESCRIPTION
Adds programs.mixing-station with the network integration the app needs on a firewalled host.

OpenSnitch only filters outbound connections, so the two directions are handled separately:

- openSnitchRule adds a declarative allow rule for the app's outbound traffic, matched on the store path of the configured package so it does not cover other Java programs. Without it OpenSnitch prompts per connection, which is impractical because the destination port depends on the mixer, discovery uses broadcasts and the app keeps opening new flows while it runs.

- openFirewall accepts the inbound traffic connection tracking does not already cover. Mixing Station binds its local ports dynamically (one driver counts down from 49150 until it finds a free port), so the mixer service ports are matched as the source port of inbound packets rather than the destination port. Multicast metering groups and the HiQNet callback port, where the mixer connects to the app, are accepted as well. Rules can be confined to specific interfaces and are emitted for both the nftables and the iptables backend.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
