### PR TITLE
python3Packages.specialized-turbo: init at 0.8.2

### DIFF
--- a/pkgs/development/python-modules/specialized-turbo/default.nix
+++ b/pkgs/development/python-modules/specialized-turbo/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  bleak,
+  buildPythonPackage,
+  cryptography,
+  fetchFromGitHub,
+  hatchling,
+  httpx,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "specialized-turbo";
+  version = "0.8.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "JamieMagee";
+    repo = "specialized-turbo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ey9XQocBDJDNenCnJ2iz4jcJ5cB+BiTt0ngvOX6PKik=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    bleak
+    cryptography
+  ];
+
+  optional-dependencies = {
+    cloud = [ httpx ];
+  };
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.cloud;
+
+  pythonImportsCheck = [ "specialized_turbo" ];
+
+  meta = {
+    description = "Python library for communicating with Specialized Turbo e-bikes over Bluetooth Low Energy";
+    homepage = "https://github.com/JamieMagee/specialized-turbo";
+    changelog = "https://github.com/JamieMagee/specialized-turbo/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19438,6 +19438,8 @@ self: super: with self; {
 
   specfile = callPackage ../development/python-modules/specfile { };
 
+  specialized-turbo = callPackage ../development/python-modules/specialized-turbo { };
+
   spectra = callPackage ../development/python-modules/spectra { };
 
   spectral-cube = callPackage ../development/python-modules/spectral-cube { };


### PR DESCRIPTION
- https://pypi.org/project/specialized-turbo/
- https://github.com/JamieMagee/specialized-turbo
- https://next.home-assistant.io/integrations/specialized_turbo/

I know I'm a little early on this one, but forgive me my own Home Assistant integration 😅 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
