### PR TITLE
curtail: add missing scour to runtime PATH for svg compression

### DIFF
--- a/pkgs/by-name/cu/curtail/package.nix
+++ b/pkgs/by-name/cu/curtail/package.nix
@@ -18,6 +18,7 @@
   optipng,
   pngquant,
   oxipng,
+  scour,
   nix-update-script,
 }:
 
@@ -74,6 +75,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
           optipng
           pngquant
           oxipng
+          scour
         ]
       }"
     )


### PR DESCRIPTION
Nixpkgs wrapper does not put `scour`, which handles SVG compression, on `PATH`, so **every SVG compression fails**. The same omission makes **Menu > About > Troubleshooting** report `Version not found` for Scour.

Upstream's [README](https://github.com/Huluti/Curtail#tech) lists Scour alongside oxipng, pngquant, jpegoptim and libwebp as the tools that "handle the actual compression work", so this is a required runtime dependency.

### Verification

Built on x86_64-linux and confirmed `scour` lands on the wrapper's `PATH`. Compressing an SVG through the built binary now succeeds, in both normal and lossy/maximum mode, and Troubleshooting reports `Scour: 0.38.2`.

> **Disclosure per CONTRIBUTING.md#automationai-policy**: this pull request summary was drafted with Claude Code (Claude Opus 5) and reviewed by me before submission. Claude was also used to intilially investigate the issue. The solution turnout to be very simple, going through manual review and test.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test