### PR TITLE
rocmPackages.sysrootCompiler: use __structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/development/rocm-modules/llvm/default.nix
+++ b/pkgs/development/rocm-modules/llvm/default.nix
@@ -180,10 +180,10 @@ let
         pname = name;
         # If this is erroring, try why-depends --precise on the symlinkJoin of inputs to look for the problem
         # nix why-depends --precise .#rocmPackages.llvm.rocm-toolchain.linked /store/path/its/not/allowed
-        disallowedRequisites = disallowedRefsForToolchain;
+        outputChecks.out.disallowedRequisites = disallowedRefsForToolchain;
         passthru.linked = linked;
-        linkPaths = linkPaths;
-        passAsFile = [ "linkPaths" ];
+        inherit linkPaths;
+        __structuredAttrs = true;
         # TODO(@LunNova): Try to use --sysroot with clang in its original location instead of
         # relying on copying the binary?
         # $clang/bin/clang++ --sysroot=$rocm-toolchain is not equivalent
@@ -221,7 +221,7 @@ let
           builtins.concatStringsSep " " (map (x: "${x}/lib") paths)
         } $out/ # create links *within* the sysroot to save space
 
-        for i in $(cat $linkPathsPath); do
+        for i in "''${linkPaths[@]}"; do
           ${lib.getExe lndir} -silent $i $out
         done
 


### PR DESCRIPTION
With `structuredAttrs` we can/should also use `outputChecks`: https://nix.dev/manual/nix/2.18/language/advanced-attributes.html?highlight=outputhash#adv-attr-outputChecks

The other changes should be rather straightforward.

I've tried to run nixpkgs-review but I've been stuck on `aotriton`, no progress in install after 3 hours - is that normal?
No problems up to that point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
