### PR TITLE
nushellPlugins.port_extension: init at 0.115.0

### DIFF
--- a/pkgs/by-name/nu/nushell/plugins/default.nix
+++ b/pkgs/by-name/nu/nushell/plugins/default.nix
@@ -12,6 +12,7 @@
   highlight = callPackage ./highlight/package.nix { };
   net = callPackage ./net/package.nix { };
   polars = callPackage ./polars/package.nix { };
+  port_extension = callPackage ./port_extension/package.nix { };
   query = callPackage ./query/package.nix { };
   semver = callPackage ./semver/package.nix { };
   skim = callPackage ./skim/package.nix { };

--- a/pkgs/by-name/nu/nushell/plugins/port_extension/package.nix
+++ b/pkgs/by-name/nu/nushell/plugins/port_extension/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nu_plugin_port_extension";
+  version = "0.115.0";
+
+  src = fetchFromGitHub {
+    owner = "fmotalleb";
+    repo = "nu_plugin_port_extension";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J+IWBiRQBwJSraSYY3wtSH+iCLebw57Z92T+iUlkHfQ=";
+  };
+
+  cargoHash = "sha256-r3EoXsPnn6JmyYjfh1Cs6HtuQSb2ZLg3UnWHFQLobBM=";
+
+  passthru.update-script = nix-update-script { };
+
+  meta = {
+    description = "Nushell plugin for listing active connections and scanning ports on a target address";
+    mainProgram = "nu_plugin_port_extension";
+    homepage = "https://github.com/fmotalleb/nu_plugin_port_extension";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dav-wolff ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Nushell plugin for listing active connections and scanning ports on a target address
https://github.com/fmotalleb/nu_plugin_port_extension

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
