### PR TITLE
haskell.compiler: apply LLVM split sections fix unconditionally

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -254,21 +254,14 @@
               "sha256-vtjT+TL/7sYPu4rcVV3xCqJQ+uqkyBbf9l0KIi97j/0=";
         })
       ]
-      ++
-        lib.optionals
-          (
-            (stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64)
-            && lib.versionAtLeast version "9.10"
-            && lib.versionOlder version "9.12"
-          )
-          [
-            # Fix LLVM backend split sections causing bin/out reference cycles: https://gitlab.haskell.org/ghc/ghc/-/issues/26770
-            (fetchpatch {
-              name = "ghc-llvm-fix-split-sections.patch";
-              url = "https://gitlab.haskell.org/ghc/ghc/-/commit/b18b2c42c32488ad6d3480a56a1fcd753cad2023.patch";
-              hash = "sha256-kEgZARwcdnWcvjuTfyqnn8V1zAUczZN0qiy/1WbCy1s=";
-            })
-          ]
+      ++ lib.optionals (lib.versionAtLeast version "9.10" && lib.versionOlder version "9.12") [
+        # Fix LLVM backend split sections causing bin/out reference cycles: https://gitlab.haskell.org/ghc/ghc/-/issues/26770
+        (fetchpatch {
+          name = "ghc-llvm-fix-split-sections.patch";
+          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/b18b2c42c32488ad6d3480a56a1fcd753cad2023.patch";
+          hash = "sha256-kEgZARwcdnWcvjuTfyqnn8V1zAUczZN0qiy/1WbCy1s=";
+        })
+      ]
       ++ lib.optionals (lib.versionOlder version "9.12") [
         (fetchpatch {
           name = "ghc-rts-Fix-compile-on-powerpc64-elf-v1.patch";


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/pull/549823#discussion_r3846074080

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
