### PR TITLE
qmk: Clean up, remove pkgsCross, add tests, adopt

### DIFF
--- a/pkgs/by-name/qm/qmk/avr.nix
+++ b/pkgs/by-name/qm/qmk/avr.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  qmk,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "qmk-avr";
+  version = "none";
+
+  src = fetchFromGitHub {
+    owner = "qmk";
+    repo = "qmk_firmware";
+    tag = "0.33.13";
+    fetchSubmodules = true;
+    hash = "sha256-FDN+pQrgdKqleku5L6xViajY1jEkjZZX5ZGx46N8dkw=";
+  };
+
+  nativeBuildInputs = [
+    qmk
+  ];
+
+  buildPhase = ''
+    qmk compile -kb bpiphany/pegasushoof -km default -e VERBOSE=true -e SKIP_GIT=true -e LTO_ENABLE=true
+  '';
+
+  installPhase = ''
+    mkdir "$out"
+    cp .build/*.hex "$out"
+  '';
+}

--- a/pkgs/by-name/qm/qmk/package.nix
+++ b/pkgs/by-name/qm/qmk/package.nix
@@ -2,17 +2,32 @@
   lib,
   python3Packages,
   fetchPypi,
-  pkgsCross,
   avrdude,
   bootloadhid,
   dfu-programmer,
   dfu-util,
   wb32-dfu-updater,
-  gcc-arm-embedded,
   gnumake,
   teensy-loader-cli,
+  binutils,
+  gcc,
+  libc,
 }:
-
+let
+  runtimeBuildTools = [
+    avrdude
+    bootloadhid
+    dfu-programmer
+    dfu-util
+    wb32-dfu-updater
+    teensy-loader-cli
+    gnumake
+    binutils
+    binutils.bintools
+    gcc
+    libc
+  ];
+in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "qmk";
   version = "1.2.0";
@@ -42,24 +57,18 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pillow
   ];
 
-  propagatedBuildInputs = [
-    # Binaries need to be in the path so this is in propagatedBuildInputs
-    avrdude
-    bootloadhid
-    dfu-programmer
-    dfu-util
-    wb32-dfu-updater
-    teensy-loader-cli
-    gcc-arm-embedded
-    gnumake
-    pkgsCross.avr.buildPackages.binutils
-    pkgsCross.avr.buildPackages.binutils.bintools
-    pkgsCross.avr.buildPackages.gcc
-    pkgsCross.avr.libc
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    "${lib.makeBinPath runtimeBuildTools}"
   ];
 
   # no tests implemented
   doCheck = false;
+
+  # Passthru helper for getting the AVR-targetting QMK
+  passthru.avr = pkgsCross.buildPackages.qmk;
 
   meta = {
     homepage = "https://github.com/qmk/qmk_cli";

--- a/pkgs/by-name/qm/qmk/package.nix
+++ b/pkgs/by-name/qm/qmk/package.nix
@@ -12,6 +12,8 @@
   binutils,
   gcc,
   libc,
+  # TESTING ONLY
+  pkgsCross,
 }:
 let
   runtimeBuildTools = [
@@ -67,9 +69,16 @@ python3Packages.buildPythonApplication (finalAttrs: {
   # no tests implemented
   doCheck = false;
 
-  # Passthru helper for getting the AVR-targetting QMK
-  passthru.avr = pkgsCross.buildPackages.qmk;
+  passthru = {
+    # Passthru helper for getting an AVR-targetting QMK
+    avr = pkgsCross.buildPackages.qmk;
 
+    tests = {
+      # Cannot use finalAttrs.finalPackage here
+      # because it is not spliced, and this must be spliced.
+      avr = pkgsCross.avr.callPackage ./avr.nix { };
+    };
+  };
   meta = {
     homepage = "https://github.com/qmk/qmk_cli";
     description = "Program to help users work with QMK Firmware";

--- a/pkgs/by-name/qm/qmk/package.nix
+++ b/pkgs/by-name/qm/qmk/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
   pkgsCross,
   avrdude,
@@ -13,7 +13,7 @@
   teensy-loader-cli,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "qmk";
   version = "1.2.0";
   pyproject = true;
@@ -23,38 +23,40 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-FkvRbExAGyt2XuTwF7z6gUGULd82KWHEy6GXXYyyikg=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  propagatedBuildInputs =
-    with python3.pkgs;
-    [
-      dotty-dict
-      hid
-      hjson
-      jsonschema
-      milc
-      pygments
-      pyserial
-      pyusb
-      pillow
-    ]
-    ++ [
-      # Binaries need to be in the path so this is in propagatedBuildInputs
-      avrdude
-      bootloadhid
-      dfu-programmer
-      dfu-util
-      wb32-dfu-updater
-      teensy-loader-cli
-      gcc-arm-embedded
-      gnumake
-      pkgsCross.avr.buildPackages.binutils
-      pkgsCross.avr.buildPackages.binutils.bintools
-      pkgsCross.avr.buildPackages.gcc
-      pkgsCross.avr.libc
-    ];
+  dependencies = with python3Packages; [
+    dotty-dict
+    hid
+    hjson
+    jsonschema
+    milc
+    pygments
+    pyserial
+    pyusb
+    pillow
+  ];
+
+  propagatedBuildInputs = [
+    # Binaries need to be in the path so this is in propagatedBuildInputs
+    avrdude
+    bootloadhid
+    dfu-programmer
+    dfu-util
+    wb32-dfu-updater
+    teensy-loader-cli
+    gcc-arm-embedded
+    gnumake
+    pkgsCross.avr.buildPackages.binutils
+    pkgsCross.avr.buildPackages.binutils.bintools
+    pkgsCross.avr.buildPackages.gcc
+    pkgsCross.avr.libc
+  ];
 
   # no tests implemented
   doCheck = false;
@@ -76,8 +78,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
         - qmk lint
       - ... and many more!
     '';
-    license = lib.licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.PLUS lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.RossSmyth ];
     mainProgram = "qmk";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. To contemporary Python packaging, structuredAttrs
2. Remove pkgsCross
3. Add test
4. Add passthru helper for getting a target

TODO: Fix arm-thumb-newlib-nano

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
