### PR TITLE
nix-easy-search: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ni/nix-easy-search/package.nix
+++ b/pkgs/by-name/ni/nix-easy-search/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "nix-easy-search";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Sh0rtRound-wq";
+    repo = "NixEasySearch";
+    rev = "v${version}";
+    hash = "sha256-LvWXZlTUVVJpcjKdVDojyuw246RgOm9dDh9LgWAT49I=";
+  };
+
+  vendorHash = null;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postInstall = ''
+    mv $out/bin/nix-easy-search $out/bin/nes
+  '';
+
+  meta = {
+    description = "Fast NixOS package search CLI with clean output";
+    homepage = "https://github.com/Sh0rtRound-wq/NixEasySearch";
+    license = lib.licenses.mit;
+    mainProgram = "nes";
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Adds `nix-easy-search` (`nes`), a fast NixOS package search CLI that
  queries                                                               
  the official package index and displays clean, human-readable output.
  Zero                                                                  
  external dependencies (pure stdlib Go), caches locally at 
  `~/.cache/nes/`.                                                      
                                                            
  Homepage: https://github.com/Sh0rtRound-wq/NixEasySearch              
                                                            
  ## Things done

  <!-- Please check what applies. Note that these are not hard          
  requirements but merely serve as information for reviewers. -->
  - Built on platform:                                                  
    - [x] x86_64-linux                                      
    - [ ] aarch64-linux
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].                               
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"  
  functionality.                                                      
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].    
  - [x] Tested basic functionality of all binary files, usually in  
  `./result/bin/`.                                                      
  - Nixpkgs Release Notes                                               
    - [ ] Package update: when the change is major or breaking.         
  - NixOS Release Notes                                                 
    - [ ] Module addition: when adding a new NixOS module.              
    - [ ] Module update: when the change is significant.  
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md],                       
  [maintainers/README.md] and other READMEs.                            
  - [x] Follows the [automation/AI policy].                             
                                                                        
  [NixOS tests]:                                                        
  https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests    
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/REA
  DME.md#package-tests                                                  
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage 
  [CONTRIBUTING.md]:                                                   
  https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md          
  [automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/C
  ONTRIBUTING.md#automationai-policy                                    
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests   
  [maintainers/README.md]:                                           
  https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md    
  [nixos/tests]:                                                    
  https://github.com/NixOS/nixpkgs/blob/master/nixos/tests              
  [pkgs/README.md]:                                                     
  https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test