### PR TITLE
tetrio-plus: 0.27.7 -> 0.28.1, update tpsecore wasm source, tpsecore: 0.1.1 -> 0.1.1-unstable-2026-04-06

### DIFF
--- a/pkgs/by-name/te/tetrio-plus/package.nix
+++ b/pkgs/by-name/te/tetrio-plus/package.nix
@@ -13,19 +13,19 @@
 }:
 
 let
-  version = "0.27.7";
+  version = "0.28.1";
   tag = "electron-v${version}-tetrio-v${tetrio-desktop.version}";
 
   src = fetchFromGitLab {
     owner = "UniQMG";
     repo = "tetrio-plus";
     inherit tag;
-    hash = "sha256-AEn1TrC0hUVRgfL2QZ5TMN8pTOm36zpHr2b/LqQp5RY=";
+    hash = "sha256-+yOqHH/RtzjVKHVpVsw2RhECMskCyAyWnjBJNslbGaw=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/resources/desktop-ci/yarn.lock";
-    hash = "sha256-LfUC2bkUX+sFq3vMMOC1YVYbpDxUSnLO9GiKdoQBdAw=";
+    hash = "sha256-ZU4ObEpJwnC71V5IemG5XWNbX/xvlWdKsXulus7ec5A=";
   };
 
 in
@@ -106,6 +106,5 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     maintainers = with lib.maintainers; [ huantian ];
     platforms = lib.platforms.linux;
-    broken = true; # not yet updated for tetrio-desktop v10
   };
 })

--- a/pkgs/by-name/te/tetrio-plus/package.nix
+++ b/pkgs/by-name/te/tetrio-plus/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r $src out/tetrioplus
     chmod -R u+w out/tetrioplus
     # Install tpsecore
-    cp ${tpsecore}/{tpsecore_bg.wasm,tpsecore.js} out/tetrioplus/source/lib/
+    cp ${tpsecore}/{tpsecore.wasm,tpsecore.js} out/tetrioplus/source/lib/
 
     # Disable useless uninstall button in the tetrio-plus popup
     substituteInPlace out/tetrioplus/desktop-manifest.js \

--- a/pkgs/by-name/tp/tpsecore/package.nix
+++ b/pkgs/by-name/tp/tpsecore/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitLab,
+  nix-update-script,
   rustPlatform,
   rustc,
   writableTmpDirAsHomeHook,
@@ -47,6 +48,8 @@ rustPlatform.buildRustPackage {
   '';
 
   doCheck = false;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Self contained toolkit for creating, editing, and previewing TPSE files";

--- a/pkgs/by-name/tp/tpsecore/package.nix
+++ b/pkgs/by-name/tp/tpsecore/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitLab,
   rustPlatform,
   rustc,
+  writableTmpDirAsHomeHook,
   binaryen,
 }:
 
@@ -22,13 +23,14 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     binaryen
     rustc.llvmPackages.lld
+    writableTmpDirAsHomeHook
   ];
 
   buildPhase = ''
     runHook preBuild
 
-    HOME=$(mktemp -d) cargo build --profile release \
-    --target wasm32-unknown-unknown --features wasm_rendering
+    cargo build --profile release \
+      --target wasm32-unknown-unknown --features wasm_rendering
 
     runHook postBuild
   '';

--- a/pkgs/by-name/tp/tpsecore/package.nix
+++ b/pkgs/by-name/tp/tpsecore/package.nix
@@ -3,30 +3,23 @@
   fetchFromGitLab,
   rustPlatform,
   rustc,
-  wasm-pack,
-  wasm-bindgen-cli_0_2_95,
   binaryen,
 }:
 
-let
-  version = "0.1.1";
-in
 rustPlatform.buildRustPackage {
   pname = "tpsecore";
-  inherit version;
+  version = "0.1.1-unstable-2026-04-06";
 
   src = fetchFromGitLab {
     owner = "UniQMG";
     repo = "tpsecore";
-    rev = "v${version}";
-    hash = "sha256-+OynnLMBEiYwdFzxGzgkcBN6xrHoH1Q6O5i+OW7RBLo=";
+    rev = "549767cac60df6f887f6012fa5d26ca12d55a2eb";
+    hash = "sha256-nnekiqs9W7oOl0/yjuQI83MsRgRZRrgipnwIbhRdLW8=";
   };
 
-  cargoHash = "sha256-EM/THiR0NV4N3mFGjRYe1cpaF82rCYnOPLxv67BronU=";
+  cargoHash = "sha256-rJDy0gbtIGM5q6w0tfgIE09HW1lQ9pEL9o+LSdX6RyU=";
 
   nativeBuildInputs = [
-    wasm-pack
-    wasm-bindgen-cli_0_2_95
     binaryen
     rustc.llvmPackages.lld
   ];
@@ -34,7 +27,8 @@ rustPlatform.buildRustPackage {
   buildPhase = ''
     runHook preBuild
 
-    HOME=$(mktemp -d) wasm-pack build --target web --release
+    HOME=$(mktemp -d) cargo build --profile release \
+    --target wasm32-unknown-unknown --features wasm_rendering
 
     runHook postBuild
   '';
@@ -42,7 +36,10 @@ rustPlatform.buildRustPackage {
   installPhase = ''
     runHook preInstall
 
-    cp -r pkg/ $out
+    mkdir -p $out
+
+    cp target/wasm32-unknown-unknown/release/tpsecore.wasm $out/
+    cp tpsecore.js $out/
 
     runHook postInstall
   '';


### PR DESCRIPTION
bumps tetrio-plus (and its tpsecore wasm source name) and updates tpsecore's build instructions to match [the build script at UniQMG/tetrio-plus (GitLab)](https://gitlab.com/UniQMG/tetrio-plus/-/blob/master/scripts/build.sh). fixes the problem blocking #509295, which has been stalled since may of this year and has no response within 10 days of comment.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
