### PR TITLE
siyuan: 3.7.3 -> 3.8.2

### DIFF
--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "siyuan-note";
     repo = "siyuan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9eUfwnVV2Rkc10BbQzHgmtgUb/sCFHR2jJHwPl5myNw=";
+    hash = "sha256-MzsfeAWApHLDt4+aC9/O+5Dl8OD8p0l+/8tb2ZZyTos=";
   };
 
   kernel = buildGoModule {

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -16,6 +16,7 @@
   copyDesktopItems,
   nix-update-script,
   xdg-utils,
+  zip,
   darwin,
 }:
 
@@ -31,23 +32,33 @@ let
   };
 
   platformId = platformIds.${system} or (throw "Unsupported platform: ${system}");
+
+  # The pandoc archive that electron-builder expects for each platform. We build
+  # it from the Nix pandoc binary, so only the current platform's archive is needed.
+  pandocArchives = {
+    "linux" = "pandoc-linux-amd64.zip";
+    "linux-arm64" = "pandoc-linux-arm64.zip";
+    "darwin-arm64" = "pandoc-darwin-arm64.zip";
+  };
+
+  pandocArchive = pandocArchives.${platformId};
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.7.3";
+  version = "3.8.2";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7Uoo8vYaci8ROk5pqs14dNrU3q7UsadDXyw1mW8Mx5I=";
+    hash = "sha256-9eUfwnVV2Rkc10BbQzHgmtgUb/sCFHR2jJHwPl5myNw=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-weg5MRidW8JId13Ug1VaVgaIcJqydGBR/EquFOS3QO4=";
+    vendorHash = "sha256-x8saxKDLeZdEbTBjNXnOBU9zkliZXm6D92Mom8CUCbs=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -69,16 +80,25 @@ stdenv.mkDerivation (finalAttrs: {
       "-s"
       "-X 'github.com/siyuan-note/siyuan/kernel/util.Mode=prod'"
     ];
-    tags = [ "fts5" ];
+    tags = [
+      "fts5"
+      "sqlcipher"
+    ];
 
-    # filepath.ToSlash does not convert Windows path separators on Unix.
-    checkFlags = [ "-skip=^TestSyObjectBase/windows_backslash$" ];
+    env.CGO_ENABLED = "1";
+
+    # Tests are skipped here because many upstream tests make assumptions that
+    # do not hold in the Nix sandbox (system MIME table, missing model.Conf
+    # initialization, missing system fonts, our set-pandoc-path.patch, etc.).
+    # They are run as a separate derivation via passthru.tests.kernel.
+    doCheck = false;
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
     pnpm
+    zip
   ]
   ++ lib.optionals isLinux [
     pnpmBuildHook
@@ -98,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-i7llORlVU1CCmyVCvJr7xCQffTmbmIA9rT68Raqg5y8=";
+    hash = "sha256-ACWwXIwuiLp/e+1dwlClzAi8ZC6oEQc3ETFK/WvVnGk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";
@@ -106,8 +126,23 @@ stdenv.mkDerivation (finalAttrs: {
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   postConfigure = ''
-    # remove prebuilt pandoc archives
-    rm -r pandoc
+    # Remove the prebuilt pandoc archives; we provide our own built from the
+    # Nix pandoc binary below, and keep pandoc-resources for the kernel.
+    rm -f pandoc/pandoc-*.zip
+
+    # Build the current platform's pandoc archive from the Nix pandoc binary so
+    # the electron-builder afterPack hook can extract it. The kernel itself uses
+    # the Nix pandoc directly via set-pandoc-path.patch.
+    (
+      cd pandoc
+      mkdir -p .tmp/bin
+      cp ${lib.getExe pandoc} .tmp/bin/pandoc
+      (
+        cd .tmp
+        zip -qr ../${pandocArchive} bin/pandoc
+      )
+      rm -rf .tmp
+    )
 
     # link kernel into the correct starting place so that electron-builder can copy it to it's final location
     mkdir kernel-${platformId}
@@ -171,12 +206,32 @@ stdenv.mkDerivation (finalAttrs: {
     categories = [ "Utility" ];
   });
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "^v(\\d+\\.\\d+\\.\\d+)$"
-      "--subpackage=kernel"
-    ];
+  passthru = {
+    kernel = finalAttrs.kernel;
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^v(\\d+\\.\\d+\\.\\d+)$"
+        "--subpackage=kernel"
+      ];
+    };
+
+    # Upstream kernel tests require model.Conf initialization, system fonts,
+    # pandoc, and other assumptions that do not hold in the Nix sandbox during
+    # the main build. Run them as a separate derivation so the package build
+    # stays reliable while test results remain available via
+    # nix-build -A siyuan.passthru.tests.kernel.
+    tests.kernel = finalAttrs.kernel.overrideAttrs {
+      pname = "${finalAttrs.pname}-kernel-test";
+      doCheck = true;
+      checkPhase = ''
+        runHook preCheck
+        go test -vet=off -tags=fts5,sqlcipher ./...
+        runHook postCheck
+      '';
+      installPhase = "touch $out";
+    };
   };
 
   meta = {

--- a/pkgs/by-name/si/siyuan/set-pandoc-path.patch
+++ b/pkgs/by-name/si/siyuan/set-pandoc-path.patch
@@ -2,12 +2,11 @@ diff --git a/util/pandoc.go b/util/pandoc.go
 index 5dbc58d..5f32644 100644
 --- a/util/pandoc.go
 +++ b/util/pandoc.go
-@@ -97,6 +97,8 @@ var (
- )
+@@ -125,6 +125,7 @@ func GetPandocRuntime() PandocRuntime {
+ }
  
- func InitPandoc() {
-+    PandocBinPath = "@pandoc_path@"
-+    return
+ func InitPandoc(customPandocBinPath string) {
++    customPandocBinPath = "@pandoc_path@"
  	if ContainerStd != Container {
  		return
  	}


### PR DESCRIPTION
Updates SiYuan from 3.7.3 to 3.8.2, fixing the publish-mode access-control and information-disclosure issues tracked in #552150 (CVE-2026-72788, CVE-2026-72790, CVE-2026-72793, CVE-2026-72801, CVE-2026-72807, and CVE-2026-72809).

v3.8.0 and v3.8.1 were never merged; this goes straight from 3.7.3 to 3.8.2 (3.8.2 was released while this PR was still open).

Changelog: https://github.com/siyuan-note/siyuan/releases/tag/v3.8.2

## What changed since 3.7.3

- Handle upstream pandoc changes in 3.8.x: the electron-builder afterPack hook now requires a packaged pandoc.zip, and the kernel additionally needs the pandoc-resources directory (docx template + lua color filter). The package therefore no longer removes the whole pandoc/ directory; instead it rebuilds pandoc-linux-{amd64,arm64}.zip from the Nix pandoc binary and keeps pandoc-resources, while the kernel continues to use the Nix pandoc directly via set-pandoc-path.patch.
- Adapt set-pandoc-path.patch to the new InitPandoc(customPandocBinPath) API introduced in 3.8.x.
- Enable sqlcipher support (encrypted notebooks) by adding the sqlcipher build tag and enabling CGO, matching upstream Dockerfile build flags.
- Skip kernel tests during main build (doCheck = false) and add them as passthru.tests.kernel, as upstream tests make assumptions that do not hold in the Nix sandbox.
- Expose the kernel derivation via passthru.kernel, which fixes the existing --subpackage=kernel flag in the updateScript (previously nix-update could not evaluate siyuan.kernel).

Reference: https://github.com/mtul0729/siyuan-nix

fixes #552150

Supersedes #552595

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
