### PR TITLE
librewolf-unwrapped: 154.0-2 -> 154.0.1-2

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "154.0-2",
+  "packageVersion": "154.0.1-2",
   "source": {
-    "rev": "154.0-2",
-    "hash": "sha256-J7n4xjl6RO9PQD0rMWeB+0EKkZcvopY8GvkM0+WbkM4="
+    "rev": "154.0.1-2",
+    "hash": "sha256-cwPJzF9kvbVGAB8lBJSTCoP26k1EKQUKGbngsKmdtt0="
   },
   "firefox": {
-    "version": "154.0",
-    "hash": "sha512-p3zWZJgq3WKGgRZ+9ZOb1r8MiUqjgMymb5tfsmWUeHTR6BnUImTx3QfIQ/im3AINomjMqf8eBk/KAZ3pGvm5lg=="
+    "version": "154.0.1",
+    "hash": "sha512-kUHjSXjC7L4bJns8xjE2FCYlc0YY5ny7v2U24UJ69m0B8ZhRIA66DbfHFZkfOefV0CAKu54s18FdWKikEbG0Eg=="
   }
 }

--- a/pkgs/by-name/li/librewolf-unwrapped/src.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.nix
@@ -1,20 +1,19 @@
 {
   lib,
   fetchurl,
-  fetchFromGitLab,
+  fetchFromForgejo,
 }:
 let
   src = lib.importJSON ./src.json;
 in
 {
   inherit (src) packageVersion;
-  source = fetchFromGitLab (
+  source = fetchFromForgejo (
     src.source
     // {
       domain = "librewolf.dev";
       owner = "librewolf";
       repo = "source";
-      fetchSubmodules = true;
     }
   );
   firefox = fetchurl (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Update Librewolf to 154.0.1-2

[diff](https://librewolf.dev/librewolf/source/compare/154.0-2...154.0.1-2)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
