### PR TITLE
lasuite-meet: 1.28.0 -> 1.29.0

### DIFF
--- a/pkgs/by-name/la/lasuite-meet/frontend.nix
+++ b/pkgs/by-name/la/lasuite-meet/frontend.nix
@@ -17,7 +17,7 @@ buildNpmPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-CRq4qpdUBOPBelmrbOgrBdQxD0tY84S3YSbCTQXBkvA=";
+    hash = "sha256-wmAyH35rNgju0GyhvQJHS6vDkFKOoIgiN4ctnu4clN0=";
   };
   npmBuildScript = "build";
 

--- a/pkgs/by-name/la/lasuite-meet/mail.nix
+++ b/pkgs/by-name/la/lasuite-meet/mail.nix
@@ -22,7 +22,7 @@ buildNpmPackage (finalAttrs: {
     pname = "${finalAttrs.pname}-npm-deps";
     inherit version src;
     inherit (finalAttrs) sourceRoot;
-    hash = "sha256-EpUeQpEerHfZ5nZMCanZ+ayzqKHnCeRE4MqVa8TApKk=";
+    hash = "sha256-kArjyi8Jp5gfC/VW5Idzobxgt+NwGHSVP/UxQf7ds4Y=";
   };
   npmBuildScript = "build";
 

--- a/pkgs/by-name/la/lasuite-meet/package.nix
+++ b/pkgs/by-name/la/lasuite-meet/package.nix
@@ -6,13 +6,13 @@
   python3,
 }:
 let
-  version = "1.28.0";
+  version = "1.29.0";
 
   src = fetchFromGitHub {
     owner = "suitenumerique";
     repo = "meet";
     tag = "v${version}";
-    hash = "sha256-BGYyAm4iX0/E1Fv9siRtOT9FXfpc3EAGhKwGRMTkoeQ=";
+    hash = "sha256-SqWKhb4oLKzFkcl96IX4OxzUHVAJn3zh2ZVEDnFVz4E=";
   };
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/suitenumerique/meet/compare/v1.28.0...v1.29.0

Changelog: https://github.com/suitenumerique/meet/blob/v1.29.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
