### PR TITLE
python3Packages.mcp: 1.29.0 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/mcp-types/default.nix
+++ b/pkgs/development/python-modules/mcp-types/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  mcp,
 
   # build-system
   hatchling,
@@ -14,19 +15,10 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mcp-types";
-  version = "2.1.1";
   pyproject = true;
   __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "modelcontextprotocol";
-    repo = "python-sdk";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-v3qS18hgOxLjm+IEa/knkfyh0Cz2QFtyqxXTZJepevU=";
-  };
-
-  # TODO: uncomment after bootstrap
-  # inherit (mcp) version src;
+  inherit (mcp) version src;
 
   sourceRoot = "${finalAttrs.src.name}/src/mcp-types";
 

--- a/pkgs/development/python-modules/mcp-types/default.nix
+++ b/pkgs/development/python-modules/mcp-types/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  uv-dynamic-versioning,
+
+  # dependencies
+  pydantic,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mcp-types";
+  version = "2.1.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "python-sdk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-v3qS18hgOxLjm+IEa/knkfyh0Cz2QFtyqxXTZJepevU=";
+  };
+
+  # TODO: uncomment after bootstrap
+  # inherit (mcp) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/src/mcp-types";
+
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = [
+    pydantic
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "mcp_types" ];
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/python-sdk/releases/tag/${finalAttrs.src.tag}";
+    description = "Model Context Protocol wire types";
+    homepage = "https://github.com/modelcontextprotocol/python-sdk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      daniel-fahey
+    ];
+  };
+})

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  python,
 
   # build-system
   hatchling,
@@ -10,15 +10,17 @@
 
   # dependencies
   anyio,
-  httpx,
-  httpx-sse,
+  httpx2,
   jsonschema,
+  mcp-types,
+  opentelemetry-api,
   pydantic,
-  pydantic-settings,
   pyjwt,
   python-multipart,
   sse-starlette,
   starlette,
+  typing-extensions,
+  typing-inspection,
   uvicorn,
 
   # optional-dependencies
@@ -27,22 +29,26 @@
   typer,
   # rich
   rich,
-  # ws
-  websockets,
 
   # tests
+  coverage,
   dirty-equals,
+  griffelib,
   inline-snapshot,
+  logfire,
   pytest-asyncio,
   pytest-examples,
   pytest-xdist,
   pytestCheckHook,
+  pyyaml,
   requests,
+  trio,
+  zensical,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "mcp";
-  version = "1.29.0";
+  version = "2.1.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -50,36 +56,27 @@ buildPythonPackage (finalAttrs: {
     owner = "modelcontextprotocol";
     repo = "python-sdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lRlj5RT/R5zrYL5XpdQR2l9t99G94WTsubN0gSQekMc=";
+    hash = "sha256-v3qS18hgOxLjm+IEa/knkfyh0Cz2QFtyqxXTZJepevU=";
   };
-
-  # time.sleep(0.1) feels a bit optimistic and it has been flaky whilst
-  # testing this on macOS under load.
-  postPatch = lib.optionalString stdenv.buildPlatform.isDarwin ''
-    substituteInPlace tests/client/test_stdio.py \
-      --replace-fail "time.sleep(0.1)" "time.sleep(1)"
-  '';
 
   build-system = [
     hatchling
     uv-dynamic-versioning
   ];
 
-  pythonRelaxDeps = [
-    "pydantic-settings"
-  ];
-
   dependencies = [
     anyio
-    httpx
-    httpx-sse
+    httpx2
     jsonschema
+    mcp-types
+    opentelemetry-api
     pydantic
-    pydantic-settings
     pyjwt
     python-multipart
     sse-starlette
     starlette
+    typing-extensions
+    typing-inspection
     uvicorn
   ];
 
@@ -91,69 +88,49 @@ buildPythonPackage (finalAttrs: {
     rich = [
       rich
     ];
-    ws = [
-      websockets
-    ];
   };
 
   pythonImportsCheck = [ "mcp" ];
 
   nativeCheckInputs = [
+    coverage
     dirty-equals
+    griffelib
     inline-snapshot
+    logfire
+    (buildPythonPackage {
+      pname = "mcp-example-stories";
+      version = "0.0.0";
+      src = finalAttrs.src;
+      sourceRoot = "${finalAttrs.src.name}/examples";
+      pyproject = true;
+      build-system = [ hatchling ];
+      pythonRemoveDeps = [ "mcp" ];
+    })
     pytest-asyncio
     pytest-examples
     pytest-xdist
     pytestCheckHook
+    pyyaml
     requests
+    trio
+    zensical
   ]
   ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
-  pytestFlags = [
-    "-Wignore::pytest.PytestRemovedIn10Warning"
-  ];
-
-  disabledTests = [
-    # attempts to run the package manager uv
-    "test_command_execution"
-
-    # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
-    "test_lifespan_cleanup_executed"
-
-    # AssertionError: Child process should be writing
-    "test_basic_child_process_cleanup"
-
-    # AssertionError: parent process should be writing
-    "test_nested_process_tree"
-
-    # AssertionError: Child should be writing
-    "test_early_parent_exit"
-
-    # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO ...
-    "test_list_tools_returns_all_tools"
-
-    # AssertionError: Server startup marker not created
-    "test_stdin_close_triggers_cleanup"
-
-    # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <function St..
-    "test_resource_template_client_interaction"
-
-    # Flaky: https://github.com/modelcontextprotocol/python-sdk/pull/1171
-    "test_notification_validation_error"
-
-    # Flaky: httpx.ConnectError: All connection attempts failed
-    "test_sse_security_"
-    "test_streamable_http_"
-    "test_streamablehttp_"
-
-    # This just feels a bit optimistic...
-    #     	assert duration < 3 * _sleep_time_seconds
-    # AssertionError: assert 0.0733884589999434 < (3 * 0.01)
-    "test_messages_are_executed_concurrently"
-
-    # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
-    "test_tool_progress"
-  ];
+  # The stdio transport starts servers as subprocesses,
+  # with only a subset (allowlist) of environment variables.
+  # It doesn't include PYTHONPATH, so tests that spawn a child interpreter can't import mcp.
+  # In upstream CI uv sync installs mcp into the venv's site-packages.
+  # But it does include HOME,
+  # and every Python process adds $HOME's user site directory to sys.path.
+  # So we write the PYTHONPATH to a .pth file there and child interpreters will import mcp again.
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+    local site="$HOME/.local/lib/${python.libPrefix}/site-packages"
+    mkdir -p "$site"
+    tr ':' '\n' <<< "$PYTHONPATH" > "$site/nix-test-env.pth"
+  '';
 
   __darwinAllowLocalNetworking = true;
 
@@ -165,6 +142,7 @@ buildPythonPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       bryanhonof
       josh
+      daniel-fahey
     ];
   };
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10547,6 +10547,8 @@ self: super: with self; {
 
   mcp = callPackage ../development/python-modules/mcp { };
 
+  mcp-types = callPackage ../development/python-modules/mcp-types { };
+
   mcpadapt = callPackage ../development/python-modules/mcpadapt { };
 
   mcstatus = callPackage ../development/python-modules/mcstatus { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23003,6 +23003,8 @@ self: super: with self; {
 
   zenoh = callPackage ../development/python-modules/zenoh { };
 
+  zensical = toPythonModule (pkgs.zensical.override { python3Packages = self; });
+
   zephyr-python-api = callPackage ../development/python-modules/zephyr-python-api { };
 
   zephyr-test-management = callPackage ../development/python-modules/zephyr-test-management { };


### PR DESCRIPTION
Diff: https://github.com/modelcontextprotocol/python-sdk/compare/v1.29.0...v2.1.1

Changelog: https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.1.1

I got all the tests to run, second opinions welcome re: my `preCheck` hack.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
