### PR TITLE
garble: 1.15.0 -> 1.17.0

### DIFF
--- a/pkgs/by-name/ga/garble/0001-Add-version-info.patch
+++ b/pkgs/by-name/ga/garble/0001-Add-version-info.patch
@@ -1,13 +1,17 @@
+diff --git a/main.go b/main.go
+index 6ef2dc50c1..0083d75a3b 100644
 --- a/main.go
 +++ b/main.go
-@@ -370,6 +370,7 @@
- 			mod = mod.Replace
- 		}
+@@ -823,6 +823,7 @@
+ 		mod = mod.Replace
+ 	}
  
-+		mod.Version = "@version@"
- 		fmt.Printf("%s %s\n\n", mod.Path, mod.Version)
- 		fmt.Printf("Build settings:\n")
- 		for _, setting := range info.Settings {
++	mod.Version = "@version@"
+ 	fmt.Fprintf(w, "%s %s\n\n", mod.Path, mod.Version)
+ 	fmt.Fprintf(w, "Build settings:\n")
+ 	for _, setting := range info.Settings {
+diff --git a/testdata/script/help.txtar b/testdata/script/help.txtar
+index 8e4eb39a53..ddc48f59b0 100644
 --- a/testdata/script/help.txtar
 +++ b/testdata/script/help.txtar
 @@ -88,7 +88,7 @@

--- a/pkgs/by-name/ga/garble/package.nix
+++ b/pkgs/by-name/ga/garble/package.nix
@@ -1,23 +1,26 @@
 {
   lib,
   stdenv,
-  buildGo125Module,
+  buildGo126Module,
   fetchFromGitHub,
   git,
   versionCheckHook,
   replaceVars,
   nix-update-script,
 }:
-
-buildGo125Module (finalAttrs: {
+# garble has strict go version requirements; we should pin the go version
+# directly prior to the first unsupported version as described in the
+# `goVersionOK()` function
+# https://github.com/burrowers/garble/blob/v0.17.0/main.go#L536
+buildGo126Module (finalAttrs: {
   pname = "garble";
-  version = "0.15.0";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "burrowers";
     repo = "garble";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9Vjv5Eis+ALUm2aaXOj4i8w3UmylPggMXqgwXtD2YA8=";
+    hash = "sha256-yIdyvKxqlrYp77biXUiCrvMyTFStafkB+y5QF1M0CEg=";
   };
 
   __darwinAllowLocalNetworking = true;
@@ -32,12 +35,20 @@ buildGo125Module (finalAttrs: {
     })
   ];
 
-  checkFlags = [
-    "-skip"
-    "TestScript/gogarble|TestScript/gotoolchain|TestScript/tiny"
-  ];
+  checkFlags =
+    let
+      skippedTests = [
+        # tries to mess with the installed go toolchain
+        "TestScript/gotoolchain"
+        # requires parts of a 32-bit glibc on some platforms
+        "TestScript/atomic"
+        # passes an `-arch` flag to gcc which does not exist
+        "TestScript/crossbuild"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
-  vendorHash = "sha256-EOmAb2k9LSzsvumsCZdeJIDKQBJBeRFt15mWAyyVl1k=";
+  vendorHash = "sha256-F0Jc15ulA+qRDZu5W3FU9dZ+oXq8lGXP4dQeWnZwYbk=";
 
   # Used for some of the tests.
   nativeCheckInputs = [


### PR DESCRIPTION
https://github.com/burrowers/garble/releases/tag/v0.16.0
https://github.com/burrowers/garble/releases/tag/v0.17.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
