### PR TITLE
tailcat: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ta/tailcat/package.nix
+++ b/pkgs/by-name/ta/tailcat/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tailcat";
+  version = "0.3.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tailscale";
+    repo = "tailcat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EwjhZzovODhW4seO3FToPLiAV+YwVbrX/u93RfbWMZ4=";
+  };
+
+  vendorHash = "sha256-3uVUHATnd2s+Axdq06/xAQ2IbzJZfP1yQ/nEopgckq0=";
+
+  subPackages = [ "cmd/tailcat" ];
+
+  ldflags = [
+    "-s"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  env.CGO_ENABLED = "0";
+
+  __darwinAllowLocalNetworking = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Like netcat, but over Tailscale's data plane, without Tailscale's control plane";
+    homepage = "https://github.com/tailscale/tailcat";
+    changelog = "https://github.com/tailscale/tailcat/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    mainProgram = "tailcat";
+  };
+})


### PR DESCRIPTION
Tailcat is netcat over Tailscale's data plane, without Tailscale's control plane - by Tailscale. One side runs a `tailcat` server and gets a short connection token; the other side connects with that token. Traffic is WireGuard-encrypted end-to-end, bootstrapped through a DERP relay network with NAT traversal upgrading to direct UDP when possible. No Tailscale account or root access needed - pure userspace CLI/library.

Homepage: https://github.com/tailscale/tailcat

Packaged from the tagged release `v0.3.0` with `versionCheckHook` (upstream started tagging releases on 2026-08-30).

Notes:
- Only `cmd/tailcat` is built (`subPackages`); the repo's other commands (`tailcat-web`, `tailcat-webdist`) are for the wasm web demo.
- `env.CGO_ENABLED = "0"` per review - the binary is fully static.

AI policy disclosure: packaging and PR description drafted with Claude Code (claude-fable-5), reviewed and tested by me.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

