### PR TITLE
nixos/radicle: Make declarative seeding possible

### DIFF
--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -301,6 +301,25 @@ in
         };
       };
     };
+    declarativeSeeding = type = attrsOf (submodule {
+      options = {
+        enable = lib.mkEnableOption {
+          type = str;
+          description = "Enable declarative seeding. Beware, this would effectively unseed repositories seeded manually (using `rad seed`) and not declared.";
+        };
+        repositories = lib.mkOption {
+          type = with lib.types; listOf str;
+          description = "The list of repositories to seed.";
+          default = [ ];
+          example = [ "rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5" ];
+        };
+      };
+    });
+    repositoriesToSeed = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      description = "List of repositories to seed";
+    };
   };
 
   config = lib.mkIf cfg.enable (
@@ -434,6 +453,43 @@ in
           })
         ]
       ))
+
+      (lib.mkIf cfg.declarativeSeeding.enable (
+        systemd.services = lib.optionalAttrs config.services.radicle.enable {
+          radicle-seed = {
+            bindsTo = [ "radicle-node.service" ];
+            after = [ "radicle-node.service" ];
+
+            path = [
+              config.services.radicle.package
+            ];
+
+            environment = env;
+
+            serviceConfig = {
+              User = config.users.users.radicle.name;
+              Group = config.users.groups.radicle.name;
+              Type = "oneshot";
+
+              ImportCredential = config.systemd.services.radicle-node.serviceConfig.ImportCredential or [ ];
+              LoadCredential = config.systemd.services.radicle-node.serviceConfig.LoadCredential or [ ];
+
+              ReadWritePaths = [ RAD_HOME ];
+              RuntimeDirectory = "radicle-seed";
+              WorkingDirectory = "/run/radicle-seed";
+              ExecStart = pkgs.writers.writeNu "radicle-seed" ''
+                let toSeed = ${''["'' + (builtins.concatStringsSep ''", "'' (lib.attrValues cfg.declatativeSeeding.repositories)) + ''"]''}
+                let seeded = ls $"(rad path)/storage" | get name | split column "/" | each { get column5 | $"rad:($in)" }
+
+                $toSeed | where $it not-in $seeded | each { |r| rad seed $r }
+                $seeded | where $it not-in $toSeed | each { |r| rad unseed $r }
+              '';
+            };
+
+            wantedBy = [ "multi-user.target" ];
+          };
+        }
+      )
     ]
   );
 


### PR DESCRIPTION
I wanted to be able to declaratively set the repositories that my node should seed.

In my local setup, the service declaration is inlined in my configuration. This PR is here to gather feedback about the idea, and its implementation (that hasn't been tested as a module).
Also, I considered adding tests, but they seemed kinda dull...
What do you think?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
