### PR TITLE
root: 6.40.00 -> 6.40.04

### DIFF
--- a/pkgs/by-name/ro/root/clang-root.nix
+++ b/pkgs/by-name/ro/root/clang-root.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "clang-root";
-  version = "20-20260408-01";
+  version = "20-20260616-01";
 
   src = fetchgit {
     url = "https://github.com/root-project/llvm-project";
     tag = "ROOT-llvm${version}";
-    hash = "sha256-EXBUI1+DWkqTH4KdVoqxPjG8WyL0P5AEemLvBJqaVrQ=";
+    hash = "sha256-WRgM1vuK2vQ5CC/QkKnLtq6d61rfo1bCV9fIxPYWKiU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -56,7 +56,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "root";
-  version = "6.40.00";
+  version = "6.40.04";
 
   passthru = {
     tests = import ./tests { inherit callPackage; };
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${finalAttrs.version}.source.tar.gz";
-    hash = "sha256-Z2+P3okmzgWQK+f0TOfUkqSiBgAi/KsOPRxE9twPveg=";
+    hash = "sha256-9jHuvuPb6hKPFBX0t4T16DY3orQxGTvOdfEDhfce/FY=";
   };
 
   clad_src = fetchFromGitHub {


### PR DESCRIPTION
ROOT 6.40.04 contains many changes and bugfixes, so it's worth to upgrade:

https://root.cern/doc/v640/release-notes.html#release-6.40.04


FYI, @veprbl