### PR TITLE
gclient2nix: name each dep after its checkout path

### DIFF
--- a/pkgs/by-name/gc/gclient2nix/package.nix
+++ b/pkgs/by-name/gc/gclient2nix/package.nix
@@ -21,8 +21,11 @@ let
     depsAttrsOrFile:
     let
       depsAttrs = if lib.isAttrs depsAttrsOrFile then depsAttrsOrFile else lib.importJSON depsAttrsOrFile;
-      fetchdep = dep: fetchers.${dep.fetcher} dep.args;
-      fetchedDeps = lib.mapAttrs (_name: fetchdep) depsAttrs;
+      # Name each source after its gclient checkout path, instead of the default "source".
+      fetchdep =
+        path: dep:
+        fetchers.${dep.fetcher} ({ name = lib.strings.sanitizeDerivationName path; } // dep.args);
+      fetchedDeps = lib.mapAttrs fetchdep depsAttrs;
       manifestContents = lib.mapAttrs (_: dep: {
         path = dep;
       }) fetchedDeps;


### PR DESCRIPTION
`importGclientDeps` fetched every dep without a `name`, so all of them showed up as `source`. Name them after their gclient checkout path instead, e.g. `src-third_party-angle`.

No hashes change, but every dep gets a new store path and has to be refetched — hence staging.

Affects `angle`, `electron`, `livekit-libwebrtc` and `signal-desktop`, plus `pdfium` once master is merged in; all still evaluate.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Verified by evaluation only, on x86_64-linux: `angle`, `livekit-libwebrtc`, `electron_41` and `signal-desktop` instantiate against this base, all 167 electron-41 deps get a name, and the sampled `outputHash` values are unchanged.

Disclosure: this pull request summary and the change were written with Claude Code (claude-opus-5), reviewed by me before submission.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
