### PR TITLE
nixos/fittrackee: init module

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -202,4 +202,4 @@
 
 ### Additions and Improvements {#sec-nixpkgs-release-26.11-lib-additions-improvements}
 
-- Create the first release note entry in this section!
+- `services.fittrackee` was added to support the existing `fittrackee` package

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1699,6 +1699,7 @@
   ./services/web-apps/filebrowser.nix
   ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/firefly-iii.nix
+  ./services/web-apps/fittrackee.nix
   ./services/web-apps/flarum.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freescout.nix

--- a/nixos/modules/services/web-apps/fittrackee.nix
+++ b/nixos/modules/services/web-apps/fittrackee.nix
@@ -1,0 +1,306 @@
+# TODO: move to web-apps
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  inherit (lib)
+    literalExpression
+    mkDefault
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    mkOption
+    optionalAttrs
+    optionals
+    types
+    ;
+  cfg = config.services.fittrackee;
+in
+{
+  options.services.fittrackee = {
+    enable = mkEnableOption "Enable FitTrackee";
+    email = {
+      enable = mkEnableOption "Is email enabled? EMAIL_URL must be set";
+      sender = mkOption {
+        description = "The email address to send mail from";
+        type = types.str;
+      };
+    };
+    openFirewall = mkEnableOption "Open Firewall";
+    user = mkOption {
+      description = "User for FitTrackee";
+      type = types.str;
+      default = "fittrackee";
+    };
+    group = mkOption {
+      description = "Group for FitTrackee";
+      type = types.str;
+      default = "fittrackee";
+    };
+    environmentFile = mkOption {
+      description = "Path to the environment file. Override base settings in here.";
+      type = types.either types.str types.path;
+      default = "";
+    };
+    package = mkPackageOption pkgs "fittrackee" { };
+    flaskPackage = mkPackageOption pkgs.python3Packages "flask" { };
+    gunicornPackage = mkPackageOption pkgs.python3Packages "gunicorn" { };
+    stateDir = mkOption {
+      description = "Where to store the state and uploads";
+      type = types.str;
+      default = "/var/lib/fittrackee";
+    };
+    settings = mkOption {
+      description = "Extra settings";
+      type = types.submodule {
+        freeformType = types.attrsOf types.str;
+        options = {
+          APP_WORKERS = mkOption {
+            description = "How many Gunicorn Workers to use";
+            type = types.int;
+            default = 1;
+          };
+          DATABASE_URL = mkOption {
+            description = "Database URL with username and password";
+            type = types.str;
+            default =
+              if cfg.database.socket != null then
+                "postgresql://${cfg.database.user}:@${cfg.database.name}?host=${cfg.database.socket}"
+              else
+                "postgresql://${cfg.database.user}:@${cfg.database.host}:${cfg.database.port}/${cfg.database.name}";
+          };
+          REDIS_URL = mkOption {
+            description = "Redis instance used by Dramatiq and Flask-Limiter.";
+            type = types.str;
+            default =
+              if cfg.redis.enable then
+                "redis://${cfg.redis.host}:${toString cfg.redis.port}/${toString cfg.redis.database}"
+              else
+                "redis://";
+          };
+          HOST = mkOption {
+            description = "Host";
+            type = types.str;
+            default = "127.0.0.1";
+          };
+          PORT = mkOption {
+            description = "What port to run Fittrackee on.";
+            type = types.port;
+            default = 8000;
+          };
+          UI_URL = mkOption {
+            description = "URL for FitTrackee";
+            type = types.str;
+            default = "http://127.0.0.1";
+          };
+          UPLOAD_FOLDER = mkOption {
+            description = "Absolute path to the directory where uploads folder will be created.";
+            type = types.str;
+            default = cfg.stateDir;
+          };
+        };
+      };
+      default = { };
+    };
+    database = {
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Database host address.";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 5432;
+        description = "Database host port.";
+      };
+
+      name = mkOption {
+        type = types.str;
+        default = "fittrackee";
+        description = "Database name.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "fittrackee";
+        description = "Database user.";
+      };
+
+      socket = mkOption {
+        type = types.nullOr types.path;
+        default = if cfg.database.createDatabase then "/run/postgresql" else null;
+        defaultText = literalExpression "null";
+        example = "/run/postgresql";
+        description = "Path to the unix socket file to use for authentication.";
+      };
+
+      createDatabase = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to create a local database automatically.";
+      };
+    };
+
+    redis = {
+      enable = mkEnableOption "Whether to use redis at all";
+
+      createLocally = lib.mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to create a local redis automatically.";
+      };
+
+      name = lib.mkOption {
+        type = types.str;
+        default = "fittrackee";
+        description = ''
+          Name of the redis server.
+          Only used if {option}`services.fittrackee.redis.createLocally` is set to true.
+        '';
+      };
+
+      host = lib.mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Redis server address.";
+      };
+
+      port = lib.mkOption {
+        type = types.port;
+        default = 6379;
+        description = "Port of the redis server.";
+      };
+
+      database = lib.mkOption {
+        type = types.int;
+        default = 1;
+        description = "Which redis db to use";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.database.createDatabase -> (cfg.database.user == cfg.database.name);
+        message = ''
+          When creating a database via NixOS, the db user and db name must be equal!
+          If you already have an existing DB+user and this assertion is new, you can safely set
+          `services.fittrackee.createDatabase` to `false` because removal of `ensureUsers`
+          and `ensureDatabases` doesn't have any effect.
+        '';
+      }
+    ];
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+    users.groups = mkIf (cfg.group == "fittrackee") { fittrackee = { }; };
+    users.users = mkIf (cfg.user == "fittrackee") {
+      fittrackee = {
+        inherit (cfg) group;
+        home = cfg.stateDir;
+        description = "FitTrackee Daemon user";
+        isSystemUser = true;
+      };
+    };
+
+    services.postgresql = optionalAttrs cfg.database.createDatabase {
+      enable = mkDefault true;
+
+      extensions = ps: with ps; [ postgis ];
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+      initialScript = builtins.toFile "init.sql" ''
+        CREATE USER ${cfg.database.user};
+        CREATE SCHEMA ${cfg.database.name} AUTHORIZATION ${cfg.database.user};
+        CREATE DATABASE ${cfg.database.name} OWNER ${cfg.database.user};
+
+        \connect ${cfg.database.name}
+
+        CREATE EXTENSION postgis;
+      '';
+    };
+
+    services.redis.servers = optionalAttrs (cfg.redis.enable && cfg.redis.createLocally) {
+      ${cfg.redis.name} = {
+        inherit (cfg.redis) port;
+
+        enable = true;
+        bind = cfg.redis.host;
+      };
+    };
+
+    systemd.services.fittrackee = {
+      environment = lib.mapAttrs (_: value: toString value) cfg.settings;
+
+      description = "Self-hosted outdoor activity tracker";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      requires = optionals cfg.database.createDatabase [
+        "postgresql.target"
+      ];
+
+      after = [
+        "network.target"
+        "postgres.service"
+        "redis.service"
+      ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+
+        Type = "simple";
+        RestartSec = 1;
+        Restart = "on-failure";
+        WorkingDirectory = "/var/lib/fittrackee";
+        ExecStart = lib.getExe' cfg.package "fittrackee";
+        ExecStartPre = "${lib.getExe' cfg.package "ftcli"} db upgrade";
+
+        SyslogIdentifier = "fittrackee";
+        StateDirectory = mkIf (cfg.stateDir == "/var/lib/fittrackee") "fittrackee";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != "") cfg.environmentFile;
+
+        RemoveIPC = true;
+        NoNewPrivileges = true;
+        CapabilityBoundingSet = "";
+        SystemCallFilter = [ "@system-service" ];
+        ProtectSystem = "full";
+        PrivateTmp = true;
+        ProtectProc = "invisible";
+        ProtectClock = true;
+        ProcSubset = "pid";
+        PrivateUsers = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [
+          "AF_LOCAL"
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+        ];
+
+        LockPersonality = true;
+        RestrictNamespaces = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        SystemCallArchitectures = "native";
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+      };
+    };
+  };
+  meta.maintainers = pkgs.fittrackee.meta.maintainers;
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -635,6 +635,7 @@ in
   firewalld = runTest ./firewalld.nix;
   firezone = runTest ./firezone/firezone.nix;
   fish = runTest ./fish.nix;
+  fittrackee = runTest ./fittrackee.nix;
   flannel = runTestOn [ "x86_64-linux" ] ./flannel.nix;
   flap-alerted = runTest ./flap-alerted.nix;
   flaresolverr = runTest ./flaresolverr.nix;

--- a/nixos/tests/fittrackee.nix
+++ b/nixos/tests/fittrackee.nix
@@ -1,0 +1,38 @@
+{ ... }:
+{
+  name = "fittrackee";
+  nodes = {
+    base =
+      { ... }:
+      {
+        services = {
+          fittrackee = {
+            enable = true;
+            database.createDatabase = true;
+          };
+        };
+      };
+    with-redis = { ... }: {
+      services = {
+        fittrackee = {
+          enable = true;
+          database.createDatabase = true;
+          redis = {
+            enable = true;
+            createLocally = true;
+          };
+        };
+      };
+    };
+  };
+
+  # https://nixos.org/manual/nixos/stable/index.html#ssec-machine-objects
+  testScript = ''
+    start_all()
+    for node in [base, with_redis]:
+      node.wait_for_unit("postgresql.service")
+      node.wait_for_unit("fittrackee.service")
+      node.wait_for_open_port(8000)
+      node.execute("curl http://127.0.0.1:8000")
+  '';
+}

--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -8,6 +8,7 @@
   postgresql,
   postgresqlTestHook,
   python3Packages,
+  nixosTests,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "fittrackee";
@@ -123,11 +124,16 @@ python3Packages.buildPythonApplication (finalAttrs: {
     export UI_URL=http://0.0.0.0:5000
   '';
 
+  passthru = {
+    tests.fittrackee = nixosTests.fittrackee;
+  };
+
   meta = {
     description = "Self-hosted outdoor activity tracker";
     homepage = "https://docs.fittrackee.org/";
     changelog = "https://codeberg.org/FitTrackee/FitTrackee/src/tag/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with lib.maintainers; [
       tebriel
       traxys


### PR DESCRIPTION
Initialize Fittrackee Module
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
