### PR TITLE
numen: disable tests on darwin

### DIFF
--- a/pkgs/by-name/nu/numen/package.nix
+++ b/pkgs/by-name/nu/numen/package.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "USE_SYSTEM_CATCH" true)
   ];
 
-  doCheck = true;
+  # needs /etc/localtime
+  doCheck = !stdenv.hostPlatform.isDarwin;
   checkInputs = [ catch2_3 ];
 
   meta = {


### PR DESCRIPTION
`numen` fails on aarch64-darwin. The library itself is fine, but its test suite cannot run in the macOS sandbox.

On Darwin, numen defaults to `NUMEN_USE_DATE_TZ=ON` because Apple's libc++ has no `std::chrono` tzdb, so it uses the vendored HowardHinnant date library with `USE_OS_TZDB=1`. That library locates the zoneinfo directory by resolving the `/etc/localtime` symlink, which the build sandbox does not provide, and 45 of 77 tests fail with `discover_tz_dir failed`. On a real macOS system the symlink exists.

## AI disclosure

Claude Opus 5 helped me identify this issue.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. (library only, no binaries)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
