### PR TITLE
nixos/pgbackrest: make the SFTP key accessible for postgres

### DIFF
--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -396,6 +396,9 @@ in
           useDefaultShell = true;
           createHome = true;
           home = cfg.repos.localhost.path or "/var/lib/pgbackrest";
+          # share access to the SFTP key with the pgBackRest group,
+          # e.g. the postgresql user
+          homeMode = lib.mkIf config.services.postgresql.enable "710";
         };
         users.groups.pgbackrest = { };
 

--- a/nixos/tests/pgbackrest/sftp.nix
+++ b/nixos/tests/pgbackrest/sftp.nix
@@ -73,7 +73,7 @@ in
         HOME="/var/lib/pgbackrest"
         cat ${snakeOilPrivateKey} > ~/sftp_key
         chown -R pgbackrest:pgbackrest ~/sftp_key
-        chmod 770 ~
+        chmod 640 ~/sftp_key
       """))
 
       with subtest("backup/restore works with local instance/remote repo (SFTP)"):


### PR DESCRIPTION
Usually, the key to the SFTP repository sits in the home directory of the pgBackRest user. By default this has mode 700 which means its not accessible by the postgres user. However, postgres needs to access the key when running archive-push or archive-get. So this PR changes the mode on the home directory of the pgBackRest user to 710 so that the postgres user (who is in the pgBackRest group) can navigate the home directory.

The sftp test worked around this by setting `chmod 770 ~` explicitly. Since this is now covered by the nixos module, the test only needs to set the permission on the key file itself.

Assisted-by: Claude Code (Claude Opus 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
