### PR TITLE
qmk: Use contemporary python packaging guidelines, adopt

### DIFF
--- a/pkgs/by-name/qm/qmk/package.nix
+++ b/pkgs/by-name/qm/qmk/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
   pkgsCross,
   avrdude,
@@ -13,7 +13,7 @@
   teensy-loader-cli,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "qmk";
   version = "1.2.0";
   pyproject = true;
@@ -23,38 +23,40 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-FkvRbExAGyt2XuTwF7z6gUGULd82KWHEy6GXXYyyikg=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  propagatedBuildInputs =
-    with python3.pkgs;
-    [
-      dotty-dict
-      hid
-      hjson
-      jsonschema
-      milc
-      pygments
-      pyserial
-      pyusb
-      pillow
-    ]
-    ++ [
-      # Binaries need to be in the path so this is in propagatedBuildInputs
-      avrdude
-      bootloadhid
-      dfu-programmer
-      dfu-util
-      wb32-dfu-updater
-      teensy-loader-cli
-      gcc-arm-embedded
-      gnumake
-      pkgsCross.avr.buildPackages.binutils
-      pkgsCross.avr.buildPackages.binutils.bintools
-      pkgsCross.avr.buildPackages.gcc
-      pkgsCross.avr.libc
-    ];
+  dependencies = with python3Packages; [
+    dotty-dict
+    hid
+    hjson
+    jsonschema
+    milc
+    pygments
+    pyserial
+    pyusb
+    pillow
+  ];
+
+  propagatedBuildInputs = [
+    # Binaries need to be in the path so this is in propagatedBuildInputs
+    avrdude
+    bootloadhid
+    dfu-programmer
+    dfu-util
+    wb32-dfu-updater
+    teensy-loader-cli
+    gcc-arm-embedded
+    gnumake
+    pkgsCross.avr.buildPackages.binutils
+    pkgsCross.avr.buildPackages.binutils.bintools
+    pkgsCross.avr.buildPackages.gcc
+    pkgsCross.avr.libc
+  ];
 
   # no tests implemented
   doCheck = false;
@@ -76,8 +78,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
         - qmk lint
       - ... and many more!
     '';
-    license = lib.licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.PLUS lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.RossSmyth ];
     mainProgram = "qmk";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

As the title says. I am now the owner of a QMK powered keyboard so I figure it should have a maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
