### PR TITLE
rustinel: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -32010,6 +32010,12 @@
     githubId = 201552597;
     name = "Yashwanth Prasannakumar";
   };
+  yunor743 = {
+    email = "hugo@perinazzo.com";
+    github = "Yunor743";
+    githubId = 30175713;
+    name = "Hugo Perinazzo";
+  };
   yzx9 = {
     email = "yuan.zx@outlook.com";
     github = "yzx9";

--- a/pkgs/by-name/ru/rustinel/package.nix
+++ b/pkgs/by-name/ru/rustinel/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+}:
+
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+
+  version = "1.3.0";
+
+  hashes = {
+    x86_64-linux = "sha256-Co3Pn9PyiFn7MDPA8wV2RttdmvvlEFjVHpCZwPBuFV0=";
+    aarch64-linux = "sha256-DhV5OkCSBnHckq2cAeEjC7PwCtJU3+uorVJtHcWPNYM=";
+  };
+
+  archName =
+    {
+      x86_64-linux = "x86_64-unknown-linux-musl";
+      aarch64-linux = "aarch64-unknown-linux-musl";
+    }
+    .${system};
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rustinel";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/Karib0u/rustinel/releases/download/v${finalAttrs.version}/rustinel-${finalAttrs.version}-${archName}.tar.gz";
+    hash = hashes.${system};
+  };
+
+  sourceRoot = "rustinel-${finalAttrs.version}-${archName}";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/rustinel/rules/{sigma,yara,ioc}
+
+    install -Dm755 rustinel $out/bin/rustinel
+
+    cp -r rules/sigma/* $out/share/rustinel/rules/sigma/
+    cp -r rules/yara/* $out/share/rustinel/rules/yara/
+    cp -r rules/ioc/* $out/share/rustinel/rules/ioc/
+
+    install -Dm644 config.toml $out/share/rustinel/config.example.toml
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open-source endpoint detection engine using eBPF, Sigma, YARA, and IOC matching";
+    homepage = "https://github.com/Karib0u/rustinel";
+    changelog = "https://github.com/Karib0u/rustinel/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ yunor743 ];
+    platforms = lib.attrNames hashes;
+    mainProgram = "rustinel";
+  };
+})


### PR DESCRIPTION
Adds [rustinel](https://github.com/Karib0u/rustinel), an open-source endpoint detection engine using eBPF, Sigma, YARA, and IOC matching for Windows, Linux, and macOS. Packages the prebuilt static musl binary from GitHub releases (v1.3.0) for `x86_64-linux` and `aarch64-linux`. The upstream maintainer (@Karib0u) has approved nixpkgs packaging and I will maintain it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

**AI disclosure:** Parts of this contribution (package derivation, testing) were produced with assistance from an LLM-based AI tool. All output has been manually reviewed, tested, and verified by the contributor.

### Packaging approach

Packages the **prebuilt static musl binary** from GitHub releases rather than building from source. Building rustinel from source requires a nightly Rust toolchain + `bpf-linker` for the eBPF program, which is heavy and fragile in the nixpkgs build environment. The musl release tarballs are fully static binaries that work unchanged in the Nix store. Same approach as other musl-shipped Rust binaries in nixpkgs (e.g. `bun`, `coder`).

Only `x86_64-linux` and `aarch64-linux` are supported (Linux eBPF requires kernel 5.8+ with BTF). Windows and macOS are out of scope.

### Contents

- `$out/bin/rustinel` -- the agent binary
- `$out/share/rustinel/rules/{sigma,yara,ioc}/` -- demo rules for testing
- `$out/share/rustinel/config.example.toml` -- unmodified reference config

No wrapper or config injection. Discovery is left to the upstream logic (`--config`, `RUSTINEL_CONFIG`, managed path `/etc/rustinel/config.toml`). A NixOS module (`services.rustinel`) is planned for a follow-up PR.

### Verification

- `nix-build -A rustinel` succeeds (x86_64-linux)
- `./result/bin/rustinel --version` prints `rustinel 1.3.0`
- `rustinel doctor` with custom config: all checks pass except `required_privileges` (expected without eBPF caps)
- `rustinel run`: loads Sigma/YARA/IOC rules, starts hot-reload, fails on eBPF map creation (expected without caps)
- `rustinel rules install linux-essential`: downloads pack, installs to writable dir, writes `state.json`
- Hashes verified against upstream `rustinel-1.3.0-checksums-sha256.txt`
- `passthru.updateScript = nix-update-script` for automated version bumps
- `nixfmt` passes