### PR TITLE
trailbase: use GitHub releases for update script

### DIFF
--- a/pkgs/by-name/tr/trailbase/package.nix
+++ b/pkgs/by-name/tr/trailbase/package.nix
@@ -107,7 +107,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       imports = [ (lib.modules.importApply ./service.nix { }) ];
       trailbase.package = lib.mkDefault finalAttrs.finalPackage;
     };
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
   };
 
   meta = {


### PR DESCRIPTION
`passthru.updateScript` is a bare `nix-update-script { }`, so r-ryantm asked `nix-update` for the newest git tag. trailbaseio/trailbase has leftover workflow-test tags (`v0.50.*`, `v0.100.*`, `v0.123.*`, commit messages like `Foo` / `BAZ`) that sort above the real 0.33 line. That produced #556759 (`0.32.2 -> 0.123.3`). `v0.123.3` is not a GitHub release.

`--use-github-releases` is the same flag other packages use for this. Latest GitHub release today is `v0.33.4`.

Does not change the package derivation. 

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Evalled `trailbase.updateScript`; it is `nix-update --use-github-releases`. Did not rebuild the package. Grok Build (xAI Grok 4.6) wrote the patch, commit, and this PR body.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test