### PR TITLE
samba: fix dylib linking on Darwin

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -309,7 +309,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Use find -type f -executable -exec echo {} \; -exec sh -c 'ldd {} | grep "not found"' \;
   # Looks like a bug in installer scripts.
   postFixup = ''
-    export SAMBA_LIBS="$(find $out -type f -regex '.*\${stdenv.hostPlatform.extensions.sharedLibrary}\(\..*\)?' -exec dirname {} \; | sort | uniq)"
+    export SAMBA_LIBS="$(find $out -type f \( -name "*${stdenv.hostPlatform.extensions.sharedLibrary}*" -o -name "*.so*" \) -exec dirname {} \; | sort -u)"
     read -r -d "" SCRIPT << EOF || true
     [ -z "\$SAMBA_LIBS" ] && exit 1;
     BIN='{}';
@@ -321,15 +321,20 @@ stdenv.mkDerivation (finalAttrs: {
     patchelf --shrink-rpath "\$BIN";
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    install_name_tool -id \$BIN \$BIN
-    for old_rpath in \$(otool -L \$BIN | grep /private/tmp/ | awk '{print \$1}'); do
-      new_rpath=\$(find \$SAMBA_LIBS -name \$(basename \$old_rpath) | head -n 1)
-      install_name_tool -change \$old_rpath \$new_rpath \$BIN
+    if [[ "\$BIN" == *${stdenv.hostPlatform.extensions.sharedLibrary}* || "\$BIN" == *.so* ]]; then
+      install_name_tool -id "\$BIN" "\$BIN" || true
+    fi
+    BUILD_TOP_CANONICAL="\$(realpath "\$NIX_BUILD_TOP" 2>/dev/null || echo "\$NIX_BUILD_TOP")"
+    for old_rpath in \$(otool -L "\$BIN" 2>/dev/null | awk '{print \$1}' | grep -F -e "\$NIX_BUILD_TOP" -e "\$BUILD_TOP_CANONICAL"); do
+      new_rpath=\$(find \$SAMBA_LIBS -name "\$(basename "\$old_rpath")" | head -n 1)
+      if [ -n "\$new_rpath" ]; then
+        install_name_tool -change "\$old_rpath" "\$new_rpath" "\$BIN"
+      fi
     done
   ''
   + ''
     EOF
-    find $out -type f -regex '.*\${stdenv.hostPlatform.extensions.sharedLibrary}\(\..*\)?' -exec $SHELL -c "$SCRIPT" \;
+    find $out -type f \( -name "*${stdenv.hostPlatform.extensions.sharedLibrary}*" -o -name "*.so*" \) -exec $SHELL -c "$SCRIPT" \;
     find $out/bin -type f -exec $SHELL -c "$SCRIPT" \;
 
     # Fix PYTHONPATH for some tools


### PR DESCRIPTION
On Darwin, Samba embeds temporary build directory paths in the dylib install names and load commands. Previously, postFixup hardcoded a match for '/private/tmp/', which fails when sandboxing or daemon builds use different build top directories such as '/nix/var/nix/builds/...'.

Fix this by:
- Dynamically matching $NIX_BUILD_TOP and its canonical path.
- Including Python C-extension .so modules in the search.
- Only setting install_name_tool -id on shared libraries.

Assisted-by: Antigravity (Gemini 3.7 Flash)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
