### PR TITLE
python3Packages.opensimplex: 0.4.5 -> 0.4.5.1, migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/opensimplex/default.nix
+++ b/pkgs/development/python-modules/opensimplex/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromForgejo,
+  setuptools,
   numpy,
   pytestCheckHook,
 }:
@@ -9,7 +10,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "opensimplex";
   version = "0.4.5.1";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -22,7 +23,9 @@ buildPythonPackage (finalAttrs: {
     sha256 = "sha256-pM/vazhFfMip4G31Zj6jv02lEGVYymYCpCVz6sGBwVw=";
   };
 
-  propagatedBuildInputs = [ numpy ];
+  build-system = [ setuptools ];
+
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [ pytestCheckHook ];
   enabledTestPaths = [ "tests/test_opensimplex.py" ];

--- a/pkgs/development/python-modules/opensimplex/default.nix
+++ b/pkgs/development/python-modules/opensimplex/default.nix
@@ -1,21 +1,23 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchFromForgejo,
   numpy,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "opensimplex";
-  version = "0.4.5";
+  version = "0.4.5.1";
   format = "setuptools";
 
-  src = fetchFromGitHub {
+  src = fetchFromForgejo {
+    domain = "code.larus.se";
     owner = "lmas";
     repo = "opensimplex";
     rev = "v${version}";
-    sha256 = "sha256-pxPak0H6Rh9KwhIsrnMvBFm1uF5XKb4B3H9cN6DM0g4=";
+    forceFetchGit = true;
+    sha256 = "sha256-pM/vazhFfMip4G31Zj6jv02lEGVYymYCpCVz6sGBwVw=";
   };
 
   propagatedBuildInputs = [ numpy ];

--- a/pkgs/development/python-modules/opensimplex/default.nix
+++ b/pkgs/development/python-modules/opensimplex/default.nix
@@ -11,6 +11,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.4.5.1";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromForgejo {
     domain = "code.larus.se";
     owner = "lmas";

--- a/pkgs/development/python-modules/opensimplex/default.nix
+++ b/pkgs/development/python-modules/opensimplex/default.nix
@@ -6,7 +6,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "opensimplex";
   version = "0.4.5.1";
   format = "setuptools";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     domain = "code.larus.se";
     owner = "lmas";
     repo = "opensimplex";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     forceFetchGit = true;
     sha256 = "sha256-pM/vazhFfMip4G31Zj6jv02lEGVYymYCpCVz6sGBwVw=";
   };
@@ -38,4 +38,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ emilytrau ];
   };
-}
+})


### PR DESCRIPTION
- [0.4.5 -> 0.4.5.1](https://code.larus.se/lmas/opensimplex/compare/v0.4.5...v0.4.5.1), no functional changes
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
