### PR TITLE
python314Packages.impacket: removed openssl legacy override

### DIFF
--- a/pkgs/development/python-modules/impacket/default.nix
+++ b/pkgs/development/python-modules/impacket/default.nix
@@ -14,27 +14,7 @@
   setuptools,
   pytestCheckHook,
   six,
-  writeText,
 }:
-
-let
-  opensslConf = writeText "openssl.conf" ''
-    openssl_conf = openssl_init
-
-    [openssl_init]
-    providers = provider_sect
-
-    [provider_sect]
-    default = default_sect
-    legacy = legacy_sect
-
-    [default_sect]
-    activate = 1
-
-    [legacy_sect]
-    activate = 1
-  '';
-in
 buildPythonPackage rec {
   pname = "impacket";
   version = "0.13.1";
@@ -64,8 +44,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  makeWrapperArgs = [ "--set-default OPENSSL_CONF ${opensslConf}" ];
 
   pythonImportsCheck = [
     "impacket"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR removes the legacy openssl override, which is not needed anymore as it was fixed upstream:
https://github.com/fortra/impacket/pull/2005


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
