### PR TITLE
svn-all-fast-export: migrate to qt6, fix on darwin

### DIFF
--- a/pkgs/applications/version-management/svn-all-fast-export/default.nix
+++ b/pkgs/applications/version-management/svn-all-fast-export/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation {
     "VERSION=${version}"
     "APR_INCLUDE=${apr.dev}/include/apr-1"
     "SVN_INCLUDE=${subversion.dev}/include/subversion-1"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "CONFIG-=app_bundle"
   ];
 
   env.NIX_LDFLAGS = "-lsvn_fs-1";

--- a/pkgs/applications/version-management/svn-all-fast-export/default.nix
+++ b/pkgs/applications/version-management/svn-all-fast-export/default.nix
@@ -2,9 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qmake,
-  qtbase,
-  qttools,
+  qt6,
   subversion,
   apr,
 }:
@@ -24,13 +22,14 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    qmake
-    qttools
+    qt6.qmake
+    qt6.qttools
   ];
   buildInputs = [
     apr.dev
     subversion.dev
-    qtbase
+    qt6.qtbase
+    qt6.qt5compat
   ];
 
   qmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1109,9 +1109,7 @@ with pkgs;
 
   gitRepo = git-repo;
 
-  svn-all-fast-export =
-    libsForQt5.callPackage ../applications/version-management/svn-all-fast-export
-      { };
+  svn-all-fast-export = callPackage ../applications/version-management/svn-all-fast-export { };
 
   inherit (haskellPackages) git-annex;
 


### PR DESCRIPTION
svn-all-fast-export supports Qt 6: https://github.com/svn-all-fast-export/svn2git/releases/tag/1.0.20

In the meantime, this PR fixed an issue on Darwin where the executable was unnecessarily put in a macOS bundle.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
