### PR TITLE
termpicker: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14450,6 +14450,12 @@
     githubId = 66669;
     name = "Jeff Zellner";
   };
+  k2on = {
+    email = "contact@koon.us";
+    github = "k2on";
+    githubId = 22125083;
+    name = "Max Koon";
+  };
   k3a = {
     email = "git+nix@catmail.app";
     name = "Mario Hros";

--- a/pkgs/by-name/te/termpicker/package.nix
+++ b/pkgs/by-name/te/termpicker/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  installShellFiles,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "termpicker";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "ChausseBenjamin";
+    repo = "termpicker";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-tUmd+GotimE8CrL6sJG7+uREnZAUsd2fEkH31575hFc=";
+  };
+
+  vendorHash = "sha256-M5YZaJdv9D8NkwD+T8tAtGH5P4IKcgjqpUoKVfLo+C0=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    $out/bin/termpicker docs --format man > termpicker.1
+    installManPage termpicker.1
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "A color picker for the terminal";
+    homepage = "https://github.com/ChausseBenjamin/termpicker";
+    license = lib.licenses.beerware;
+    mainProgram = "termpicker";
+    maintainers = with lib.maintainers; [ k2on ];
+  };
+})


### PR DESCRIPTION
Add [termpicker](https://github.com/ChausseBenjamin/termpicker), a color picker in the terminal.

<img src="https://github.com/ChausseBenjamin/termpicker/raw/master/assets/demo.gif" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
