### PR TITLE
darkplaces: add darwin support

### DIFF
--- a/pkgs/by-name/da/darkplaces/package.nix
+++ b/pkgs/by-name/da/darkplaces/package.nix
@@ -23,8 +23,13 @@ stdenv.mkDerivation {
     zlib
     libjpeg
     SDL2
-    libx11
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ libx11 ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace makefile.inc \
+      --replace-fail '$(SDLCONFIG_STATICLIBS)' '$(SDLCONFIG_LIBS)'
+  '';
 
   buildFlags = [ "release" ];
 
@@ -38,12 +43,18 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  postFixup = ''
-    patchelf \
-      --add-needed ${libvorbis}/lib/libvorbisfile.so \
-      --add-needed ${libvorbis}/lib/libvorbis.so \
-      $out/bin/darkplaces
-  '';
+  postFixup =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf \
+        --add-needed ${libvorbis}/lib/libvorbisfile.so \
+        --add-needed ${libvorbis}/lib/libvorbis.so \
+        $out/bin/darkplaces
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      ${stdenv.cc.targetPrefix}install_name_tool \
+        -add_rpath ${lib.getLib libvorbis}/lib \
+        $out/bin/darkplaces
+    '';
 
   meta = {
     homepage = "https://www.icculus.org/twilight/darkplaces/";
@@ -56,6 +67,6 @@ stdenv.mkDerivation {
     '';
     maintainers = with lib.maintainers; [ necrophcodr ];
     license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
