### PR TITLE
emscripten: fix `-fwasm-exceptions` link failure

### DIFF
--- a/pkgs/development/compilers/emscripten/0002-libunwind-restore-Unwind_CallPersonality.patch
+++ b/pkgs/development/compilers/emscripten/0002-libunwind-restore-Unwind_CallPersonality.patch
@@ -1,0 +1,31 @@
+libunwind: restore _Unwind_CallPersonality for release-LLVM pairing
+
+Nixpkgs pairs the emscripten runtime with the generic llvmPackages release
+LLVM instead of the trunk commit emsdk pins (default.nix already patches
+EXPECTED_LLVM_VERSION accordingly). Release LLVM (<= 22.x) WasmEHPrepare
+still emits calls to _Unwind_CallPersonality in landing pads; emscripten's
+system libs dropped that entry point when the personality wrapper moved
+into libc++abi as __gxx_wasm_personality_v0 (called directly by trunk
+LLVM's codegen). Restore the old entry point as a forwarder so that
+-fwasm-exceptions links. Drop this when llvmPackages reaches an LLVM that
+calls the personality directly.
+
+--- a/system/lib/libunwind/src/Unwind-wasm.c
++++ b/system/lib/libunwind/src/Unwind-wasm.c
+@@ -80,4 +80,16 @@
+   return 0;
+ }
+ 
++/// Restored from LLVM <= 22.x libunwind: release LLVM's WasmEHPrepare emits
++/// calls to _Unwind_CallPersonality in landing pads, while emscripten's pinned
++/// (trunk) LLVM calls the personality directly. The personality wrapper that
++/// used to live here moved into libc++abi as __gxx_wasm_personality_v0, so
++/// forward to it. Needed when pairing this runtime with a release LLVM.
++_Unwind_Reason_Code __gxx_wasm_personality_v0(void *exception_ptr);
++
++_LIBUNWIND_EXPORT _Unwind_Reason_Code
++_Unwind_CallPersonality(void *exception_ptr) {
++  return __gxx_wasm_personality_v0(exception_ptr);
++}
++
+ #endif // defined(__WASM_EXCEPTIONS__)

--- a/pkgs/development/compilers/emscripten/0002-libunwind-restore-Unwind_CallPersonality.patch
+++ b/pkgs/development/compilers/emscripten/0002-libunwind-restore-Unwind_CallPersonality.patch
@@ -12,15 +12,12 @@ calls the personality directly.
 
 --- a/system/lib/libunwind/src/Unwind-wasm.c
 +++ b/system/lib/libunwind/src/Unwind-wasm.c
-@@ -80,4 +80,16 @@
+@@ -95,4 +95,13 @@
    return 0;
  }
  
-+/// Restored from LLVM <= 22.x libunwind: release LLVM's WasmEHPrepare emits
-+/// calls to _Unwind_CallPersonality in landing pads, while emscripten's pinned
-+/// (trunk) LLVM calls the personality directly. The personality wrapper that
-+/// used to live here moved into libc++abi as __gxx_wasm_personality_v0, so
-+/// forward to it. Needed when pairing this runtime with a release LLVM.
++/// Release LLVM (<= 22.x) still emits calls to this helper; its body moved
++/// into libc++abi as __gxx_wasm_personality_v0 (llvm-project #209282).
 +_Unwind_Reason_Code __gxx_wasm_personality_v0(void *exception_ptr);
 +
 +_LIBUNWIND_EXPORT _Unwind_Reason_Code

--- a/pkgs/development/compilers/emscripten/0002-libunwind-restore-Unwind_CallPersonality.patch
+++ b/pkgs/development/compilers/emscripten/0002-libunwind-restore-Unwind_CallPersonality.patch
@@ -1,23 +1,18 @@
-libunwind: restore _Unwind_CallPersonality for release-LLVM pairing
+libunwind: restore _Unwind_CallPersonality for release LLVM
 
-Nixpkgs pairs the emscripten runtime with the generic llvmPackages release
-LLVM instead of the trunk commit emsdk pins (default.nix already patches
-EXPECTED_LLVM_VERSION accordingly). Release LLVM (<= 22.x) WasmEHPrepare
-still emits calls to _Unwind_CallPersonality in landing pads; emscripten's
-system libs dropped that entry point when the personality wrapper moved
-into libc++abi as __gxx_wasm_personality_v0 (called directly by trunk
-LLVM's codegen). Restore the old entry point as a forwarder so that
--fwasm-exceptions links. Drop this when llvmPackages reaches an LLVM that
-calls the personality directly.
+Nixpkgs builds emscripten with the release LLVM, not the llvm-project
+main commit that emsdk pins. Release LLVM (<= 22.x) emits calls to
+_Unwind_CallPersonality. llvm-project PR #209282 moved that helper into
+libc++abi, renamed to __gxx_wasm_personality_v0. Add the old name back
+as a forwarder to the new name. Remove this patch when llvmPackages
+reaches LLVM 23.
 
 --- a/system/lib/libunwind/src/Unwind-wasm.c
 +++ b/system/lib/libunwind/src/Unwind-wasm.c
-@@ -95,4 +95,13 @@
+@@ -95,4 +95,11 @@
    return 0;
  }
  
-+/// Release LLVM (<= 22.x) still emits calls to this helper; its body moved
-+/// into libc++abi as __gxx_wasm_personality_v0 (llvm-project #209282).
 +_Unwind_Reason_Code __gxx_wasm_personality_v0(void *exception_ptr);
 +
 +_LIBUNWIND_EXPORT _Unwind_Reason_Code

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
     (replaceVars ./0001-emulate-clang-sysroot-include-logic.patch {
       resourceDir = "${llvmEnv}/lib/clang/${lib.versions.major llvmPackages.llvm.version}/";
     })
-    # Readd the entry point release LLVM emits; without it, -fwasm-exceptions fails to link.
     ./0002-libunwind-restore-Unwind_CallPersonality.patch
   ];
 

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -69,6 +69,9 @@ stdenv.mkDerivation rec {
     (replaceVars ./0001-emulate-clang-sysroot-include-logic.patch {
       resourceDir = "${llvmEnv}/lib/clang/${lib.versions.major llvmPackages.llvm.version}/";
     })
+    # Release LLVM still emits _Unwind_CallPersonality, which emscripten's
+    # system libs dropped; without this, -fwasm-exceptions fails to link.
+    ./0002-libunwind-restore-Unwind_CallPersonality.patch
   ];
 
   buildPhase = ''

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -69,8 +69,7 @@ stdenv.mkDerivation rec {
     (replaceVars ./0001-emulate-clang-sysroot-include-logic.patch {
       resourceDir = "${llvmEnv}/lib/clang/${lib.versions.major llvmPackages.llvm.version}/";
     })
-    # Release LLVM still emits _Unwind_CallPersonality, which emscripten's
-    # system libs dropped; without this, -fwasm-exceptions fails to link.
+    # Readd the entry point release LLVM emits; without it, -fwasm-exceptions fails to link.
     ./0002-libunwind-restore-Unwind_CallPersonality.patch
   ];
 

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation rec {
     (replaceVars ./0001-emulate-clang-sysroot-include-logic.patch {
       resourceDir = "${llvmEnv}/lib/clang/${lib.versions.major llvmPackages.llvm.version}/";
     })
+    # Remove this patch when llvmPackages reaches LLVM 23
     ./0002-libunwind-restore-Unwind_CallPersonality.patch
   ];
 
@@ -195,6 +196,21 @@ stdenv.mkDerivation rec {
     fi
 
         runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  # C++ exceptions with -fwasm-exceptions must compile and link
+  # see https://github.com/NixOS/nixpkgs/pull/556385
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    pushd $TMPDIR
+    echo 'int main() { try { throw 42; } catch (int) { return 0; } return 1; }' > throw.cpp
+    $out/bin/em++ -fwasm-exceptions throw.cpp -o throw.js
+    popd
+
+    runHook postInstallCheck
   '';
 
   passthru = {


### PR DESCRIPTION
## Problem

With the nixpkgs `emscripten` package, compiling any C++ program with `-fwasm-exceptions` fails to link:

```
wasm-ld: error: undefined symbol: _Unwind_CallPersonality
```

`-fwasm-exceptions` is the clang flag that implements C++ exceptions with the native WebAssembly exception instructions.

Tested with emscripten 6.0.6 and 6.0.8.

## Cause

- Nixpkgs builds emscripten with the generic `llvmPackages` release LLVM (currently 22.1.8), not the llvm-project `main` commit that emsdk pins.
  - `pkgs/development/compilers/emscripten/default.nix` already patches emscripten's `EXPECTED_LLVM_VERSION` check to allow this pairing.
- Release LLVM (<= 22.x) compiles `catch` handlers to call the helper `_Unwind_CallPersonality`
  - ([`WasmEHPrepare.cpp`, release/22.x](https://github.com/llvm/llvm-project/blob/release/22.x/llvm/lib/CodeGen/WasmEHPrepare.cpp)).
  - LLVM's own libunwind defines that helper ([`Unwind-wasm.c`, release/22.x](https://github.com/llvm/llvm-project/blob/release/22.x/libunwind/src/Unwind-wasm.c)).



- llvm-project [#209282](https://github.com/llvm/llvm-project/pull/209282) removed the helper
  - generated code now calls the personality function `__gxx_wasm_personality_v0` directly.

- Emscripten's vendored runtime follows llvm `main`, so 6.0.x ships only the new scheme
  - [`Unwind-wasm.c` (tag 6.0.6)](https://github.com/emscripten-core/emscripten/blob/6.0.6/system/lib/libunwind/src/Unwind-wasm.c) no longer defines `_Unwind_CallPersonality`
  - [`cxa_personality.cpp` line 1126 (tag 6.0.6)](https://github.com/emscripten-core/emscripten/blob/6.0.6/system/lib/libcxxabi/src/cxa_personality.cpp#L1126) defines `__gxx_wasm_personality_v0`.

### Summary

The release-LLVM compiler calls a function that no emscripten runtime library defines.

## Approach

- Restore `_Unwind_CallPersonality` in the bundled libunwind, as a forwarder to `__gxx_wasm_personality_v0`; restoring the existing mechanism before this bug was introduced ([see #209282](https://github.com/llvm/llvm-project/pull/209282)).


## How to reproduce

`throw.cpp`:

```cpp
#include <cstdio>
int main() {
  try { throw 42; } catch (int e) { std::printf("caught %d\n", e); }
}
```

```console
$ em++ -fwasm-exceptions throw.cpp -o throw.js
$ node throw.js
```

- Before this pr:
  - the final link fails with `undefined symbol: _Unwind_CallPersonality`.
- This PR:
  - the build completes and `node throw.js` prints `caught 42`


## Testing

- 33 packages impacted, 29 build, including `emscripten`
- 4 failures:`emscriptenPackages.{json_c, libxml2, xmlmirror, zlib}`
  - These are existing failures on master
    - existing issues tracking these failures:
      - [#339349](https://github.com/NixOS/nixpkgs/issues/339349)
      - [#502641](https://github.com/NixOS/nixpkgs/issues/502641)

## Disclosure

An LLM tool (Claude Code, model Claude Fable 5) helped diagnose the problem and draft this PR.
I reviewed and tested the change.

---

## Things done 

- [x] Built on platform(s): x86_64-linux
- [ ] Tested, as applicable: NixOS tests — none exist for emscripten
- [x] Tested compilation of all packages that depend on this change: `nixpkgs-review wip` — 29 of 33 built; the 4 failures are pre-existing on master (see Testing)
- [x] Tested basic functionality of all binary files: the `em++ -fwasm-exceptions` test program compiles and runs
- [x] Fits CONTRIBUTING.md
