### PR TITLE
beads: 1.0.3 -> 1.2.2

### DIFF
--- a/pkgs/by-name/be/beads/package.nix
+++ b/pkgs/by-name/be/beads/package.nix
@@ -15,16 +15,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "beads";
-  version = "1.0.3";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "gastownhall";
     repo = "beads";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-K3X67XgUl55mZS4r4V/KTbXPNqCV7fPHi8HnrDime+E=";
+    hash = "sha256-HSZ1z4WaHQDPomW6nNs8iUnld36BuHnOVaODD5mxY00=";
   };
 
-  vendorHash = "sha256-Rn1MnasYUOBbIgjFx0E6R2Zak6la1VajDkHqoiFpHtw=";
+  vendorHash = "sha256-WWEwGpCwMPD7jaz02zN745RQQqYTQttehbcT3J9hayM=";
 
   subPackages = [ "cmd/bd" ];
 
@@ -56,6 +56,9 @@ buildGoModule (finalAttrs: {
       skippedTests = [
         # Upstream test bug: version gap 0.55.0->1.0.0 triggers "very old" warning instead of expected "ok"
         "TestCheckMetadataVersionTracking"
+        # Installs a hook with a `#!/usr/bin/env sh` shebang, then exercises it via
+        # `git worktree add`; /usr/bin/env doesn't exist in the Nix build sandbox
+        "TestInstallHooksBeads_WorktreeAccess"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # Checks for /etc/passwd which isn't available in sandbox


### PR DESCRIPTION
This was prepared with the assistance of Claude Code (Sonnet 5). I (the submitter) reviewed the diff, ran the build and full upstream test suite locally, and take responsibility for this contribution per the [automation/AI policy]. See the `Assisted-by:` trailer on the commit for tool/model disclosure.

Bumps `beads` 1.0.3 -> 1.2.2.

v1.2.0 and v1.2.1 were accidentally published upstream without release testing. v1.2.2 is a recovery release that supersedes them by re-releasing the tested v1.1.2 code under a higher version number — the 1.2.x-only features (work leases, events journal, sync federation, HTTP API server, provenance events) are **not** included here and are expected in a future release. See the [v1.2.2 release notes](https://github.com/gastownhall/beads/releases/tag/v1.2.2) for the full recovery/schema-migration context (relevant to existing `bd` users, not to this packaging change).

Also skips one new upstream test, `TestInstallHooksBeads_WorktreeAccess`: it installs a git hook with a `#!/usr/bin/env sh` shebang and then execs it via `git worktree add`. That fails only because the Nix build sandbox has no `/usr/bin/env` — same category as the two pre-existing sandbox-only skips already in this file, not a functional regression in `bd`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
