### PR TITLE
openlogi: bundle the agent on darwin

### DIFF
--- a/pkgs/by-name/op/openlogi/package.nix
+++ b/pkgs/by-name/op/openlogi/package.nix
@@ -93,8 +93,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoBuildFlags = [
     "--package=openlogi"
     "--package=openlogi-gui"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
     "--package=openlogi-agent"
   ];
 
@@ -121,7 +119,28 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     mkdir -p "$out/Applications" "$out/bin"
     mv "$app_path" "$out/Applications/"
+
+    # The GUI can only auto-start the agent from a login-item helper nested in
+    # its own bundle, resolved relative to its own executable (the layout
+    # upstream's `xtask macos bundle` assembles for the DMG).
+    helper="$out/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app"
+
     install -Dm755 "$release_target/openlogi" "$out/bin/openlogi"
+    install -Dm755 "$release_target/openlogi-agent" "$helper/Contents/MacOS/openlogi-agent"
+    ln -s "$helper/Contents/MacOS/openlogi-agent" "$out/bin/openlogi-agent"
+
+    # Upstream's own packaging inputs, installed verbatim rather than
+    # re-authored here (they are what `xtask macos bundle` puts in the DMG).
+    install -Dm644 crates/openlogi-gui/bundle/agent-release/Info.plist \
+      "$helper/Contents/Info.plist"
+
+    # The plist ships a 0.0.0 version sentinel (xtask stamps it at bundle
+    # time); stamp the package version instead.
+    substituteInPlace "$helper/Contents/Info.plist" \
+      --replace-fail "<string>0.0.0</string>" "<string>${finalAttrs.version}</string>"
+
+    install -Dm644 crates/openlogi-gui/icon/AppIcon.icns \
+      "$helper/Contents/Resources/AppIcon.icns"
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     install -Dm755 "$release_target/openlogi" "$out/bin/openlogi"


### PR DESCRIPTION
**Motivation:** Until now, the Darwin package shipped only the CLI and the GUI. The GUI is a pure IPC client that can only auto-start the background agent from a login-item helper nested in its own bundle (`crates/openlogi-gui/src/ipc_client.rs`, `agent_binary_path`), so the app opened to "Can't reach the background service" and retried forever.

**What was done:** Builds `openlogi-agent` on every platform (Linux already did). On Darwin, embeds it as the login-item helper the GUI launches from inside its own bundle (`Contents/Library/LoginItems/OpenLogiAgent.app`), the layout upstream's `xtask macos bundle` produces for the DMG, and links `bin/openlogi-agent` to it.

**Related:**

- #554233 bumps the version and touches only `version` and the two hashes, so the two changes are independent. Note for that bump: from upstream v0.8.2 the GUI starts the agent through `SMAppService`, which additionally needs the service plist in `Contents/Library/LaunchAgents`.
- A user of the package reports having had to bundle the agent by hand and asks for the package to do it: https://github.com/NixOS/nixpkgs/pull/554233#issuecomment-5402767570

**Disclosure:** drafted with Claude Code (Claude Fable 5); I reviewed and tested every part.

cc @imcvampire

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin (sandboxed)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (`nixpkgs-review wip --staged` on aarch64-darwin: 1 package built, no dependents)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`openlogi --version`; launched `OpenLogi.app`: it found and started the embedded agent and completed the IPC handshake, on an MX Master 3S over Bluetooth)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
