### PR TITLE
CONTRIBUTING: list nix fmt first among formatter commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -587,9 +587,9 @@ CI [enforces](./.github/workflows/lint.yml) all Nix files to be formatted using 
 
 You can ensure this locally using either of these commands:
 ```
-nix-shell --run treefmt
-nix develop --command treefmt
 nix fmt
+nix develop --command treefmt
+nix-shell --run treefmt
 ```
 
 If you're starting your editor in `nix-shell` or `nix develop`, you can also set it up to automatically run `treefmt` on save.


### PR DESCRIPTION
The formatting section listed `nix-shell --run treefmt` first. That is a valid way to run the formatter, but it is also the heaviest of the three, requires NIX_PATH (which I don't define by default, and flakes are more out of the box), and it is easy to take it as the default, which my agent was doing, and then it was forgetting to format before sending. And I was always having to steer it towards the nix fmt approach anyway.

This only reorders the three commands so `nix fmt` comes first. Same commands, same meaning. It's a trivial text edit so no behavior to break.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The file edit is mine. Grok Build (xAI Grok 4.6) wrote the commit message and this PR body.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test