### PR TITLE
tomlplusplus: only run checks on GNU platforms

### DIFF
--- a/pkgs/by-name/to/tomlplusplus/package.nix
+++ b/pkgs/by-name/to/tomlplusplus/package.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "tomlplusplus";
   version = "3.4.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "marzer";
     repo = "tomlplusplus";

--- a/pkgs/by-name/to/tomlplusplus/package.nix
+++ b/pkgs/by-name/to/tomlplusplus/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  checkInputs = [
+  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isGnu [
     glibcLocales
   ];
 
@@ -49,9 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dbuild_examples=true"
   ];
 
-  # almost all tests fail on Darwin with the following exception:
+  # locale tests seem to only work with glibc
+  # darwin also fails the following:
   # libc++abi: terminating due to uncaught exception of type std::runtime_error: collate_byname<char>::collate_byname failed to construct for
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  doCheck = stdenv.hostPlatform.isGnu;
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/556703

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux.pkgsStatic
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
