### PR TITLE
nixos/foot: don't write settings if empty

### DIFF
--- a/nixos/modules/programs/foot/default.nix
+++ b/nixos/modules/programs/foot/default.nix
@@ -89,9 +89,9 @@ in
     ];
 
     programs = {
-      foot.settings.main.include = lib.optionals (cfg.theme != null) [
-        "${cfg.package.themes}/share/foot/themes/${cfg.theme}"
-      ];
+      foot.settings.main = lib.mkIf (cfg.theme != null) {
+        include = [ "${cfg.package.themes}/share/foot/themes/${cfg.theme}" ];
+      };
       # https://codeberg.org/dnkl/foot/wiki#user-content-shell-integration
       bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ". ${./bashrc} # enable shell integration for foot terminal";
       fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration "source ${./config.fish} # enable shell integration for foot terminal";

--- a/nixos/modules/programs/foot/default.nix
+++ b/nixos/modules/programs/foot/default.nix
@@ -78,7 +78,9 @@ in
     environment = lib.mkMerge [
       {
         systemPackages = [ cfg.package ];
-        etc."xdg/foot/foot.ini".source = settingsFormat.generate "foot.ini" cfg.settings;
+        etc."xdg/foot/foot.ini" = lib.mkIf (cfg.settings != { }) {
+          source = settingsFormat.generate "foot.ini" cfg.settings;
+        };
       }
       (lib.mkIf cfg.xdg.serverAutostart {
         etc."xdg/autostart/foot-server.desktop".source =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
