### PR TITLE
mpv: configure fonts that comes with scripts

### DIFF
--- a/pkgs/by-name/mp/mpv/package.nix
+++ b/pkgs/by-name/mp/mpv/package.nix
@@ -3,6 +3,7 @@
   buildEnv,
   lib,
   makeBinaryWrapper,
+  makeFontsConf,
   mpvScripts,
   mpv-unwrapped,
   symlinkJoin,
@@ -14,6 +15,10 @@
   # to have a `scriptName` passthru attribute that points to the name of the
   # script that would reside in the script's derivation's
   # `$out/share/mpv/scripts/`.
+  #
+  # A script that comes with fonts (e.g. icon font used by OSC replacement)
+  # can provide `passthru.fontDirectories` with a list of dirs.
+  # They will be merged into fontconfig for the wrapper.
   #
   # A script can optionally also provide `passthru.extraWrapperArgs`
   # attribute.
@@ -70,6 +75,24 @@ let
       ":"
       fallbackBinPath
     ]
+    ++ (
+      let
+        fontDirectories = lib.concatMap (script: script.fontDirectories or [ ]) scripts;
+      in
+      lib.optionals (fontDirectories != [ ]) (
+        [
+          "--set"
+          "FONTCONFIG_FILE"
+          (toString (makeFontsConf {
+            inherit fontDirectories;
+          }))
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          "--add-flags"
+          "--osd-font-provider=fontconfig"
+        ]
+      )
+    )
     ++ (lib.lists.flatten (
       map
         # For every script in the `scripts` argument, add the necessary flags to the wrapper

--- a/pkgs/by-name/mp/mpv/scripts/modernx-zydezu.nix
+++ b/pkgs/by-name/mp/mpv/scripts/modernx-zydezu.nix
@@ -3,7 +3,6 @@
   buildLua,
   fetchFromGitHub,
   installFonts,
-  makeFontsConf,
   mpvScripts,
   nix-update-script,
 }:
@@ -21,13 +20,7 @@ buildLua (finalAttrs: {
 
   nativeBuildInputs = [ installFonts ];
 
-  passthru.extraWrapperArgs = [
-    "--set"
-    "FONTCONFIG_FILE"
-    (toString (makeFontsConf {
-      fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
-    }))
-  ];
+  passthru.fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/mp/mpv/scripts/modernx.nix
+++ b/pkgs/by-name/mp/mpv/scripts/modernx.nix
@@ -3,7 +3,6 @@
   buildLua,
   fetchFromGitHub,
   installFonts,
-  makeFontsConf,
   nix-update-script,
 }:
 buildLua (finalAttrs: {
@@ -20,13 +19,7 @@ buildLua (finalAttrs: {
 
   nativeBuildInputs = [ installFonts ];
 
-  passthru.extraWrapperArgs = [
-    "--set"
-    "FONTCONFIG_FILE"
-    (toString (makeFontsConf {
-      fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
-    }))
-  ];
+  passthru.fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/mp/mpv/scripts/modernz.nix
+++ b/pkgs/by-name/mp/mpv/scripts/modernz.nix
@@ -3,7 +3,6 @@
   buildLua,
   fetchFromGitHub,
   installFonts,
-  makeFontsConf,
   nix-update-script,
 }:
 buildLua (finalAttrs: {
@@ -20,13 +19,7 @@ buildLua (finalAttrs: {
 
   nativeBuildInputs = [ installFonts ];
 
-  passthru.extraWrapperArgs = [
-    "--set"
-    "FONTCONFIG_FILE"
-    (toString (makeFontsConf {
-      fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
-    }))
-  ];
+  passthru.fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/mp/mpv/scripts/mpv-osc-modern.nix
+++ b/pkgs/by-name/mp/mpv/scripts/mpv-osc-modern.nix
@@ -3,7 +3,6 @@
   buildLua,
   fetchFromGitHub,
   installFonts,
-  makeFontsConf,
   nix-update-script,
 }:
 buildLua (finalAttrs: {
@@ -20,13 +19,7 @@ buildLua (finalAttrs: {
 
   nativeBuildInputs = [ installFonts ];
 
-  passthru.extraWrapperArgs = [
-    "--set"
-    "FONTCONFIG_FILE"
-    (toString (makeFontsConf {
-      fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
-    }))
-  ];
+  passthru.fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/mp/mpv/scripts/uosc.nix
+++ b/pkgs/by-name/mp/mpv/scripts/uosc.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   gitUpdater,
-  makeFontsConf,
   buildLua,
   buildGoModule,
   installFonts,
@@ -30,13 +29,8 @@ buildLua (finalAttrs: {
   };
 
   # the script uses custom "texture" fonts as the background for ui elements.
-  # In order for mpv to find them, we need to adjust the fontconfig search path.
+  passthru.fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
   passthru.extraWrapperArgs = [
-    "--set"
-    "FONTCONFIG_FILE"
-    (toString (makeFontsConf {
-      fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
-    }))
     "--set"
     "MPV_UOSC_ZIGGY"
     (lib.getExe' finalAttrs.tools "ziggy")

--- a/pkgs/by-name/mp/mpv/scripts/uosc.nix
+++ b/pkgs/by-name/mp/mpv/scripts/uosc.nix
@@ -5,6 +5,7 @@
   makeFontsConf,
   buildLua,
   buildGoModule,
+  installFonts,
 }:
 
 buildLua (finalAttrs: {
@@ -20,6 +21,8 @@ buildLua (finalAttrs: {
   };
   passthru.updateScript = gitUpdater { };
 
+  nativeBuildInputs = [ installFonts ];
+
   tools = buildGoModule {
     pname = "uosc-bin";
     inherit (finalAttrs) version src;
@@ -28,7 +31,6 @@ buildLua (finalAttrs: {
 
   # the script uses custom "texture" fonts as the background for ui elements.
   # In order for mpv to find them, we need to adjust the fontconfig search path.
-  postInstall = "cp -r src/fonts $out/share";
   passthru.extraWrapperArgs = [
     "--set"
     "FONTCONFIG_FILE"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

i tried to use modernz script on darwin (which worked pretty well on my nixos laptop) and it just shows text fallback for the icons

closes https://github.com/NixOS/nixpkgs/issues/464174

also move mpvScripts.uosc to use installFonts hook per https://github.com/NixOS/nixpkgs/issues/495640

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
