### PR TITLE
delly: 2.1.0 -> 2.6.0; delly: fix build failure on `aarch64-darwin`; delly: adopt package as maintainer

### DIFF
--- a/pkgs/by-name/de/delly/package.nix
+++ b/pkgs/by-name/de/delly/package.nix
@@ -23,11 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-W7qPiwYwTv26XLlBX2ZCTu6HGZrKcb4rlY2DCllm21w=";
   };
 
-  postPatch = lib.optionalString stdenv.cc.isClang ''
-    substituteInPlace Makefile \
-      --replace-fail "-std=c++17" "-std=c++14"
-  '';
-
   buildInputs = [
     boost
     bzip2

--- a/pkgs/by-name/de/delly/package.nix
+++ b/pkgs/by-name/de/delly/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests = {
     simple = runCommand "${finalAttrs.pname}-test" { } ''
       mkdir $out
-      ${lib.getExe delly} call -g ${delly.src}/example/ref.fa ${delly.src}/example/sr.bam > $out/sr.vcf
+      ${lib.getExe delly} sr -g ${delly.src}/example/ref.fa ${delly.src}/example/sr.bam > $out/sr.vcf
       ${lib.getExe delly} lr -g ${delly.src}/example/ref.fa ${delly.src}/example/lr.bam > $out/lr.vcf
       ${lib.getExe delly} cnv -g ${delly.src}/example/ref.fa -m ${delly.src}/example/map.fa.gz ${delly.src}/example/sr.bam > cnv.vcf
     '';

--- a/pkgs/by-name/de/delly/package.nix
+++ b/pkgs/by-name/de/delly/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dellytools";
     repo = "delly";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-W7qPiwYwTv26XLlBX2ZCTu6HGZrKcb4rlY2DCllm21w=";
   };
 
@@ -55,8 +55,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "Structural variant caller for mapped DNA sequenced data";
+    description = "Structural variant discovery by integrated paired-end and split-read analysis";
     homepage = "https://github.com/dellytools/delly";
+    changelog = "https://github.com/dellytools/delly/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "delly";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
@@ -68,5 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
       split-reads and read-depth to sensitively and accurately delineate
       genomic rearrangements throughout the genome.
     '';
+    maintainers = with lib.maintainers; [
+      debtquity
+    ];
   };
 })

--- a/pkgs/by-name/de/delly/package.nix
+++ b/pkgs/by-name/de/delly/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "delly";
-  version = "2.1.0";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "dellytools";
     repo = "delly";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-pDylNWYdt7vrQUqaIE2XBopcETAFqHfZP+8mqeoUN+U=";
+    hash = "sha256-W7qPiwYwTv26XLlBX2ZCTu6HGZrKcb4rlY2DCllm21w=";
   };
 
   postPatch = lib.optionalString stdenv.cc.isClang ''


### PR DESCRIPTION
* bump version
** diff: https://github.com/dellytools/delly/compare/v2.1.0...v2.6.0
** changelog: https://github.com/dellytools/delly/releases/tag/v2.6.0
* remove `postPatch` to resolve build failure
* adopt package as maintainer

Resolves: #556820 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
