### PR TITLE
font-manager: fix build

### DIFF
--- a/pkgs/by-name/fo/font-manager/package.nix
+++ b/pkgs/by-name/fo/font-manager/package.nix
@@ -47,6 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/FontManager/font-manager/commit/cc0c148d90741e39615e3380d283f684a052dd94.patch";
       hash = "sha256-bRn+jVjBu6ZqmQCErgcqxv6OyFa4hkPYB5bvK7rEibA=";
     })
+    # Build fix for https://github.com/FontManager/font-manager/issues/467
+    # Vendored from https://github.com/FontManager/font-manager/pull/468
+    # Drop or switch to `fetchpatch` once upstream merges a fix.
+    ./pr-468-Fix-compilation-error-with-newer-Vala-versions.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fo/font-manager/pr-468-Fix-compilation-error-with-newer-Vala-versions.patch
+++ b/pkgs/by-name/fo/font-manager/pr-468-Fix-compilation-error-with-newer-Vala-versions.patch
@@ -1,0 +1,37 @@
+From e2ad529a88929bbc76906ac78260dacf4d8c8c6b Mon Sep 17 00:00:00 2001
+From: Jan Baier <jan.baier@amagical.net>
+Date: Fri, 1 May 2026 17:25:25 +0200
+Subject: [PATCH] Fix compilation error with newer Vala versions
+
+Fixes #467
+---
+ src/font-manager/Collections.vala | 2 +-
+ src/font-manager/FontList.vala    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/font-manager/Collections.vala b/src/font-manager/Collections.vala
+index 5e7f5cdbfe4cd7a36358866e7f65b12accd7f697..43531e5413d3a35023b4233bd225cd140f18bdb1 100644
+--- a/src/font-manager/Collections.vala
++++ b/src/font-manager/Collections.vala
+@@ -523,7 +523,7 @@ namespace FontManager {
+             var row = ((CollectionListRow) source.widget);
+             var drag_icon = new Gtk.Label(row.item_label.label);
+             drag_icon.add_css_class("FontManagerListRowDrag");
+-            var gtk_drag_icon = (Gtk.DragIcon) Gtk.DragIcon.get_for_drag(drag);
++            var gtk_drag_icon = new Gtk.DragIcon.get_for_drag(drag);
+             gtk_drag_icon.set_child(drag_icon);
+             return;
+         }
+diff --git a/src/font-manager/FontList.vala b/src/font-manager/FontList.vala
+index c8b170cb1cc8160883c94fe035a4e7d625b81173..9720dc2bc6c2ca65f5c77db2a85638f65166fddc 100644
+--- a/src/font-manager/FontList.vala
++++ b/src/font-manager/FontList.vala
+@@ -669,7 +669,7 @@ namespace FontManager {
+             widget_set_name(drag_count, "FontManagerListDragCount");
+             drag_icon.add_overlay(drag_count);
+             drag_count.set_label(selected_items.length.to_string());
+-            var gtk_drag_icon = (Gtk.DragIcon) Gtk.DragIcon.get_for_drag(drag);
++            var gtk_drag_icon = new Gtk.DragIcon.get_for_drag(drag);
+             gtk_drag_icon.set_child(drag_icon);
+             return;
+         }


### PR DESCRIPTION
fixes `nix-build -A font-manager` from x86_64-linux.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
