### PR TITLE
sage: fix tests with gfan 0.8beta

### DIFF
--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -160,6 +160,13 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-EMn/fr5WlRQtFj5GHo02kczasmKaiqFfRSVZo2uvOPI=";
     })
 
+    # https://github.com/sagemath/sage/pull/42480, landed in 10.10.beta5
+    (fetchpatch2 {
+      name = "gfan-0_8-doctest-order.patch";
+      url = "https://github.com/sagemath/sage/commit/7ee0e41ce28f2c52b2ecb1041032e605af4ce0cc.patch?full_index=1";
+      hash = "sha256-msXUEbeO2rbP5m+EV8WmX6i8oQIfRLWEDGbIdz//lek=";
+    })
+
     # work around https://github.com/ipython/ipython/issues/15207, which
     # will likely be properly fixed in IPython 9.16.
     ./patches/ipython-9_15-workaround.patch


### PR DESCRIPTION
Backports sagemath/sage#42480, which makes the Sage doctests independent of ordering differences between gfan versions.

This fixes the Sage 10.9 build after gfan was updated to 0.8beta in #554108.

Fixes #556667

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
