### PR TITLE
caelestia-shell: add updateScript

### DIFF
--- a/pkgs/by-name/ca/caelestia-cli/package.nix
+++ b/pkgs/by-name/ca/caelestia-cli/package.nix
@@ -74,7 +74,6 @@ python3.pkgs.buildPythonApplication rec {
         --replace-fail '"qs", "-c", "caelestia"' '"caelestia-shell"'
 
     substituteInPlace src/caelestia/subcommands/toggle.py \
-        --replace-fail 'discord' 'discord' \
         --replace-fail '["todoist"]' '["todoist.desktop"]'
   '';
 
@@ -83,7 +82,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   meta = {
-    description = "The main control script for the Caelestia dotfiles";
+    description = "The main control script for the Caelestia Shell";
     homepage = "https://github.com/caelestia-dots/cli";
     license = lib.licenses.gpl3Only;
     mainProgram = "caelestia";

--- a/pkgs/by-name/ca/caelestia-shell/package.nix
+++ b/pkgs/by-name/ca/caelestia-shell/package.nix
@@ -202,6 +202,7 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit plugin extras m3shapesModule;
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/ca/caelestia-shell/update.sh
+++ b/pkgs/by-name/ca/caelestia-shell/update.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq python3 nix
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+PKG_NIX="$ROOT/package.nix"
+
+TAG="$(curl -sL https://api.github.com/repos/caelestia-dots/shell/releases/latest | jq -r .tag_name)"
+VERSION="${TAG#v}"
+
+REV="$(curl -sL "https://api.github.com/repos/caelestia-dots/shell/commits/$TAG" | jq -r .sha)"
+
+TAR_URL="https://github.com/caelestia-dots/shell/releases/download/v${VERSION}/caelestia-shell-v${VERSION}.tar.gz"
+SHELL_RAW="$(nix-prefetch-url "$TAR_URL" 2>/dev/null | tail -n 1)"
+SHELL_SRI="$(nix hash convert --to sri --hash-algo sha256 "$SHELL_RAW")"
+
+CMAKE_TXT="$(curl -sL "https://raw.githubusercontent.com/caelestia-dots/shell/$REV/CMakeLists.txt")"
+M3_REV="$(echo "$CMAKE_TXT" | grep "set(M3SHAPES_REV" | awk '{print $2}' | tr -d ')')"
+M3_RAW="$(nix-prefetch-url --unpack "https://github.com/soramanew/m3shapes/archive/$M3_REV.tar.gz" 2>/dev/null | tail -n 1)"
+M3_SRI="$(nix hash convert --to sri --hash-algo sha256 "$M3_RAW")"
+
+python3 - << PY
+import re
+
+with open("$PKG_NIX", "r") as f:
+    content = f.read()
+
+content = re.sub(r'version\s*=\s*"[^"]+";', f'version = "$VERSION";', content, count=1)
+content = re.sub(r'rev\s*=\s*"[^"]+";', f'rev = "$REV";', content, count=1)
+
+m3_pattern = r'(m3shapes_src\s*=\s*fetchFromGitHub\s*\{[^}]*?rev\s*=\s*")[^"]+(";\s*hash\s*=\s*")[^"]+(";\s*\};)'
+content = re.sub(m3_pattern, rf'\g<1>$M3_REV\g<2>$M3_SRI\g<3>', content, flags=re.DOTALL)
+
+shell_pattern = r'(shellSrc\s*=\s*fetchurl\s*\{[^}]*?hash\s*=\s*")[^"]+(";\s*\};)'
+content = re.sub(shell_pattern, rf'\g<1>$SHELL_SRI\g<2>', content, flags=re.DOTALL)
+
+with open("$PKG_NIX", "w") as f:
+    f.write(content)
+PY
+
+echo "Successfully updated caelestia-shell to $VERSION ($REV)"


### PR DESCRIPTION
Adds `passthru.updateScript = ./update.sh;` to `caelestia-shell` to automate multi-source updates (`version`, `rev`, `shellSrc.hash`, and `m3shapes_src.hash`), updates the description for `caelestia-cli`, and removes the redundant patch line.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
