### PR TITLE
edamame: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18779,6 +18779,11 @@
     githubId = 43088426;
     name = "Mihnea Stoian";
   };
+  mijowi = {
+    github = "mijowi";
+    githubId = 10594600;
+    name = "mijowi";
+  };
   mikaeladev = {
     email = "mikaeladev@icloud.com";
     github = "mikaeladev";

--- a/pkgs/by-name/ed/edamame/package.nix
+++ b/pkgs/by-name/ed/edamame/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "edamame";
+  version = "0.1.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mijowi";
+    repo = "edamame";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZLnp2ej2E3+qg2LOPPZundT+XsgYR4EbhYd7uqCWab8=";
+  };
+
+  cargoHash = "sha256-O/cFL8yRvCnQUBlmooveChD5RiSbU6gbFGSxeQctLGs=";
+
+  # The watcher tests need live inotify/FSEvents notifications, which the Nix
+  # build sandbox doesn't deliver — on Darwin builders not at all.  Both skips
+  # are needed: the second test's name does not contain "watcher", so the
+  # first pattern misses it.  Everything else runs offline fine.
+  checkFlags = [
+    "--skip=watcher"
+    "--skip=rewatching_a_different_file_redirects_events"
+  ];
+
+  meta = {
+    description = "Fast TUI Markdown editor and viewer";
+    homepage = "https://github.com/mijowi/edamame";
+    changelog = "https://github.com/mijowi/edamame/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mijowi ];
+    mainProgram = "edamame";
+    platforms = lib.platforms.unix; # dist ships macOS + Linux, no Windows
+  };
+})


### PR DESCRIPTION
Adds edamame, a fast TUI Markdown editor and viewer written in Rust. It renders the document (headings, table grids, inline images, Mermaid diagrams) while you edit, dropping only the cursor line to raw Markdown. Apache-2.0.

I'm the upstream author and am adding myself as maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
