### PR TITLE
python3Packages.cot: fix build, migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/cot/default.nix
+++ b/pkgs/development/python-modules/cot/default.nix
@@ -12,6 +12,7 @@
   requests,
   distutils,
   setuptools,
+  standard-pkg-resources,
   stdenv,
   verboselogs,
   versioneer,
@@ -37,9 +38,9 @@ buildPythonPackage rec {
     distutils
     pyvmomi
     requests
+    standard-pkg-resources
     verboselogs
     pyopenssl
-    setuptools
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/cot/default.nix
+++ b/pkgs/development/python-modules/cot/default.nix
@@ -4,7 +4,6 @@
   colorlog,
   fetchPypi,
   mock,
-  pyopenssl,
   pytest-mock,
   pytestCheckHook,
   pyvmomi,
@@ -21,7 +20,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "cot";
   version = "2.2.1";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -36,14 +35,13 @@ buildPythonPackage (finalAttrs: {
     versioneer
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     colorlog
     distutils
     pyvmomi
     requests
     standard-pkg-resources
     verboselogs
-    pyopenssl
   ];
 
   nativeCheckInputs = [
@@ -63,7 +61,6 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # Many tests require network access and/or ovftool (https://code.vmware.com/web/tool/ovf)
     # try enabling these tests with ovftool once/if it is added to nixpkgs
-    "HelperGenericTest"
     "TestCOTAddDisk"
     "TestCOTAddFile"
     "TestCOTEditHardware"
@@ -79,8 +76,6 @@ buildPythonPackage (finalAttrs: {
     "test_help"
     # Failing TestCOTDeployESXi tests
     "test_serial_fixup_stubbed"
-    "test_serial_fixup_stubbed_create"
-    "test_serial_fixup_stubbed_vm_not_found"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ "test_serial_fixup_invalid_host" ];
 

--- a/pkgs/development/python-modules/cot/default.nix
+++ b/pkgs/development/python-modules/cot/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage (finalAttrs: {
   version = "2.2.1";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     pname = "cot";
     inherit (finalAttrs) version;

--- a/pkgs/development/python-modules/cot/default.nix
+++ b/pkgs/development/python-modules/cot/default.nix
@@ -18,13 +18,14 @@
   versioneer,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cot";
   version = "2.2.1";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "cot";
+    inherit (finalAttrs) version;
     hash = "sha256-9LNVNBX5DarGVvidPoLnmz11F5Mjm7FzpoO0zAzrJjU=";
   };
 
@@ -95,4 +96,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ evanjs ];
   };
-}
+})


### PR DESCRIPTION
- fix build, closes #548249
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
