### PR TITLE
regreet: fix static backgrounds falling back to GStreamer

### DIFF
--- a/pkgs/by-name/re/regreet/package.nix
+++ b/pkgs/by-name/re/regreet/package.nix
@@ -5,13 +5,17 @@
   pkg-config,
   wrapGAppsHook4,
   accountsservice,
+  bubblewrap,
   dbus,
   glib,
+  glycin-loaders,
   gst_all_1,
   gtk4,
+  libglycin,
   pango,
   librsvg,
   libseccomp,
+  shared-mime-info,
   nix-update-script,
 }:
 
@@ -37,6 +41,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     dbus
     glib
     gtk4
+    # Static backgrounds are decoded by glycin since 0.5.0, not GStreamer
+    libglycin.setupHook
+    glycin-loaders
     gst_all_1.gstreamer # Used for animated wallpapers or video playback
     gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-base
@@ -44,6 +51,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     librsvg
     libseccomp
   ];
+
+  # glycin also needs the MIME database to detect the image type, and bwrap in
+  # PATH for its sandbox; a greeter session provides neither
+  # See https://github.com/NixOS/nixpkgs/issues/557002
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+      --prefix PATH : "${lib.makeBinPath [ bubblewrap ]}"
+    )
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Fixes #557002. See [this comment](https://github.com/NixOS/nixpkgs/issues/557002#issuecomment-5438509897) for the corrected analysis — my first take on that issue was incomplete.

ReGreet 0.5.0 decodes static background images with [glycin](https://gitlab.gnome.org/GNOME/glycin), which needs three things at runtime that the wrapper does not provide:

1. the loader processes shipped by `glycin-loaders`, discovered through `XDG_DATA_DIRS`;
2. the MIME database (`shared-mime-info`), also via `XDG_DATA_DIRS` — without it the content type of the file is never determined, so no loader is even spawned;
3. `bwrap`, looked up in `PATH`, to sandbox the loader.

With any one of them missing, `load_image()` fails and ReGreet silently falls back to `gtk::MediaFile` with `set_loop(true)`, decoding the still JPEG/PNG as a looping video through GStreamer. On a login screen that burns CPU continuously and, after 10–15 s, kills the greeter: `Gdk-Message: Error 22 (Invalid argument) dispatching to Wayland display`, after which greetd logs `check_children: greeter exited without creating a session` and restarts the greeter — the screen blanks and the login screen reappears.

The ReGreet 0.5.0 release notes list *“Fix high resource usage of GStreamer on static images by using glycin instead”*, so the packaging gap silently reverts an upstream fix. Earlier history: #532825 was the same GStreamer path in the 0.4.x era, fixed by #530302.

This is invisible when ReGreet is started from a desktop session, because `XDG_DATA_DIRS` and `PATH` there already carry all three pieces. A greeter session carries none.

### Verification

Run in a nested headless sway with a deliberately bare environment (`env -i`, as in a greetd session), so that only the wrapper can supply anything. Indicators, both binary and reproducible:

* `grep -c libgst /proc/$PID/maps` — 105 mappings once `gtk::MediaFile` is constructed, 45 when it is not;
* number of `glycin-*` loader processes — non-zero only when glycin actually decodes.

| loaders | MIME database | bwrap | libgst mappings | glycin loader processes |
| --- | --- | --- | --- | --- |
| — | — | — | 105 | 0 |
| ✓ | — | ✓ | 105 | 0 |
| — | ✓ | ✓ | 105 | 0 |
| ✓ | ✓ | — | 105 | 0 |
| ✓ | ✓ | ✓ | **45** | **5** |

The last row is this PR, checked twice; the background image renders and the greeter idles quietly.

I originally quoted idle-CPU figures on the issue and have retracted them: the GStreamer spin does not always materialise inside a short measurement window, so CPU did not discriminate reliably. The two indicators above do.

The GStreamer inputs are deliberately kept — they are what plays animated and video backgrounds.

### A question for maintainers

`bwrap` is not in `PATH` on a stock NixOS system, and the MIME database is not guaranteed either, so this is not really regreet-specific: any glycin consumer that runs outside a full desktop session hits it. Would you rather have both handled in `libglycin`'s `path-hook.sh`, so every consumer gets a working setup? I kept this PR scoped to regreet because that is the reported bug, and I am happy to redo it in the hook instead.

### Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests] — none exist for this package
  - [ ] [Package tests] at `passthru.tests` — none exist for this package
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality
- [ ] Ran `nixpkgs-review` on this PR — not run; ofborg built the package on x86_64-linux and aarch64-linux, and nothing else depends on it
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module
  - [ ] Module update: when the change is significant
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs
- [x] Follows the [automation/AI policy]

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy

### Disclosure

Per the [automation/AI policy]: the investigation, this change and the text of this pull request were produced with LLM assistance (Claude Code, model `claude-opus-5`), driven and reviewed by me. The commit carries an `Assisted-by:` trailer.

Nothing here rests on the model's reasoning alone: every row of the table above is a separate run of the built package in a bare environment, read off `/proc/$PID/maps` and the process list. An earlier version of the issue quoted idle-CPU figures that turned out not to be reproducible; they were retracted in [a follow-up comment](https://github.com/NixOS/nixpkgs/issues/557002#issuecomment-5438509897) and replaced with the two indicators used here.

/cc @fufexan
