### PR TITLE
swipeaerospace: 0.3.1 -> 0.3.3

### DIFF
--- a/pkgs/by-name/sw/swipeaerospace/package.nix
+++ b/pkgs/by-name/sw/swipeaerospace/package.nix
@@ -85,7 +85,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "swipeaerospace";
-  version = "0.3.1";
+  version = "0.3.3";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "MediosZ";
     repo = "SwipeAeroSpace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-468QGWjbRtA9Fml6jjeJZBTCUEp227cQPckqwyLK0dM=";
+    hash = "sha256-lEWbZ/FvxtlY4VnFRk//tDeVrW9+udyJ+hbUsG61jhI=";
   };
 
   # Keep SettingsView unchanged, but open it through a regular WindowGroup.


### PR DESCRIPTION
## Description of changes

Bumps `swipeaerospace` from 0.3.1 to 0.3.3.

0.3.1 predates upstream's compatibility fix for AeroSpace's 0.21
socket protocol ([MediosZ/SwipeAeroSpace@38c9a4d](https://github.com/MediosZ/SwipeAeroSpace/commit/38c9a4d), released in 0.3.2). On
current AeroSpace releases (e.g. 0.21.3-Beta), the swipe gesture is
detected by the app but the workspace-switch command silently fails
against the server, so the addon appears to do nothing.

Changes between the two versions: https://github.com/MediosZ/SwipeAeroSpace/compare/v0.3.1...v0.3.3

Verified the existing `settings-window.patch` still applies cleanly to v0.3.3, and built successfully with `nix build` (aarch64-darwin) using the updated hash.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
  - [ ] x86_64-darwin
  - [ ] aarch64-linux
  - [ ] x86_64-linux
- [x] Tested, as applicable:
  - Package builds successfully and the resulting app now correctly switches AeroSpace workspaces on trackpad swipe (previously silently failed)
- [x] Checked that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)