### PR TITLE
obscura: add render support

### DIFF
--- a/pkgs/by-name/ob/obscura/package.nix
+++ b/pkgs/by-name/ob/obscura/package.nix
@@ -5,6 +5,9 @@
   rustPlatform,
   openssl,
   pkg-config,
+  cmake,
+  perl,
+  git,
   nix-update-script,
   versionCheckHook,
   _experimental-update-script-combinators,
@@ -27,8 +30,24 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-tBuPQjjqXkF+vcBRXXyi9+gcBzg8L3QH2jjixBzGODE=";
 
+  # Enable the `render` (HTML rendering/PDF) and `stealth` (anti-bot
+  # evasion) features.
+  buildFeatures = [
+    "render"
+    "stealth"
+  ];
+
   nativeBuildInputs = [
     pkg-config
+    # Sets LIBCLANG_PATH/BINDGEN_EXTRA_CLANG_ARGS for crates using the
+    # `bindgen` crate at build time (e.g. boringssl's rust bindings).
+    rustPlatform.bindgenHook
+    # btls-sys (pulled in via the `render` feature) builds its bundled
+    # BoringSSL checkout with CMake during the build.
+    cmake
+    perl
+    # btls-sys also runs `git init` on the BoringSSL checkout.
+    git
   ];
 
   buildInputs = [


### PR DESCRIPTION
Added render and stealth support for obscura

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
