### PR TITLE
patchutils: patch bash shebangs, add missing wrappers, enable parallel building

### DIFF
--- a/pkgs/tools/text/patchutils/generic.nix
+++ b/pkgs/tools/text/patchutils/generic.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   perl,
+  bashNonInteractive,
   makeWrapper,
   version,
   sha256,
@@ -20,7 +21,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ perl ] ++ extraBuildInputs;
+  buildInputs = [
+    perl
+    bashNonInteractive
+  ]
+  ++ extraBuildInputs;
   hardeningDisable = [ "format" ];
 
   preConfigure = ''
@@ -28,9 +33,11 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    for bin in $out/bin/{splitdiff,rediff,editdiff,dehtmldiff}; do
-      wrapProgram "$bin" \
-        --prefix PATH : "$out/bin"
+    for bin in $out/bin/*; do
+      if [[ ! -h "$bin" ]]; then
+        wrapProgram "$bin" \
+          --prefix PATH : "$out/bin"
+      fi
     done
   '';
 

--- a/pkgs/tools/text/patchutils/generic.nix
+++ b/pkgs/tools/text/patchutils/generic.nix
@@ -23,9 +23,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl ] ++ extraBuildInputs;
   hardeningDisable = [ "format" ];
 
-  # tests fail when building in parallel
-  enableParallelBuilding = false;
-
   preConfigure = ''
     export PERL=${perl.interpreter}
   '';


### PR DESCRIPTION
- Fix #556799 by providing Bash in the package inputs so `patchShebangs` can do its job.
- While we're at it, enable parallel building, since I haven't been able to reproduce any issues with that option.

`dehtmldiff` appears to be broken with gawk, but that seems to be a very longstanding bug that's also present upstream, so I don't propose to fix it here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
