### PR TITLE
gnustep-back: allow patches for gershwin

### DIFF
--- a/pkgs/by-name/gn/gnustep-back/package.nix
+++ b/pkgs/by-name/gn/gnustep-back/package.nix
@@ -3,12 +3,14 @@
   clangStdenv,
   fetchzip,
   cairo,
+  fetchpatch,
   fontconfig,
   freetype,
   gnustep-gui,
   libxft,
   libxmu,
   pkg-config,
+  withGershwinPatches ? false,
   wrapGNUstepAppsHook,
 }:
 
@@ -32,6 +34,19 @@ clangStdenv.mkDerivation (finalAttrs: {
     freetype
     libxft
     libxmu
+  ];
+
+  patches = lib.optionals withGershwinPatches [
+    (fetchpatch {
+      name = "inter-bold.patch";
+      url = "https://raw.githubusercontent.com/gershwin-desktop/gershwin-developer/54f56923a7c47fc721c51e6195369a98f5e55661/Library/Patches/libs-back/inter-bold.patch";
+      sha256 = "sha256-jau7Npjy/aGfBK3SC0ub/ZJS2oz3rUIeUPZZaks5nho=";
+    })
+    (fetchpatch {
+      name = "net-wm-pid.patch";
+      url = "https://raw.githubusercontent.com/gershwin-desktop/gershwin-developer/5983da933e19dc6c84498501314cde0310961c73/Library/Patches/libs-back/net-wm-pid.patch";
+      sha256 = "sha256-hB6NobYKZIlhR728TDObU8CN/6Slzf7DawPHicZfE4o=";
+    })
   ];
 
   propagatedBuildInputs = [ gnustep-gui ];


### PR DESCRIPTION
This PR introduces an argument to gnustep-back so that it can be overridden and patched for use in building gershwin components. The patches derive from the https://github.com/gershwin-desktop/gershwin-developer repo.

This PR was created without the use of AI assisted coding tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
