### PR TITLE
sourceHighlight: enable structuredAttrs, modernize

### DIFF
--- a/pkgs/by-name/so/sourceHighlight/package.nix
+++ b/pkgs/by-name/so/sourceHighlight/package.nix
@@ -8,7 +8,7 @@
   llvmPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "source-highlight";
   version = "3.1.9";
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnu/src-highlite/source-highlight-${version}.tar.gz";
+    url = "mirror://gnu/src-highlite/source-highlight-${finalAttrs.version}.tar.gz";
     sha256 = "148w47k3zswbxvhg83z38ifi85f9dqcpg7icvvw1cm6bg21x4zrs";
   };
 
@@ -53,11 +53,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  # source-highlight uses it's own binary to generate documentation.
+  # source-highlight uses its own binary to generate documentation.
   # During cross-compilation, that binary was built for the target
-  # platform architecture, so it can't run on the build host.
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-    substituteInPlace Makefile.in --replace "src doc tests" "src tests"
+  # platform architecture, so it may not run on the build host.
+  postPatch = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    substituteInPlace Makefile.in --replace-fail "src doc tests" "src tests"
   '';
 
   strictDeps = true;
@@ -78,12 +78,19 @@ stdenv.mkDerivation rec {
     "--with-bash-completion=${placeholder "out"}/share/bash-completion/completions"
   ];
 
+  env = lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
+    # Force linking to "libgcc" so tests pass
+    NIX_CFLAGS_COMPILE = "-lgcc";
+  };
+
   doCheck = true;
 
   enableParallelBuilding = true;
   # Upstream uses the same intermediate files in multiple tests, running
   # them in parallel by make will eventually break one or more tests.
   enableParallelChecking = false;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Source code renderer with syntax highlighting";
@@ -96,8 +103,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };
-}
-// lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
-  # Force linking to "libgcc" so tests pass
-  NIX_CFLAGS_COMPILE = "-lgcc";
-}
+})


### PR DESCRIPTION
No change in CA hashes for the outputs.

Also tested `pkgsCross.aarch64-multiplatform.sourceHighlight`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
