### PR TITLE
feishin: bump electron to v43, clean up

### DIFF
--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildNpmPackage,
   fetchFromGitHub,
-  electron_41,
+  electron_43,
   mpv-unwrapped,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -27,7 +27,7 @@ let
     hash = "sha256-2UKJBUZNUpUUZIG1JFXok7YJdzqt+Ge0ykHUm8BeNcw=";
   };
 
-  electron = electron_41;
+  electron = electron_43;
 
   # Fix pnpm issue on darwin https://github.com/NixOS/nixpkgs/issues/525627
   pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_latest; };

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -15,27 +15,24 @@
   makeDesktopItem,
   nix-update-script,
   webVersion ? false,
+  nixosTests,
 }:
 let
+  electron = electron_43;
+
+  # Fix pnpm issue on darwin https://github.com/NixOS/nixpkgs/issues/525627
+  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_latest; };
+in
+buildNpmPackage (finalAttrs: {
   pname = "feishin";
   version = "1.15.1";
 
   src = fetchFromGitHub {
     owner = "jeffvli";
     repo = "feishin";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2UKJBUZNUpUUZIG1JFXok7YJdzqt+Ge0ykHUm8BeNcw=";
   };
-
-  electron = electron_43;
-
-  # Fix pnpm issue on darwin https://github.com/NixOS/nixpkgs/issues/525627
-  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_latest; };
-in
-buildNpmPackage {
-  inherit pname version;
-
-  inherit src;
 
   __structuredAttrs = true;
 
@@ -44,9 +41,9 @@ buildNpmPackage {
 
   npmDeps = null;
   pnpmDeps = fetchPnpmDeps {
-    inherit
+    inherit pnpm;
+    inherit (finalAttrs)
       pname
-      pnpm
       version
       src
       ;
@@ -145,12 +142,19 @@ buildNpmPackage {
     })
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+
+    # add a tests
+    tests = {
+      inherit (nixosTests.feishin) caddy nginx;
+    };
+  };
 
   meta = {
     description = "Full-featured Jellyfin, Navidrome, and OpenSubsonic Compatible Music Player";
     homepage = "https://github.com/jeffvli/feishin";
-    changelog = "https://github.com/jeffvli/feishin/releases/tag/v${version}";
+    changelog = "https://github.com/jeffvli/feishin/releases/tag/v${finalAttrs.version}";
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
@@ -161,4 +165,4 @@ buildNpmPackage {
     ];
   }
   // lib.optionalAttrs (!webVersion) { mainProgram = "feishin"; };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Work towards: #555100

## Things done
- rewrite to use finalAttrs
- added a tests
- bump electron version to v43
- basic test passed in NixOS-WSL
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
