### PR TITLE
libopus: switch to fetchFromGitLab and fetch models separately

### DIFF
--- a/pkgs/by-name/li/libopus/package.nix
+++ b/pkgs/by-name/li/libopus/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
+  fetchzip,
   gitUpdater,
   meson,
   python3,
@@ -16,13 +17,24 @@
   testers,
 }:
 
+let
+  models = fetchzip (finalAttrs: {
+    pname = "opus-models";
+    version = "a5177ec6fb7d15058e99e57029746100121f68e4890b1467d4094aa336b6013e";
+    url = "https://media.xiph.org/opus/models/opus_data-${finalAttrs.version}.tar.gz";
+    hash = "sha256-aCOYMJoOGgdFCYZdFlUKiXjzssQKlQnCsTD3i5gGzCA=";
+  });
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libopus";
   version = "1.6.1";
 
-  src = fetchurl {
-    url = "https://downloads.xiph.org/releases/opus/opus-${finalAttrs.version}.tar.gz";
-    hash = "sha256-b/y1kyB76SWE3xWzJGbtZLvsmRCfAHyCIF8BlFckEaE=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xiph.org";
+    owner = "xiph";
+    repo = "opus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-I1f+J//ZJBMj88+PQhsYBjz3fm4Ll3ckZD+fYa6/3Y0=";
   };
 
   patches = [
@@ -32,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs meson/
+    echo 'PACKAGE_VERSION="${finalAttrs.version}"' > package_version
+    ln -s ${models}/* ./dnn/
   '';
 
   outputs = [
@@ -61,6 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.xiph.org/xiph/opus.git";
       rev-prefix = "v";
     };
+
+    inherit models;
 
     tests = {
       inherit ffmpeg-headless;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
