### PR TITLE
[Backport release-26.05] fluxcd: 2.8.8 -> 2.9.4

### DIFF
--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -85,7 +85,6 @@ buildGoModule rec {
       ryan4yin
       SchahinRohani
       stealthybox
-      superherointj
     ];
     mainProgram = "flux";
   };

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "2.8.8";
-  srcHash = "sha256-ECFEzYhnhse2yrfWYaeN5dE+HUvCy5RKZ2OceCb5+sA=";
-  vendorHash = "sha256-pV7eoiGhWk6KYZbK8bamXJY/NdK7ZYqrVcCTX9ccLJc=";
-  manifestsHash = "sha256-fF21nDstKUrlW6fgm0DrDtntR/0cnHMEzRltjBm9nwA=";
+  version = "2.9.0";
+  srcHash = "sha256-zMlaBIxhmKFeBFhCC3M1wc9sKjSjUzpNLti53ow5SgU=";
+  vendorHash = "sha256-J1MofT7PwcQ74XwVumu7PfkAteKR6iJIZe+vMoaD+Eg=";
+  manifestsHash = "sha256-PAbQa76mwu6BNR7AX88IhQM9Veg01va4THJ/6B6pu9A=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "2.9.0";
-  srcHash = "sha256-zMlaBIxhmKFeBFhCC3M1wc9sKjSjUzpNLti53ow5SgU=";
-  vendorHash = "sha256-J1MofT7PwcQ74XwVumu7PfkAteKR6iJIZe+vMoaD+Eg=";
-  manifestsHash = "sha256-PAbQa76mwu6BNR7AX88IhQM9Veg01va4THJ/6B6pu9A=";
+  version = "2.9.1";
+  srcHash = "sha256-aVJpUigIkGXsjvb40hEkZ2OiUghGcte3Msq4DMLIcbU=";
+  vendorHash = "sha256-TG41xOrAAVBsE6CJ4av6y3bxfudk6gV49+/xB9Qu5ME=";
+  manifestsHash = "sha256-DeTjdgOZyvrpQvIoXyVUfRIbHoJ9o74FRuTpVgT1/3I=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "2.9.3";
-  srcHash = "sha256-xu+9Ks+Jrzxk+D2GUmw68/mprNf8ynQZiCmMNpVkR4M=";
-  vendorHash = "sha256-h5APVAwqyodfaoNq5SqHF/3Vu3O2XfdlZ9O/apA49pc=";
-  manifestsHash = "sha256-L1dSNLFKtAGS7A+vvz7t68YifOxWoFxPTmNB31iaGoo=";
+  version = "2.9.4";
+  srcHash = "sha256-7Suhsg1tWn6gzkPDQT4BII0hTCM3HCCZTTtFVNumA9A=";
+  vendorHash = "sha256-3CMj5MI5cILnyWoWkcBzD5X626nsQ6nfipeqN35IQEk=";
+  manifestsHash = "sha256-+187K4w//AxtSYcrA3NoVCSFpTkjNqZmfOlbdzD9YmI=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "2.9.1";
-  srcHash = "sha256-aVJpUigIkGXsjvb40hEkZ2OiUghGcte3Msq4DMLIcbU=";
-  vendorHash = "sha256-TG41xOrAAVBsE6CJ4av6y3bxfudk6gV49+/xB9Qu5ME=";
-  manifestsHash = "sha256-DeTjdgOZyvrpQvIoXyVUfRIbHoJ9o74FRuTpVgT1/3I=";
+  version = "2.9.2";
+  srcHash = "sha256-a4925TZIqYqSk4/gyjwTeThOaQiIt1S3Md7b9eu7H20=";
+  vendorHash = "sha256-iPj7F/7u5MrxoZJ4qk6XONeUmAXkMckpXK/P0HNQ78A=";
+  manifestsHash = "sha256-uSfH2hcz1+rqHc9szCe4V40mTl6d+Li308WW9xLVXWs=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "2.9.2";
-  srcHash = "sha256-a4925TZIqYqSk4/gyjwTeThOaQiIt1S3Md7b9eu7H20=";
-  vendorHash = "sha256-iPj7F/7u5MrxoZJ4qk6XONeUmAXkMckpXK/P0HNQ78A=";
-  manifestsHash = "sha256-uSfH2hcz1+rqHc9szCe4V40mTl6d+Li308WW9xLVXWs=";
+  version = "2.9.3";
+  srcHash = "sha256-xu+9Ks+Jrzxk+D2GUmw68/mprNf8ynQZiCmMNpVkR4M=";
+  vendorHash = "sha256-h5APVAwqyodfaoNq5SqHF/3Vu3O2XfdlZ9O/apA49pc=";
+  manifestsHash = "sha256-L1dSNLFKtAGS7A+vvz7t68YifOxWoFxPTmNB31iaGoo=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";


### PR DESCRIPTION
Manual backport of the fluxcd 2.9.4 to `release-26.05`

auto-backport failed: https://github.com/NixOS/nixpkgs/pull/552029#issuecomment-5343533101

Cherry-picked from master:

- 3ce0672e05be fluxcd: remove superherointj from maintainers (#532708)
- 627d8c6c4727 fluxcd: 2.8.8 -> 2.9.0 (#537960)
- 9c672d119ddf fluxcd: 2.9.0 -> 2.9.1 (#539442)
- bf13b635d62a fluxcd: 2.9.1 -> 2.9.2 (#542794)
- 5b79c00d1290 fluxcd: 2.9.2 -> 2.9.3 (#545856)
- f7003d522005 fluxcd: 2.9.3 -> 2.9.4 (#552029)

resulting `pkgs/by-name/fl/fluxcd` is identical to master

- built on aarch64-linux
- tested basic functionality of the binary (`flux --version`, `flux check`)
