### PR TITLE
profile-sync-daemon: 6.50 -> 6.55

### DIFF
--- a/nixos/modules/services/desktops/profile-sync-daemon.nix
+++ b/nixos/modules/services/desktops/profile-sync-daemon.nix
@@ -39,14 +39,6 @@ in
             description = "Profile Sync daemon";
             wants = [ "psd-resync.service" ];
             wantedBy = [ "default.target" ];
-            path = with pkgs; [
-              rsync
-              kmod
-              gawk
-              net-tools
-              util-linux
-              profile-sync-daemon
-            ];
             unitConfig = {
               RequiresMountsFor = [ "/home/" ];
             };
@@ -65,14 +57,6 @@ in
             wants = [ "psd-resync.timer" ];
             partOf = [ "psd.service" ];
             wantedBy = [ "default.target" ];
-            path = with pkgs; [
-              rsync
-              kmod
-              gawk
-              net-tools
-              util-linux
-              profile-sync-daemon
-            ];
             serviceConfig = {
               Type = "oneshot";
               ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon resync";

--- a/pkgs/by-name/pr/profile-sync-daemon/package.nix
+++ b/pkgs/by-name/pr/profile-sync-daemon/package.nix
@@ -2,31 +2,54 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  makeWrapper,
   util-linux,
   coreutils,
+  rsync,
+  kmod,
+  gawk,
+  net-tools,
+  fuse3,
+  fuse-overlayfs,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "profile-sync-daemon";
-  version = "6.50";
+  version = "6.55";
 
   src = fetchFromGitHub {
     owner = "graysky2";
     repo = "profile-sync-daemon";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Wb9YLxuu9i9s/Y6trz5NZDU9WRywe3138cp5Q2gWbxM=";
+    hash = "sha256-obbPAcHX3o8avAQROO97weZ+3/eOZ4tafNx9ri09DNA=";
   };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    rsync
+    kmod
+    gawk
+    net-tools
+    util-linux
+    fuse3
+    fuse-overlayfs
+  ];
 
   installPhase = ''
     PREFIX=\"\" DESTDIR=$out make install
     substituteInPlace $out/bin/profile-sync-daemon \
-      --replace "/usr/" "$out/" \
-      --replace "sudo " "/run/wrappers/bin/sudo "
+      --replace-fail "/usr/" "$out/" \
+      --replace-fail "sudo " "/run/wrappers/bin/sudo "
     # $HOME detection fails (and is unnecessary)
     sed -i '/^HOME/d' $out/bin/profile-sync-daemon
     substituteInPlace $out/bin/psd-overlay-helper \
-      --replace "PATH=/usr/bin:/bin" "PATH=${util-linux.bin}/bin:${coreutils}/bin" \
-      --replace "sudo " "/run/wrappers/bin/sudo "
+      --replace-fail "PATH=/usr/bin:/bin" "PATH=${util-linux.bin}/bin:${coreutils}/bin" \
+      --replace-fail "sudo " "/run/wrappers/bin/sudo "
+    wrapProgram $out/bin/profile-sync-daemon \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates the package to 6.55. Useful because firefox 147+ uses ~/.config/mozilla instead of ~/.mozilla, and 6.50 still expects the old path; the firefox home-manager module adopted the new path for >=26.05 also.

The actual latest version is 7.04, but 7.0+ dropped the old simple tmpfs mode and also **does not copy the profile files** (meaning after enabling services.psd the profile directory would be empty, at least on my machine) so I think it's best to stick to 6.55 for now to avoid breaking anyone's config

I've also used wrapProgram to have necessary stuff in PATH outside of the service too (+ added fuse deps needed by the overlayfs mode)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
