### PR TITLE
spectral-mic: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/by-name/sp/spectral-mic/package.nix
+++ b/pkgs/by-name/sp/spectral-mic/package.nix
@@ -65,7 +65,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # xdg-utils would otherwise fail the spawn silently.
     wrapProgram $out/bin/spectral \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath dlopenLibs}" \
-      --prefix PATH : "${lib.makeBinPath [ xdg-utils ]}"
+      --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}"
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/sp/spectral-mic/package.nix
+++ b/pkgs/by-name/sp/spectral-mic/package.nix
@@ -12,6 +12,7 @@
   libxrandr,
   fontconfig,
   pipewire,
+  xdg-utils,
   versionCheckHook,
 }:
 let
@@ -29,7 +30,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "spectral-mic";
-  version = "0.8.0";
+  version = "0.9.0";
 
   __structuredAttrs = true;
 
@@ -38,10 +39,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "mmc";
     repo = "spectral";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2HaTOLhHVLYKnEsWjvLf1GqPvtBdrjotG1kZj9mbwkk=";
+    hash = "sha256-Uq/Xc6OzHitsUq2gawuRX8qZ52XGIGhXxV9BC+QXGig=";
   };
 
-  cargoHash = "sha256-OMrYfPQim9H178LnRUg2Ues9Nf2txz4u+tEddrllKME=";
+  cargoHash = "sha256-xtLPe7kasHoSQl3Q/7iRSLjLeMMY9w1aw2yupTBDS00=";
 
   nativeBuildInputs = [
     pkg-config
@@ -60,8 +61,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm644 assets/spectral.png $out/share/icons/hicolor/512x512/apps/page.codeberg.mmc.Spectral.png
     install -Dm644 THIRD-PARTY.md $out/share/licenses/spectral-mic/THIRD-PARTY.md
 
+    # The GUI shells out to xdg-open for its Help links; hosts without
+    # xdg-utils would otherwise fail the spawn silently.
     wrapProgram $out/bin/spectral \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath dlopenLibs}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath dlopenLibs}" \
+      --prefix PATH : "${lib.makeBinPath [ xdg-utils ]}"
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Release update. Changelog: https://codeberg.org/mmc/spectral/src/tag/v0.9.0/CHANGELOG.md

Highlights of 0.9.0: the virtual microphone survives its capture device being unplugged (it waits up to 30 s and reattaches by itself), a security fix for voice-test recordings that were world-readable on distributions with world-readable home directories, and a batch of replug, settings-persistence, and voice-test robustness fixes.

One packaging-relevant change beyond version and hashes: the GUI's Help links now shell out to `xdg-open`, so the wrapper gains `xdg-utils` on PATH, matching upstream's own Nix package.

No breaking changes. The MSRV moved to 1.92 (Slint 1.17), which nixpkgs' current rustc satisfies.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
