### PR TITLE
nixos/doc: Improve the configuration/adding-custom-packages chapter

### DIFF
--- a/nixos/doc/manual/configuration/adding-custom-packages.section.md
+++ b/nixos/doc/manual/configuration/adding-custom-packages.section.md
@@ -41,15 +41,14 @@ tree. For instance, here is how you specify a build of the
 {
   environment.systemPackages =
     let
-      my-hello =
-        with pkgs;
-        stdenv.mkDerivation rec {
-          name = "hello-2.8";
-          src = fetchurl {
-            url = "mirror://gnu/hello/${name}.tar.gz";
-            hash = "sha256-5rd/gffPfa761Kn1tl3myunD8TuM+66oy1O7XqVGDXM=";
-          };
+      my-hello = pkgs.stdenv.mkDerivation (finalAttrs: {
+        pname = "hello";
+        version = "2.8";
+        src = pkgs.fetchurl {
+          url = "mirror://gnu/hello/hello-${finalAttrs.version}.tar.gz";
+          hash = "sha256-5rd/gffPfa761Kn1tl3myunD8TuM+66oy1O7XqVGDXM=";
         };
+      });
     in
     [ my-hello ];
 }
@@ -59,27 +58,28 @@ Of course, you can also move the definition of `my-hello` into a
 separate Nix expression, e.g.
 
 ```nix
-{ environment.systemPackages = [ (import ./my-hello.nix) ]; }
+{ environment.systemPackages = [ (pkgs.callPackage ./my-hello.nix { }) ]; }
 ```
 
 where `my-hello.nix` contains:
 
 ```nix
-with import <nixpkgs> { }; # bring all of Nixpkgs into scope
+{ stdenv, fetchurl }: # declare dependencies as arguments
 
-stdenv.mkDerivation rec {
-  name = "hello-2.8";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hello";
+  version = "2.8";
   src = fetchurl {
-    url = "mirror://gnu/hello/${name}.tar.gz";
+    url = "mirror://gnu/hello/hello-${finalAttrs.version}.tar.gz";
     hash = "sha256-5rd/gffPfa761Kn1tl3myunD8TuM+66oy1O7XqVGDXM=";
   };
-}
+})
 ```
 
-This allows testing the package easily:
+This allows testing the package without building a whole system configuration:
 
 ```ShellSession
-$ nix-build my-hello.nix
+$ nix-build -E 'with import <nixpkgs> { }; callPackage ./my-hello.nix { }'
 $ ./result/bin/hello
 Hello, world!
 ```


### PR DESCRIPTION
Improve the "Adding Custom Packages" -> "Building with Nix" section to use less error-prone patterns for defining packages:
- Define the example "separate Nix expression" package as a standard package expression and use `pkgs.callPackage`
- Don't use `with`, especially for unpacking the whole nixpkgs namespace just for two package dependencies (using the standard package expr syntax solves this anyway); only use `with` in the `nix-build` for testing, but I'm not aware of a better/cleaner way of running this sort of build
- Remove `rec` and use the `finalAttrs` pattern with `stdenv.mkDerivation` instead

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
