### PR TITLE
ungoogled-chromium: 151.0.7922.173-1 -> 152.0.7977.64-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -853,28 +853,28 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "151.0.7922.173",
+    "version": "152.0.7977.64",
     "deps": {
       "depot_tools": {
-        "rev": "94e89b10b92cc9d6e58fc8d1b6474b7d29e8a114",
-        "hash": "sha256-2kfg2f5lamTyq0BMEt5LGuc4BW07Zx+Z9hZCErTVuUs="
+        "rev": "38c391feba5fb96812f9028da12413ffc39df394",
+        "hash": "sha256-yOd+k4GJ/unOVCm2Fj1oDHOMKV87CuBO/z0li3owNQk="
       },
       "gn": {
-        "version": "0-unstable-2026-06-29",
-        "rev": "1d86777e7f2562a86ecea77d1809ac4f82bb5bfe",
-        "hash": "sha256-T2LdISIkp8fcUli5ZetTqrESBAc7coJhWdJv7I+o9kk="
+        "version": "0-unstable-2026-07-23",
+        "rev": "641ace93dd9560e75e7add0d08f77b446fbb3b78",
+        "hash": "sha256-ovLx6KaORdXqnWgbsGEty10k2CHuCmTk3yEqy5//ovk="
       },
       "ungoogled-patches": {
-        "rev": "151.0.7922.173-1",
-        "hash": "sha256-m7Wp64ns06DXbjMcLT9Dz6WBBqBGCPkrCuveYZ/VqZ4="
+        "rev": "152.0.7977.64-1",
+        "hash": "sha256-9esE3TgtKiwwFL5pu87aEQznelMVtNXBslggYAJTEbc="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "a96602f30358e9b5d256a0464e7e4d4bec223004",
-        "hash": "sha256-uumIVSzf318Xd1JB9jESXgpLxXlrvMDclOzSFQqweZ8=",
+        "rev": "506c834ecceaa943c5f41e6cfe7f68acb5c45346",
+        "hash": "sha256-KEr9nzF55+c8Rvvay3SZjcWMDWVGTyv1f5Pjv3ckl3E=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -884,13 +884,13 @@
       },
       "src/third_party/compiler-rt/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git",
-        "rev": "57d6af57c374757d67349eaf85b41efc3c603bd3",
-        "hash": "sha256-9nnW5gittMng5VvDiMrd2Q7rstZqgd+uhx9+k/W3XMY="
+        "rev": "e1c9323385b40780f574f440a8a9ad83855712b0",
+        "hash": "sha256-oxGL+ct1z5S9wduYINjiZrjJx1HlAJjyMPEoDyhIfvo="
       },
       "src/third_party/libc++/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
-        "rev": "5abc7f839700f0f17338434e1c1c6a8c87c00c11",
-        "hash": "sha256-vT1km7JgVpotDoNK+ae1gplSHcwrVNLsv/QAFUrDsIM="
+        "rev": "b16984ce99c702355a5b2b4c52574e82cec41fb9",
+        "hash": "sha256-ZVgUAi5rYj17N3nAEvLQXZLCxnmvxIo2RpJ3geTSyWQ="
       },
       "src/third_party/libc++abi/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git",
@@ -899,13 +899,13 @@
       },
       "src/third_party/libunwind/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
-        "rev": "6de9f6eebca9aefbb32383a92baa9bf0f59f1457",
-        "hash": "sha256-o0MSKm65+hFyUO4CZkzoozt1Lup+/1JYmV9FEXCnD0Q="
+        "rev": "b2ff0e6b9ac002918d7a9ce982eee88dcc27a450",
+        "hash": "sha256-VK9w68Im896xi4cymhtfvh7xdRJZB78YEvUYyxqBu48="
       },
       "src/third_party/llvm-libc/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git",
-        "rev": "265cc6a83652bac5cb8ceb59741bc288ebe6b312",
-        "hash": "sha256-yFp/1m0tPdMZAExu88DphqTklb2fVC2pLSE7SPU13aI="
+        "rev": "3ea89f4304312567e31a8eb45e0737577e65b676",
+        "hash": "sha256-g8ZtRI0yazHgli0/TMz/SeAJ5SoMZdir+/29GFQAczM="
       },
       "src/chrome/test/data/perf/canvas_bench": {
         "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
@@ -924,18 +924,18 @@
       },
       "src/docs/website": {
         "url": "https://chromium.googlesource.com/website.git",
-        "rev": "18d64b46a208ab5432e2a9a44f700ece50e8cc3e",
-        "hash": "sha256-OxAlqEh0+yldlU5XQorwFtocTLJ0AjYRO8xwjN8PxyQ="
+        "rev": "e9dfa88cee41c025709e79164ceb0758cfe76a67",
+        "hash": "sha256-mWAwegdaC7LEOYN5Y/xcJBv4R9dInK4VW35/U8rn7Wg="
       },
       "src/media/cdm/api": {
         "url": "https://chromium.googlesource.com/chromium/cdm.git",
-        "rev": "33c977516b3dfe5b065bc298aa74175e1999ab51",
-        "hash": "sha256-GsaRxLnsz1jrFZ3m5tv65d1dioG23uJnmfa+WD7XcFc="
+        "rev": "d6c4e1ea4c8fc3dcd98ac3ab5a981f63067223a4",
+        "hash": "sha256-DnDeyVG+uEDBg4tA84rMBhLXy9hSpP8CX8f7Y34jLLg="
       },
       "src/net/third_party/quiche/src": {
         "url": "https://quiche.googlesource.com/quiche.git",
-        "rev": "4729ceb221725bb52c6f4d48229d9c3ba059c36e",
-        "hash": "sha256-ekGYdv1AiQLPGxN16hpJBn/jhtVrmZPcunO4wNRjSog="
+        "rev": "1ba0d99a5c2fec4f4dbb7f98f251b05dcf4e2968",
+        "hash": "sha256-odzVQD9WyldgAv8QRvXABKaSLy1DL6DRhdVQSer4HVM="
       },
       "src/testing/libfuzzer/fuzzers/wasm_corpus": {
         "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git",
@@ -944,8 +944,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "a17d6c8e92696bc78bcbdaf56fc197ebd0cc1fde",
-        "hash": "sha256-lz8BqENfeHI31L1EOHWlCcE+tANVwuZVrqVDYXMjqQU="
+        "rev": "736ed80c7552a4b267bd54a282b971aa4555cb3e",
+        "hash": "sha256-3ZCIFT7j944HWPOiADQa88TQZctLej5vbrBFA/FwyHw="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -959,13 +959,13 @@
       },
       "src/third_party/angle/third_party/VK-GL-CTS/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
-        "rev": "06ae3bf12ae573de7144c5935505993a07fe69d3",
-        "hash": "sha256-8HV3ieJS3P5cfAhVtJ+4bo2B6kR1wseO+qwhuAG8O5M="
+        "rev": "3b7cbad78e93bcda20ccf68efae2d71695dd0f65",
+        "hash": "sha256-bPgrkZ3my/tl+H2/YuAxmn83svPSw4l6lnz8zGHQtuk="
       },
       "src/third_party/anonymous_tokens/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git",
-        "rev": "f5499d91ee1b8ab56b6d110e8e9a0d94c0a6eca7",
-        "hash": "sha256-hKdtDbVKC4v0BFsuGouG/6f/4VK8M0yIMCPxHWw1ESk="
+        "rev": "e07c92bc81cfd4203e6158cac115fc44c27b31b8",
+        "hash": "sha256-NY/RkTCl/7KBJuIS6pa3sjdgyccWDrSfrUwBqWgL/4I="
       },
       "src/third_party/aria-practices/src": {
         "url": "https://chromium.googlesource.com/external/github.com/w3c/aria-practices.git",
@@ -984,23 +984,23 @@
       },
       "src/third_party/dav1d/libdav1d": {
         "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git",
-        "rev": "77ef66354d76a3c8aa4b11cde8093294fce23b0f",
-        "hash": "sha256-YYFY2OYumhE7WMDr7DNfr+drqQAoNJRiYepbdRjhNRM="
+        "rev": "54706fc6bc0cdecab7e9593974a4039cc038fca7",
+        "hash": "sha256-L3a9MmPWJlxmRa19glWDLvkXHev5oiM5/fxtKOBPMxI="
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "29256ad98530582b82d1d6b76bae8354f1565e74",
-        "hash": "sha256-7fh6g+xTrmqa1flbs2NTdiQiaj8N3LShIx3GeqqbZq0="
+        "rev": "571752c9cb3ed36a3194854374984427794c4dda",
+        "hash": "sha256-YMgRmVMXo1Ra5M034zij/ik/1aHpb3veK4VWsKHIwhI="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
-        "rev": "ed6452b13c76f7b4da216a9952bc7837aeb0f031",
-        "hash": "sha256-bKhh53IG5k5UPEUbcjY5+Xv+/H/qnNdoW9CFWffozkA="
+        "rev": "463cf73610d911e8eff95ae345143137cf610be4",
+        "hash": "sha256-+WG+0KALV10B+1hOJzyiU4azlJIej/F5DtqtSkEN040="
       },
       "src/third_party/dawn/third_party/directx-shader-compiler/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler",
-        "rev": "02e491eb019766b866bcf09c427365713353841b",
-        "hash": "sha256-h70zf9zCWHxbdBloRETQBQJRDdF/zYVEE0wj2Iav5y8="
+        "rev": "1f8a14aecd4f2f25991fa9f7aad6c320fea91409",
+        "hash": "sha256-nesLgajCiFHwb2TKwzlCERFb6wOkwqpMT5z6nzj2Q9Y="
       },
       "src/third_party/dawn/third_party/directx-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
@@ -1019,13 +1019,23 @@
       },
       "src/third_party/dawn/third_party/webgpu-cts": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
-        "rev": "663ea46471861e51f6a320e078a1fe39bf7f623e",
-        "hash": "sha256-yPgQhVgy3atQtqBi/FPOMeZqoEyGOpSID4Fhh3zSLRE="
+        "rev": "499044af47ec2717e06e644d0943e6fcdb3f3538",
+        "hash": "sha256-M8TWqKdqoiZ01vbDpcRyPWIOaBPCPdSSflxcIpbYjFA="
       },
       "src/third_party/dawn/third_party/webgpu-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers",
-        "rev": "a11ef4462405c4506ad7284e5b1edeff2750bb54",
-        "hash": "sha256-gEoyN14mN1Pkym/d4LtBe5hwV+3K+Ln3OXJVMfXf9lI="
+        "rev": "b3f67b89929c133403fd95638be4ef96b56ddca0",
+        "hash": "sha256-pLsvlbh1BCEtfQNejm2XilpelZmNg1/NuLq0agIGqQI="
+      },
+      "src/third_party/disarm/src": {
+        "url": "https://chromium.googlesource.com/external/github.com/aengelke/disarm.git",
+        "rev": "2d13d3f410a52daff1c5d8ef07d623332f372560",
+        "hash": "sha256-uQC4EhF4ytsGzc5B0uaQKDmuVIGiPDPbY275yIeyWVE="
+      },
+      "src/third_party/fadec/src": {
+        "url": "https://chromium.googlesource.com/external/github.com/aengelke/fadec.git",
+        "rev": "c9f78f532b9004de278489019ab2c6c28ae9746e",
+        "hash": "sha256-+4xVWPOeXrf8tgEQicoMKzBbz5XMB1H7sBfOBfwiDvs="
       },
       "src/third_party/highway/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/highway.git",
@@ -1044,13 +1054,13 @@
       },
       "src/third_party/boringssl/src": {
         "url": "https://boringssl.googlesource.com/boringssl.git",
-        "rev": "29e593e29165df578ab778269a1f04da2055c32f",
-        "hash": "sha256-141WOYj1OLfQmrs7otUnwJmvGKnt0O3T3rH9q0exOZ0="
+        "rev": "572a4c68475d284b34675f45ddbb9c158ef3c2ae",
+        "hash": "sha256-gW+Ksd/boITK5ZTDIwhIgPAdPQNi8MvP7ru6qMdtorI="
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
-        "rev": "9aebd3d8ef5a246deb2c929b5666aaba160ebce6",
-        "hash": "sha256-dIEFfTWa/GazNcCY3gigcxPCljN8IFKaKhYhgqWaBm0="
+        "rev": "69e9aada412e81575a95d0d94f4592fe1b8dfc15",
+        "hash": "sha256-v0Qw8nlXR6Dnkbt7I0Fe7HKv9mtf/9h0xl4HaCHPJjA="
       },
       "src/third_party/cast_core/public/src": {
         "url": "https://chromium.googlesource.com/cast_core/public",
@@ -1059,8 +1069,8 @@
       },
       "src/third_party/catapult": {
         "url": "https://chromium.googlesource.com/catapult.git",
-        "rev": "c7282e69291240dbee993364a340934982443334",
-        "hash": "sha256-kYmzjsjMDj96QBwpvZagsqsibouMx/q3UkuMFJd1jt4="
+        "rev": "d810008022eeaefcbea50393ea5baa0930b27047",
+        "hash": "sha256-H2CpevfSmr6suNHkkO97u0Nmu1n3g9v36ea+M8JPpZo="
       },
       "src/third_party/ced/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
@@ -1094,28 +1104,28 @@
       },
       "src/third_party/cros_system_api": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
-        "rev": "14884f726cc15dfacbcde0f0aa7fd3fe8f44ba7e",
-        "hash": "sha256-MTqcRpDJNltx2Jed4wn9L9vy7Oi+uMAzQlZhHIdh6UU="
+        "rev": "54e5484f94e59fdc31e7821293692a8bb47f88a3",
+        "hash": "sha256-TUW8y9as37owHYgg4mTs9ZUmZ4G+N1Njtrs6eyY5MDU="
       },
       "src/third_party/crossbench": {
         "url": "https://chromium.googlesource.com/crossbench.git",
-        "rev": "09cc246dd2b3697225e8ee277628b9e890e37adb",
-        "hash": "sha256-qHmQ9+kQ0C0IcqJJox2eN3WSZyKPdt7FCMccrBVrN80="
+        "rev": "eb6e4790f4fc6f2f66a20aba07de9a58985db46b",
+        "hash": "sha256-kEMKNDP57Q3m2eBjb0McScZTxrFpLTIE/9dSAupTOJ4="
       },
       "src/third_party/crossbench-web-tests": {
         "url": "https://chromium.googlesource.com/chromium/web-tests.git",
-        "rev": "b5fd07ef7b048d8cf8cc59856db939173c4bb83e",
-        "hash": "sha256-RC70rVFobg5NY8IU0bwd0taDZht9qVfDW7FuR0gnys0="
+        "rev": "92d748acb154cb58c76ad1d509378d5aa8669755",
+        "hash": "sha256-vh6uX1jXhxDgqfXnme/nh8W+O4Qq+Fx33lSQ08LNunM="
       },
       "src/third_party/depot_tools": {
         "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-        "rev": "94e89b10b92cc9d6e58fc8d1b6474b7d29e8a114",
-        "hash": "sha256-2kfg2f5lamTyq0BMEt5LGuc4BW07Zx+Z9hZCErTVuUs="
+        "rev": "38c391feba5fb96812f9028da12413ffc39df394",
+        "hash": "sha256-yOd+k4GJ/unOVCm2Fj1oDHOMKV87CuBO/z0li3owNQk="
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "3edf00b60c60c9248990a39a702ca4882809fe06",
-        "hash": "sha256-14qm+rI536GCqNkd9umSpJ9JoXf/47wuknJsVUb3ty0="
+        "rev": "941348cf79c423892e1c7c219091a7103d18a68b",
+        "hash": "sha256-/b+NCAr1jRJd/Uq4Cf5aO/yTdNP00ImIWuSJ4aP+TEw="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1129,8 +1139,8 @@
       },
       "src/third_party/eigen3/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
-        "rev": "3fccdcd589b11da58e5e5d87c9f1f537c7c642f6",
-        "hash": "sha256-4cXU5J7LBAMxnqC9GyX85dcuL7pNJPCl4jpCpmzQOWE="
+        "rev": "d53ac33805ba0a23fa139adaf24227fb6707e6fa",
+        "hash": "sha256-+s/4HVUzKJR5OVcoxwiEzB8F89lov24g0HBPg3tp9Xs="
       },
       "src/third_party/farmhash/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
@@ -1149,8 +1159,8 @@
       },
       "src/third_party/ffmpeg": {
         "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
-        "rev": "ad41607c61898cf7150e0fb20fe4bbabd44922a3",
-        "hash": "sha256-41qpsOTedB51WMzzHXDiXA19OIzA7wG/Qgbz6IkmWpk="
+        "rev": "2b68d2babae73714846961fb0ee47e3b3d2e39a9",
+        "hash": "sha256-Bl8lAM5sHLZ9BHSIaWr5+P/8s014SXsgSmdLya5gd64="
       },
       "src/third_party/flac": {
         "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
@@ -1164,8 +1174,8 @@
       },
       "src/third_party/fontconfig/src": {
         "url": "https://chromium.googlesource.com/external/fontconfig.git",
-        "rev": "d62c2ab268d1679335daa8fb0ea6970f35224a76",
-        "hash": "sha256-Oo4ewK86dbEkO5EXyGWvdmsPHa8Wk1BHQah784vIem0="
+        "rev": "b707078e6e8bb6fd115e2080e69b3194c05e4f1c",
+        "hash": "sha256-8kCxPpJgVtZryhtTUG/36oo8mlDiKmWALGUxMDQ+wOQ="
       },
       "src/third_party/fp16/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git",
@@ -1179,8 +1189,8 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "12f5eb32aedb3e27d47c22b0447dc4363703ed94",
-        "hash": "sha256-CXkHYz+xFSnClEjLqE5WlJQriHrdRZ/P7/15AtUiFCw="
+        "rev": "656cb777798fa420a13faba3758779e9ed6c4798",
+        "hash": "sha256-i1X/ETNJTAL3A5pOiUcZRYpqjhPvZIm8FG1HMQreW6g="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
@@ -1189,13 +1199,13 @@
       },
       "src/third_party/harfbuzz/src": {
         "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
-        "rev": "511df88b82e697cd2a0f1f0635787aa0b18bddbb",
-        "hash": "sha256-wEOux4PN+3/IhTp55bTGjkQEl0I5VoQ/NWrkdzTWiKg="
+        "rev": "28f4dc622fef010dab12f4275ac195b5d4a4a704",
+        "hash": "sha256-wqycfs0TITlLu0iJICjAqSX82u8LGrr/NaZ+pgPvycs="
       },
       "src/third_party/ink/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink.git",
-        "rev": "e959d434fa1e4965c72799b80c1431f1e9ad2dcd",
-        "hash": "sha256-t5cO3YKV6FiLrp+Av4tnDhfcBAfP4sATGJW4BmBu0+Q="
+        "rev": "e781093cb91ad22a666f1880f5122fe2ed30ecfd",
+        "hash": "sha256-j9FIfGrrNEQB3wI2zMvjUksLBEdx8yrVf1NAbJSyjAI="
       },
       "src/third_party/instrumented_libs": {
         "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git",
@@ -1209,8 +1219,8 @@
       },
       "src/third_party/oak/src": {
         "url": "https://chromium.googlesource.com/external/github.com/project-oak/oak.git",
-        "rev": "96c00a6c99ac382f3f3a8f376bc7a70890d1adaa",
-        "hash": "sha256-+ouwII+i5CbWoJ3NAxQPmczofzkPwtZTtjIPaXyyXt8="
+        "rev": "e6c31df79a45e4ad6e25a85872622822c48d7e66",
+        "hash": "sha256-O8eRirwsYi68wydxhy/+KD6IFmMmmNq/EPnJTJZFjvs="
       },
       "src/third_party/ots/src": {
         "url": "https://chromium.googlesource.com/external/github.com/khaledhosny/ots.git",
@@ -1219,8 +1229,8 @@
       },
       "src/third_party/libgav1/src": {
         "url": "https://chromium.googlesource.com/codecs/libgav1.git",
-        "rev": "9b9ac8689588b245fb1ab6ce5a61c0aaaf81dc91",
-        "hash": "sha256-g2fM5AD6x7njzy6mEQVetru7IYbVj7urLaNZBISSJwc="
+        "rev": "c1deec657b32b911920c78e078cfd089faa77200",
+        "hash": "sha256-HV9Ob0UywJcJD9+crmPmZmx8rJMomJQU0KZbCxBg5Ww="
       },
       "src/third_party/googletest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git",
@@ -1239,13 +1249,13 @@
       },
       "src/third_party/nlohmann_json/src": {
         "url": "https://chromium.googlesource.com/external/github.com/nlohmann/json.git",
-        "rev": "75d9166a68355d2cd5a98bfd1a75a3a3dae8f071",
-        "hash": "sha256-t+ygFLws+E4D0Avia7swt4wruaDFaAT6shN6tl92q8k="
+        "rev": "3565f40229515411177c196ec912a06307802ed6",
+        "hash": "sha256-kngBPCN5i+5kzJ95pJ5vY2RLa9P4JYs4e+7Qn3QWsc4="
       },
       "src/third_party/jsoncpp/source": {
         "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
-        "rev": "b5ab350ff38ed25fa5b6e0dc30820f2215cad345",
-        "hash": "sha256-VvHdQkp7JZrcWca513oLG8sa+NOjW12Z6hi0cVHCMsQ="
+        "rev": "edc01ab10f52135ec80e3589b6b4e0a9c65b27fd",
+        "hash": "sha256-mdQo7AiS3DzTF8CqCRT9oL60AzGLQCFng7KUFaFEBIM="
       },
       "src/third_party/leveldatabase/src": {
         "url": "https://chromium.googlesource.com/external/leveldb.git",
@@ -1254,18 +1264,18 @@
       },
       "src/third_party/libFuzzer/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git",
-        "rev": "4b46c0ed586f91aa1ad9b5ebbcad907c9dd956e5",
-        "hash": "sha256-xXHjGaNlp47bZnTOVZcwNrb1O16MSMJg9YE7AFSfGWY="
+        "rev": "3f386be62e362fa50284ebd24262966f1a93798e",
+        "hash": "sha256-vQBWi+4ynPBhZma/2+ApbhT9tbOCd8U+QrabC8GnqKQ="
       },
       "src/third_party/fuzztest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git",
-        "rev": "1a18c86d947c25ff2b73562a90d41a2207e8cba9",
-        "hash": "sha256-e3YahhYNt/y30uEPhHMvbz7tIve14ciYdM3sO56cRYg="
+        "rev": "239bf6cc1ffcbad7d5c96e3b836b474654cbf96c",
+        "hash": "sha256-h268YPbMTgr5zd0bhTh1Xj/BcCxBhDD60o6+oelW/BQ="
       },
       "src/third_party/domato/src": {
         "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git",
-        "rev": "053714bccbda79cf76dac3fee48ab2b27f21925e",
-        "hash": "sha256-fYxoA0fxKe9U23j+Jp0MWj4m7RfsRpM0XjF6/yOhX1I="
+        "rev": "fadff396cc45d521cc594d3e2396e27e887b1963",
+        "hash": "sha256-5hs+IRwCYA4hSKMzJ9NjW1DSW5YZN5bcHEcNAnfAfac="
       },
       "src/third_party/libaddressinput/src": {
         "url": "https://chromium.googlesource.com/external/libaddressinput.git",
@@ -1274,13 +1284,13 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "b973895c4c1e93f770433258ece300344f744964",
-        "hash": "sha256-6w66nlUkL88c3M7YB6I7nLYwpBxbjbfqcmmrrueN8/8="
+        "rev": "d08a82575de50dc99f3b3d324e7b8304836fe0ef",
+        "hash": "sha256-32WklYoVgBiMxnY+2nOckwmKjZBKZtgwKBmStoO8y/Q="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
-        "rev": "ef606847911d4968b80f778135d3528bf4041b74",
-        "hash": "sha256-yThyl7Ec0JqxBWRqZ2C9euw3RVrky1lLt1YONBJTnRI="
+        "rev": "61f5abadda7b179f90e557fed6ae7a3d78bd8231",
+        "hash": "sha256-N9YwO68d3CXPje43fWs9CoO5Sc3wIULta7n8cp+2Efs="
       },
       "src/third_party/nearby/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
@@ -1364,8 +1374,8 @@
       },
       "src/third_party/libphonenumber/src": {
         "url": "https://chromium.googlesource.com/external/libphonenumber.git",
-        "rev": "5f4c9f039934e2d56fb71c17bdf43d4ceb78fdbf",
-        "hash": "sha256-350wPwBWEgBDiAttVFPR9NC30JKtiqGeMZ9sMXjWlXY="
+        "rev": "eee81630a337b9045c6db4577cf60bb1a2c6cbd1",
+        "hash": "sha256-voK+aAFzFGTXg6UVprNiD5Mbh6hW75EKbtzqIjPsxI0="
       },
       "src/third_party/libprotobuf-mutator/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git",
@@ -1389,8 +1399,8 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "91bba32d5cebc0c132bafa78f937643aa41bb7e5",
-        "hash": "sha256-YK/TbAjNjsyWlvk2z+X2GbcVk16JWGEwAoEnwYsFxeQ="
+        "rev": "ade52487a37ef76a0f209bd39bea9fe67d6db4c4",
+        "hash": "sha256-Ke28x3c0Ssg2GFfHmFlfW8fex3jSuBcN0e6PXzH0b5g="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
@@ -1404,8 +1414,8 @@
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "8aeb3a9ca36341a640528e59b34b5d641080dca8",
-        "hash": "sha256-FGl0xK7ooaRFzFBxuV6oOu3h1x2b/myLLO2En3xgVCk="
+        "rev": "26e56be0f984af3dae4d0c0ab7a0bac8ac20e1b0",
+        "hash": "sha256-Ievf2MXM7VX9+R85N3i2W+1jZSbt5mvy1SCNc0iqJYw="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
@@ -1421,6 +1431,11 @@
         "url": "https://chromium.googlesource.com/chromiumos/platform/minigbm.git",
         "rev": "9d21b5cb5896c0cde186b54d430131f9f537104c",
         "hash": "sha256-uzdoA4yBp3ZIHYtW/OsxfNwxtxKFo+V9jx3u3MEkrV8="
+      },
+      "src/third_party/pipewire/src": {
+        "url": "https://chromium.googlesource.com/external/gitlab.freedesktop.org/pipewire/pipewire.git",
+        "rev": "b741e0c74f5436f0c925f7741140db0efd32cf4e",
+        "hash": "sha256-sxS6+LtvpEWCKoKLDUSYkW4+rrcIXPjWPBglReIDh/k="
       },
       "src/third_party/nasm": {
         "url": "https://chromium.googlesource.com/chromium/deps/nasm.git",
@@ -1454,13 +1469,13 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "c01585b18e5b7492a5ecfc9b179af023a560455e",
-        "hash": "sha256-wU8qxIM8ktbrmTCe4wGB9Hfl643BHcJrByNTLXRmd5k="
+        "rev": "8f3e90282ef137adf7d380079c3178b24407104a",
+        "hash": "sha256-4OhJcWZJ3UC/Mf4DJNzLLYQtrw0y0suO/wy0d1GYP4w="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "ec4b996c753b3e301b183736f54566239b0df68d",
-        "hash": "sha256-2tv43yeasCuUgr4JnTz58x31Zq4M56xJUozp8uZVbTI="
+        "rev": "9c7ce42050379be8c24a270f395e00c7347965cb",
+        "hash": "sha256-wbHdFhzbOP98IOQnXyUWDQtjt/nOD4VABSyvErhLBI4="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -1494,13 +1509,13 @@
       },
       "src/third_party/ruy/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ruy.git",
-        "rev": "2af88863614a8298689cc52b1a47b3fcad7be835",
-        "hash": "sha256-4To1BMUgzj2/sV7USN9W0CgHnpRmaktEspfhwWWeVBc="
+        "rev": "2264753777198e4393fb83c44c693462d57a2be1",
+        "hash": "sha256-ZzkeS9ujkcFxtBQW+IWLXUYBF79N2jBw1CLyyn70/64="
       },
       "src/third_party/search_engines_data/resources": {
         "url": "https://chromium.googlesource.com/external/search_engines_data.git",
-        "rev": "b4f28b2133e46ebbb5483ea53d9cd4b533594531",
-        "hash": "sha256-KAMu3FteZgN8nmj1rToFbiLNM/CPfU+9AJ84poMSkmI="
+        "rev": "cf814b5cc732a437b4ee636f1c7907f8f1ced51a",
+        "hash": "sha256-koTwcthcJn3a4XH+rY+E3z4uvWbv+1yuX9qkcqu5t5A="
       },
       "src/third_party/sframe/src": {
         "url": "https://chromium.googlesource.com/external/github.com/cisco/sframe",
@@ -1509,8 +1524,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "7ad44b72c93c242f96f2563edb566439fe816c0a",
-        "hash": "sha256-hCMg8otfjZU/zzlLZT4ywLFAU1HbXymSTqr7BfQcu5E="
+        "rev": "b6d106297ff9ef2ff8094033695d045e87775581",
+        "hash": "sha256-sun/P/JVhTKfRwmVK5dgnz8UZEFnQoyXZZS6PN5z9us="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -1524,8 +1539,8 @@
       },
       "src/third_party/sqlite/src": {
         "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git",
-        "rev": "fc121d7d03cd6cbf499ec06a5112b263471b1181",
-        "hash": "sha256-hf9PxQhXEKT49GbkFYCvRPBT0Qu+hDnDpebI92yO1Oo="
+        "rev": "0a5fe1b18a5b651b6c4c90d397e3d0b8061f73fb",
+        "hash": "sha256-y+lJK8Qi22KUcYyY62x9xCXej85on9e0FxySaMNSYPY="
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",
@@ -1539,23 +1554,23 @@
       },
       "src/third_party/tflite/src": {
         "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
-        "rev": "66fe77c30816f9c0a503fb9f2f12fdb56c6eee76",
-        "hash": "sha256-1m9caGzYfg1ISFzra6BEDhWEHkmqMrzo0P1mvf6JfT8="
+        "rev": "7bedf2e94aff6ca62150d74fd40aa63cb73c6583",
+        "hash": "sha256-Uv1SbtjalHt7XLAcvOfiycgepDrEK8/JdpD3GPK1MNo="
       },
       "src/third_party/litert/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-ai-edge/LiteRT.git",
-        "rev": "ee121300b37b49cd4f9942c0f1256936aa9e611a",
-        "hash": "sha256-D4lNgq9YvCuajK2qfHVJzQ54BPShna0EkTEDw43J5/g="
+        "rev": "1ae23176dd5d3a43e35961d8236d5adda7f8c0a1",
+        "hash": "sha256-xcCqZA8BKZG/TV/fAUAWPOoZwSQkRDATlhE6A05PyX0="
       },
       "src/third_party/vulkan-deps": {
         "url": "https://chromium.googlesource.com/vulkan-deps",
-        "rev": "285f3b19c49c06a71994a664567418504d5367d9",
-        "hash": "sha256-UZ6eGC1Zwx3ysDeTa1YPnjQ29GuDDqxfbvQsPFSQsvc="
+        "rev": "9bf18397113dbdc7adf4f76408df7f79d4ad141a",
+        "hash": "sha256-ol8SSAFHrEfsKWUmg64klpFFXIlZU4gyibENmzZD454="
       },
       "src/third_party/glslang/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
-        "rev": "ce138e2c2d6992b31ff4cd2e955904637785a881",
-        "hash": "sha256-zJ+612mODx6ptEWXzf1Q1WFSlgSTEoWaXlD07v1Z1yI="
+        "rev": "8292684e941bf22583b257bd9dfe47daccacb665",
+        "hash": "sha256-1D971MPCHr8vnj31IFUwe1s+X3UAabxYUQ1Cd/VyqDA="
       },
       "src/third_party/spirv-cross/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
@@ -1564,43 +1579,43 @@
       },
       "src/third_party/spirv-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
-        "rev": "daa093dd29aab8cbb6562b808370562f56e399fb",
-        "hash": "sha256-2xYphq6uMRlPaaaVSiwqPrWRkCfyOMjeJcWewRja/WY="
+        "rev": "29981f65241605e08b0ede4cfeb999fe3b723c6a",
+        "hash": "sha256-tGY4H3+5p9M5LBK/xxRdMT9CX+qq3e7fPkaftnpjU9I="
       },
       "src/third_party/spirv-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
-        "rev": "d5bbf95d87dd6d2694fbf09acfb42a00c93575e8",
-        "hash": "sha256-VGq4LDVzCj2KG14YIio//kE0/d3fUyuaPb4pg/GbsXc="
+        "rev": "a665e21f3061f34064b39937cf00fe8d8769f4ef",
+        "hash": "sha256-4m/xdMk/r4C5zdU/CZzdoXtRN0MWs8pN5QUPI5Ej3+w="
       },
       "src/third_party/vulkan-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
-        "rev": "d2d8ded679e53c9f27c0c7a18750e661745886eb",
-        "hash": "sha256-d/3CSWsu5ttwLlG4bSnJ+47vvQSkZVeKSjhEP139rn0="
+        "rev": "d314eae73fdc90847bb8304a86ee7c6a8ee023b6",
+        "hash": "sha256-YU51vfV/8vQqVTngS2SRHKXpgxU/5IJ+jAT5pcYUcpw="
       },
       "src/third_party/vulkan-loader/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
-        "rev": "0d210fdf88a81b0e833096079f73dda477da62f8",
-        "hash": "sha256-FTv0TIZhWNhczuzq5/H09P4e61JkrrRQTcYOBvt7vDU="
+        "rev": "59a70594de4559fd3aed73fe8ac2d6c48ca002d4",
+        "hash": "sha256-M/gm3fkCcFZJyslWCO/v2DzuavTOfvvKvx+0bNihEqs="
       },
       "src/third_party/vulkan-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
-        "rev": "b7ae55b37cda76d16368c302f37cb0c7ea2f8409",
-        "hash": "sha256-FADvu38L8F52pGlC0kDRlqaN4FnIlgLggv2hsQ5YuqU="
+        "rev": "286299bb6b732e4b22771cfb9d7d421542d40501",
+        "hash": "sha256-kbySCu2c5nh6icnPQV6qplfg1gHFnGPEYOG6G6TG8EU="
       },
       "src/third_party/vulkan-utility-libraries/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries",
-        "rev": "ba450228e2ebb4059f8a7d4bb36610464e2f0741",
-        "hash": "sha256-gETVlFG3sj/sp+0SA4nY4HwVPpk129MIstMrM2fUlnM="
+        "rev": "e9585c3e3d41ab608ee3b098ce4721d357308fc8",
+        "hash": "sha256-WcSiUe3vB7zUO0vpqcVJkKqhnZXz76ApWaoMO49efXg="
       },
       "src/third_party/vulkan-validation-layers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
-        "rev": "cf9b84986ad6f29b73e781be7e55535adfe3b680",
-        "hash": "sha256-xKCChjPpLlWoiWLt2H+t6VmE3brl2P+Y3fTZausO8Ps="
+        "rev": "11079f041fa85ec27c40c4ef2d63531138a2ab98",
+        "hash": "sha256-1lG6shUQRKXtojLHwfZD6gDz5yVnNoVp6BHMyUz70Co="
       },
       "src/third_party/vulkan_memory_allocator": {
         "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
-        "rev": "7e55b011e16182fc349149abbd3aaf3b1db46421",
-        "hash": "sha256-fOnFkcQDEGIe5yB507qnP9nA1LBBPFblncNiJ8JxAwI="
+        "rev": "82a9d47e4f9d91f0e32d2b6acd9714fcee1933a0",
+        "hash": "sha256-cllZTX7WHoVNugE0efOfY71y8BJg+8w/MI9EDHaVswM="
       },
       "src/third_party/wayland/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git",
@@ -1629,13 +1644,13 @@
       },
       "src/third_party/webgl/src": {
         "url": "https://chromium.googlesource.com/external/khronosgroup/webgl.git",
-        "rev": "216b10fafd3f6a900c715a8c758a4c7f9883b030",
-        "hash": "sha256-Aax2hr/9Zq6Avk+TMU1OMBLGshUL6hyRTX6eoOQesqM="
+        "rev": "064aaf18207438d4f6dd10c98b02b25778257b7f",
+        "hash": "sha256-1B0qHufnOreV7z6TAQggfX5l8TeLq2NgQg0a5Cr0Q3M="
       },
       "src/third_party/webgpu-cts/src": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
-        "rev": "663ea46471861e51f6a320e078a1fe39bf7f623e",
-        "hash": "sha256-yPgQhVgy3atQtqBi/FPOMeZqoEyGOpSID4Fhh3zSLRE="
+        "rev": "499044af47ec2717e06e644d0943e6fcdb3f3538",
+        "hash": "sha256-M8TWqKdqoiZ01vbDpcRyPWIOaBPCPdSSflxcIpbYjFA="
       },
       "src/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
@@ -1649,13 +1664,13 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "f20ebb8adbf4fa781830e4384c61f732bd28a217",
-        "hash": "sha256-r6slVo1WGITEXqyu8iMrV6Pyo3giJkxBbrmJdGLooRc="
+        "rev": "6f37672d358475cd17544121a12494da454d85fb",
+        "hash": "sha256-c0h6bD8zNZbacnOgRei+yVB+5+AvfglW+eQDNZU945M="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
-        "rev": "50869df0ea703b4f41b238bfe26aec6ec9c86889",
-        "hash": "sha256-V7inWJqH7Q4Ac/ZB//7XHrpgfAYUPBxWBerBem6Q/Kk="
+        "rev": "7411f488fe2e2c205c3d3b3d28638b7356522930",
+        "hash": "sha256-AMuAaCbNJYnSeac1B1IRSUh4rlE2KphT04/Ak4Pig5M="
       },
       "src/third_party/weston/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/weston.git",
@@ -1664,8 +1679,8 @@
       },
       "src/third_party/xnnpack/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
-        "rev": "4b7c368f5e48d9292c5834593c2f83e66b55ce83",
-        "hash": "sha256-EJ118E6awFO+yW8FkzlaBWVCkwduK1X/j/Evuzka+8k="
+        "rev": "09c4a9137f3a19b053dc45724a62f4f73ec7746a",
+        "hash": "sha256-eoS9qQ1hOJJBw6RQ2mTyRQb/AaAj8XnFbtqPpAb99y4="
       },
       "src/third_party/libei/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.freedesktop.org/libinput/libei.git",
@@ -1679,13 +1694,13 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "4b407bc23f23059b1019cde542601c2cf8f70eb2",
-        "hash": "sha256-TB1A+iIyZOdlbHvim1JOaXOf9uQnoAYqbUL2+PFKUcs="
+        "rev": "6aacaf6256a069ee455142333b7d38cad1c8d6e0",
+        "hash": "sha256-1NX4HP/BIJ6bWxoF42K89X8ADHuHjA5akkOL/WkIeME="
       },
       "src/agents/shared": {
         "url": "https://chromium.googlesource.com/chromium/agents.git",
-        "rev": "aa733bca85501395a2854a1e86084aa707704c3e",
-        "hash": "sha256-SORAKZ5ZVaXH8FuajaVa7mRM4VIvmmKlDXYzyy1iqlU="
+        "rev": "559f135fc214d637f85174c6be7010804e31f1e5",
+        "hash": "sha256-/PhF9Pc8wPx+TLABd3yD218TfEatBySazVci1Wc+9e4="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #556739

https://chromereleases.googleblog.com/2026/08/stable-channel-update-for-desktop_0256176589.html

This update includes 327 security fixes.

CVEs:
CVE-2026-79282 CVE-2026-79290 CVE-2026-79054 CVE-2026-79121
CVE-2026-79224 CVE-2026-79052 CVE-2026-79150 CVE-2026-78935
CVE-2026-79012 CVE-2026-79200 CVE-2026-78989 CVE-2026-79069
CVE-2026-79175 CVE-2026-79218 CVE-2026-79195 CVE-2026-78939
CVE-2026-79194 CVE-2026-79247 CVE-2026-79219 CVE-2026-79047
CVE-2026-79292 CVE-2026-78986 CVE-2026-79039 CVE-2026-78934
CVE-2026-79011 CVE-2026-78911 CVE-2026-79257 CVE-2026-79202
CVE-2026-79212 CVE-2026-79183 CVE-2026-79155 CVE-2026-79093
CVE-2026-79019 CVE-2026-79187 CVE-2026-79288 CVE-2026-79130
CVE-2026-78965 CVE-2026-79117 CVE-2026-79082 CVE-2026-79111
CVE-2026-79072 CVE-2026-79142 CVE-2026-78948 CVE-2026-78908
CVE-2026-78895 CVE-2026-79043 CVE-2026-79235 CVE-2026-79232
CVE-2026-79118 CVE-2026-79174 CVE-2026-78900 CVE-2026-79188
CVE-2026-79189 CVE-2026-79048 CVE-2026-79240 CVE-2026-79014
CVE-2026-79198 CVE-2026-79131 CVE-2026-79149 CVE-2026-79275
CVE-2026-79138 CVE-2026-79026 CVE-2026-79027 CVE-2026-78904
CVE-2026-78899 CVE-2026-78954 CVE-2026-79274 CVE-2026-78938
CVE-2026-78952 CVE-2026-79236 CVE-2026-79078 CVE-2026-79209
CVE-2026-79030 CVE-2026-79216 CVE-2026-79007 CVE-2026-78893
CVE-2026-79222 CVE-2026-79071 CVE-2026-79076 CVE-2026-79088
CVE-2026-79104 CVE-2026-79044 CVE-2026-78958 CVE-2026-78961
CVE-2026-79262 CVE-2026-79106 CVE-2026-79176 CVE-2026-78966
CVE-2026-79186 CVE-2026-79267 CVE-2026-79016 CVE-2026-79010
CVE-2026-79286 CVE-2026-78945 CVE-2026-78999 CVE-2026-78941
CVE-2026-79032 CVE-2026-79109 CVE-2026-79256 CVE-2026-79237
CVE-2026-78898 CVE-2026-78985 CVE-2026-79028 CVE-2026-79210
CVE-2026-79046 CVE-2026-79129 CVE-2026-78937 CVE-2026-78987
CVE-2026-78990 CVE-2026-78909 CVE-2026-79271 CVE-2026-79144
CVE-2026-79065 CVE-2026-79192 CVE-2026-79140 CVE-2026-79128
CVE-2026-78942 CVE-2026-79116 CVE-2026-79006 CVE-2026-79095
CVE-2026-79084 CVE-2026-78991 CVE-2026-79248 CVE-2026-78891
CVE-2026-79031 CVE-2026-79110 CVE-2026-79136 CVE-2026-78907
CVE-2026-79087 CVE-2026-79231 CVE-2026-78969 CVE-2026-79137
CVE-2026-79057 CVE-2026-78894 CVE-2026-79264 CVE-2026-78910
CVE-2026-79066 CVE-2026-79255 CVE-2026-79086 CVE-2026-79038
CVE-2026-78940 CVE-2026-79107 CVE-2026-79120 CVE-2026-79270
CVE-2026-79067 CVE-2026-79213 CVE-2026-78943 CVE-2026-79259
CVE-2026-79208 CVE-2026-79251 CVE-2026-79226 CVE-2026-79042
CVE-2026-79122 CVE-2026-79199 CVE-2026-79013 CVE-2026-79074
CVE-2026-79215 CVE-2026-79049 CVE-2026-79132 CVE-2026-79201
CVE-2026-79051 CVE-2026-79053 CVE-2026-79285 CVE-2026-78906
CVE-2026-79250 CVE-2026-79020 CVE-2026-79217 CVE-2026-79204
CVE-2026-78912 CVE-2026-78955 CVE-2026-79143 CVE-2026-79241
CVE-2026-78967 CVE-2026-79214 CVE-2026-79228 CVE-2026-78953
CVE-2026-79229 CVE-2026-79002 CVE-2026-79272 CVE-2026-79127
CVE-2026-79151 CVE-2026-78936 CVE-2026-78905 CVE-2026-79050
CVE-2026-79008 CVE-2026-78975 CVE-2026-79287 CVE-2026-79094
CVE-2026-79173 CVE-2026-78976 CVE-2026-79276 CVE-2026-79191
CVE-2026-79099 CVE-2026-79024 CVE-2026-79193 CVE-2026-79242
CVE-2026-79180 CVE-2026-79293 CVE-2026-79023 CVE-2026-79146
CVE-2026-79238 CVE-2026-78949 CVE-2026-79291 CVE-2026-79283
CVE-2026-78892 CVE-2026-79070 CVE-2026-79205 CVE-2026-78903
CVE-2026-78959 CVE-2026-79234 CVE-2026-78983 CVE-2026-79083
CVE-2026-78944 CVE-2026-79178 CVE-2026-79059 CVE-2026-79245
CVE-2026-78978 CVE-2026-79103 CVE-2026-79154 CVE-2026-79230
CVE-2026-79068 CVE-2026-79269 CVE-2026-79085 CVE-2026-79134
CVE-2026-79064 CVE-2026-79003 CVE-2026-79220 CVE-2026-78951
CVE-2026-79249 CVE-2026-79091 CVE-2026-79265 CVE-2026-78913
CVE-2026-79258 CVE-2026-79211 CVE-2026-79252 CVE-2026-78962
CVE-2026-78901 CVE-2026-79097 CVE-2026-79227 CVE-2026-79203
CVE-2026-79033 CVE-2026-79139 CVE-2026-79221 CVE-2026-79034
CVE-2026-79075 CVE-2026-78960 CVE-2026-78984 CVE-2026-78963
CVE-2026-79004 CVE-2026-79182 CVE-2026-79185 CVE-2026-79073
CVE-2026-79266 CVE-2026-79025 CVE-2026-79141 CVE-2026-78974
CVE-2026-79055 CVE-2026-79263 CVE-2026-79124 CVE-2026-79184
CVE-2026-79289 CVE-2026-79001 CVE-2026-79077 CVE-2026-78950
CVE-2026-79196 CVE-2026-79000 CVE-2026-78979 CVE-2026-79181
CVE-2026-79190 CVE-2026-79206 CVE-2026-78897 CVE-2026-79119
CVE-2026-79089 CVE-2026-79147 CVE-2026-79098 CVE-2026-79022
CVE-2026-79233 CVE-2026-79261 CVE-2026-78977 CVE-2026-79040
CVE-2026-79273 CVE-2026-79243 CVE-2026-79123 CVE-2026-79005
CVE-2026-79090 CVE-2026-78946 CVE-2026-78968 CVE-2026-79041
CVE-2026-79284 CVE-2026-78896 CVE-2026-79058 CVE-2026-79009
CVE-2026-79060 CVE-2026-79177 CVE-2026-78956 CVE-2026-79239
CVE-2026-79015 CVE-2026-79108 CVE-2026-79056 CVE-2026-79018
CVE-2026-78980 CVE-2026-78947 CVE-2026-79244 CVE-2026-79112
CVE-2026-79246 CVE-2026-79223 CVE-2026-79045 CVE-2026-79197
CVE-2026-79148 CVE-2026-79125 CVE-2026-79207 CVE-2026-79017
CVE-2026-79105 CVE-2026-79225 CVE-2026-79021 CVE-2026-79133
CVE-2026-79179 CVE-2026-79152 CVE-2026-78981 CVE-2026-78957
CVE-2026-79126 CVE-2026-78915 CVE-2026-79253 CVE-2026-79260
CVE-2026-79254 CVE-2026-78914 CVE-2026-78964

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
