### PR TITLE
lib.extendMkDerivation: provide cumulation attribute and optimise

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -905,7 +905,8 @@ rec {
             let
               previous = if isFunction fpargs then fpargs final else fpargs;
             in
-            removeAttrs previous excludeDrvArgNames // extendDrvArgs final previous
+            (if excludeDrvArgNames == [ ] then previous else removeAttrs previous excludeDrvArgNames)
+            // extendDrvArgs final previous
           )
         );
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -775,26 +775,61 @@ rec {
     # Inputs
 
     `extendMkDerivation`-specific configurations
-    : `constructDrv` (required)
-      : Base build helper, the `mkDerivation`-like build helper to extend.
+      - Core configurations
+        `constructDrv` (required)
+        : Base build helper, the `mkDerivation`-like build helper to extend.
 
-      `excludeDrvArgNames` (default to `[ ]`)
-      : Argument names not to pass from the input fixed-point arguments to `constructDrv`.
-        It doesn't apply to the updating arguments returned by `extendDrvArgs`.
+        `excludeDrvArgNames` (default to `[ ]`)
+        : Argument names not to pass from the input fixed-point arguments to `constructDrv`.
+          It doesn't apply to the updating arguments returned by `extendDrvArgs`.
 
-      `excludeFunctionArgNames` (default to `[ ]`)
-      : `__functionArgs` attribute names to remove from the result build helper.
-        `excludeFunctionArgNames` is useful for argument deprecation while avoiding ellipses.
+        `extendDrvArgs` (required)
+        : An extension (overlay) of the argument set, like the one taken by [`overrideAttrs`](#sec-pkg-overrideAttrs) but applied before passing to `constructDrv`.
 
-      `extendDrvArgs` (required)
-      : An extension (overlay) of the argument set, like the one taken by [`overrideAttrs`](#sec-pkg-overrideAttrs) but applied before passing to `constructDrv`.
+        `transformDrv` (default to `lib.id`)
+        : Function to apply to the result derivation.
 
-      `inheritFunctionArgs` (default to `true`)
-      : Whether to inherit `__functionArgs` from the base build helper.
-        Set `inheritFunctionArgs` to `false` when `extendDrvArgs`'s `args` set pattern does not contain an ellipsis.
+      - `__functionArgs` configurations
 
-      `transformDrv` (default to `lib.id`)
-      : Function to apply to the result derivation.
+        `excludeFunctionArgNames` (default to `[ ]`)
+        : `__functionArgs` attribute names to remove from the result build helper.
+          `excludeFunctionArgNames` is useful for argument deprecation while avoiding ellipses.
+
+        `inheritFunctionArgs` (default to `true`)
+        : Whether to inherit `__functionArgs` from the base build helper.
+          Set `inheritFunctionArgs` to `false` when `extendDrvArgs`'s `args` set pattern does not contain an ellipsis.
+
+    # Outputs
+
+    - The result callable set
+
+      `extendMkDerivation` returns a callable set with `__functionArgs`,
+      which takes both fixed-point arguments and a plain argument set.
+
+      Considering only the core configurations, the `extendMkDerivation` (as a function) behaves like:
+
+      ```nix
+      {
+        constructDrv,
+        excludeDrvArgNames ? [ ],
+        extendDrvArgs,
+        transformDrv ? lib.id,
+      }:
+      fpargs:
+      transformDrv (
+        constructDrv (
+          final:
+          let
+            previous = if lib.isFunction fpargs then fpargs final else fpargs;
+          in
+          removeAttrs previous excludeDrvArgNames // extendDrvArgs final previous
+        )
+      )
+      ```
+
+    - Additional callable set attributes
+
+      `extendMkDerivation` add/pass additional attributes to the result callable set, including the core configurations.
 
     # Type
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -829,7 +829,16 @@ rec {
 
     - Additional callable set attributes
 
-      `extendMkDerivation` add/pass additional attributes to the result callable set, including the core configurations.
+      `extendMkDerivation` add/pass additional attributes to the result callable set, including
+
+      - Core configurations
+
+      - `cumulation`
+
+        The cumulated version of the core configurations
+        from the bottom-most `constructDrv` to the current configuration.
+        That is, `lib.extendMkDerivation (cfg // cumulation)` is equivalent to `lib.extendMkDerivation cfg`,
+        while `cumulation.constructDrv` is usually a variation of `stdenv.mkDerivation`.
 
     # Type
 
@@ -894,7 +903,44 @@ rec {
       extendDrvArgs,
       inheritFunctionArgs ? true,
       transformDrv ? id,
-    }:
+    }@cfg:
+    let
+      cumulation =
+        if constructDrv ? cumulation then
+          {
+            inherit (constructDrv.cumulation) constructDrv;
+            excludeDrvArgNames = lib.uniqueStrings (
+              constructDrv.cumulation.excludeDrvArgNames ++ excludeDrvArgNames
+            );
+            extendDrvArgs =
+              final: previous:
+              constructDrv.cumulation.extendDrvArgs final (
+                # Absorb `excludeDrvArgNames`'s functionality.
+                (if excludeDrvArgNames == [ ] then previous else removeAttrs previous excludeDrvArgNames)
+                // extendDrvArgs final previous
+              );
+            transformDrv =
+              if cfg ? transformDrv then
+                drv: transformDrv (constructDrv.cumulation.transformDrv drv)
+              else
+                constructDrv.cumulation.transformDrv;
+          }
+        else
+          {
+            inherit
+              constructDrv
+              excludeDrvArgNames
+              transformDrv
+              ;
+            extendDrvArgs =
+              final: previous:
+              let
+                background =
+                  if excludeDrvArgNames != [ ] then removeAttrs previous excludeDrvArgNames else previous;
+              in
+              background // extendDrvArgs final previous;
+          };
+    in
     {
       # Adds the fixed-point style support
       __functor =
@@ -920,6 +966,7 @@ rec {
       inherit
         # Expose to the result build helper.
         constructDrv
+        cumulation
         excludeDrvArgNames
         extendDrvArgs
         transformDrv


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Summary:
- Provide a callable set attribute `cumulation`, the cumulated version of the core configurations from the bottom-most `constructDrv` to the current configuration.

- Improve `lib.extendMkDerivation`'s documentation
  - Group input variables into "Core configurations", "`__functionArgs` configurations", etc.
  - Provide a simplified reference implementation in the `Outputs` section.

As `cumulation.extendDrvArgs` folds `excludeDrvArgNames` and `extendDrvArgs` all the way to `stdenv.mkDerivation`, this attribute allows mixing different backend build helpers to create a custom set of `stdenv.mkDerivation` arguments.

This facilitates the `lib.extendMkDerivation`-restructuring for build helpers which choose its backends build helper at call time, such as `fetchFromGitHub` (`fetchzip` and `fetchgit`) or `fetchFromBitBucket` (`fetchzip`, `fetchgit` and `fetchhg`).

Initial effort for:
- PR #462034

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
