### PR TITLE
aalib: refactor, adopt, fix license

### DIFF
--- a/pkgs/by-name/aa/aalib/package.nix
+++ b/pkgs/by-name/aa/aalib/package.nix
@@ -8,11 +8,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "aalib";
   version = "1.4rc5";
-
-  src = fetchurl {
-    url = "mirror://sourceforge/aa-project/aalib-${finalAttrs.version}.tar.gz";
-    sha256 = "1vkh19gb76agvh4h87ysbrgy82hrw88lnsvhynjf4vng629dmpgv";
-  };
+  __structuredAttrs = true;
 
   outputs = [
     "bin"
@@ -21,7 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
     "info"
   ];
-  setOutputFlags = false; # Doesn't support all the flags
+
+  src = fetchurl {
+    url = "mirror://sourceforge/aa-project/aalib-${finalAttrs.version}.tar.gz";
+    hash = "sha256-+93akjDPbuKk9XBrSxHiGQrkX17aHwQJ3E+Zs14KcO4=";
+  };
 
   patches = [
     # Fix implicit `int` on `main` error with newer versions of clang
@@ -29,17 +29,32 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix build against opaque aalib API
     ./ncurses-6.5.patch
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ ./darwin.patch ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # fixes build on darwin
+    ./darwin.patch
+  ];
+
+  strictDeps = true;
+  buildInputs = [ ncurses ];
+
+  setOutputFlags = false; # Doesn't support all the flags
+  configureFlags = [
+    "--without-x"
+    "--with-ncurses=${ncurses.dev}"
+    "--bindir=$bin/bin"
+    "--includedir=$dev/include"
+    "--libdir=$out/lib"
+  ];
+
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
 
   preConfigure =
     # The configure script does the correct thing when 'system' is already set
-    # Export it explicitly in case __structuredAttrs is true.
+    # Export it explicitly for __structuredAttrs.
     ''
       export system
-      appendToVar configureFlags \
-        "--bindir=$bin/bin" \
-        "--includedir=$dev/include" \
-        "--libdir=$out/lib"
     ''
     # There is a check for linux-gnu on POWER that disables shared library creation if /lib/ld.so.1 doesn't exists
     # (which it never does for us), because it assumes that it is then running on / targeting MkLinux, which supposedly
@@ -50,26 +65,18 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail 'powerpc*) dynamic_linker=no ;;' ""
     '';
 
-  buildInputs = [ ncurses ];
-
-  configureFlags = [
-    "--without-x"
-    "--with-ncurses=${ncurses.dev}"
-  ];
-
-  env = lib.optionalAttrs stdenv.cc.isGNU {
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-  };
-
   postInstall = ''
     mkdir -p $dev/bin
     mv $bin/bin/aalib-config $dev/bin/aalib-config
-    substituteInPlace $out/lib/libaa.la --replace-fail "${ncurses.dev}/lib" "${ncurses.out}/lib"
+    substituteInPlace $out/lib/libaa.la \
+      --replace-fail "${ncurses.dev}/lib" "${ncurses.out}/lib"
   '';
 
   meta = {
     description = "ASCII art graphics library";
+    homepage = "https://aa-project.sourceforge.net/aalib";
+    license = lib.licenses.lgpl2Plus; # multiple files have LGPL header with the "any later version"
+    maintainers = with lib.maintainers; [ quantenzitrone ];
     platforms = lib.platforms.unix;
-    license = lib.licenses.lgpl2;
   };
 })


### PR DESCRIPTION
- convert hash to sri
- move all configureFlags into the attribute instead of setting them in preConfigure
- add patch comment to darwin patch
- enable strictDeps & structuredAttrs
- move attributes around until nixpkgs-hammering was happy


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
