### PR TITLE
qir-runner: 0.8.3 -> 0.9.6

### DIFF
--- a/pkgs/by-name/qi/qir-runner/package.nix
+++ b/pkgs/by-name/qi/qir-runner/package.nix
@@ -1,9 +1,8 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   rustPlatform,
-  llvmPackages_19,
+  llvmPackages_20,
   libffi,
   zlib,
   libxml2,
@@ -11,23 +10,24 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qir-runner";
-  version = "0.8.3";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "qir-alliance";
     repo = "qir-runner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-k93I/DE8Jx0DbloBVNhKKay/L26H5TPX5yvkHKe/yBg=";
+    hash = "sha256-5RfcHlJvdRjWfG6RbvIeCoMuos7O3Avu44uGcuOcz90=";
   };
 
-  nativeBuildInputs = [ llvmPackages_19.llvm ];
+  nativeBuildInputs = [ llvmPackages_20.llvm.dev ];
   buildInputs = [
     libffi
     zlib
     libxml2
+    llvmPackages_20.llvm
   ];
 
-  cargoHash = "sha256-U/9oDOPhlSL1ViW1n5C4MWRvUvU4c/cuATLNIx7FkiM=";
+  cargoHash = "sha256-0CLYpdfu9T6db6tarDF7i5dkIXjSzsmvtN+yuqZvB6s=";
 
   meta = {
     description = "QIR bytecode runner to assist with QIR development and validation";
@@ -35,8 +35,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://qir-alliance.github.io/qir-runner";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.bbenno ];
-    # llvm-sys crate locates llvm by calling llvm-config
-    # which is not available when cross compiling
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
   };
 })


### PR DESCRIPTION
https://github.com/qir-alliance/qir-runner/releases/tag/v0.9.0
https://github.com/qir-alliance/qir-runner/releases/tag/v0.9.4
https://github.com/qir-alliance/qir-runner/releases/tag/v0.9.5
https://github.com/qir-alliance/qir-runner/releases/tag/v0.9.6

the switch to properly using `llvmPackages_20.llvm.dev` (for llvm-config) in `nativeBuildInputs` and `llvmPackages_20.llvm` (for the libraries) in `buildInputs` *should* fix the cross scenario, so we've optimistically unmarked this as broken, though we do not currently have the resources to cross-build llvm to test it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
