### PR TITLE
it87: unstable-2025-12-26 -> unstable-2026-08-25

### DIFF
--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -9,15 +9,15 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}-${kernel.version}";
   pname = "it87";
-  version = "unstable-2025-12-26";
+  version = "unstable-2026-08-25";
 
   # Original is no longer maintained.
   # This is the same upstream as the AUR uses.
   src = fetchFromGitHub {
     owner = "frankcrawford";
     repo = "it87";
-    rev = "a9eb2495220cba861ef3df63fa15265e878293b6";
-    hash = "sha256-iWyOctK+TFhVCOw2LiV4NiNFEAqNXOpSdGY//VwO8Ko=";
+    rev = "c567739c639533177abd66894a6a8d561337285f";
+    hash = "sha256-MvaqqiwUA15lqJXgRapABqSUrOfeP9bkEdb7IEZuUOE=";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


  Update `it87` from `unstable-2025-12-26` to `unstable-2026-08-25`.

  This update includes upstream MMIO/H2RAM/ECIO support and related fixes,including MMIO access for supported Gigabyte Super I/O chips, ACPI resource conflict handling, tachometer enable-mask fixes, and improved restoration of firmware state when unloading the module.

  Upstream changes:
  https://github.com/frankcrawford/it87/compare/a9eb2495220cba861ef3df63fa15265e878293b6...c567739c639533177abd66894a6a8d561337285f

  The updated module was also tested on real hardware:

  - Motherboard: Gigabyte B650M AORUS ELITE AX ICE
  - Super I/O: IT8689E revision 2
  - Kernel: Linux 6.18.45
  - The module loaded without `force_id` or `ignore_resource_conflict`
  - The IT8689E was detected through MMIO at `0xfe100000`
  - Six fan inputs and six PWM controls were exposed through hwmon
  - Fan RPM, temperature, voltage, and PWM values were read successfully

  No PWM values were written during the hardware test.

  Assisted by OpenAI Codex (GPT-5). The changes and test results were reviewed by the
  submitter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
