### PR TITLE
tcl: fix build on Darwin

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -94,7 +94,13 @@ stdenv.mkDerivation (finalAttrs: {
   autoreconfFlags = "--force --verbose";
 
   configureFlags = [
-    "tcl_cv_sys_version=${stdenv.hostPlatform.uname.system}"
+    # tcl_cv_sys_version is intended to be set to `$(uname -s)-$(uname -r)`.
+    "tcl_cv_sys_version=${
+      lib.concatStringsSep "-" [
+        stdenv.hostPlatform.uname.system
+        (lib.optionalString (stdenv.hostPlatform.uname.release != null) stdenv.hostPlatform.uname.release)
+      ]
+    }"
     # During cross compilation, the tcl build system assumes that libc
     # functions are broken if it cannot test if they are broken or not and
     # then causes a link error on static platforms due to symbol conflict.


### PR DESCRIPTION
`tcl_cv_sys_version` is intended to be set to `$(uname -s)-$(uname -r)`,
but we were only passing effectively `$(uname -s)`.

## Things done



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
