### PR TITLE
rocqPackages.relation-algebra: 1.8.0 → 1.9.0

### DIFF
--- a/pkgs/development/rocq-modules/relation-algebra/default.nix
+++ b/pkgs/development/rocq-modules/relation-algebra/default.nix
@@ -19,6 +19,7 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
+      (case (isEq "9.2") "1.9.0")
       (case (range "9.0" "9.2") "1.8.1")
       (case (isEq "8.20") "1.7.11")
       (case (range "8.18" "8.19") "1.7.10")
@@ -35,6 +36,7 @@ mkRocqDerivation {
 
   releaseRev = v: if lib.versions.range "1.7.6" "1.7.9" v then "v.${v}" else "v${v}";
 
+  release."1.9.0".hash = "sha256-VxeyxOhvyZzvJss93IFsoU/k6QinpepFUdIf8PG4V9A=";
   release."1.8.1".hash = "sha256-pVeoPt8z1StOfFu5ALCAAxKHecxVNTn9dBXt+nL5d2s=";
   release."1.8.0".hash = "sha256-RnY+a57KnStACteaT5dKQoCCH0qp7/W+4qoaApIilj0=";
   release."1.7.11".hash = "sha256-ZOV0lUdduSabW9Qsz70clkO7QK/NK2STaHqBWcXb7nI=";

--- a/pkgs/development/rocq-modules/relation-algebra/default.nix
+++ b/pkgs/development/rocq-modules/relation-algebra/default.nix
@@ -19,7 +19,7 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
-      (case (range "9.0" "9.1") "1.8.0")
+      (case (range "9.0" "9.2") "1.8.1")
       (case (isEq "8.20") "1.7.11")
       (case (range "8.18" "8.19") "1.7.10")
       (case (isEq "8.17") "1.7.9")
@@ -35,7 +35,8 @@ mkRocqDerivation {
 
   releaseRev = v: if lib.versions.range "1.7.6" "1.7.9" v then "v.${v}" else "v${v}";
 
-  release."1.8.0".sha256 = "sha256-RnY+a57KnStACteaT5dKQoCCH0qp7/W+4qoaApIilj0=";
+  release."1.8.1".hash = "sha256-pVeoPt8z1StOfFu5ALCAAxKHecxVNTn9dBXt+nL5d2s=";
+  release."1.8.0".hash = "sha256-RnY+a57KnStACteaT5dKQoCCH0qp7/W+4qoaApIilj0=";
   release."1.7.11".hash = "sha256-ZOV0lUdduSabW9Qsz70clkO7QK/NK2STaHqBWcXb7nI=";
   release."1.7.10".hash = "sha256-h738L+dybhmWZwTSLJrhv+sB+cIbj0+62Zcy9BH5sVo=";
   release."1.7.9".hash = "sha256-1WzAZyj6q7s0u/9r7lahzxTl8612EA540l9wpm7TYEg=";


### PR DESCRIPTION
Tested: https://github.com/rocq-community/coq-nix-toolbox/pull/504

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
