### PR TITLE
tauon: 11.1.1 -> 12.0.0

### DIFF
--- a/pkgs/by-name/ta/tauon/package.nix
+++ b/pkgs/by-name/ta/tauon/package.nix
@@ -28,12 +28,12 @@
   withDiscordRPC ? true,
 }:
 let
-  version = "11.1.1";
+  version = "12.0.0";
   src = fetchFromGitHub {
     owner = "Taiko2k";
     repo = "Tauon";
     tag = "v${version}";
-    hash = "sha256-/E8+c8FX8JnSaYgaXRKE2u6eIWjkL4yGU1WQTluGWjY=";
+    hash = "sha256-IefyP/sKdalt6HZR8SirFnVP+qZY6U843Jr2OoZW+xU=";
   };
 
   lrclib-solver = rustPlatform.buildRustPackage {

--- a/pkgs/by-name/ta/tauon/package.nix
+++ b/pkgs/by-name/ta/tauon/package.nix
@@ -69,6 +69,10 @@ python3Packages.buildPythonApplication {
   postPatch = ''
     substituteInPlace src/tauon/t_modules/t_phazor.py \
       --replace-fail 'base_path = Path(pctl.install_directory).parent.parent / "build"' 'base_path = Path("${placeholder "out"}/${python3Packages.python.sitePackages}")'
+
+    substituteInPlace pyproject.toml \
+      --replace-fail '/usr/include/pipewire-0.3' '${pipewire.dev}/include/pipewire-0.3' \
+      --replace-fail '/usr/include/spa-0.2' '${pipewire.dev}/include/spa-0.2'
   '';
 
   pythonRemoveDeps = [


### PR DESCRIPTION
After: #549863 (based on it, since it has quite a few reviews already and touches the same file)
This PR would also fix the related issue (#549538) by just not crashing when the tray icon is not created, because of https://github.com/Taiko2k/Tauon/commit/7c7bbd167c97acfca3ba077bf0fab7df36b008d0.

Release Notes: https://github.com/Taiko2k/Tauon/releases/tag/v12.0.0
Full Changelog: https://github.com/Taiko2k/Tauon/compare/v11.1.1...v12.0.0

The first (new) commit updates the version and hash.
The second fixes a crash on launch (and the related non-critical error during the build).

I'm unsure if the crash is replicable without `audio.use-pipewire = true`, but it's worth fixing either way.
It was introduced by https://github.com/Taiko2k/Tauon/commit/1f555d011d816ec55657575a5c8b04a54b21ab11, which set up `setuptools` to compile `phazor.c` with pipewire using some hardcoded `/usr/include` library paths, so I just `substitueInPlace`d them with the actual library paths from the `pipewire.dev` package.
There may be a better way to do that, but it seems fairly straightforward and will fail loudly.
Adding `pipewire`/`pipewire.dev` to the `LD_LIBRARY_PATH` doesn't work, since `phazor.c` is using `<pipewire/pipewire.h>` directly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
