### PR TITLE
nixos/gtklock: don't write config if empty

### DIFF
--- a/nixos/modules/programs/wayland/gtklock.nix
+++ b/nixos/modules/programs/wayland/gtklock.nix
@@ -61,13 +61,15 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.gtklock.config.main = {
-      style = lib.mkIf (cfg.style != null) "${pkgs.writeText "style.css" cfg.style}";
+    programs.gtklock.config.main = lib.mkMerge [
+      (lib.mkIf (cfg.style != null) {
+        style = "${pkgs.writeText "style.css" cfg.style}";
+      })
 
-      modules = lib.mkIf (cfg.modules != [ ]) (
-        map (pkg: "${pkg}/lib/gtklock/${lib.removePrefix "gtklock-" pkg.pname}.so") cfg.modules
-      );
-    };
+      (lib.mkIf (cfg.modules != [ ]) {
+        modules = map (pkg: "${pkg}/lib/gtklock/${lib.removePrefix "gtklock-" pkg.pname}.so") cfg.modules;
+      })
+    ];
 
     environment.etc."xdg/gtklock/config.ini" = lib.mkIf (cfg.config != { }) {
       source = configFormat.generate "config.ini" cfg.config;

--- a/nixos/modules/programs/wayland/gtklock.nix
+++ b/nixos/modules/programs/wayland/gtklock.nix
@@ -69,7 +69,9 @@ in
       );
     };
 
-    environment.etc."xdg/gtklock/config.ini".source = configFormat.generate "config.ini" cfg.config;
+    environment.etc."xdg/gtklock/config.ini" = lib.mkIf (cfg.config != { }) {
+      source = configFormat.generate "config.ini" cfg.config;
+    };
 
     environment.systemPackages = [ cfg.package ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
