### PR TITLE
coqPackages: add deprecation warnings for aliases

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -84,6 +84,8 @@
 
 - `nix-serve-ng` (and `haskellPackages.nix-serve-ng`) is now built against Lix instead of CppNix, following upstream which has switched to Lix as its supported Nix implementation.
 
+- The `coqPackages` and `coq` attributes, along with their versioned variants for Rocq ≥ 9.0, are now deprecated aliases for `rocqPackages` and `rocqPackages.coq` (the latter providing Coq compatibility binaries, use `rocq-core` if you do not need them). They still work but emit a warning. Users should migrate to `rocq-core` and `rocqPackages`. Older Coq 8.x attributes such as `coq_8_20` and `coqPackages_8_20` remain unchanged.
+
 - Linux kernel configuration has been moved out of the `linux-kernel` field of the platform structure into the kernel builders:
   - `linux-kernel.name` has been removed.
   - `linux-kernel.target` is available as the `target` parameter and passthru attribute on the kernel builders.

--- a/pkgs/by-name/co/coq-kernel/package.nix
+++ b/pkgs/by-name/co/coq-kernel/package.nix
@@ -3,7 +3,7 @@
   callPackage,
   runCommand,
   makeWrapper,
-  coq,
+  rocqPackages,
   imagemagick,
   python312,
 }:
@@ -18,6 +18,8 @@
 # nix run --impure --expr 'with import <nixpkgs> {}; jupyter.override { definitions.coq = coq-kernel.definition; }'
 
 let
+  coq = rocqPackages.coq;
+
   # Nixpkgs master is currently on python3 >= python313. This doesn't work with
   # this package, because it depends on the "future" package, which is no longer
   # compatible with Python 3.13.

--- a/pkgs/by-name/fr/frama-c/package.nix
+++ b/pkgs/by-name/fr/frama-c/package.nix
@@ -7,7 +7,6 @@
   graphviz,
   doxygen,
   ocamlPackages,
-  coq,
   dune,
   why3,
   withWP ? true,

--- a/pkgs/by-name/sa/satallax/package.nix
+++ b/pkgs/by-name/sa/satallax/package.nix
@@ -7,10 +7,11 @@
   which,
   eprover,
   makeWrapper,
-  coq,
+  rocqPackages,
 }:
 
 let
+  coq = rocqPackages.coq;
   inherit (ocaml-ng.ocamlPackages_4_14) ocaml;
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/test/coq/overrideCoqDerivation/default.nix
+++ b/pkgs/test/coq/overrideCoqDerivation/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  coq,
+  coq_8_20,
   mkCoqPackages,
   runCommand,
 }:
@@ -11,7 +11,7 @@ let
   # dontFilter to true here so that _all_ packages are visible in coqPackages.
   # There may be some versions of the top-level coq and coqPackages that don't
   # build QuickChick, which is what we are using for this test below.
-  coqWithAllPackages = coq // {
+  coqWithAllPackages = coq_8_20 // {
     dontFilter = true;
   };
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -600,6 +600,16 @@ mapAliases {
   copilot-cli = throw "'copilot-cli' was removed due to upstream end-of-life."; # Added 2026-05-11
   copilot-language-server-fhs = warnAlias "The package set `copilot-language-server-fhs` has been renamed to `copilot-language-server`." copilot-language-server; # Added 2025-09-07
   copper = throw "'copper' has been removed, as it was broken since 22.11"; # Added 2025-08-22
+  coq = warnAlias "'coq' is deprecated, use 'rocqPackages.coq' instead, or 'rocq-core' if you do not need the Coq compatibility binaries" rocqPackages.coq; # Added 2026-08-26
+  coq_9_0 = warnAlias "'coq_9_0' is deprecated, use 'rocqPackages_9_0.coq' instead, or 'rocq-core_9_0' if you do not need the Coq compatibility binaries" rocqPackages_9_0.coq; # Added 2026-08-26
+  coq_9_1 = warnAlias "'coq_9_1' is deprecated, use 'rocqPackages_9_1.coq' instead, or 'rocq-core_9_1' if you do not need the Coq compatibility binaries" rocqPackages_9_1.coq; # Added 2026-08-26
+  coq_9_2 = warnAlias "'coq_9_2' is deprecated, use 'rocqPackages_9_2.coq' instead, or 'rocq-core_9_2' if you do not need the Coq compatibility binaries" rocqPackages_9_2.coq; # Added 2026-08-26
+  coq_9_3 = warnAlias "'coq_9_3' is deprecated, use 'rocqPackages_9_3.coq' instead, or 'rocq-core_9_3' if you do not need the Coq compatibility binaries" rocqPackages_9_3.coq; # Added 2026-08-26
+  coqPackages = warnAlias "'coqPackages' is deprecated, use 'rocqPackages' instead" rocqPackages; # Added 2026-08-26
+  coqPackages_9_0 = warnAlias "'coqPackages_9_0' is deprecated, use 'rocqPackages_9_0' instead" rocqPackages_9_0; # Added 2026-08-26
+  coqPackages_9_1 = warnAlias "'coqPackages_9_1' is deprecated, use 'rocqPackages_9_1' instead" rocqPackages_9_1; # Added 2026-08-26
+  coqPackages_9_2 = warnAlias "'coqPackages_9_2' is deprecated, use 'rocqPackages_9_2' instead" rocqPackages_9_2; # Added 2026-08-26
+  coqPackages_9_3 = warnAlias "'coqPackages_9_3' is deprecated, use 'rocqPackages_9_3' instead" rocqPackages_9_3; # Added 2026-08-26
   cordless = throw "'cordless' has been removed due to being archived upstream. Consider using 'discordo' instead."; # Added 2025-06-07
   coreboot-configurator = throw "'coreboot-configurator' has been removed because it was discontinued.  All settings are now found in BIOS."; # Added 2026-07-28
   corepack_20 = nodejs_20;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3158,7 +3158,7 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };
 
-  inherit (coqPackages_9_0) compcert;
+  inherit (rocqPackages_9_0) compcert;
 
   corretto11 = javaPackages.compiler.corretto11;
   corretto17 = javaPackages.compiler.corretto17;
@@ -10216,20 +10216,6 @@ with pkgs;
     rocqPackages
     rocq-core
     ;
-
-  inherit (rocqPackages) coq;
-
-  # Deprecated aliases
-
-  coqPackages = rocqPackages;
-  coqPackages_9_0 = rocqPackages_9_0;
-  coq_9_0 = rocqPackages_9_0.coq;
-  coqPackages_9_1 = rocqPackages_9_1;
-  coq_9_1 = rocqPackages_9_1.coq;
-  coqPackages_9_2 = rocqPackages_9_2;
-  coq_9_2 = rocqPackages_9_2.coq;
-  coqPackages_9_3 = rocqPackages_9_3;
-  coq_9_3 = rocqPackages_9_3.coq;
 
   inherit
     (callPackage ./coq-packages.nix {


### PR DESCRIPTION
Follow up of PR #541797.

If these warnings first appear in NixOS 26.11, this should allow removing the aliases in NixOS 27.05.

~~Question: does this warrant a Nixpkgs Release Notes item or only when we remove the alias?~~ I added one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
