### PR TITLE
roon-server: 2.70.1671 -> 2.71.1683

### DIFF
--- a/pkgs/by-name/ro/roon-server/package.nix
+++ b/pkgs/by-name/ro/roon-server/package.nix
@@ -16,7 +16,7 @@
   stdenv,
 }:
 let
-  version = "2.70.1671";
+  version = "2.71.1683";
   urlVersion = builtins.replaceStrings [ "." ] [ "0" ] version;
 in
 stdenv.mkDerivation {
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.roonlabs.com/updates/production/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-    hash = "sha256-vYFhYMGFyu/eaQnVoRij9aUP9aZvxBj8N7yHmXD7904=";
+    hash = "sha256-z/8rORTsDUhgh2hfep62jMVeAvX/c5HW4vBkVnvhcQc=";
   };
 
   dontConfigure = true;
@@ -50,19 +50,14 @@ stdenv.mkDerivation {
       # NB: While this might seem like odd behavior, it's what Roon expects. The
       # tarball distribution provides scripts that do a bunch of nonsense on top
       # of what wrapBin is doing here, so consider it the lesser of two evils.
-      # I didn't bother checking whether the symlinks are really necessary, but
-      # I wouldn't put it past Roon to have custom code based on the binary
-      # name, so we're playing it safe.
       wrapBin = binPath: ''
         (
           binDir="$(dirname "${binPath}")"
           binName="$(basename "${binPath}")"
-          dotnetDir="$out/RoonDotnet"
+          actualBin="$binDir/$binName.exe"
 
-          ln -sf "$dotnetDir/dotnet" "$dotnetDir/$binName"
           rm "${binPath}"
-          makeWrapper "$dotnetDir/$binName" "${binPath}" \
-            --add-flags "$binDir/$binName.dll" \
+          makeWrapper "$actualBin" "${binPath}" \
             --argv0 "$binName" \
             --prefix LD_LIBRARY_PATH : "${
               lib.makeLibraryPath [
@@ -72,7 +67,7 @@ stdenv.mkDerivation {
                 openssl
               ]
             }" \
-            --prefix PATH : "$dotnetDir" \
+            --prefix PATH : "$binDir" \
             --prefix PATH : "${
               lib.makeBinPath [
                 alsa-utils
@@ -80,8 +75,7 @@ stdenv.mkDerivation {
                 ffmpeg
               ]
             }" \
-            --chdir "$binDir" \
-            --set DOTNET_ROOT "$dotnetDir"
+            --chdir "$binDir"
         )
       '';
     in


### PR DESCRIPTION
https://community.roonlabs.com/t/roon-2-71-hotfix-1683-is-live/323450

Updates Roon Server to 2.71.1683 and adapts its wrappers to upstream's switch from a shared .NET runtime to self-contained binaries.

Closes #552889.

Thanks to @DirectXMan12 for identifying the upstream layout change and providing the updated wrapper.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --extra-nixpkgs-config '{ allowUnfree = true; }' --package roon-server`
Commit: `c2bb4505e50d8a4d5b0e921bc4b5d6d7564a87da`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>roon-server</li>
  </ul>
</details>

Prepared with assistance from Pi coding agent using OpenAI Codex GPT-5.6-sol.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
