### PR TITLE
crow-translate: 4.0.2 -> 4.1.0

### DIFF
--- a/pkgs/by-name/cr/crow-translate/package.nix
+++ b/pkgs/by-name/cr/crow-translate/package.nix
@@ -3,25 +3,28 @@
   stdenv,
   fetchFromGitLab,
   cmake,
+  espeak-ng,
   leptonica,
+  pkg-config,
   qt6,
   tesseract,
   testers,
   kdePackages,
   onnxruntime,
   withPiper ? true,
+  withTts ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "crow-translate";
-  version = "4.0.2";
+  version = "4.1.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "office";
     repo = "crow-translate";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hrxYC6zdh4aG9AkHZcnOE5jihJSo3xrq0hzBRE8NtRw=";
+    hash = "sha256-A7B/NneWCKLy2BWPOTSXr9CIbSHkL3xih9QMwmEPG34=";
     fetchSubmodules = true;
   };
 
@@ -32,13 +35,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     kdePackages.extra-cmake-modules
     qt6.qttools
     qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
+    kdePackages.kiconthemes
     kdePackages.kwayland
+    espeak-ng
     leptonica
     tesseract
     qt6.qtbase
@@ -52,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "ONNXRuntime_USE_STATIC" false)
     (lib.cmakeBool "WITH_PIPER_TTS" withPiper)
+    (lib.cmakeBool "WITH_TTS" withTts)
+    (lib.cmakeBool "ESPEAKNG_USE_SYSTEM" true)
   ];
   # Necessary for KWin D-BUS authorization for taking screenshots, without
   # which the app falls back to interactive capture, which has some limitations.


### PR DESCRIPTION
crow-translate 4.0.2 -> 4.1.0.

Release notes: https://invent.kde.org/office/crow-translate/-/releases/v4.1.0

Upstream changes that affect the expression:
- KF6::IconThemes is now a hard dependency (add kdePackages.kiconthemes; configure fails with "Could NOT find KF6 (missing: IconThemes)" without it)
- New WITH_TTS option, default ON (mirrored as a withTts passthrough flag)
- New ESPEAKNG_USE_SYSTEM option: link the system espeak-ng via pkg-config instead of building the bundled copy. Enabled here; nixpkgs' espeak-ng snapshot provides espeak_TextToPhonemesWithTerminator, and crow's configure probes for that symbol

Built and verified on top of 70a9c9e (nixpkgs != master): binary reports 4.1.0, links the system libespeak-ng.so.1, TTS and OCR symbols present.

Disclosure per the automation policy: the PR body was drafted with LLM help; the expression changes were authored and reviewed by the upstream crow-translate maintainer (co-author of the upstream build changes), and the build output was verified manually.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
