### PR TITLE
curl: Fix TODOs from #553075

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -113,28 +113,17 @@ stdenv.mkDerivation (finalAttrs: {
   #
   # Where the host has no shell at all, `patchShebangs --host` finds nothing
   # and leaves the shebang as shipped, which is the best available answer.
-  #
-  # TODO: take the first branch unconditionally --- in the spirit of strictDeps,
-  # it is good to always be defensive rather than do something unnecessarily
-  # that we can only get away with when build == host.
-  + (
-    if isCross then
-      ''
-        local f flag
-        for f in scripts/*; do
-          if [[ "$f" == scripts/wcurl ]]; then
-            flag=--host
-          else
-            flag=--build
-          fi
-          patchShebangs "$flag" "$f"
-        done
-      ''
-    else
-      ''
-        patchShebangs scripts
-      ''
-  );
+  + ''
+    local f flag
+    for f in scripts/*; do
+      if [[ "$f" == scripts/wcurl ]]; then
+        flag=--host
+      else
+        flag=--build
+      fi
+      patchShebangs "$flag" "$f"
+    done
+  '';
 
   outputs = [
     "bin"
@@ -289,13 +278,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Some hosts have no shell for the scripts to point at: MinGW is the one in
   # tree, where `bash` is marked unsupported because it needs a POSIX layer. We
   # cannot patch shebangs in that case.
-  #
-  # TODO: drop the isCross part of the condition --- in the spirit of
-  # `strictDeps` it is good to have the dep (when it is available), even if it
-  # is gratuitous in the `build = host` case.
-  buildInputs = lib.optional (
-    isCross && lib.meta.availableOn stdenv.hostPlatform runtimeShellPackage
-  ) runtimeShellPackage;
+  buildInputs = lib.optional (lib.meta.availableOn stdenv.hostPlatform runtimeShellPackage) runtimeShellPackage;
 
   passthru =
     let


### PR DESCRIPTION
That PR left two TODOs for a later mass-rebuild. Now that PR is in staging, we can fix those TODOs.

The diff should be self-explanatory, as the now-deleted TODOs said what is supposed to happen.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
