### PR TITLE
python3Packages.wasmtime: 47.0.1 -> 48.0.0

### DIFF
--- a/pkgs/development/python-modules/itkwasm/default.nix
+++ b/pkgs/development/python-modules/itkwasm/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "itkwasm";
-  version = "1.0b200";
+  version = "1.0b201";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-vhN4Nm5tuGDRYYZKFyC+mH+LxW4UXmVxZDzsQI48U4s=";
+    hash = "sha256-f1DRcDlGW0y8VwfIrCEWaUIhN3zrgsbWsK/SJRbtbqM=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/wasmtime/default.nix
+++ b/pkgs/development/python-modules/wasmtime/default.nix
@@ -18,14 +18,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "wasmtime";
-  version = "47.0.1";
+  version = "48.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "wasmtime-py";
     tag = finalAttrs.version;
-    hash = "sha256-EtozWiHv354jDu0pHAI2vnx1c53Ldq4WBhTSFPZICSs=";
+    hash = "sha256-OpA/LCCYAYNULiIqcXY070wjO5vNQ/ek35wDwgjoKj0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Fixes the build issue mentioned in https://github.com/NixOS/nixpkgs/pull/554614#issuecomment-5408359235

had to bump itkwasm, 1.0b200 threw
```
ImportError: cannot import name 'DirPerms' from 'wasmtime' (/nix/store/zpi3g21vkj946scl7fjmzpph7p50ki0g-python3.13-wasmtime-48.0.0/lib/python3.13/site-packages/wasmtime/__init__.py)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
