### PR TITLE
 python3Packages.tensorflow: mark unsupported configurations as broken,  python3Packages.etils: dont use tensorflow when broken 

### DIFF
--- a/pkgs/development/python-modules/etils/default.nix
+++ b/pkgs/development/python-modules/etils/default.nix
@@ -109,7 +109,7 @@ buildPythonPackage (finalAttrs: {
       ++ self.etree
       ++ self.etree-dm
       ++ self.etree-jax
-      ++ self.etree-tf;
+      ++ lib.optionals (!tensorflow.meta.broken) self.etree-tf;
   });
 
   pythonImportsCheck = [ "etils" ];
@@ -144,6 +144,9 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError: assert '/tmp/to/something' == '/private/tmp/to/something'
     "test_repr"
+  ]
+  ++ lib.optionals tensorflow.meta.broken [
+    "test_use_backend"
   ];
 
   disabledTestPaths = [
@@ -152,6 +155,18 @@ buildPythonPackage (finalAttrs: {
 
     # Requires unpackaged fiddle
     "etils/epy/text_utils_test.py"
+  ]
+  ++ lib.optionals tensorflow.meta.broken [
+    "etils/ecolab/array_as_img_test.py"
+    "etils/enp/array_spec_test.py"
+    "etils/enp/array_types/dtypes_test.py"
+    "etils/enp/checking_test.py"
+    "etils/enp/compat_test.py"
+    "etils/enp/geo_utils_test.py"
+    "etils/enp/interp_utils_test.py"
+    "etils/enp/linalg_test.py"
+    "etils/enp/numpy_utils_test.py"
+    "etils/etree/tree_utils_test.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -51,20 +51,17 @@ let
   inherit (cudaPackages) cudatoolkit cudnn;
 
   isCudaJetson = cudaSupport && cudaPackages.flags.isJetsonBuild;
+
+  pyVerNoDot = lib.strings.stringAsChars (x: lib.optionalString (x != ".") x) python.pythonVersion;
+  cuda = lib.optionalString cudaSupport (if isCudaJetson then "_jetson" else "_gpu");
+  key = "${stdenv.system}_${pyVerNoDot}${cuda}";
 in
 buildPythonPackage (finalAttrs: {
   pname = "tensorflow" + lib.optionalString cudaSupport "-gpu";
   version = packages."${"version" + lib.optionalString isCudaJetson "_jetson"}";
   format = "wheel";
 
-  src =
-    let
-      pyVerNoDot = lib.strings.stringAsChars (x: lib.optionalString (x != ".") x) python.pythonVersion;
-      platform = stdenv.system;
-      cuda = lib.optionalString cudaSupport (if isCudaJetson then "_jetson" else "_gpu");
-      key = "${platform}_${pyVerNoDot}${cuda}";
-    in
-    fetchurl (packages.${key} or (throw "tensorflow-bin: unsupported configuration: ${key}"));
+  src = fetchurl (packages.${key} or (throw "tensorflow-bin: unsupported configuration: ${key}"));
 
   buildInputs = [ llvmPackages.openmp ];
 
@@ -241,6 +238,6 @@ buildPythonPackage (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = [ ];
     # unsupported combination
-    broken = stdenv.hostPlatform.isDarwin && cudaSupport;
+    broken = stdenv.hostPlatform.isDarwin && cudaSupport || !(packages ? ${key});
   };
 })


### PR DESCRIPTION
tensorflow is tensorflow-bin, which is not available for python 3.14, which is now the default python3Packages.

This PR mark that as broken, and allow etils to workaround that fact.

My goal here is to get mujoco back, and it really looks like mujoco is fine on python 3.14 without tensorflow.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
