### PR TITLE
diamond: 2.1.16 -> 2.2.5; diamond: fix build failure on `aarch64-darwin`

### DIFF
--- a/pkgs/by-name/di/diamond/package.nix
+++ b/pkgs/by-name/di/diamond/package.nix
@@ -3,7 +3,8 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  zlib
+  sqlite,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -13,12 +14,15 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "bbuchfink";
     repo = "diamond";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qt9oNHru1qBwrcncqvQzjinWGfFW0jexOqHWCWHiWX0=";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ zlib ];
+  buildInputs = [
+    sqlite
+    zlib
+  ];
 
   meta = {
     description = "Accelerated BLAST compatible local sequence aligner";
@@ -34,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
       - Buchfink B, Reuter K, Drost HG, "Sensitive protein alignments at tree-of-life scale using DIAMOND", Nature Methods 18, 366–368 (2021). doi:10.1038/s41592-021-01101-x
     '';
     homepage = "https://github.com/bbuchfink/diamond";
+    changelog = "https://github.com/bbuchfink/diamond/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
   };

--- a/pkgs/by-name/di/diamond/package.nix
+++ b/pkgs/by-name/di/diamond/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/bbuchfink/diamond";
     changelog = "https://github.com/bbuchfink/diamond/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      debtquity
+    ];
   };
 })

--- a/pkgs/by-name/di/diamond/package.nix
+++ b/pkgs/by-name/di/diamond/package.nix
@@ -3,18 +3,18 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  zlib,
+  zlib
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "diamond";
-  version = "2.1.16";
+  version = "2.2.5";
 
   src = fetchFromGitHub {
     owner = "bbuchfink";
     repo = "diamond";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-/rSnyOlQ7PWMpoX8vojOmD73jrvIDLjT5LOB7MyTnMo=";
+    hash = "sha256-qt9oNHru1qBwrcncqvQzjinWGfFW0jexOqHWCWHiWX0=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
* bump version to latest
** changelog: https://github.com/bbuchfink/diamond/releases/tag/v2.2.5
** diff: https://github.com/bbuchfink/diamond/compare/v2.1.16...v2.2.5
* add sqlite as build input
* add self as maintainer since package has no maintainers

Resolves: #556800

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
