### PR TITLE
[Backport release-26.05] fluxcd-operator: 0.49.0 -> 0.58.1

### DIFF
--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator";
-  version = "0.50.0";
+  version = "0.52.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "fluxcd-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4FIsad3/57KtyTVQE0T4jhQGEvuEw9/ZFWsriLyc6Ok=";
+    hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
   };
 
-  vendorHash = "sha256-DxXTepwTjgc+Xy3MAIFcYZ/XZZ3zGgyStmXN2/BqM74=";
+  vendorHash = "sha256-DW+dnakqnpSiV7MlzshGEzoy3Osv93dAsJYe4cR0sJ4=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator";
-  version = "0.49.0";
+  version = "0.50.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "fluxcd-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hWMXoJ47+kDmMGkGV9GOJ9ssdK6RVvcmxf3fiQYhvgM=";
+    hash = "sha256-4FIsad3/57KtyTVQE0T4jhQGEvuEw9/ZFWsriLyc6Ok=";
   };
 
-  vendorHash = "sha256-UANjDzaYJ5t10ZzG0a7oftKQVqj1HcE6/LmlnLapCPY=";
+  vendorHash = "sha256-DxXTepwTjgc+Xy3MAIFcYZ/XZZ3zGgyStmXN2/BqM74=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -9,13 +9,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator";
-  version = "0.52.0";
+  version = "0.54.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "flux-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
+    hash = "sha256-Bxzqm4I+wTj1k8ppa4cohsowmgc7H76EuHCYlCiJ5Qk=";
   };
 
   vendorHash = "sha256-DW+dnakqnpSiV7MlzshGEzoy3Osv93dAsJYe4cR0sJ4=";

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator";
-  version = "0.57.0";
+  version = "0.58.1";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "flux-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qY+uxYGkeiffU5UTsh7oVL1Cp8uKMj4/F6+Y62BSUPY=";
+    hash = "sha256-XGjRP9JvEpuVNKcErTKmKi4TGBADpbI1DDXYDd0Bbb4=";
   };
 
-  vendorHash = "sha256-uTj6P6UZtfFf7jBrRZMWJ3HObiSR/tPlFICk6Cw12WQ=";
+  vendorHash = "sha256-9iDxoWnizmTQ4FqxjlGPQO8Au2FxIdcgggtP+3dTOaU=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
-    repo = "fluxcd-operator";
+    repo = "flux-operator";
     tag = "v${finalAttrs.version}";
     hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
   };

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -9,13 +9,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator";
-  version = "0.54.0";
+  version = "0.55.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "flux-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Bxzqm4I+wTj1k8ppa4cohsowmgc7H76EuHCYlCiJ5Qk=";
+    hash = "sha256-MWtjoTQuB6G/f9MnKOkIKlbI5tvaP5TLb5PvEySNLFM=";
   };
 
   vendorHash = "sha256-DW+dnakqnpSiV7MlzshGEzoy3Osv93dAsJYe4cR0sJ4=";

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator";
-  version = "0.56.0";
+  version = "0.57.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "flux-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wx6FI4X5kBtbz1ZWeF35RSNu/FP3y4pfLnnn7ltofRQ=";
+    hash = "sha256-qY+uxYGkeiffU5UTsh7oVL1Cp8uKMj4/F6+Y62BSUPY=";
   };
 
-  vendorHash = "sha256-sPAmFrB8Lxedsp1rmmsp2p4at0to7syxK9IR6Geh+ak=";
+  vendorHash = "sha256-uTj6P6UZtfFf7jBrRZMWJ3HObiSR/tPlFICk6Cw12WQ=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -9,16 +9,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "fluxcd-operator";
-  version = "0.55.0";
+  version = "0.56.0";
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
     repo = "flux-operator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MWtjoTQuB6G/f9MnKOkIKlbI5tvaP5TLb5PvEySNLFM=";
+    hash = "sha256-wx6FI4X5kBtbz1ZWeF35RSNu/FP3y4pfLnnn7ltofRQ=";
   };
 
-  vendorHash = "sha256-DW+dnakqnpSiV7MlzshGEzoy3Osv93dAsJYe4cR0sJ4=";
+  vendorHash = "sha256-sPAmFrB8Lxedsp1rmmsp2p4at0to7syxK9IR6Geh+ak=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Manual backport of fluxcd-operator 0.49.0 -> 0.58.1 to `release-26.05`
(no backports were tagged on the original PRs)

Cherry-picked from master:

- 9c9961126829 fluxcd-operator: 0.49.0 -> 0.50.0 (#527273)
- e0d8c9c45e37 fluxcd-operator: 0.50.0 -> 0.52.0 (#530880)
- af24e675e55b treewide: follow some GitHub redirects for `fetchFromGitHub` (#538077)
  — partial pick restricted to `pkgs/by-name/fl/fluxcd-operator` (repo rename `fluxcd-operator` -> `flux-operator`)
- 7c8da776237d fluxcd-operator: 0.52.0 -> 0.54.0 (#539475)
- 3de3f9caeeba fluxcd-operator: 0.54.0 -> 0.55.0 (#542812)
- 8ef669b0c356 fluxcd-operator: 0.55.0 -> 0.56.0 (#545889)
- 7d8b1a135c54 fluxcd-operator: 0.56.0 -> 0.57.0 (#549137)
- 188a6d87daf9 fluxcd-operator: 0.57.0 -> 0.58.1 (#555333)

resulting `pkgs/by-name/fl/fluxcd-operator` is identical to master

- built on aarch64-linux
- tested basic functionality of the binary (`flux-operator --version`)
