### PR TITLE
switch-to-configuration: restart units that see a stale /etc when using etc-overlay

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -807,6 +807,9 @@ rec {
       + optionalString (def ? stopIfChanged && !def.stopIfChanged) ''
         X-StopIfChanged=false
       ''
+      + optionalString (def ? restartOnStaleEtc && !def.restartOnStaleEtc) ''
+        X-RestartOnStaleEtc=false
+      ''
       + optionalString (def ? notSocketActivated && def.notSocketActivated) ''
         X-NotSocketActivated=true
       ''

--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -554,6 +554,23 @@ rec {
         '';
       };
 
+      restartOnStaleEtc = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether the service should be restarted during a NixOS
+          configuration switch when its mount namespace still uses the
+          previous `/etc`. This can happen with
+          {option}`system.etc.overlay.enable` when the service's `/etc`
+          has namespace-local submounts, e.g. from `BindPaths=` or
+          `ConfigurationDirectory=`, which prevent the mount replacement
+          from propagating into the service's mount namespace.
+
+          Services with {option}`restartIfChanged` set to `false` are
+          never restarted for a stale `/etc`.
+        '';
+      };
+
       reloadIfChanged = mkOption {
         type = types.bool;
         default = false;

--- a/nixos/tests/activation/etc-overlay-mutable.nix
+++ b/nixos/tests/activation/etc-overlay-mutable.nix
@@ -39,6 +39,51 @@
         };
       };
 
+      systemd.services =
+        let
+          sleeper = "/run/current-system/sw/bin/sleep infinity";
+        in
+        {
+          # The /etc copy gets a namespace-local child mount: umount
+          # propagation is blocked, the service must be restarted.
+          sandboxed = {
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              ExecStart = sleeper;
+              PrivateMounts = true;
+              BindReadOnlyPaths = [ "/etc/pam.d" ];
+            };
+          };
+          # Plain slave namespace: receives the mount replacement via
+          # propagation, must not be restarted.
+          ns-slave = {
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              ExecStart = sleeper;
+              PrivateMounts = true;
+            };
+          };
+          # Explicitly opted out of receiving host mount changes. Must
+          # neither see the new /etc nor be restarted.
+          ns-private = {
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              ExecStart = sleeper;
+              MountFlags = "private";
+            };
+          };
+          # Stranded like `sandboxed`, but opted out of the restart.
+          opted-out = {
+            wantedBy = [ "multi-user.target" ];
+            restartOnStaleEtc = false;
+            serviceConfig = {
+              ExecStart = sleeper;
+              PrivateMounts = true;
+              BindReadOnlyPaths = [ "/etc/pam.d" ];
+            };
+          };
+        };
+
       # Prerequisites
       boot.initrd.systemd.enable = true;
 
@@ -100,8 +145,15 @@
         assert machine.succeed("head -c 10 /etc/bigfile") == "aaaaaaaaaa"
         machine.succeed("getfattr -h -n trusted.overlay.redirect /run/nixos-etc-metadata/bigfile")
 
+      def main_pid(service_name):
+          return machine.succeed(f"systemctl show -P MainPID {service_name}.service").strip()
+
       with subtest("switching to the same generation"):
         machine.succeed("/run/current-system/bin/switch-to-configuration test")
+
+      # The switch above already replaced the /etc mount once. Capture the
+      # main PIDs now so that we can use them later in our assertions.
+      pids = {service: main_pid(service) for service in ["sandboxed", "ns-slave", "ns-private", "opted-out"]}
 
       with subtest("the initrd didn't get rebuilt"):
         machine.succeed("test /run/current-system/initrd -ef /run/current-system/specialisation/new-generation/initrd")
@@ -137,6 +189,29 @@
         print(machine.succeed("stat /etc/mountpoint/extra-file"))
         print(machine.succeed("findmnt /etc/filemount"))
 
+      with subtest("stranded mount namespaces are restarted, propagated ones are not"):
+        # The namespace-local bind mount under /etc blocked the umount
+        # propagation. The unit kept the old /etc and must have been
+        # restarted by the switch.
+        assert main_pid("sandboxed") != pids["sandboxed"], "sandboxed was not restarted"
+        pid = main_pid("sandboxed")
+        assert machine.succeed(f"nsenter -t {pid} -m cat /etc/newgen") == "newgen"
+
+        # The plain slave namespace received the mount replacement via
+        # propagation, so restarting it would be gratuitous.
+        assert main_pid("ns-slave") == pids["ns-slave"], "ns-slave was restarted"
+        assert machine.succeed(f"nsenter -t {pids['ns-slave']} -m cat /etc/newgen") == "newgen"
+
+        # MountFlags=private opted out of host mount changes: not
+        # restarted, still on the old /etc.
+        assert main_pid("ns-private") == pids["ns-private"], "ns-private was restarted"
+        machine.fail(f"nsenter -t {pids['ns-private']} -m test -e /etc/newgen")
+
+        # Stranded, but restartOnStaleEtc = false must be honored.
+        assert main_pid("opted-out") == pids["opted-out"], "opted-out was restarted"
+        machine.fail(f"nsenter -t {pids['opted-out']} -m test -e /etc/newgen")
+
+      with subtest("switching to yet another generation"):
         machine.succeed(f"{newergen} switch")
         assert machine.succeed("cat /etc/newergen") == "newergen"
 

--- a/pkgs/by-name/sw/switch-to-configuration-ng/Cargo.lock
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/Cargo.lock
@@ -236,6 +236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +277,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -342,6 +358,12 @@ dependencies = [
  "thiserror",
  "uuid",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
@@ -457,6 +479,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +545,19 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -574,6 +630,7 @@ dependencies = [
  "libsystemd",
  "log",
  "nix 0.31.1",
+ "procfs",
  "regex",
  "rust-ini",
  "syslog",

--- a/pkgs/by-name/sw/switch-to-configuration-ng/Cargo.toml
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/Cargo.toml
@@ -18,6 +18,7 @@ glob = "0.3.1"
 libsystemd = "0.7.2"
 log = "0.4.21"
 nix = { version = "0.31.1", features = ["fs", "signal"] }
+procfs = { version = "0.18.0", default-features = false }
 regex = "1.12.3"
 rust-ini = { version = "0.21.3", features = ["inline-comment"] }
 syslog = "7.0.0"

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -69,6 +69,7 @@ const SYSINIT_REACTIVATION_TARGET: &str = "sysinit-reactivation.target";
 const START_LIST_FILE: &str = "/run/nixos/start-list";
 const RESTART_LIST_FILE: &str = "/run/nixos/restart-list";
 const RELOAD_LIST_FILE: &str = "/run/nixos/reload-list";
+const TRY_RESTART_LIST_FILE: &str = "/run/nixos/try-restart-list";
 
 // Parse restart/reload requests by the activation script. Activation scripts may write
 // newline-separated units to the restart file and switch-to-configuration will handle them. While
@@ -336,6 +337,163 @@ fn get_active_units<'a, 'b>(
 
             acc
         }))
+}
+
+/// Returns the active services whose mount namespace still resolves /etc through a stale
+/// superblock, plus warnings for units that could not be inspected.
+///
+/// Replacing the /etc mount during activation (`system.etc.overlay.enable`) only happens in the
+/// host mount namespace. Other namespaces receive the new mount via mount event propagation,
+/// moved beneath their /etc copy, and the kernel then reveals it by unmounting the copy.
+/// That unmount is skipped for copies with namespace-local child mounts (created by e.g.
+/// BindReadOnlyPaths= or ConfigurationDirectory= sandboxing), leaving the service on the previous
+/// generation's /etc until restarted, with the current /etc invisible beneath it.
+fn stale_etc_units(
+    active_units: &HashMap<String, UnitState>,
+) -> Result<(Vec<String>, Vec<anyhow::Error>)> {
+    let mut stale = Vec::new();
+    let mut warnings = Vec::new();
+
+    let host_etc = std::fs::metadata("/etc").context("Failed to stat /etc")?;
+
+    for (name, unit) in active_units {
+        if !name.ends_with(".service") {
+            continue;
+        }
+        match unit_uses_stale_etc(unit, host_etc.dev()) {
+            Ok(true) => stale.push(name.clone()),
+            Ok(false) => {}
+            Err(err) => {
+                warnings.push(err.context(format!("Failed to inspect {name}")));
+            }
+        }
+    }
+
+    Ok((stale, warnings))
+}
+
+/// Whether the unit's main process resolves /etc through a stale superblock, true if the current
+/// host /etc mount was propagated into the unit's mount namespace but is stuck beneath the mount
+/// the unit still resolves.
+fn unit_uses_stale_etc(unit: &UnitState, host_etc_dev: u64) -> Result<bool> {
+    let pid: u32 = unit
+        .proxy
+        .get("org.freedesktop.systemd1.Service", "MainPID")
+        .context("Failed to get MainPID")?;
+    // No main process to inspect, e.g. RemainAfterExit= oneshots.
+    if pid == 0 {
+        return Ok(false);
+    }
+
+    // The path resolves through the unit's mount namespace. The device identifies the
+    // superblock.
+    let Some(etc) = stat_process_path(&format!("/proc/{pid}/root/etc"))? else {
+        // The process exited mid-scan.
+        return Ok(false);
+    };
+    if etc.dev() == host_etc_dev {
+        // Same superblock, so the umount of the old mount propagated already
+        return Ok(false);
+    }
+
+    // Different superblock, check whether the new mount sits beneath, or whether
+    // we are in a mount namespace that opted out of mount propagation.
+    current_etc_tucked_beneath(pid, etc.dev(), host_etc_dev)
+}
+
+/// Whether, in the mount namespace of the given process, the /etc mount with device `host_dev`
+/// sits directly beneath the /etc mount with device `top_dev`. Mounting beneath a mount makes the
+/// new mount its parent.
+fn current_etc_tucked_beneath(pid: u32, top_dev: u64, host_dev: u64) -> Result<bool> {
+    let pid = i32::try_from(pid).context("Invalid pid")?;
+    let Ok(process) = procfs::process::Process::new(pid) else {
+        // The process exited mid-scan.
+        return Ok(false);
+    };
+    let mountinfo = match process.mountinfo() {
+        Ok(mountinfo) => mountinfo,
+        Err(procfs::ProcError::NotFound(_)) => return Ok(false),
+        Err(err) => {
+            return Err(err).with_context(|| format!("Failed to read mountinfo of pid {pid}"));
+        }
+    };
+
+    // Formats a device number the way mountinfo's `majmin` field spells it.
+    let major_minor = |dev: u64| {
+        format!(
+            "{}:{}",
+            nix::sys::stat::major(dev),
+            nix::sys::stat::minor(dev)
+        )
+    };
+
+    let etc_mounts: Vec<_> = mountinfo
+        .into_iter()
+        .filter(|mount| mount.mount_point == Path::new("/etc"))
+        .collect();
+    let Some(top_mount) = etc_mounts
+        .iter()
+        .find(|mount| mount.majmin == major_minor(top_dev))
+    else {
+        return Ok(false);
+    };
+    let top_mount_parent_id = top_mount.pid;
+    // Look for a mount that is the *parent* of the top mount and has same device as the
+    // host_dev.
+    // When we slide a mount underneath the previous /etc mountpoint, it means that the
+    // new mount is now the *parent* of the old one since it sits one layer lower in the
+    // mount tree, beneath the old mount.
+    Ok(etc_mounts
+        .iter()
+        .any(|mount| mount.mnt_id == top_mount_parent_id && mount.majmin == major_minor(host_dev)))
+}
+
+/// Paths of a unit's file in the given toplevel. Template instances without their own unit file
+/// fall back to their template unit. Returns the unit file, the base unit name and the base unit
+/// file.
+fn toplevel_unit_paths(toplevel: &Path, unit: &str) -> (PathBuf, String, PathBuf) {
+    let unit_file = toplevel.join("etc/systemd/system").join(unit);
+    let mut base_unit = unit.to_string();
+    let mut base_unit_file = unit_file.clone();
+
+    // Detect template instances.
+    if !unit_file.exists() {
+        if let Some((Some(template_name), Some(template_instance))) =
+            TEMPLATE_UNIT_RE.captures(unit).map(|captures| {
+                (
+                    captures.get(1).map(|c| c.as_str()),
+                    captures.get(2).map(|c| c.as_str()),
+                )
+            })
+        {
+            base_unit = format!("{template_name}@.{template_instance}");
+            base_unit_file = toplevel.join("etc/systemd/system").join(&base_unit);
+        }
+    }
+
+    (unit_file, base_unit, base_unit_file)
+}
+
+/// Whether the unit opted out of being restarted for a stale /etc, either specifically
+/// (X-RestartOnStaleEtc=false) or in general (X-RestartIfChanged=false).
+fn opts_out_of_stale_etc_restart(toplevel: &Path, unit: &str) -> bool {
+    let (unit_file, _, base_unit_file) = toplevel_unit_paths(toplevel, unit);
+    let Ok(unit_info) = parse_unit(&unit_file, &base_unit_file) else {
+        // Not a unit managed by this configuration, restart it.
+        return false;
+    };
+    !parse_systemd_bool(Some(&unit_info), "Service", "X-RestartIfChanged", true)
+        || !parse_systemd_bool(Some(&unit_info), "Service", "X-RestartOnStaleEtc", true)
+}
+
+/// stat() that treats a path vanishing (process exit during the scan) as absence instead of an
+/// error.
+fn stat_process_path(path: &str) -> Result<Option<std::fs::Metadata>> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err).with_context(|| format!("Failed to stat {path}")),
+    }
 }
 
 // This function takes a single ini file that specified systemd configuration like unit
@@ -1890,6 +2048,7 @@ won't take effect until you reboot the system.
     let mut units_to_start = map_from_list_file(START_LIST_FILE);
     let mut units_to_restart = map_from_list_file(RESTART_LIST_FILE);
     let mut units_to_reload = map_from_list_file(RELOAD_LIST_FILE);
+    let mut units_to_try_restart = map_from_list_file(TRY_RESTART_LIST_FILE);
 
     let dbus_conn = LocalConnection::new_system().context("Failed to open dbus connection")?;
     let systemd = systemd1_proxy(&dbus_conn);
@@ -2254,24 +2413,7 @@ won't take effect until you reboot the system.
         .unwrap_or_default()
         .lines()
     {
-        let new_unit_file = toplevel.join("etc/systemd/system").join(unit);
-        let mut base_unit = unit.to_string();
-        let mut new_base_unit_file = new_unit_file.clone();
-
-        // Detect template instances.
-        if let Some((Some(template_name), Some(template_instance))) =
-            TEMPLATE_UNIT_RE.captures(unit).map(|captures| {
-                (
-                    captures.get(1).map(|c| c.as_str()),
-                    captures.get(2).map(|c| c.as_str()),
-                )
-            })
-        {
-            if !new_unit_file.exists() {
-                base_unit = format!("{template_name}@.{template_instance}");
-                new_base_unit_file = toplevel.join("etc/systemd/system").join(&base_unit);
-            }
-        }
+        let (new_unit_file, base_unit, new_base_unit_file) = toplevel_unit_paths(&toplevel, unit);
 
         let mut base_name = base_unit.as_str();
         if let Some(Some(new_base_name)) = UNIT_NAME_RE
@@ -2325,6 +2467,48 @@ won't take effect until you reboot the system.
     // We can remove the file now because it has been propagated to the other reload file
     remove_file_if_exists(RELOAD_BY_ACTIVATION_LIST_FILE)
         .with_context(|| format!("Failed to remove {RELOAD_BY_ACTIVATION_LIST_FILE}"))?;
+
+    // The activation script may have replaced the /etc mount. Services whose mount namespaces
+    // did not receive the replacement are stuck on the previous /etc and get a try-restart in the
+    // restart phase below. Errors only produce warnings, the affected services then simply keep
+    // the old /etc.
+    match get_active_units(&systemd).and_then(|units| stale_etc_units(&units)) {
+        Ok((stale_units, warnings)) => {
+            for warning in warnings {
+                eprintln!("warning: {warning:#}");
+            }
+            let (mut opted_out, mut scheduled): (Vec<String>, Vec<String>) = stale_units
+                .into_iter()
+                .partition(|unit| opts_out_of_stale_etc_restart(&toplevel, unit));
+            if !scheduled.is_empty() {
+                scheduled.sort_by_key(|name| name.to_lowercase());
+                eprintln!(
+                    "scheduling restart of the following units still using the previous /etc: {}",
+                    scheduled.join(", ")
+                );
+                for unit in scheduled {
+                    units_to_try_restart.insert(unit, ());
+                }
+            }
+            if !opted_out.is_empty() {
+                opted_out.sort_by_key(|name| name.to_lowercase());
+                eprintln!(
+                    "NOT restarting the following units still using the previous /etc: {}",
+                    opted_out.join(", ")
+                );
+            }
+        }
+        Err(err) => {
+            eprintln!("warning: failed to check for services using the previous /etc: {err:#}");
+        }
+    }
+
+    // A try-restart supersedes a reload
+    for unit in units_to_try_restart.keys() {
+        if units_to_reload.remove(unit).is_some() {
+            unrecord_unit(RELOAD_LIST_FILE, unit);
+        }
+    }
 
     // Restart systemd if necessary. Note that this is done using the current version of systemd,
     // just in case the new one has trouble communicating with the running pid 1.
@@ -2547,6 +2731,44 @@ won't take effect until you reboot the system.
         remove_file_if_exists(RESTART_LIST_FILE)
             .with_context(|| format!("Failed to remove {RESTART_LIST_FILE}"))?;
     }
+
+    // Try-restart the queued units. TryRestartUnit only restarts units that are still running,
+    // so a unit that stopped since it was queued is not started by accident. Units the switch
+    // already acts on are skipped, they get their new state from that anyway. Failures are not
+    // worth failing the switch over.
+    let mut try_restart_units = units_to_try_restart
+        .keys()
+        .filter(|unit| {
+            !units_to_restart.contains_key(*unit)
+                && !units_to_stop.contains_key(*unit)
+                && !units_to_start.contains_key(*unit)
+        })
+        .map(String::as_str)
+        .collect::<Vec<&str>>();
+    if !try_restart_units.is_empty() {
+        try_restart_units.sort_by_key(|name| name.to_lowercase());
+        eprintln!(
+            "try-restarting the following units: {}",
+            try_restart_units.join(", ")
+        );
+
+        for unit in try_restart_units {
+            match systemd.try_restart_unit(unit, "replace") {
+                Ok(job_path) => {
+                    let mut jobs = submitted_jobs.borrow_mut();
+                    jobs.insert(job_path, Job::Restart);
+                }
+                Err(err) => {
+                    eprintln!("warning: failed to restart {unit}: {err}");
+                }
+            }
+        }
+
+        block_on_jobs(&dbus_conn, &submitted_jobs)?;
+    }
+
+    remove_file_if_exists(TRY_RESTART_LIST_FILE)
+        .with_context(|| format!("Failed to remove {TRY_RESTART_LIST_FILE}"))?;
 
     // Start all active targets, as well as changed units we stopped above. The latter is necessary
     // because some may not be dependencies of the targets (i.e., they were manually started).


### PR DESCRIPTION
When using etc-overlay, units that set up their own mount namespace and have nested
submounts inside the namespace (like eg `BindPaths` or `ConfigurationDirectory`
options) are being skipped by the kernel's umount propagation logic when we umount
the previous /etc in the main mount namespace, and therefore they continue to see
the old /etc contents after the system switched to a new configuration.

Since there is no directly usable mechanism at the kernel or systemd level to
influence this behaviour, our best bet is to detect it at switch-time and restart
those units so that they reconstruct their mount namespace from scratch.

We don't need to make this conditional on the etc-overlay being enabled because the check is cheap and there will never be a stale etc mount when not using the overlay.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]: `nixosTests.activation-etc-overlay-mutable` (extended with a regression test), `nixosTests.activation-etc-overlay-immutable`, `nixosTests.switchTest`.
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
