### PR TITLE
ameba-ls: add updateScript, 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/by-name/am/ameba-ls/package.nix
+++ b/pkgs/by-name/am/ameba-ls/package.nix
@@ -18,6 +18,8 @@ crystal.buildCrystalPackage rec {
   pname = "ameba-ls";
   version = "0.1.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "crystal-ameba";
     repo = "ameba-ls";

--- a/pkgs/by-name/am/ameba-ls/package.nix
+++ b/pkgs/by-name/am/ameba-ls/package.nix
@@ -3,6 +3,11 @@
   fetchFromGitHub,
   crystal_1_15,
   versionCheckHook,
+  _experimental-update-script-combinators,
+  nix-update-script,
+  writeShellScript,
+  crystal2nix,
+  runCommand,
 }:
 
 let
@@ -44,6 +49,38 @@ crystal.buildCrystalPackage rec {
   ];
   doInstallCheck = true;
   versionCheckProgram = "${placeholder "out"}/bin/ameba-ls";
+
+  passthru = {
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script {
+        extraArgs = [
+          "--use-github-releases"
+          "--src-only"
+        ];
+      })
+      (
+        (_experimental-update-script-combinators.copyAttrOutputToFile "ameba-ls.shardLock" "${toString ./.}/shard.lock")
+        // {
+          supportedFeatures = [ ];
+        }
+      )
+      {
+        command = [
+          (writeShellScript "update-lock" "cd $1; ${lib.getExe crystal2nix}")
+          ./.
+        ];
+      }
+      {
+        command = [
+          "rm"
+          "${toString ./.}/shard.lock"
+        ];
+      }
+    ];
+    shardLock = runCommand "shard.lock" { inherit src; } ''
+      cp "$src/shard.lock" "$out"
+    '';
+  };
 
   meta = {
     description = "Crystal language server powered by Ameba linter";

--- a/pkgs/by-name/am/ameba-ls/package.nix
+++ b/pkgs/by-name/am/ameba-ls/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  crystal_1_15,
+  crystal,
   versionCheckHook,
   _experimental-update-script-combinators,
   nix-update-script,
@@ -10,13 +10,9 @@
   runCommand,
 }:
 
-let
-  # Use the same Crystal minor version as specified in upstream
-  crystal = crystal_1_15;
-in
 crystal.buildCrystalPackage rec {
   pname = "ameba-ls";
-  version = "0.1.0";
+  version = "0.2.0";
 
   __structuredAttrs = true;
 
@@ -24,7 +20,7 @@ crystal.buildCrystalPackage rec {
     owner = "crystal-ameba";
     repo = "ameba-ls";
     tag = "v${version}";
-    hash = "sha256-TEHjR+34wrq24XJNLhWZCEzcDEMDlmUHv0iiF4Z6JlI=";
+    hash = "sha256-0HIs+KpsiIDDh9pqg1bDLAcvCV2M7S5TJGtLycNxndI=";
   };
 
   shardsFile = ./shards.nix;

--- a/pkgs/by-name/am/ameba-ls/shards.nix
+++ b/pkgs/by-name/am/ameba-ls/shards.nix
@@ -1,25 +1,25 @@
 {
-  ameba = {
+  "ameba" = {
     url = "https://github.com/crystal-ameba/ameba.git";
-    rev = "a21dea0b44642f4fc87429283f8b0dd9f1e47a9f";
-    sha256 = "1kzr4ynd4r5w87y2czzrlir1dvqmv43ijm07804kgsy1g20k00fs";
+    rev = "v1.7.0";
+    sha256 = "0blfyizcajyrgbfxhiwnvf1xmz3wfx6kpf9jf8x7daxihany4r9z";
   };
-  larimar = {
+  "larimar" = {
     url = "https://github.com/nobodywasishere/larimar.git";
-    rev = "97d37e665f7189a7ec35f54fb65003a8438d6cf0";
-    sha256 = "0s5hnfdybwbfk8sbjzrly2p6xppc5niww14h9cx00xkm8m1rlyj2";
+    rev = "84872f191466e41eb986a905e1559ffb8f160684";
+    sha256 = "0w5l4kx7895hshk3gydn9lrhdvykm8k2whc7j05yqfqk0yx80j6i";
   };
-  lsprotocol = {
+  "lsprotocol" = {
     url = "https://github.com/nobodywasishere/lsprotocol-crystal.git";
     rev = "28986890c7657af4aefea8355ca3f3c7fc2bc9dd";
     sha256 = "0pccgq5g87mnvrhpgw3j22p3wgch8kp1svxcrbz2dha7zvgn65kj";
   };
-  rwlock = {
+  "rwlock" = {
     url = "https://github.com/spider-gazelle/readers-writer.git";
-    tag = "v1.0.7";
+    rev = "v1.0.7";
     sha256 = "1cs4ang50cza7sb5zh94rl1ppwcn9z1l8jjcsshhy4w72wkbqyny";
   };
-  tree_sitter = {
+  "tree_sitter" = {
     url = "https://github.com/crystal-lang-tools/crystal-tree-sitter.git";
     rev = "1d46ca231a641b30b8e7fbbae7eba050f7717a9f";
     sha256 = "16g0ii3b3pmpnwmx2iz9dr1865pgfka7a724dfj62csjavqm5i1k";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/crystal-ameba/ameba-ls/releases/tag/v0.2.0

Diff: https://github.com/crystal-ameba/ameba-ls/compare/v0.1.0...v0.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
