### PR TITLE
sw, sw_swaybar, sw_swaybg: init at 0-unstable-2026-04-04

### DIFF
--- a/pkgs/by-name/sw/sw/package.nix
+++ b/pkgs/by-name/sw/sw/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "sw";
+  version = "0-unstable-2026-04-04";
+
+  src = fetchFromGitHub {
+    owner = "pd2s";
+    repo = "sw";
+    rev = "fe226c9de2c5034eb13aa0d76ecf73d81fabdec0";
+    hash = "sha256-uWKJfJXVfUQrdThnBURloTLDQpn138wpIOHXKQg2E7c=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  buildPhase = ''
+    mkdir -p $out/include $out/lib64/pkgconfig
+
+    BUILD_PATH=/build HEADER_INSTALL_PATH=$out/include LIBRARY_INSTALL_PATH=$out/lib64 PKGCONFIG_INSTALL_PATH=$out/lib64/pkgconfig ./build.sh install
+  '';
+
+  meta = {
+    description = "Simple/suckless widgets";
+    homepage = "https://github.com/pd2s/sw";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.corbinwunderlich ];
+  };
+}

--- a/pkgs/by-name/sw/sw_swaybar/package.nix
+++ b/pkgs/by-name/sw/sw_swaybar/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  systemd,
+  freetype,
+  harfbuzz,
+  resvg,
+  wayland,
+  fontconfig,
+  wayland-scanner,
+  wayland-protocols,
+  libxkbcommon,
+}:
+stdenv.mkDerivation rec {
+  pname = "sw_swaybar";
+  version = "0-unstable-2026-04-04";
+
+  src = fetchFromGitHub {
+    owner = "pd2s";
+    repo = "sw";
+    rev = "fe226c9de2c5034eb13aa0d76ecf73d81fabdec0";
+    hash = "sha256-uWKJfJXVfUQrdThnBURloTLDQpn138wpIOHXKQg2E7c=";
+  };
+
+  sourceRoot = "${src.name}/examples/sw_swaybar";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    systemd
+    freetype
+    harfbuzz
+    resvg
+    wayland
+    fontconfig
+    libxkbcommon
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${src} -I./include -I${fontconfig.dev}/include/fontconfig";
+  NIX_LDFLAGS = "-lfreetype -lwayland-client -lresvg -lharfbuzz";
+
+  postConfigure = ''
+    mkdir -p include
+
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml include/xdg-shell.c
+    wayland-scanner private-code $src/wlr-layer-shell-unstable-v1.xml include/wlr-layer-shell-unstable-v1.c
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/unstable/tablet/tablet-unstable-v2.xml include/tablet-unstable-v2.c
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/staging/cursor-shape/cursor-shape-v1.xml include/cursor-shape-v1.c
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml include/xdg-decoration-unstable-v1.c
+    wayland-scanner client-header ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml include/xdg-shell.h
+    wayland-scanner client-header $src/wlr-layer-shell-unstable-v1.xml include/wlr-layer-shell-unstable-v1.h
+    wayland-scanner client-header ${wayland-protocols}/share/wayland-protocols/staging/cursor-shape/cursor-shape-v1.xml include/cursor-shape-v1.h
+    wayland-scanner client-header ${wayland-protocols}/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml include/xdg-decoration-unstable-v1.h
+  '';
+
+  buildPhase = ''
+    ./build.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp -ar sw_swaybar $out/bin
+  '';
+
+  meta = {
+    description = "A nearly feature-compatible swaybar replacement with tray DBus Menu support";
+    homepage = "https://github.com/pd2s/sw";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.corbinwunderlich ];
+    mainProgram = "sw_swaybar";
+  };
+}

--- a/pkgs/by-name/sw/sw_swaybg/package.nix
+++ b/pkgs/by-name/sw/sw_swaybg/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  resvg,
+  wayland,
+  wayland-scanner,
+  wayland-protocols,
+  libxkbcommon,
+}:
+stdenv.mkDerivation rec {
+  pname = "sw_swaybg";
+  version = "0-unstable-2026-04-04";
+
+  src = fetchFromGitHub {
+    owner = "pd2s";
+    repo = "sw";
+    rev = "fe226c9de2c5034eb13aa0d76ecf73d81fabdec0";
+    hash = "sha256-uWKJfJXVfUQrdThnBURloTLDQpn138wpIOHXKQg2E7c=";
+  };
+
+  sourceRoot = "${src.name}/examples/sw_swaybg";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    resvg
+    wayland
+    libxkbcommon
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${src} -I./include";
+  NIX_LDFLAGS = "-lwayland-client -lresvg";
+
+  postConfigure = ''
+    mkdir -p include
+
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml include/xdg-shell.c
+    wayland-scanner private-code $src/wlr-layer-shell-unstable-v1.xml include/wlr-layer-shell-unstable-v1.c
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/unstable/tablet/tablet-unstable-v2.xml include/tablet-unstable-v2.c
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/staging/cursor-shape/cursor-shape-v1.xml include/cursor-shape-v1.c
+    wayland-scanner private-code ${wayland-protocols}/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml include/xdg-decoration-unstable-v1.c
+    wayland-scanner client-header ${wayland-protocols}/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml include/xdg-shell.h
+    wayland-scanner client-header $src/wlr-layer-shell-unstable-v1.xml include/wlr-layer-shell-unstable-v1.h
+    wayland-scanner client-header ${wayland-protocols}/share/wayland-protocols/staging/cursor-shape/cursor-shape-v1.xml include/cursor-shape-v1.h
+    wayland-scanner client-header ${wayland-protocols}/share/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml include/xdg-decoration-unstable-v1.h
+  '';
+
+  buildPhase = ''
+    ./build.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp -ar sw_swaybg $out/bin
+  '';
+
+  meta = {
+    description = "A feature-compatible swaybg replacement with support for more image formats";
+    homepage = "https://github.com/pd2s/sw";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.corbinwunderlich ];
+    mainProgram = "sw_swaybg";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
