### PR TITLE
python3Packages.{ciscoisesdk,ixnetwork-restpy,stcrestclient}: init

### DIFF
--- a/pkgs/development/python-modules/ciscoisesdk/default.nix
+++ b/pkgs/development/python-modules/ciscoisesdk/default.nix
@@ -1,0 +1,57 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pythonOlder,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  fastjsonschema,
+  requests,
+  requests-toolbelt,
+  xmltodict,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ciscoisesdk";
+  version = "2.4.5";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "CiscoISE";
+    repo = "ciscoisesdk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DidTHJnrG4ptVeURz+M9s68oEqNI8CNghsF+ReUk3so=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    fastjsonschema
+    requests
+    requests-toolbelt
+    xmltodict
+  ];
+
+  pythonImportsCheck = [ "ciscoisesdk" ];
+
+  # The test suite talks to a live Cisco ISE deployment.
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/CiscoISE/ciscoisesdk/releases/tag/${finalAttrs.src.tag}";
+    description = "Cisco Identity Services Engine (ISE) Platform SDK";
+    homepage = "https://github.com/CiscoISE/ciscoisesdk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/development/python-modules/ixnetwork-restpy/default.nix
+++ b/pkgs/development/python-modules/ixnetwork-restpy/default.nix
@@ -1,0 +1,55 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  packaging,
+  requests,
+  websocket-client,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ixnetwork-restpy";
+  version = "1.11.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "ixnetwork_restpy";
+    inherit (finalAttrs) version;
+    hash = "sha256-Ag8RGuWUr/hbQ5S/IpHhWivTuhd8L5eYAuAS8lOhesI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    packaging
+    requests
+    setuptools
+    websocket-client
+  ];
+
+  pythonImportsCheck = [
+    "ixnetwork_restpy"
+    "uhd_restpy"
+  ];
+
+  # The test suite requires a live IxNetwork chassis/session.
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/OpenIxia/ixnetwork_restpy/blob/-/RELEASENOTES.md";
+    description = "IxNetwork Python client library (RestPy)";
+    homepage = "https://github.com/OpenIxia/ixnetwork_restpy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/development/python-modules/stcrestclient/default.nix
+++ b/pkgs/development/python-modules/stcrestclient/default.nix
@@ -1,0 +1,43 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  requests,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "stcrestclient";
+  version = "1.9.8";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Viavi-TestCenter";
+    repo = "py-stcrestclient";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fQ3TF/ub5gGZetdUrKTA2HbrxM7HO/05ZlJKhbq1Qbc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
+
+  pythonImportsCheck = [ "stcrestclient" ];
+
+  meta = {
+    changelog = "https://github.com/Viavi-TestCenter/py-stcrestclient/releases/tag/${finalAttrs.src.tag}";
+    description = "Client modules for the Spirent TestCenter (STC) ReST API";
+    homepage = "https://github.com/Viavi-TestCenter/py-stcrestclient";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19929,6 +19929,8 @@ self: super: with self; {
 
   statsmodels = callPackage ../development/python-modules/statsmodels { };
 
+  stcrestclient = callPackage ../development/python-modules/stcrestclient { };
+
   std-uritemplate = callPackage ../development/python-modules/std-uritemplate { };
 
   std2 = callPackage ../development/python-modules/std2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3126,6 +3126,8 @@ self: super: with self; {
 
   ciscoconfparse2 = callPackage ../development/python-modules/ciscoconfparse2 { };
 
+  ciscoisesdk = callPackage ../development/python-modules/ciscoisesdk { };
+
   ciscomobilityexpress = callPackage ../development/python-modules/ciscomobilityexpress { };
 
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8625,6 +8625,8 @@ self: super: with self; {
 
   ixia = callPackage ../development/python-modules/ixia { };
 
+  ixnetwork-restpy = callPackage ../development/python-modules/ixnetwork-restpy { };
+
   j2cli = callPackage ../development/python-modules/j2cli { };
 
   j2lint = callPackage ../development/python-modules/j2lint { };


### PR DESCRIPTION
Various dependency packages for [`pyats`](https://github.com/CiscoTestAutomation/pyats) that I'll add as a followup.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
