### PR TITLE
rad-key: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/by-name/ra/rad-key/package.nix
+++ b/pkgs/by-name/ra/rad-key/package.nix
@@ -1,23 +1,32 @@
 {
   lib,
-  rustPlatform,
+  stdenvNoCC,
   fetchFromRadicle,
+  zig_0_16,
   versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+let
+  zig = zig_0_16;
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "rad-key";
-  version = "0.1.1";
+  version = "0.2.0";
+
   __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromRadicle {
     seed = "radicle.defelo.de";
     repo = "zFF3JpT1VrrsDYogDPtVZMHw6P4x";
     tag = "releases/${finalAttrs.version}";
-    hash = "sha256-0lPVkgBHfIG4fF/JuEnRznnHR9VaX91UBjmHqoFj2rk=";
+    hash = "sha256-l0PJo8unFWgBu+0NofjjryWsQx3RcT0oPHe/j2YEZW0=";
   };
 
-  cargoHash = "sha256-W/4h+hvsmydZim4HrylLWADINRcwP8cOgoBtPbuSxKY=";
+  nativeBuildInputs = [ zig ];
+
+  doCheck = true;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
@@ -27,6 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Convert between Radicle identities and public SSH keys";
     homepage = "https://radicle.defelo.de/nodes/radicle.defelo.de/rad:zFF3JpT1VrrsDYogDPtVZMHw6P4x";
+    changelog = "https://radicle.defelo.de/nodes/radicle.defelo.de/rad:zFF3JpT1VrrsDYogDPtVZMHw6P4x/tree/CHANGELOG.md";
     license = lib.licenses.mit;
     teams = [ lib.teams.radicle ];
     mainProgram = "rad-key";


### PR DESCRIPTION
Changelog: https://radicle.defelo.de/nodes/radicle.defelo.de/rad:zFF3JpT1VrrsDYogDPtVZMHw6P4x/tree/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
