### PR TITLE
nixos/restic: Add noCache option to backups

### DIFF
--- a/nixos/modules/services/backup/restic.nix
+++ b/nixos/modules/services/backup/restic.nix
@@ -318,6 +318,14 @@ in
               '';
               example = 0.1;
             };
+
+            noCache = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Disables local caching of repository data. May improve performance for local repositories.
+              '';
+            };
           };
         }
       )
@@ -398,7 +406,8 @@ in
           "--what='sleep'"
           "--why=${lib.escapeShellArg "Scheduled backup ${name}"} "
         ];
-        resticCmd = "${lib.optionalString backup.inhibitsSleep inhibitCmd}${lib.getExe backup.package}${extraOptions}";
+        cacheFlag = lib.optionalString backup.noCache " --no-cache";
+        resticCmd = "${lib.optionalString backup.inhibitsSleep inhibitCmd}${lib.getExe backup.package}${extraOptions}${cacheFlag}";
         excludeFlags = lib.optional (
           backup.exclude != [ ]
         ) "--exclude-file=${pkgs.writeText "exclude-patterns" (lib.concatStringsSep "\n" backup.exclude)}";
@@ -422,11 +431,13 @@ in
       lib.nameValuePair "restic-backups-${name}" (
         {
           environment = {
-            # not %C, because that wouldn't work in the wrapper script
-            RESTIC_CACHE_DIR = "/var/cache/restic-backups-${name}";
             RESTIC_PASSWORD_FILE = backup.passwordFile;
             RESTIC_REPOSITORY = backup.repository;
             RESTIC_REPOSITORY_FILE = backup.repositoryFile;
+          }
+          // lib.optionalAttrs (!backup.noCache) {
+            # not %C, because that wouldn't work in the wrapper script
+            RESTIC_CACHE_DIR = "/var/cache/restic-backups-${name}";
           }
           // lib.optionalAttrs (backup.rcloneOptions != null) (
             lib.mapAttrs' (
@@ -464,9 +475,11 @@ in
               ++ checkCmd;
             User = backup.user;
             RuntimeDirectory = "restic-backups-${name}";
+            PrivateTmp = true;
+          }
+          // lib.optionalAttrs (!backup.noCache) {
             CacheDirectory = "restic-backups-${name}";
             CacheDirectoryMode = "0700";
-            PrivateTmp = true;
           }
           // lib.optionalAttrs (backup.environmentFile != null) {
             EnvironmentFile = backup.environmentFile;
@@ -514,7 +527,8 @@ in
       name: backup:
       let
         extraOptions = lib.concatMapStrings (arg: " -o ${arg}") backup.extraOptions;
-        resticCmd = "${lib.getExe backup.package}${extraOptions}";
+        cacheFlag = lib.optionalString backup.noCache " --no-cache";
+        resticCmd = "${lib.getExe backup.package}${extraOptions}${cacheFlag}";
       in
       pkgs.writeShellScriptBin "restic-${name}" ''
         set -a  # automatically export variables


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a new NixOS service option, `services.restic.backups.<name>.noCache`. Restic, being designed for backing up to remote and cloud systems, keeps a local cache of data by default for faster access to previously read data. However, this cache can result in worse performance when accessing a local repository (especially if the cache would be on the same storage device as the repository). Restic includes a command-line option to disable the cache, `--no-cache`. With this PR, setting `noCache = true` causes the associated systemd service to pass this flag to restic to disable the cache.

The service does already have options for adding arguments to restic calls, namely `extraBackupArgs`, `pruneOpts`, and `checkOpts`. (There's also `extraOptions`, but that's specifically for `--option` flags.) However, I believe these options aren't a sufficient alternative to this PR for three reasons: 1) Setting the `--no-cache` option will generally be intended as an all-or-nothing option, so specifying it with these options would mean having to specify it three times, which is more error-prone. 2) Setting the options this way doesn't provide the flag automatically to the wrapper created by `createWrapper`, which can further result in mistakes. 3) As of #387116, the service can run `restic unlock`, with no option to add arguments to the call, meaning it will always try to initialize a cache if it performs a prune step.

An important note about this PR is how the option is passed to restic. It seems like these kinds of options are usually passed to the service via environment variables, but as far as I can see, there is no environment variable equivalent to `--no-cache`. I assume this is using environment variable as a form of setting precedence (as the command-line arguments usually supersede the environment variables), so this could cause complications if the user tries to combine `noCache = true` with other cache-specific arguments (like `--with-cache` or `--cache-dir`). However, I don't see much workaround to this, and having `noCache = true` disable caching more aggressively like this should be a good enough solution.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ~~Built~~ Tested on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all ~~binary files, usually in `./result/bin/`~~ services.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
