### PR TITLE
jbig2dec: fix CVE-2026-38076

### DIFF
--- a/pkgs/by-name/jb/jbig2dec/package.nix
+++ b/pkgs/by-name/jb/jbig2dec/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   python3,
   autoconf,
   automake,
@@ -16,6 +17,15 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://github.com/ArtifexSoftware/jbig2dec/archive/${finalAttrs.version}/jbig2dec-${finalAttrs.version}.tar.gz";
     hash = "sha256-qXBTaaZjOrpTJpNFDsgCxWI5fhuCRmLegJ7ekvZ6/yE=";
   };
+
+  # Remove with the first release containing cc37d0931aa71582f7128736a068c92cd8712d9b.
+  patches = [
+    (fetchpatch {
+      name = "CVE-2026-38076.patch";
+      url = "https://github.com/ArtifexSoftware/jbig2dec/commit/cc37d0931aa71582f7128736a068c92cd8712d9b.patch";
+      hash = "sha256-NdmE3xT5M6Ini6FJcKqCJmJkBTFnnq66/YV3Ky5PVNM=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs test_jbig2dec.py


### PR DESCRIPTION
Applies upstream validation for oversized IAID symbol-code lengths, fixing CVE-2026-38076 in jbig2dec 0.20.
Upstream fix: [ArtifexSoftware/jbig2dec@cc37d09](https://github.com/ArtifexSoftware/jbig2dec/commit/cc37d0931aa71582f7128736a068c92cd8712d9b)
References: [CVE-2026-38076](https://www.cve.org/CVERecord?id=CVE-2026-38076), [Ubuntu USN-8582-1](https://ubuntu.com/security/notices/USN-8582-1), [Nix Security Tracker suggestion 11576](https://tracker.security.nixos.org/suggestions/by-id/11576)
A manual backport to staging-26.05 will be required after this change reaches master.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
