### PR TITLE
btrfs-assistant: 2.2 -> 2.3.1

### DIFF
--- a/pkgs/by-name/bt/btrfs-assistant/package.nix
+++ b/pkgs/by-name/bt/btrfs-assistant/package.nix
@@ -17,21 +17,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "btrfs-assistant";
-  version = "2.2";
+  version = "2.3.1";
 
   src = fetchFromGitLab {
     owner = "btrfs-assistant";
     repo = "btrfs-assistant";
     rev = finalAttrs.version;
-    hash = "sha256-hFWYT+YIgnqBigpPkGdsLj6rcg4CjJffAyXlR23QP0Y=";
+    hash = "sha256-sjqLmpiLdoV9wUxNqeBTzw4gkj5o0/guXzqp1uYhYnA=";
   };
 
   patches = [
-    # Disable -Werror
-    # https://gitlab.com/btrfs-assistant/btrfs-assistant/-/issues/134
+    # Avoid unprivileged crashes before command-line arguments are processed.
+    # https://gitlab.com/btrfs-assistant/btrfs-assistant/-/merge_requests/98
     (fetchpatch {
-      url = "https://gitlab.com/btrfs-assistant/btrfs-assistant/-/commit/edc0a13bac5189a1a910f5adab01b2d5b60c76f6.diff";
-      hash = "sha256-kGyp5OaSGk4OvhtyNSygJEW+wAJksK8opxtLPbhA+10=";
+      url = "https://gitlab.com/btrfs-assistant/btrfs-assistant/-/commit/5fb306c7871e5be63a8adf6fbce31c50fce7512b.diff";
+      hash = "sha256-JU9l611OoSOqKMI1cGRoFY9rnf1MC58DeMnI5vmAhKo=";
     })
   ];
 
@@ -39,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     git
     pkg-config
+    qt6.qttools
     qt6.wrapQtAppsHook
   ];
 
@@ -47,20 +48,17 @@ stdenv.mkDerivation (finalAttrs: {
     coreutils
     qt6.qtbase
     qt6.qtsvg
-    qt6.qttools
     qt6.qtwayland
     util-linux
   ]
   ++ lib.optionals enableSnapper [ snapper ];
 
-  prePatch = lib.optionalString enableSnapper ''
-    substituteInPlace src/main.cpp \
-      --replace-fail '/usr/bin/snapper' "${lib.getExe snapper}"
-  '';
-
   postPatch = ''
     substituteInPlace src/org.btrfs-assistant.pkexec.policy \
       --replace-fail '/usr/bin' "$out/bin"
+
+    substituteInPlace src/main.cpp \
+      --replace-fail '/usr/share/btrfs-assistant/translations' "$out/share/btrfs-assistant/translations"
 
     substituteInPlace src/btrfs-assistant \
       --replace-fail 'btrfs-assistant-bin' "$out/bin/btrfs-assistant-bin"
@@ -69,6 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'btrfs-assistant' "$out/bin/btrfs-assistant"
   ''
   + lib.optionalString enableSnapper ''
+    substituteInPlace src/main.cpp \
+      --replace-fail '/usr/bin/snapper' "${lib.getExe snapper}"
+
     substituteInPlace src/btrfs-assistant.conf \
       --replace-fail '/usr/bin/snapper' "${lib.getExe snapper}"
   '';


### PR DESCRIPTION

- [Changelog](https://gitlab.com/btrfs-assistant/btrfs-assistant/-/blob/2.3.1/changelog)
- Replaces the obsolete `-Werror` backport with the upstream fix for unprivileged CLI crashes.
- Uses the Nix store path for the new translation catalogs.

CLI smoke test: `btrfs-assistant-bin --version` and `--help` both exit 0 in headless mode.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
