### PR TITLE
hamr: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16168,6 +16168,13 @@
     githubId = 4238928;
     name = "liberodark";
   };
+  libewa = {
+    email = "linus@libewa.xyz";
+    github = "libewa";
+    githubId = 67926131;
+    name = "Linus Warnatz";
+    keys = [ { fingerprint = "EBD0 29E0 73D2 959A 9DC1  A74A 7BCA 3874 C2A0 475C"; } ];
+  };
   libjared = {
     email = "jared@perrycode.com";
     github = "hypevhs";

--- a/pkgs/by-name/ha/hamr/package.nix
+++ b/pkgs/by-name/ha/hamr/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  nodejs,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "hamr";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "p2r3";
+    repo = "ha.mr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DeG0TVYrKm9JghUBtqL1YxvQAvtVUIVvoe8kVJEIeKE=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/lib
+    cp alphabets.js compress.js standalone.js $out/lib
+    makeWrapper ${lib.getExe nodejs} $out/bin/hamr \
+      --add-flags "$out/lib/standalone.js"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Static URL compressor and QR code optimizer";
+    homepage = "https://github.com/p2r3/ha.mr";
+    mainProgram = "hamr";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.libewa ];
+  };
+  strictDeps = true;
+  __structuredAttrs = true;
+})


### PR DESCRIPTION
[hamr] is a link compressor. This commandline tool allows compressing and decompressing links even without a connection to ha.mr.

Links created by the tool look like this:
- http://ha.mr#[)D;6EK7uK*a.!YR5bbjM9&-
- http://ha.mr#💂🏻🇬🇲👩🏼‍❤️‍💋‍👨🏾🇳🇫👰🏼‍♀️🕵🏽👨🏾‍🫯‍👨🏼♦️🧜🏼🖐🏻📼🫲🏻👨🏽‍❤️‍👨🏿 (using emoji as the encoding)
- HTTP://HA.MR/V:YNOV$WF8K293G-1PHW*WRMPJP7 (optimized for QR code ASCII mode)

[hamr]: https://ha.mr

I accidentally closed the previous PR #552580. The reviewer on that PR was @coolcuber.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
