### PR TITLE
rust: fix 1.98.0 build on darwin

### DIFF
--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -65,6 +65,21 @@ rec {
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       install_name_tool -change "/usr/lib/libcurl.4.dylib" \
       "${lib.getLib curl}/lib/libcurl.4.dylib" "$out/bin/cargo"
+
+      # Since 1.98.0 the darwin tarball links LLVM dynamically and ships an
+      # unversioned libLLVM.dylib (rust-lang/rust#157205).
+      # This shadows our nixpkgs-built libLLVM.dylib when we run our own
+      # toolchain, leading to missing symbols.
+      # Rename the dylib that upstream ships to avoid the shadowing, similar
+      # to what upstream already does for linux.
+      if [ -e "$out/lib/libLLVM.dylib" ]; then
+        versioned=libLLVM-rust-bootstrap-${version}.dylib
+        mv "$out/lib/libLLVM.dylib" "$out/lib/$versioned"
+        install_name_tool -id "@rpath/$versioned" "$out/lib/$versioned"
+        find "$out/bin" "$out/lib" -type f \( -perm -0100 -o -name '*.dylib' \) \
+          -exec install_name_tool -change "@rpath/libLLVM.dylib" \
+          "@rpath/$versioned" {} \;
+      fi
     '';
 
     # The strip tool in cctools 973.0.1 and up appears to break rlibs in the


### PR DESCRIPTION
Since 1.98.0 the darwin tarball links LLVM dynamically and ships an unversioned libLLVM.dylib (rust-lang/rust#157205).
This shadows our nixpkgs-built libLLVM.dylib when we run our own toolchain, leading to missing symbols.
Rename the dylib that upstream ships to avoid the shadowing, similar to what upstream already does for linux.

See https://github.com/NixOS/nixpkgs/pull/556706


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
