### PR TITLE
xssearch: 0.1.9 -> 0.2.0

### DIFF
--- a/pkgs/by-name/xs/xssearch/package.nix
+++ b/pkgs/by-name/xs/xssearch/package.nix
@@ -8,7 +8,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "xssearch";
-  version = "0.1.9";
+  version = "0.2.0";
 
   __structuredAttrs = true;
 
@@ -16,10 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "affolter-engineering";
     repo = "xssearch";
     tag = finalAttrs.version;
-    hash = "sha256-09knkYBnIjZsdAlczYIeqtn0XGAvCD+RF3o9sGSUorw=";
+    hash = "sha256-b0pS8iu6iIO1VwmHWp7yhZiP7ngbdrUz5PCz5NjHZTo=";
   };
 
-  cargoHash = "sha256-t+IcNrjHlVVKrYuLiRrlteT4jQLRiWUsj9RTTTflTiA=";
+  cargoHash = "sha256-uS4PJhBRUuvbRFafO7HSG7+b5cb8k0YDRWgy4Iz8JMU=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
Diff: https://github.com/affolter-engineering/xssearch/compare/0.1.9...0.2.0

Changelog: https://github.com/affolter-engineering/xssearch/releases/tag/0.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
