### PR TITLE
nixos/paperless: Add option to setup extra domains

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -375,6 +375,21 @@ in
       description = "Domain under which paperless will be available.";
     };
 
+    extraDomains = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      example = [
+        "paperless-alt-domain.example.com"
+        "paperless-another-domain.example.com"
+      ];
+      description = ''
+        Extra domains under which paperless will be available.
+
+        The primary {option}`services.paperless.domain` doesn't need
+        to be repeated here, but it needs to be set.
+      '';
+    };
+
     exporter = {
       enable = lib.mkEnableOption "regular automatic document exports";
 
@@ -434,6 +449,10 @@ in
             assertion = cfg.configureNginx -> cfg.domain != null;
             message = "${opt.configureNginx} requires ${opt.domain} to be configured.";
           }
+          {
+            assertion = (cfg.extraDomains != [ ]) -> cfg.domain != null;
+            message = "${opt.extraDomains} requires ${opt.domain} to be configured.";
+          }
         ];
 
         services.paperless.manage = manage;
@@ -444,6 +463,7 @@ in
           upstreams.paperless.servers."${cfg.address}:${toString cfg.port}" = { };
           virtualHosts.${cfg.domain} = {
             forceSSL = lib.mkDefault true;
+            serverAliases = cfg.extraDomains;
             locations = {
               "/".proxyPass = "http://paperless";
               "/static/" = {
@@ -476,6 +496,14 @@ in
         services.paperless.settings = lib.mkMerge [
           (lib.mkIf (cfg.domain != null) {
             PAPERLESS_URL = "https://${cfg.domain}";
+          })
+          (lib.mkIf (cfg.extraDomains != [ ]) {
+            PAPERLESS_CSRF_TRUSTED_ORIGINS = lib.mkDefault (
+              lib.concatMapStringsSep "," (d: "https://${d}") cfg.extraDomains
+            );
+            PAPERLESS_CORS_ALLOWED_HOSTS = lib.mkDefault (
+              lib.concatMapStringsSep "," (d: "https://${d}") cfg.extraDomains
+            );
           })
           (lib.mkIf cfg.database.createLocally {
             PAPERLESS_DBENGINE = "postgresql";

--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -23,6 +23,10 @@
                 enable = true;
                 configureNginx = true;
                 domain = "localhost";
+                extraDomains = [
+                  "paperless1.example.com"
+                  "paperless2.example.com"
+                ];
                 passwordFile = builtins.toFile "password" "admin";
 
                 exporter = {
@@ -55,6 +59,13 @@
 
     def test_paperless(node):
       node.wait_for_unit("paperless-consumer.service")
+
+      with subtest("Extra domains are configured correctly"):
+        nginx_conf = node.succeed("cat /etc/nginx/nginx.conf")
+        assert "server_name localhost paperless1.example.com paperless2.example.com;" in nginx_conf, "extraDomains missing from server_name"
+
+        origins = node.succeed("systemctl show paperless-web -p Environment | grep -o 'PAPERLESS_CSRF_TRUSTED_ORIGINS=[^ ]*'").strip()
+        assert origins == "PAPERLESS_CSRF_TRUSTED_ORIGINS=https://paperless1.example.com,https://paperless2.example.com"
 
       with subtest("Add a document via the file system"):
         node.succeed(


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds an option to the paperless-ngx module to make the application work under multiple domains. While you could serve the application under multiple domains without this change, most actions would fail due to CSRF blocks, this fixes that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
