### PR TITLE
tcl: Give Cygwin the import library it says it has

### DIFF
--- a/pkgs/development/interpreters/tcl/8.6.nix
+++ b/pkgs/development/interpreters/tcl/8.6.nix
@@ -3,6 +3,7 @@
   stdenv,
   callPackage,
   fetchurl,
+  fetchpatch,
   ...
 }@args:
 
@@ -19,11 +20,36 @@ callPackage ./generic.nix (
       hash = "sha256-kcuPphdxxjwmLvtVMFm3x61nV6+lhXr2Jl5LC9wqFKU=";
     };
 
-    # Backport of upstream check-in `fd06472ef41e1d73`; see the patch.
-    # TODO apply unconditionally; only `win` is patched, but doing so
-    # today would be a mass rebuild for a no-op elsewhere.
-    patches = lib.optionals stdenv.hostPlatform.isWindows [
-      ./8.6-windows-disable-tzdata.patch
-    ];
+    patches =
+      # Cygwin wants the DLL in `bin` and an import library,
+      # `libtcl8.6.dll.a`, in `lib`; that is what `tclConfig.sh` describes
+      # when it says `-L${libdir} -ltcl8.6`. This branch's `unix` build
+      # system builds no import library at all, so nothing can link against
+      # Tcl. Upstream fixed that on 9.0 and never backported it.
+      #
+      # https://core.tcl-lang.org/tcl/tktview/17960b80db
+      #
+      # `decode` renames the path: 9.0 has `unix/configure.ac` where this
+      # branch still has `unix/configure.in`. The hunks themselves apply as
+      # they are. `includes` drops the rest of the check-in: the generated
+      # `unix/configure`, which `autoreconfHook` rebuilds anyway, and a
+      # `changes.md` entry that has no counterpart here.
+      lib.optionals stdenv.hostPlatform.isCygwin [
+        (fetchpatch {
+          url = "https://github.com/tcltk/tcl/commit/1685fee268dcf1334b015840d873366a3cd8d237.patch";
+          decode = "sed -e 's|configure[.]ac|configure.in|g'";
+          includes = [
+            "unix/tcl.m4"
+            "unix/configure.in"
+          ];
+          hash = "sha256-SWZuY4NvN9z9ka+TTICbCxPZHzhV/8JYDRPI/Vhc/8o=";
+        })
+      ]
+      # Backport of upstream check-in `fd06472ef41e1d73`; see the patch.
+      # TODO apply unconditionally; only `win` is patched, but doing so
+      # today would be a mass rebuild for a no-op elsewhere.
+      ++ lib.optionals stdenv.hostPlatform.isWindows [
+        ./8.6-windows-disable-tzdata.patch
+      ];
   }
 )

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -20,6 +20,13 @@
 }:
 
 let
+  # `patches` here touch `configure.in`/`configure.ac`, so the generated
+  # `configure` the tarball ships has to be rebuilt. Only the platforms
+  # that get such a patch pay for it: `win` everywhere, and `unix` for
+  # 8.6 on Cygwin, which is the only branch missing the import library.
+  needsAutoreconf =
+    stdenv.hostPlatform.isWindows || (stdenv.hostPlatform.isCygwin && lib.versionOlder version "9.0");
+
   baseInterp = stdenv.mkDerivation rec {
     pname = "tcl";
     inherit version src;
@@ -68,14 +75,9 @@ let
       ++ lib.optionals (stdenv.hostPlatform.isWindows && stdenv.buildPlatform != stdenv.hostPlatform) [
         buildPackages.tcl
       ]
-      # `patches` touches `configure.in`/`configure.ac` only, so the generated
-      # `configure` the tarball ships has to be rebuilt. The default hook is
-      # the newest autoconf that works for both, 8.6's 2.59-era
-      # `configure.in` included.
-      #
-      # TODO make unconditional, which means `preAutoreconf` must `cd unix`
-      # too. Only `win` needs regenerating today.
-      ++ lib.optionals stdenv.hostPlatform.isWindows [
+      # The default hook is the newest autoconf that works for every tree we
+      # regenerate, 8.6's 2.59-era `configure.in` included.
+      ++ lib.optionals needsAutoreconf [
         autoreconfHook
       ];
 
@@ -87,25 +89,25 @@ let
     # `unix` but with its own `Makefile.in` and a smaller set of options. Cygwin
     # is not Windows for this purpose: it is POSIX enough for the `unix` one.
     #
-    # Whichever phase reaches it first does the `cd`; on Windows that is
-    # `autoreconfPhase`, below.
-    preConfigure = lib.optionalString (!stdenv.hostPlatform.isWindows) ''
-      cd unix
+    # Whichever phase reaches it first does the `cd`; where we regenerate
+    # `configure` that is `autoreconfPhase`, below.
+    preConfigure = lib.optionalString (!needsAutoreconf) ''
+      cd ${if stdenv.hostPlatform.isWindows then "win" else "unix"}
     '';
 
     # `null`, not `""`: an empty string is still a variable, and adding one to
     # every other platform's derivation is a mass rebuild for nothing.
     preAutoreconf =
-      if stdenv.hostPlatform.isWindows then
+      if needsAutoreconf then
         ''
-          cd win
+          cd ${if stdenv.hostPlatform.isWindows then "win" else "unix"}
         ''
       else
         null;
 
     # No `--install`: there is no automake here, and letting `autoreconf`
     # regenerate `aclocal.m4` would lose the `tcl.m4` the build depends on.
-    autoreconfFlags = if stdenv.hostPlatform.isWindows then "--force --verbose" else null;
+    autoreconfFlags = if needsAutoreconf then "--force --verbose" else null;
 
     # Note: pre-9.0 flags are temporarily interspersed to avoid a mass rebuild.
     configureFlags =
@@ -194,17 +196,19 @@ let
         # files, so `tclsh86.exe` rather than `tclsh8.6`.
         infix =
           if stdenv.hostPlatform.isWindows then lib.replaceStrings [ "." ] [ "" ] release else release;
-        # On Cygwin, shared libs are in the bin directory. TODO dedup
-        # with this other packages, consider doing the same or Mingw.
-        # See #431820.
-        linkDir = if !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isCygwin then "bin" else "lib";
-        linkExtension = if stdenv.hostPlatform.isWindows then "${dllExtension}.a" else dllExtension;
-        # Tcl 9 names its Cygwin DLL the way that platform does, `cygtcl9.0.dll`;
-        # 8.6 called it `libtcl8.6.dll`. See the Cygwin `SHLIB_LD` in 9.0's
-        # `unix/tcl.m4`, which rewrites `cyg%.dll` to `lib%.dll` for the import
-        # library. Only the DLL is affected, not the static or import library.
-        dllPrefix =
-          if stdenv.hostPlatform.isCygwin && lib.versionAtLeast version "9.0" then "cyg" else "lib";
+        # On PE platforms --- Mingw and Cygwin alike --- the DLL lives in
+        # `bin` and the thing one links against is the import library in
+        # `lib`, so that is what the unversioned name should point at.
+        #
+        # The import library is always `lib`-prefixed, even where the DLL
+        # is not: Tcl 9 names its Cygwin DLL the way that platform does,
+        # `cygtcl9.0.dll`, and 9.0's Cygwin `SHLIB_LD` in `unix/tcl.m4`
+        # rewrites `cyg%.dll` to `lib%.dll.a` for the import library.
+        linkExtension =
+          if stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isCygwin then
+            "${dllExtension}.a"
+          else
+            dllExtension;
       in
       ''
         make install-private-headers
@@ -213,7 +217,7 @@ let
           ln -s $out/lib/libtcl${infix}${staticExtension} $out/lib/libtcl${staticExtension}
         fi
         ${lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-          ln -s $out/${linkDir}/${dllPrefix}tcl${infix}${linkExtension} $out/lib/libtcl${linkExtension}
+          ln -s $out/lib/libtcl${infix}${linkExtension} $out/lib/libtcl${linkExtension}
         ''}
       '';
 


### PR DESCRIPTION
`tclConfig.sh` on Cygwin says `-L${libdir} -ltcl8.6`, and upstream confirms that is right: "The normal way on Cygwin is to have a cygtcl9.x.dll in /usr/bin and a libtcl9.x.dll.a file in /usr/lib." 9.0's `unix` build system does exactly that, and the `win` build system has always done the Mingw equivalent, but 8.6's `unix` one builds no import library at all --- so `-ltcl8.6` finds nothing and linking against Tcl fails outright. `pkgsCross.x86_64-pc-cygwin.sqlite`, which links the Tcl extension, is one casualty.

Upstream fixed this for 9.0 in check-in `1685fee268dcf133` and never backported it, so `fetchpatch` that check-in for 8.6. Only the path needs adjusting --- 9.0 has `unix/configure.ac` where 8.6 still has `unix/configure.in` --- which `decode` does; the hunks themselves apply as they are. Patching `configure.in` means regenerating `configure`, so `autoreconfHook` now runs for Cygwin too, on the branch that gets the patch.

https://core.tcl-lang.org/tcl/tktview/17960b80db

With an import library in `lib` on both branches, the unversioned convenience link can be what Mingw's already is --- `libtcl.dll.a` pointing at the versioned import library --- rather than a `.dll` symlink in `lib` pointing off into `bin`. That drops `linkDir` and `dllPrefix`.

Native and Mingw derivations are unchanged, hash for hash.

Assisted-by: Claude Code (Claude Opus 5)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
