### PR TITLE
npb: init at 1.0.0

### DIFF
--- a/pkgs/by-name/np/npb/package.nix
+++ b/pkgs/by-name/np/npb/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  git,
+  nix-eval-jobs,
+  nix-output-monitor,
+  versionCheckHook,
+  nix-update-script,
+}:
+let
+  # Use the version of nix that came with nix-eval-jobs per the upstream npb
+  # packaging.  This (a) keeps closure sizes down, since it means this package
+  # doesn't pull in both Nixpkgs' nix and nix-eval-jobs' nix, (b) removes any
+  # risk of incompatibilities between calls to nix inside and outside
+  # nix-eval-jobs, and (c) means that -- at time of writing -- we automatically
+  # get at least version v2.35 of nix, which npb needs, even though the default
+  # Nixpkgs nix version is v2.34.
+  inherit (nix-eval-jobs) nix;
+
+  buildCanExecuteHost = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "npb";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "samestep";
+    repo = "npb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pXatlxVJnrt8JFf+TPcUAL1U5mz4kWn8qfRtVHekYjA=";
+  };
+
+  cargoHash = "sha256-pZAaTweVR/JkTdtB4/FtXfSDPFTl1+cEdqx5finWMBk=";
+
+  nativeBuildInputs = lib.optional buildCanExecuteHost installShellFiles;
+
+  env = {
+    GIT_BIN = lib.getExe git;
+    NIX_BIN =
+      # nix must be at least v2.35, as npb depends on the lazy source copying
+      # added in that version.
+      assert lib.versionAtLeast nix.version "2.35";
+      lib.getExe nix;
+    NIX_STORE_BIN = lib.getExe' nix "nix-store";
+    NIX_INSTANTIATE_BIN = lib.getExe' nix "nix-instantiate";
+    NIX_EVAL_JOBS_BIN = lib.getExe nix-eval-jobs;
+    NOM_BIN = lib.getExe nix-output-monitor;
+  };
+
+  postInstall = lib.optionalString buildCanExecuteHost ''
+    completion_tmp_dir="$(mktemp -d --tmpdir)"
+    args=()
+    for shell in bash fish zsh; do
+        "$out"/bin/npb --completions "$shell" > "$completion_tmp_dir"/"$shell"
+        args+=("--$shell" "$completion_tmp_dir"/"$shell")
+    done
+    installShellCompletion --cmd npb "''${args[@]}"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nixpkgs build comparison tool";
+    longDescription = ''
+      A CLI tool to generate reports on the differences in build outcomes
+      between a pair of Nixpkgs commits.
+    '';
+    mainProgram = "npb";
+    homepage = "https://github.com/samestep/npb";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      samestep
+      me-and
+    ];
+  };
+})


### PR DESCRIPTION
npb is an alternative to nixpkgs-review, with a focus on comparing build
results before and after any given change.

@samestep, as with npc, I've added you as a maintainer since it's your project, but you obviously get to opt out!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
