### PR TITLE
[Backport release-26.05] fluxcd-operator-mcp: 0.50.0 -> 0.58.1

### DIFF
--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator-mcp";
-  version = "0.50.0";
+  version = "0.52.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "fluxcd-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4FIsad3/57KtyTVQE0T4jhQGEvuEw9/ZFWsriLyc6Ok=";
+    hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
   };
 
-  vendorHash = "sha256-DxXTepwTjgc+Xy3MAIFcYZ/XZZ3zGgyStmXN2/BqM74=";
+  vendorHash = "sha256-DW+dnakqnpSiV7MlzshGEzoy3Osv93dAsJYe4cR0sJ4=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
-    repo = "fluxcd-operator";
+    repo = "flux-operator";
     tag = "v${finalAttrs.version}";
     hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
   };

--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator-mcp";
-  version = "0.58.0";
+  version = "0.58.1";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "flux-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2+/60Hp1OGvVJtFUFom1ax4ALdxXOoevEXt9oyUjazI=";
+    hash = "sha256-XGjRP9JvEpuVNKcErTKmKi4TGBADpbI1DDXYDd0Bbb4=";
   };
 
-  vendorHash = "sha256-uTj6P6UZtfFf7jBrRZMWJ3HObiSR/tPlFICk6Cw12WQ=";
+  vendorHash = "sha256-9iDxoWnizmTQ4FqxjlGPQO8Au2FxIdcgggtP+3dTOaU=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator-mcp";
-  version = "0.52.0";
+  version = "0.58.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "flux-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
+    hash = "sha256-2+/60Hp1OGvVJtFUFom1ax4ALdxXOoevEXt9oyUjazI=";
   };
 
-  vendorHash = "sha256-DW+dnakqnpSiV7MlzshGEzoy3Osv93dAsJYe4cR0sJ4=";
+  vendorHash = "sha256-uTj6P6UZtfFf7jBrRZMWJ3HObiSR/tPlFICk6Cw12WQ=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Manual backport of fluxcd-operator-mcp 0.50.0 -> 0.58.1 to `release-26.05`

auto-backport failed: https://github.com/NixOS/nixpkgs/pull/557006#issuecomment-5443495258
(no backports were tagged on the earlier PRs)

Cherry-picked from master:

- dddb0d1d8917 fluxcd-operator-mcp: 0.50.0 -> 0.52.0 (#532296)
- af24e675e55b treewide: follow some GitHub redirects for `fetchFromGitHub` (#538077)
  — partial pick restricted to `pkgs/by-name/fl/fluxcd-operator-mcp` (repo rename `fluxcd-operator` -> `flux-operator`)
- 8b420c4eadcb fluxcd-operator-mcp: 0.52.0 -> 0.58.0 (#541120)
- 49c7875dacdd fluxcd-operator-mcp: 0.58.0 -> 0.58.1 (#557006)

resulting `pkgs/by-name/fl/fluxcd-operator-mcp` is identical to master

- built on aarch64-linux
- tested basic functionality of the binary (`flux-operator-mcp --version`)
