### PR TITLE
termdir: init at 0.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28023,6 +28023,12 @@
     githubId = 5991987;
     name = "Alexander Sosedkin";
   };
+  t4ce = {
+    email = "jonasb@post.com";
+    github = "t4ce";
+    githubId = 7328864;
+    name = "Jonas Baethke";
+  };
   t4ccer = {
     email = "t4ccer@gmail.com";
     github = "t4ccer";

--- a/pkgs/by-name/te/termdir/package.nix
+++ b/pkgs/by-name/te/termdir/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "termdir";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "t4ce";
+    repo = "texplo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-E6KFkMra90APBF/UoSP3oUWGYE6+5tAaW43PVxB8y20=";
+  };
+
+  cargoHash = "sha256-Ah1aNeuVKFaSEaDbF23SSXKuksBwvpcM9GkgHqK2/BA=";
+
+  meta = {
+    description = "Fast terminal directory explorer";
+    homepage = "https://github.com/t4ce/texplo";
+    changelog = "https://github.com/t4ce/texplo/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.t4ce ];
+    mainProgram = "td";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/te/termdir/package.nix
+++ b/pkgs/by-name/te/termdir/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-E6KFkMra90APBF/UoSP3oUWGYE6+5tAaW43PVxB8y20=";
   };
 
-  cargoHash = "sha256-Ah1aNeuVKFaSEaDbF23SSXKuksBwvpcM9GkgHqK2/BA=";
+  cargoHash = "sha256-RGRZ/uMlG8SroXTWss/pq57VBZZcWpHmTNiVKM9+aKI=";
 
   meta = {
     description = "Fast terminal directory explorer";


### PR DESCRIPTION
Adds `termdir`, a fast terminal directory explorer operated with the short `td` command.

Upstream: https://github.com/t4ce/texplo
Release: https://github.com/t4ce/texplo/releases/tag/v0.14.0

## Things done

- Built on platform:
  - [x] x86_64-linux (Ubuntu)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Upstream test suite (`cargo test --locked --all-targets`, 13 tests)
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of `td` from the Nix result.
- [x] Fits the relevant Nixpkgs contribution and package guidelines.
- [x] Follows the automation/AI policy.

## AI disclosure

OpenAI Codex was used interactively to audit upstream release readiness, draft the package expression and maintainer entry, and run checks. The upstream author reviewed and directed the work. The upstream Rust test suite passed locally, and the Nix package was built and launched successfully on Ubuntu x86_64-linux.