### PR TITLE
materia-theme: reinit without gtk-engine-murrine

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17743,6 +17743,17 @@
     githubId = 56825922;
     name = "Markus Nyman";
   };
+  marrobHD = {
+    email = "may@kuzu.sh";
+    github = "marrobHD";
+    githubId = 29308361;
+    name = "May";
+    keys = [
+      {
+        fingerprint = "2908 6DCF 6374 6968 DACA  8B8F 8B5F F186 D06F 16B9";
+      }
+    ];
+  };
   marsupialgutz = {
     email = "mars@possums.xyz";
     github = "skulldogged";

--- a/pkgs/by-name/ma/materia-theme-transparent/package.nix
+++ b/pkgs/by-name/ma/materia-theme-transparent/package.nix
@@ -21,6 +21,7 @@ materia-theme.overrideAttrs {
     platforms = lib.platforms.all;
     maintainers = [
       lib.maintainers.corbinwunderlich
+      lib.maintainers.marrobHD
     ];
   };
 }

--- a/pkgs/by-name/ma/materia-theme-transparent/package.nix
+++ b/pkgs/by-name/ma/materia-theme-transparent/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  materia-theme,
+}:
+materia-theme.overrideAttrs {
+  pname = "materia-theme-transparent";
+  version = "0-unstable-2021-03-22";
+
+  src = fetchFromGitHub {
+    owner = "ckissane";
+    repo = "materia-theme-transparent";
+    rev = "c5d95bbddd59a717bfc4976737af429a89ba74e0";
+    hash = "sha256-dHcwPTZFWO42wu1LbtGCMm2w/YHbjSUJnRKcaFllUbs=";
+  };
+
+  meta = {
+    description = "Transparent Material Design theme for GNOME/GTK based desktop environments";
+    homepage = "https://github.com/ckissane/materia-theme-transparent";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+    maintainers = [
+      lib.maintainers.corbinwunderlich
+    ];
+  };
+}

--- a/pkgs/by-name/ma/materia-theme/package.nix
+++ b/pkgs/by-name/ma/materia-theme/package.nix
@@ -46,5 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/nana-4/materia-theme";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.marrobHD ];
   };
 })

--- a/pkgs/by-name/ma/materia-theme/package.nix
+++ b/pkgs/by-name/ma/materia-theme/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  sassc,
+  gnome-shell,
+  gnome-themes-extra,
+  gdk-pixbuf,
+  librsvg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "materia-theme";
+  version = "20210322";
+
+  src = fetchFromGitHub {
+    owner = "nana-4";
+    repo = "materia-theme";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-dHcwPTZFWO42wu1LbtGCMm2w/YHbjSUJnRKcaFllUbs=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    sassc
+  ];
+
+  buildInputs = [
+    gnome-themes-extra
+    gdk-pixbuf
+    librsvg
+  ];
+
+  mesonFlags = [
+    (lib.mesonOption "gnome_shell_version" (lib.versions.majorMinor gnome-shell.version))
+  ];
+
+  meta = {
+    description = "Material Design theme for GNOME/GTK based desktop environments";
+    homepage = "https://github.com/nana-4/materia-theme";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1629,7 +1629,6 @@ mapAliases {
   marwaita-yellow = throw "'marwaita-yellow' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   massif-visualizer = throw "'massif-visualizer' has been removed due to outdated KF5 dependencies."; # Added 2026-05-01
   mastodon-bot = throw "'mastodon-bot' has been removed because it was archived by upstream in 2021."; # Added 2025-11-07
-  materia-theme = throw "'materia-theme' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   material-kwin-decoration = throw "'material-kwin-decoration' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   matheria-theme-transparent = throw "'matheria-theme-transparent' has been removed because it depended on 'gtk-engine-murrine', which was removed because it was unmaintained upstream and depended on GTK 2."; # Added 2026-07-22
   mathlibtools = throw "mathlibtools has been removed as it was archived upstream in 2023"; # Added 2025-07-09


### PR DESCRIPTION
Reinit materia-theme without gtk-engine-murrine as it was removed: https://github.com/NixOS/nixpkgs/pull/553074
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
