### PR TITLE
essh: 0.2.8 -> 0.3.3

### DIFF
--- a/pkgs/by-name/es/essh/package.nix
+++ b/pkgs/by-name/es/essh/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   pkg-config,
   rustPlatform,
@@ -9,18 +10,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "essh";
-  version = "0.2.8";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "matthart1983";
     repo = "essh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-njBhA3CSTAlWjcgY3y+hvl19By2QGy2tHP8+FxgycIA=";
+    hash = "sha256-dK9M730LgS4CG/BAOSfvH2T06RJsEWHVFT0/VoFvt3Q=";
   };
 
   __structuredAttrs = true;
 
-  cargoHash = "sha256-TlvUdlKnRA/L5oePn+YWum1wy3ktHFuXP5V+nH2QNnc=";
+  cargoHash = "sha256-2ZAvm3LJHpLF99ahLdTFKuneRMLn6XryNd+ZT2uSawE=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -34,6 +35,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   checkFlags = [
     "--skip=mock_ssh_server_drives_real_connect_flow_end_to_end"
+    "--skip=an_unroutable_address_fails_on_our_timeout_not_the_os"
+    "--skip=an_unreachable_host_does_not_wedge_the_ui"
+    "--skip=help_teaches_a_binding_that_works_everywhere"
+    "--skip=it_starts_and_shows_the_launcher"
+    "--skip=typing_in_the_launcher_filters_without_stalling"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=macos_command_set_produces_real_readings_on_this_host"
+    "--skip=a_closed_port_is_named_as_refused_not_as_a_timeout"
   ];
 
   meta = {


### PR DESCRIPTION
Changelog: https://github.com/matthart1983/essh/releases/tag/v0.3.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
