### PR TITLE
kde-modernclock: init at 0.2.0-unstable-2024-03-07

### DIFF
--- a/pkgs/by-name/kd/kde-modernclock/package.nix
+++ b/pkgs/by-name/kd/kde-modernclock/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kde-modernclock";
+  version = "0.2.0-unstable-2024-03-07";
+
+  src = fetchFromGitHub {
+    owner = "Prayag2";
+    repo = "kde_modernclock";
+    rev = "5c86f0f23d2646be7e9872fc5e769bdce259af92";
+    hash = "sha256-+FqTNdMbWXp27ZdfcgQvLE+yr2z6KxXbIIPpQTffEIE=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/plasma/plasmoids/com.github.prayag2.modernclock
+    cp -r package/* $out/share/plasma/plasmoids/com.github.prayag2.modernclock/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=unstable" ];
+  };
+
+  meta = {
+    description = "Modern clock widget for KDE Plasma desktop";
+    homepage = "https://github.com/Prayag2/kde_modernclock";
+    changelog = "https://github.com/Prayag2/kde_modernclock/releases";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ subham-roy ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Modern Clock is a minimal clock/date plasmoid for KDE Plasma 6. Pure QML — installs package/ to $out/share/plasma/plasmoids.

https://github.com/Prayag2/kde_modernclock

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Disclosure: commit and PR description drafted with opencode (muse-spark-1.2-contributor-free), reviewed by maintainer.