### PR TITLE
nixos/test-driver: cleanup junit.xml creation

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -80,17 +80,18 @@ class JunitXMLLogger(AbstractLogger):
             self.failure = False
 
     def __init__(self, outfile: Path) -> None:
-        self.tests: dict[str, JunitXMLLogger.TestCaseState] = {
-            "main": self.TestCaseState()
-        }
-        self.currentSubtest = "main"
+        self.testsuite = JunitXMLLogger.TestCaseState()
+        self.tests: dict[str, JunitXMLLogger.TestCaseState] = {}
+        self.currentSubtest = None
         self.outfile: Path = outfile
         self._print_serial_logs = True
         self._log_level = LogLevel.INFO
         atexit.register(self.close)
 
     def log(self, message: str, attributes: dict[str, str] = {}) -> None:
-        self.tests[self.currentSubtest].stdout += message + os.linesep
+        self.testsuite.stdout += message + os.linesep
+        if self.currentSubtest:
+            self.tests[self.currentSubtest].stdout += message + os.linesep
 
     @contextmanager
     def subtest(self, name: str, attributes: dict[str, str] = {}) -> Iterator[None]:
@@ -109,19 +110,28 @@ class JunitXMLLogger(AbstractLogger):
 
     def debug(self, *args, **kwargs) -> None:
         if self._log_level <= LogLevel.DEBUG:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
+            self.testsuite.stdout += args[0] + os.linesep
+            if self.currentSubtest:
+                self.tests[self.currentSubtest].stdout += args[0] + os.linesep
 
     def info(self, *args, **kwargs) -> None:
         if self._log_level <= LogLevel.INFO:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
+            self.testsuite.stdout += args[0] + os.linesep
+            if self.currentSubtest:
+                self.tests[self.currentSubtest].stdout += args[0] + os.linesep
 
     def warning(self, *args, **kwargs) -> None:
         if self._log_level <= LogLevel.WARNING:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
+            self.testsuite.stdout += args[0] + os.linesep
+            if self.currentSubtest:
+                self.tests[self.currentSubtest].stdout += args[0] + os.linesep
 
     def error(self, *args, **kwargs) -> None:
-        self.tests[self.currentSubtest].stderr += args[0] + os.linesep
-        self.tests[self.currentSubtest].failure = True
+        self.testsuite.stderr += args[0] + os.linesep
+        self.testsuite.failure = True
+        if self.currentSubtest:
+            self.tests[self.currentSubtest].stderr += args[0] + os.linesep
+            self.tests[self.currentSubtest].failure = True
 
     def log_test_error(self, *args, **kwargs) -> None:
         self.error(*args, **kwargs)
@@ -141,6 +151,9 @@ class JunitXMLLogger(AbstractLogger):
     def close(self) -> None:
         with open(self.outfile, "w") as f:
             test_cases = []
+            if len(self.tests) == 0:
+                self.tests.setdefault("main", self.TestCaseState())
+                self.tests["main"].failure = self.testsuite.failure
             for name, test_case_state in self.tests.items():
                 tc = TestCase(
                     name,
@@ -151,7 +164,12 @@ class JunitXMLLogger(AbstractLogger):
                     tc.add_failure_info("test case failed")
 
                 test_cases.append(tc)
-            ts = TestSuite("NixOS integration test", test_cases)
+            ts = TestSuite(
+                "NixOS integration test",
+                test_cases,
+                stdout=self.testsuite.stdout,
+                stderr=self.testsuite.stderr,
+            )
             f.write(TestSuite.to_xml_string([ts]))
 
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -175,6 +175,16 @@ in
           touch $out
         '';
     efivars = runTestOn [ "x86_64-linux" ] ./nixos-test-driver/efivars.nix;
+    junit =
+      pkgs.runCommand "junit-xml-has-correct-testcases"
+        {
+          test = runTest ./nixos-test-driver/junit.nix;
+          nativeBuildInputs = [ pkgs.yq-go ];
+        }
+        ''
+          [[ 2 = $(yq '.testsuites.testsuite.+@tests' $test/junit.xml) ]]
+          touch $out
+        '';
   };
 
   # NixOS vm tests and non-vm unit tests

--- a/nixos/tests/nixos-test-driver/junit.nix
+++ b/nixos/tests/nixos-test-driver/junit.nix
@@ -1,0 +1,25 @@
+# This tests the generation of junit files via the test driver.
+{
+  name = "junit";
+
+  extraDriverArgs = [ "--junit=junit.xml" ];
+
+  nodes.machine = {
+    # Speeds up the boot significantly
+    networking.useNetworkd = true;
+
+    environment.etc."something".text = "nothing";
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("systemd-networkd is started"):
+      machine.succeed("systemctl status systemd-networkd.service")
+
+    with subtest("/etc is populated correctly"):
+      output = machine.succeed("cat /etc/something")
+      t.assertEqual(output, "nothing")
+  '';
+}


### PR DESCRIPTION
- All logs are now stored in system-out of the testsuite
- A "main" test case is now only created if there is no other subtest.
  In other words: if there are any subtests, these are treated as the
  only test cases in the suite. This is more aligned with expections of
  users and makes the junit.xml more useful for reporting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
