### PR TITLE
clap-validator: init at 0.4.1

### DIFF
--- a/pkgs/by-name/cl/clap-validator/package.nix
+++ b/pkgs/by-name/cl/clap-validator/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "clap-validator";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "free-audio";
+    repo = "clap-validator";
+    rev = finalAttrs.version;
+    hash = "sha256-4GmmZIMRoPUEbsT34iCaOWRhYmhMonF9BXnc/rFQV0M=";
+  };
+
+  cargoHash = "sha256-m6VebZM8jVm22Xk8URpHF+UAHOJWYC74Ha3bpFuz1VU=";
+
+  checkFlags = [
+    # Disabled failing tests because the test plugins expect a directory layout
+    # not present in the build environment and therefore failed to build.
+    "--skip=fuzz_clack_effect"
+    "--skip=fuzz_clack_synth"
+    "--skip=validate_clack_effect"
+    "--skip=validate_clack_synth"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://github.com/free-audio/clap-validator/releases/tag/${finalAttrs.version}";
+    description = "Development tooling for validation of CLAP audio plugins";
+    homepage = "https://github.com/free-audio/clap-validator";
+    license = lib.licenses.mit;
+    mainProgram = "clap-validator";
+    maintainers = [ lib.maintainers.ginkogruen ];
+  };
+})


### PR DESCRIPTION
Adds `clap-validator`, a development tooling to test audio plugins developed for the open-source [CLAP](https://cleveraudio.org/) standard.
The tool runs a suite of tests against any given CLAP plugin and validates it to work correctly.

Repository at: https://github.com/free-audio/clap-validator.

I chose to disable the tests which build test plugins and then run the tool against them because the plugin builds were failing in the Nix build environment due to changed paths.
I'm also not sure if the tests could even be run if the plugins were built. So I would especially appreciate any review input on this matter.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test