### PR TITLE
mdbook-sitemap: init at 0.1.2

### DIFF
--- a/pkgs/by-name/md/mdbook-sitemap/package.nix
+++ b/pkgs/by-name/md/mdbook-sitemap/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  mdbook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mdbook-sitemap";
+  version = "0.1.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sonneko";
+    repo = "mdbook-sitemap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-saLueA7DijUEJ978wZf8TaAh5f7Nu1fDo4+i+wFgXqA=";
+  };
+
+  cargoHash = "sha256-7Rlrrnya8axhM4r9NxyONXkVL2lQde1BCfR3o+SIz/k=";
+
+  # the tests generate a book with mdBook with a sitemap
+  # so it needs mdbook-sitemap (the built binary) to be in the $PATH
+  nativeCheckInputs = [ mdbook ];
+  preCheck = ''
+    PATH+=":$(echo "$PWD"/target/*/release)"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Renderer tool to generate a sitemap.xml file for an mdBook project";
+    homepage = "https://github.com/sonneko/mdbook-sitemap";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      pinage404
+    ];
+    mainProgram = "mdbook-sitemap";
+  };
+})


### PR DESCRIPTION
Package https://github.com/sonneko/mdbook-sitemap a renderer plugin for mdBook to generate the `sitemap.xml` file

This package is recent but solve a known [issue of mdBook](https://github.com/rust-lang/mdBook/issues/1491#issuecomment-4698560029)

@matthiasbeyer i added you as co-maintainer because you do it for almost all mdbook packages, let me know if you want to be removed =)

```nix
  nativeCheckInputs = [ mdbook ];
```

Is required by this test

https://github.com/sonneko/mdbook-sitemap/blob/137e8470b986cac6b29f328cc0de8b297d210774/tests/mod.rs#L33

```nix
  preCheck = ''
    cargo build --offline
  '';
```

Is required by the test

https://github.com/sonneko/mdbook-sitemap/blob/137e8470b986cac6b29f328cc0de8b297d210774/tests/mod.rs#L31

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
