### PR TITLE
picgo: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/by-name/pi/picgo/package.nix
+++ b/pkgs/by-name/pi/picgo/package.nix
@@ -6,7 +6,7 @@
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
-  electron_41,
+  electron_43,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
@@ -18,13 +18,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "picgo";
-  version = "3.0.1";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "Molunerfinn";
     repo = "PicGo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uxgrtuxcIlwCuz3X2hL0ZSpq8hMA4JxQD8ibNFw+35g=";
+    hash = "sha256-wT9CfPchNbD2CzSVA9kZAYsstpc2mvgqAl305rmrUdo=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -48,6 +48,15 @@ stdenv.mkDerivation (finalAttrs: {
     NODE_ENV = "development";
   };
 
+  postPatch = ''
+    # Maximizing a hidden BrowserWindow makes it visible on Linux. Defer restoring
+    # the maximized state until the main window is explicitly shown.
+    # https://github.com/Molunerfinn/PicGo/blob/4676326eb88d087432989366d71e61e17a039e98/src/main/apis/app/window/windowList.ts#L83-L94
+    substituteInPlace src/main/apis/app/window/windowList.ts \
+      --replace-fail "      window.maximize()" \
+        "      window.once('show', () => window.maximize())"
+  '';
+
   buildPhase = ''
     runHook preBuild
 
@@ -57,12 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postBuild = ''
-    cp -r src/renderer/public/. dist_electron/renderer/
-
-    # Renderer assets are loaded from a file:// URL, so root-relative paths like
-    # /squareLogo.png resolve to the filesystem root. Copy the renderer public assets
-    # next to index.html and rewrite those references to relative paths.
-    # https://github.com/Molunerfinn/PicGo/blob/dev/src/renderer/components/independent-window/mini/picgo-mini-page.tsx
+    # Renderer assets are loaded from a file:// URL, so the mini window logo must
+    # use a path relative to its index.html.
     substituteInPlace dist_electron/renderer/assets/mini-*.js \
       --replace-fail '"/squareLogo.png"' '"./squareLogo.png"'
   '';
@@ -92,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     # ELECTRON_FORCE_IS_PACKAGED makes PicGo use its production resource path,
     # but with the nixpkgs Electron wrapper process.resourcesPath points to Electron
     # itself, so point PicGo at the installed public assets
-    makeWrapper ${lib.getExe electron_41} $out/bin/picgo \
+    makeWrapper ${lib.getExe electron_43} $out/bin/picgo \
       --add-flags "--class=picgo" \
       --add-flags "$out/lib/picgo/.launcher.cjs" \
       --set NODE_ENV production \


### PR DESCRIPTION
Changelog: <https://github.com/Molunerfinn/PicGo/releases/tag/v3.0.2>

Bump electron version to v43, See #555100 

Fix maximized state shows hidden main window on Linux by postPatch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
