### PR TITLE
realvnc-vnc-viewer: 7.15.1 -> 8.5.0, unavailable urls fixed

### DIFF
--- a/pkgs/by-name/re/realvnc-vnc-viewer/darwin.nix
+++ b/pkgs/by-name/re/realvnc-vnc-viewer/darwin.nix
@@ -1,7 +1,9 @@
 {
   stdenvNoCC,
   fetchurl,
-  undmg,
+  gzip,
+  xar,
+  cpio,
   pname,
   version,
   meta,
@@ -10,19 +12,38 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   inherit pname version meta;
 
   src = fetchurl rec {
-    name = "VNC-Viewer-${finalAttrs.version}-MacOSX-universal.dmg";
-    url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
-    hash = "sha256-nWS7XsAQFcp2uoXXzT+a542Q9vwloZEQHqf4eieKqUA=";
+    name = "RealVNC-Connect-Viewer-${finalAttrs.version}-MacOSX-universal.pkg";
+    url = "https://downloads.realvnc.com/download/file/realvnc-connect-viewer/${name}";
+    hash = "sha256-+7lwjzGTIkAxp+CFb2chlAQ4TTr6EBPqWyQsC1JSVlk=";
   };
-  sourceRoot = ".";
 
-  nativeBuildInputs = [ undmg ];
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [
+    gzip
+    xar
+    cpio
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    xar -xf $src
+    gunzip -dc RealVNC-Connect-Viewer-${finalAttrs.version}-MacOSX-universal-comp.pkg/Payload > decompressed.out
+    cat decompressed.out | cpio -it | grep -v '/._' > file-list-no-resource-forks.txt
+    cat decompressed.out | cpio -i -E file-list-no-resource-forks.txt
+
+    runHook postUnpack
+  '';
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/Applications
-    cp -r *.app $out/Applications
+    cp -r Applications/*.app $out/Applications
 
     runHook postInstall
   '';

--- a/pkgs/by-name/re/realvnc-vnc-viewer/linux.nix
+++ b/pkgs/by-name/re/realvnc-vnc-viewer/linux.nix
@@ -3,56 +3,87 @@
   fetchurl,
   autoPatchelfHook,
   rpmextract,
+  buildFHSEnv,
   libx11,
   libxext,
+  libepoxy,
+  fontconfig,
+  glib,
+  gtk3,
+  xdg-utils,
+  shared-mime-info,
+  desktop-file-utils,
   pname,
   version,
   meta,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  inherit pname version;
+let
+  vncviewer-unwrapped = stdenv.mkDerivation (finalAttrs: {
+    inherit pname version;
 
-  src =
-    {
-      "x86_64-linux" = fetchurl rec {
-        name = "VNC-Viewer-${finalAttrs.version}-Linux-x64.rpm";
-        url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
-        hash = "sha256-rIOP7d8qrOeMgaQRYo+GRXT1fLnPegdpONT0p5aBCxM=";
-      };
-    }
-    .${stdenv.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    src =
+      {
+        "x86_64-linux" = fetchurl rec {
+          name = "RealVNC-Connect-Viewer-${finalAttrs.version}-Linux-x64.rpm";
+          url = "https://downloads.realvnc.com/download/file/realvnc-connect-viewer/${name}";
+          hash = "sha256-x/NG9ivYUbtrFxksglCLF+lGA2OO2VdEN1qPsvum7tQ=";
+        };
+      }
+      .${stdenv.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    rpmextract
+    nativeBuildInputs = [
+      autoPatchelfHook
+      rpmextract
+    ];
+    buildInputs = [
+      libx11
+      libxext
+      libepoxy
+      fontconfig
+      glib
+      gtk3
+      stdenv.cc.cc.libgcc or null
+    ];
+
+    unpackPhase = ''
+      rpmextract $src
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mv usr $out
+      find $out -xtype l -delete
+
+      runHook postInstall
+    '';
+  });
+in
+buildFHSEnv {
+  # buildFHSEnv needed because the newer version uses a tricky hardcoded external binary path:
+  # /usr/bin/xdg-mime. Otherwise a crash will take place when openning browser or signing in
+  inherit pname version meta;
+
+  runScript = "${vncviewer-unwrapped}/lib/rvncconnect/rvncconnect";
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons
+    cp -r ${vncviewer-unwrapped}/share/applications/. $out/share/applications/
+    cp -r ${vncviewer-unwrapped}/share/icons/. $out/share/icons/
+
+    substituteInPlace $out/share/applications/com.realvnc.rvncconnect.desktop \
+      --replace-fail /usr/lib/rvncconnect/rvncconnect $out/bin/realvnc-vnc-viewer \
+      --replace-fail /usr/share/icons/hicolor/scalable/apps/com.realvnc.rvncconnect.svg $out/share/icons/hicolor/scalable/apps/com.realvnc.rvncconnect.svg
+    substituteInPlace $out/share/applications/com.realvnc.rvncconnect.connect.uri.desktop \
+      --replace-fail /usr/lib/rvncconnect/rvncconnect $out/bin/realvnc-vnc-viewer
+  '';
+
+  targetPkgs = pkgs: [
+    vncviewer-unwrapped
+    xdg-utils
+    shared-mime-info
+    desktop-file-utils
   ];
-  buildInputs = [
-    libx11
-    libxext
-    stdenv.cc.cc.libgcc or null
-  ];
-
-  unpackPhase = ''
-    rpmextract $src
-  '';
-
-  postPatch = ''
-    substituteInPlace ./usr/share/applications/realvnc-vncviewer.desktop \
-      --replace /usr/share/icons/hicolor/48x48/apps/vncviewer48x48.png vncviewer48x48.png
-    substituteInPlace ./usr/share/mimelnk/application/realvnc-vncviewer-mime.desktop \
-      --replace /usr/share/icons/hicolor/48x48/apps/vncviewer48x48.png vncviewer48x48.png
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    mv usr $out
-
-    runHook postInstall
-  '';
-
-  meta = meta // {
-    mainProgram = "vncviewer";
-  };
-})
+}

--- a/pkgs/by-name/re/realvnc-vnc-viewer/package.nix
+++ b/pkgs/by-name/re/realvnc-vnc-viewer/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "realvnc-vnc-viewer";
-  version = "7.15.1";
+  version = "8.5.0";
 
   meta = {
     description = "VNC remote desktop client software by RealVNC";
@@ -21,7 +21,7 @@ let
       onedragon
     ];
     platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
-    mainProgram = "vncviewer";
+    mainProgram = "realvnc-vnc-viewer";
   };
 in
 if stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
Update RealVNC Connect Viewer from 7.15.1 to 8.5.0.

The upstream changed their download format and layout in 8.x:
- Linux switched from `.rpm` at `viewer.files` to `.rpm` at `realvnc-connect-viewer`, with desktop/icon filenames changed.
- The hardcoded binary `/usr/bin/xdg-mime`. So, wrap the package in `buildFHSEnv`, avoiding a crash when opening the browser or signing in.
- macOS switched from `.dmg` to a `.pkg` installer. Repackaged with `xar` + `cpio`, matching how other `.pkg`-based packages (e.g. `enpass-mac`) are handled.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
