### PR TITLE
nixos/matter-server: fix service with enableStrictShellChecks enabled

### DIFF
--- a/nixos/modules/services/home-automation/matter-server.nix
+++ b/nixos/modules/services/home-automation/matter-server.nix
@@ -71,7 +71,7 @@ in
         # specified. This symlinks /data at the systemd-managed
         # /var/lib/matter-server, so all files get dropped into the state
         # directory.
-        ln -s $STATE_DIRECTORY $RUNTIME_DIRECTORY/data
+        ln -s "$STATE_DIRECTORY" "$RUNTIME_DIRECTORY/data"
 
         # Create directories to hold certificates and OTA updates.
         CERT_DIR="$CACHE_DIRECTORY/certs"
@@ -87,8 +87,8 @@ in
                 vendorid = vendorId;
                 storage-path = storagePath;
                 log-level = cfg.logLevel;
-                paa-root-cert-dir = "$CERT_DIR";
-                ota-provider-dir = "$OTA_UPDATE_DIR";
+                paa-root-cert-dir = ''"$CERT_DIR"'';
+                ota-provider-dir = ''"$OTA_UPDATE_DIR"'';
               }
               // cfg.extraArgs
             )


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
