### PR TITLE
stdenv/check-meta: move remedation message into dedicated file

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -11,9 +11,6 @@ let
     attrValues
     concatMap
     concatMapStrings
-    concatStrings
-    concatStringsSep
-    filter
     findFirst
     foldl'
     getName
@@ -63,12 +60,17 @@ let
     ;
   checkProblems = genCheckProblems config;
 
+  inherit (import ./remediations.nix { inherit lib; })
+    remediateOutputsToInstall
+    remediate_allowlist
+    remediate_predicate
+    remediate_insecure
+    getNameWithVersion
+    ;
+
   # If we're in hydra, we can dispense with the more verbose error
   # messages and make problems easier to spot.
   inHydra = config.inHydra or false;
-
-  getNameWithVersion =
-    attrs: attrs.name or "${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}";
 
   allowUnfree = config.allowUnfree || getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
 
@@ -238,108 +240,6 @@ let
   showSourceType = showLicenseOrSourceType;
 
   pos_str = meta: meta.position or "«unknown-file»";
-
-  remediation_env_var =
-    allow_attr:
-    {
-      Unfree = "NIXPKGS_ALLOW_UNFREE";
-      UnsupportedSystem = "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM";
-      NonSource = "NIXPKGS_ALLOW_NONSOURCE";
-    }
-    .${allow_attr};
-  remediation_phrase =
-    allow_attr:
-    {
-      Unfree = "unfree packages";
-      UnsupportedSystem = "packages that are unsupported for this system";
-      NonSource = "packages not built from source";
-    }
-    .${allow_attr};
-  remediate_predicate = predicateConfigAttr: attrs: ''
-
-    Alternatively you can configure a predicate to allow specific packages:
-      { nixpkgs.config.${predicateConfigAttr} = pkg: builtins.elem (lib.getName pkg) [
-          "${getName attrs}"
-        ];
-      }
-  '';
-
-  # flakeNote will be printed in the remediation messages below.
-  flakeNote = "
-   Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
-         then pass `--impure` in order to allow use of environment variables.
-    ";
-
-  remediate_allowlist = allow_attr: rebuild_amendment: ''
-    a) To temporarily allow ${remediation_phrase allow_attr}, you can use an environment variable
-       for a single invocation of the nix tools.
-
-         $ export ${remediation_env_var allow_attr}=1
-         ${flakeNote}
-    b) For `nixos-rebuild` you can set
-      { nixpkgs.config.allow${allow_attr} = true; }
-    in configuration.nix to override this.
-    ${rebuild_amendment}
-    c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-      { allow${allow_attr} = true; }
-    to ~/.config/nixpkgs/config.nix.
-  '';
-
-  remediate_insecure =
-    attrs:
-    ''
-
-      Known issues:
-    ''
-    + (concatStrings (map (issue: " - ${issue}\n") attrs.meta.knownVulnerabilities))
-    + ''
-
-      You can install it anyway by allowing this package, using the
-      following methods:
-
-      a) To temporarily allow all insecure packages, you can use an environment
-         variable for a single invocation of the nix tools:
-
-           $ export NIXPKGS_ALLOW_INSECURE=1
-           ${flakeNote}
-      b) for `nixos-rebuild` you can add ‘${getNameWithVersion attrs}’ to
-         `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
-         like so:
-
-           {
-             nixpkgs.config.permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
-      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-         ‘${getNameWithVersion attrs}’ to `permittedInsecurePackages` in
-         ~/.config/nixpkgs/config.nix, like so:
-
-           {
-             permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
-    '';
-
-  remediateOutputsToInstall =
-    attrs:
-    let
-      expectedOutputs = attrs.meta.outputsToInstall or [ ];
-      actualOutputs = attrs.outputs or [ "out" ];
-      missingOutputs = filter (output: !elem output actualOutputs) expectedOutputs;
-    in
-    ''
-      The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${concatStringsSep ", " expectedOutputs}
-
-      however ${getNameWithVersion attrs} only has the outputs: ${concatStringsSep ", " actualOutputs}
-
-      and is missing the following outputs:
-
-      ${concatStrings (map (output: "  - ${output}\n") missingOutputs)}
-    '';
 
   metaType =
     let

--- a/pkgs/stdenv/generic/remediations.nix
+++ b/pkgs/stdenv/generic/remediations.nix
@@ -1,0 +1,136 @@
+{ lib }:
+let
+  inherit (builtins)
+    filter
+    elem
+    ;
+
+  inherit (lib)
+    getName
+    concatStrings
+    concatStringsSep
+    ;
+
+  getNameWithVersion =
+    attrs: attrs.name or "${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}";
+
+  remediation_env_var =
+    allow_attr:
+    {
+      Unfree = "NIXPKGS_ALLOW_UNFREE";
+      UnsupportedSystem = "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM";
+      NonSource = "NIXPKGS_ALLOW_NONSOURCE";
+    }
+    .${allow_attr};
+  remediation_phrase =
+    allow_attr:
+    {
+      Unfree = "unfree packages";
+      UnsupportedSystem = "packages that are unsupported for this system";
+      NonSource = "packages not built from source";
+    }
+    .${allow_attr};
+  # flakeNote will be printed in the remediation messages below.
+  flakeNote = "
+   Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
+         then pass `--impure` in order to allow use of environment variables.
+    ";
+
+in
+{
+  inherit getNameWithVersion;
+  remediateOutputsToInstall =
+    attrs:
+    let
+      expectedOutputs =
+        (
+          attrs:
+          let
+            expectedOutputs = attrs.meta.outputsToInstall or [ ];
+            actualOutputs = attrs.outputs or [ "out" ];
+            missingOutputs = filter (output: !elem output actualOutputs) expectedOutputs;
+          in
+          ''
+            The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${concatStringsSep ", " expectedOutputs}
+
+            however ${getNameWithVersion attrs} only has the outputs: ${concatStringsSep ", " actualOutputs}
+
+            and is missing the following outputs:
+
+            ${concatStrings (map (output: "  - ${output}\n") missingOutputs)}
+          ''
+        ).meta.outputsToInstall or [ ];
+      actualOutputs = attrs.outputs or [ "out" ];
+      missingOutputs = filter (output: !elem output actualOutputs) expectedOutputs;
+    in
+    ''
+      The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${concatStringsSep ", " expectedOutputs}
+
+      however ${getNameWithVersion attrs} only has the outputs: ${concatStringsSep ", " actualOutputs}
+
+      and is missing the following outputs:
+
+      ${concatStrings (map (output: "  - ${output}\n") missingOutputs)}
+    '';
+
+  remediate_predicate = predicateConfigAttr: attrs: ''
+
+    Alternatively you can configure a predicate to allow specific packages:
+      { nixpkgs.config.${predicateConfigAttr} = pkg: builtins.elem (lib.getName pkg) [
+          "${getName attrs}"
+        ];
+      }
+  '';
+  remediate_allowlist = allow_attr: rebuild_amendment: ''
+    a) To temporarily allow ${remediation_phrase allow_attr}, you can use an environment variable
+       for a single invocation of the nix tools.
+
+         $ export ${remediation_env_var allow_attr}=1
+         ${flakeNote}
+    b) For `nixos-rebuild` you can set
+      { nixpkgs.config.allow${allow_attr} = true; }
+    in configuration.nix to override this.
+    ${rebuild_amendment}
+    c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+      { allow${allow_attr} = true; }
+    to ~/.config/nixpkgs/config.nix.
+  '';
+  remediate_insecure =
+    attrs:
+    ''
+
+      Known issues:
+    ''
+    + (concatStrings (map (issue: " - ${issue}\n") attrs.meta.knownVulnerabilities))
+    + ''
+
+      You can install it anyway by allowing this package, using the
+      following methods:
+
+      a) To temporarily allow all insecure packages, you can use an environment
+         variable for a single invocation of the nix tools:
+
+           $ export NIXPKGS_ALLOW_INSECURE=1
+           ${flakeNote}
+      b) for `nixos-rebuild` you can add ‘${getNameWithVersion attrs}’ to
+         `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
+         like so:
+
+           {
+             nixpkgs.config.permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+         ‘${getNameWithVersion attrs}’ to `permittedInsecurePackages` in
+         ~/.config/nixpkgs/config.nix, like so:
+
+           {
+             permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+    '';
+}


### PR DESCRIPTION
This is moving the remediation messagesd into their dedicated file where all their (internal) utiltiy functions aren't cluttering the check-meta implementation and the remediation messages could potentially be emitted from other places in nixpkgs while keeping the styling the same.

The driving motivation behind this is moving more checks into meta.problems and there we should very likely emit the messages in the same flavour users might be used to (either visually, by script or the wording).

This was previously proposed as part of #545234 but is worthwhile on its own IMO and eases the need for constant rebasing on the other PR whenever something small changes in the remediation world.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (`hello`still builds :-) )
- Tested, as applicable:
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
