### PR TITLE
vxwm: init at 2.3-unstable-2026-08-08

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1939,6 +1939,7 @@
   ./services/x11/window-managers/none.nix
   ./services/x11/window-managers/oxwm.nix
   ./services/x11/window-managers/twm.nix
+  ./services/x11/window-managers/vxwm.nix
   ./services/x11/window-managers/windowlab.nix
   ./services/x11/window-managers/wmii.nix
   ./services/x11/window-managers/xmonad.nix

--- a/nixos/modules/services/x11/window-managers/vxwm.nix
+++ b/nixos/modules/services/x11/window-managers/vxwm.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.vxwm;
+in
+{
+  options = {
+    services.xserver.windowManager.vxwm.enable = mkEnableOption "vxwm";
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "vxwm";
+      start = ''
+        ${pkgs.vxwm}/bin/vxwm &
+        waitPID=$!
+      '';
+    };
+    environment.systemPackages = [ pkgs.vxwm ];
+  };
+}

--- a/pkgs/by-name/vx/vxwm/package.nix
+++ b/pkgs/by-name/vx/vxwm/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  pkg-config,
+  libx11,
+  libxft,
+  libxinerama,
+  fontconfig,
+}:
+stdenv.mkDerivation {
+  pname = "vxwm";
+  version = "2.3-unstable-2026-08-08";
+
+  src = fetchFromCodeberg {
+    owner = "wh1tepearl";
+    repo = "vxwm";
+    rev = "e3c929a622f87a4463fd1feb99dd3faf3acd3f55";
+    hash = "sha256-W7BYpvU1oBfHN3QzZDvDhWVEQ4w/1hKRFdiDzpqfhJ8=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libx11
+    libxft
+    libxinerama
+    fontconfig
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "MANPREFIX=$(out)/share/man"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Versatile X Window Manager for X11 forked from dwm";
+    homepage = "https://codeberg.org/wh1tepearl/vxwm";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dmkhitaryan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "vxwm";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Builds `vxwm`, a versatile X Window Manager for X11 forked from `dwm` where windows exist across infinite tags on a continuous canvas. Additionally includes the module for the window manager under `services.xserver.windowManager.vxwm`.

Homepage: https://codeberg.org/wh1tepearl/vxwm

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
