### PR TITLE
python3Packages.nameparser: 1.1.3 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/nameparser/default.nix
+++ b/pkgs/development/python-modules/nameparser/default.nix
@@ -1,29 +1,48 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  unittestCheckHook,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  hypothesis,
+  pytest-timeout,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nameparser";
-  version = "1.1.3";
-  format = "setuptools";
+  version = "2.1.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-qiQArXHM+AcGdbQDEaJXyTRln5GFSxVOG6bCZHYcBJ0=";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "derek73";
+    repo = "python-nameparser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MDzw2F9oH6cvvIYxYRv85+e61uGYFDWubfJ+WP8h7mQ=";
   };
 
-  nativeCheckInputs = [ unittestCheckHook ];
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    hypothesis
+    pytest-timeout
+  ];
+
+  disabledTests = [
+    # Flaky when build system is under dynamic load
+    "test_parse_cost_grows_no_worse_than_linearly"
+    "test_policy_gated_cost_grows_no_worse_than_linearly"
+  ];
 
   pythonImportsCheck = [ "nameparser" ];
 
   meta = {
     description = "Module for parsing human names into their individual components";
     homepage = "https://github.com/derek73/python-nameparser";
-    changelog = "https://github.com/derek73/python-nameparser/releases/tag/v${version}";
+    changelog = "https://github.com/derek73/python-nameparser/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
- bump version to `2.1.0`
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
