### PR TITLE
sonic-pi: update to v5.0.0

### DIFF
--- a/pkgs/by-name/so/sonic-pi/package.nix
+++ b/pkgs/by-name/so/sonic-pi/package.nix
@@ -7,6 +7,10 @@
   copyDesktopItems,
   cmake,
   pkg-config,
+  git,
+  rustc,
+  cargo,
+  rustPlatform,
   catch2_3,
   ncurses,
   kdePackages,
@@ -15,8 +19,8 @@
   reproc,
   platform-folders,
   ruby_3_3,
-  beamPackages,
   alsa-lib,
+  libsndfile,
   rtmidi,
   boost186,
   aubio,
@@ -25,13 +29,6 @@
   pipewire,
   supercollider-with-sc3-plugins,
   parallel,
-
-  withTauWidget ? false,
-
-  withImGui ? false,
-  gl3w,
-  SDL2,
-  fmt,
 }@args:
 
 let
@@ -41,25 +38,38 @@ let
     ps.rake
     ps.rexml
   ]);
+
+  ableton-link = fetchFromGitHub {
+    owner = "Ableton";
+    repo = "link";
+    tag = "Link-4.0";
+    hash = "sha256-jbVFzb3TwNMbWogPHLtmdWEfcOxNlQmuhao4duEvNQM=";
+    fetchSubmodules = true;
+  };
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sonic-pi";
-  version = "4.6.0";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "sonic-pi-net";
     repo = "sonic-pi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-sF/ksVhUzSV5P3Oe/T8hAiFMFiuOMEPmuBlUZtPSvtk=";
+    hash = "sha256-wUW/KxL4f0ftH0euLShEhBL11/mErl+VWMoe/H2Ab+k=";
+    fetchSubmodules = true;
   };
 
-  mixFodDeps = beamPackages.fetchMixDeps {
-    inherit (finalAttrs) version;
-    pname = "mix-deps-sonic-pi";
-    mixEnv = "test";
-    src = "${finalAttrs.src}/app/server/beam/tau";
-    hash = "sha256-UoETv6X/Q/RmKb0uCsu59DH7OF0H+A9e7+4uRM/B1Wk=";
+  cargoRoot = "app/external/supersonic/rust";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      cargoRoot
+      ;
+    hash = "sha256-ch2og6OP9LUPAo4waL/fCD4f9oVjY2NV6MncbtnpnkI=";
   };
 
   strictDeps = true;
@@ -70,10 +80,11 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
     cmake
     pkg-config
+    git
+    rustc
+    cargo
+    rustPlatform.cargoSetupHook
     ruby
-    beamPackages.erlang
-    beamPackages.elixir
-    beamPackages.hex
   ];
 
   buildInputs = [
@@ -91,17 +102,11 @@ stdenv.mkDerivation (finalAttrs: {
     platform-folders
     ruby
     alsa-lib
+    libsndfile
+    jack2
     rtmidi
     boost186
     aubio
-  ]
-  ++ lib.optionals withTauWidget [
-    kdePackages.qtwebengine
-  ]
-  ++ lib.optionals withImGui [
-    gl3w
-    SDL2
-    fmt
   ];
 
   nativeCheckInputs = [
@@ -112,8 +117,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DUSE_SYSTEM_LIBS=ON"
-    "-DBUILD_IMGUI_INTERFACE=${if withImGui then "ON" else "OFF"}"
-    "-DWITH_QT_GUI_WEBENGINE=${if withTauWidget then "ON" else "OFF"}"
+    "-DSUPERSONIC_SYSTEM_SNDFILE=ON"
+    "-DSUPERSONIC_CARGO_OFFLINE=ON"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DFETCHCONTENT_SOURCE_DIR_ABLETONLINK=/build/ableton-link"
     "-DAPP_INSTALL_ROOT=${placeholder "out"}/app"
   ];
 
@@ -124,47 +131,25 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs app bin
   '';
 
-  preConfigure =
-    # Set build environment
-    ''
-      export SONIC_PI_HOME="$TMPDIR/spi"
+  preConfigure = ''
+    git init
+    git config user.name "Nix Build"
+    git config user.email "nix@build.local"
+    git add .
+    git commit -m "init"
 
-      export HEX_HOME="$TEMPDIR/hex"
-      export HEX_OFFLINE=1
-      export MIX_REBAR3='${beamPackages.rebar3}/bin/rebar3'
-      export REBAR_GLOBAL_CONFIG_DIR="$TEMPDIR/rebar3"
-      export REBAR_CACHE_DIR="$TEMPDIR/rebar3.cache"
-      export MIX_HOME="$TEMPDIR/mix"
-      export MIX_DEPS_PATH="$TEMPDIR/deps"
-      export MIX_ENV=prod
-    ''
-    # Copy Mix dependency sources
-    + ''
-      echo 'Copying ${finalAttrs.mixFodDeps} to Mix deps'
-      cp --no-preserve=mode -R '${finalAttrs.mixFodDeps}' "$MIX_DEPS_PATH"
-    ''
-    # Change to project base directory
-    + ''
-      cd app
-    ''
-    # Prebuild Ruby vendored dependencies and Qt docs
-    + ''
-      ./linux-prebuild.sh -o
-    '';
-
-  # Build BEAM server
-  postBuild = ''
-    ../linux-post-tau-prod-release.sh -o
+    SRC_DIR="$PWD"
+    cp -r '${ableton-link}' /build/ableton-link
+    chmod -R +w /build/ableton-link
+    pushd /build/ableton-link
+    cmake -DLINK_PATCH_DIR="$SRC_DIR/app/external/supersonic/external" -P "$SRC_DIR/app/external/supersonic/external/apply-link-patches.cmake"
+    popd
+    cd app
+    ./linux-prebuild.sh -o
   '';
 
   checkPhase = ''
     runHook preCheck
-  ''
-  # BEAM tests
-  + ''
-    pushd ../server/beam/tau
-    MIX_ENV=test TAU_ENV=test mix test
-    popd
   ''
   # Ruby tests
   + ''
@@ -217,28 +202,6 @@ stdenv.mkDerivation (finalAttrs: {
           pipewire.jack
         ]
       }
-  ''
-  # If ImGui was built, Wrap ImGui into bin
-  + ''
-    if [ -e $out/app/build/gui/imgui/sonic-pi-imgui ]; then
-      makeWrapper $out/app/build/gui/imgui/sonic-pi-imgui $out/bin/sonic-pi-imgui \
-        --inherit-argv0 \
-        --prefix PATH : ${
-          lib.makeBinPath [
-            ruby
-            supercollider-with-sc3-plugins
-            jack2
-            jack-example-tools
-            pipewire.jack
-          ]
-        }
-    fi
-  ''
-  # Remove runtime Erlang references
-  + ''
-    for file in $(grep -FrIl '${beamPackages.erlang}/lib/erlang' $out/app/server/beam/tau); do
-      substituteInPlace "$file" --replace-fail '${beamPackages.erlang}/lib/erlang' $out/app/server/beam/tau/_build/prod/rel/tau
-    done
   '';
 
   stripDebugList = [

--- a/pkgs/by-name/so/sonic-pi/update.sh
+++ b/pkgs/by-name/so/sonic-pi/update.sh
@@ -5,16 +5,8 @@ set -euo pipefail
 
 nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixpkgs repo\nAre we running from within the nixpkgs git repo?\n' >&2; exit 1))"
 
-stripwhitespace() {
-    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
-}
-
 nixeval() {
     nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1" | jq -r .
-}
-
-vendorhash() {
-    (nix --extra-experimental-features nix-command build --impure --argstr nixpkgs "$nixpkgs" --argstr attr "$1" --expr '{ nixpkgs, attr }: let pkgs = import nixpkgs {}; in (pkgs.lib.getAttrFromPath (pkgs.lib.splitString "." attr) pkgs).overrideAttrs (attrs: { outputHash = pkgs.lib.fakeHash; })' --no-link 2>&1 >/dev/null | tail -n3 | grep -F got: | cut -d: -f2- | stripwhitespace) 2>/dev/null || true
 }
 
 findpath() {
@@ -40,11 +32,4 @@ if [ "$updated" -eq 0 ]; then
     exit 0
 fi
 
-curhash="$(nixeval "$attr.mixFodDeps.outputHash")"
-newhash="$(vendorhash "$attr.mixFodDeps")"
-
-if [ -n "$newhash" ] && [ "$curhash" != "$newhash" ]; then
-    sed -i -e "s|\"$curhash\"|\"$newhash\"|" "$pkgpath"
-else
-    echo 'update.sh: New vendorHash same as old vendorHash, nothing to do.'
-fi
+cd "$nixpkgs" && update-source-version "$attr" "$version" --source-key=cargoDeps --file="$pkgpath"


### PR DESCRIPTION
Changes: https://github.com/sonic-pi-net/sonic-pi/releases/tag/v5.0.0

Restructured a bit because of the move to SuperSonic

Assisted-by: Gemini 3.5 Flash Lite


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
