### PR TITLE
Revert "rust: 1.97.1 -> 1.98.0"

### DIFF
--- a/pkgs/development/compilers/rust/1_97.nix
+++ b/pkgs/development/compilers/rust/1_97.nix
@@ -50,8 +50,8 @@ let
 in
 import ./default.nix
   {
-    rustcVersion = "1.98.0";
-    rustcSha256 = "sha256-siau83X/vp++K4X96Za1BxbVnVUmjiQNBSOWU0t16Sk=";
+    rustcVersion = "1.97.1";
+    rustcSha256 = "sha256-YiwrQpxTy/3A3TpR0DVU6RzWPr7BkSwfVwlkDN/vGp0=";
 
     llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
     llvmSharedForHost = llvmSharedFor pkgsBuildHost;
@@ -65,30 +65,30 @@ import ./default.nix
     # Note: the version MUST be the same version that we are building. Upstream
     # ensures that each released compiler can compile itself:
     # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
-    bootstrapVersion = "1.98.0";
+    bootstrapVersion = "1.97.1";
 
     # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
     bootstrapHashes = {
-      i686-unknown-linux-gnu = "2706508ca1bc0e2a1205b761d6044d0185bbe322d437225a6c6b74fa917616ab";
-      x86_64-unknown-linux-gnu = "aa30409afa67bd1ada244cefd82c7980e6a65bc113bb978e934b2413c75e3900";
-      x86_64-unknown-linux-musl = "b2cf07e41d4747ddf3b20962ca9de2a08da00646f55ab4c1b51cef99895bae0a";
-      arm-unknown-linux-gnueabihf = "9fcdd10e5855ea8c7af75d5b709f7125e06b0dd653e14235503d5ef885a7350d";
-      armv7-unknown-linux-gnueabihf = "fe4b4ad389108c8b90ae77ed66b62073468a77892483bc11d2be570b64b866db";
-      aarch64-unknown-linux-gnu = "5fbb4282403046d52a4672765c6761a809bf9f33e699b17e6eb7a93ab7770cc3";
-      aarch64-unknown-linux-musl = "c26e37bb6f20e49498c552e53e3f34871ba2f7610c7f8b2cce38a48e3570c7de";
-      x86_64-apple-darwin = "66f4e2e17275753deaba8437380de21072b56b5a083cf954bacb6376df0834fc";
-      aarch64-apple-darwin = "026ec75bec81fb8c10b11df98f1336ee39f4bc11e04d6745dffe9fca81e5c0b5";
-      powerpc64-unknown-linux-gnu = "7ed997cfa306e503362129334e58aebe3b2db9bf2b75a96803636d4098db9ca7";
-      powerpc64le-unknown-linux-gnu = "c20df5c7133492efc4a5e66f9a41aef3dcb50d2a0d8acef98e635ab1c3e49fdb";
-      powerpc64le-unknown-linux-musl = "278b9d213ea3c28e4191bd068ef9d4c722548f775abee90b9d06aefcce6d74f8";
-      riscv64gc-unknown-linux-gnu = "64757537fada45bb7c203ec0d77fda72a11f5d24cf9dcab84cc4168256858a0c";
-      s390x-unknown-linux-gnu = "0c698f9ef09c91e3694149e0f090c8d7ef58d443f89d6dae41c6ca481cc6ec5e";
-      loongarch64-unknown-linux-gnu = "f01c72bff960ae872eb2b809c6243f7b9adf57c7257eb53293f8fe71f526be6e";
-      loongarch64-unknown-linux-musl = "8690a377e5a54b9b42c0f8e35b13c8e22686587995522469a248cbfe326c2bbf";
-      x86_64-unknown-freebsd = "c8d2765c9a3a599c8e475ac8b5b448ac9e2d64a891b6014ce5c07dbfc23ce36c";
+      i686-unknown-linux-gnu = "914c2702deada0b9cf1d64bb3495d76e55cb3eba07d508472dde8b55a93e3759";
+      x86_64-unknown-linux-gnu = "b4cdbc7cc6b0ee0a2666b1872769fdb2ad8393b28b63952f6493b4b400e4832b";
+      x86_64-unknown-linux-musl = "40dbea28193cf2b488cf3e4a89274ccfb60efa50883f19917a382f84fd05bdc4";
+      arm-unknown-linux-gnueabihf = "ba62fe07ad85b507907705a14adc1e8bc258de5f6177ba41d77bbff9f469a4ce";
+      armv7-unknown-linux-gnueabihf = "e89c5e33aaddc6ef56857000c9117875c2997e9a1a500bd7b16277c9874b002f";
+      aarch64-unknown-linux-gnu = "2f2496c70bd336a66a4c8baf2d303ba161f3552f192444c3639ba903c7c1e2c5";
+      aarch64-unknown-linux-musl = "c5f45b5c6eb7f8fdb277c54c08402b7c931516740fbd4eccc26ba148f7cd5d57";
+      x86_64-apple-darwin = "5f4c84d2bcce7983468642855a45fc4978fba1324cfdd1ea0b182face3ab4ffa";
+      aarch64-apple-darwin = "cbd14c36f039f6f11f38148a6295d8234d18ddf20bea53031c86f119423a8b26";
+      powerpc64-unknown-linux-gnu = "2b507d5eb9b5c4c041b50e93e069db56d094f02e6df103dc74c016155141bfae";
+      powerpc64le-unknown-linux-gnu = "ff524eef5a59d801df09ccad5cdaf9ea1f0a07d75cbed2a7e9f013a9eb76a3c1";
+      powerpc64le-unknown-linux-musl = "15630f33fbea2dd9661f8482b6c612da271549aba40401444aaa53650e646b9b";
+      riscv64gc-unknown-linux-gnu = "59bec35d8febb2ab918fa41cffbaa5b07146a63bdc33f029ff756d70a3151ece";
+      s390x-unknown-linux-gnu = "808268af9e880d41b8cb32b242e38c9bd3ea7aba6409b02fbffa0fbc5370c538";
+      loongarch64-unknown-linux-gnu = "d5a925962854730ae7641420d8337af93988ea4ff47b503a856ec53776c87841";
+      loongarch64-unknown-linux-musl = "3fb653299d228e3e0726afb179b07dd10a51a2ecc3cdfcd740011b1d8420ca97";
+      x86_64-unknown-freebsd = "77866a4c449bcccb40e9d6712bf3eb899d29018ed8e841fd9d8d59370751f152";
     };
 
-    selectRustPackage = pkgs: pkgs.rust_1_98;
+    selectRustPackage = pkgs: pkgs.rust_1_97;
   }
 
   (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3999,15 +3999,15 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... }@args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_98 = callPackage ../development/compilers/rust/1_98.nix { };
-  rust = rust_1_98;
+  rust_1_97 = callPackage ../development/compilers/rust/1_97.nix { };
+  rust = rust_1_97;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
-  rustPackages_1_98 = rust_1_98.packages.stable;
-  rustPackages = rustPackages_1_98;
+  rustPackages_1_97 = rust_1_97.packages.stable;
+  rustPackages = rustPackages_1_97;
 
   inherit (rustPackages)
     cargo


### PR DESCRIPTION
This reverts commit ece38ea5b4095f9161940e39d93bc850d9e1a86f (#554749).

The update to rust 1.98.0 seems to cause issues with the bootstrap binaries on aarch64-darwin, such that they are no longer able to build rustc itself. The exact cause is yet unknown, and until this is diagnosed and the root cause is found, we revert this change to minimize impacts. We can remake this change once someone has diagnosed the cause and is able to provide a fix; there's ≈no cost to doing it later, while people are being affected on staging right now.

<details>
<summary>the failing build logs</summary>

```
structuredAttrs is enabled
Running phase: unpackPhase
@nix {"action":"setPhase","phase":"unpackPhase"}
unpacking source archive /nix/store/w2xd5pbnnkhwsz35jsziwd64c3capf7x-rustc-1.98.0-src.tar.gz
source root is rustc-1.98.0-src
setting SOURCE_DATE_EPOCH to timestamp 1787083138 of file "rustc-1.98.0-src/yarn.lock"
unpackPhase completed in 46 seconds
Running phase: patchPhase
@nix {"action":"setPhase","phase":"patchPhase"}
patching script interpreter paths in src/etc
src/etc/htmldocck.py: interpreter directive changed from "#!/usr/bin/env python" to "/nix/store/k07j8cq0iyvna81qlhwxz8xq6pkz02z8-python3-3.14.7/bin/python"
src/etc/dec2flt_table.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/k07j8cq0iyvna81qlhwxz8xq6pkz02z8-python3-3.14.7/bin/python3"
src/etc/generate-keyword-tests.py: interpreter directive changed from "#!/usr/bin/env python" to "/nix/store/k07j8cq0iyvna81qlhwxz8xq6pkz02z8-python3-3.14.7/bin/python"
src/etc/pre-push.sh: interpreter directive changed from "#!/usr/bin/env bash" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/bash"
src/etc/rust-gdbgui: interpreter directive changed from "#!/bin/sh" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/sh"
src/etc/cat-and-grep.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/sh"
src/etc/rust-lldb: interpreter directive changed from "#!/bin/sh" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/sh"
src/etc/indenter: interpreter directive changed from "#!/usr/bin/env python" to "/nix/store/k07j8cq0iyvna81qlhwxz8xq6pkz02z8-python3-3.14.7/bin/python"
src/etc/cpu-usage-over-time-plot.sh: interpreter directive changed from "#!/bin/bash" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/bash"
src/etc/installer/pkg/postinstall: interpreter directive changed from "#!/bin/sh" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/sh"
src/etc/rust-gdb: interpreter directive changed from "#!/bin/sh" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/sh"
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix {"action":"setPhase","phase":"updateAutotoolsGnuConfigScriptsPhase"}
Running phase: configurePhase
@nix {"action":"setPhase","phase":"configurePhase"}
patching script interpreter paths in ./configure
./configure: interpreter directive changed from "#!/bin/sh" to "/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/sh"
configure flags: --prefix=/nix/store/riy4bfh3pbpx4wf85xqhdayamxya5l59-rustc-1.98.0 --sysconfdir=/nix/store/riy4bfh3pbpx4wf85xqhdayamxya5l59-rustc-1.98.0/etc --release-channel=stable --set=build.rustc=/nix/store/l550zx6sqgny9w0y5mx7pvrp7sdzb8dn-rustc-bootstrap-wrapper-1.98.0/bin/rustc --set=build.cargo=/nix/store/hgcnfqa94psrbl36lqd8xryb4ncnyczn-cargo-bootstrap-1.98.0/bin/cargo --tools=rustc\,rustdoc\,rust-analyzer-proc-macro-srv --enable-rpath --enable-vendor --disable-lld --build=aarch64-apple-darwin --host=aarch64-apple-darwin --target=wasm32-unknown-unknown\,wasm32v1-none\,bpfel-unknown-none\,bpfeb-unknown-none\,aarch64-apple-darwin --set=target.\"aarch64-apple-darwin\".cc=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang --set=target.\"aarch64-apple-darwin\".cc=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang --set=target.\"aarch64-apple-darwin\".cc=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang --set=target.\"aarch64-apple-darwin\".linker=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang --set=target.\"aarch64-apple-darwin\".linker=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang --set=target.\"aarch64-apple-darwin\".linker=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang --set=target.\"aarch64-apple-darwin\".cxx=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang++ --set=target.\"aarch64-apple-darwin\".cxx=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang++ --set=target.\"aarch64-apple-darwin\".cxx=/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang++ --set=target.\"aarch64-apple-darwin\".crt-static=false --set=target.\"aarch64-apple-darwin\".crt-static=false --set=target.\"aarch64-apple-darwin\".crt-static=false --enable-llvm-link-shared --set=target.\"aarch64-apple-darwin\".llvm-config=/nix/store/8ndg11bfgn831sh0ibhv41awhax3b1cc-llvm-21.1.8-dev/bin/llvm-config --set=target.\"aarch64-apple-darwin\".llvm-config=/nix/store/8ndg11bfgn831sh0ibhv41awhax3b1cc-llvm-21.1.8-dev/bin/llvm-config --set=target.\"aarch64-apple-darwin\".llvm-config=/nix/store/8ndg11bfgn831sh0ibhv41awhax3b1cc-llvm-21.1.8-dev/bin/llvm-config --set=target.wasm32-unknown-unknown.optimized-compiler-builtins=false --set=target.wasm32v1-none.optimized-compiler-builtins=false --enable-profiler --set=target.wasm32-unknown-unknown.profiler=false --set=target.wasm32v1-none.profiler=false --set=target.bpfel-unknown-none.profiler=false --set=target.bpfeb-unknown-none.profiler=false --set=rust.frame-pointers
configure: processing command line
configure: 
configure: build.configure-args := ['--prefix=/nix/store/riy4bfh3pbpx4wf85xqhdaya ...
configure: install.prefix       := /nix/store/riy4bfh3pbpx4wf85xqhdayamxya5l59-ru ...
configure: install.sysconfdir   := /nix/store/riy4bfh3pbpx4wf85xqhdayamxya5l59-ru ...
configure: rust.channel         := stable
configure: build.rustc          := /nix/store/l550zx6sqgny9w0y5mx7pvrp7sdzb8dn-ru ...
configure: build.cargo          := /nix/store/hgcnfqa94psrbl36lqd8xryb4ncnyczn-ca ...
configure: target."aarch64-apple-darwin".cc := /nix/store/zb4dn54dd83q4vch99hy18k ...
configure: target."aarch64-apple-darwin".cc := /nix/store/zb4dn54dd83q4vch99hy18k ...
configure: target."aarch64-apple-darwin".cc := /nix/store/zb4dn54dd83q4vch99hy18k ...
configure: target."aarch64-apple-darwin".linker := /nix/store/zb4dn54dd83q4vch99h ...
configure: target."aarch64-apple-darwin".linker := /nix/store/zb4dn54dd83q4vch99h ...
configure: target."aarch64-apple-darwin".linker := /nix/store/zb4dn54dd83q4vch99h ...
configure: target."aarch64-apple-darwin".cxx := /nix/store/zb4dn54dd83q4vch99hy18 ...
configure: target."aarch64-apple-darwin".cxx := /nix/store/zb4dn54dd83q4vch99hy18 ...
configure: target."aarch64-apple-darwin".cxx := /nix/store/zb4dn54dd83q4vch99hy18 ...
configure: target."aarch64-apple-darwin".crt-static := False
configure: target."aarch64-apple-darwin".crt-static := False
configure: target."aarch64-apple-darwin".crt-static := False
configure: target."aarch64-apple-darwin".llvm-config := /nix/store/8ndg11bfgn831s ...
configure: target."aarch64-apple-darwin".llvm-config := /nix/store/8ndg11bfgn831s ...
configure: target."aarch64-apple-darwin".llvm-config := /nix/store/8ndg11bfgn831s ...
configure: target.wasm32-unknown-unknown.optimized-compiler-builtins := False
configure: target.wasm32v1-none.optimized-compiler-builtins := False
configure: target.wasm32-unknown-unknown.profiler := False
configure: target.wasm32v1-none.profiler := False
configure: target.bpfel-unknown-none.profiler := False
configure: target.bpfeb-unknown-none.profiler := False
configure: rust.frame-pointers  := True
configure: build.tools          := ['rustc', 'rustdoc', 'rust-analyzer-proc-macro ...
configure: rust.rpath           := True
configure: build.vendor         := True
configure: rust.lld             := False
configure: build.build          := aarch64-apple-darwin
configure: build.host           := ['aarch64-apple-darwin']
configure: build.target         := ['wasm32-unknown-unknown', 'wasm32v1-none', 'b ...
configure: llvm.link-shared     := True
configure: build.profiler       := True
configure: profile              := dist
configure: 
configure: writing `bootstrap.toml` in current directory
configure: 
configure: run `python3 /nix/var/nix/builds/nix-6068-1967939055/rustc-1.98.0-src/x.py --help`
Running phase: buildPhase
@nix {"action":"setPhase","phase":"buildPhase"}
build flags: -j2 SHELL=/nix/store/yqk6qhawnigv832m2zhcbs25nb37r73i-bash-5.3p15/bin/bash
Building bootstrap
warning: a `-j` argument was passed to Cargo but Cargo is also configured with an external jobserver in its environment, ignoring the `-j` parameter
   Compiling libc v0.2.186
   Compiling proc-macro2 v1.0.89
   Compiling typenum v1.17.0
   Compiling memchr v2.7.6
   Compiling version_check v0.9.5
   Compiling unicode-ident v1.0.13
   Compiling generic-array v0.14.7
   Compiling shlex v1.3.0
   Compiling cc v1.2.28
   Compiling quote v1.0.37
   Compiling cfg-if v1.0.0
   Compiling crossbeam-utils v0.8.20
   Compiling syn v2.0.87
   Compiling pkg-config v0.3.31
   Compiling serde v1.0.215
   Compiling lzma-sys v0.1.20
   Compiling aho-corasick v1.1.3
   Compiling rustix v1.1.4
   Compiling regex-syntax v0.8.5
   Compiling getrandom v0.3.2
   Compiling clap_lex v0.7.2
   Compiling heck v0.5.0
   Compiling anstyle v1.0.10
   Compiling clap_derive v4.5.18
   Compiling clap_builder v4.5.20
   Compiling regex-automata v0.4.9
   Compiling crossbeam-epoch v0.9.18
   Compiling block-buffer v0.10.4
   Compiling crypto-common v0.1.6
   Compiling bstr v1.10.0
   Compiling errno v0.3.14
   Compiling bitflags v2.6.0
   Compiling log v0.4.22
   Compiling semver v1.0.23
   Compiling serde_json v1.0.132
   Compiling same-file v1.0.6
   Compiling object v0.37.3
   Compiling walkdir v2.5.0
   Compiling globset v0.4.15
   Compiling digest v0.10.7
   Compiling crossbeam-deque v0.8.5
   Compiling clap v4.5.20
   Compiling filetime v0.2.27
   Compiling cpufeatures v0.2.15
   Compiling once_cell v1.20.2
   Compiling itoa v1.0.11
   Compiling fastrand v2.3.0
   Compiling bootstrap v0.0.0 (/nix/var/nix/builds/nix-6068-1967939055/rustc-1.98.0-src/src/bootstrap)
   Compiling ryu v1.0.18
   Compiling tempfile v3.27.0
   Compiling sha2 v0.10.8
   Compiling clap_complete v4.5.37
   Compiling tar v0.4.45
   Compiling ignore v0.4.23
   Compiling xz2 v0.1.7
   Compiling toml v0.5.11
   Compiling serde_derive v1.0.215
   Compiling cmake v0.1.54
   Compiling termcolor v1.4.1
   Compiling build_helper v0.1.0 (/nix/var/nix/builds/nix-6068-1967939055/rustc-1.98.0-src/src/build_helper)
   Compiling opener v0.8.4
   Compiling home v0.5.12
    Finished `dev` profile [unoptimized] target(s) in 19.39s
WARNING: The `change-id` is missing in the `bootstrap.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.
NOTE: to silence this warning, add `change-id = 158169` or `change-id = "ignore"` at the top of `bootstrap.toml`
Building stage1 compiler artifacts (stage0 -> stage1, aarch64-apple-darwin)
warning: a `-j` argument was passed to Cargo but Cargo is also configured with an external jobserver in its environment, ignoring the `-j` parameter
   Compiling proc-macro2 v1.0.106
   Compiling unicode-ident v1.0.24
   Compiling quote v1.0.45
error: linking with `/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang` failed: exit status: 134
  |
  = note:  "/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang" "/nix/var/nix/builds/nix-6068-1967939055/rustc-1.98.0-src/build/aarch64-apple-darwin/stage1-rustc/release/build/proc-macro2/413786e66d1ec588/out/rustc3Ga5ig/symbols.o" "<2 object files omitted>" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=14.0.0" "-o" "/nix/var/nix/builds/nix-6068-1967939055/rustc-1.98.0-src/build/aarch64-apple-darwin/stage1-rustc/release/build/proc-macro2/413786e66d1ec588/out/build_script_build" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: dyld[7443]: Symbol not found: _LLVMInitializeLanaiAsmParser
            Referenced from: <1A2F26C0-A976-3E9E-89A0-E147F01E0989> /nix/store/6fgrwdc1iwn27zqi1gvkgvzjginbr9k6-clang-21.1.8/bin/clang-21
            Expected in:     <13E0A81C-A9D5-36EE-96BF-3BBF78BF808D> /nix/store/p7y3bzjzg8qdld5qfswgpwzgwmwxisdz-rustc-bootstrap-1.98.0/lib/libLLVM.dylib
          /nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang: line 287:  7443 Abort trap: 6              /nix/store/6fgrwdc1iwn27zqi1gvkgvzjginbr9k6-clang-21.1.8/bin/clang "@$responseFile"
          

error: could not compile `proc-macro2` (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: linking with `/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang` failed: exit status: 134
  |
  = note:  "/nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang" "/nix/var/nix/builds/nix-6068-1967939055/rustc-1.98.0-src/build/aarch64-apple-darwin/stage1-rustc/release/build/quote/710b02f8fa5d5659/out/rustcejMRFc/symbols.o" "<2 object files omitted>" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=14.0.0" "-o" "/nix/var/nix/builds/nix-6068-1967939055/rustc-1.98.0-src/build/aarch64-apple-darwin/stage1-rustc/release/build/quote/710b02f8fa5d5659/out/build_script_build" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: dyld[7451]: Symbol not found: _LLVMInitializeLanaiAsmParser
            Referenced from: <1A2F26C0-A976-3E9E-89A0-E147F01E0989> /nix/store/6fgrwdc1iwn27zqi1gvkgvzjginbr9k6-clang-21.1.8/bin/clang-21
            Expected in:     <13E0A81C-A9D5-36EE-96BF-3BBF78BF808D> /nix/store/p7y3bzjzg8qdld5qfswgpwzgwmwxisdz-rustc-bootstrap-1.98.0/lib/libLLVM.dylib
          /nix/store/zb4dn54dd83q4vch99hy18kg0n8p9nwb-clang-wrapper-21.1.8/bin/clang: line 287:  7451 Abort trap: 6              /nix/store/6fgrwdc1iwn27zqi1gvkgvzjginbr9k6-clang-21.1.8/bin/clang "@$responseFile"
          

error: could not compile `quote` (build script) due to 1 previous error
Build completed unsuccessfully in 0:00:24
make: *** [Makefile:19: all] Error 1
```
</details>

In the future, we (as a collective overall) should be more careful about getting multiplatform testing *before* we merge these.

cc @reckenrode

## Things done

- Built on platform:
  - [x] x86_64-linux: this is "built" in the sense that this is on top of the previous pr, which is on a staging/staging-next merge base, so it ends up just pulling the artifacts from hydra. the dep closure on latest staging is too big for me to build right now.
  - [x] aarch64-linux: as above.
  - [x] aarch64-darwin: as above.
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
