### PR TITLE
nixos/selfoss: Port to RFC42-style settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -209,6 +209,15 @@
 
 - The papra NixOS module is now hardening the systemd unit by default. If this breaks any of the configured directories, please reconfigure them through `services.papra.environment` to enable sandbox passthrough.
 
+- `services.selfoss.extraConfig` and `services.selfoss.database` have been removed in favor of the structured [](#opt-services.selfoss.settings) option. When moving the `database` options to `settings`, you should also switch to the upstream naming:
+
+  - `type` → [`db_type`](#opt-services.selfoss.settings.db_type)
+  - `host` → [`db_host`](#opt-services.selfoss.settings.db_host)
+  - `name` → [`db_database`](#opt-services.selfoss.settings.db_database)
+  - `username` → [`db_user`](#opt-services.selfoss.settings.db_user)
+  - `password` → [`db_password`](#opt-services.selfoss.settings.db_password)
+  - `port` → [`db_port`](#opt-services.selfoss.settings.db_port)
+
 - `slskd` has been updated to v0.25.0, which renames the `global` option to `transfers`. Please review the [changelog](https://github.com/slskd/slskd/releases#release-0.25.0).
 
 - [firefox-syncserver.database.type](#opt-services.firefox-syncserver.database.type) no longer defaults to `"mysql"`. You must now explicitly choose between `"mysql"` and `"postgresql"`. New deployments should prefer PostgreSQL.

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -21,25 +21,58 @@ let
 
   dataDir = "/var/lib/selfoss";
 
-  selfoss-config =
-    let
-      db_type = cfg.database.type;
-      default_port = if (db_type == "mysql") then 3306 else 5342;
-    in
-    pkgs.writeText "selfoss-config.ini" ''
-      [globals]
-      ${lib.optionalString (db_type != "sqlite") ''
-        db_type=${db_type}
-        db_host=${cfg.database.host}
-        db_database=${cfg.database.name}
-        db_username=${cfg.database.user}
-        db_password=${cfg.database.password}
-        db_port=${toString (if (cfg.database.port != null) then cfg.database.port else default_port)}
-      ''}
-      ${cfg.extraConfig}
-    '';
+  settingsFormat = pkgs.formats.iniWithGlobalSection {
+    mkKeyValue = lib.generators.mkKeyValueDefault {
+      mkValueString =
+        v:
+        if v == null then
+          ""
+        else if v == true then
+          "1"
+        else if v == false then
+          "0"
+        else
+          lib.generators.mkValueStringDefault { } v;
+    } "=";
+  };
+
+  selfoss-config = settingsFormat.generate "config.ini" { globalSection = cfg.settings; };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "selfoss" "database" "type" ]
+      [ "services" "selfoss" "settings" "db_type" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "selfoss" "database" "host" ]
+      [ "services" "selfoss" "settings" "db_host" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "selfoss" "database" "name" ]
+      [ "services" "selfoss" "settings" "db_database" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "selfoss" "database" "username" ]
+      [ "services" "selfoss" "settings" "db_user" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "selfoss" "database" "password" ]
+      [ "services" "selfoss" "settings" "db_password" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "selfoss" "database" "port" ]
+      [ "services" "selfoss" "settings" "db_port" ]
+    )
+    (lib.mkRemovedOptionModule [ "services" "selfoss" "extraConfig" ] ''
+      Use services.selfoss.settings instead.
+
+      This is part of the general move to use structured settings instead of raw
+      text for config as introduced by RFC0042:
+      https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md
+    '')
+  ];
+
   options = {
     services.selfoss = {
       enable = mkEnableOption "selfoss";
@@ -63,67 +96,75 @@ in
         '';
       };
 
-      database = {
-        type = mkOption {
-          type = types.enum [
-            "pgsql"
-            "mysql"
-            "sqlite"
-          ];
-          default = "sqlite";
-          description = ''
-            Database to store feeds. Supported are sqlite, pgsql and mysql.
-          '';
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          # Only single level of config supported
+          freeformType = types.attrsOf settingsFormat.lib.types.atom;
+
+          options = {
+            db_type = mkOption {
+              type = types.enum [
+                "pgsql"
+                "mysql"
+                "sqlite"
+              ];
+              default = "sqlite";
+              description = ''
+                Database to store feeds. Supported are sqlite, pgsql and mysql.
+              '';
+            };
+
+            db_host = mkOption {
+              type = types.str;
+              default = "localhost";
+              description = ''
+                Host of the database (has no effect if type is "sqlite").
+              '';
+            };
+
+            db_database = mkOption {
+              type = types.str;
+              default = "tt_rss";
+              description = ''
+                Name of the existing database (has no effect if type is "sqlite").
+              '';
+            };
+
+            db_user = mkOption {
+              type = types.str;
+              default = "tt_rss";
+              description = ''
+                The database user. The user must exist and has access to
+                the specified database (has no effect if type is "sqlite").
+              '';
+            };
+
+            db_password = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                The database user's password (has no effect if type is "sqlite").
+              '';
+            };
+
+            db_port = mkOption {
+              type = types.nullOr types.port;
+              default = null;
+              description = ''
+                The database's port. If not set, the default ports will be
+                provided (5432 and 3306 for pgsql and mysql respectively)
+                (has no effect if type is "sqlite").
+              '';
+            };
+          };
         };
 
-        host = mkOption {
-          type = types.str;
-          default = "localhost";
-          description = ''
-            Host of the database (has no effect if type is "sqlite").
-          '';
-        };
+        default = { };
 
-        name = mkOption {
-          type = types.str;
-          default = "tt_rss";
-          description = ''
-            Name of the existing database (has no effect if type is "sqlite").
-          '';
-        };
-
-        user = mkOption {
-          type = types.str;
-          default = "tt_rss";
-          description = ''
-            The database user. The user must exist and has access to
-            the specified database (has no effect if type is "sqlite").
-          '';
-        };
-
-        password = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = ''
-            The database user's password (has no effect if type is "sqlite").
-          '';
-        };
-
-        port = mkOption {
-          type = types.nullOr types.port;
-          default = null;
-          description = ''
-            The database's port. If not set, the default ports will be
-            provided (5432 and 3306 for pgsql and mysql respectively)
-            (has no effect if type is "sqlite").
-          '';
-        };
-      };
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
         description = ''
-          Extra configuration added to config.ini
+          Configuration for selfoss, see
+          <https://selfoss.aditu.de/docs/administration/options/>
+          for supported values.
         '';
       };
     };

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -123,7 +123,7 @@ in
   config = mkIf cfg.enable {
     services.phpfpm.pools = mkIf (cfg.pool == "${poolName}") {
       ${poolName} = {
-        user = config.services.nginx.user;
+        user = mkDefault config.services.nginx.user;
         settings = mapAttrs (name: mkDefault) {
           "listen.owner" = config.services.nginx.user;
           "listen.group" = config.services.nginx.group;

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -4,8 +4,17 @@
   pkgs,
   ...
 }:
-with lib;
+
 let
+  inherit (lib)
+    mapAttrs
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+
   cfg = config.services.selfoss;
 
   poolName = "selfoss_pool";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Switch to RFC 42 and allow customizing pool user without `mkForce` (follow up to #510765 and https://github.com/fossar/selfoss/issues/1567).

cc https://github.com/NixOS/nixpkgs/issues/144575

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of selfoss using the config below
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<details>
<summary>NixOS VM config used for testing</summary>

```nix
{
  config,
  pkgs,
  ...
}:

{
  imports = [
    <nixpkgs/nixos/modules/virtualisation/qemu-vm.nix>
  ];

  environment.systemPackages = [
    pkgs.php
  ];

  services.nginx = {
    enable = true;

    virtualHosts = {
      "localhost" = {
        root = "/var/lib/selfoss"; # hardcoded in the module
        extraConfig = ''
          include ${pkgs.selfoss}/.nginx.conf;
          location ~ \.php$ {
            fastcgi_pass unix:${config.services.phpfpm.pools.${config.services.selfoss.pool}.socket};
            include ${config.services.nginx.package}/conf/fastcgi.conf;
            fastcgi_param PATH_INFO $fastcgi_path_info;
            fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
          }
        '';
      };
    };
  };

  services.selfoss = {
    enable = true;

    # legacy options
    database = {
      type = "sqlite";
    };

    # various option types
    settings = {
      public = false;
      debug = 1;
      items_lifetime = 99999;
      auto_stream_more = true;
      logger_level = "DEBUG";
    };
  };

  services.openssh = {
    enable = true;
    settings = {
      PermitEmptyPasswords = true;
    };
  };

  users = {
    mutableUsers = false;

    users = {
      root = {
        password = "";
        openssh.authorizedKeys.keys = [
        ];
      };
    };
  };

  networking.firewall = {
    enable = true;
    allowedTCPPorts = [ 80 ];
  };

  virtualisation = {
    forwardPorts = [
      {
        from = "host";
        host.port = 2222;
        guest.port = 22;
      }

      {
        from = "host";
        host.port = 8080;
        guest.port = 80;
      }
    ];
  };

  system.stateVersion = "26.05";
}
```

</details>
