### PR TITLE
libpqxx: build with cmake

### DIFF
--- a/pkgs/by-name/li/libpqxx/package.nix
+++ b/pkgs/by-name/li/libpqxx/package.nix
@@ -3,11 +3,11 @@
   stdenv,
   gcc14Stdenv,
   fetchFromGitHub,
+  cmake,
   libpq,
-  python3,
   postgresql,
   postgresqlTestHook,
-  autoreconfHook,
+  testers,
 }:
 
 # Work around issue reported in https://github.com/NixOS/nixpkgs/issues/476278.
@@ -26,45 +26,51 @@
   outputs = [
     "out"
     "dev"
+    "doc"
   ];
 
-  nativeBuildInputs = [
-    # Needed because Makefile.am is patched to disable the tools/lint test.
-    autoreconfHook
-    python3
-  ];
+  nativeBuildInputs = [ cmake ];
 
-  buildInputs = [
-    libpq
-  ];
+  buildInputs = [ libpq ];
 
   nativeCheckInputs = [
     postgresql
     postgresqlTestHook
   ];
 
-  postPatch = ''
-    # Disable linting step for tests, it tries to install packages with pip.
-    substituteInPlace Makefile.am \
-      --replace-fail "TESTS = tools/lint" ""
-
-    patchShebangs ./tools/splitconfig.py
-    # Needed for autoreconfHook
-    patchShebangs tools/*.py
-  '';
-
-  configureFlags = [
-    "--disable-documentation"
-    "--enable-shared"
+  cmakeFlags = [
+    (lib.strings.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
   ];
 
-  doCheck = lib.meta.availableOn stdenv.hostPlatform postgresqlTestHook;
+  postInstall = ''
+    # cmake somehow messes up that file so make it manually
+    substitute ../libpqxx.pc.in $out/lib/pkgconfig/libpqxx.pc \
+      --subst-var-by prefix ${placeholder "out"} \
+      --subst-var-by exec_prefix ${placeholder "out"} \
+      --subst-var-by libdir ${placeholder "out"}/lib \
+      --subst-var-by includedir ${placeholder "dev"}/include \
+      --subst-var-by VERSION ${lib.escapeShellArg finalAttrs.version}
+  '';
 
-  enableParallelBuilding = true;
+  checkPhase = ''
+    runHook preCheck
+    test/runner
+    runHook postCheck
+  '';
+
+  doCheck = lib.meta.availableOn stdenv.hostPlatform postgresqlTestHook;
 
   __structuredAttrs = true;
 
   strictDeps = true;
+
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+    cmake-config = testers.hasCmakeConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "libpqxx" ];
+    };
+  };
 
   meta = {
     changelog = "https://github.com/jtv/libpqxx/releases/tag/${finalAttrs.version}";
@@ -73,6 +79,7 @@
     homepage = "https://pqxx.org/development/libpqxx/";
     license = lib.licenses.bsd3;
     maintainers = [ ];
+    pkgConfigModules = [ "libpqxx" ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
relevant changes:
- build doc and split doc output (i couldn't find a way to disable doc)
  - DBUILD_DOC=FALSE didn't work
- no libtool .la file anymore

<details>
<summary>diffs:</summary>

```
$ diff --recursive result{-1,}/
Binary files result-1/lib/libpqxx-7.10.so and result/lib/libpqxx-7.10.so differ
Only in result/lib: libpqxx.la
Binary files result-1/lib/libpqxx.so and result/lib/libpqxx.so differ
```

The binary diff is not comparable, so lets just see if anything breaks :).

```
$ diff --recursive result{-1,}-dev
diff '--color=auto' --recursive result-1-dev/include/pqxx/config-public-compiler.h result-dev/include/pqxx/config-public-compiler.h
1,89c1,8
< /* include/pqxx/config.h.in.  Generated from configure.ac by autoheader.  */
< /* Define to 1 if you have the <dlfcn.h> header file. */
< /* #undef HAVE_DLFCN_H */
< /* Define to 1 if you have the <inttypes.h> header file. */
< /* #undef HAVE_INTTYPES_H */
< /* Define to 1 if you have the `pq' library (-lpq). */
< /* #undef HAVE_LIBPQ */
< /* Define to 1 if you have the <stdint.h> header file. */
< /* #undef HAVE_STDINT_H */
< /* Define to 1 if you have the <stdio.h> header file. */
< /* #undef HAVE_STDIO_H */
< /* Define to 1 if you have the <stdlib.h> header file. */
< /* #undef HAVE_STDLIB_H */
< /* Define to 1 if you have the <strings.h> header file. */
< /* #undef HAVE_STRINGS_H */
< /* Define to 1 if you have the <string.h> header file. */
< /* #undef HAVE_STRING_H */
< /* Define to 1 if you have the <sys/stat.h> header file. */
< /* #undef HAVE_SYS_STAT_H */
< /* Define to 1 if you have the <sys/types.h> header file. */
< /* #undef HAVE_SYS_TYPES_H */
< /* Define to 1 if you have the <unistd.h> header file. */
< /* #undef HAVE_UNISTD_H */
< /* Define to the sub-directory where libtool stores uninstalled libraries. */
< /* #undef LT_OBJDIR */
< /* Name of package */
< /* #undef PACKAGE */
< /* Define to the address where bug reports for this package should be sent. */
< /* #undef PACKAGE_BUGREPORT */
< /* Define to the full name of this package. */
< /* #undef PACKAGE_NAME */
< /* Define to the full name and version of this package. */
< /* #undef PACKAGE_STRING */
< /* Define to the one symbol short name of this package. */
< /* #undef PACKAGE_TARNAME */
< /* Define to the home page for this package. */
< /* #undef PACKAGE_URL */
< /* Define to the version of this package. */
< /* #undef PACKAGE_VERSION */
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_ASSUME */
< /* Define if this feature is available. */
< #define PQXX_HAVE_CHARCONV_FLOAT
< /* Define if this feature is available. */
< #define PQXX_HAVE_CHARCONV_INT
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_CMP */
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_CONCEPTS */
< /* Define if this feature is available. */
< #define PQXX_HAVE_CXA_DEMANGLE
< /* Define if this feature is available. */
< #define PQXX_HAVE_GCC_PURE
< /* Define if this feature is available. */
< #define PQXX_HAVE_GCC_VISIBILITY
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_LIKELY */
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_MULTIDIM */
< /* Define if this feature is available. */
< #define PQXX_HAVE_PATH
< /* Define if this feature is available. */
< #define PQXX_HAVE_POLL
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_RANGES */
< /* Define if this feature is available. */
< #define PQXX_HAVE_SLEEP_FOR
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_SOURCE_LOCATION */
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_SPAN */
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_SSIZE */
< /* Define if this feature is available. */
< #define PQXX_HAVE_STRERROR_R
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_STRERROR_S */
< /* Define if this feature is available. */
< #define PQXX_HAVE_THREAD_LOCAL
< /* Define if this feature is available. */
< /* #undef PQXX_HAVE_YEAR_MONTH_DAY */
< /* Define to 1 if all of the C90 standard headers exist (not just the ones
<    required in a freestanding environment). This macro is provided for
<    backward compatibility; new code need not use it. */
< /* #undef STDC_HEADERS */
< /* Version number of package */
< /* #undef VERSION */
< /* Define if this feature is available. */
< #define no_need_fslib
---
> /* Automatically generated from config.h: public/compiler config. */
>
> #define PQXX_HAVE_ASSUME 1
> #define PQXX_HAVE_GCC_PURE 1
> #define PQXX_HAVE_GCC_VISIBILITY 1
> #define PQXX_HAVE_LIKELY 1
> #define PQXX_HAVE_PATH 1
> #define PQXX_HAVE_STRERROR_R 1
Only in result-1-dev/lib: cmake
diff '--color=auto' --recursive result-1-dev/lib/pkgconfig/libpqxx.pc result-dev/lib/pkgconfig/libpqxx.pc
1,4c1,4
< prefix=/nix/store/nxj99cqbw0g330l5g4f81vbsgm3qq832-libpqxx-7.10.7
< exec_prefix=/nix/store/nxj99cqbw0g330l5g4f81vbsgm3qq832-libpqxx-7.10.7
< libdir=/nix/store/nxj99cqbw0g330l5g4f81vbsgm3qq832-libpqxx-7.10.7/lib
< includedir=/nix/store/yc0pjfrs84px85ykkhvr1lkkq8v2x7iv-libpqxx-7.10.7-dev/include
---
> prefix=/nix/store/brk20i0haq76zg1zl5g4c6f223siq6i4-libpqxx-7.10.7
> exec_prefix=${prefix}
> libdir=/nix/store/brk20i0haq76zg1zl5g4c6f223siq6i4-libpqxx-7.10.7/lib
> includedir=/nix/store/b6fyxkk6kbaj8ddnm6nflvi0fdp6479d-libpqxx-7.10.7-dev/include
diff '--color=auto' --recursive result-1-dev/nix-support/propagated-build-inputs result-dev/nix-support/propagated-build-inputs
1c1
<  /nix/store/nxj99cqbw0g330l5g4f81vbsgm3qq832-libpqxx-7.10.7
\ No newline at end of file
---
>  /nix/store/brk20i0haq76zg1zl5g4c6f223siq6i4-libpqxx-7.10.7
\ No newline at end of file
```

</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
