### PR TITLE
telego: init at 0.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25832,6 +25832,12 @@
     githubId = 12714892;
     name = "Thomas Jasny";
   };
+  scratch-net = {
+    email = "telego.support@proton.me";
+    github = "Scratch-net";
+    githubId = 7219414;
+    name = "Alex";
+  };
   screendriver = {
     email = "nix@echooff.de";
     github = "screendriver";

--- a/pkgs/by-name/te/telego/package.nix
+++ b/pkgs/by-name/te/telego/package.nix
@@ -1,0 +1,55 @@
+{
+  buildGo127Module,
+  fetchFromGitHub,
+  lib,
+  versionCheckHook,
+}:
+
+# Telego requires Go 1.27 in go.mod.
+buildGo127Module (finalAttrs: {
+  pname = "telego";
+  version = "0.5.4";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Scratch-net";
+    repo = "telego";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VY8rwxVdJy3x0W547yJBOC/m3XioAC/DZ/iBJONTgE0=";
+  };
+
+  vendorHash = "sha256-1DOS0O2lB3ByEp/x+1TwvreBjqA+C8X7W2Ch4jdLZ74=";
+
+  subPackages = [ "cmd/telego" ];
+
+  # Build only the command, but run the complete repository test suite.
+  preCheck = ''
+    unset subPackages
+  '';
+
+  tags = [
+    "poll_opt"
+    "gc_opt"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "High-performance Telegram MTProxy with TLS fronting and WEB protocol support";
+    homepage = "https://github.com/Scratch-net/telego";
+    changelog = "https://github.com/Scratch-net/telego/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "telego";
+    maintainers = with lib.maintainers; [ scratch-net ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Package telEgo, a high-performance Telegram MTProxy written in Go with TLS fronting and WEB protocol support.

The package uses Go 1.27 as required by `go.mod`. Its check phase runs the complete repository test suite, and the install check verifies `telego version`.

Homepage: https://github.com/Scratch-net/telego

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
