### PR TITLE
python3Packages.gflanguages: switch to fetchFromGitHub

### DIFF
--- a/pkgs/development/python-modules/gflanguages/default.nix
+++ b/pkgs/development/python-modules/gflanguages/default.nix
@@ -52,12 +52,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "gflanguages" ];
 
-  disabledTests = [
-    # AssertionError
-    "test_exemplars_are_in_script"
-    "test_sample_texts_are_in_script"
-  ];
-
   meta = {
     description = "Python library for Google Fonts language metadata";
     homepage = "https://github.com/googlefonts/lang";

--- a/pkgs/development/python-modules/gflanguages/default.nix
+++ b/pkgs/development/python-modules/gflanguages/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   protobuf,
   pytestCheckHook,
   regex,
@@ -12,14 +12,16 @@
   gfmetadata,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gflanguages";
   version = "0.7.10";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-d5tSIlJhwlJ/8lwYlfLoPglV57+bNehlnghDwk4nNU0=";
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "lang";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N7hFJ9qvb+i8j7NKGtJivFnrCKBE4tsvBAclrFBGFiw=";
   };
 
   # Relax the dependency on protobuf 3. Other packages in the Google Fonts
@@ -59,11 +61,11 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for Google Fonts language metadata";
     homepage = "https://github.com/googlefonts/lang";
-    changelog = "https://github.com/googlefonts/lang/releases/tag/v${version}";
+    changelog = "https://github.com/googlefonts/lang/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       danc86
       jopejoe1
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
