### PR TITLE
gitcomet: clean up expression and add longDescription

### DIFF
--- a/pkgs/by-name/gi/gitcomet/package.nix
+++ b/pkgs/by-name/gi/gitcomet/package.nix
@@ -14,8 +14,9 @@
   wayland,
   git,
   xdg-utils,
-  makeWrapper,
+  makeBinaryWrapper,
   writableTmpDirAsHomeHook,
+  testers,
   versionCheckHook,
   nix-update-script,
 }:
@@ -34,8 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-L/UXaXC1zymbNfv7SGmOYSvUy/767mAWqL+3jwJwWcE=";
 
-  cargoDepsName = finalAttrs.pname;
-
+  # Disable upstream's rustflags overrides to avoid linker and CPU target issues
   postPatch = ''
     rm .cargo/config.toml
   '';
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     desktop-file-utils
-    makeWrapper
+    makeBinaryWrapper
   ];
 
   buildInputs = [
@@ -114,16 +114,27 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex=^v([0-9]+[.][0-9]+[.][0-9]+)$"
-    ];
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex=^v([0-9]+[.][0-9]+[.][0-9]+)$"
+        "--use-github-releases"
+      ];
+    };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
   };
 
   meta = {
     description = "Fast, resource-efficient Git GUI written in Rust";
+    longDescription = ''
+      GitComet is a Git graphical client built with Rust and the gpui
+      toolkit, using gix as its Git implementation.
+    '';
     homepage = "https://gitcomet.dev";
     changelog = "https://github.com/Auto-Explore/GitComet/releases/tag/v${finalAttrs.version}";
+    # ofl covers the bundled font assets.
     license = with lib.licenses; [
       agpl3Only
       ofl


### PR DESCRIPTION
- Switch to `makeBinaryWrapper` for faster application startup.
- Add `passthru.tests.version` using `testers.testVersion`.
- Add `--use-github-releases` to `updateScript` to track official GitHub releases.
- Clarify `postPatch` comment documenting why upstream's `.cargo/config.toml` is removed.
- Add `meta.longDescription` and licensing comments.
- Remove redundant `cargoDepsName`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

