### PR TITLE
zfp: enable __structuredAttrs

### DIFF
--- a/pkgs/by-name/zf/zfp/package.nix
+++ b/pkgs/by-name/zf/zfp/package.nix
@@ -28,10 +28,12 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "zfp";
   version = "1.0.1";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "LLNL";
     repo = "zfp";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-iZxA4lIviZQgaeHj6tEQzEFSKocfgpUyf4WvUykb9qk=";
   };
 
@@ -59,21 +61,17 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     llvmPackages.openmp
   ];
 
-  # compile CUDA code for all extant GPUs so the binary will work with any GPU
-  # and driver combination. to be ultimately solved upstream:
-  # https://github.com/LLNL/zfp/issues/178
-  # NB: not in cmakeFlags due to https://github.com/NixOS/nixpkgs/issues/114044
-  preConfigure = lib.optionalString enableCuda ''
-    cmakeFlagsArray+=(
-      "-DCMAKE_CUDA_FLAGS=-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_87,code=sm_87 -gencode=arch=compute_86,code=compute_86"
-    )
-  '';
-
   cmakeFlags = [
   ]
   ++ lib.optional (bitStreamWordSize != 64) "-DZFP_BIT_STREAM_WORD_SIZE=${toString bitStreamWordSize}"
   ++ lib.optional enableCfp "-DBUILD_CFP=ON"
-  ++ lib.optional enableCuda "-DZFP_WITH_CUDA=ON"
+  # compile CUDA code for all extant GPUs so the binary will work with any GPU
+  # and driver combination. to be ultimately solved upstream:
+  # https://github.com/LLNL/zfp/issues/178
+  ++ lib.optionals enableCuda [
+    "-DZFP_WITH_CUDA=ON"
+    "-DCMAKE_CUDA_FLAGS=-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_87,code=sm_87 -gencode=arch=compute_86,code=compute_86"
+  ]
   ++ lib.optional enableFortran "-DBUILD_ZFORP=ON"
   ++ lib.optional enableOpenMP "-DZFP_WITH_OPENMP=ON"
   ++ lib.optional enablePython "-DBUILD_ZFPY=ON"
@@ -82,9 +80,9 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   # the testzfp regression test only supports the default 64-bit bitstream word
-  preCheck = lib.optionalString (bitStreamWordSize != 64) ''
-    checkFlagsArray+=(ARGS="--exclude-regex testzfp")
-  '';
+  checkFlags = lib.optionals (bitStreamWordSize != 64) [
+    "ARGS=\"--exclude-regex testzfp\""
+  ];
 
   passthru.tests = {
     cmake-config = testers.hasCmakeConfigModules {

--- a/pkgs/by-name/zf/zfp/package.nix
+++ b/pkgs/by-name/zf/zfp/package.nix
@@ -62,22 +62,32 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    (lib.cmakeBool "BUILD_CFP" enableCfp)
+    (lib.cmakeBool "BUILD_ZFORP" enableFortran)
+    (lib.cmakeBool "ZFP_WITH_OPENMP" enableOpenMP)
+    (lib.cmakeBool "BUILD_ZFPY" enablePython)
+    (lib.cmakeBool "BUILD_UTILITIES" enableUtilities)
+    (lib.cmakeBool "ZFP_WITH_CUDA" enableCuda)
   ]
-  ++ lib.optionals (bitStreamWordSize != 64) [
-    "-DZFP_BIT_STREAM_WORD_SIZE=${toString bitStreamWordSize}"
-  ]
-  ++ lib.optionals enableCfp [ "-DBUILD_CFP=ON" ]
   # compile CUDA code for all extant GPUs so the binary will work with any GPU
   # and driver combination. to be ultimately solved upstream:
   # https://github.com/LLNL/zfp/issues/178
   ++ lib.optionals enableCuda [
-    "-DZFP_WITH_CUDA=ON"
-    "-DCMAKE_CUDA_FLAGS=-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_87,code=sm_87 -gencode=arch=compute_86,code=compute_86"
+    (lib.cmakeFeature "CMAKE_CUDA_FLAGS" (toString [
+      "-gencode=arch=compute_52,code=sm_52"
+      "-gencode=arch=compute_60,code=sm_60"
+      "-gencode=arch=compute_61,code=sm_61"
+      "-gencode=arch=compute_70,code=sm_70"
+      "-gencode=arch=compute_75,code=sm_75"
+      "-gencode=arch=compute_80,code=sm_80"
+      "-gencode=arch=compute_86,code=sm_86"
+      "-gencode=arch=compute_87,code=sm_87"
+      "-gencode=arch=compute_86,code=compute_86"
+    ]))
   ]
-  ++ lib.optionals enableFortran [ "-DBUILD_ZFORP=ON" ]
-  ++ lib.optionals enableOpenMP [ "-DZFP_WITH_OPENMP=ON" ]
-  ++ lib.optionals enablePython [ "-DBUILD_ZFPY=ON" ]
-  ++ [ "-DBUILD_UTILITIES=${if enableUtilities then "ON" else "OFF"}" ];
+  ++ lib.optionals (bitStreamWordSize != 64) [
+    (lib.cmakeFeature "ZFP_BIT_STREAM_WORD_SIZE" (toString bitStreamWordSize))
+  ];
 
   doCheck = true;
 

--- a/pkgs/by-name/zf/zfp/package.nix
+++ b/pkgs/by-name/zf/zfp/package.nix
@@ -46,8 +46,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   buildInputs =
-    lib.optional enableCuda cudatoolkit
-    ++ lib.optional enableFortran gfortran
+    lib.optionals enableCuda [ cudatoolkit ]
+    ++ lib.optionals enableFortran [ gfortran ]
     ++ lib.optionals enablePython (
       with python3Packages;
       [
@@ -63,8 +63,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
   ]
-  ++ lib.optional (bitStreamWordSize != 64) "-DZFP_BIT_STREAM_WORD_SIZE=${toString bitStreamWordSize}"
-  ++ lib.optional enableCfp "-DBUILD_CFP=ON"
+  ++ lib.optionals (bitStreamWordSize != 64) [
+    "-DZFP_BIT_STREAM_WORD_SIZE=${toString bitStreamWordSize}"
+  ]
+  ++ lib.optionals enableCfp [ "-DBUILD_CFP=ON" ]
   # compile CUDA code for all extant GPUs so the binary will work with any GPU
   # and driver combination. to be ultimately solved upstream:
   # https://github.com/LLNL/zfp/issues/178
@@ -72,9 +74,9 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     "-DZFP_WITH_CUDA=ON"
     "-DCMAKE_CUDA_FLAGS=-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_87,code=sm_87 -gencode=arch=compute_86,code=compute_86"
   ]
-  ++ lib.optional enableFortran "-DBUILD_ZFORP=ON"
-  ++ lib.optional enableOpenMP "-DZFP_WITH_OPENMP=ON"
-  ++ lib.optional enablePython "-DBUILD_ZFPY=ON"
+  ++ lib.optionals enableFortran [ "-DBUILD_ZFORP=ON" ]
+  ++ lib.optionals enableOpenMP [ "-DZFP_WITH_OPENMP=ON" ]
+  ++ lib.optionals enablePython [ "-DBUILD_ZFPY=ON" ]
   ++ [ "-DBUILD_UTILITIES=${if enableUtilities then "ON" else "OFF"}" ];
 
   doCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
