### PR TITLE
handy: 0.9.1 -> 0.9.5

### DIFF
--- a/pkgs/by-name/ha/handy/package.nix
+++ b/pkgs/by-name/ha/handy/package.nix
@@ -55,7 +55,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "handy";
-  version = "0.9.1";
+  version = "0.9.5";
 
   __structuredAttrs = true;
 
@@ -63,11 +63,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "cjpais";
     repo = "Handy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GuHMK98wmqv2ryrMF243CjRGMbjZ0ykX89RJbjwaP6U=";
+    hash = "sha256-CYSvo03b7d8CeLtvSdO9cyGSdrlpDupKGHITr7E7LuI=";
   };
 
   cargoRoot = "src-tauri";
-  cargoHash = "sha256-CNHWa70nAYbdgXO62s1iaW6nBacorgEVZIgkMZx/CNs=";
+  cargoHash = "sha256-B9vl5epJc9z0yfTZHknomL5gwp3r33hvDjL2pf1Odpo=";
 
   nativeInstallInputs = [ jq ];
 
@@ -246,9 +246,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
       outputHash =
         {
-          "x86_64-linux" = "sha256-1jZBFvX9Ch3jNGPgSnOE8yNCXlHru7tcMJZ5uNZtE1g=";
-          "aarch64-linux" = "sha256-MsY2tOdBg11OMyQLRkLoVKxyrcqa0yVddfcYuIVWSxw=";
-          "aarch64-darwin" = "sha256-Fw0va7mq0F36qa15bDFVL01Q5pEprWhza78CzurLoLg=";
+          "x86_64-linux" = "sha256-bkBgSjXPPLCG2ex67jP/euEX/i4IDaK38g6YkXDDAW0=";
+          "aarch64-linux" = "sha256-D2NbqAu3kWWwVlSJ8gjjfU2+Ibej/00D422kVbokeGw=";
+          "aarch64-darwin" = "sha256-FTE7l5Cls6Hky49SKFHArPQRlRsEfDhldLP/XqeFTKM=";
         }
         .${stdenv.hostPlatform.system};
 


### PR DESCRIPTION
https://github.com/cjpais/Handy/compare/v0.9.1...v0.9.5

- Rebased from #550429 which had stuck OfBorg darwin jobs and hash mismatch reports.
- Verified locally on 2026-08-27:
  - x86_64-linux frontendDeps: sha256-bkBgSjXPPLCG2ex67jP/euEX/i4IDaK38g6YkXDDAW0= (built successfully)
  - aarch64-linux frontendDeps: sha256-D2NbqAu3kWWwVlSJ8gjjfU2+Ibej/00D422kVbokeGw= (built via qemu-aarch64 + binfmt, verified)
  - aarch64-darwin: sha256-FTE7l5Cls6Hky49SKFHArPQRlRsEfDhldLP/XqeFTKM= (unverified on Linux, same as #550429)
  - src hash sha256-CYSvo03b7d8CeLtvSdO9cyGSdrlpDupKGHITr7E7LuI= and cargoHash sha256-B9vl5epJc9z0yfTZHknomL5gwp3r33hvDjL2pf1Odpo= verified (vendor built)
- Addresses comment https://github.com/NixOS/nixpkgs/pull/550429#issuecomment-5228265467 where pbsds reported mismatch got sha256-xah6...; with current nixpkgs bun 1.3.13 the D2Nbq hash is correct for aarch64-linux (tested).

Fixes #550429 (parallel green PR).

## Things done
- Built on platform:
  - [x] x86_64-linux (frontendDeps + vendor)
  - [x] aarch64-linux (frontendDeps via qemu)
  - [ ] aarch64-darwin (cannot build on Linux)
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
- [x] Ran local build for frontendDeps on x86_64 and aarch64
- [x] Fits CONTRIBUTING.md
