### PR TITLE
masterpdfeditor4: fix desktop file

### DIFF
--- a/pkgs/by-name/ma/masterpdfeditor4/package.nix
+++ b/pkgs/by-name/ma/masterpdfeditor4/package.nix
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
 
     substituteInPlace masterpdfeditor4.desktop \
-      --replace 'Exec=/opt/master-pdf-editor-4' "Exec=$out/bin" \
-      --replace 'Path=/opt/master-pdf-editor-4' "Path=$out/bin" \
-      --replace 'Icon=/opt/master-pdf-editor-4' "Icon=masterpdfeditor4"
+      --replace-fail 'Exec=/opt/master-pdf-editor-4/' "Exec=" \
+      --replace-fail 'Path=/opt/master-pdf-editor-4' "" \
+      --replace-fail 'Icon=/opt/master-pdf-editor-4/masterpdfeditor4.png' "Icon=masterpdfeditor4"
 
     install -Dm644 -t $out/share/icons/hicolor/128x128/apps masterpdfeditor4.png
     install -Dm644 -t $out/share/applications masterpdfeditor4.desktop


### PR DESCRIPTION
Fixes #551308
also cleanup of the store paths so we don't have odd garbage collecting problems
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
