### PR TITLE
ghc: add loongarch64-linux support

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -199,7 +199,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @Artturin @Ericson2314 @lo
 /doc/languages-frameworks/haskell.section.md  @sternenseemann @maralorn @wolfgangwalther
 /maintainers/scripts/haskell                  @sternenseemann @maralorn @wolfgangwalther
 /pkgs/development/compilers/ghc               @sternenseemann @maralorn @wolfgangwalther
-/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix  @sternenseemann @maralorn @wolfgangwalther @OPNA2608 @liberodark
+/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix  @sternenseemann @maralorn @wolfgangwalther @OPNA2608 @liberodark @NixOS/loongarch64
 /pkgs/development/haskell-modules             @sternenseemann @maralorn @wolfgangwalther
 /pkgs/test/haskell                            @sternenseemann @maralorn @wolfgangwalther
 /pkgs/top-level/release-haskell.nix           @sternenseemann @maralorn @wolfgangwalther

--- a/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
@@ -27,6 +27,32 @@ let
   # GHC upstream doesn't release bindist tarballs for some platforms.
   # We're using Debian's binary package, and patching it into a usable-in-Nixpkgs state.
   ghcDebs = {
+    loongarch64-linux = {
+      toolPrefix = "loongarch64-linux-gnu-";
+      src = {
+        url = "http://ftp.ports.debian.org/debian-ports/pool-loong64/main/g/ghc/ghc_9.6.6-4+b1_loong64.deb";
+        sha256 = "f14b5e3c8e6bd233b5be8e72c369fea0644f2a804d7636f930c05b4abf77d57f";
+      };
+      exePathForLibraryCheck = null;
+      archSpecificLibraries = [
+        {
+          nixPackage = gmp;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = ncurses6;
+          fileToCheckFor = "libtinfo.so.6";
+        }
+        {
+          nixPackage = numactl;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = libffi;
+          fileToCheckFor = null;
+        }
+      ];
+    };
     powerpc64-linux = {
       toolPrefix = "powerpc64-linux-gnu-";
       src = {

--- a/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
@@ -346,6 +346,10 @@ stdenv.mkDerivation (finalAttrs: {
       # riscv64-linux
       lib.maintainers.liberodark
     ];
-    teams = [ lib.teams.haskell ];
+    teams = [
+      lib.teams.haskell
+      # loongarch64-linux
+      lib.teams.loongarch64
+    ];
   };
 })

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -257,7 +257,7 @@
       ++
         lib.optionals
           (
-            stdenv.hostPlatform.isRiscV64
+            (stdenv.hostPlatform.isRiscV64 || stdenv.hostPlatform.isLoongArch64)
             && lib.versionAtLeast version "9.10"
             && lib.versionOlder version "9.12"
           )

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -353,6 +353,20 @@
             })
           ]
 
+      # Enable GHCi on LoongArch64 (not in upstream's hardcoded platform list)
+      ++ lib.optionals stdenv.targetPlatform.isLoongArch64 [
+        (
+          if lib.versionOlder version "9.10" then
+            ./ghc-9.6-hadrian-Enable-GHCi-on-all-platforms.patch
+          else if lib.versionOlder version "9.12" then
+            ./ghc-9.10-hadrian-Enable-GHCi-on-all-platforms.patch
+          else if lib.versionOlder version "9.14" then
+            ./ghc-9.12-hadrian-Enable-GHCi-on-all-platforms.patch
+          else
+            null
+        )
+      ]
+
       ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; });
 
     stdenv = stdenvNoCC;

--- a/pkgs/development/compilers/ghc/ghc-9.10-hadrian-Enable-GHCi-on-all-platforms.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.10-hadrian-Enable-GHCi-on-all-platforms.patch
@@ -1,0 +1,42 @@
+From a19a206f1daba6f8bb72138ea7fc0b80b51e40c1 Mon Sep 17 00:00:00 2001
+From: darkyzhou <me@zqy.io>
+Date: Mon, 29 Dec 2025 10:13:16 +0800
+Subject: [PATCH] hadrian: Enable GHCi on all platforms
+
+This removes the platform-specific restrictions for GHCi support,
+allowing it to be built on all target OS and architecture combinations.
+
+Originally implemented for Debian packaging to ensure GHCi availability
+across all supported platforms.
+
+Co-authored-by: Ilias Tsitsimpis <iliastsi@debian.org>
+---
+ hadrian/src/Oracles/Setting.hs | 12 ++----------
+ 1 file changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/hadrian/src/Oracles/Setting.hs b/hadrian/src/Oracles/Setting.hs
+index e854c1c..cb5a91c 100644
+--- a/hadrian/src/Oracles/Setting.hs
++++ b/hadrian/src/Oracles/Setting.hs
+@@ -196,16 +196,8 @@ hostSupportsRPaths = queryHostTarget (\t -> let os = archOS_OS (tgtArchOs t)
+ -- | Check whether the target supports GHCi.
+ ghcWithInterpreter :: Action Bool
+ ghcWithInterpreter = do
+-    goodOs <- anyTargetOs [ OSMinGW32, OSLinux, OSSolaris2 -- TODO "cygwin32"?,
+-                          , OSFreeBSD, OSDragonFly, OSNetBSD, OSOpenBSD
+-                          , OSDarwin, OSKFreeBSD ]
+-    goodArch <- (||) <$>
+-                anyTargetArch [ ArchX86, ArchX86_64, ArchPPC
+-                              , ArchAArch64, ArchS390X
+-                              , ArchPPC_64 ELF_V1, ArchPPC_64 ELF_V2
+-                              , ArchRISCV64 ]
+-                              <*> isArmTarget
+-    return $ goodOs && goodArch
++    -- Enable GHCi on all platforms
++    return True
+ 
+ -- | Which variant of the ARM architecture is the target (or 'Nothing' if not
+ -- ARM)?
+-- 
+2.51.2
+

--- a/pkgs/development/compilers/ghc/ghc-9.12-hadrian-Enable-GHCi-on-all-platforms.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.12-hadrian-Enable-GHCi-on-all-platforms.patch
@@ -1,0 +1,44 @@
+From 25e167be6b213fbbd2c274cc7d4dbea4406fefb0 Mon Sep 17 00:00:00 2001
+From: darkyzhou <me@zqy.io>
+Date: Mon, 29 Dec 2025 21:24:43 +0800
+Subject: [PATCH] hadrian: Enable GHCi on all platforms
+
+This removes the platform-specific restrictions for GHCi support,
+allowing it to be built on all target OS and architecture combinations.
+
+Originally implemented for Debian packaging to ensure GHCi availability
+across all supported platforms.
+
+Co-authored-by: Ilias Tsitsimpis <iliastsi@debian.org>
+---
+ hadrian/src/Oracles/Setting.hs | 14 ++------------
+ 1 file changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/hadrian/src/Oracles/Setting.hs b/hadrian/src/Oracles/Setting.hs
+index 5818750..2bad8d4 100644
+--- a/hadrian/src/Oracles/Setting.hs
++++ b/hadrian/src/Oracles/Setting.hs
+@@ -198,18 +198,8 @@ targetSupportsRPaths = queryTargetTarget (\t -> let os = archOS_OS (tgtArchOs t)
+ -- | Check whether the target supports GHCi.
+ ghcWithInterpreter :: Action Bool
+ ghcWithInterpreter = do
+-    goodOs <- anyTargetOs [ OSMinGW32, OSLinux, OSSolaris2 -- TODO "cygwin32"?,
+-                          , OSFreeBSD, OSDragonFly, OSNetBSD, OSOpenBSD
+-                          , OSDarwin, OSKFreeBSD
+-                          , OSWasi ]
+-    goodArch <- (||) <$>
+-                anyTargetArch [ ArchX86, ArchX86_64, ArchPPC
+-                              , ArchAArch64, ArchS390X
+-                              , ArchPPC_64 ELF_V1, ArchPPC_64 ELF_V2
+-                              , ArchRISCV64
+-                              , ArchWasm32 ]
+-                              <*> isArmTarget
+-    return $ goodOs && goodArch
++    -- Enable GHCi on all platforms
++    return True
+ 
+ -- | Which variant of the ARM architecture is the target (or 'Nothing' if not
+ -- ARM)?
+-- 
+2.51.2
+

--- a/pkgs/development/compilers/ghc/ghc-9.6-hadrian-Enable-GHCi-on-all-platforms.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.6-hadrian-Enable-GHCi-on-all-platforms.patch
@@ -1,0 +1,39 @@
+From 2bf7be28ffdee724c7b252c83e9ef4576262e145 Mon Sep 17 00:00:00 2001
+From: darkyzhou <me@zqy.io>
+Date: Mon, 29 Dec 2025 10:16:33 +0800
+Subject: [PATCH] hadrian: Enable GHCi on all platforms
+
+This removes the platform-specific restrictions for GHCi support,
+allowing it to be built on all target OS and architecture combinations.
+
+Originally implemented for Debian packaging to ensure GHCi availability
+across all supported platforms.
+
+Co-authored-by: Ilias Tsitsimpis <iliastsi@debian.org>
+---
+ hadrian/src/Oracles/Setting.hs | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/hadrian/src/Oracles/Setting.hs b/hadrian/src/Oracles/Setting.hs
+index a0f639d..a27b87c 100644
+--- a/hadrian/src/Oracles/Setting.hs
++++ b/hadrian/src/Oracles/Setting.hs
+@@ -302,13 +302,8 @@ hostSupportsRPaths = anyHostOs (elfOSes ++ machoOSes)
+ -- | Check whether the target supports GHCi.
+ ghcWithInterpreter :: Action Bool
+ ghcWithInterpreter = do
+-    goodOs <- anyTargetOs [ "mingw32", "cygwin32", "linux", "solaris2"
+-                          , "freebsd", "dragonfly", "netbsd", "openbsd"
+-                          , "darwin", "kfreebsdgnu" ]
+-    goodArch <- anyTargetArch [ "i386", "x86_64", "powerpc"
+-                              , "arm", "aarch64", "s390x"
+-                              , "powerpc64", "powerpc64le" ]
+-    return $ goodOs && goodArch
++    -- Enable GHCi on all platforms
++    return True
+ 
+ -- | Variants of the ARM architecture.
+ data ArmVersion = ARMv5 | ARMv6 | ARMv7
+-- 
+2.51.2
+

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -123,6 +123,8 @@ in
             bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isRiscV64 then
             bb.packages.ghc966DebianBinary
+          else if stdenv.buildPlatform.isLoongArch64 then
+            bb.packages.ghc966DebianBinary
           else
             bb.packages.ghc948;
         inherit (buildPackages.python3Packages) sphinx;
@@ -139,6 +141,8 @@ in
             # No bindist, "borrowing" the GHC from Debian
             bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isRiscV64 then
+            bb.packages.ghc966DebianBinary
+          else if stdenv.buildPlatform.isLoongArch64 then
             bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isi686 then
             bb.packages.ghc948
@@ -158,6 +162,8 @@ in
             # No bindist, "borrowing" the GHC from Debian
             bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isRiscV64 then
+            bb.packages.ghc966DebianBinary
+          else if stdenv.buildPlatform.isLoongArch64 then
             bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isi686 then
             bb.packages.ghc967


### PR DESCRIPTION
Following #549823's riscv64-linux work, here is the PR for loongarch64-linux support.

The diff should be pretty straightforward, except for a few patches introduced in the second commit. These patches enable GHCi unconditionally (hence on loongarch64-linux) for versions prior to 9.14. Although Debian applies [a similar fix](https://sources.debian.org/patches/ghc/9.10.3-4/hadrian-enable-interpreter/) to GHC 9.10.3, we have multiple GHC versions to patch, so we cannot practically reuse the Debian one.

All credit goes to @darkyzhou for the work; I'm doing nothing but the rebases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
