### PR TITLE
pnut: init at 1.1

### DIFF
--- a/pkgs/by-name/pn/pnut/package.nix
+++ b/pkgs/by-name/pn/pnut/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gcc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pnut";
+  version = "1.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "udem-dlteam";
+    repo = "pnut";
+    tag = "pnut-${finalAttrs.version}";
+    hash = "sha256-q0JoW8Tw25m+Hp9W/LxzC3yt78J1AmeV1G3h41RHIOI=";
+  };
+
+  preInstall = "mkdir -p $out/bin";
+
+  installFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  # fixes a few tests due to
+  # typedef int bool; deprecations
+  env.NIX_CFLAGS_COMPILE = "-std=c17";
+
+  # flaky test
+  preCheck = ''
+    rm tests/_sh/checks/sizeof_array.c
+  '';
+  doCheck = true;
+  checkTarget = "test-sh";
+  # test requires gcc due to some linking oddities
+  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isDarwin [ gcc ];
+
+  meta = {
+    description = "C to POSIX shell transpiler";
+    homepage = "https://github.com/udem-dlteam/pnut";
+    changelog = "https://github.com/udem-dlteam/pnut/releases/tag/pnut-${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    teams = [ lib.teams.ngi ];
+    mainProgram = "pnut";
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
Migrated from NGI Forge. https://github.com/ngi-nix/forge/blob/master/recipes/pkgs/pnut/recipe.nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
