### PR TITLE
[26.05] filebrowser-quantum: 1.4.0-stable -> 1.5.2-stable

### DIFF
--- a/pkgs/by-name/fi/filebrowser-quantum/package.nix
+++ b/pkgs/by-name/fi/filebrowser-quantum/package.nix
@@ -6,13 +6,13 @@
 }:
 
 let
-  version = "1.4.0-stable";
+  version = "1.5.2-stable";
 
   src = fetchFromGitHub {
     owner = "gtsteffaniak";
     repo = "filebrowser";
     tag = "v${version}";
-    hash = "sha256-Ojz1VTtlCFUTodQ66mr0ozLKsx3kUirm79HuFJu33yQ=";
+    hash = "sha256-1qG6IayTqL4x3CqJyvVSG8Fu4s6ywhWI9t1j9c+wTZM=";
   };
 
   frontend = buildNpmPackage {
@@ -20,7 +20,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}/frontend";
-    npmDepsHash = "sha256-tisZA7v0WsynNxgbww48eERz9+om4w8MW4IMzQIyh+Y=";
+    npmDepsHash = "sha256-J1PddXU79T0GVcAgxYEW/vraqYxbTvASw8RmW8dDeOw=";
 
     buildPhase = ''
       runHook preBuild
@@ -47,7 +47,7 @@ buildGoModule {
 
   sourceRoot = "${src.name}/backend";
 
-  vendorHash = "sha256-WvilFCwTGXecsD/afUpLL6TrGzr/cgkQeltCKKDc4AI=";
+  vendorHash = "sha256-YAMh0WMe1zDCJq8BuPcekb1J8RvRoxOmsZarKI1ZWcs=";
 
   preBuild = ''
     mkdir -p http/embed


### PR DESCRIPTION
Backport of #554697 to `release-26.05`

Original PR: https://github.com/NixOS/nixpkgs/pull/554697
Commit: `c5c3ebdb826f092392ff7b13aa8885fec2129843` (merged as `f0863cd0fbdec9f837188efbfdd5eb5c14f49fa8`)
Cherry-picked with `git cherry-pick -x c5c3ebdb826f092392ff7b13aa8885fec2129843`.

This release fixes several High & Moderate security vulnerabilities (see [CHANGELOG](https://github.com/gtsteffaniak/filebrowser/releases/tag/v1.5.2-stable)). `filebrowser-quantum: 1.4.0-stable -> 1.5.2-stable`, acceptable per [CONTRIBUTING.md#changes-acceptable-for-releases] (security fix / patch).

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Disclosure: Original commit includes `Assisted-by: opencode (deepseek-v4-flash-free)` per Automation/AI policy (CONTRIBUTING.md#automationai-policy). This PR description was assisted by opencode (muse-spark-1.2-contributor-free).
