### PR TITLE
various: buildGo125Module -> buildGoModule where trivial

### DIFF
--- a/pkgs/by-name/f2/f2/package.nix
+++ b/pkgs/by-name/f2/f2/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
   fetchFromGitHub,
-  buildGo125Module,
+  buildGoModule,
   exiftool,
   nix-update-script,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "f2";
   version = "2.2.2";
 

--- a/pkgs/by-name/gi/gitlab-container-registry/package.nix
+++ b/pkgs/by-name/gi/gitlab-container-registry/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitLab,
 }:
 
-buildGo125Module rec {
+buildGoModule rec {
   pname = "gitlab-container-registry";
   version = "4.41.0";
   rev = "v${version}-gitlab";

--- a/pkgs/by-name/go/go-away/package.nix
+++ b/pkgs/by-name/go/go-away/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
-  # tinygo currently only supports Go <=1.25
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitea,
   nix-update-script,
 
@@ -14,7 +13,7 @@
   tinygo,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "go-away";
   version = "0.7.0";
 

--- a/pkgs/by-name/go/go-camo/package.nix
+++ b/pkgs/by-name/go/go-camo/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   nixosTests,
   scdoc,
 }:
 
-buildGo125Module rec {
+buildGoModule rec {
   pname = "go-camo";
   version = "2.7.5";
 
@@ -19,6 +19,8 @@ buildGo125Module rec {
   };
 
   vendorHash = "sha256-Fl+amgzolwcuz+eVQzD6mfBdMNzUm6UCwf9BbAt+85U=";
+
+  __darwinAllowLocalNetworking = true;
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/go/gobuster/package.nix
+++ b/pkgs/by-name/go/gobuster/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
 }:
 
-buildGo125Module rec {
+buildGoModule rec {
   pname = "gobuster";
   version = "3.8.2";
 

--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  buildGo125Module,
+  buildGoModule,
   fetchFromCodeberg,
   fetchYarnDeps,
   nodejs,
@@ -21,7 +21,7 @@
   # See: https://docs.gotosocial.org/en/latest/advanced/builds/nowasm/
   withWasm ? stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isAarch64,
 }:
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "gotosocial";
   version = "0.22.1";
 

--- a/pkgs/by-name/jj/jjui/package.nix
+++ b/pkgs/by-name/jj/jjui/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
   nix-update-script,
   versionCheckHook,
   stdenv,
 }:
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "jjui";
   version = "0.10.9";
   __structuredAttrs = true;

--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
   fetchpatch,
   installShellFiles,
@@ -9,7 +9,7 @@
   fuse3,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "plakar";
   version = "1.1.4";
 

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -1,6 +1,6 @@
 {
   buildTeleport,
-  buildGo125Module,
+  buildGoModule,
   wasm-bindgen-cli_0_2_122,
   withRdpClient ? true,
   extPatches ? [ ],
@@ -14,6 +14,6 @@ buildTeleport {
   cargoHash = "sha256-cjks+Gv4CdlqWaJFFeyFsIuc3KsE7A/1MEDQB36pTkk=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_122;
-  buildGoModule = buildGo125Module;
+  buildGoModule = buildGoModule;
   inherit withRdpClient extPatches;
 }

--- a/pkgs/by-name/tp/tpm-trust/package.nix
+++ b/pkgs/by-name/tp/tpm-trust/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
   stdenv,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "tpm-trust";
   version = "0.4.1";
 


### PR DESCRIPTION
go 1.25 is now end-of-life, and will no longer receive updates. as security issues appear, this is going to be problematic. nixpkgs will also (likely, we're not involved in this) be phasing these versions out soon enough. accordingly, we unpin here wherever it's simply a matter of changing the `buildGo125Module` to `buildGoModule`. a few others seem to need proper package updates alongside it, which can be done separately.

each commit message references where the pin was added. in general, we opt for unpinning as opposed to pinning a new version, as this creates churn on every compiler update and extra work for the go maintainers, especially since go's compatibility across versions is *fairly* strong. if a given package has a compelling reason to consistently pin an old version (rather than a one-off failure), this should probably be indicated within the file itself (e.g. the comment in `pkgs/applications/networking/cluster/nomad/default.nix`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (everything builds on x86_64-linux and aarch64-linux)
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
