### PR TITLE
nixos/tests/pgbackrest: optimize performance

### DIFF
--- a/nixos/tests/pgbackrest/sftp.nix
+++ b/nixos/tests/pgbackrest/sftp.nix
@@ -33,7 +33,12 @@ in
           sftp-host-key-hash-type = "sha256";
           sftp-host-user = "backup";
           sftp-private-key-file = "/var/lib/pgbackrest/sftp_key";
+          # speedup for transferring the 970 files in this test
+          bundle = true;
         };
+
+        # speedup for the test
+        settings.start-fast = true;
 
         stanzas.default.jobs.future = {
           schedule = "3000-01-01";


### PR DESCRIPTION
On my machine, running nixos/tests/pgbackrest/sftp.nix takes ~43s which seemed slow given that we _only_ do a backup between 2 vms. This PR optimizes that to ~21s.

`bundle = true` is a ~15s speedup because the "hello world" postgres database that we are transferring consists of 970 files. Transferring each file individually is slow. With `bundle = true` they are transferred as a single file which is faster. This also means the test is more realistic because most real life scenarios will probably be using `bundle = true`.

Another ~5s speedup was setting `start-fast = true;` for pgbackrest.

Assisted-by: Claude Code (Claude Opus 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
