### PR TITLE
segger-jlink: 952 -> 970

### DIFF
--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -1,33 +1,33 @@
 {
-  version = "952";
+  version = "970";
   x86_64-linux = {
     os = "Linux";
     name = "x86_64";
     ext = "tgz";
-    hash = "sha256-Nhsu/5RX/c/uSVw9im0K204TjOvm4B7zKFILOmGG7w8=";
+    hash = "sha256-oYDvdsSIw/rlM/foZRUuD/0TzvONOtQL5fr3XmJkowI=";
   };
   i686-linux = {
     os = "Linux";
     name = "i386";
     ext = "tgz";
-    hash = "sha256-4nxRdHjX2iU+v4yE3nhPT1BV/edEmOgV7itmWukWRyw=";
+    hash = "sha256-CyazbUsfjXsSFIvM5Nw1zvDdaiLec+4pPkbXixuQkpg=";
   };
   aarch64-linux = {
     os = "Linux";
     name = "arm64";
     ext = "tgz";
-    hash = "sha256-MFBQpgtE9PA6sXbQV+YOEavvB2vtZ9NOP59EhccLWHw=";
+    hash = "sha256-nkM7QzYMu8Zs85/AFUGHySXK2isFhZghSxeLFRRPaRA=";
   };
   armv7l-linux = {
     os = "Linux";
     name = "arm";
     ext = "tgz";
-    hash = "sha256-KoSgRi8+EQakf+IF5jUx9OWha9cQWbFBC5Rn1Awy9zg=";
+    hash = "sha256-rXvdkXZj4WQwvxmX+ArkMcjdaytPDcwcQ15nvwg2gW0=";
   };
   aarch64-darwin = {
     os = "MacOSX";
     name = "arm64";
     ext = "pkg";
-    hash = "sha256-uglfWXxoKC4yZ/2N4LUFp6ZZin//yWkdtO6LyFv/MkE=";
+    hash = "sha256-hUsQ57PjKAXj/fY5J0QA633qKO79MjTcjMLLJxz2XlI=";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumb update 952 -> 970
[Segger Release Notes](https://www.segger.com/downloads/jlink/ReleaseNotes_JLink.html)

Linux platforms also built on a Lima VM on Apple Silicon (aarch64-linux natively, x86_64-linux through Rosetta). Binaries were only executed on aarch64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
