### PR TITLE
retroshare: fix desktop entry

### DIFF
--- a/pkgs/by-name/re/retroshare/package.nix
+++ b/pkgs/by-name/re/retroshare/package.nix
@@ -107,6 +107,10 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # BT DHT bootstrap
     cp libbitdht/src/bitdht/bdboot.txt $out/share/retroshare
+
+    substituteInPlace $out/share/applications/retroshare.desktop \
+      --replace-fail "/usr/bin/retroshare" "retroshare" \
+      --replace-fail "/usr/share/pixmaps/retroshare.xpm" "retroshare"
   '';
 
   meta = {


### PR DESCRIPTION
Added a post-install substituteInPlace so that the desktop entry produced by retroshare's build scripts has correct paths instead of /usr/bin and so on.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].