### PR TITLE
gimagereader: unstable-2025-06-04 -> 3.4.3, use podofo 1.x, finalAttrs

### DIFF
--- a/pkgs/by-name/gi/gimagereader/package.nix
+++ b/pkgs/by-name/gi/gimagereader/package.nix
@@ -33,20 +33,19 @@
   kdePackages,
   qt6Packages,
   withQt6 ? false,
-  wrapQtAppsHook ? null,
 }:
 
 let
   pythonEnv = python3.withPackages (ps: with ps; [ pygobject3 ]);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gimagereader";
   version = "5aff249fdc119caa1464af9405259799b4f69d8b";
 
   src = fetchFromGitHub {
     owner = "manisandro";
     repo = "gImageReader";
-    rev = "${version}";
+    rev = "${finalAttrs.version}";
     sha256 = "sha256-xS63iGY1yf0NEnGuss0sme1vSYd2L3sOUd/g8yyPn1k=";
   };
 
@@ -102,9 +101,9 @@ stdenv.mkDerivation rec {
     description = "Simple Gtk/Qt front-end to tesseract-ocr";
     mainProgram = if withQt6 then "gImageReader-qt6" else "gImageReader";
     homepage = "https://github.com/manisandro/gImageReader";
-    changelog = "https://github.com/manisandro/gImageReader/blob/${version}/NEWS";
+    changelog = "https://github.com/manisandro/gImageReader/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ teto ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/gi/gimagereader/package.nix
+++ b/pkgs/by-name/gi/gimagereader/package.nix
@@ -6,7 +6,7 @@
   pkg-config,
   libuuid,
   sane-backends,
-  podofo0,
+  podofo,
   libjpeg,
   djvulibre,
   libxmlxx3,
@@ -40,13 +40,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gimagereader";
-  version = "5aff249fdc119caa1464af9405259799b4f69d8b";
+  version = "3.4.3";
 
   src = fetchFromGitHub {
     owner = "manisandro";
     repo = "gImageReader";
-    rev = "${finalAttrs.version}";
-    sha256 = "sha256-xS63iGY1yf0NEnGuss0sme1vSYd2L3sOUd/g8yyPn1k=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-sNAQfTJYL5um65UmCyzIH/0qkF3lF7CnrVQ+dLfYf2Q=";
   };
 
   nativeBuildInputs = [
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     libzip
     libuuid
     sane-backends
-    podofo0
+    podofo
     libjpeg
     djvulibre
     tesseract
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Simple Gtk/Qt front-end to tesseract-ocr";
     mainProgram = if withQt6 then "gImageReader-qt6" else "gImageReader";
     homepage = "https://github.com/manisandro/gImageReader";
-    changelog = "https://github.com/manisandro/gImageReader/blob/${finalAttrs.version}/NEWS";
+    changelog = "https://github.com/manisandro/gImageReader/blob/v${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ teto ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
