### PR TITLE
python3Packages.ngff-zarr: 0.42.1 -> 0.43.0

### DIFF
--- a/pkgs/development/python-modules/ngff-zarr/default.nix
+++ b/pkgs/development/python-modules/ngff-zarr/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "ngff-zarr";
-  version = "0.42.1";
+  version = "0.43.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -40,7 +40,7 @@ buildPythonPackage (finalAttrs: {
     owner = "fideus-labs";
     repo = "ngff-zarr";
     tag = "py-v${finalAttrs.version}";
-    hash = "sha256-gioxY26IPQr9f917wYm24ned1/iQyGbASlOFSwkYflE=";
+    hash = "sha256-sif/OhQ/bfnUd7wp5Y+eWqY7uv5peiAt4Zl/alWvGu0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/py/";
@@ -153,6 +153,7 @@ buildPythonPackage (finalAttrs: {
     "test_tiff_file_to_ngff_images_with_channel_names"
     "test_tiff_file_to_ngff_images_with_channels"
     "test_tiff_file_to_ngff_images_with_ome_metadata"
+    "test_tiff_file_to_ngff_images_with_ome_translation"
     "test_tiff_file_to_ngff_images_with_partial_channel_names"
     "test_tiff_file_to_ngff_images_with_sample_axis"
     "test_tiff_file_to_ngff_images_without_channel_names"


### PR DESCRIPTION
Changelog: https://github.com/fideus-labs/ngff-zarr/releases/tag/py-v0.43.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
