### PR TITLE
nixos/rtl-tcp: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28578,6 +28578,14 @@
     githubId = 70479099;
     matrix = "@eyes1238:matrix.org";
   };
+  the-bober = {
+    email = "rares.dobrisan@gmail.com";
+    github = "the-bober";
+    name = "Dobrisan Rares Florin";
+    githubId = 57683192;
+    matrix = "@bobe:tchncs.de";
+    keys = [ { fingerprint = "0C15 3680 68EC D1B3 B324 9E99 01DC 0D38 7CA1 7B2A"; } ];
+  };
   theaninova = {
     name = "Thea Schöbl";
     email = "dev@theaninova.de";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -726,6 +726,7 @@
   ./services/hardware/rasdaemon.nix
   ./services/hardware/ratbagd.nix
   ./services/hardware/rauc.nix
+  ./services/hardware/rtl-tcp.nix
   ./services/hardware/sane.nix
   ./services/hardware/sane_extra_backends/brscan4.nix
   ./services/hardware/sane_extra_backends/brscan5.nix

--- a/nixos/modules/services/hardware/rtl-tcp.nix
+++ b/nixos/modules/services/hardware/rtl-tcp.nix
@@ -54,7 +54,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/rtl_tcp -a ${cfg.listenAddress} -p ${toString cfg.port} ${lib.escapeShellArgs cfg.extraArgs}";
+        ExecStart = "${cfg.package}/bin/rtl_tcp -a ${cfg.listenAddress} -p ${toString cfg.port} ${utils.escapeSystemdExecArgs cfg.extraArgs}";
         Restart = "on-failure";
         RestartSec = "5s";
         DynamicUser = true;

--- a/nixos/modules/services/hardware/rtl-tcp.nix
+++ b/nixos/modules/services/hardware/rtl-tcp.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.rtl-tcp;
+in
+{
+  options.services.rtl-tcp = {
+    enable = lib.mkEnableOption "RTL-SDR TCP Server";
+
+    package = lib.mkPackageOption pkgs "rtl-sdr" { };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "IP address on which rtl_tcp will listen.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 1234;
+      description = "TCP port on which rtl_tcp will listen.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the specified port in the firewall.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "-g" "29" "-b" "16" ];
+      description = "Additional command-line arguments to pass to rtl_tcp.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.rtl-sdr.enable = lib.mkDefault true;
+
+    systemd.services.rtl-tcp = {
+      description = "RTL-SDR TCP Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/rtl_tcp -a ${cfg.listenAddress} -p ${toString cfg.port} ${lib.escapeShellArgs cfg.extraArgs}";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        DynamicUser = true;
+        SupplementaryGroups = [ "plugdev" ];
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ the-bober ];
+}

--- a/nixos/modules/services/hardware/rtl-tcp.nix
+++ b/nixos/modules/services/hardware/rtl-tcp.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.services.rtl-tcp;
@@ -30,7 +35,12 @@ in
     extraArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      example = [ "-g" "29" "-b" "16" ];
+      example = [
+        "-g"
+        "29"
+        "-b"
+        "16"
+      ];
       description = "Additional command-line arguments to pass to rtl_tcp.";
     };
   };

--- a/nixos/modules/services/hardware/rtl-tcp.nix
+++ b/nixos/modules/services/hardware/rtl-tcp.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 


### PR DESCRIPTION
This PR introduces a new NixOS module for `rtl-tcp` (`services.rtl-tcp`), allowing users to run an RTL-SDR TCP spectrum server as a managed `systemd` background service.

### Features
* Configurable package, listening address, port, and firewall rules (`openFirewall`).
* Supports passing arbitrary flags via `extraArgs`.
* Automatically sets `hardware.rtl-sdr.enable = true` by default to ensure required `udev` rules and kernel driver blacklists are handled.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test