### PR TITLE
pulumi-java: init at 1.36.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31193,6 +31193,11 @@
     githubId = 28888242;
     name = "WORLDofPEACE";
   };
+  wormt = {
+    github = "wormt";
+    githubId = 209373679;
+    name = "wormt";
+  };
   WoutSwinkels = {
     name = "Wout Swinkels";
     email = "nixpkgs@woutswinkels.com";

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-java/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-java/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "pulumi-java";
+  version = "1.36.2";
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-java";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y7gaZerDYfD+t2xMK3Iw9q8v3MRdIZMt2/KEnpEj/l8=";
+    fetchSubmodules = true;
+  };
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  checkFlags = [
+    "-skip=^${
+      lib.concatStringsSep "$|^" [
+        "TestLanguage"
+        "TestLanguagePublished"
+        "TestLanguageLocal"
+        "TestLanguageExtraTypes"
+        "TestPluginsAndDependencies_vendored"
+        "TestPluginsAndDependencies_subdir"
+        "TestPluginsAndDependencies_moduleMode"
+      ]
+    }$"
+  ];
+
+  sourceRoot = "source";
+  vendorHash = "sha256-gq1+k5KyziNUR0XTbEJJ5m0QDmMH4WNbA6At25a6DnM=";
+
+  subPackages = [ "pkg/cmd/pulumi-language-java" ];
+
+  meta = {
+    description = "Language host for Pulumi programs written in Java";
+    homepage = "https://github.com/pulumi/pulumi-java";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ wormt ];
+    mainProgram = "pulumi-language-java";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the pulumi-java language host which allows `pulumi` to run Java code. https://www.pulumi.com/docs/iac/languages-sdks/java/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
