### PR TITLE
ipfs-cluster: 1.1.5 -> 1.1.6, buildGo125Module -> buildGoModule

### DIFF
--- a/pkgs/by-name/ip/ipfs-cluster/package.nix
+++ b/pkgs/by-name/ip/ipfs-cluster/package.nix
@@ -1,20 +1,20 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "ipfs-cluster";
-  version = "1.1.5";
+  version = "1.1.6";
 
-  vendorHash = "sha256-ARzpn/LzFIA+3ghW+xdQvFFiFwxT79dk4vpgEKoEBzk=";
+  vendorHash = "sha256-j8eMvlmTd0SIZD/8up7wCRZkSRxDBM0coVJIKydfXhg=";
 
   src = fetchFromGitHub {
     owner = "ipfs-cluster";
     repo = "ipfs-cluster";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-TOUntNZtTj6cS+6+MwIwKdUZ/gB5D63osn4+fpGGkDY=";
+    hash = "sha256-d0lFvxYwJXV6RtI3mDjDwCrD5DUOYWq3aOZv7tNZnBE=";
   };
 
   checkFlags =


### PR DESCRIPTION
https://github.com/ipfs-cluster/ipfs-cluster/releases/tag/v1.1.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
