### PR TITLE
qaseprite: init at 1.0.3; tiled: add qaseprite plugin

### DIFF
--- a/pkgs/by-name/qa/qaseprite/package.nix
+++ b/pkgs/by-name/qa/qaseprite/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchzip,
+  freetype,
+  harfbuzz,
+  libxcursor,
+  libxi,
+  libpng,
+  libsForQt5,
+  ninja,
+  pixman,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qaseprite";
+  version = "1.0.3";
+
+  __structuredAttrs = true;
+
+  src = fetchzip {
+    url = "https://github.com/mapeditor/qaseprite/releases/download/${finalAttrs.version}/qaseprite-${finalAttrs.version}-source.tar.gz";
+    hash = "sha256-plRmszRdGISL0Iu59Dh8JlmfTIwcJt/TjoBy8wfPLPA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    freetype
+    harfbuzz
+    libxcursor
+    libxi
+    libpng
+    libsForQt5.qtbase
+    pixman
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_CCACHE" false)
+    (lib.cmakeBool "USE_SHARED_ZLIB" true)
+    (lib.cmakeBool "USE_SHARED_LIBPNG" true)
+    (lib.cmakeBool "USE_SHARED_PIXMAN" true)
+    (lib.cmakeBool "USE_SHARED_FREETYPE" true)
+    (lib.cmakeBool "USE_SHARED_HARFBUZZ" true)
+    (lib.cmakeFeature "HARFBUZZ_INCLUDE_DIRS" "${lib.getDev harfbuzz}/include/harfbuzz")
+    (lib.cmakeFeature "QT_PLUGIN_PATH" "${placeholder "out"}/${libsForQt5.qtbase.qtPluginPrefix}")
+  ];
+
+  dontWrapQtApps = true;
+
+  strictDeps = true;
+
+  meta = {
+    description = "Qt image format plugin for reading Aseprite images";
+    homepage = "https://github.com/mapeditor/qaseprite";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ayushthoren ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ti/tiled/package.nix
+++ b/pkgs/by-name/ti/tiled/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   pkg-config,
+  qaseprite,
   qbs,
   libsForQt5,
   zlib,
@@ -12,6 +13,7 @@
 
 let
   qtEnv = libsForQt5.env "tiled-qt-env" [
+    qaseprite
     libsForQt5.qtbase
     libsForQt5.qtdeclarative
     libsForQt5.qtsvg


### PR DESCRIPTION
Tiled supports loading `.ase/.aseprite` tilesets upstream, but the nixpkgs package did not provide the `qaseprite` Qt image plugin, causing Aseprite tilesets to render as missing images.

`qaseprite` was not previously packaged in nixpkgs, so this adds it at version `1.0.3` with myself as a maintainer.

The Tiled package now includes `qaseprite` in its Qt runtime environment so the image plugin is available at runtime.

Fixes #556653

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
