### PR TITLE
[26.05] ocamlPackages.cohttp: 6.2.1 → 6.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -22,7 +22,7 @@ buildDunePackage (finalAttrs: {
   pname = "cohttp";
   version =
     if lib.versionAtLeast ocaml.version "5.2" then
-      "6.2.2"
+      "6.3.0"
     else if lib.versionAtLeast ocaml.version "4.13" then
       "6.2.1"
     else
@@ -32,7 +32,7 @@ buildDunePackage (finalAttrs: {
     url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${finalAttrs.version}/cohttp-${finalAttrs.version}.tbz";
     hash =
       {
-        "6.2.2" = "sha256-SZzYsJTO5LAP5rn2MiaA+B/ocWHpY6GWsQnBiCYQr2I=";
+        "6.3.0" = "sha256-MRMPaKnwpc2NcbVfBCRW5tNb+LeranGrbXvX29tgeyQ=";
         "6.2.1" = "sha256-ZQgCR3Y0QtHcPNkGeLgjO3mHcvA2rIHNHqreH11mpl8=";
         "5.3.1" = "sha256-9eJz08Lyn/R71+Ftsj4fPWzQGkC+ACCJhbxDTIjUV2s=";
       }

--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -15,18 +15,24 @@
   fmt,
   alcotest,
   crowbar,
+  ppx_expect,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "cohttp";
-  version = if lib.versionAtLeast ocaml.version "4.13" then "6.2.1" else "5.3.1";
-
-  minimalOCamlVersion = "4.08";
+  version =
+    if lib.versionAtLeast ocaml.version "5.2" then
+      "6.2.2"
+    else if lib.versionAtLeast ocaml.version "4.13" then
+      "6.2.1"
+    else
+      "5.3.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${finalAttrs.version}/cohttp-${finalAttrs.version}.tbz";
     hash =
       {
+        "6.2.2" = "sha256-SZzYsJTO5LAP5rn2MiaA+B/ocWHpY6GWsQnBiCYQr2I=";
         "6.2.1" = "sha256-ZQgCR3Y0QtHcPNkGeLgjO3mHcvA2rIHNHqreH11mpl8=";
         "5.3.1" = "sha256-9eJz08Lyn/R71+Ftsj4fPWzQGkC+ACCJhbxDTIjUV2s=";
       }
@@ -34,7 +40,7 @@ buildDunePackage (finalAttrs: {
   };
 
   postPatch = ''
-    substituteInPlace cohttp/src/dune --replace 'bytes base64' 'base64'
+    substituteInPlace cohttp/src/dune --replace-warn 'bytes base64' 'base64'
   '';
 
   buildInputs = [
@@ -61,8 +67,8 @@ buildDunePackage (finalAttrs: {
     fmt
     alcotest
   ]
-  ++ lib.optionals (lib.versionOlder finalAttrs.version "6.0.0") [
-    crowbar
+  ++ [
+    (if lib.versionOlder finalAttrs.version "6.0.0" then crowbar else ppx_expect)
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/cohttp/eio.nix
+++ b/pkgs/development/ocaml-modules/cohttp/eio.nix
@@ -10,6 +10,7 @@
   alcotest,
   ca-certs,
   eio_main,
+  ppx_expect,
   tls-eio,
 }:
 
@@ -37,6 +38,7 @@ buildDunePackage {
     alcotest
     ca-certs
     eio_main
+    ppx_expect
     tls-eio
   ];
 

--- a/pkgs/development/ocaml-modules/cohttp/http.nix
+++ b/pkgs/development/ocaml-modules/cohttp/http.nix
@@ -1,7 +1,6 @@
 {
   buildDunePackage,
   cohttp,
-  ppx_expect,
 }:
 
 buildDunePackage {
@@ -12,8 +11,6 @@ buildDunePackage {
     ;
 
   minimalOCamlVersion = "5.1";
-
-  propagatedBuildInputs = [ ppx_expect ];
 
   meta = cohttp.meta // {
     description = "CoHTTP implementation using the Lwt concurrency library";

--- a/pkgs/development/ocaml-modules/cohttp/lwt-jsoo.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-jsoo.nix
@@ -9,6 +9,7 @@
   js_of_ocaml-lwt,
   nodejs,
   lwt_ppx,
+  ppx_expect,
 }:
 
 buildDunePackage {
@@ -29,6 +30,7 @@ buildDunePackage {
   checkInputs = [
     nodejs
     lwt_ppx
+    ppx_expect
   ];
 
   meta = cohttp-lwt.meta // {

--- a/pkgs/development/ocaml-modules/cohttp/server-lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/cohttp/server-lwt-unix.nix
@@ -4,6 +4,7 @@
   cohttp-lwt-unix,
   http,
   lwt,
+  ppx_expect,
 }:
 
 buildDunePackage (finalAttrs: {
@@ -15,7 +16,10 @@ buildDunePackage (finalAttrs: {
     lwt
   ];
 
-  checkInputs = [ cohttp-lwt-unix ];
+  checkInputs = [
+    cohttp-lwt-unix
+    ppx_expect
+  ];
   doCheck = true;
 
   meta = cohttp.meta // {

--- a/pkgs/development/ocaml-modules/cohttp/top.nix
+++ b/pkgs/development/ocaml-modules/cohttp/top.nix
@@ -1,4 +1,8 @@
-{ buildDunePackage, cohttp }:
+{
+  buildDunePackage,
+  cohttp,
+  ppx_expect,
+}:
 
 buildDunePackage {
   pname = "cohttp-top";
@@ -7,6 +11,7 @@ buildDunePackage {
   propagatedBuildInputs = [ cohttp ];
 
   doCheck = true;
+  checkInputs = [ ppx_expect ];
 
   meta = cohttp.meta // {
     description = "CoHTTP toplevel pretty printers for HTTP types";


### PR DESCRIPTION
Backport #550127 & #554762.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
