### PR TITLE
dankcalendar: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28503,6 +28503,12 @@
     githubId = 41830259;
     name = "Thomas Marchand";
   };
+  th1nkk1d = {
+    email = "witheep@gmail.com";
+    github = "Th1nkK1D";
+    githubId = 8860448;
+    name = "Withee Poositasai";
+  };
   thall = {
     email = "niclas.thall@gmail.com";
     github = "thall";


### PR DESCRIPTION
Standalone calendar app with the look and feel of [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) integrating local, Google, Microsoft, CalDAV, and iCloud calendars. It runs as a lightweight daemon with a tray icon, keep accounts in sync in the background. It also serves as an optional, and preferable, calendar backend for `dms-shell` since v1.5.0 (was packaged in nixpkgs from https://github.com/NixOS/nixpkgs/pull/539682).

Homepage: https://danklinux.com/docs/dankcalendar/
GitHub: https://github.com/AvengeMedia/dankcalendar

Packaging notes:

- Built with the `withshell` build tag, as upstream's `core/Makefile` does for releases, so the quickshell UI is embedded into the binary. The `postPatch` mirrors upstream's `make -C core sync-shell`, replacing the `DankCommon` symlink (which points into the `dank-qml-common` submodule and would dangle after the copy) with the real directory, and dropping dev-only files.
- The UI is launched by executing `qs` from `PATH`. As with the existing `dms-shell` package, quickshell is expected to come from the user's compositor setup rather than being wrapped in.
- Shell completions are generated by running the built binary, so they are guarded on `stdenv.buildPlatform.canExecute stdenv.hostPlatform`.

Also adds me (`th1nkk1d`) to the maintainer list in a separate commit.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The `dankcalendar: init` commit was written with Claude Code (claude-opus-5) and carries an `Assisted-by:` trailer according to the AI policy. I have reviewed the code, built it, and tested the resulting binary myself. Been using it for a day, both desktop app and background daemon working as expected (Currently, my favorite calendar app on DMS).

## Need advices
- This PR scope only include the packaging, providing `dcal` binary. It does not integrate with NixOS module configuration.
  - We have [`programs.dms-shell.enableCalendarEvents`](https://search.nixos.org/options?channel=unstable&query=dms-shell&type=options#show=option%253Aprograms.dms-shell.enableCalendarEvents) integrating DMS calendar through `khal` which is [not preferred by DMS](https://danklinux.com/docs/dankmaterialshell/calendar-integration) anymore. I have no idea what should we do when we're integrating `dcal` while considering breaking changes risk for existing user.
  - Just the binary is working fine. DMS settings auto-discover the calendar backend, either  `dcal` and `khal` binary. And DankCalendar have option to enable auto-start daemon by putting desktop file in autostart directory.
    - However, the desktop file hardcode nix-store to `dcal` binary which will changes when new version is released, this is not so clean.
    - Alternatively, the package also provide systemd service which look more appropriated to be wired into NixOS module.
- On the package maintainers field, currently I put myself as I created this PR. But I'm not sure if I should hand it to current maintainers for DMS related packages.


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test