### PR TITLE
python3Packages.urlscan-python: 0.0.1 -> 2026.08.18

### DIFF
--- a/pkgs/development/python-modules/urlscan-python/default.nix
+++ b/pkgs/development/python-modules/urlscan-python/default.nix
@@ -13,7 +13,7 @@
   uv-dynamic-versioning,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "urlscan-python";
   version = "2026.08.18";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "urlscan";
     repo = "urlscan-python";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-N7l4+Izn0fhRuoOejtR4/WHTxfoaQVWM6EdSIB0wm+0=";
   };
 
@@ -51,8 +51,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python API client for urlscan.io";
     homepage = "https://github.com/urlscan/urlscan-python/";
-    changelog = "https://github.com/urlscan/urlscan-python/releases/tag/${src.tag}";
+    changelog = "https://github.com/urlscan/urlscan-python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/urlscan-python/default.nix
+++ b/pkgs/development/python-modules/urlscan-python/default.nix
@@ -9,19 +9,20 @@
   pytest-randomly,
   pytest-timeout,
   pytestCheckHook,
+  python-dotenv,
   uv-dynamic-versioning,
 }:
 
 buildPythonPackage rec {
   pname = "urlscan-python";
-  version = "0.0.1";
+  version = "2026.08.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "urlscan";
     repo = "urlscan-python";
     tag = "v${version}";
-    hash = "sha256-HkovBmmVvUYA5U43w5TUOcwhZAN/0o0BETd1s9R940w=";
+    hash = "sha256-N7l4+Izn0fhRuoOejtR4/WHTxfoaQVWM6EdSIB0wm+0=";
   };
 
   build-system = [
@@ -37,9 +38,15 @@ buildPythonPackage rec {
     pytest-randomly
     pytest-timeout
     pytestCheckHook
+    python-dotenv
   ];
 
   pythonImportsCheck = [ "urlscan" ];
+
+  disabledTestPaths = [
+    # Tests require an API key
+    "tests/integration"
+  ];
 
   meta = {
     description = "Python API client for urlscan.io";


### PR DESCRIPTION
Changelog: https://github.com/urlscan/urlscan-python/releases/tag/v2026.08.18


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
