### PR TITLE
python3Packages.shiboken6-generator: add hook

### DIFF
--- a/pkgs/development/python-modules/shiboken6-generator/default.nix
+++ b/pkgs/development/python-modules/shiboken6-generator/default.nix
@@ -5,6 +5,7 @@
   python,
   cmake,
   stdenv,
+  makeShellWrapper,
 }:
 
 let
@@ -33,6 +34,7 @@ stdenv'.mkDerivation (finalAttrs: {
       ps.packaging
       ps.setuptools
     ]))
+    makeShellWrapper
   ];
 
   buildInputs = [
@@ -53,6 +55,12 @@ stdenv'.mkDerivation (finalAttrs: {
     python3 setup.py egg_info --build-type=shiboken6-generator
     cp -r shiboken6_generator.egg-info $out/${python.sitePackages}/
   '';
+
+  postFixup = ''
+    wrapProgramShell $out/bin/shiboken6 --add-flags '--typesystem-paths=$NIXPKGS_SHIBOKEN6_TYPESYSTEMS_PATH'
+  '';
+
+  setupHook = ./shiboken6-hook.sh;
 
   meta = {
     description = "Generator for the pyside6 Qt bindings - tools";

--- a/pkgs/development/python-modules/shiboken6-generator/shiboken6-hook.sh
+++ b/pkgs/development/python-modules/shiboken6-generator/shiboken6-hook.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+# Variables we use here are set by the stdenv, no use complaining about them
+# shellcheck disable=SC2164
+
+shibokenEnvHook() {
+  if [ -d "$1/share/PySide6/typesystems" ]; then
+    addToSearchPath NIXPKGS_SHIBOKEN6_TYPESYSTEMS_PATH "$1/share/PySide6/typesystems"
+  fi
+  if [ -d "$1/include/PySide6" ]; then
+    for i in "$1/include/PySide6/"*; do
+      # horrible hack, see https://github.com/KDE/extra-cmake-modules/blob/bbbaae0dbbbea3a283ba45b00dd10fb0d7b631d9/modules/ECMGeneratePythonBindings.cmake#L84
+      if [ -d "$i" ]; then
+        export NIX_CFLAGS_COMPILE+=" -isystem $i"
+      fi
+    done
+  fi
+}
+addEnvHooks "$targetOffset" shibokenEnvHook

--- a/pkgs/kde/frameworks/kjobwidgets/default.nix
+++ b/pkgs/kde/frameworks/kjobwidgets/default.nix
@@ -7,7 +7,5 @@ mkKdeDerivation {
 
   extraNativeBuildInputs = [ qttools ];
 
-  # FIXME: depends on kcoreaddons typesystem info, we need
-  # a Shiboken wrapper to propagate this properly.
-  extraCmakeFlags = [ "-DBUILD_PYTHON_BINDINGS=OFF" ];
+  hasPythonBindings = true;
 }

--- a/pkgs/kde/gear/akonadi-calendar/default.nix
+++ b/pkgs/kde/gear/akonadi-calendar/default.nix
@@ -2,11 +2,7 @@
 mkKdeDerivation {
   pname = "akonadi-calendar";
 
-  extraCmakeFlags = [
-    # FIXME: depends on kcoreaddons typesystem info, we need
-    # a Shiboken wrapper to propagate this properly.
-    "-DBUILD_PYTHON_BINDINGS=OFF"
-  ];
+  hasPythonBindings = true;
 
   meta.mainProgram = "kalendarac";
 }

--- a/pkgs/kde/gear/akonadi/default.nix
+++ b/pkgs/kde/gear/akonadi/default.nix
@@ -28,9 +28,6 @@ mkKdeDerivation {
 
   extraCmakeFlags = [
     "-DDATABASE_BACKEND=${lib.toUpper backend}"
-    # FIXME: depends on kcoreaddons typesystem info, we need
-    # a Shiboken wrapper to propagate this properly.
-    "-DBUILD_PYTHON_BINDINGS=OFF"
   ]
   ++ lib.optionals (backend == "mysql") [
     "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb}/bin"
@@ -38,6 +35,8 @@ mkKdeDerivation {
   ++ lib.optionals (backend == "postgres") [
     "-DPOSTGRES_PATH=${lib.getBin libpq}/bin"
   ];
+
+  hasPythonBindings = true;
 
   extraNativeBuildInputs = [
     qttools
@@ -54,7 +53,6 @@ mkKdeDerivation {
   ++ lib.optionals (backend == "sqlite") [ sqlite ];
 
   # Hardcoded as a QString, which is UTF-16 so Nix can't pick it up automatically
-
   postFixup = ''
     mkdir -p $out/nix-support
   ''

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -78,6 +78,7 @@ let
   # FIXME(later): this is wrong for cross, some of these things really need to go into nativeBuildInputs,
   # but cross is currently very broken anyway, so we can figure this out later.
   deps = map (dep: self.${dep}) filteredDepNames;
+  pyDeps = builtins.concatMap (dep: if dep ? python then [ dep.python ] else [ ]) deps;
 
   traceDuplicateDeps =
     attrName: attrValue:
@@ -127,9 +128,13 @@ let
     buildInputs = [
       qt6.qtbase
     ]
-    ++ lib.optionals hasPythonBindings [
-      python3Packages.pyside6
-    ]
+    ++ lib.optionals hasPythonBindings (
+      [
+        python3Packages.pyside6
+      ]
+      # pyDeps manually propagated in moveOutputsHook
+      ++ pyDeps
+    )
     ++ extraBuildInputs;
 
     # FIXME: figure out what to propagate here

--- a/pkgs/kde/lib/move-outputs-hook.sh
+++ b/pkgs/kde/lib/move-outputs-hook.sh
@@ -1,6 +1,15 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2154
 
+declare -a NIXPKGS_KDE_PYTHON_DEPS
+
+findKDEPythonDepsHook() {
+  if [ -d "$1/share/PySide6/typesystems" ]; then
+    NIXPKGS_KDE_PYTHON_DEPS+=("$1")
+  fi
+}
+addEnvHooks "$targetOffset" findKDEPythonDepsHook
+
 moveKF6Outputs() {
     if [ -n "$devtools" ]; then
         mkdir -p "$devtools"
@@ -8,10 +17,11 @@ moveKF6Outputs() {
     fi
 
     if [ -n "$python" ]; then
-        mkdir -p "$python"
+        mkdir -p "$python/nix-support"
         moveToOutput 'lib/python*' "$python"
         moveToOutput 'share/PySide6' "$python"
         moveToOutput 'include/PySide6' "$python"
+        echo "${NIXPKGS_KDE_PYTHON_DEPS[@]}" > "$python/nix-support/propagated-build-inputs"
     fi
 }
 


### PR DESCRIPTION
Also wire up everything to build KDE stuff with it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
