### PR TITLE
gogcli: 0.37.0 -> 0.38.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24984,6 +24984,12 @@
     githubId = 201613730;
     name = "rsahwe";
   };
+  rschaffar = {
+    email = "robert@projektbuero.at";
+    github = "rschaffar";
+    githubId = 3285720;
+    name = "Robert Schaffar-Taurok";
+  };
   rseichter = {
     email = "nixos.org@seichter.de";
     github = "rseichter";

--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -7,13 +7,13 @@
 
 buildGo127Module (finalAttrs: {
   pname = "gogcli";
-  version = "0.37.0";
+  version = "0.38.1";
 
   src = fetchFromGitHub {
     owner = "openclaw";
     repo = "gogcli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UQa9Z7zv2IuH7GL1udNee2F+uB2BAZA5a0/2XtFcBWg=";
+    hash = "sha256-AaChyDvbMnPkWkBCnpISQm8U2WjXvwBSCfuN6fuIHaY=";
   };
 
   vendorHash = "sha256-+Nbuwok3dY/82gUDKeGgrC0F1ZqXSW8IpV6Q1yzIPvo=";

--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -38,7 +38,10 @@ buildGo127Module (finalAttrs: {
     description = "CLI tool for interacting with Google APIs (Gmail, Calendar, Drive, and more)";
     homepage = "https://github.com/openclaw/gogcli";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ macalinao ];
+    maintainers = with lib.maintainers; [
+      macalinao
+      rschaffar
+    ];
     mainProgram = "gog";
   };
 })


### PR DESCRIPTION
Updates gogcli from 0.37.0 to 0.38.1.

- Diff: https://github.com/openclaw/gogcli/compare/v0.37.0...v0.38.1
- Changelog 0.38.1: https://github.com/openclaw/gogcli/blob/v0.38.1/CHANGELOG.md#0381---2026-08-25
- Changelog 0.38.0: https://github.com/openclaw/gogcli/blob/v0.38.1/CHANGELOG.md#0380---2026-08-25

The 0.38 releases add the full BigQuery Connected Sheets lifecycle, read-only
Apps Script inspection, least-privilege Gmail sending scopes, exact RFC822
sending, and additional security, dry-run, download, and configuration-locking
fixes.

I am also adding myself as a co-maintainer alongside @macalinao after preparing
and testing the recent gogcli updates.

cc @macalinao @kirillrdy

@kirillrdy, I hope you don't mind me continuing to ping you for this package.
You seemed invested in it during the previous reviews.

Verified on `x86_64-linux` using Go 1.27.0:

- `nix build --no-link --print-out-paths .#gogcli`;
- `nix build --no-link --print-out-paths .#gogcli.tests.version`;
- executed the binary and confirmed its version, tag, build-date metadata, and
  relevant schema commands;
- ran the full upstream `go test ./...` suite in a temporary Nix override with
  `GOFLAGS=-mod=vendor` and its test-only Git and Python prerequisites.

Verified on `aarch64-linux` under binfmt emulation:

- `nix build --no-link --print-out-paths .#legacyPackages.aarch64-linux.gogcli`;
- `nix build --no-link --print-out-paths .#legacyPackages.aarch64-linux.gogcli.tests.version`;
- confirmed the resulting binary is an ARM aarch64 ELF executable;
- executed the binary and confirmed its version, tag, build-date metadata, and
  schema command.

`nixpkgs-review rev HEAD -b master -p gogcli --no-shell --print-result`
passed at commit `e217aa3be9698cce5e1ff46d1b69562a089354af`; one package
(`gogcli`) was rebuilt successfully against freshly fetched `master`.

I rebuilt my local NixOS configuration from that exact commit and verified that
the active system closure contains the expected `gogcli-0.38.1` output. Both
configured isolated account wrappers reported the expected version, tag, and
build-date metadata. Authentication and keyring diagnostics passed, followed by
bounded read-only Gmail search and sanitized-message retrieval, Calendar and
Drive reads, and Connected Sheets data-source listing. I also validated Apps
Script live against a disposable standalone project: created the fixture, read
its metadata and content under the read-only guard, pulled its single default
file into a private local directory, verified `0700`/`0600` directory/file
permissions, moved the project to Drive trash, and confirmed `trashed=true`.
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (under binfmt emulation)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation/AI disclosure

The routine version and hash update was produced with `nix-update`. The upstream
change review, validation plan, testing, and this pull request summary were
prepared with assistance from pi (`openai-codex/gpt-5.6-sol`). I reviewed the
changes and test results.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
