### PR TITLE
nixos/zsh: add options for compinit dump file

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -21,6 +21,12 @@ let
     )
   );
 
+  compInitArgs =
+    if cfg.disableCompInitDumpFile then
+      " -D"
+    else
+      lib.optionalString (cfg.compInitDumpFile != null) " -d \"${cfg.compInitDumpFile}\"";
+
   zshStartupNotes = ''
     # Note that generated /etc/zprofile and /etc/zshrc files do a lot of
     # non-standard setup to make zsh usable with no configuration by default.
@@ -169,6 +175,26 @@ in
         type = lib.types.bool;
       };
 
+      compInitDumpFile = lib.mkOption {
+        default = null;
+        example = "$XDG_CACHE_HOME/zsh/zcompdump";
+        description = ''
+          Path passed to {command}`compinit` with the
+          `-d` option to set the completion dump file location.
+          If unset, `compinit` uses its default dump file.
+        '';
+        type = lib.types.nullOr lib.types.str;
+      };
+
+      disableCompInitDumpFile = lib.mkOption {
+        default = false;
+        description = ''
+          Disable reading and writing the completion dump file
+          by passing the `-D` option to {command}`compinit`.
+        '';
+        type = lib.types.bool;
+      };
+
       enableLsColors = lib.mkOption {
         default = true;
         description = ''
@@ -265,7 +291,7 @@ in
 
       ${lib.optionalString cfg.enableGlobalCompInit ''
         # Enable autocompletion.
-        autoload -U compinit && compinit
+        autoload -U compinit && compinit${compInitArgs}
       ''}
 
       ${lib.optionalString cfg.enableBashCompletion ''


### PR DESCRIPTION
Added options to configure how the NixOS Zsh module handles the compinit dump file.

`programs.zsh.compInitDumpFile` allows the user to specify the dump file location passed to compinit via `-d`. This is useful for keeping the generated `.zcompdump` file out of the home directory, for example by placing it under `$XDG_CACHE_HOME` instead.

`programs.zsh.disableCompInitDumpFile` disables the dump file entirely by passing `-D` to compinit.

Both options preserve the existing behavior by default, invoking compinit without additional arguments when left unconfigured.

*I am very open to suggestions on the option descriptions, how adding the arguments is handled, etc.*

Resolves #556921 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
