### PR TITLE
nixos/pgbackrest: add support for repo cipher

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -229,6 +229,8 @@
 
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
 
+- `services.pgbackrest.repos.<name>.cipher-pass-file` added: allows to specify the encryption key for a repository.
+
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade

--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -53,7 +53,14 @@ let
     ];
 
   fullConfig = {
-    global = normalize (cfg.settings // flattenWithIndex cfg.repos "repo");
+    # cipher-pass-file is not a pgBackRest option, it is turned into
+    # cipher-pass in a separate config file at runtime.
+    global = normalize (
+      cfg.settings
+      // flattenWithIndex (lib.mapAttrs (
+        _: repo: removeAttrs repo [ "cipher-pass-file" ]
+      ) cfg.repos) "repo"
+    );
   }
   // lib.mapAttrs' (
     cmd: settings: lib.nameValuePair "global:${cmd}" (normalize settings)
@@ -87,6 +94,14 @@ let
       default = null;
       internal = true;
     };
+
+  # pgBackRest automatically reads the .conf files in this directory
+  secretsPath = "/run/pgbackrest-secrets";
+  secretsFile = "${secretsPath}/cipher-pass.conf";
+
+  cipherPassOptions = flattenWithIndex (lib.mapAttrs (
+    _: repo: lib.optionalAttrs (repo.cipher-pass-file != null) { cipher-pass = repo.cipher-pass-file; }
+  ) cfg.repos) "repo";
 in
 
 {
@@ -96,10 +111,9 @@ in
 
   # TODO: Add enableServer option and corresponding pgBackRest TLS server service.
   # TODO: Write wrapper around pgbackrest to turn --repo=<name> into --repo=<number>
-  # The following two are dependent on improvements upstream:
+  # The following is dependent on improvements upstream:
   #   https://github.com/pgbackrest/pgbackrest/issues/2621
   # TODO: Add support for more repository types
-  # TODO: Support passing encryption key safely
   options.services.pgbackrest = {
     enable = lib.mkEnableOption "pgBackRest";
 
@@ -146,6 +160,15 @@ in
 
                   The file must be accessible by both the pgbackrest and the postgres users.
                 '';
+              };
+
+              options.cipher-pass-file = lib.mkOption {
+                type = nullOr externalPath;
+                default = null;
+                description = ''
+                  Path to a file containing the repository passphrase.
+                '';
+                example = "/run/secrets/pgbackrest-cipher-pass";
               };
 
               # The following options should not be used; they would store secrets in the store.
@@ -410,6 +433,9 @@ in
           {
             description = "pgBackRest job ${job} for stanza ${stanza}";
 
+            requires = lib.optional (cipherPassOptions != { }) "pgbackrest-secrets.service";
+            after = lib.optional (cipherPassOptions != { }) "pgbackrest-secrets.service";
+
             serviceConfig = {
               User = "pgbackrest";
               Group = "pgbackrest";
@@ -442,6 +468,37 @@ in
           }
         ) namedJobs;
       }
+
+      (lib.mkIf (cipherPassOptions != { }) {
+        environment.etc."pgbackrest/conf.d".source = secretsPath;
+
+        systemd.tmpfiles.settings.pgbackrest.${secretsPath}.d = {
+          user = "pgbackrest";
+          group = "pgbackrest";
+          mode = "0750";
+        };
+
+        systemd.services.pgbackrest-secrets = {
+          description = "Repository passphrases for pgBackRest";
+          wantedBy = [ "multi-user.target" ];
+          before = [ "postgresql.service" ] ++ lib.mapAttrsToList (name: _: "${name}.service") namedJobs;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script = ''
+            echo "[global]" > ${secretsFile}.new
+            ${lib.concatLines (
+              lib.mapAttrsToList (
+                option: file: ''printf '%s=%s\n' ${option} "$(cat ${file})" >> ${secretsFile}.new''
+              ) cipherPassOptions
+            )}
+            chown pgbackrest:pgbackrest ${secretsFile}.new
+            chmod 0640 ${secretsFile}.new
+            mv ${secretsFile}.new ${secretsFile}
+          '';
+        };
+      })
 
       # The default stanza is set up for the local postgresql instance.
       # It does not backup automatically, the systemd timer still needs to be set.

--- a/nixos/tests/pgbackrest/sftp.nix
+++ b/nixos/tests/pgbackrest/sftp.nix
@@ -2,6 +2,9 @@
 let
   inherit (import ../ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
   backupPath = "/home/backup";
+  cipherPassFile = "/run/cipher-pass";
+  cipherPass = "my_cipher";
+  cipherType = "aes-256-cbc";
 in
 {
   name = "pgbackrest-sftp";
@@ -24,15 +27,22 @@ in
         '';
       };
 
+      # Stands in for whatever secret manager provides the passphrase at runtime.
+      systemd.services.pgbackrest-secrets.preStart = ''
+        echo -n "${cipherPass}" > ${cipherPassFile}
+      '';
+
       services.pgbackrest = {
         enable = true;
         repos.backup = {
           type = "sftp";
-          path = "/home/backup";
+          path = backupPath;
           sftp-host-key-check-type = "none";
           sftp-host-key-hash-type = "sha256";
           sftp-host-user = "backup";
           sftp-private-key-file = "/var/lib/pgbackrest/sftp_key";
+          cipher-type = cipherType;
+          cipher-pass-file = cipherPassFile;
         };
 
         stanzas.default.jobs.future = {
@@ -79,6 +89,14 @@ in
       with subtest("backup/restore works with local instance/remote repo (SFTP)"):
         primary.succeed("sudo -u pgbackrest pgbackrest --stanza=default stanza-create", timeout=10)
         primary.succeed("sudo -u pgbackrest pgbackrest --stanza=default check")
+
+        # The passphrase reaches pgBackRest without passing through the store.
+        primary.fail("grep -r '${cipherPass}' /etc/pgbackrest/pgbackrest.conf")
+        primary.succeed("sudo -u postgres test -r /etc/pgbackrest/conf.d/cipher-pass.conf")
+        assert "640 pgbackrest pgbackrest" in primary.succeed(
+            "stat -c '%a %U %G' /etc/pgbackrest/conf.d/cipher-pass.conf"
+        )
+        assert "${cipherType}" in primary.succeed("sudo -u pgbackrest pgbackrest --stanza=default info")
 
         primary.systemctl("start pgbackrest-default-future")
 


### PR DESCRIPTION
Currently, the module does not provide a way to specify repo ciphers. There is a todo comment for it:

```nix
# TODO: Support passing encryption key safely
```

This PR addresses the TODO by adding a new option `services.pgbackrest.repos.<name>.cipher-pass-file`. By taking the file path only, we ensure the secret is not copied into the nix store.

Assisted-by: Claude Code (Claude Opus 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
