### PR TITLE
[Backport release-26.05] heroic{,-unwrapped}: 2.22.0 -> 2.22.1; gogdl: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/by-name/go/gogdl/package.nix
+++ b/pkgs/by-name/go/gogdl/package.nix
@@ -6,7 +6,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gogdl";
-  version = "1.2.1";
+  version = "1.2.2";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     repo = "heroic-gogdl";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-qYarDcwrVrTpLHQYdWQvXL5+V1wMyL06+n5t6LXKBHI=";
+    hash = "sha256-gXAlZa4rml8fH54jpOIXZN0/1iieLpZwpii5ICHQ2Sc=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/go/gogdl/package.nix
+++ b/pkgs/by-name/go/gogdl/package.nix
@@ -6,7 +6,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gogdl";
-  version = "1.2.2";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     repo = "heroic-gogdl";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-gXAlZa4rml8fH54jpOIXZN0/1iieLpZwpii5ICHQ2Sc=";
+    hash = "sha256-tTd41ufxPObXwLpA1F0HXNEROnJwHt4WpojsRnNLml0=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/he/heroic-unwrapped/fix-non-steam-shortcuts.patch
+++ b/pkgs/by-name/he/heroic-unwrapped/fix-non-steam-shortcuts.patch
@@ -1,11 +1,11 @@
 diff --git a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
-index ebef6aa4..c8bd853d 100644
+index 28c917ce..f3b09c55 100644
 --- a/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
 +++ b/src/backend/shortcuts/nonesteamgame/nonesteamgame.ts
-@@ -252,7 +252,7 @@ async function addNonSteamGame(props: {
+@@ -255,7 +255,7 @@ async function addNonSteamGame(game: Game): Promise<boolean> {
      // add new Entry
      const newEntry = {} as ShortcutEntry
-     newEntry.AppName = props.gameInfo.title
+     newEntry.AppName = gameInfo.title
 -    newEntry.Exe = `"${app.getPath('exe')}"`
 +    newEntry.Exe = `"heroic"`
      newEntry.StartDir = `"${process.cwd()}"`

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -12,7 +12,7 @@
   makeWrapper,
   # Electron updates can break Heroic, so try to use same version as upstream.
   # If the used electron version is higher than upstream's then the node-abi package might need to be updated
-  electron,
+  electron_43,
   vulkan-helper,
   gogdl,
   nile,
@@ -22,6 +22,7 @@
 
 let
   pnpm = pnpm_10;
+  electron = electron_43;
 
   legendary = callPackage ./legendary.nix { };
   epic-integration = callPackage ./epic-integration.nix { };
@@ -29,13 +30,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "heroic-unwrapped";
-  version = "2.22.0";
+  version = "2.22.1";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "HeroicGamesLauncher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RDJDeL5exEzF2BhEWoiXWsTpV5hytrB6RDoXV0mTWTw=";
+    hash = "sha256-CpbCXmvfwXT16ZG/6fwPWSjBwK02ykJ/GuZk1VcW+tU=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -47,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-lPHL6pA39hvEtq5WkcAXfcY3a0VPseQL/nI+oEjIZeE=";
+    hash = "sha256-NrglT9vtDMAYXmZ4G3vifvLXu1yS6xbp+cqE6B6vQFc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Backport of #550824 
Update of `legendary` skipped because it cannot be built on 26.05 due to outdated `uv-build`. Heroic however works fine with the current version.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
