### PR TITLE
file-rename: 0.20 -> 2.02

### DIFF
--- a/pkgs/by-name/fi/file-rename/package.nix
+++ b/pkgs/by-name/fi/file-rename/package.nix
@@ -8,11 +8,11 @@
 
 perlPackages.buildPerlPackage {
   pname = "File-Rename";
-  version = "0.20";
+  version = "2.02";
 
   src = fetchurl {
-    url = "mirror://cpan/authors/id/R/RM/RMBARKER/File-Rename-0.20.tar.gz";
-    sha256 = "1cf6xx2hiy1xalp35fh8g73j67r0w0g66jpcbc6971x9jbm7bvjy";
+    url = "mirror://cpan/authors/id/R/RM/RMBARKER/File-Rename-2.02.tar.gz";
+    hash = "sha256-U3tggAi2gTba4Li9Gv5eq3UmS7ZLsXg57mW9tHTFIN8=";
   };
 
   # Fix an incorrect platform test that misidentifies Darwin as Windows

--- a/pkgs/by-name/fi/file-rename/package.nix
+++ b/pkgs/by-name/fi/file-rename/package.nix
@@ -1,8 +1,6 @@
 {
   lib,
-  stdenv,
   fetchurl,
-  perl,
   perlPackages,
 }:
 
@@ -14,19 +12,6 @@ perlPackages.buildPerlPackage {
     url = "mirror://cpan/authors/id/R/RM/RMBARKER/File-Rename-2.02.tar.gz";
     hash = "sha256-U3tggAi2gTba4Li9Gv5eq3UmS7ZLsXg57mW9tHTFIN8=";
   };
-
-  # Fix an incorrect platform test that misidentifies Darwin as Windows
-  postPatch = ''
-    substituteInPlace Makefile.PL \
-      --replace '/win/i' '/MSWin32/'
-  '';
-
-  postFixup = ''
-    substituteInPlace $out/bin/rename \
-      --replace "#!${perl}/bin/perl" "#!${perl}/bin/perl -I $out/${perl.libPrefix}"
-  '';
-
-  doCheck = !stdenv.hostPlatform.isDarwin;
 
   meta = {
     description = "Perl extension for renaming multiple files";


### PR DESCRIPTION
Update File-Rename from 0.20 to 2.02.

Upstream release: https://metacpan.org/release/RMBARKER/File-Rename-2.02

On aarch64-darwin, the package builds and its test suite passes without the existing Darwin-specific workarounds, so those are removed in a separate commit.

Assisted-by: ChatGPT (GPT-5.6 Sol)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md, [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].