### PR TITLE
nixos/pgbackrest: enable logging to file by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -225,6 +225,8 @@
 
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
 
+- `services.pgbackrest` now keeps its lock files in {file}`/run/pgbackrest` instead of {file}`/tmp`, so that pgbackrest and the postgres user share access to them.
+
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -227,6 +227,8 @@
 
 - `services.pgbackrest` now keeps its lock files in {file}`/run/pgbackrest` instead of {file}`/tmp`, so that pgbackrest and the postgres user share access to them.
 
+- `services.pgbackrest` now writes a log file by default, in {file}`/var/log/pgbackrest`, rotated weekly: `log-level-file` defaults to `info` instead of `off`.
+
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade

--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -100,7 +100,7 @@ let
 
   # paths that need to be accessed by all members of the pgbackrest group,
   # e.g. the postgresql user and the pgbackrest user
-  groupPaths = pathsFor "lock-path";
+  groupPaths = pathsFor "log-path" ++ pathsFor "lock-path";
 in
 
 {
@@ -394,7 +394,8 @@ in
       {
         services.pgbackrest.settings = {
           log-level-console = lib.mkDefault "info";
-          log-level-file = lib.mkDefault "off";
+          log-level-file = lib.mkDefault "info";
+          log-path = lib.mkDefault "/var/log/pgbackrest";
           lock-path = lib.mkDefault "/run/pgbackrest";
           cmd-ssh = lib.getExe pkgs.openssh;
         };
@@ -423,6 +424,19 @@ in
             mode = "2770";
           };
         });
+
+        # pgBackRest appends to its log files and never rotates them itself.
+        services.logrotate.settings.pgbackrest = {
+          files = map (path: "${path}/*.log") (pathsFor "log-path");
+          # The log directory is group writable, which logrotate refuses to
+          # touch as root.
+          su = "pgbackrest pgbackrest";
+          frequency = "weekly";
+          rotate = 4;
+          compress = true;
+          missingok = true;
+          notifempty = true;
+        };
 
         systemd.services = lib.mapAttrs (
           _:

--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -87,6 +87,20 @@ let
       default = null;
       internal = true;
     };
+
+  # Values of a path option across the global section and every command section.
+  pathsFor =
+    option:
+    lib.unique (
+      lib.filter (p: p != null) (
+        [ (cfg.settings.${option} or null) ]
+        ++ lib.mapAttrsToList (_: command: command.${option} or null) cfg.commands
+      )
+    );
+
+  # paths that need to be accessed by all members of the pgbackrest group,
+  # e.g. the postgresql user and the pgbackrest user
+  groupPaths = pathsFor "lock-path";
 in
 
 {
@@ -381,6 +395,7 @@ in
         services.pgbackrest.settings = {
           log-level-console = lib.mkDefault "info";
           log-level-file = lib.mkDefault "off";
+          lock-path = lib.mkDefault "/run/pgbackrest";
           cmd-ssh = lib.getExe pkgs.openssh;
         };
 
@@ -398,6 +413,16 @@ in
           home = cfg.repos.localhost.path or "/var/lib/pgbackrest";
         };
         users.groups.pgbackrest = { };
+
+        # ensure groupPaths and their contents are accessible for members of
+        # the group
+        systemd.tmpfiles.settings.pgbackrest = lib.genAttrs groupPaths (_: {
+          d = {
+            user = "pgbackrest";
+            group = "pgbackrest";
+            mode = "2770";
+          };
+        });
 
         systemd.services = lib.mapAttrs (
           _:
@@ -453,9 +478,15 @@ in
             user = "postgres";
           };
         };
-        # If PostgreSQL runs on the same machine, any restore will have to be done with that user.
-        # Keeping the lock file in a directory writeable by the postgres user prevents errors.
-        services.pgbackrest.commands.restore.lock-path = "/tmp/postgresql";
+        # postgresql is running with ProtectSystem=strict which disallows
+        # writing to e.g. /run. This punches holes into that so that it can
+        # write into the groupPaths as necessary.
+        systemd.services.postgresql.serviceConfig.ReadWritePaths = map (path: "-${path}") (
+          lib.unique (
+            groupPaths ++ lib.optional (cfg.repos.localhost.path or null != null) cfg.repos.localhost.path
+          )
+        );
+
         services.postgresql.identMap = ''
           postgres pgbackrest postgres
         '';

--- a/nixos/tests/pgbackrest/sftp.nix
+++ b/nixos/tests/pgbackrest/sftp.nix
@@ -80,6 +80,9 @@ in
         primary.succeed("sudo -u pgbackrest pgbackrest --stanza=default stanza-create", timeout=10)
         primary.succeed("sudo -u pgbackrest pgbackrest --stanza=default check")
 
+        # ensure pgbackrest user could write logs
+        primary.succeed("test -s /var/log/pgbackrest/default-stanza-create.log")
+
         primary.systemctl("start pgbackrest-default-future")
 
         # corrupt cluster
@@ -87,6 +90,10 @@ in
         primary.execute("rm ${nodes.primary.services.postgresql.dataDir}/global/pg_control")
 
         primary.succeed("sudo -u postgres pgbackrest --stanza=default restore --delta")
+
+        # ensure postgres user could write logs
+        primary.succeed("test -s /var/log/pgbackrest/default-restore.log")
+        primary.fail("grep -q ERROR /var/log/pgbackrest/*.log")
 
         primary.systemctl("start postgresql")
         primary.wait_for_unit("postgresql.target")


### PR DESCRIPTION
Depends on #556692 (this PR includes the commit)

Currently, _most_ of the pgbackrest log output is going to journald:

1. backup jobs, since each job is its own systemd unit
2. Synchronous archive-push, a child of the postgresql.service, logs to postgresql's journal.

There are two reasons why this PR enables logging to file by default in addition to the existing journal logs:

1. Commands such as a `restore` are usually executed manually. They will log their output to the operators shell whose history may be temporary. Since these are critical operations that are usually executed under pressure, it is nice to have their output permanently saved in a file just in case you ever have to retrace your steps.

2. The async archiver. It runs as a dedicated process under the postgres service. It does not log anything to the console/postgres-journal because the timing of its log messages would not match that of the other log messages in that journal (it is asynchronous). It would just be confusing. Therefore, the pgbackrest implementation silences console output for the async archiver [here](https://github.com/pgbackrest/pgbackrest/blob/908a11a841e85d4e66e4aa551380b52aabfe606f/src/command/archive/push/push.c#L350). For debugging the backup process, these logs are essential. The only way to get them is to have it log to a dedicated file.

This PR enables logging to file by default. The log files need to be accessible by the pgbackrest user as well as the postgresql user since its archive commands write logs as well.

Assisted-by: Claude Code (Claude Opus 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
