### PR TITLE
drasl: 3.4.4 -> 4.0.1

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -47,6 +47,8 @@
 
 - Gradle 7 has been removed because it is end-of-life. Please [upgrade to a newer version of Gradle](https://docs.gradle.org/current/userguide/upgrading_version_7.html).
 
+- `drasl` 4.0.0 has restructured its configuration options for user registration. See the [release notes](https://github.com/unmojang/drasl/blob/master/doc/release-notes.md#drasl-400).
+
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.
 
 - The existing `wasm32-wasi` target has become `wasm32-wasip1` and `pkgsCross.wasi32` has become `pkgsCross.wasm32-wasip1`, aligning with LLVM's nomenclature. Aliases are in place and old forms will continue to be parsed but there might be some breakage if you're relying on the exact form of these (e.g., in sysroot paths).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -158,6 +158,8 @@
 
 - The `jetty_11` package has been removed as it reached end of life. Use `jetty_12` instead.
 
+- `drasl` 4.0.0 has restructured its configuration options for user registration. See the [release notes](https://github.com/unmojang/drasl/blob/master/doc/release-notes.md#drasl-400) and review your `services.drasl.settings`.
+
 - The Mullvad VPN service now has a separate toggle to enable the Mullvad VPN graphical user interface. If you have previously used Mullvad on a desktop by setting `services.mullvad-vpn.package` to `pkgs.mullvad-vpn`, you should now **unset that option**, and enable `services.mullvad-vpn.gui.enable`. The VPN will not work if `services.mullvad-vpn.package` is set to `pkgs.mullvad-vpn`, as `pkgs.mullvad-vpn` no longer contains the Mullvad Daemon; please ensure that `services.mullvad-vpn.package` is set to `pkgs.mullvad`, regardless if you plan to enable the graphical user interface or not.
 
 - A number of options for `services.llama-cpp` have been removed in favor of the structured [](#opt-services.llama-cpp.settings) option, attributes from which are used as arguments to `llama-server` executable, you can see all available options by running `llama-server --help`. Configuring model presets using Nix attribute set via `services.llama-cpp.modelsPreset` is no longer supported, please use `services.llama-cpp.settings.models-preset` with a path to an INI file containing desired options.

--- a/nixos/modules/services/web-apps/drasl.nix
+++ b/nixos/modules/services/web-apps/drasl.nix
@@ -74,6 +74,30 @@ in
     };
   };
   config = lib.mkIf cfg.enable {
+    warnings =
+      let
+        s = cfg.settings;
+        oidcDepNames = map (e: e.Name or "<unnamed>") (
+          lib.filter (e: e ? RequireInvite) (s.RegistrationOIDC or [ ])
+        );
+      in
+      lib.optional (s ? ForwardSkins)
+        "services.drasl.settings.ForwardSkins is deprecated: set ForwardSkins on individual FallbackAPIServers instead."
+      ++
+        lib.optional (s ? AllowAddingDeletingPlayers)
+          "services.drasl.settings.AllowAddingDeletingPlayers is deprecated: now controlled by CreateNewPlayer.Allow and the presence of ImportExistingPlayer."
+      ++
+        lib.optional (s ? RegistrationNewPlayer)
+          "services.drasl.settings.RegistrationNewPlayer is deprecated: use RegistrationUsernamePassword.CreateNewPlayer and RegistrationOIDC.CreateNewPlayer."
+      ++
+        lib.optional (s ? RegistrationExistingPlayer)
+          "services.drasl.settings.RegistrationExistingPlayer is deprecated: use RegistrationUsernamePassword.ImportExistingPlayer and RegistrationOIDC.ImportExistingPlayer."
+      ++
+        lib.optional (s ? ImportExistingPlayer && !(lib.isList s.ImportExistingPlayer))
+          "services.drasl.settings.ImportExistingPlayer is using the deprecated single-table [ImportExistingPlayer] form. Use [[ImportExistingPlayer]] with FallbackAPIServerNickname, and define the API server in [[FallbackAPIServers]]."
+      ++
+        lib.optional (oidcDepNames != [ ])
+          "services.drasl.settings.RegistrationOIDC[].RequireInvite is deprecated for entries: ${lib.concatStringsSep ", " oidcDepNames}. Use RegistrationOIDC.CreateNewPlayer.RequireInvite and RegistrationOIDC.ImportExistingPlayer.RequireInvite.";
     assertions = [
       {
         assertion = lib.allUnique cfg.settings.RegistrationOIDC;

--- a/pkgs/by-name/dr/drasl/package.nix
+++ b/pkgs/by-name/dr/drasl/package.nix
@@ -10,13 +10,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "drasl";
-  version = "3.4.4";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "unmojang";
     repo = "drasl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GHwgN1yWf/xav2t03/09x/U0c6fRBDmEn0mDIv+V9ic=";
+    hash = "sha256-wSQEW6DJzualvG/xjMS9iv4j0SRKP6HWG0EliuE32ik=";
   };
 
   nativeBuildInputs = [
@@ -27,10 +27,10 @@ buildGoModule (finalAttrs: {
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-L0y04zLgno5kKUACyokma8uk/fNY2mwdMwsq217SCqI=";
+    hash = "sha256-2Oc7Ib/hcAaqBOGFAWMbj/YWnYyskCgWgZ4Jyo6y+ck=";
   };
 
-  vendorHash = "sha256-4Rk59bnDFYpraoGvkBUW6Z5fiXUmm2RLwS1wxScWAMQ=";
+  vendorHash = "sha256-07VlwgzgeHX4W2HAYqKzIpGmq6kN/kprYZPUsCwqhiw=";
 
   overrideModAttrs = oldAttrs: {
     nativeBuildInputs = lib.filter (drv: drv != npmHooks.npmConfigHook) oldAttrs.nativeBuildInputs;
@@ -55,7 +55,7 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    description = "Yggdrasil-compatible API server for Minecraft";
+    description = "Alternative API server for Minecraft";
     homepage = "https://github.com/unmojang/drasl";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
Update [Drasl](https://github.com/Unmojang/Drasl) to ~4.0.0~ 4.0.1. Release notes: https://github.com/unmojang/drasl/blob/master/doc/release-notes.md#drasl-400

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
