### PR TITLE
avahi: Do not disable timeout cleanup on watch cleanup

### DIFF
--- a/pkgs/by-name/av/avahi/package.nix
+++ b/pkgs/by-name/av/avahi/package.nix
@@ -178,7 +178,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/avahi/avahi/compare/0ccadca425af151ebb67f276e5cc88e50266a8e6%5E%5E...0ccadca425af151ebb67f276e5cc88e50266a8e6.patch";
       hash = "sha256-yi40iuQmTAW+nLsOIJhh7kg4vG/lqT/PCaSEBPfF2mw=";
     })
-
+    (fetchpatch {
+      name = "Do-not-disable-timeout-cleanup-on-watch-cleanup.patch";
+      url =  "https://github.com/avahi/avahi/commit/b3ad387c74f20368f6dcf60f97d20a3bf8ba9782.patch";
+      hash = "sha256-/0A0a06ajbmRGiKEbJylcZmlM+2nnZxYkb4XbaOdg8A=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Upstream patch:

```
Subject: [PATCH] Do not disable timeout cleanup on watch cleanup

This was causing timeouts to never be removed from the linked list that
tracks them, resulting in both memory and CPU usage to grow larger over
time.
```

This is slated for the avahi 0.9 release but is a problem now on 0.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
