### PR TITLE
tcl: Use `finalAttrs.finalPackage` to avoid needing let-in

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -20,215 +20,211 @@
   ...
 }:
 
-let
-  baseInterp = stdenv.mkDerivation (finalAttrs: {
-    pname = "tcl";
-    inherit version src;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tcl";
+  inherit version src;
 
-    outputs = [
-      "out"
-      "man"
-    ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
-    setOutputFlags = false;
+  setOutputFlags = false;
 
-    inherit patches;
+  inherit patches;
 
-    postPatch = ''
-      substituteInPlace library/clock.tcl \
-        --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
-        --replace-fail "/usr/share/lib/zoneinfo" "" \
-        --replace-fail "/usr/lib/zoneinfo" "" \
-        --replace-fail "/usr/local/etc/zoneinfo" ""
+  postPatch = ''
+    substituteInPlace library/clock.tcl \
+      --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
+      --replace-fail "/usr/share/lib/zoneinfo" "" \
+      --replace-fail "/usr/lib/zoneinfo" "" \
+      --replace-fail "/usr/local/etc/zoneinfo" ""
+  ''
+  # A shared Cygwin build tries to configure the windows build system
+  # to separately build these DLLs so it can load them later. That's
+  # not gonna work for us --- in Nixpkgs this would need to be a
+  # separate derivation with a separate wrapped C compiler --- so
+  # let's just drop this for now.
+  #
+  # Matching just the recursive `make` and not the whole `( cd ...; ... )`
+  # around it: 8.6 writes that without inner spaces and 9.0 with, and the
+  # part we care about is the same either way.
+  + lib.optionalString stdenv.hostPlatform.isCygwin ''
+    substituteInPlace unix/Makefile.in \
+      --replace-fail "\''${MAKE} winextensions" true
+  ''
+  + extraPatch;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "9.0") [
+    # Only used to detect the presence of zlib. Could be replaced with a stub.
+    zip
+  ]
+  # In the windows build, `install-msgs` (and `install-tzdata`, but
+  # we don't do that) are done via TCL not via shell. This is for
+  # the sake of the "build = host = windows" case; we are merely
+  # doing build = unix, host = windows, where the old shell way would
+  # have worked.
+  ++ lib.optionals (stdenv.hostPlatform.isWindows && stdenv.buildPlatform != stdenv.hostPlatform) [
+    buildPackages.tcl
+  ];
+
+  buildInputs = [
+    bashNonInteractive
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "9.0") [
+    zlib
+  ];
+
+  strictDeps = true;
+
+  # Windows has its own build system under `win`, autoconf like the one under
+  # `unix` but with its own `Makefile.in` and a smaller set of options. Cygwin
+  # is not Windows for this purpose: it is POSIX enough for the `unix` one.
+  preAutoreconf = ''
+    cd ${if stdenv.hostPlatform.isWindows then "win" else "unix"}
+  '';
+
+  # No `--install`: there is no automake here, and letting `autoreconf`
+  # regenerate `aclocal.m4` would lose the `tcl.m4` the build depends on.
+  autoreconfFlags = "--force --verbose";
+
+  configureFlags = [
+    "tcl_cv_sys_version=${stdenv.hostPlatform.uname.system}"
+    # During cross compilation, the tcl build system assumes that libc
+    # functions are broken if it cannot test if they are broken or not and
+    # then causes a link error on static platforms due to symbol conflict.
+    # These functions are *checks notes* strtoul and strstr. These are
+    # never broken on modern platforms!
+    "tcl_cv_strtod_unbroken=ok"
+    "tcl_cv_strtoul_unbroken=ok"
+    "tcl_cv_strstr_unbroken=ok"
+    # Note: using $out instead of $man to prevent a runtime dependency on $man.
+    "--mandir=${placeholder "out"}/share/man"
+    # Don't install tzdata because NixOS already has a more up-to-date copy.
+    "--with-tzdata=no"
+  ]
+  ++ lib.optionals (lib.versionOlder version "9.0") [
+    # Enabled is the default pre-9.0, but we don't want to leave
+    # anything to chance. 9.0 and later the option is gone and
+    # threads are always enabled.
+    "--enable-threads"
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "9.0") [
+    # By default, tcl libraries get zipped and embedded into libtcl*.so,
+    # which gets `zipfs mount`ed at runtime. This is fragile (for example
+    # stripping the .so removes the zip trailer), so we install them as
+    # traditional files.
+    # This might make tcl slower to start from slower storage on cold cache,
+    # however according to my benchmarks on fast storage and warm cache
+    # tcl built with --disable-zipfs actually starts in half the time.
+    "--disable-zipfs"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
+    # Does not exist in the `win` build system.
+    "--enable-man-symlinks"
+  ]
+  ++ lib.optional stdenv.hostPlatform.is64bit "--enable-64bit";
+
+  # https://core.tcl-lang.org/thread/tktview/30e201c7111a438e2fe6aadc9d733b954874cbb9
+  env = lib.optionalAttrs (lib.versionAtLeast version "9.0") { ZIPFS_BUILD = 0; };
+
+  buildFlags = lib.optionals stdenv.hostPlatform.isStatic [
+    # Don't use the default Make target for static,
+    # since it builds shared libraries for bundled packages.
+    "binaries"
+    "libraries"
+    "doc"
+  ];
+
+  makeFlags = lib.optionals stdenv.hostPlatform.isStatic [
+    "INSTALL_PACKAGE_TARGETS="
+  ];
+
+  enableParallelBuilding = true;
+
+  allowedImpureDLLs = lib.optionals stdenv.hostPlatform.isCygwin [ "USER32.dll" ];
+
+  postInstall =
+    let
+      exeExtension = stdenv.hostPlatform.extensions.executable;
+      dllExtension = stdenv.hostPlatform.extensions.sharedLibrary;
+      staticExtension = stdenv.hostPlatform.extensions.staticLibrary;
+      # The `win` build system drops the dot from the version when naming
+      # files, so `tclsh86.exe` rather than `tclsh8.6`.
+      infix =
+        if stdenv.hostPlatform.isWindows then lib.replaceStrings [ "." ] [ "" ] release else release;
+      # On Cygwin, shared libs are in the bin directory. TODO dedup
+      # with this other packages, consider doing the same or Mingw.
+      # See #431820.
+      linkDir = if !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isCygwin then "bin" else "lib";
+      linkExtension = if stdenv.hostPlatform.isWindows then "${dllExtension}.a" else dllExtension;
+      # Tcl 9 names its Cygwin DLL the way that platform does, `cygtcl9.0.dll`;
+      # 8.6 called it `libtcl8.6.dll`. See the Cygwin `SHLIB_LD` in 9.0's
+      # `unix/tcl.m4`, which rewrites `cyg%.dll` to `lib%.dll` for the import
+      # library. Only the DLL is affected, not the static or import library.
+      dllPrefix =
+        if stdenv.hostPlatform.isCygwin && lib.versionAtLeast version "9.0" then "cyg" else "lib";
+    in
     ''
-    # A shared Cygwin build tries to configure the windows build system
-    # to separately build these DLLs so it can load them later. That's
-    # not gonna work for us --- in Nixpkgs this would need to be a
-    # separate derivation with a separate wrapped C compiler --- so
-    # let's just drop this for now.
-    #
-    # Matching just the recursive `make` and not the whole `( cd ...; ... )`
-    # around it: 8.6 writes that without inner spaces and 9.0 with, and the
-    # part we care about is the same either way.
-    + lib.optionalString stdenv.hostPlatform.isCygwin ''
-      substituteInPlace unix/Makefile.in \
-        --replace-fail "\''${MAKE} winextensions" true
+      make install-private-headers
+      ln -s $out/bin/tclsh${infix}${exeExtension} $out/bin/tclsh${exeExtension}
+      if [[ -e $out/lib/libtcl${infix}${staticExtension} ]]; then
+        ln -s $out/lib/libtcl${infix}${staticExtension} $out/lib/libtcl${staticExtension}
+      fi
     ''
-    + extraPatch;
-
-    nativeBuildInputs = [
-      autoreconfHook
-    ]
-    ++ lib.optionals (lib.versionAtLeast version "9.0") [
-      # Only used to detect the presence of zlib. Could be replaced with a stub.
-      zip
-    ]
-    # In the windows build, `install-msgs` (and `install-tzdata`, but
-    # we don't do that) are done via TCL not via shell. This is for
-    # the sake of the "build = host = windows" case; we are merely
-    # doing build = unix, host = windows, where the old shell way would
-    # have worked.
-    ++ lib.optionals (stdenv.hostPlatform.isWindows && stdenv.buildPlatform != stdenv.hostPlatform) [
-      buildPackages.tcl
-    ];
-
-    buildInputs = [
-      bashNonInteractive
-    ]
-    ++ lib.optionals (lib.versionAtLeast version "9.0") [
-      zlib
-    ];
-
-    strictDeps = true;
-
-    # Windows has its own build system under `win`, autoconf like the one under
-    # `unix` but with its own `Makefile.in` and a smaller set of options. Cygwin
-    # is not Windows for this purpose: it is POSIX enough for the `unix` one.
-    preAutoreconf = ''
-      cd ${if stdenv.hostPlatform.isWindows then "win" else "unix"}
+    + lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+      ln -s $out/${linkDir}/${dllPrefix}tcl${infix}${linkExtension} $out/lib/libtcl${linkExtension}
     '';
 
-    # No `--install`: there is no automake here, and letting `autoreconf`
-    # regenerate `aclocal.m4` would lose the `tcl.m4` the build depends on.
-    autoreconfFlags = "--force --verbose";
+  __structuredAttrs = true;
 
-    configureFlags = [
-      "tcl_cv_sys_version=${stdenv.hostPlatform.uname.system}"
-      # During cross compilation, the tcl build system assumes that libc
-      # functions are broken if it cannot test if they are broken or not and
-      # then causes a link error on static platforms due to symbol conflict.
-      # These functions are *checks notes* strtoul and strstr. These are
-      # never broken on modern platforms!
-      "tcl_cv_strtod_unbroken=ok"
-      "tcl_cv_strtoul_unbroken=ok"
-      "tcl_cv_strstr_unbroken=ok"
-      # Note: using $out instead of $man to prevent a runtime dependency on $man.
-      "--mandir=${placeholder "out"}/share/man"
-      # Don't install tzdata because NixOS already has a more up-to-date copy.
-      "--with-tzdata=no"
-    ]
-    ++ lib.optionals (lib.versionOlder version "9.0") [
-      # Enabled is the default pre-9.0, but we don't want to leave
-      # anything to chance. 9.0 and later the option is gone and
-      # threads are always enabled.
-      "--enable-threads"
-    ]
-    ++ lib.optionals (lib.versionAtLeast version "9.0") [
-      # By default, tcl libraries get zipped and embedded into libtcl*.so,
-      # which gets `zipfs mount`ed at runtime. This is fragile (for example
-      # stripping the .so removes the zip trailer), so we install them as
-      # traditional files.
-      # This might make tcl slower to start from slower storage on cold cache,
-      # however according to my benchmarks on fast storage and warm cache
-      # tcl built with --disable-zipfs actually starts in half the time.
-      "--disable-zipfs"
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
-      # Does not exist in the `win` build system.
-      "--enable-man-symlinks"
-    ]
-    ++ lib.optional stdenv.hostPlatform.is64bit "--enable-64bit";
+  meta = {
+    description = "Tcl scripting language";
+    homepage = "https://www.tcl.tk/";
+    license = lib.licenses.tcltk;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ agbrooks ];
+  };
 
-    # https://core.tcl-lang.org/thread/tktview/30e201c7111a438e2fe6aadc9d733b954874cbb9
-    env = lib.optionalAttrs (lib.versionAtLeast version "9.0") { ZIPFS_BUILD = 0; };
-
-    buildFlags = lib.optionals stdenv.hostPlatform.isStatic [
-      # Don't use the default Make target for static,
-      # since it builds shared libraries for bundled packages.
-      "binaries"
-      "libraries"
-      "doc"
-    ];
-
-    makeFlags = lib.optionals stdenv.hostPlatform.isStatic [
-      "INSTALL_PACKAGE_TARGETS="
-    ];
-
-    enableParallelBuilding = true;
-
-    allowedImpureDLLs = lib.optionals stdenv.hostPlatform.isCygwin [ "USER32.dll" ];
-
-    postInstall =
-      let
-        exeExtension = stdenv.hostPlatform.extensions.executable;
-        dllExtension = stdenv.hostPlatform.extensions.sharedLibrary;
-        staticExtension = stdenv.hostPlatform.extensions.staticLibrary;
-        # The `win` build system drops the dot from the version when naming
-        # files, so `tclsh86.exe` rather than `tclsh8.6`.
-        infix =
-          if stdenv.hostPlatform.isWindows then lib.replaceStrings [ "." ] [ "" ] release else release;
-        # On Cygwin, shared libs are in the bin directory. TODO dedup
-        # with this other packages, consider doing the same or Mingw.
-        # See #431820.
-        linkDir = if !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isCygwin then "bin" else "lib";
-        linkExtension = if stdenv.hostPlatform.isWindows then "${dllExtension}.a" else dllExtension;
-        # Tcl 9 names its Cygwin DLL the way that platform does, `cygtcl9.0.dll`;
-        # 8.6 called it `libtcl8.6.dll`. See the Cygwin `SHLIB_LD` in 9.0's
-        # `unix/tcl.m4`, which rewrites `cyg%.dll` to `lib%.dll` for the import
-        # library. Only the DLL is affected, not the static or import library.
-        dllPrefix =
-          if stdenv.hostPlatform.isCygwin && lib.versionAtLeast version "9.0" then "cyg" else "lib";
-      in
-      ''
-        make install-private-headers
-        ln -s $out/bin/tclsh${infix}${exeExtension} $out/bin/tclsh${exeExtension}
-        if [[ -e $out/lib/libtcl${infix}${staticExtension} ]]; then
-          ln -s $out/lib/libtcl${infix}${staticExtension} $out/lib/libtcl${staticExtension}
-        fi
-      ''
-      + lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-        ln -s $out/${linkDir}/${dllPrefix}tcl${infix}${linkExtension} $out/lib/libtcl${linkExtension}
+  passthru =
+    let
+      libPrefix = "tcl${release}";
+    in
+    {
+      inherit release version libPrefix;
+      isTcl9 = lib.versions.major version == "9";
+      libdir = "lib/${libPrefix}";
+      tclPackageHook = callPackage (
+        { buildPackages }:
+        makeSetupHook {
+          name = "tcl-package-hook";
+          propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
+          meta = {
+            inherit (finalAttrs.meta) maintainers platforms;
+            license = lib.licenses.mit;
+          };
+        } ./tcl-package-hook.sh
+      ) { };
+      tclRequiresCheckHook = callPackage (
+        { buildPackages }:
+        makeSetupHook {
+          name = "tcl-requires-check-hook";
+          propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
+          meta = {
+            inherit (finalAttrs.meta) maintainers platforms;
+            license = lib.licenses.mit;
+          };
+        } ./tcl-requires-check-hook.sh
+      ) { };
+      # verify that Tcl's clock library can access tzdata
+      tests.tzdata = runCommand "${finalAttrs.pname}-test-tzdata" { } ''
+        ${baseInterp}/bin/tclsh <(echo "set t [clock scan {2004-10-30 05:00:00} \
+                                      -format {%Y-%m-%d %H:%M:%S} \
+                                      -timezone :America/New_York]") > $out
       '';
-
-    __structuredAttrs = true;
-
-    meta = {
-      description = "Tcl scripting language";
-      homepage = "https://www.tcl.tk/";
-      license = lib.licenses.tcltk;
-      platforms = lib.platforms.all;
-      maintainers = with lib.maintainers; [ agbrooks ];
+      mkTclDerivation = callPackage ./mk-tcl-derivation.nix { tcl = finalAttrs.finalPackage; };
     };
-
-    passthru =
-      let
-        libPrefix = "tcl${release}";
-      in
-      {
-        inherit release version libPrefix;
-        isTcl9 = lib.versions.major version == "9";
-        libdir = "lib/${libPrefix}";
-        tclPackageHook = callPackage (
-          { buildPackages }:
-          makeSetupHook {
-            name = "tcl-package-hook";
-            propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
-            meta = {
-              inherit (finalAttrs.meta) maintainers platforms;
-              license = lib.licenses.mit;
-            };
-          } ./tcl-package-hook.sh
-        ) { };
-        tclRequiresCheckHook = callPackage (
-          { buildPackages }:
-          makeSetupHook {
-            name = "tcl-requires-check-hook";
-            propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
-            meta = {
-              inherit (finalAttrs.meta) maintainers platforms;
-              license = lib.licenses.mit;
-            };
-          } ./tcl-requires-check-hook.sh
-        ) { };
-        # verify that Tcl's clock library can access tzdata
-        tests.tzdata = runCommand "${finalAttrs.pname}-test-tzdata" { } ''
-          ${baseInterp}/bin/tclsh <(echo "set t [clock scan {2004-10-30 05:00:00} \
-                                        -format {%Y-%m-%d %H:%M:%S} \
-                                        -timezone :America/New_York]") > $out
-        '';
-        mkTclDerivation = callPackage ./mk-tcl-derivation.nix { tcl = finalAttrs.finalPackage; };
-      };
-  });
-
-in
-baseInterp
+})

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -226,14 +226,9 @@ let
                                         -format {%Y-%m-%d %H:%M:%S} \
                                         -timezone :America/New_York]") > $out
         '';
+        mkTclDerivation = callPackage ./mk-tcl-derivation.nix { tcl = finalAttrs.finalPackage; };
       };
   });
 
-  mkTclDerivation = callPackage ./mk-tcl-derivation.nix { tcl = baseInterp; };
-
 in
-baseInterp.overrideAttrs (self: {
-  passthru = self.passthru // {
-    inherit mkTclDerivation;
-  };
-})
+baseInterp


### PR DESCRIPTION
In two commits for easier reviewing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
