### PR TITLE
rockxy: init at 0.36.0+53

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16545,6 +16545,12 @@
     name = "Jan Schmitt";
     keys = [ { fingerprint = "1763 9903 2D7C 5B82 5D5A  0EAD A2BC 3C6F 1435 1991"; } ];
   };
+  locnguyenhuu = {
+    email = "bystephenx@gmail.com";
+    github = "LocNguyenHuu";
+    githubId = 9362970;
+    name = "Stephen";
+  };
   locnide = {
     email = "locnide@alpaga.dev";
     github = "locnide";

--- a/pkgs/by-name/ro/rockxy/package.nix
+++ b/pkgs/by-name/ro/rockxy/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  undmg,
+  _7zz,
   versionCheckHook,
   writeShellScript,
   re-plistbuddy,
@@ -36,7 +36,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  nativeBuildInputs = [ undmg ];
+  # Rockxy's DMG uses APFS, which is unsupported by undmg.
+  # Preserve symlinks and ignore Apple extended-attribute streams so they are
+  # not extracted as files that would invalidate the signed app bundle.
+  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
+
+  nativeBuildInputs = [ _7zz ];
 
   sourceRoot = ".";
 

--- a/pkgs/by-name/ro/rockxy/package.nix
+++ b/pkgs/by-name/ro/rockxy/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  versionCheckHook,
+  writeShellScript,
+  re-plistbuddy,
+  writeShellApplication,
+  cacert,
+  common-updater-scripts,
+  curl,
+  jq,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rockxy";
+  version = "0.36.0+53";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src =
+    let
+      versionParts = lib.splitString "+" finalAttrs.version;
+      releaseVersion = lib.elemAt versionParts 0;
+      buildVersion = lib.elemAt versionParts 1;
+    in
+    fetchurl {
+      url = "https://github.com/RockxyApp/Rockxy/releases/download/v${releaseVersion}/Rockxy-${releaseVersion}-${buildVersion}.dmg";
+      hash = "sha256-e377Im79wofk/zaXmIUnjT9t1KovgzZdypc6RZ4FNoU=";
+    };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R Rockxy.app "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = writeShellScript "rockxy-version-check" ''
+    shortVersion="$(${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleShortVersionString" "$1")"
+    buildVersion="$(${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleVersion" "$1")"
+    printf '%s+%s\n' "$shortVersion" "$buildVersion"
+  '';
+  versionCheckProgramArg = [
+    "${placeholder "out"}/Applications/Rockxy.app/Contents/Info.plist"
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "rockxy-update-script";
+    runtimeInputs = [
+      cacert
+      common-updater-scripts
+      curl
+      jq
+    ];
+    text = ''
+      metadata="$(curl --fail --silent --show-error \
+        https://raw.githubusercontent.com/RockxyApp/Rockxy/main/releases/latest.json)"
+      releaseVersion="$(jq --exit-status --raw-output '.version' <<< "$metadata")"
+      buildVersion="$(jq --exit-status --raw-output '.build' <<< "$metadata")"
+      update-source-version rockxy "$releaseVersion+$buildVersion"
+    '';
+  });
+
+  meta = {
+    description = "Native macOS HTTP/S and WebSocket debugging proxy";
+    homepage = "https://rockxy.io/";
+    changelog = "https://github.com/RockxyApp/Rockxy/releases/tag/v${lib.elemAt (lib.splitString "+" finalAttrs.version) 0}";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ locnguyenhuu ];
+    platforms = [ "aarch64-darwin" ];
+    hydraPlatforms = [ ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Packages Rockxy 0.36.0 build 53 for `aarch64-darwin` from the official signed and notarized upstream DMG.

The derivation:

- installs the app bundle under `$out/Applications`
- extracts the APFS-formatted DMG with `_7zz`, preserving symlinks and excluding Apple extended-attribute streams that would otherwise corrupt the signed bundle
- verifies both `CFBundleShortVersionString` and `CFBundleVersion`
- preserves the signed bundle by disabling fixup
- marks the binary distribution as unfree and `binaryNativeCode`
- disables Hydra builds because redistribution is restricted
- includes an updater sourced from the public `releases/latest.json` metadata

Rockxy is a native macOS application and does not support NixOS or Linux. Current nixpkgs master has also dropped `x86_64-darwin`, so the package is scoped to `aarch64-darwin`.

Validation performed locally on an `aarch64-darwin` host after reviewer feedback:

- Nix 2.35.2 multi-user installation with daemon sandboxing enabled (`sandbox = true`)
- `nixfmt 1.4.0 --check` passed for both changed Nix files
- whitespace checks passed for both PR commits
- `nix-build . -A rockxy --arg config '{ allowUnfree = true; }' --no-out-link` passed
- the same derivation passed a forced reproducibility rebuild with `--check`
- `versionCheckHook` verified `0.36.0+53`
- `nixpkgs-review pr 556901 -p rockxy --systems aarch64-darwin --extra-nixpkgs-config '{ allowUnfree = true; }'` passed with one package built: `rockxy`
- the app copied into the Nix store passed `codesign --verify --deep --strict` and Gatekeeper assessment (`accepted`, `source=Notarized Developer ID`)
- the GUI app launched successfully from its exact `/nix/store/.../Applications/Rockxy.app` path; the proxy was not enabled during this smoke test

The first local derivation build exposed that the upstream DMG is APFS-formatted and therefore cannot be unpacked by `undmg`. Commit `3719a9474a45` fixes that issue using the established nixpkgs `_7zz` pattern for APFS disk images.

Automation disclosure: this package bootstrap, its two commits, and this pull request summary were prepared with assistance from OpenAI Codex (GPT-5). The submitter remains responsible for the resulting changes and validation.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
