### PR TITLE
voxtype: add HIP variant

### DIFF
--- a/pkgs/by-name/vo/voxtype-hip/package.nix
+++ b/pkgs/by-name/vo/voxtype-hip/package.nix
@@ -1,0 +1,6 @@
+{
+  voxtype,
+  ...
+}@args:
+
+voxtype.override ({ hipSupport = true; } // removeAttrs args [ "voxtype" ])

--- a/pkgs/by-name/vo/voxtype-hip/package.nix
+++ b/pkgs/by-name/vo/voxtype-hip/package.nix
@@ -1,6 +1,7 @@
 {
   voxtype,
-  ...
 }@args:
 
-voxtype.override ({ hipSupport = true; } // removeAttrs args [ "voxtype" ])
+(voxtype.override ({ hipSupport = true; } // removeAttrs args [ "voxtype" ])).overrideAttrs (prev: {
+  passthru = removeAttrs prev.passthru [ "update-script" ];
+})

--- a/pkgs/by-name/vo/voxtype-onnx/package.nix
+++ b/pkgs/by-name/vo/voxtype-onnx/package.nix
@@ -1,0 +1,6 @@
+{
+  voxtype,
+  ...
+}@args:
+
+voxtype.override ({ onnxSupport = true; } // removeAttrs args [ "voxtype" ])

--- a/pkgs/by-name/vo/voxtype-onnx/package.nix
+++ b/pkgs/by-name/vo/voxtype-onnx/package.nix
@@ -1,6 +1,8 @@
 {
   voxtype,
-  ...
 }@args:
 
-voxtype.override ({ onnxSupport = true; } // removeAttrs args [ "voxtype" ])
+(voxtype.override ({ onnxSupport = true; } // removeAttrs args [ "voxtype" ])).overrideAttrs
+  (prev: {
+    passthru = removeAttrs prev.passthru [ "update-script" ];
+  })

--- a/pkgs/by-name/vo/voxtype-vulkan/package.nix
+++ b/pkgs/by-name/vo/voxtype-vulkan/package.nix
@@ -1,0 +1,6 @@
+{
+  voxtype,
+  ...
+}@args:
+
+voxtype.override ({ vulkanSupport = true; } // removeAttrs args [ "voxtype" ])

--- a/pkgs/by-name/vo/voxtype-vulkan/package.nix
+++ b/pkgs/by-name/vo/voxtype-vulkan/package.nix
@@ -1,6 +1,8 @@
 {
   voxtype,
-  ...
 }@args:
 
-voxtype.override ({ vulkanSupport = true; } // removeAttrs args [ "voxtype" ])
+(voxtype.override ({ vulkanSupport = true; } // removeAttrs args [ "voxtype" ])).overrideAttrs
+  (prev: {
+    passthru = removeAttrs prev.passthru [ "update-script" ];
+  })

--- a/pkgs/by-name/vo/voxtype/package.nix
+++ b/pkgs/by-name/vo/voxtype/package.nix
@@ -54,6 +54,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "voxtype";
   version = "0.7.5";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "peteonrails";
     repo = "voxtype";

--- a/pkgs/by-name/vo/voxtype/package.nix
+++ b/pkgs/by-name/vo/voxtype/package.nix
@@ -173,7 +173,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     downloadPage = "https://voxtype.io/download/";
     changelog = "https://github.com/peteonrails/voxtype/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ DuskyElf ];
+    maintainers = with lib.maintainers; [
+      DuskyElf
+      pbek
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "voxtype";
   };

--- a/pkgs/by-name/vo/voxtype/package.nix
+++ b/pkgs/by-name/vo/voxtype/package.nix
@@ -36,6 +36,10 @@
   onnxSupport ? false,
   onnxruntime,
 
+  hipSupport ? false,
+  rocmPackages,
+  rocmGpuTargets ? builtins.concatStringsSep ";" rocmPackages.clr.gpuTargets,
+
   waylandSupport ? stdenv.hostPlatform.isLinux,
   waylandRuntimePackages ? [
     dotool
@@ -68,6 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildFeatures =
     [ ]
     ++ lib.optionals vulkanSupport [ "gpu-vulkan" ]
+    ++ lib.optionals hipSupport [ "gpu-hipblas" ]
     ++ lib.optionals onnxSupport [
       "parakeet-load-dynamic"
       "moonshine"
@@ -85,6 +90,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     makeBinaryWrapper
     pkg-config
   ]
+  ++ lib.optionals hipSupport [
+    rocmPackages.clr
+  ]
   ++ lib.optionals vulkanSupport [
     shaderc
     vulkan-headers
@@ -95,6 +103,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     alsa-lib
     openssl
   ]
+  ++ lib.optionals hipSupport (
+    with rocmPackages;
+    [
+      clr
+      hipblas
+      rocblas
+    ]
+  )
   ++ lib.optionals vulkanSupport [
     vulkan-headers
     vulkan-loader
@@ -112,6 +128,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     RUSTFLAGS = lib.optionalString (
       stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64
     ) "-C target-cpu=x86-64-v3";
+  }
+  // lib.optionalAttrs hipSupport {
+    HIP_PATH = "${rocmPackages.clr}";
+    AMDGPU_TARGETS = rocmGpuTargets;
   };
 
   preBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2940,9 +2940,6 @@ with pkgs;
   vimpager = callPackage ../tools/misc/vimpager { };
   vimpager-latest = callPackage ../tools/misc/vimpager/latest.nix { };
 
-  voxtype-vulkan = callPackage ../by-name/vo/voxtype/package.nix { vulkanSupport = true; };
-  voxtype-onnx = callPackage ../by-name/vo/voxtype/package.nix { onnxSupport = true; };
-
   openconnectPackages = {
     inherit openconnect openconnect_openssl;
   };


### PR DESCRIPTION
voxtype-vulkan is terribly slow on my AMD Radeon RX 7900 XT graphics card.
I want to suggest adding a HIP variant that runs very fast on AMD graphic cards.
I named it `voxtype-hip`.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
