### PR TITLE
kea.services.{dns, dhcp}: init

### DIFF
--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -106,20 +106,36 @@ stdenv.mkDerivation (finalAttrs: {
     ninja doc
   '';
 
-  passthru.tests = {
-    kea = nixosTests.kea;
-    prefix-delegation = nixosTests.systemd-networkd-ipv6-prefix-delegation;
-    networking-scripted = lib.recurseIntoAttrs {
-      inherit (nixosTests.networking.scripted) dhcpDefault dhcpSimple dhcpOneIf;
+  passthru = {
+    services = {
+      dhcp = {
+        imports = [
+          (lib.modules.importApply ./service-dhcp4.nix { })
+        ];
+        kea-dhcp.package = finalAttrs.finalPackage;
+      };
+      dns = {
+        kea-dhcp-dns.package = finalAttrs.finalPackage;
+        imports = [
+          (lib.modules.importApply ./service-dns.nix { })
+        ];
+      };
     };
-    networking-networkd = lib.recurseIntoAttrs {
-      inherit (nixosTests.networking.networkd) dhcpDefault dhcpSimple dhcpOneIf;
-    };
+    tests = {
+      kea = nixosTests.kea;
+      prefix-delegation = nixosTests.systemd-networkd-ipv6-prefix-delegation;
+      networking-scripted = lib.recurseIntoAttrs {
+        inherit (nixosTests.networking.scripted) dhcpDefault dhcpSimple dhcpOneIf;
+      };
+      networking-networkd = lib.recurseIntoAttrs {
+        inherit (nixosTests.networking.networkd) dhcpDefault dhcpSimple dhcpOneIf;
+      };
 
-    version = testers.testVersion {
-      package = kea;
-      command = "kea-shell -v";
-      version = finalAttrs.version;
+      version = testers.testVersion {
+        package = kea;
+        command = "kea-shell -v";
+        version = finalAttrs.version;
+      };
     };
   };
 

--- a/pkgs/by-name/ke/kea/service-dhcp.nix
+++ b/pkgs/by-name/ke/kea/service-dhcp.nix
@@ -1,0 +1,103 @@
+{ formats }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+let
+  cfg = config.services.kea-dhcp;
+  format = formats.json { };
+in
+{
+  options.kea-dhcp = {
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The package you want to use.";
+    };
+
+    type = lib.mkOption {
+      type = lib.types.enum [
+        "dhcp4"
+        "dhcp6"
+      ];
+    };
+
+    settings = {
+      type = format.type;
+      default = null;
+      description = "Settings for KeaDHCP";
+      example = {
+        valid-lifetime = 4000;
+        renew-timer = 1000;
+        rebind-timer = 2000;
+        preferred-lifetime = 3000;
+        interfaces-config = {
+          interfaces = [
+            "eth0"
+          ];
+        };
+        lease-database = {
+          type = "memfile";
+          persist = true;
+          name = "/var/lib/kea/dhcp6.leases";
+        };
+        subnet6 = [
+          {
+            id = 1;
+            subnet = "2001:db8:1::/64";
+            pools = [
+              {
+                pool = "2001:db8:1::1-2001:db8:1::ffff";
+              }
+            ];
+          }
+        ];
+      };
+    };
+  };
+
+  config = {
+    configData."${cfg.type}-server.conf" = lib.generators.toINI { } cfg.settings;
+    process = {
+      argv =
+        lib.optional (cfg.type == "dhcp4") "kea-dhcp4" ++ lib.optional (cfg.type == "dhcp6") "kea-ghcp6";
+      flags = {
+        "c" = config.configData."${cfg.type}-server.conf".path;
+      };
+
+      flagFormat = name: {
+        option = "-${name}";
+      };
+    };
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.service = {
+      description =
+        lib.optionalString (cfg.type == "dhcp4") "Kea DHCP4 Server"
+        ++ lib.optionalString (cfg.type == "dhcp6") "Kea DHCP6 Server";
+      documentation =
+        if (cfg.type == "dhcp4") then
+          [
+            "man:kea-dhcp4(8)"
+            "https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/dhcp4-srv.html"
+          ]
+        else if lib.optional (cfg.type == "dhcp6") then
+          [
+            "man:kea-dhcp6(8)"
+            "https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/dhcp6-srv.html"
+          ]
+        else
+          [ ];
+
+      serviceConfig = {
+        Restart = "on-failure";
+        DymanicUser = true;
+        AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.eveeifyeve ];
+}

--- a/pkgs/by-name/ke/kea/service-dns.nix
+++ b/pkgs/by-name/ke/kea/service-dns.nix
@@ -1,0 +1,71 @@
+{ formats }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
+let
+  cfg = config.kea-dhcp-dns;
+  format = formats.json { };
+in
+{
+  options.kea-dhcp-dns = {
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The package you want to use.";
+    };
+
+    settings = {
+      type = format.type;
+      default = null;
+      description = "Settings for KeaDHCP DNS";
+      example = {
+        ip-address = "127.0.0.1";
+        port = 53001;
+        dns-server-timeout = 100;
+        ncr-protocol = "UDP";
+        ncr-format = "JSON";
+        tsig-keys = [ ];
+        forward-ddns = {
+          ddns-domains = [ ];
+        };
+        reverse-ddns = {
+          ddns-domains = [ ];
+        };
+      };
+    };
+  };
+
+  config = {
+    configData."dhcp-ddns.conf" = lib.generators.toINI { } cfg.settings;
+    process = {
+      argv = [ (lib.getExe' cfg.package "kea-dhcp-ddns") ];
+      flags = {
+        "c" = config.configData."dhcp-ddns.conf".path;
+      };
+
+      flagFormat = name: {
+        option = "-${name}";
+      };
+    };
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.service = {
+      description = "Kea DHCP-DDNS Server";
+      documentation = [
+        "man:kea-dhcp-ddns(8)"
+        "https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/ddns.html"
+      ];
+
+      serviceConfig = {
+        Restart = "on-failure";
+        DymanicUser = true;
+        AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.eveeifyeve ];
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds KeaDHCP modular services support.
Waiting on https://github.com/NixOS/nixpkgs/issues/545287 to be completed for `runtimeDirectory` and also no testing has been done.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
