### PR TITLE
packages-info: index packages' desktop entries

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -129,6 +129,39 @@ lib.makeOverridable (
       else
         builtins.concatStringsSep ";" value;
 
+    # Translations, e.g. `Name[de]`. There is no argument for them, so
+    # `extraConfig` is the only way one reaches an item.
+    localizedFields = {
+      "Name" = "desktopName";
+      "GenericName" = "genericName";
+      "Comment" = "comment";
+      "Keywords" = "keywords";
+      "Icon" = "icon";
+    };
+
+    localized = lib.foldl' (
+      acc: key:
+      let
+        parts = lib.splitString "[" key;
+        name = lib.head parts;
+      in
+      if lib.length parts != 2 || !(localizedFields ? ${name}) then
+        acc
+      else
+        let
+          locale = lib.removeSuffix "]" (lib.elemAt parts 1);
+          field = localizedFields.${name};
+          value = extraConfig.${key};
+        in
+        acc
+        // {
+          ${locale} = (acc.${locale} or { }) // {
+            ${field} =
+              if field == "keywords" then lib.filter (item: item != "") (lib.splitString ";" value) else value;
+          };
+        }
+    ) { } (builtins.attrNames extraConfig);
+
     # The [Desktop Entry] section of the desktop file, as an attribute set.
     # Please keep in spec order.
     mainSection = {
@@ -203,5 +236,20 @@ lib.makeOverridable (
     destination = "${destination}/${name}.${extension}";
     text = builtins.concatStringsSep "\n" content;
     checkPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
+    # Read by `pkgs/top-level/desktop-entries.nix` for `packages.json`.
+    passthru.desktopEntry = {
+      inherit
+        type
+        desktopName
+        genericName
+        comment
+        icon
+        keywords
+        mimeTypes
+        categories
+        noDisplay
+        localized
+        ;
+    };
   }
 )

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -129,4 +129,130 @@ lib.recurseIntoAttrs {
     in
     assert pkgs.config.allowVariants -> (all.hello == all-reversed.hello);
     pkgs.emptyFile;
+
+  # `makeDesktopItem`'s `passthru` and file-parsed info have to agree
+  desktopEntries =
+    let
+      inherit (import ../../top-level/desktop-entries.nix { inherit lib; })
+        entriesOf
+        parseDesktopEntry
+        ;
+
+      item = pkgs.makeDesktopItem {
+        name = "test-entry";
+        desktopName = "Test Entry";
+        genericName = "Tester";
+        comment = "Exercises the desktop entry index";
+        exec = "test-entry %U";
+        icon = "test-entry";
+        keywords = [
+          "one"
+          "two"
+        ];
+        mimeTypes = [
+          "text/plain"
+          "x-scheme-handler/test"
+        ];
+        categories = [
+          "Utility"
+          "Development"
+        ];
+        noDisplay = true;
+        extraConfig = {
+          "Name[de]" = "Testeintrag";
+          "Comment[de]" = "Uebt den Index";
+          "Keywords[de]" = "eins;zwei";
+          "X-Test-Not-Localized" = "ignored";
+        };
+      };
+
+      # Entries not from `makeDesktopItem` won't expose their info by `passthru`
+      rendered = pkgs.writeText "test-entry.desktop" item.text;
+
+      entry = {
+        type = "Application";
+        desktopName = "Test Entry";
+        genericName = "Tester";
+        comment = "Exercises the desktop entry index";
+        icon = "test-entry";
+        keywords = [
+          "one"
+          "two"
+        ];
+        mimeTypes = [
+          "text/plain"
+          "x-scheme-handler/test"
+        ];
+        categories = [
+          "Utility"
+          "Development"
+        ];
+        noDisplay = true;
+        localized.de = {
+          desktopName = "Testeintrag";
+          comment = "Uebt den Index";
+          keywords = [
+            "eins"
+            "zwei"
+          ];
+        };
+      };
+
+      tests = {
+        passthru = {
+          expr = entriesOf { desktopItems = [ item ]; };
+          expected = [ entry ];
+        };
+
+        # The rendered file must parse back to what the passthru gave
+        renderedFallback = {
+          expr = entriesOf { desktopItems = [ rendered ]; };
+          expected = [ entry ];
+        };
+
+        # `desktopItems` is not always a list; some packages assign a bare item
+        bareItem = {
+          expr = entriesOf { desktopItems = item; };
+          expected = [ entry ];
+        };
+
+        # The other way an item reaches a package
+        passthruDesktopItem = {
+          expr = entriesOf { passthru.desktopItem = item; };
+          expected = [ entry ];
+        };
+
+        # A plain path into `$src` has nothing to read, so it is skipped
+        plainPath = {
+          expr = entriesOf { desktopItems = [ "share/applications/test-entry.desktop" ]; };
+          expected = [ ];
+        };
+
+        # What almost every package is
+        noItems = {
+          expr = entriesOf { };
+          expected = [ ];
+        };
+
+        # A trailing action section must not leak into the entry
+        firstSectionOnly = {
+          expr =
+            (parseDesktopEntry ''
+              [Desktop Entry]
+              Type=Application
+              Name=First
+
+              [Desktop Action new]
+              Name=Second
+            '').desktopName;
+          expected = "First";
+        };
+      };
+
+      failed = lib.filterAttrs (_: test: test.expr != test.expected) tests;
+    in
+    assert lib.assertMsg (failed == { }) ''
+      tests.top-level.desktopEntries: ${lib.concatStringsSep ", " (lib.attrNames failed)} failed
+      ${lib.generators.toPretty { } failed}'';
+    pkgs.emptyFile;
 }

--- a/pkgs/top-level/desktop-entries.nix
+++ b/pkgs/top-level/desktop-entries.nix
@@ -1,0 +1,114 @@
+# Desktop entries for `packages.json`'s `desktopEntries` from `makeDesktopItem`.
+# Evaluation only sees the entries nixpkgs itself constructs; a consumer merges this
+# with an index read from built packages, which uses the same schema.
+{ lib }:
+
+let
+  # Discard context to serialize entries with store paths
+  discardContext =
+    value: if value == null then null else builtins.unsafeDiscardStringContext (toString value);
+
+  splitSemicolons = value: lib.filter (item: item != "") (lib.splitString ";" value);
+
+  # Keys that support localizing, like `Name[de]`
+  localizedFields = {
+    "Name" = "desktopName";
+    "GenericName" = "genericName";
+    "Comment" = "comment";
+    "Keywords" = "keywords";
+    "Icon" = "icon";
+  };
+
+  discardLocalized = lib.mapAttrs (
+    _locale:
+    lib.mapAttrs (
+      field: value: if field == "keywords" then lib.map discardContext value else discardContext value
+    )
+  );
+
+  # Parse a `.desktop` file: get the first section (up to the next `\n[`)
+  parseDesktopEntry =
+    text:
+    let
+      body = lib.splitString "\n" (lib.head (lib.splitString "\n[" text));
+      # Also drops the `[Desktop Entry]` header (no `=`)
+      kv = lib.filter (lib.hasInfix "=") body;
+      attrs = lib.listToAttrs (
+        lib.map (line: {
+          name = lib.head (lib.splitString "=" line);
+          value = lib.concatStringsSep "=" (lib.tail (lib.splitString "=" line));
+        }) kv
+      );
+      localized = lib.foldl' (
+        acc: key:
+        let
+          parts = lib.splitString "[" key;
+          name = lib.head parts;
+        in
+        if lib.length parts != 2 || !(localizedFields ? ${name}) then
+          acc
+        else
+          let
+            locale = lib.removeSuffix "]" (lib.elemAt parts 1);
+            field = localizedFields.${name};
+          in
+          acc
+          // {
+            ${locale} = (acc.${locale} or { }) // {
+              ${field} = if field == "keywords" then splitSemicolons attrs.${key} else attrs.${key};
+            };
+          }
+      ) { } (lib.attrNames attrs);
+    in
+    {
+      type = attrs.Type or null;
+      desktopName = attrs.Name or null;
+      genericName = attrs.GenericName or null;
+      comment = attrs.Comment or null;
+      icon = attrs.Icon or null;
+      keywords = splitSemicolons (attrs.Keywords or "");
+      mimeTypes = splitSemicolons (attrs.MimeType or "");
+      categories = splitSemicolons (attrs.Categories or "");
+      noDisplay = attrs.NoDisplay or "" == "true";
+      inherit localized;
+    };
+
+  # Unify `makeDesktopItem`'s passthru and rendered files
+  entryOf =
+    item:
+    let
+      entry =
+        item.passthru.desktopEntry or (parseDesktopEntry (builtins.unsafeDiscardStringContext item.text));
+    in
+    {
+      type = discardContext entry.type;
+      desktopName = discardContext entry.desktopName;
+      genericName = discardContext entry.genericName;
+      comment = discardContext entry.comment;
+      icon = discardContext entry.icon;
+      keywords = lib.map discardContext entry.keywords;
+      mimeTypes = lib.map discardContext entry.mimeTypes;
+      categories = lib.map discardContext entry.categories;
+      noDisplay = entry.noDisplay or null == true;
+      localized = discardLocalized entry.localized;
+    };
+
+  # An item given as a plain path into `$src` carries nothing at eval time
+  hasEntry = item: lib.isDerivation item && (((item.passthru or { }) ? desktopEntry) || item ? text);
+in
+{
+  inherit parseDesktopEntry;
+
+  # `desktopItems` may be a bare item rather than a list of them.
+  entriesOf =
+    package:
+    lib.pipe
+      (
+        lib.toList (package.desktopItems or [ ])
+        ++ lib.optional ((package.passthru or { }) ? desktopItem) package.passthru.desktopItem
+      )
+      [
+        (lib.filter hasEntry)
+        (lib.map entryOf)
+      ];
+}

--- a/pkgs/top-level/packages-info.nix
+++ b/pkgs/top-level/packages-info.nix
@@ -5,6 +5,9 @@
 let
   pkgs = import ../.. { config = import ./packages-config.nix; };
   inherit (pkgs) lib;
+
+  inherit (import ./desktop-entries.nix { inherit lib; }) entriesOf;
+
   generateInfo =
     path: value:
     let
@@ -12,6 +15,9 @@ let
         if path == [ "AAAAAASomeThingsFailToEvaluate" ] || !(lib.isAttrs value) then
           [ ]
         else if lib.isDerivation value then
+          let
+            entries = entriesOf value;
+          in
           [
             {
               name = lib.showAttrPath path;
@@ -33,6 +39,7 @@ let
                 # the optional pattern from above.
                 pname = value.pname or value.name;
                 version = value.version or "";
+                ${if entries != [ ] then "desktopEntries" else null} = entries;
               };
             }
           ]


### PR DESCRIPTION
To facilitate package search front-ends, expose info on packages' desktop entries through `packages.json`:

- expose `makeDesktopItem`'s metadata by `passthru`
- add a `desktopEntries` field in `pkgs/top-level/packages-info.nix`'s generated `packages.json`

Note that this so far exposes info just on the desktop entries available at eval time, rather than at builds (as `packages-info.nix` is limited to the sandbox). Info on desktop entries from derivations can make for a potential [follow-up](https://github.com/NixOS/nixpkgs/commit/c290edc0a5fa9e2236bdcc34dec7752e6c31e8f3), or may be deferred to potential [downstream consumers](https://github.com/NixOS/nixos-search/pull/1547/changes#diff-544da4704739bc57d1b1243fff778ec5bc5056182d03a6752f01e66fdd3cee8d).

Assisted-by: Claude Code:claude-opus-5

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
