### PR TITLE
sstorytime: 0-unstable-2026-08-12 -> 1.0-beta-unstable-2026-08-20

### DIFF
--- a/nixos/modules/services/web-apps/sstorytime.nix
+++ b/nixos/modules/services/web-apps/sstorytime.nix
@@ -164,7 +164,7 @@ in
       description = ''
         Runs tools in a transient unit with the same user, state directory,
         and environment as {option}`systemd.services.sstorytime`.
-        Example: {command}`sstorytime-run N4L -u notes.n4l`.
+        Example: {command}`sstorytime-run N4L -wipe -u notes.n4l`.
       '';
     };
   };

--- a/nixos/tests/sstorytime.nix
+++ b/nixos/tests/sstorytime.nix
@@ -39,7 +39,7 @@
 
       machine.succeed("ln -s ${package.examples}/share/examples /tmp/examples")
 
-      machine.succeed("sstorytime-run N4L -v -u /tmp/examples/SSTorytime.n4l")
+      machine.succeed("sstorytime-run N4L -v -wipe -u /tmp/examples/SSTorytime.n4l")
 
       output = machine.succeed("sstorytime-run searchN4L -v SSTorytime")
       assert "notes about SSTorytime in N4L" in output, "Failed to search for term in graph."

--- a/pkgs/by-name/ss/sstorytime/package.nix
+++ b/pkgs/by-name/ss/sstorytime/package.nix
@@ -12,15 +12,15 @@
 
 buildGoModule (finalAttrs: {
   pname = "sstorytime";
-  version = "0-unstable-2026-08-12";
+  version = "1.0-beta-unstable-2026-08-20";
 
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "markburgess";
     repo = "SSTorytime";
-    rev = "9085a82bd2357e914d862879224bc9d807f7e049";
-    hash = "sha256-ZA3qN//bkCU+yl7uych8Pz7J4AbtlBwRxqV/d/GkEZg=";
+    rev = "a9b34d5197cb0a9fb586bc4722eb8153dffaf044";
+    hash = "sha256-NYMIxUlx5jf2weTdMxziMhZ7dMxPc5L330wRFzhDmFw=";
   };
 
   vendorHash = "sha256-lei5IG02QYSigHmLArlE7huDFVGoVMkw8DTEQeJWFX0=";
@@ -103,10 +103,10 @@ buildGoModule (finalAttrs: {
       fi
     done
 
-    if "$bin" -u examples/doors.n4l >/dev/null; then
-      echo "ok N4L -u doors.n4l"
+    if "$bin" -wipe -u examples/doors.n4l >/dev/null; then
+      echo "ok N4L -wipe -u doors.n4l"
     else
-      echo "FAIL N4L -u doors.n4l"
+      echo "FAIL N4L -wipe -u doors.n4l"
       failed=1
     fi
 


### PR DESCRIPTION
## Summary

Bump [SSTorytime](https://github.com/markburgess/SSTorytime) to `a9b34d5` (`1.0-beta` plus later commits).

https://github.com/markburgess/SSTorytime/compare/9085a82bd2357e914d862879224bc9d807f7e049...a9b34d5197cb0a9fb586bc4722eb8153dffaf044

Upstream no longer supports `N4L -u` without `-wipe` (incremental upload is disabled). installCheck, the NixOS test, and the module example now pass `-wipe`.

Ran via `nix-shell maintainers/scripts/update.nix --argstr package sstorytime`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Assisted by Grok Build (xAI Grok 4.6). Commit has an `Assisted-by:` trailer.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test