### PR TITLE
nixos/pgbackrest: share access to lock files with postgres user

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -225,6 +225,8 @@
 
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
 
+- `services.pgbackrest` now keeps its lock files in {file}`/run/pgbackrest` instead of {file}`/tmp`, so that pgbackrest and the postgres user share access to them.
+
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade

--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -87,6 +87,20 @@ let
       default = null;
       internal = true;
     };
+
+  # Values of a path option across the global section and every command section.
+  pathsFor =
+    option:
+    lib.unique (
+      lib.filter (p: p != null) (
+        [ (cfg.settings.${option} or null) ]
+        ++ lib.mapAttrsToList (_: command: command.${option} or null) cfg.commands
+      )
+    );
+
+  # paths that need to be accessed by all members of the pgbackrest group,
+  # e.g. the postgresql user and the pgbackrest user
+  groupPaths = pathsFor "lock-path";
 in
 
 {
@@ -381,6 +395,7 @@ in
         services.pgbackrest.settings = {
           log-level-console = lib.mkDefault "info";
           log-level-file = lib.mkDefault "off";
+          lock-path = lib.mkDefault "/run/pgbackrest";
           cmd-ssh = lib.getExe pkgs.openssh;
         };
 
@@ -398,6 +413,16 @@ in
           home = cfg.repos.localhost.path or "/var/lib/pgbackrest";
         };
         users.groups.pgbackrest = { };
+
+        # ensure groupPaths and their contents are accessible for members of
+        # the group
+        systemd.tmpfiles.settings.pgbackrest = lib.genAttrs groupPaths (_: {
+          d = {
+            user = "pgbackrest";
+            group = "pgbackrest";
+            mode = "2770";
+          };
+        });
 
         systemd.services = lib.mapAttrs (
           _:
@@ -453,9 +478,15 @@ in
             user = "postgres";
           };
         };
-        # If PostgreSQL runs on the same machine, any restore will have to be done with that user.
-        # Keeping the lock file in a directory writeable by the postgres user prevents errors.
-        services.pgbackrest.commands.restore.lock-path = "/tmp/postgresql";
+        # postgresql is running with ProtectSystem=strict which disallows
+        # writing to e.g. /run. This punches holes into that so that it can
+        # write into the groupPaths as necessary.
+        systemd.services.postgresql.serviceConfig.ReadWritePaths = map (path: "-${path}") (
+          lib.unique (
+            groupPaths ++ lib.optional (cfg.repos.localhost.path or null != null) cfg.repos.localhost.path
+          )
+        );
+
         services.postgresql.identMap = ''
           postgres pgbackrest postgres
         '';


### PR DESCRIPTION
Currently, there are 3 different lock file locations:

1. All postgres commands such as `archive-push` and `archive-get` write to postgresql's private tmpfs since it has `PrivateTmp = true`. 
2. All pgbackrest commands write to `/tmp/pgbackrest`. 
3. Then there is a special rule for `restore` to write to `/tmp/postgresql`. 

This results in pgBackRest commands not working correctly. All of these commands should be sharing one lock file location. 

Another problem is that /tmp may be cleaned up age based. So the locks may be deleted occasionally resulting in weird behavior.

In the release notes of [pgBackRest 1.00](https://pgbackrest.org/release.html#unsupported) it says for lock files: 

> These days /run/pgbackrest is the preferred location but that would require init scripts which are not part of this release.

With nixos we have access to init scripts so this PR implements that suggestion.

Also see follow up https://github.com/NixOS/nixpkgs/pull/556699

Assisted-by: Claude Code (Claude Opus 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
