### PR TITLE
mesonlsp: 4.3.7 -> 5.0.4, refactor, adopt

### DIFF
--- a/pkgs/by-name/me/mesonlsp/disable-tests-that-require-network-access.patch
+++ b/pkgs/by-name/me/mesonlsp/disable-tests-that-require-network-access.patch
@@ -1,26 +1,12 @@
-From 5a886abd956607503e9dc7cd22923eaf8b01e46f Mon Sep 17 00:00:00 2001
+From 32376566bc8e0e8b43e51cd7e6f14f15ac219baf Mon Sep 17 00:00:00 2001
 From: Pavel Sobolev <contact@paveloom.dev>
 Date: Mon, 3 Jun 2024 20:31:27 +0300
 Subject: [PATCH] Disable tests that require network access.
 
 ---
- tests/integration/meson.build |  2 --
- tests/libutils/test.cpp       | 20 --------------------
- 2 files changed, 22 deletions(-)
+ tests/libutils/test.cpp | 20 --------------------
+ 1 file changed, 20 deletions(-)
 
-diff --git a/tests/integration/meson.build b/tests/integration/meson.build
-index da1b3b76..8908e690 100644
---- a/tests/integration/meson.build
-+++ b/tests/integration/meson.build
-@@ -51,8 +51,6 @@ wrap_files = files(
-     'wrap-test/vorbis.wrap',
- )
-
--test('wrap-test', wrap_tester, args: [wrap_files], timeout: 200000)
--
- partial_interpreter_tests = [
-     [
-         'foreach',
 diff --git a/tests/libutils/test.cpp b/tests/libutils/test.cpp
 index 2b20191c..c313312b 100644
 --- a/tests/libutils/test.cpp
@@ -28,7 +14,7 @@ index 2b20191c..c313312b 100644
 @@ -131,26 +131,6 @@ TEST(UtilsTest, testMergingDirectories) {
    ASSERT_EQ('a', std::ifstream(outputDir / "i1/a.txt").get());
  }
-
+ 
 -TEST(UtilsTest, testDownloadAndExtraction) {
 -  auto zipFileName = std::filesystem::path{randomFile() + "-1"};
 -  auto result = downloadFile(
@@ -52,6 +38,6 @@ index 2b20191c..c313312b 100644
  int main(int argc, char **argv) {
    testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();
---
-2.45.1
+-- 
+2.55.0
 

--- a/pkgs/by-name/me/mesonlsp/package.nix
+++ b/pkgs/by-name/me/mesonlsp/package.nix
@@ -1,11 +1,9 @@
 {
   lib,
   stdenv,
-  llvmPackages_19,
   fetchFromGitHub,
 
   gtest,
-  makeWrapper,
   meson,
   ninja,
   pkg-config,
@@ -15,45 +13,91 @@
   libarchive,
   libossp_uuid,
   libpkgconf,
+  tomlplusplus,
   libuuid,
   nlohmann_json,
+  tree-sitter,
   pkgsStatic,
 
-  mesonlsp,
+  versionCheckHook,
   nix-update-script,
-  testers,
 }:
 
-let
-  stdenv' = if stdenv.hostPlatform.isDarwin then llvmPackages_19.stdenv else stdenv;
-in
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mesonlsp";
-  version = "4.3.7";
+  version = "5.0.4";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "JCWasmx86";
     repo = "mesonlsp";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-QhZv4PTcf1jzSOcp1+bPZWf5COugCIMq1zkhc0PJjUQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j8J/IREXYwH6KP9KlUTAfLpNN3n7yJSxoh8fqcvQ2P8=";
   };
 
-  patches = [ ./disable-tests-that-require-network-access.patch ];
+  mesonSubprojects = {
+    ada = fetchFromGitHub {
+      owner = "ada-url";
+      repo = "ada";
+      rev = "v2.7.4";
+      hash = "sha256-V5LwL03x7/a9Lvg1gPvgGipo7IICU7xyO2D3GqP6Lbw=";
+    };
+
+    muon = fetchFromGitHub {
+      owner = "JCWasmx86";
+      repo = "muon";
+      rev = "cea0b8e6c2874d1f2ce4057a17bd37090f619b6b";
+      hash = "sha256-MM47mdMKpQBykWeL1aSufH/BYfy+uAWVJLWWMhXolsE=";
+    };
+
+    sha256 = fetchFromGitHub {
+      owner = "amosnier";
+      repo = "sha-2";
+      rev = "49265c656f9b370da660531db8cc6bf0a2e110a6";
+      hash = "sha256-X9M/ZATYXUiE4oGorPBnsdaKnKaObarnMRh6QEfkBls=";
+    };
+
+    tree-sitter-ini = fetchFromGitHub {
+      owner = "JCWasmx86";
+      repo = "tree-sitter-ini";
+      rev = "848b6269f7039739aebd169fbd3d5e6e34bef661";
+      hash = "sha256-Lmlp20gxwfkWMbk81pBwfS7nc3ZBcMfjPzFB2ozhhLk=";
+    };
+
+    tree-sitter-meson = fetchFromGitHub {
+      owner = "JCWasmx86";
+      repo = "tree-sitter-meson";
+      rev = "09665faff74548820c10d77dd8738cd76d488572";
+      hash = "sha256-ice2NdK1/U3NylIQDnNCN41rK/G6uqFOX+OeNf3zm18=";
+    };
+  };
+
+  patches = [
+    # TODO: use mesonCheckFlag once nixpkgs updates to meson 1.12.0
+    ./disable-tests-that-require-network-access.patch
+  ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
-    gtest
-    makeWrapper
     meson
     ninja
     pkg-config
     python3
   ];
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
   buildInputs = [
     curl
+    gtest
     libarchive
     libpkgconf
     nlohmann_json
+    tomlplusplus
+    tree-sitter
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libossp_uuid
@@ -61,101 +105,46 @@ stdenv'.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ libuuid ];
 
-  mesonFlags = [ "-Dbenchmarks=false" ];
-
-  mesonCheckFlags = [ "--print-errorlogs" ];
+  mesonFlags = with lib.strings; [
+    (mesonBool "use_own_tree_sitter" false) # one less vendored dependency
+    (mesonBool "benchmarks" false)
+    # meson flags from $src/mesonlsp.spec
+    # couldn't get it to find tracy anyway
+    (mesonEnable "muon:tracy" false)
+    (mesonEnable "muon:meson-docs" false)
+    (mesonEnable "muon:meson-tests" false)
+    (mesonEnable "muon:man-pages" false)
+    (mesonEnable "muon:website" false)
+    (mesonEnable "muon:native_backtrace" false)
+  ];
 
   doCheck = true;
+  doInstallCheck = true;
 
-  postUnpack =
-    let
-      ada = fetchFromGitHub {
-        owner = "ada-url";
-        repo = "ada";
-        rev = "v2.7.4";
-        hash = "sha256-V5LwL03x7/a9Lvg1gPvgGipo7IICU7xyO2D3GqP6Lbw=";
-      };
+  postUnpack = ''
+    (
+      cd "$sourceRoot"
 
-      muon = fetchFromGitHub {
-        owner = "JCWasmx86";
-        repo = "muon";
-        rev = "62af239567ec3b086bae7f02d4aed3a545949155";
-        hash = "sha256-k883mKwuP35f0WtwX8ybl9uYbvA3y6Vxtv2EJMpZDEs=";
-      };
+      ${lib.concatMapAttrsStringSep "\n" (name: value: ''
+        cp -R --no-preserve=mode,ownership ${value} subprojects/${name}
+      '') finalAttrs.mesonSubprojects}
 
-      sha256 = fetchFromGitHub {
-        owner = "amosnier";
-        repo = "sha-2";
-        rev = "49265c656f9b370da660531db8cc6bf0a2e110a6";
-        hash = "sha256-X9M/ZATYXUiE4oGorPBnsdaKnKaObarnMRh6QEfkBls=";
-      };
-
-      tomlplusplus = fetchFromGitHub {
-        owner = "marzer";
-        repo = "tomlplusplus";
-        rev = "v3.4.0";
-        hash = "sha256-h5tbO0Rv2tZezY58yUbyRVpsfRjY3i+5TPkkxr6La8M=";
-      };
-
-      tree-sitter = fetchFromGitHub {
-        owner = "tree-sitter";
-        repo = "tree-sitter";
-        rev = "v0.20.8";
-        hash = "sha256-278zU5CLNOwphGBUa4cGwjBqRJ87dhHMzFirZB09gYM=";
-      };
-
-      tree-sitter-ini = fetchFromGitHub {
-        owner = "JCWasmx86";
-        repo = "tree-sitter-ini";
-        rev = "20aa563306e9406ac55babb4474521060df90a30";
-        hash = "sha256-1hHjtghBIf7lOPpupT1pUCZQCnzUi4Qt/yHSCdjMhCU=";
-      };
-
-      tree-sitter-meson = fetchFromGitHub {
-        owner = "JCWasmx86";
-        repo = "tree-sitter-meson";
-        rev = "09665faff74548820c10d77dd8738cd76d488572";
-        hash = "sha256-ice2NdK1/U3NylIQDnNCN41rK/G6uqFOX+OeNf3zm18=";
-      };
-    in
-    ''
-      (
-        cd "$sourceRoot/subprojects"
-
-        cp -R --no-preserve=mode,ownership ${ada} ada
-        cp "packagefiles/ada/meson.build" ada
-
-        cp -R --no-preserve=mode,ownership ${muon} muon
-
-        cp -R --no-preserve=mode,ownership ${sha256} sha256
-        cp "packagefiles/sha256/meson.build" sha256
-
-        cp -R --no-preserve=mode,ownership ${tomlplusplus} tomlplusplus-3.4.0
-
-        cp -R --no-preserve=mode,ownership ${tree-sitter} tree-sitter-0.20.8
-        cp "packagefiles/tree-sitter-0.20.8/meson.build" tree-sitter-0.20.8
-
-        cp -R --no-preserve=mode,ownership ${tree-sitter-ini} tree-sitter-ini
-        cp "packagefiles/tree-sitter-ini/meson.build" tree-sitter-ini
-
-        cp -R --no-preserve=mode,ownership ${tree-sitter-meson} tree-sitter-meson
-        cp "packagefiles/tree-sitter-meson/meson.build" tree-sitter-meson
-      )
-    '';
+      meson subprojects packagefiles --apply
+    )
+  '';
 
   postPatch = ''
-    substituteInPlace subprojects/muon/include/compilers.h \
-      --replace-fail 'compiler_language new' 'compiler_language new_'
-
     patchShebangs src/libtypenamespace
   '';
 
+  mesonCheckFlags = [
+    "--print-errorlogs"
+    # requires internet
+    # "--exclude=utilstest" (meson 1.12.0)
+  ];
+
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = mesonlsp;
-      version = "v${finalAttrs.version}";
-    };
   };
 
   meta = {
@@ -164,9 +153,7 @@ stdenv'.mkDerivation (finalAttrs: {
     changelog = "https://github.com/JCWasmx86/mesonlsp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     mainProgram = "mesonlsp";
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.quantenzitrone ];
     platforms = lib.platforms.unix;
-    # ../src/liblog/log.cpp:41:7: error: call to 'format' is ambiguous
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 })


### PR DESCRIPTION
the refactor includes:
- enabling `strictDeps` and `__structuredAttrs`
- moving meson subproject deps to an attribute `mesonSubprojects` which makes the derivation look neater by having all sources grouped together and also makes the subproject dependencies overridable with overrideAttrs
- using `versionCheckHook` instead of `testers.checkVersion`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - [ ] pkgsStatic - dependency tomlplusplus fails to build #556703
    - [ ] pkgsCross.aarch64-multiplatform - dependency tree-sitter fails to build
    - [ ] pkgsCross.x86_64-freebsd - fails to build because it can't find a c compiler for the platform
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
