### PR TITLE
python3Packages.numpy-typing-compat: 20251206.2.4 -> 20260602.2.5, modernize

### DIFF
--- a/pkgs/development/python-modules/numpy-typing-compat/default.nix
+++ b/pkgs/development/python-modules/numpy-typing-compat/default.nix
@@ -5,15 +5,14 @@
   uv-build,
   numpy,
 }:
-
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "numpy-typing-compat";
   version = "20251206.2.4";
   pyproject = true;
 
   src = fetchPypi {
     pname = "numpy_typing_compat";
-    inherit version;
+    version = finalAttrs.version;
     hash = "sha256-WYgtI6r/BUolNtqAVkASzc4zSHZXvk15xZJbuHBfyrw=";
   };
 
@@ -39,4 +38,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ tm-drtina ];
   };
-}
+})

--- a/pkgs/development/python-modules/numpy-typing-compat/default.nix
+++ b/pkgs/development/python-modules/numpy-typing-compat/default.nix
@@ -7,18 +7,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "numpy-typing-compat";
-  version = "20251206.2.4";
+  version = "20260602.2.5";
   pyproject = true;
 
   src = fetchPypi {
     pname = "numpy_typing_compat";
     version = finalAttrs.version;
-    hash = "sha256-WYgtI6r/BUolNtqAVkASzc4zSHZXvk15xZJbuHBfyrw=";
+    hash = "sha256-GIWmeOmiRWSDntXRcRwAMXNft95/C17YjVUOXUWo1Pk=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml --replace-fail "uv_build>=0.9,<0.10" "uv_build>=0.9,<=0.10"
-  '';
 
   build-system = [
     uv-build

--- a/pkgs/development/python-modules/optype/default.nix
+++ b/pkgs/development/python-modules/optype/default.nix
@@ -12,19 +12,19 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "optype";
-  version = "0.15.0";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jorenham";
     repo = "optype";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tzbS+CeWGxMXK1LFN/LslI6kfbVQPjqYlDB7fX0ogfU=";
+    hash = "sha256-mtcGblOEyLfOmBwQCC+jX9wvpXiRJE/DNPfPMpcKEOI=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "uv_build>=0.9.16,<0.10.0" uv_build
+    substituteInPlace tests/numpy/test_any_array.py \
+      --replace-fail "np.timedelta64(0)" "np.timedelta64(0, \"s\")"
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/scipy-stubs/default.nix
+++ b/pkgs/development/python-modules/scipy-stubs/default.nix
@@ -6,8 +6,7 @@
   optype,
   scipy,
 }:
-
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "scipy-stubs";
   version = "1.17.0.1";
   pyproject = true;
@@ -15,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "scipy";
     repo = "scipy-stubs";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wzXRnTaSYOePt3XvZ/OeBOQCKObuCL1rWrVDo73yM1I=";
   };
 
@@ -48,4 +47,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ jolars ];
   };
-}
+})

--- a/pkgs/development/python-modules/scipy-stubs/default.nix
+++ b/pkgs/development/python-modules/scipy-stubs/default.nix
@@ -8,19 +8,19 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "scipy-stubs";
-  version = "1.17.0.1";
+  version = "1.18.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scipy";
     repo = "scipy-stubs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wzXRnTaSYOePt3XvZ/OeBOQCKObuCL1rWrVDo73yM1I=";
+    hash = "sha256-manM9kHSk7+iSytce0ZEwE2oN4KJYsc1JVh/1CPHNHI=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "uv_build>=0.9.25,<0.10.0" "uv_build"
+      --replace-fail "uv_build>=0.12.5,<0.13" "uv_build"
   '';
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
