### PR TITLE
treewide: remove some superfluous definitions of CMAKE_BUILD_TYPE (just the trivial CMAKE_BUILD_TYPE=Release case)

### DIFF
--- a/pkgs/by-name/et/ete-unwrapped/package.nix
+++ b/pkgs/by-name/et/ete-unwrapped/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeDir = "../src";
   cmakeFlags = [
     (lib.cmakeBool "CROSS_COMPILE32" false)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_DEDSERVER" true)
     (lib.cmakeBool "BUILD_CLIENT" true)
     (lib.cmakeBool "BUILD_ETMAIN_MOD" true)

--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     (lib.cmakeBool "CROSS_COMPILE32" false)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_SERVER" true)
     (lib.cmakeBool "BUILD_CLIENT" true)
     (lib.cmakeBool "BUNDLED_WOLFSSL" false)

--- a/pkgs/by-name/fa/fastdds/package.nix
+++ b/pkgs/by-name/fa/fastdds/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DBUILD_SHARED_LIBS=ON"
     "-DSECURITY=ON"
     "-DCOMPILE_EXAMPLES=OFF"

--- a/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
+++ b/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
@@ -43,10 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
     (lib.cmakeBool "feather_tk_UI_LIB" true)
     (lib.cmakeFeature "feather_tk_API" "GL_4_1")

--- a/pkgs/by-name/fr/friction-graphics/package.nix
+++ b/pkgs/by-name/fr/friction-graphics/package.nix
@@ -70,7 +70,6 @@ clangStdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DQSCINTILLA_INCLUDE_DIRS=${libsForQt5.qscintilla}/include"
     "-DQSCINTILLA_LIBRARIES_DIRS=${libsForQt5.qscintilla}/lib/"
     "-DQSCINTILLA_LIBRARIES=${

--- a/pkgs/by-name/ip/ipu6-camera-hal/package.nix
+++ b/pkgs/by-name/ip/ipu6-camera-hal/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/pkgs/by-name/jf/jfbview/package.nix
+++ b/pkgs/by-name/jf/jfbview/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_TESTING" false)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "/") # relative to $out
   ];
 

--- a/pkgs/by-name/me/melodeon/package.nix
+++ b/pkgs/by-name/me/melodeon/package.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.wrapQtAppsHook
   ];
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   meta = {
     description = "QWebEngine wrapper for MaterialSkin on Lyrion Music Server (formerly Logitech Media Server)";
     mainProgram = "melodeon";

--- a/pkgs/by-name/or/orthanc-plugin-dicomweb/package.nix
+++ b/pkgs/by-name/or/orthanc-plugin-dicomweb/package.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DSTATIC_BUILD=OFF"
     "-DORTHANC_FRAMEWORK_SOURCE=system"
     "-DORTHANC_FRAMEWORK_ROOT=${orthanc.framework}/include/orthanc-framework"

--- a/pkgs/by-name/or/orthanc/package.nix
+++ b/pkgs/by-name/or/orthanc/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "DCMTK_DICTIONARY_DIR_AUTO" "${dcmtk}/share/dcmtk-${dcmtk.version}")
     (lib.cmakeFeature "DCMTK_LIBRARIES" "dcmjpls;oflog;ofstd")
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
 
     (lib.cmakeBool "BUILD_CONNECTIVITY_CHECKS" false)
     (lib.cmakeBool "UNIT_TESTS_WITH_HTTP_CONNEXIONS" false)

--- a/pkgs/by-name/os/oshu/package.nix
+++ b/pkgs/by-name/os/oshu/package.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlag = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DOSHU_DEFAULT_SKIN=minimal"
   ];
 

--- a/pkgs/by-name/pu/pulse-visualizer/package.nix
+++ b/pkgs/by-name/pu/pulse-visualizer/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-G Ninja"
     "-DCMAKE_CXX_COMPILER=clang++"
     "-DCMAKE_C_COMPILER=clang"
-    "-DCMAKE_BUILD_TYPE=Release"
   ];
 
   meta = {

--- a/pkgs/by-name/ql/qlever/package.nix
+++ b/pkgs/by-name/ql/qlever/package.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeFeature "LOGLEVEL" "INFO")
     (lib.cmakeBool "USE_PARALLEL" true)
     (lib.cmakeBool "_NO_TIMING_TESTS" true)

--- a/pkgs/by-name/sv/sview/package.nix
+++ b/pkgs/by-name/sv/sview/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DUSE_UPDATER=OFF"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_INSTALL_LIBDIR=/lib"
     "-DCMAKE_INSTALL_BINDIR=/bin"
     "-DCMAKE_INSTALL_DATAROOTDIR=/share"

--- a/pkgs/by-name/tu/turingdb/package.nix
+++ b/pkgs/by-name/tu/turingdb/package.nix
@@ -114,7 +114,6 @@ turingstdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "NIX_BUILD" true)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-fopenmp")
     (lib.cmakeFeature "CMAKE_EXE_LINKER_FLAGS" "-lgomp")
     (lib.cmakeFeature "FLEX_INCLUDE_DIR" "${lib.getDev flex}/include")

--- a/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
+++ b/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DUSE_SYSTEM_CPR=ON"
-    "-DCMAKE_BUILD_TYPE=Release"
   ];
 
   # Wrapper script because the things are hardcoded so we just

--- a/pkgs/by-name/vm/vmaware/package.nix
+++ b/pkgs/by-name/vm/vmaware/package.nix
@@ -22,10 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/wt/wtf/package.nix
+++ b/pkgs/by-name/wt/wtf/package.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "source/src";
 
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
-  ];
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/xl/xlink/package.nix
+++ b/pkgs/by-name/xl/xlink/package.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "XLINK_BUILD_EXAMPLES" true)
     (lib.cmakeBool "XLINK_BUILD_TESTS" true)
     (lib.cmakeBool "XLINK_LIBUSB_SYSTEM" true)
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
   ];
 
   postInstall = ''

--- a/pkgs/development/rocm-modules/hipcc/default.nix
+++ b/pkgs/development/rocm-modules/hipcc/default.nix
@@ -28,9 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "/usr/bin/lsb_release" "${lsb-release}/bin/lsb_release"
   '';
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
   postInstall = ''
     rm -r $out/hip/bin
     ln -s $out/bin $out/hip/bin

--- a/pkgs/development/rocm-modules/miopen/default.nix
+++ b/pkgs/development/rocm-modules/miopen/default.nix
@@ -215,7 +215,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DGPU_ARCHS=${lib.concatStringsSep ";" supportedTargets}"
     "-DCMAKE_VERBOSE_MAKEFILE=ON"
     "-DCMAKE_MODULE_PATH=${clr}/hip/cmake"
-    "-DCMAKE_BUILD_TYPE=Release"
 
     # needs to stream to stdout so bzcat rather than bunzip2
     "-DUNZIPPER=${bzip2}/bin/bzcat"

--- a/pkgs/development/rocm-modules/rccl/default.nix
+++ b/pkgs/development/rocm-modules/rccl/default.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DHIP_CLANG_NUM_PARALLEL_JOBS=4"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DROCM_PATH=${clr}"
     "-DHIP_COMPILER=${clr}/bin/amdclang++"
     "-DCMAKE_CXX_COMPILER=${clr}/bin/amdclang++"

--- a/pkgs/development/rocm-modules/rocshmem/default.nix
+++ b/pkgs/development/rocm-modules/rocshmem/default.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "CMAKE_POSITION_INDEPENDENT_CODE" true)
     (lib.cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
     (lib.cmakeFeature "ROCM_PATH" "${clr}")

--- a/pkgs/development/rocm-modules/rocsolver/default.nix
+++ b/pkgs/development/rocm-modules/rocsolver/default.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DHIP_CLANG_NUM_PARALLEL_JOBS=4"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_VERBOSE_MAKEFILE=ON"
     # Manually define CMAKE_INSTALL_<DIR>
     # See: https://github.com/NixOS/nixpkgs/pull/197838


### PR DESCRIPTION
This takes care of superfluous definitions of CMAKE_BUILD_TYPE=Release, which is the default. Hopefully this is easy to review because it's entirely removing lines of code.

Part of https://github.com/NixOS/nixpkgs/issues/427019. Partially conflicts with https://github.com/NixOS/nixpkgs/pull/442105.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
