### PR TITLE
jet: fix native image with GraalVM 25.2.4

### DIFF
--- a/pkgs/by-name/je/jet/package.nix
+++ b/pkgs/by-name/je/jet/package.nix
@@ -19,7 +19,23 @@ buildGraalvmNativeImage (finalAttrs: {
     "-H:Log=registerResource:"
     "--no-fallback"
     "--no-server"
+    "-J-Djet.native=true"
+    # GraalVM >= 25.1 no longer discovers @AutomaticFeature annotations.
+    "--features=InitAtBuildTimeFeature"
   ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    output="$(
+      printf '%s\n' '{"value":1}' \
+        | $out/bin/jet --from json --to edn --keywordize
+    )"
+    test "$output" = '{:value 1}'
+
+    runHook postInstallCheck
+  '';
 
   passthru.tests.version = testers.testVersion {
     inherit (finalAttrs) version;


### PR DESCRIPTION
Fix `jet`'s native executable with GraalVM 25.2.4.

GraalVM 25.1 stopped loading a build step that Jet needs (`InitAtBuildTimeFeature`). This PR loads it explicitly and enables Jet's fixes for native builds.

The new test converts a small JSON value to EDN. It catches the startup failure that the version test missed.

Upstream build configuration:
- https://github.com/borkdude/jet/blob/v0.7.27/script/compile
- https://github.com/borkdude/jet/blob/v0.7.27/project.clj

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package jet`
Commit: `d5f4df73f723dde032f4235dace38b0b96d369d8`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>jet</li>
  </ul>
</details>

Prepared with assistance from Pi coding agent using OpenAI Codex GPT-5.6-sol.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
