### PR TITLE
python3Packages.pyopenjtalk-plus: init at 0.4.1.post9, enable japanese support on piper-tts

### DIFF
--- a/pkgs/by-name/pi/piper-tts/package.nix
+++ b/pkgs/by-name/pi/piper-tts/package.nix
@@ -10,9 +10,10 @@
   espeak-ng,
 
   # extras
-  withTrain ? true,
-  withHTTP ? true,
   withAlignment ? true,
+  withHTTP ? true,
+  withJapanese ? true,
+  withTrain ? true,
 }:
 
 let
@@ -81,11 +82,21 @@ python3Packages.buildPythonApplication rec {
       onnxruntime
       pathvalidate
     ]
-    ++ lib.optionals withTrain optional-dependencies.train
+    ++ lib.optionals withAlignment optional-dependencies.alignment
     ++ lib.optionals withHTTP optional-dependencies.http
-    ++ lib.optionals withAlignment optional-dependencies.alignment;
+    ++ lib.optionals withJapanese optional-dependencies.ja
+    ++ lib.optionals withTrain optional-dependencies.train;
 
   optional-dependencies = {
+    alignment = with python3Packages; [
+      onnx
+    ];
+    http = with python3Packages; [
+      flask
+    ];
+    ja = with python3Packages; [
+      pyopenjtalk-plus
+    ];
     train =
       with python3Packages;
       [
@@ -99,20 +110,11 @@ python3Packages.buildPythonApplication rec {
         torch
       ]
       ++ jsonargparse.optional-dependencies.signatures;
-    http = with python3Packages; [
-      flask
-    ];
-    alignment = with python3Packages; [
-      onnx
-    ];
     zh = with python3Packages; [
       # g2pw # not packaged
       transformers
       sentence-stream
       unicode-rbnf
-    ];
-    ja = [
-      # pyopenjtalk-plus # not packaged
     ];
   };
 

--- a/pkgs/development/python-modules/pyopenjtalk-plus/default.nix
+++ b/pkgs/development/python-modules/pyopenjtalk-plus/default.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  replaceVars,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchgit,
+  cmake,
+  cython,
+  numpy,
+  setuptools,
+  pydantic,
+  sudachipy,
+  sudachidict-core,
+  typing-extensions,
+  pytestCheckHook,
+  onnxruntime,
+  tokenizers,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "pyopenjtalk-plus";
+  version = "0.4.1.post9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tsukumijima";
+    repo = "pyopenjtalk-plus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-o/NC8/XBGegpNaVToFmnQRID1XrsEBAuZjjgLxhniyU=";
+    fetchSubmodules = true;
+  };
+
+  # logic to download these if not present is built in, but won't work in the sandbox, and the files are required for tests
+  tsqyomiModelDir = fetchgit {
+    url = "https://huggingface.co/tsukumijima/tsqyomi-models";
+    rev = "680596dd2ad2bad59ee5db3741e197cfce79f9b4";
+    fetchLFS = true;
+    rootDir = "v4";
+    hash = "sha256-pOUnXml1QlpTthC48DBPb2iziOmAu4/9gb0trGItNTE=";
+  };
+
+  patches = [
+    (replaceVars ./tsqyomi_model_dir.patch {
+      model_dir = finalAttrs.tsqyomiModelDir;
+    })
+  ];
+
+  postPatch = ''
+    grep -q ${finalAttrs.tsqyomiModelDir.rev} pyopenjtalk/tsqyomi/model.py || (echo "wrong model rev in nix package" && exit 1)
+  '';
+
+  build-system = [
+    cmake
+    cython
+    numpy
+    setuptools
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  dependencies = [
+    numpy
+    pydantic
+    sudachipy
+    sudachidict-core
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    onnxruntime
+    tokenizers
+  ];
+
+  preCheck = ''
+    # the built extension modules are only present in $out
+    # so we make sure to resolve pyopenjtalk from $out
+    mv pyopenjtalk _pyopenjtalk
+    # not all files in the dictionary dir are installed into $out
+    # however, the tests still need them, so we specify the original dictionary dir
+    export OPEN_JTALK_DICT_DIR=_pyopenjtalk/dictionary
+  '';
+
+  pythonImportsCheck = [ "pyopenjtalk" ];
+
+  meta = {
+    description = "Python wrapper for OpenJTalk with additional improvements";
+    homepage = "https://github.com/tsukumijima/pyopenjtalk-plus";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jcaesar ];
+  };
+})

--- a/pkgs/development/python-modules/pyopenjtalk-plus/tsqyomi_model_dir.patch
+++ b/pkgs/development/python-modules/pyopenjtalk-plus/tsqyomi_model_dir.patch
@@ -1,0 +1,14 @@
+diff --git a/pyopenjtalk/tsqyomi/model.py b/pyopenjtalk/tsqyomi/model.py
+index 5bbdb0a..ffd2853 100644
+--- a/pyopenjtalk/tsqyomi/model.py
++++ b/pyopenjtalk/tsqyomi/model.py
+@@ -636,6 +636,9 @@ def load_model(
+         _is_model_loading = True
+ 
+     try:
++        # next two lines are patched in by nixpkgs:
++        if model_dir is None:
++            model_dir = "@model_dir@";
+         # ローカル配置のモデルも Hub 配布のモデルも同じ ONNX 検証を行う
+         if model_dir is not None:
+             directory = Path(model_dir)

--- a/pkgs/development/python-modules/sudachipy/default.nix
+++ b/pkgs/development/python-modules/sudachipy/default.nix
@@ -9,7 +9,6 @@
   sudachi-rs,
   setuptools-rust,
   pytestCheckHook,
-  pythonAtLeast,
   sudachidict-core,
   tokenizers,
   sudachipy,
@@ -19,8 +18,6 @@ buildPythonPackage rec {
   format = "setuptools";
   pname = "sudachipy";
   inherit (sudachi-rs) src version;
-
-  disabled = pythonAtLeast "3.14"; # The pyo3 version used does not support 3.14+
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15655,6 +15655,8 @@ self: super: with self; {
 
   pyopenjtalk = callPackage ../development/python-modules/pyopenjtalk { };
 
+  pyopenjtalk-plus = callPackage ../development/python-modules/pyopenjtalk-plus { };
+
   pyopensprinkler = callPackage ../development/python-modules/pyopensprinkler { };
 
   pyopenssl = callPackage ../development/python-modules/pyopenssl { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* init pyopenjtalk-plus, which is a fork of the already packaged pyopenjtalk. I'm doing this because I want to:
* enable Japanese support on piper-tts, which was so far disabled because of the missing pyopenjtalk-plus
* (removed unnecessary broken marker from sudachipy — Python 3.14 support came with the latest release, required for pyopenjtalk-plus)

The pyopenjtalk-plus build is different enough from its original that I think keeping those as one package with overrides would cause unreasonable headaches.

Overall, I'm not totally sure it's necessary to use pyopenjtalk-plus to get good Japanese support out of piper-tts. I've tried passing the existing pyopenjtalk, and to my ears there's no relevant difference in the outputs. I'm not a native speaker though.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

LLM Disclosure: The code in this PR is partially written with dirge 0.24 invoking qwen3.8:27B, with some additional research done by muse-glimmer. Prose and that awful postInstall hook are written by me.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 556403`
Commit: `6c71b31d15fd3ab61c35797bb05c81e5f21b659c`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>local-ai</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 11 packages built:</summary>
  <ul>
    <li>calibre</li>
    <li>convertx</li>
    <li>piper-tts</li>
    <li>python313Packages.pyopenjtalk-plus</li>
    <li>python314Packages.pyopenjtalk-plus</li>
    <li>python314Packages.sudachidict-core</li>
    <li>python314Packages.sudachidict-full</li>
    <li>python314Packages.sudachidict-small</li>
    <li>python314Packages.sudachipy</li>
    <li>unbook</li>
    <li>wyoming-piper</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
