### PR TITLE
handy: 0.9.1 -> 0.9.6

### DIFF
--- a/pkgs/by-name/ha/handy/package.nix
+++ b/pkgs/by-name/ha/handy/package.nix
@@ -55,7 +55,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "handy";
-  version = "0.9.1";
+  version = "0.9.6";
 
   __structuredAttrs = true;
 
@@ -63,11 +63,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "cjpais";
     repo = "Handy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GuHMK98wmqv2ryrMF243CjRGMbjZ0ykX89RJbjwaP6U=";
+    hash = "sha256-6eNa9iNjwKgLL8t72GeMHTxjyHaeVl+9VF/QWjlHzts=";
   };
 
   cargoRoot = "src-tauri";
-  cargoHash = "sha256-CNHWa70nAYbdgXO62s1iaW6nBacorgEVZIgkMZx/CNs=";
+  cargoHash = "sha256-fzTklIGMCE2ugLc6KIj3XDqxB4qjhtm14LKBUb8kBWE=";
 
   nativeInstallInputs = [ jq ];
 
@@ -246,9 +246,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
       outputHash =
         {
-          "x86_64-linux" = "sha256-1jZBFvX9Ch3jNGPgSnOE8yNCXlHru7tcMJZ5uNZtE1g=";
-          "aarch64-linux" = "sha256-MsY2tOdBg11OMyQLRkLoVKxyrcqa0yVddfcYuIVWSxw=";
-          "aarch64-darwin" = "sha256-Fw0va7mq0F36qa15bDFVL01Q5pEprWhza78CzurLoLg=";
+          "x86_64-linux" = "sha256-huOC2smHU0sGIxeyvWmzdewUEpKHfdSGNhf9xWpH9Jk=";
+          "aarch64-linux" = "sha256-UDn8nIgIx23ampe43Qr0j9h+hlU9g1QzzlIlbRH2CKs=";
+          "aarch64-darwin" = "sha256-8Rw4iNvqeq/sRvZpbtZo0f0iPAwu1TeB8Y+ut4kb9uw=";
         }
         .${stdenv.hostPlatform.system};
 


### PR DESCRIPTION
https://github.com/cjpais/Handy/compare/v0.9.1...v0.9.6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (via binfmt+qemu)
  - [ ] aarch64-darwin (hash computed via `bun install --cpu=arm64 --os=darwin` in nix sandbox; cross-checked with x86_64/aarch64-linux builds)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

### Details
- Update `src` hash, `cargoHash` and `frontendDeps` hashes for all platforms
- Verified `handy.passthru.frontendDeps` for x86_64-linux and aarch64-linux via local `nix build` with `extra-platforms = aarch64-linux` and qemu binfmt
- aarch64-darwin hash derived via `bun install --cpu=arm64 --os=darwin` inside nix sandbox (deterministic, matches x86 approach which reproduces the same hash as native build)
- Changelog: https://github.com/cjpais/Handy/releases/tag/v0.9.6
