### PR TITLE
sqawk,tclPackages.tabulate: init at 0.24.0

### DIFF
--- a/pkgs/by-name/sq/sqawk/package.nix
+++ b/pkgs/by-name/sq/sqawk/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  tcl,
+  tclPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sqawk";
+  version = "0.24.0";
+
+  src = fetchFromGitHub {
+    owner = "dbohdan";
+    repo = "sqawk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ES7P9m/meudN3RKd3DgFMuaTChyMwus7cKEYxasi/3w=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    tcl
+    tcl.tclPackageHook
+  ];
+
+  buildInputs = [
+    tclPackages.tcllib
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = {
+    description = "Like awk, but with SQL and table joins";
+    homepage = "https://github.com/dbohdan/sqawk/";
+    license = lib.licenses.mit;
+    mainProgram = "sqawk";
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/tcl-modules/by-name/ta/tabulate/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ta/tabulate/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  mkTclDerivation,
+  sqawk,
+}:
+
+mkTclDerivation {
+  pname = "tabulate";
+  version = sqawk.version;
+
+  src = sqawk.src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 lib/tabulate.tcl $out/lib/tabulate/tabulate.tcl
+    cat > $out/lib/tabulate/pkgIndex.tcl <<EOF
+    package ifneeded tabulate ${sqawk.version} {
+      source $out/lib/tabulate/tabulate.tcl
+      package provide tabulate ${sqawk.version}
+    }
+    EOF
+    mkdir $out/bin
+    ln -s $out/lib/tabulate/tabulate.tcl $out/bin/tabulate.tcl
+    runHook postInstall
+  '';
+
+  tclRequiresCheck = [ "tabulate" ];
+
+  meta = {
+    description = "Convert standard input or Tcl lists into pretty-printed tables";
+    homepage = "https://wiki.tcl-lang.org/page/tabulate";
+    license = lib.licenses.mit;
+    mainProgram = "tabulate.tcl";
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
awk but with SQL https://github.com/dbohdan/sqawk

I also added the `tabulate` tcl library that's distributed as part of sqawk https://wiki.tcl-lang.org/page/tabulate

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
