### PR TITLE
alembic: fix reference cycle on darwin

### DIFF
--- a/pkgs/by-name/al/alembic/package.nix
+++ b/pkgs/by-name/al/alembic/package.nix
@@ -52,6 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
     "-DConfigPackageLocation=${placeholder "dev"}/lib/cmake/Alembic"
     "-DCMAKE_INSTALL_PREFIX=${placeholder "dev"}"
     "-DQUIET=ON"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Upstream defaults the dylib's install RPATH to $dev/..., embedding a $dev
+    # path in the $lib output and cycling with the CMake config in $dev. Linux
+    # is spared by patchelf --shrink-rpath; Darwin has no such step. Overriding
+    # the (guarded) default to the real lib dir breaks the cycle without a patch.
+    "-DCMAKE_INSTALL_RPATH=${placeholder "lib"}/lib"
   ];
 
   postPatch = ''


### PR DESCRIPTION
On Darwin, `alembic` fails to build with an output reference cycle:

    error: cycle detected in build of '…-alembic-1.8.12.drv'
           in the references of output 'dev' from output 'lib'

This blocks Blender (and anything else depending on alembic) on Darwin.

### Cause

Alembic sets its shared library's install RPATH to `${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}`. We point `CMAKE_INSTALL_PREFIX` at the `dev` output, so the library in `lib` gets an RPATH pointing into `dev`. `dev` already references `lib` (through its CMake config), so the two outputs reference each other and Nix rejects the cycle.

Why it works on Linux: `fixupPhase` runs `patchelf --shrink-rpath`, which strips the unused `dev` entry before references are scanned.

### Fix

Set the install RPATH explicitly to the `lib` output on Darwin. Alembic only applies its default when `CMAKE_INSTALL_RPATH` is unset, so overriding it is enough.

### Testing (aarch64-darwin)

- `nix-build -A alembic` succeeds; `lib` has no `dev` reference and the dylib
  RPATH resolves to `…-alembic-1.8.12-lib/lib`.
- `nix-build -A blender` succeeds.

Related: #429309
Upstream RPATH logic: alembic/alembic#476

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
