### PR TITLE
yandex-music: 5.63.1 -> 5.116.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -118,6 +118,12 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `yandex-music` has been switched to the official Linux client instead of a repack of the Windows build.
+  The repack-specific package options (`trayEnabled`, `trayStyle`, `trayAlways`, `devTools`,
+  `vibeAnimationMaxFps`, `customTitleBar`, `electronArguments`) were removed: the official client
+  configures tray and title bar natively. The profile directory changed from `~/.config/yandex-music`
+  to `~/.config/YandexMusic`, so re-login is required.
+
 - Artalk has been updated to 2.10.0. Its default configuration and data
   directory discovery changed; see the [upstream migration
   guide](https://artalk.js.org/en/guide/releases/v2.10.0.html) when invoking

--- a/pkgs/by-name/ya/yandex-music/package.nix
+++ b/pkgs/by-name/ya/yandex-music/package.nix
@@ -1,122 +1,78 @@
 {
-  fetchurl,
-  stdenvNoCC,
   lib,
+  stdenvNoCC,
+  fetchurl,
+  dpkg,
   makeWrapper,
-  p7zip,
   asar,
-  jq,
-  python3,
   electron,
-  fetchFromGitHub,
-  electronArguments ? "",
-
-  # Whether to enable tray menu by default
-  trayEnabled ? true,
-  # Style of tray: 1 - default style, 2 - mono black, 3 - mono white
-  trayStyle ? 1,
-  # Whether to leave application in tray disregarding of its play state
-  trayAlways ? false,
-  # Whether to enable developers tools
-  devTools ? false,
-  # Vibe animation FPS can be  from 0 (black screen) to any reasonable number.
-  # Recommended 25 - 144. Default 25.
-  vibeAnimationMaxFps ? 25,
-  # Yandex Music's custom Windows-styled titlebar. Also makes the window frameless.
-  customTitleBar ? false,
 }:
-assert lib.assertMsg (trayStyle >= 1 && trayStyle <= 3) "Tray style must be withing 1 and 3";
-assert lib.assertMsg (vibeAnimationMaxFps >= 0) "Vibe animation max FPS must be greater then 0";
+
 stdenvNoCC.mkDerivation rec {
   pname = "yandex-music";
-  version = "5.63.1";
+  version = "5.116.3";
 
-  src = fetchFromGitHub {
-    owner = "cucumber-sp";
-    repo = "yandex-music-linux";
-    # tags are retagged for some bug fixes
-    rev = "066a6c7f503304d2181db04c5ed379a80f9137b8";
-    hash = "sha256-z+gmUG0/7ykF42+OlFGZC268Tj8+vpfgZRYrW4otpfM=";
+  src = fetchurl {
+    url = "https://desktop.app.music.yandex.net/stable/Yandex_Music_amd64_${version}.deb";
+    hash = "sha256-GvjQiwPN0VrD+Os4b8VNMxT5i4HG4izThZmiCpja9Bg=";
   };
 
   nativeBuildInputs = [
-    p7zip
-    asar
-    jq
-    python3
+    dpkg
     makeWrapper
+    asar
   ];
 
-  passthru.updateScript = ./update.sh;
+  dontConfigure = true;
 
-  ymExe =
-    let
-      ym_info = builtins.fromJSON (builtins.readFile ./ym_info.json);
-    in
-    fetchurl {
-      url = ym_info.exe_link;
-      hash = ym_info.exe_hash;
-    };
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x "$src" .
+    runHook postUnpack
+  '';
 
   buildPhase = ''
     runHook preBuild
-    bash "./repack.sh" -o "./app" "$ymExe"
+    asar extract "opt/Яндекс Музыка/resources/app.asar" app
+    cp -r "opt/Яндекс Музыка/resources/assets" app/assets
+    substituteInPlace app/index.js \
+      --replace-fail "process.resourcesPath" "__dirname"
+    asar pack app app.asar
     runHook postBuild
   '';
-
-  config =
-    let
-      inherit (lib) optionalString;
-    in
-    ''
-      ELECTRON_ARGS="${electronArguments}"
-      VIBE_ANIMATION_MAX_FPS=${toString vibeAnimationMaxFps}
-    ''
-    + optionalString trayEnabled ''
-      TRAY_ENABLED=${toString trayStyle}
-    ''
-    + optionalString trayAlways ''
-      ALWAYS_LEAVE_TO_TRAY=1
-    ''
-    + optionalString devTools ''
-      DEV_TOOLS=1
-    ''
-    + optionalString customTitleBar ''
-      CUSTOM_TITLE_BAR=1
-    '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/share/nodejs"
-    mv app/yandex-music.asar "$out/share/nodejs"
+    install -Dm644 app.asar "$out/share/yandex-music/app.asar"
 
-    CONFIG_FILE="$out/share/yandex-music.conf"
-    echo "$config" >> "$CONFIG_FILE"
+    for size in 16x16 32x32 48x48 64x64 128x128 256x256 512x512; do
+      install -Dm644 \
+        "usr/share/icons/hicolor/$size/apps/yandexmusic.png" \
+        "$out/share/icons/hicolor/$size/apps/yandexmusic.png"
+    done
 
-    install -Dm755 "$src/templates/yandex-music.sh" "$out/bin/yandex-music"
-    substituteInPlace "$out/bin/yandex-music"                                  \
-      --replace-fail "%electron_path%" "${electron}/bin/electron"              \
-      --replace-fail "%asar_path%" "$out/share/nodejs/yandex-music.asar"
+    install -Dm644 usr/share/applications/yandexmusic.desktop \
+      "$out/share/applications/yandex-music.desktop"
+    substituteInPlace "$out/share/applications/yandex-music.desktop" \
+      --replace-fail 'Exec="/opt/Яндекс Музыка/yandexmusic" %U' "Exec=$out/bin/yandex-music %U"
 
-    wrapProgram "$out/bin/yandex-music"                                        \
-      --set-default YANDEX_MUSIC_CONFIG "$CONFIG_FILE"
-
-    install -Dm644 "./app/favicon.png" "$out/share/icons/hicolor/48x48/apps/yandex-music.png"
-    install -Dm644 "./app/favicon.svg" "$out/share/icons/hicolor/scalable/apps/yandex-music.svg"
-
-    install -Dm644 "$src/templates/desktop" "$out/share/applications/yandex-music.desktop"
+    makeWrapper "${electron}/bin/electron" "$out/bin/yandex-music" \
+      --add-flags "$out/share/yandex-music/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto}}"
 
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Personal recommendations, selections for any occasion and new music";
     homepage = "https://music.yandex.ru/";
-    downloadPage = "https://music.yandex.ru/download/";
-    changelog = "https://github.com/cucumber-sp/yandex-music-linux/releases/tag/v${version}";
+    downloadPage = "https://desktop.app.music.yandex.net/stable/";
     license = lib.licenses.unfree;
-    platforms = lib.platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ shved ];
+    mainProgram = "yandex-music";
   };
 }

--- a/pkgs/by-name/ya/yandex-music/update.sh
+++ b/pkgs/by-name/ya/yandex-music/update.sh
@@ -1,70 +1,11 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p common-updater-scripts fd jq
+#! nix-shell -i bash -p common-updater-scripts curl
 
 set -eou pipefail
 
-OWNER="cucumber-sp"
-REPO="yandex-music-linux"
-URL="https://api.github.com/repos/$OWNER/$REPO"
-RAW="https://raw.githubusercontent.com/$OWNER/$REPO"
+version="$(
+  curl -fsSL https://desktop.app.music.yandex.net/stable/latest-linux.yml |
+    sed -n 's/^version: \(.*\)$/\1/p'
+)"
 
-attrname="yandex-music"
-latest_release="$(curl --silent "$URL/releases/latest")"
-latest_tag="$(curl --silent "$URL/tags?per_page=1")"
-commit_hash="$(jq -r '.[0].commit.sha' <<<"$latest_tag")"
-tag=$(jq -r '.tag_name' <<<"$latest_release")
-# drop 'v' prefix
-version="${tag#v}"
-
-date=$(jq -r '.created_at' <<<"$latest_release")
-# truncate time
-date=${date%T*}
-
-importTree="(let tree = import ./.; in if builtins.isFunction tree then tree {} else tree)"
-
-# Old version with rc part (e.g. 5.61.1rc3)
-oldVersion=$(nix-instantiate --eval -E "with $importTree; $attrname.version" | tr -d '"')
-# Rc part of old version (without "rc) (e.g. 3)
-oldVersionRc="${oldVersion##*rc}"
-
-# If old version does not have "rc" part - assume rc is 0
-if [ "$oldVersionRc" == "$oldVersion" ]; then
-  oldVersionRc="0"
-fi
-# Old version w/o rc part (e.g 5.61.1)
-oldVersion="${oldVersion%%rc*}"
-# Remove "rc" part from new version. There should be no "rc" part at all but
-# better to play it safe.
-version="${version%%rc*}"
-
-rc=""
-
-# If new version is the same as old version - increase rc and format rc part
-if [ "$version" == "$oldVersion" ]; then
-  rc="rc$((oldVersionRc + 1))";
-fi
-
-# update version; otherwise fail
-update-source-version "$attrname" "$version$rc" --ignore-same-hash --rev="$commit_hash"
-
-# set yandex-music dir
-dir="pkgs/by-name/ya/yandex-music"
-
-# download and save new version of 'exe' file
-ym_info=$(curl --silent "$RAW/$commit_hash/utility/version_info.json" |\
-    jq '.ym')
-
-exe_name="$(jq -r '.exe_name' <<<"$ym_info")"
-exe_link="$(jq -r '.exe_link' <<<"$ym_info")"
-exe_sha256="$(jq -r '.exe_sha256' <<<"$ym_info")"
-exe_hash="$(nix-hash --to-sri --type sha256  "$exe_sha256")"
-
-jq '.' > "$dir/ym_info.json" <<- EOJSON ||\
-        echo "Please run the script in the root of the Nixpkgs repo"
-{
-    "version": "$version",
-    "exe_name": "$exe_name",
-    "exe_link": "$exe_link",
-    "exe_hash": "$exe_hash"
-}
-EOJSON
+update-source-version yandex-music "$version"

--- a/pkgs/by-name/ya/yandex-music/ym_info.json
+++ b/pkgs/by-name/ya/yandex-music/ym_info.json
@@ -1,6 +1,0 @@
-{
-  "version": "5.63.1",
-  "exe_name": "Yandex_Music_x64_5.63.1.exe",
-  "exe_link": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.63.1.exe",
-  "exe_hash": "sha256-mGDjo/HjRRWtCGV95vtBwZpUepR/5opy6NQpM3HBVHo="
-}


### PR DESCRIPTION
## Description

Switches `yandex-music` to the official Linux desktop client and updates it from 5.63.1 to 5.116.3.

Yandex now ships an official Linux build as an Electron `.deb`, published on a stable update feed (`https://desktop.app.music.yandex.net/stable/latest-linux.yml`) that the app's built-in updater consumes. This replaces the previous packaging, which repacked the Windows `.exe` from [cucumber-sp/yandex-music-linux](https://github.com/cucumber-sp/yandex-music-linux) with build-time `sed` patches of minified JS and had lagged behind upstream (5.63.1, while the official Linux client is at 5.116.3).

- Source is now the official amd64 `.deb`; only `resources/app.asar`, the hicolor icons and the desktop file are installed, running on the nixpkgs `electron` (tested with 43.4)
- Repack-specific package options (`trayEnabled`, `trayStyle`, `trayAlways`, `devTools`, `vibeAnimationMaxFps`, `customTitleBar`, `electronArguments`) are dropped: tray and title bar are handled natively by the official build's own settings
- Adds `passthru.updateScript` reading the official update feed; `ym_info.json` is removed as no longer needed
- Tray icon assets, which the official layout places next to the Electron binary, are packed into `app.asar` so the tray works with the nixpkgs `electron`
- Tested on x86_64-linux (NixOS 26.05pre, Wayland): the app launches, the UI renders, tray icon shows correctly, login and playback work

<!--
  Please summarise the changes you have done and explain why they are necessary here ^

  For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
  For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI disclosure: this change was prepared with the assistance of an AI coding agent (ox-alpha), reviewed and tested by @KintaraVault; the commit carries an `Assisted-by:` trailer.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
