### PR TITLE
nixos/nextcloud: simplify imaginary configuration

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -994,6 +994,20 @@ in
               "OC\\Preview\\TXT"
               "OC\\Preview\\OpenDocument"
             ];
+            defaultText = lib.literalExpression ''
+              [
+                "OC\\Preview\\PNG"
+                "OC\\Preview\\JPEG"
+                "OC\\Preview\\GIF"
+                "OC\\Preview\\BMP"
+                "OC\\Preview\\XBitmap"
+                "OC\\Preview\\Krita"
+                "OC\\Preview\\WebP"
+                "OC\\Preview\\MarkDown"
+                "OC\\Preview\\TXT"
+                "OC\\Preview\\OpenDocument"
+              ]
+            '';
             description = ''
               The preview providers that should be explicitly enabled.
             '';
@@ -1624,16 +1638,12 @@ in
             # https://docs.nextcloud.com/server/latest/admin_manual/installation/server_tuning.html#previews
             (lib.mkIf cfg.imaginary.enable {
               preview_imaginary_url = "http://${config.services.imaginary.address}:${toString config.services.imaginary.port}";
-
-              # Imaginary replaces a few of the built-in providers, so the default value has to be adjusted.
-              enabledPreviewProviders = lib.mkDefault [
-                "OC\\Preview\\Imaginary"
-                "OC\\Preview\\ImaginaryPDF"
-                "OC\\Preview\\Krita"
-                "OC\\Preview\\MarkDown"
-                "OC\\Preview\\TXT"
-                "OC\\Preview\\OpenDocument"
-              ];
+              enabledPreviewProviders = lib.mkOptionDefault (
+                lib.mkBefore [
+                  "OC\\Preview\\Imaginary"
+                  "OC\\Preview\\ImaginaryPDF"
+                ]
+              );
             })
           ];
         };


### PR DESCRIPTION
Simplify Imaginary setup by reusing the `defaultPreviewProvider` list. By putting the Imaginary service providers first, we ensure that they are used before falling back to standard image providers.

Also setting webp as default preview format since this is recommended by upstream https://docs.nextcloud.com/server/latest/admin_manual/installation/server_tuning.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
