### PR TITLE
whatcable: 1.2.1 -> 1.4.0

### DIFF
--- a/pkgs/by-name/wh/whatcable/package.nix
+++ b/pkgs/by-name/wh/whatcable/package.nix
@@ -10,14 +10,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "whatcable";
-  version = "1.2.1";
+  version = "1.4.0";
 
   strictDeps = true;
   __structuredAttrs = true;
 
   src = fetchzip {
     url = "https://github.com/darrylmorley/whatcable/releases/download/v${finalAttrs.version}/WhatCable.zip";
-    hash = "sha256-znu0y7rj7HYxTs3Kr9hR44461NoROMKGX0KHsaNfAes=";
+    hash = "sha256-5m1cdmkNppkPCigMi5nk0d//DYiXL0R5wsBWVLF8JL8=";
   };
 
   dontPatch = true;


### PR DESCRIPTION
## Package update

- Version: `1.2.1` -> `1.4.0`
- Upstream release: https://github.com/darrylmorley/whatcable/releases/tag/v1.4.0
- Nixpkgs base: `d7e1d8887d64030909906145070134b0b2acd7d9`

## Verification

- Update: `nix-shell -I nixpkgs=. maintainers/scripts/update.nix --argstr package whatcable --arg commit true --arg skip-prompt true`
- Build: `nix-build --no-out-link -A whatcable` on `aarch64-darwin`
- Package check: `whatcable-cli`

This draft was generated by Tyce Herrman's fork-only Darwin maintainer workflow and requires manual review.