### PR TITLE
snipe-it: 8.4.1 -> 8.7.2

### DIFF
--- a/nixos/modules/services/web-apps/snipe-it.nix
+++ b/nixos/modules/services/web-apps/snipe-it.nix
@@ -341,6 +341,7 @@ in
       APP_URL = cfg.appURL;
       DB_HOST = db.host;
       DB_PORT = db.port;
+      DB_SOCKET = lib.mkIf db.createLocally "/run/mysqld/mysqld.sock";
       DB_DATABASE = db.name;
       DB_USERNAME = db.user;
       DB_PASSWORD._secret = db.passwordFile;

--- a/pkgs/by-name/sn/snipe-it/0001-Fix-backup-restoration-when-using-a-unix-socket.patch
+++ b/pkgs/by-name/sn/snipe-it/0001-Fix-backup-restoration-when-using-a-unix-socket.patch
@@ -1,0 +1,27 @@
+From 8c04235655a79f9b39003e49ea3bfa921e42e371 Mon Sep 17 00:00:00 2001
+From: Marie Ramlow <me@nycode.dev>
+Date: Wed, 26 Aug 2026 17:16:42 +0200
+Subject: [PATCH] Fix backup restoration when using a unix socket
+
+---
+ app/Console/Commands/RestoreFromBackup.php | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/app/Console/Commands/RestoreFromBackup.php b/app/Console/Commands/RestoreFromBackup.php
+index ba5d9aa8df..f449420cc5 100644
+--- a/app/Console/Commands/RestoreFromBackup.php
++++ b/app/Console/Commands/RestoreFromBackup.php
+@@ -510,7 +510,9 @@ class RestoreFromBackup extends Command
+             ' --batch '.
+             ' --binary-mode '.
+             ' -u '.escapeshellarg($connectionConfig['username']).' '.
+-            ' -P '.escapeshellarg($connectionConfig['port']).' '.
++            (empty($connectionConfig['unix_socket'])
++                ? ' -P '.escapeshellarg($connectionConfig['port'])
++                : ' -S '.escapeshellarg($connectionConfig['unix_socket'])). ' '.
+             escapeshellarg($connectionConfig['database']), // yanked -p since we pass via ENV
+             [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+             $pipes,
+-- 
+2.55.0
+

--- a/pkgs/by-name/sn/snipe-it/package.nix
+++ b/pkgs/by-name/sn/snipe-it/package.nix
@@ -12,16 +12,20 @@ let
 in
 php.buildComposerProject2 (finalAttrs: {
   pname = "snipe-it";
-  version = "8.4.1";
+  version = "8.7.2";
+
+  patches = [
+    ./0001-Fix-backup-restoration-when-using-a-unix-socket.patch
+  ];
 
   src = fetchFromGitHub {
     owner = "grokability";
     repo = "snipe-it";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SSz0bFhspS3c5z0+mpub6gIqiMwzJ/5YfzPs9NdClCo=";
+    hash = "sha256-ND/Et3zRhD4axNNfaq4MW4sLj3634VhnDdAtZUxnEJU=";
   };
 
-  vendorHash = "sha256-crHl0CU5nf1SuXWf2O4tDLiNW1T7ku5cfNXjeNE6bDw=";
+  vendorHash = "sha256-9mihxUDylADJCbLSxVj+qHfT8BW6rO2qjRzhGQJT0jM=";
 
   postInstall = ''
     snipe_it_out="$out/share/php/snipe-it"


### PR DESCRIPTION
Hardcoded `-P <port>` argument to mariadb lead to permission denied errors, because it was no longer connecting to MariaDB over the unix socket. See upstream PR: https://github.com/grokability/snipe-it/pull/19558

Fixes: https://github.com/NixOS/nixpkgs/issues/552187 (CVE-2026-19579)
Fixes: https://github.com/NixOS/nixpkgs/issues/542109 (CVE-2026-55479, CVE-2026-55476, CVE-2026-55516, CVE-2026-55466, CVE-2026-55481, CVE-2026-55843, CVE-2026-55515, CVE-2026-55464, CVE-2026-55461, CVE-2026-55452, CVE-2026-55474, CVE-2026-55460, CVE-2026-55475, CVE-2026-55478, CVE-2026-54329, CVE-2026-55469, CVE-2026-55472, CVE-2026-55462)
Fixes: https://github.com/NixOS/nixpkgs/issues/539900 (CVE-2026-48492)
Fixes: https://github.com/NixOS/nixpkgs/issues/539888 (CVE-2026-55542)
Fixes: https://github.com/NixOS/nixpkgs/issues/529813 (CVE-2026-48507)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
