### PR TITLE
[Backport release-26.05] angie: remove stale knownVulnerabilities warning

### DIFF
--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -43,8 +43,5 @@ callPackage ../nginx/generic.nix args rec {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ izorkin ];
-    knownVulnerabilities = [
-      "angie is insufficiently maintained in nixpkgs. Security updates are frequently delayed. Please consider stepping up as maintainer or switching to an alternative."
-    ];
   };
 }


### PR DESCRIPTION
Backport of #548875 to release-26.05. Removes the now-stale knownVulnerabilities marker from angie: the 1.12.1 security bump already landed on this branch, and angie now has an active co-maintainer, so the warning falsely blocks angie builds on stable.