### PR TITLE
wrangler: 4.94.0 -> 4.125.0

### DIFF
--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -20,13 +20,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wrangler";
-  version = "4.94.0";
+  version = "4.125.0";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "workers-sdk";
     rev = "wrangler@${finalAttrs.version}";
-    hash = "sha256-GW/esuGs7EdIDAUfx4ieTyZ8I84MnnZFW04LucGmbDI=";
+    hash = "sha256-4waGrQngRu4YTufvGJDoxP5pqXFwtJJ2IRSru3+R82w=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-FLbECanDqNZ05K2JHXv8lIgNM6oUtYxWrUw54IeEf5A=";
+    hash = "sha256-3Ma7zMlFtOKYgEKCS0eZM9+lKiVH7tnTsbjzQIJN7OI=";
   };
   # pnpm packageManager version in workers-sdk root package.json may not match nixpkgs
   postPatch = ''
@@ -72,27 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
     autoPatchelfHook
   ];
 
-  # @cloudflare/vitest-pool-workers wanted to run a server as part of the build process
-  # so I simply removed it
-  postBuild =
-    let
-      extraDeps = [
-        "unenv-preset"
-        "workers-utils"
-        "local-explorer-ui"
-        "codemod"
-        "cli-shared-helpers"
-        "miniflare"
-        "wrangler"
-      ];
-    in
-    ''
-      mv packages/vitest-pool-workers packages/~vitest-pool-workers
+  # Avoid V8 heap exhaustion on aarch64-darwin.
+  env.NODE_OPTIONS = "--max-old-space-size=4096";
 
-      for pkg in ${toString extraDeps}; do
-        NODE_ENV="production" pnpm --filter "$pkg" run build
-      done
-    '';
+  postBuild = ''
+    NODE_ENV="production" pnpm --filter wrangler... run build
+  '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Diff: https://github.com/cloudflare/workers-sdk/compare/wrangler@4.94.0...wrangler@4.125.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
