### PR TITLE
nixos: pkgs.systemd -> config.systemd.package

### DIFF
--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -58,7 +58,7 @@ let
           example = lib.literalExpression ''
             {
               "/EFI/BOOT/BOOTX64.EFI".source =
-                "''${pkgs.systemd}/lib/systemd/boot/efi/systemd-bootx64.efi";
+                "''${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi";
 
               "/loader/entries/nixos.conf".source = systemdBootEntry;
             }
@@ -227,7 +227,7 @@ in
           "10-esp" = {
             contents = {
               "/EFI/BOOT/BOOTX64.EFI".source =
-                "''${pkgs.systemd}/lib/systemd/boot/efi/systemd-bootx64.efi";
+                "''${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi";
             };
             repartConfig = {
               Type = "esp";

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -154,7 +154,7 @@ let
       script =
         "exec "
         + lib.optionalString cfg.inhibitsSleep ''
-          ${pkgs.systemd}/bin/systemd-inhibit \
+          ${config.systemd.package}/bin/systemd-inhibit \
               --who="borgbackup" \
               --what="sleep" \
               --why="Scheduled backup" \

--- a/nixos/modules/services/backup/restic.nix
+++ b/nixos/modules/services/backup/restic.nix
@@ -392,7 +392,7 @@ in
       let
         extraOptions = lib.concatMapStrings (arg: " -o ${arg}") backup.extraOptions;
         inhibitCmd = lib.concatStringsSep " " [
-          "${pkgs.systemd}/bin/systemd-inhibit"
+          "${config.systemd.package}/bin/systemd-inhibit"
           "--mode='block'"
           "--who='restic'"
           "--what='sleep'"

--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -291,7 +291,7 @@ in
         };
         initial_session = mkIf (cfgAutoLogin.enable && (cfgAutoLogin.user != null)) {
           inherit (cfgAutoLogin) user;
-          command = ''${getExe pkgs.bash} -lc "${pkgs.systemd}/bin/systemd-cat $(<${autoLoginCommand})"'';
+          command = ''${getExe pkgs.bash} -lc "${config.systemd.package}/bin/systemd-cat $(<${autoLoginCommand})"'';
         };
       };
     };

--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -332,7 +332,7 @@
           # devices needed here become available. This is terribly broken and
           # essentially no better than a random sleep(). See PR #452645 for
           # an attempt to fix this issue.
-          ExecStartPre = "-${lib.getExe' pkgs.systemd "udevadm"} settle --timeout=180";
+          ExecStartPre = "-${lib.getExe' config.systemd.package "udevadm"} settle --timeout=180";
           ExecStart =
             let
               script = pkgs.callPackage ./cdi-generate.nix {

--- a/nixos/modules/services/home-automation/homebridge.nix
+++ b/nixos/modules/services/home-automation/homebridge.nix
@@ -405,17 +405,17 @@ in
         commands = [
           {
             # Ability to restart homebridge service
-            command = "${pkgs.systemd}/bin/systemctl restart homebridge";
+            command = "${config.systemd.package}/bin/systemctl restart homebridge";
             options = [ "NOPASSWD" ];
           }
           {
             # Ability to shutdown server
-            command = "${pkgs.systemd}/bin/shutdown -h now";
+            command = "${config.systemd.package}/bin/shutdown -h now";
             options = [ "NOPASSWD" ];
           }
           {
             # Ability to restart server
-            command = "${pkgs.systemd}/bin/shutdown -r now";
+            command = "${config.systemd.package}/bin/shutdown -r now";
             options = [ "NOPASSWD" ];
           }
         ];

--- a/nixos/modules/services/misc/blenderfarm.nix
+++ b/nixos/modules/services/misc/blenderfarm.nix
@@ -96,7 +96,7 @@ in
         ln -s ${lib.getExe cfg.blenderPackage} BlenderData/nix-blender-linux64/blender
       ''
       + lib.optionalString (cfg.basicSecurityPasswordFile != null) ''
-        BLENDFARM_PASSWORD=$(${pkgs.systemd}/bin/systemd-creds cat BLENDFARM_PASS_FILE)
+        BLENDFARM_PASSWORD=$(${config.systemd.package}/bin/systemd-creds cat BLENDFARM_PASS_FILE)
         sed -i "s/null/\"$BLENDFARM_PASSWORD\"/g" ServerSettings
       '';
       serviceConfig = {

--- a/nixos/modules/services/misc/cfdyndns.nix
+++ b/nixos/modules/services/misc/cfdyndns.nix
@@ -78,7 +78,7 @@ in
           export CLOUDFLARE_EMAIL="${cfg.email}"
         ''}
         ${lib.optionalString (cfg.apiTokenFile != null) ''
-          export CLOUDFLARE_APITOKEN=$(${pkgs.systemd}/bin/systemd-creds cat CLOUDFLARE_APITOKEN_FILE)
+          export CLOUDFLARE_APITOKEN=$(${config.systemd.package}/bin/systemd-creds cat CLOUDFLARE_APITOKEN_FILE)
         ''}
         ${pkgs.cfdyndns}/bin/cfdyndns
       '';

--- a/nixos/modules/services/misc/duckdns.nix
+++ b/nixos/modules/services/misc/duckdns.nix
@@ -96,7 +96,7 @@ in
       startAt = "*:0/5";
       path = [
         pkgs.gnused
-        pkgs.systemd
+        config.systemd.package
         pkgs.curl
         pkgs.gawk
         duckdns

--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -361,7 +361,7 @@ let
             MONITOR = <generated from config.power.ups.upsmon.monitor>
             NOTIFYCMD = "''${cfg.package}/bin/upssched";
             POWERDOWNFLAG = "/run/killpower";
-            SHUTDOWNCMD = "''${pkgs.systemd}/bin/shutdown now";
+            SHUTDOWNCMD = "''${config.systemd.package}/bin/shutdown now";
           }
         '';
         description = "Additional settings to add to `upsmon.conf`.";
@@ -398,7 +398,7 @@ let
         );
         NOTIFYCMD = lib.mkDefault "${cfg.package}/bin/upssched";
         POWERDOWNFLAG = lib.mkDefault "/run/killpower";
-        SHUTDOWNCMD = lib.mkDefault "${pkgs.systemd}/bin/shutdown now";
+        SHUTDOWNCMD = lib.mkDefault "${config.systemd.package}/bin/shutdown now";
       };
     };
   };

--- a/nixos/modules/services/networking/autossh-ng.nix
+++ b/nixos/modules/services/networking/autossh-ng.nix
@@ -120,7 +120,7 @@ in
                   else
                     "-o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"";
                 ready = pkgs.writers.writeBash "systemd-signal-ready" ''
-                  ${pkgs.systemd}/bin/systemd-notify --ready
+                  ${config.systemd.package}/bin/systemd-notify --ready
                 '';
               in
               ''

--- a/nixos/modules/services/networking/clatd.nix
+++ b/nixos/modules/services/networking/clatd.nix
@@ -97,7 +97,7 @@ in
         source = pkgs.writeShellScript "restart-clatd" ''
           [ "$DEVICE_IFACE" = "${cfg.settings.clat-dev or "clat"}" ] && exit 0
           [ "$2" != "up" ] && [ "$2" != "down" ] && exit 0
-          ${pkgs.systemd}/bin/systemctl restart clatd.service
+          ${config.systemd.package}/bin/systemctl restart clatd.service
         '';
       }
     ];

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -302,7 +302,7 @@ in
         ]
         ++ lib.optional cfg.setHostname (
           pkgs.writeShellScriptBin "hostname" ''
-            ${lib.getExe' pkgs.systemd "hostnamectl"} set-hostname --transient $1
+            ${lib.getExe' config.systemd.package "hostnamectl"} set-hostname --transient $1
           ''
         );
 

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -31,7 +31,8 @@ let
   format = pkgs.formats.keyValue { };
   settingsFile = format.generate "pocket-id-env-vars" cfg.settings;
 
-  exportCredentials = n: _: ''export ${n}="$(${pkgs.systemd}/bin/systemd-creds cat ${n}_FILE)"'';
+  exportCredentials =
+    n: _: ''export ${n}="$(${config.systemd.package}/bin/systemd-creds cat ${n}_FILE)"'';
   exportAllCredentials = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList exportCredentials vars);
   getLoadCredentialList = lib.mapAttrsToList (n: v: "${n}_FILE:${v}") cfg.credentials;
 in

--- a/nixos/modules/services/web-apps/librechat.nix
+++ b/nixos/modules/services/web-apps/librechat.nix
@@ -9,7 +9,8 @@ let
   meiliCfg = config.services.meilisearch;
   format = pkgs.formats.yaml { };
   configFile = format.generate "librechat.yaml" cfg.settings;
-  exportCredentials = n: _: ''export ${n}="$(${pkgs.systemd}/bin/systemd-creds cat ${n}_FILE)"'';
+  exportCredentials =
+    n: _: ''export ${n}="$(${config.systemd.package}/bin/systemd-creds cat ${n}_FILE)"'';
   exportAllCredentials = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList exportCredentials vars);
   getLoadCredentialList = lib.mapAttrsToList (n: v: "${n}_FILE:${v}") cfg.credentials;
 in

--- a/nixos/modules/system/boot/clevis-luks-askpass.nix
+++ b/nixos/modules/system/boot/clevis-luks-askpass.nix
@@ -55,7 +55,7 @@ in
 
       storePaths = [
         cfg.package
-        "${pkgs.systemd}/lib/systemd/systemd-reply-password"
+        "${config.systemd.package}/lib/systemd/systemd-reply-password"
         "${pkgs.jose}/bin/jose"
         "${pkgs.curl}/bin/curl"
         "${pkgs.cryptsetup}/bin/cryptsetup"

--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -92,7 +92,7 @@ in
     systemd.services.systemd-journal-gatewayd.serviceConfig.ExecStart = [
       # Clear the default command line
       ""
-      "${pkgs.systemd}/lib/systemd/systemd-journal-gatewayd ${cliArgs}"
+      "${config.systemd.package}/lib/systemd/systemd-journal-gatewayd ${cliArgs}"
     ];
 
     systemd.sockets.systemd-journal-gatewayd = {

--- a/nixos/modules/system/boot/systemd/journald-remote.nix
+++ b/nixos/modules/system/boot/systemd/journald-remote.nix
@@ -123,7 +123,7 @@ in
     systemd.services.systemd-journal-remote.serviceConfig.ExecStart = [
       # Clear the default command line
       ""
-      "${pkgs.systemd}/lib/systemd/systemd-journal-remote ${cliArgs}"
+      "${config.systemd.package}/lib/systemd/systemd-journal-remote ${cliArgs}"
     ];
 
     systemd.sockets.systemd-journal-remote = {

--- a/nixos/tests/appliance-repart-image.nix
+++ b/nixos/tests/appliance-repart-image.nix
@@ -57,7 +57,7 @@ in
               in
               {
                 "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source =
-                  "${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+                  "${config.systemd.package}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
 
                 "/EFI/Linux/${config.system.boot.loader.ukiFile}".source =
                   "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";


### PR DESCRIPTION
Using the config-defined systemd package is preferred for when you
override the global systemd package across the entire config.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
