### PR TITLE
orca-slicer: drop gcc-unwrapped

### DIFF
--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -16,7 +16,6 @@
   eigen_5,
   expat,
   ffmpeg,
-  gcc-unwrapped,
   glew,
   glfw,
   glib,
@@ -102,7 +101,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     eigen_5
     expat
     ffmpeg
-    gcc-unwrapped
     glew
     glfw
     glib


### PR DESCRIPTION
`gcc-unwrapped`'s default output only ships `libstdc++.a` — the shared `libstdc++.so` lives in its `lib` output. Having it in `buildInputs` puts that static archive on the linker search path, so `-lstdc++` resolves to it and a second copy of libstdc++ is linked into the executable. Those symbols land in `.dynsym` and interpose over the `libstdc++.so.6` every shared library uses, leaving the process with two sets of `std::locale` facet ids and two allocator states.

Anything `dlopen`'d that touches a locale can then free across the boundary. The proprietary Bambu networking plugin does, seconds after startup:

```
#4 malloc_printerr             (libc.so.6)
#6 std::locale::_Impl::~_Impl  (.orca-slicer-wrapped)
#7 std::locale::~locale        (libstdc++.so.6)
#8 libbambu_networking_02.03.00.62.so

free(): invalid size
```

The dependency is vestigial: added in aa1203429f56 ("orca-slicer: fix gcc14") when the package stopped being an override of `bambu-studio` — which has never had it — and `clangStdenv` already provides libstdc++ via the compiler wrapper.

| | before | after |
| --- | --- | --- |
| `libstdc++.so.6` as `DT_NEEDED` | absent | present |
| libstdc++ symbols defined by the executable | 3401 | 189 |
| startup with the Bambu plugin installed | `SIGABRT` every run | 3/3 runs fine |

Installed file list and runtime closure are unchanged.

Note on the issue: deleting the config file as a workaround is a red herring — a fresh config just hasn't downloaded the plugin yet. The trigger is the plugin in `~/.config/OrcaSlicer/plugins`.

Fixes #543013

Keeping the dependency as `(lib.getLib gcc-unwrapped)` also fixes it — I built and tested that too, happy to switch if preferred. Since the closure is identical either way, dropping it seemed better than keeping one whose only effect is a hazardous link order.

### Disclosure

I used AI (Claude Code, Claude Opus 5) to identify the root cause, as disclosed in the commit's `Assisted-by:` trailer. I built and tested both candidate fixes myself.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
