### PR TITLE
gershwin-assets: init at 0-unstable-2026-02-01

### DIFF
--- a/pkgs/by-name/ge/gershwin-assets/package.nix
+++ b/pkgs/by-name/ge/gershwin-assets/package.nix
@@ -1,0 +1,31 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
+}:
+
+stdenvNoCC.mkDerivation {
+  strictDeps = true;
+  __structuredAttrs = true;
+  pname = "gershwin-assets";
+  version = "0-unstable-2026-02-01";
+  dontBuild = true;
+
+  src = fetchFromGitHub {
+    owner = "gershwin-desktop";
+    repo = "gershwin-assets";
+    rev = "9266b6edd28ce7fb6d9e6dfcf9cca4cc4b1c3038";
+    hash = "sha256-Scc33jaG/lJqEjunU9MGKGIM47YgRACoipsWsnPe2U8=";
+  };
+
+  env.DESTDIR = placeholder "out";
+
+  meta = {
+    homepage = "https://github.com/gershwin-desktop/gershwin-assets";
+    description = "Assets for the Gershwin Desktop";
+    maintainers = with lib.maintainers; [
+      OulipianSummer
+    ];
+  };
+  platforms = lib.platforms.linux;
+}


### PR DESCRIPTION
This PR introduces a simple component of the [Gershwin Dekstop](https://github.com/gershwin-desktop) called [gershwin-assets](https://github.com/gershwin-desktop/gershwin-assets).

It is a simple collection of graphics, sounds, and other media used in the Gershwin Desktop environment.

This PR was made without the use of generative AI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
