### PR TITLE
ameba: 1.6.4 -> 1.7.0

### DIFF
--- a/pkgs/by-name/am/ameba/package.nix
+++ b/pkgs/by-name/am/ameba/package.nix
@@ -1,21 +1,21 @@
 {
   lib,
   fetchFromGitHub,
-  crystal_1_17,
+  crystal_1_19,
   coreutils,
 }:
 let
-  crystal = crystal_1_17;
+  crystal = crystal_1_19;
 in
 crystal.buildCrystalPackage rec {
   pname = "ameba";
-  version = "1.6.4";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "crystal-ameba";
     repo = "ameba";
     tag = "v${version}";
-    hash = "sha256-2gEwgXjB6zcJQAdUGQfZFe8WcqT5fyb8Qbxk0qwn+c8=";
+    hash = "sha256-P2XirYKxq3Y6cjK5O013fPzag9uWR9jdetlLxX70ji4=";
   };
 
   format = "make";
@@ -24,7 +24,7 @@ crystal.buildCrystalPackage rec {
   meta = {
     description = "Static code analysis tool for Crystal";
     mainProgram = "ameba";
-    homepage = "https://crystal-ameba.github.io";
+    homepage = "https://crystal-ameba.org";
     changelog = "https://github.com/crystal-ameba/ameba/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = [ ];


### PR DESCRIPTION
Update ameba to 1.7.0: https://github.com/crystal-ameba/ameba/releases/tag/v1.7.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
