### PR TITLE
sbcl: fix memory envvar name

### DIFF
--- a/pkgs/development/compilers/sbcl/patches/dynamic-space-size-envvar-2.6.3-feature.patch
+++ b/pkgs/development/compilers/sbcl/patches/dynamic-space-size-envvar-2.6.3-feature.patch
@@ -1,7 +1,7 @@
 From 6bb8cde826589777e50ddb78e8e1fe7652194a4f Mon Sep 17 00:00:00 2001
 From: Hraban Luyat <hraban@0brg.net>
 Date: Sat, 13 Apr 2024 14:04:57 -0400
-Subject: [PATCH 1/2] feat: SBCL_DYNAMIC_SPACE_SIZE envvar
+Subject: [PATCH 1/2] feat: NIX_SBCL_DYNAMIC_SPACE_SIZE envvar
 
 ---
  src/runtime/runtime.c | 27 +++++++++++++++++++++++++++
@@ -27,14 +27,14 @@ index 295ee2b3c..5c4560f50 100644
 + */
 +static void
 +read_memsize_from_env(void) {
-+  const char *val = getenv("SBCL_DYNAMIC_SPACE_SIZE");
++  const char *val = getenv("NIX_SBCL_DYNAMIC_SPACE_SIZE");
 +  // The distinction is blurry between setting an envvar to the empty string and
 +  // unsetting it entirely. Depending on the calling environment it can even be
 +  // tricky to properly unset an envvar in the first place. An empty envvar is
 +  // practically always intended to just mean “unset”, so let’s interpret it
 +  // that way.
 +  if (val != NULL && (strcmp(val, "") != 0)) {
-+    dynamic_space_size = parse_size_arg(val, "SBCL_DYNAMIC_SPACE_SIZE");
++    dynamic_space_size = parse_size_arg(val, "NIX_SBCL_DYNAMIC_SPACE_SIZE");
 +  }
 +}
 +

--- a/pkgs/development/compilers/sbcl/patches/dynamic-space-size-envvar-2.6.3-tests.patch
+++ b/pkgs/development/compilers/sbcl/patches/dynamic-space-size-envvar-2.6.3-tests.patch
@@ -24,11 +24,11 @@ index 000000000..72ef0cc79
 +set -e
 +
 +# Allow slight shrinkage if heap relocation has to adjust for alignment
-+SBCL_DYNAMIC_SPACE_SIZE=234mb run_sbcl_with_args --script <<EOF
++NIX_SBCL_DYNAMIC_SPACE_SIZE=234mb run_sbcl_with_args --script <<EOF
 +(assert (<= 0 (- (* 234 1024 1024) (sb-ext:dynamic-space-size)) 65536))
 +EOF
 +
-+SBCL_DYNAMIC_SPACE_SIZE=555mb run_sbcl_with_args --dynamic-space-size 234mb --script <<EOF
++NIX_SBCL_DYNAMIC_SPACE_SIZE=555mb run_sbcl_with_args --dynamic-space-size 234mb --script <<EOF
 +(assert (<= 0 (- (* 234 1024 1024) (sb-ext:dynamic-space-size)) 65536))
 +EOF
 +
@@ -56,7 +56,7 @@ index faa647e1a..1f2821b5d 100644
  echo "::: Success"
  
 +echo "::: Running :DYNAMIC-SPACE-SIZE-ENV-ACCEPT"
-+SBCL_DYNAMIC_SPACE_SIZE=432MB ./"$tmpcore" --no-userinit --no-sysinit --noprint <<EOF
++NIX_SBCL_DYNAMIC_SPACE_SIZE=432MB ./"$tmpcore" --no-userinit --no-sysinit --noprint <<EOF
 +  (when (dynamic-space-size-good-p 432)
 +    (exit :code 42))
 +EOF
@@ -66,7 +66,7 @@ index faa647e1a..1f2821b5d 100644
 +echo "::: Success"
 +
 +echo "::: Running :DYNAMIC-SPACE-SIZE-PRECEDENCE"
-+SBCL_DYNAMIC_SPACE_SIZE=432MB ./"$tmpcore" --dynamic-space-size 333MB \
++NIX_SBCL_DYNAMIC_SPACE_SIZE=432MB ./"$tmpcore" --dynamic-space-size 333MB \
 +  --no-userinit --no-sysinit --noprint <<EOF
 +  (when (dynamic-space-size-good-p 333))
 +    (exit :code 42))
@@ -112,7 +112,7 @@ index faa647e1a..1f2821b5d 100644
  echo "::: Success"
  
 +echo "::: Running :DYNAMIC-SPACE-SIZE-ENV-IGNORE"
-+SBCL_DYNAMIC_SPACE_SIZE=432MB ./"${tmpcore}2" --no-userinit --no-sysinit --noprint <<EOF
++NIX_SBCL_DYNAMIC_SPACE_SIZE=432MB ./"${tmpcore}2" --no-userinit --no-sysinit --noprint <<EOF
 +  (when (dynamic-space-size-good-p 260)
 +    (exit :code 42))
 +EOF


### PR DESCRIPTION
Somehow accidentally removed the NIX_ prefix during the migration in "https://github.com/NixOS/nixpkgs/pull/505169".

🤦

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
