### PR TITLE
nixos/tests/grub: restrict to buildable platforms, and small aarch64-linux fixes

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -93,6 +93,10 @@ let
     makeTest {
       name = "boot-" + name;
       nodes = { };
+      meta = {
+        # NixOS VM tests cannot run on darwin.
+        platforms = lib.platforms.linux;
+      };
       testScript = ''
         machine = create_machine("${startCommand}")
         machine.start()
@@ -147,6 +151,10 @@ let
     makeTest {
       name = "boot-netboot-" + name;
       nodes = { };
+      meta = {
+        # NixOS VM tests cannot run on darwin.
+        platforms = lib.platforms.linux;
+      };
       testScript = ''
         machine = create_machine("${startCommand}")
         machine.start()

--- a/nixos/tests/bootspec.nix
+++ b/nixos/tests/bootspec.nix
@@ -49,6 +49,8 @@ in
   grub = makeTest {
     name = "grub-with-bootspec";
     meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+    # NixOS VM tests cannot run on darwin.
+    meta.platforms = pkgs.lib.platforms.linux;
 
     nodes.machine = {
       imports = [
@@ -69,6 +71,8 @@ in
   legacy-boot = makeTest {
     name = "legacy-boot-with-bootspec";
     meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+    # NixOS VM tests cannot run on darwin.
+    meta.platforms = pkgs.lib.platforms.linux;
 
     nodes.machine = {
       imports = [

--- a/nixos/tests/grub/basic.nix
+++ b/nixos/tests/grub/basic.nix
@@ -20,8 +20,10 @@
         enable = true;
         users.alice.password = "supersecret";
 
-        # OCR is not accurate enough
-        extraConfig = "serial; terminal_output serial";
+        # OCR is not accurate enough. Use GRUB's own serial terminal and the
+        # "dumb" terminfo type so the menu is emitted as plain sequential text
+        # without cursor-address or clear-screen escape sequences.
+        extraConfig = "serial; terminal_output serial; terminfo serial dumb";
       };
     };
 

--- a/nixos/tests/grub/basic.nix
+++ b/nixos/tests/grub/basic.nix
@@ -4,6 +4,10 @@
 
   meta = with lib.maintainers; {
     maintainers = [ rnhmjoj ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
   };
 
   nodes.machine =

--- a/nixos/tests/grub/efi.nix
+++ b/nixos/tests/grub/efi.nix
@@ -7,6 +7,7 @@
       tomfitzhenry
       rnhmjoj
     ];
+    platforms = lib.platforms.linux;
   };
 
   nodes.machine =

--- a/nixos/tests/grub/efi.nix
+++ b/nixos/tests/grub/efi.nix
@@ -22,7 +22,15 @@
 
         # Read GRUB from the serial console so its output can be matched
         # deterministically with wait_for_console_text, rather than via OCR.
-        extraConfig = "serial; terminal_output serial";
+        #
+        # GRUB's own "serial" terminal (8250/16550 COM ports) only exists on
+        # x86. On EFI, GRUB exposes the platform serial via the EFI SerialIO
+        # protocol as the terminfo terminal "serial_efi0", which EDK2 routes
+        # to the serial port the test reads; this works on both x86_64 and
+        # aarch64. We switch it to the "dumb" terminfo type so GRUB emits
+        # plain sequential text without cursor-address or clear-screen escape
+        # sequences, keeping the console log linear and readable.
+        extraConfig = "terminal_output serial_efi0; terminfo serial_efi0 dumb";
       };
       boot.loader.efi.canTouchEfiVariables = true;
     };

--- a/nixos/tests/grub/graphical.nix
+++ b/nixos/tests/grub/graphical.nix
@@ -7,6 +7,10 @@
       tomfitzhenry
       rnhmjoj
     ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
   };
 
   nodes.machine =

--- a/nixos/tests/grub/hashed-password.nix
+++ b/nixos/tests/grub/hashed-password.nix
@@ -34,8 +34,10 @@
 
         # Read GRUB from the serial console so its output can be matched
         # deterministically; OCR would work but is flakier, which matters for
-        # the multi-step interactive login exercised below.
-        extraConfig = "serial; terminal_output serial";
+        # the multi-step interactive login exercised below. Use the "dumb"
+        # terminfo type so the menu is emitted as plain sequential text
+        # without cursor-address or clear-screen escape sequences.
+        extraConfig = "serial; terminal_output serial; terminfo serial dumb";
       };
     };
 

--- a/nixos/tests/grub/hashed-password.nix
+++ b/nixos/tests/grub/hashed-password.nix
@@ -7,6 +7,10 @@
       tomfitzhenry
       rnhmjoj
     ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
   };
 
   nodes.machine =

--- a/nixos/tests/grub/mirrored-boots.nix
+++ b/nixos/tests/grub/mirrored-boots.nix
@@ -7,6 +7,10 @@
       tomfitzhenry
       rnhmjoj
     ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
   };
 
   nodes.machine =

--- a/nixos/tests/grub/mirrored-boots.nix
+++ b/nixos/tests/grub/mirrored-boots.nix
@@ -35,7 +35,10 @@
 
         # Read GRUB from the serial console so its output can be matched
         # deterministically with wait_for_console_text, rather than via OCR.
-        extraConfig = "serial; terminal_output serial";
+        # Use the "dumb" terminfo type so the menu is emitted as plain
+        # sequential text without cursor-address or clear-screen escape
+        # sequences.
+        extraConfig = "serial; terminal_output serial; terminfo serial dumb";
       };
     };
 

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -46,7 +46,19 @@ let
         boot.initrd.systemd.enable = ${boolToString systemdStage1};
 
         ${optionalString (bootLoader == "grub") ''
-          boot.loader.grub.extraConfig = "serial; terminal_output serial";
+          # Read GRUB from the serial console so its output can be matched
+          # deterministically with wait_for_console_text. GRUB's own "serial"
+          # terminal (8250/16550 COM ports) only exists on x86; on EFI, GRUB
+          # exposes the platform serial via the EFI SerialIO protocol as the
+          # terminfo terminal "serial_efi0", which EDK2 routes to the serial
+          # port. Use the "dumb" terminfo type so the menu is emitted as
+          # plain sequential text without cursor-address or clear-screen
+          # escape sequences.
+          boot.loader.grub.extraConfig =
+            if grubUseEfi then
+              "terminal_output serial_efi0; terminfo serial_efi0 dumb"
+            else
+              "serial; terminal_output serial; terminfo serial dumb";
           ${
             if grubUseEfi then
               ''

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -686,11 +686,16 @@ let
       meta = {
         # put global maintainers here, individuals go into makeInstallerTest fkt call
         maintainers = (meta.maintainers or [ ]);
-        # non-EFI tests can only run on x86
-        platforms = mkIf (!isEfi) [
-          "x86_64-linux"
-          "i686-linux"
-        ];
+        # NixOS VM tests cannot run on darwin. Non-EFI tests can only run on
+        # x86.
+        platforms =
+          if isEfi then
+            pkgs.lib.platforms.linux
+          else
+            [
+              "x86_64-linux"
+              "i686-linux"
+            ];
         inherit broken;
       };
       nodes =

--- a/nixos/tests/nixos-rebuild-install-bootloader.nix
+++ b/nixos/tests/nixos-rebuild-install-bootloader.nix
@@ -3,6 +3,11 @@ import ./make-test-python.nix (
   {
     name = "nixos-rebuild-install-bootloader";
 
+    meta = {
+      # NixOS VM tests cannot run on darwin.
+      platforms = lib.platforms.linux;
+    };
+
     nodes = {
       machine =
         { lib, pkgs, ... }:

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -69,6 +69,11 @@ import ./make-test-python.nix (
   {
     name = "os-prober";
 
+    meta = {
+      # NixOS VM tests cannot run on darwin.
+      platforms = lib.platforms.linux;
+    };
+
     nodes.machine =
       { config, pkgs, ... }:
       (

--- a/pkgs/by-name/gr/grub2/package.nix
+++ b/pkgs/by-name/gr/grub2/package.nix
@@ -745,6 +745,7 @@ stdenv.mkDerivation rec {
     nixos-install-simple = nixosTests.installer.simple;
     nixos-install-grub-uefi = nixosTests.installer.simpleUefiGrub;
     nixos-install-grub-uefi-spec = nixosTests.installer.simpleUefiGrubSpecialisation;
+    nixos-os-prober = nixosTests.os-prober;
   };
 
   meta = {


### PR DESCRIPTION
While reviewing https://github.com/NixOS/nixpkgs/pull/481112 I noticed many GRUB failures, all of which were just test bugs.

See each commit for an explanation but in short:

* restrict legacy BIOS tests to x86
* restrict tests to Linux (no Darwin)
* fix some aarch64-linux tests by giving a working boot terminal, which the tests assert against.
* switch the terminal type to "dumb", so it renders plainly on qemu stdout, rather than outputting GRUB's terminal escape characters

I used DeepSeek v4 Flash for help with some diagnosis, and drafting commit messages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
