### PR TITLE
rocqPackages.math-classes: init at 9.2.0 for Coq ≥ 9.0

### DIFF
--- a/pkgs/development/rocq-modules/math-classes/default.nix
+++ b/pkgs/development/rocq-modules/math-classes/default.nix
@@ -11,24 +11,17 @@ mkCoqDerivation {
   pname = "math-classes";
   inherit version;
   defaultVersion =
+    let
+      case = case: out: { inherit case out; };
+    in
     with lib.versions;
     lib.switch coq.coq-version [
-      {
-        case = range "8.17" "8.20";
-        out = "8.19.0";
-      }
-      {
-        case = range "8.12" "8.18";
-        out = "8.18.0";
-      }
-      {
-        case = range "8.12" "8.17";
-        out = "8.17.0";
-      }
-      {
-        case = range "8.6" "8.16";
-        out = "8.15.0";
-      }
+      (case (range "9.0" "9.3") "9.2.0")
+      (case (range "9.0" "9.1") "9.0.0")
+      (case (range "8.17" "8.20") "8.19.0")
+      (case (range "8.12" "8.18") "8.18.0")
+      (case (range "8.12" "8.17") "8.17.0")
+      (case (range "8.6" "8.16") "8.15.0")
     ] null;
   release."8.12.0".hash = "sha256:14nd6a08zncrl5yg2gzk0xf4iinwq4hxnsgm4fyv07ydbkxfb425";
   release."8.13.0".hash = "sha256:1ln7ziivfbxzbdvlhbvyg3v30jgblncmwcsam6gg3d1zz6r7cbby";
@@ -36,6 +29,8 @@ mkCoqDerivation {
   release."8.17.0".hash = "sha256-WklL8pgYTd0l4TGt7h7tWj1qcFcXvoPn25+XKF1pIKA=";
   release."8.18.0".hash = "sha256-0WwPss8+Vr37zX616xeuS4TvtImtSbToFQkQostIjO8=";
   release."8.19.0".hash = "sha256-rsV96W9MPFi/DKsepNPm1QnC2DMemio+uALIgzVYw0w=";
+  release."9.0.0".hash = "sha256-b8GPb1MRg5ZLieDTaoozy6ju10FhVdb6/XhKmyac1V4=";
+  release."9.2.0".hash = "sha256-NdmZcaNg0AmJXRsB3reyxrOYOnj/ZHgv3kF9Bxw+Q3I=";
 
   mlPlugin = true; # uses coq-bignums.plugin
 


### PR DESCRIPTION
Tested: https://github.com/rocq-community/coq-nix-toolbox/pull/503

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
