### PR TITLE
nix-easy-search: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26208,6 +26208,11 @@
     githubId = 5512096;
     name = "Sébastien Guimmara";
   };
+  sh0rtround = {
+    github = "Sh0rtRound-wq";
+    githubId = 97189175;
+    name = "Sh0rtRound";
+  };
   shadaj = {
     github = "shadaj";
     githubId = 543055;

--- a/pkgs/by-name/ni/nix-easy-search/package.nix
+++ b/pkgs/by-name/ni/nix-easy-search/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "nix-easy-search";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Sh0rtRound-wq";
+    repo = "NixEasySearch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LvWXZlTUVVJpcjKdVDojyuw246RgOm9dDh9LgWAT49I=";
+  };
+
+  vendorHash = null;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postInstall = ''
+    mv $out/bin/nix-easy-search $out/bin/nes
+  '';
+
+  meta = {
+    description = "Fast NixOS package search CLI with clean output";
+    homepage = "https://github.com/Sh0rtRound-wq/NixEasySearch";
+    license = lib.licenses.mit;
+    mainProgram = "nes";
+    maintainers = [ lib.maintainers.sh0rtround ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
  Add `nix-easy-search` (CLI: `nes`), a fast NixOS package search tool written in Go. Also adds myself        
  (`sh0rtround`) as a maintainer.                                                                             
                                                                                                              
  Homepage: https://github.com/Sh0rtRound-wq/NixEasySearch                                                    
                  
  AI disclosure: package.nix was written with AI assistance (Claude). I have reviewed all content for         
  correctness before submission.
                                                                                                              
  ## Things done  

  - Built on platform:                                                                                        
    - [x] x86_64-linux
    - [ ] aarch64-linux                                                                                       
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].                                                                     
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.                         
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].                                          
  - [X] Tested basic functionality of all binary files, usually in `./result/bin/`.                           
  - Nixpkgs Release Notes                                                                                     
    - [ ] Package update: when the change is major or breaking.                                               
  - NixOS Release Notes                                                                                       
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.                                                      
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].                                                                   
                  
  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests                           
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage                                       
  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md                             
  [automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests                                         
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests                                     
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test  