### PR TITLE
coqPackages.hierarchy-builder: fix old versions

### DIFF
--- a/pkgs/development/rocq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/rocq-modules/hierarchy-builder/default.nix
@@ -66,6 +66,9 @@ let
     lib.optionalAttrs (lib.versions.isGe "1.2.0" o.version || o.version == "dev") {
       buildPhase = "make build";
     }
+    // (lib.optionalAttrs (lib.versions.range "1.1" "1.6" o.version) {
+      nativeBuildInputs = [ rocq-core.ocamlPackages.ocaml ] ++ o.nativeBuildInputs;
+    })
     // (
       if lib.versions.range "1.1.0" "1.9.1" o.version then
         { installFlags = [ "DESTDIR=$(out)" ] ++ o.installFlags; }


### PR DESCRIPTION
Fixes build of `hierarchy-builder` with Coq 8.12 – 8.17.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
