### PR TITLE
nixos/pgbackrest: drop wolfgangwalther as maintainer

### DIFF
--- a/nixos/modules/services/backup/pgbackrest.nix
+++ b/nixos/modules/services/backup/pgbackrest.nix
@@ -90,10 +90,6 @@ let
 in
 
 {
-  meta = {
-    maintainers = with lib.maintainers; [ wolfgangwalther ];
-  };
-
   # TODO: Add enableServer option and corresponding pgBackRest TLS server service.
   # TODO: Write wrapper around pgbackrest to turn --repo=<name> into --repo=<number>
   # The following two are dependent on improvements upstream:

--- a/nixos/tests/pgbackrest/posix.nix
+++ b/nixos/tests/pgbackrest/posix.nix
@@ -6,10 +6,6 @@ in
 {
   name = "pgbackrest-posix";
 
-  meta = {
-    maintainers = with lib.maintainers; [ wolfgangwalther ];
-  };
-
   nodes.primary =
     {
       pkgs,

--- a/nixos/tests/pgbackrest/sftp.nix
+++ b/nixos/tests/pgbackrest/sftp.nix
@@ -6,10 +6,6 @@ in
 {
   name = "pgbackrest-sftp";
 
-  meta = {
-    maintainers = with lib.maintainers; [ wolfgangwalther ];
-  };
-
   nodes.primary =
     {
       pkgs,


### PR DESCRIPTION
Not using this anymore and don't want to stand in anyone's way.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
