### PR TITLE
virtualboxGuestAdditions: less CI builds

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -1,26 +1,26 @@
 {
-  stdenv,
-  kernel,
-  fetchurl,
-  lib,
-  pam,
-  libxslt,
-  libxext,
-  libxcursor,
-  libxmu,
-  glib,
-  libxrandr,
   dbus,
-  xz,
+  fetchurl,
+  glib,
+  lib,
+  libxcrypt,
+  libxcursor,
+  libxext,
+  libxmu,
+  libxrandr,
+  libxslt,
+  linuxHeaders,
+  makeself,
+  openssl,
+  pam,
+  patchelf,
   pkg-config,
+  stdenv,
   which,
   xorg-server,
   xrandr,
+  xz,
   yasm,
-  patchelf,
-  makeself,
-  linuxHeaders,
-  openssl,
   virtualboxVersion,
   virtualboxSubVersion,
   virtualboxSha256,
@@ -31,7 +31,7 @@ let
   buildType = "release";
 in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "VirtualBox-GuestAdditions-builder-${kernel.version}";
+  pname = "VirtualBox-GuestAdditions-builder";
   version = "${virtualboxVersion}${virtualboxSubVersion}";
 
   inherit virtualboxVersion virtualboxSubVersion;
@@ -53,8 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     linuxHeaders
     xz
-  ]
-  ++ kernel.moduleBuildDependencies;
+    libxcrypt
+  ];
+
   buildInputs = [
     dbus
     libxslt
@@ -64,9 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxmu
     libxrandr
   ];
-
-  KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
-  KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
 
   prePatch = ''
     rm -r src/VBox/Additions/x11/x11include/
@@ -139,7 +137,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     ./configure \
       --only-additions \
-      --with-linux=${kernel.dev} \
       --disable-kmods
 
     sed -e 's@PKG_CONFIG_PATH=.*@PKG_CONFIG_PATH=${glib.dev}/lib/pkgconfig @' \


### PR DESCRIPTION
Only build the generic virtualboxGuestAdditions tar once, instead of building it for every kernel version.
The tar is then used to build the kernel modules for the specific kernel version.

Before, both steps were kernel dependent. Hence, more builds were required when updating virtualbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
