### PR TITLE
fceux: pin to ffmpeg 8 to fix build failure

### DIFF
--- a/pkgs/by-name/fc/fceux/package.nix
+++ b/pkgs/by-name/fc/fceux/package.nix
@@ -4,7 +4,7 @@
   SDL2,
   cmake,
   fetchFromGitHub,
-  ffmpeg,
+  ffmpeg_8,
   libx11,
   libxdmcp,
   libxcb,
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     SDL2
-    ffmpeg
+    ffmpeg_8
     libx11
     libxdmcp
     libxcb


### PR DESCRIPTION
The fceux build is broken by https://github.com/NixOS/nixpkgs/pull/549284 because it is not compatible with ffmpeg 9 (upstream https://github.com/TASEmulators/fceux/pull/850 ).

This pins to ffmpeg 8 for now, fixing the build, as is being done for other packages with similar issues (such as https://github.com/NixOS/nixpkgs/pull/556470 ).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - (Not applicable) ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - (Not applicable) ~Module addition: when adding a new NixOS module.~
  - (Not applicable) ~Module update: when the change is significant.~
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
