### PR TITLE
zsh-z: 0-unstable-2021-02-15 -> 2.0.0, modernise

### DIFF
--- a/pkgs/by-name/zs/zsh-z/package.nix
+++ b/pkgs/by-name/zs/zsh-z/package.nix
@@ -4,15 +4,15 @@
   fetchFromGitHub,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zsh-z";
-  version = "0-unstable-2021-02-15";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "agkozak";
     repo = "zsh-z";
-    rev = "595c883abec4682929ffe05eb2d088dd18e97557";
-    sha256 = "sha256-HnwUWqzwavh/Qox+siOe5lwTp7PBdiYx+9M0NMNFx00=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-r12crTTTYRYztuTCz7/59d4ig/O1x+I7lvf4r+b2fFM=";
   };
 
   strictDeps = true;
@@ -30,4 +30,4 @@ stdenvNoCC.mkDerivation {
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.evalexpr ];
   };
-}
+})

--- a/pkgs/by-name/zs/zsh-z/package.nix
+++ b/pkgs/by-name/zs/zsh-z/package.nix
@@ -8,6 +8,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zsh-z";
   version = "2.0.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "agkozak";
     repo = "zsh-z";
@@ -26,6 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "Jump quickly to directories that you have visited frequently in the past, or recently";
     homepage = "https://github.com/agkozak/zsh-z";
+    changelog = "https://github.com/agkozak/zsh-z/releases/tag/v${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.evalexpr ];


### PR DESCRIPTION
Does a standard package update and modernise on `zsh-z`, i didnt test it but the `./result/share` folder looks fine

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
