### PR TITLE
gccNGPackages: Support MinGW cross compilation

### DIFF
--- a/pkgs/development/compilers/gcc/ng/README.md
+++ b/pkgs/development/compilers/gcc/ng/README.md
@@ -44,10 +44,18 @@ Given that, the sysroot is derived from `stdenv.cc.libc` too, so it cannot disag
 
 ## Threading
 
-Which threading model is available is a property of the libc, so the libc declares it as `passthru.threadModel`; `libgcc` reads it from there, and `libstdcxx` takes both the model and the generated `gthr-default.h` from `libgcc`.
+The threading model comes from whatever provides the threads, which declares it as `passthru.threadModel`; `libgcc` reads it from there, and `libstdcxx` takes both the model and the generated `gthr-default.h` from `libgcc`.
+
+Usually that is the libc.
+Where the libc's own threading is not what we want, a separate library supplies it, and `libgcc` is given it as the `threads` argument, which takes precedence.
+MinGW is the case in point: its libc offers only `win32`, so we build against `windows.mcfgthreads` and get `mcf`, the same choice the monolithic `gcc` makes through `threadsCross`.
+Unlike `threadsCross`, the model is not spelled out at the use site — the package declares its own, exactly as a libc does.
+
+That library is built with `windows.crossThreadsStdenv`, which on a `useGccNG` platform is stage 3 of the bootstrap chain — the same compiler that then builds the threaded `libgcc`.
+Being plain C with no threading model of its own, it does not mind that stage 3's libgcc has none, and that is what keeps the arrangement from being circular.
 
 Reading it from the compiler instead, with `$CC -v | sed -n 's/^Thread model: //p'`, reports the wrong component: in this set the compiler is configured separately from libgcc, so the two can disagree.
-A platform whose libc declares nothing gets `single`.
+A platform with nothing to declare a model gets `single`.
 
 ## Relationship to the monolithic set
 

--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -28,6 +28,17 @@ assert lib.assertMsg (lib.xor (gitRelease != null) (officialRelease != null)) (
 let
   monorepoSrc' = monorepoSrc;
 
+  # libgomp is OpenMP on top of pthreads, and will refuse to build with
+  # any other threading model.
+  hasLibgomp = targetGccPackages.libgcc.threadModel == "posix";
+
+  libgompCflags = lib.optionals hasLibgomp [
+    "-B${targetGccPackages.libgomp}/lib"
+  ];
+  libgompIncludeCflags = lib.optionals hasLibgomp [
+    "-I${targetGccPackages.libgomp}/lib/gcc/${metadata.release_version}/include"
+  ];
+
   metadata = rec {
     inherit
       (import ./common-let.nix {
@@ -129,7 +140,9 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc}/lib"
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
-          "-B${targetGccPackages.libgomp}/lib"
+        ]
+        ++ libgompCflags
+        ++ [
           "-B${targetGccPackages.libstdcxx}/lib"
           "-B${targetGccPackages.libgfortran}/lib/"
         ];
@@ -146,9 +159,9 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc}/lib"
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
-          "-B${targetGccPackages.libgomp}/lib"
-          "-I${targetGccPackages.libgomp}/lib/gcc/${metadata.release_version}/include"
-        ];
+        ]
+        ++ libgompCflags
+        ++ libgompIncludeCflags;
       };
 
       gcc = wrapCCWith {
@@ -162,14 +175,16 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc}/lib"
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
-          "-B${targetGccPackages.libgomp}/lib"
+        ]
+        ++ libgompCflags
+        ++ [
           # `libcxx` above tells cc-wrapper where the C++ *headers* are; it does
           # not put the library itself on the link path for a GNU compiler. So
           # every C++ link failed with `cannot find -lstdc++` until this was
           # added, in the same style as the other runtime libraries.
           "-B${targetGccPackages.libstdcxx}/lib"
-          "-I${targetGccPackages.libgomp}/lib/gcc/${metadata.release_version}/include"
-        ];
+        ]
+        ++ libgompIncludeCflags;
       };
 
       # Stage 1 of the bootstrap chain; see ../README.md.

--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -15,6 +15,7 @@
   binutils,
   buildGccPackages,
   targetGccPackages,
+  windows,
   makeScopeWithSplicing',
   otherSplices,
   ...
@@ -112,8 +113,47 @@ makeScopeWithSplicing' {
     gccPackages:
     let
       callPackage = gccPackages.newScope (args // metadata);
+
+      # Every compiler from the threaded `libgcc-libc` onwards needs the
+      # threading library's headers and import library: that is what
+      # `gthr-default.h` includes and what libstdc++ and user code link
+      # against. As with the runtime libraries, it is the *target* build.
+      threadsPackages = lib.optional (targetGccPackages.threads != null) targetGccPackages.threads;
+
+      # `extraPackages` only reaches builds that go through a stdenv, so name
+      # the directories here too, as the runtime libraries are: otherwise the
+      # wrapped compiler run by hand cannot find the `mcfgthread` header.
+      threadsCflags = lib.optionals (targetGccPackages.threads != null) [
+        "-B${targetGccPackages.threads}/lib"
+        "-isystem ${lib.getDev targetGccPackages.threads}/include"
+      ];
+
+      # A gcc *configured* for a threading model links that model's library
+      # through its own specs. Ours is configured independently of the runtimes
+      # (see ../README.md), so the flag has to come from the wrapper instead;
+      # without it libstdc++ fails to link on undefined `__MCF_gthr_*`.
+      #
+      # A whole `nixSupport` fragment rather than just the flag list: an empty
+      # `cc-ldflags` still gets written by `cc-wrapper`, so setting the
+      # attribute unconditionally would rebuild every wrapper everywhere.
+      threadsNixSupport = lib.optionalAttrs ((targetGccPackages.threads.threadModel or null) == "mcf") {
+        cc-ldflags = [ "-lmcfgthread" ];
+      };
     in
     {
+      # Where the libc's own threading is not the one we want, a separate
+      # library supplies it: MinGW offers only `win32`, and `mcfgthreads` gives
+      # `mcf`, which is the better answer on Windows. `null`, the answer
+      # everywhere else, means "whatever the libc offers".
+      # The model is not written down here; the package declares it, in the
+      # same `passthru.threadModel` a libc uses.
+      #
+      # This stays out of the bootstrap cycle by itself: it is built with
+      # `windows.crossThreadsStdenv`, which on `useGccNG` platforms is stage 3
+      # — real libc, bootstrap single-threaded libgcc — the very compiler that
+      # goes on to build the threaded `libgcc-libc`.
+      threads = if stdenv.hostPlatform.isMinGW then windows.mcfgthreads else null;
+
       stdenv = overrideCC stdenv gccPackages.gcc;
 
       gcc-unwrapped = callPackage ./gcc {
@@ -135,17 +175,21 @@ makeScopeWithSplicing' {
         bintools = binutils;
         extraPackages = [
           targetGccPackages.libgcc
-        ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
-          "-B${targetGccPackages.libatomic}/lib"
         ]
-        ++ libgompCflags
-        ++ [
-          "-B${targetGccPackages.libstdcxx}/lib"
-          "-B${targetGccPackages.libgfortran}/lib/"
-        ];
+        ++ threadsPackages;
+        nixSupport = threadsNixSupport // {
+          cc-cflags = [
+            "-B${targetGccPackages.libgcc}/lib"
+            "-B${targetGccPackages.libssp}/lib"
+            "-B${targetGccPackages.libatomic}/lib"
+          ]
+          ++ libgompCflags
+          ++ [
+            "-B${targetGccPackages.libstdcxx}/lib"
+            "-B${targetGccPackages.libgfortran}/lib/"
+          ]
+          ++ threadsCflags;
+        };
       };
 
       gfortranNoLibgfortran = wrapCCWith {
@@ -154,14 +198,18 @@ makeScopeWithSplicing' {
         bintools = binutils;
         extraPackages = [
           targetGccPackages.libgcc
-        ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
-          "-B${targetGccPackages.libatomic}/lib"
         ]
-        ++ libgompCflags
-        ++ libgompIncludeCflags;
+        ++ threadsPackages;
+        nixSupport = threadsNixSupport // {
+          cc-cflags = [
+            "-B${targetGccPackages.libgcc}/lib"
+            "-B${targetGccPackages.libssp}/lib"
+            "-B${targetGccPackages.libatomic}/lib"
+          ]
+          ++ libgompCflags
+          ++ libgompIncludeCflags
+          ++ threadsCflags;
+        };
       };
 
       gcc = wrapCCWith {
@@ -170,21 +218,25 @@ makeScopeWithSplicing' {
         bintools = binutils;
         extraPackages = [
           targetGccPackages.libgcc
-        ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
-          "-B${targetGccPackages.libatomic}/lib"
         ]
-        ++ libgompCflags
-        ++ [
-          # `libcxx` above tells cc-wrapper where the C++ *headers* are; it does
-          # not put the library itself on the link path for a GNU compiler. So
-          # every C++ link failed with `cannot find -lstdc++` until this was
-          # added, in the same style as the other runtime libraries.
-          "-B${targetGccPackages.libstdcxx}/lib"
-        ]
-        ++ libgompIncludeCflags;
+        ++ threadsPackages;
+        nixSupport = threadsNixSupport // {
+          cc-cflags = [
+            "-B${targetGccPackages.libgcc}/lib"
+            "-B${targetGccPackages.libssp}/lib"
+            "-B${targetGccPackages.libatomic}/lib"
+          ]
+          ++ libgompCflags
+          ++ [
+            # `libcxx` above tells cc-wrapper where the C++ *headers* are; it does
+            # not put the library itself on the link path for a GNU compiler. So
+            # every C++ link failed with `cannot find -lstdc++` until this was
+            # added, in the same style as the other runtime libraries.
+            "-B${targetGccPackages.libstdcxx}/lib"
+          ]
+          ++ libgompIncludeCflags
+          ++ threadsCflags;
+        };
       };
 
       # Stage 1 of the bootstrap chain; see ../README.md.
@@ -207,12 +259,19 @@ makeScopeWithSplicing' {
       # follows from the compiler, never from an argument.
       libgcc-no-libc = callPackage ./libgcc {
         stdenv = overrideCC stdenv buildGccPackages.gccNoLibgcc;
+        # The bootstrap libgcc predates the threading library. Spelled out so
+        # `callPackage` does not fill it in from the set's own `threads`.
+        threads = null;
       };
 
       # The real one, built against the finished libc, so it can use that
-      # libc's threads. This is what everything above the libc gets.
+      # libc's threads — or the separate threading library where we have asked
+      # for one. This is what everything above the libc gets.
       libgcc-libc = callPackage ./libgcc {
         stdenv = overrideCC stdenv buildGccPackages.gccWithLibcAndBasicLibgcc;
+        # Spelled out for the same reason as the `null` above, and so that it
+        # is this set's own answer.
+        inherit (gccPackages) threads;
       };
 
       libgcc =
@@ -280,10 +339,14 @@ makeScopeWithSplicing' {
         bintools = binutils;
         extraPackages = [
           targetGccPackages.libgcc
-        ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-        ];
+        ]
+        ++ threadsPackages;
+        nixSupport = threadsNixSupport // {
+          cc-cflags = [
+            "-B${targetGccPackages.libgcc}/lib"
+          ]
+          ++ threadsCflags;
+        };
       };
 
       libssp = callPackage ./libssp {
@@ -296,11 +359,15 @@ makeScopeWithSplicing' {
         bintools = binutils;
         extraPackages = [
           targetGccPackages.libgcc
-        ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
-        ];
+        ]
+        ++ threadsPackages;
+        nixSupport = threadsNixSupport // {
+          cc-cflags = [
+            "-B${targetGccPackages.libgcc}/lib"
+            "-B${targetGccPackages.libssp}/lib"
+          ]
+          ++ threadsCflags;
+        };
       };
 
       libatomic = callPackage ./libatomic {
@@ -313,12 +380,16 @@ makeScopeWithSplicing' {
         bintools = binutils;
         extraPackages = [
           targetGccPackages.libgcc
-        ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
-          "-B${targetGccPackages.libatomic}/lib"
-        ];
+        ]
+        ++ threadsPackages;
+        nixSupport = threadsNixSupport // {
+          cc-cflags = [
+            "-B${targetGccPackages.libgcc}/lib"
+            "-B${targetGccPackages.libssp}/lib"
+            "-B${targetGccPackages.libatomic}/lib"
+          ]
+          ++ threadsCflags;
+        };
       };
 
       libgfortran = callPackage ./libgfortran {

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -13,6 +13,13 @@
   which,
   python3,
 
+  # A threading library separate from the libc, for targets whose libc does not
+  # offer the model we want — MinGW, with `mcfgthreads`. `null` means "whatever
+  # the libc offers". Whatever is passed has to be buildable without threads
+  # itself, since it comes before the libgcc that would otherwise provide them;
+  # see the bootstrap chain in ../../README.md.
+  threads ? null,
+
   # Build `libgcc_s` as well as `libgcc.a`. Only ever worth turning *off*: the
   # assertion below refuses to force it on where the default says it cannot
   # work, since what follows from that is a link failure much further away.
@@ -61,9 +68,11 @@ let
   # finished libc. Everything below reads that one value.
   libc = stdenv.cc.libc or null;
 
-  # Which threading model may be used is decided by the libc, so take it from
-  # there rather than guess — and pass it on in `passthru` so that `libstdcxx`,
-  # which has to agree, reads the same answer instead of probing for its own.
+  # Which threading model may be used is decided by whatever provides the
+  # threads — usually the libc, but the separate `threads` package where one
+  # is given — so take it from there rather than guess, and pass it on in
+  # `passthru` so that `libstdcxx`, which has to agree, reads the same answer
+  # instead of probing for its own.
   #
   # A headers-only package declares no `threadModel`, and a real libc does.
   # That build exists only to get the libc built and is thrown away afterwards,
@@ -82,7 +91,10 @@ let
   # "spec files" (more powerful than CLI flags) would be be able to get the
   # compiler `-v` flag correct with respect to the libraries it happend to be
   # wrapped with.
-  threadModel = if libc == null then "single" else libc.threadModel or "single";
+  #
+  # A `threads` package wins over the libc: that is the point of asking for
+  # one, and it is only passed to the builds that come after the libc.
+  threadModel = threads.threadModel or (libc.threadModel or "single");
 in
 
 assert enableShared -> __defaultEnableShared;
@@ -110,6 +122,10 @@ stdenv.mkDerivation (finalAttrs: {
     which
     python3
   ];
+
+  # The `gthr-<model>.h` header for a non-libc threading model includes that
+  # library's own headers, and `libgcc_s` links against it.
+  buildInputs = lib.optional (threads != null) threads;
 
   patches = [
     (fetchpatch {

--- a/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
@@ -57,6 +57,13 @@ stdenv.mkDerivation (finalAttrs: {
       cp libgcc/gthr*.h "$out/libgcc"
       cp libgcc/unwind-pe.h "$out/libgcc"
 
+    ''
+    # Target-specific `gthr` headers live under `libgcc/config/<cpu>/` rather
+    # than at the top of `libgcc`, and libstdc++'s `gthr-default.h` rule names
+    # them by path relative to the tree root, so reproduce that layout.
+    + ''
+      cp --parents libgcc/config/*/gthr*.h "$out"
+
       cp -r libstdc++-v3 "$out"
 
       cp -r libiberty "$out"

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -30,6 +30,8 @@ makeScopeWithSplicing' {
       crossThreadsStdenv = overrideCC stdenvNoLibc (
         if stdenv.hostPlatform.useLLVM or false then
           buildPackages.llvmPackages.clangNoLibcxx
+        else if stdenv.hostPlatform.useGccNG or false then
+          buildPackages.gccNGPackages.gccWithLibcAndBasicLibgcc
         else
           buildPackages.gccWithoutTargetLibc.override (old: {
             bintools = old.bintools.override {

--- a/pkgs/os-specific/windows/mcfgthreads/default.nix
+++ b/pkgs/os-specific/windows/mcfgthreads/default.nix
@@ -37,6 +37,12 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
+  # A libgcc built against this library gets the "mcf" threading model, which
+  # on Windows beats the "win32" model the bare libc offers. Same attribute a
+  # libc uses to declare what it provides; see `threadModel` in
+  # pkgs/development/compilers/gcc/ng/common/libgcc/default.nix.
+  passthru.threadModel = "mcf";
+
   meta = {
     description = "Threading support library for Windows 7 and above";
     homepage = "https://github.com/lhmouse/mcfgthread/wiki";

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation {
     (lib.enableFeature stdenv.hostPlatform.isAarch64 "libarm64")
   ];
 
+  # MinGW has no pthreads of its own; threading goes through the Win32 API
+  # declared by these headers. See `threadModel` in
+  # pkgs/development/compilers/gcc/ng/common/libgcc/default.nix.
+  passthru.threadModel = "win32";
+
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -23,6 +23,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    # Headers-only stand-in used to bootstrap a toolchain before the real libc
+    # exists: runtimes can compile against it, but not link.
+    headersOnly = true;
     tests = {
       inherit (nixosTests) wine;
     };

--- a/pkgs/os-specific/windows/mingw-w64/pthreads.nix
+++ b/pkgs/os-specific/windows/mingw-w64/pthreads.nix
@@ -16,4 +16,10 @@ stdenv.mkDerivation {
   preConfigure = ''
     cd mingw-w64-libraries/winpthreads
   '';
+
+  # Supplies the pthreads API MinGW itself lacks, so a libgcc built against it
+  # gets the "posix" threading model rather than the bare libc's "win32". Same
+  # attribute a libc uses to declare what it provides; see `threadModel` in
+  # pkgs/development/compilers/gcc/ng/common/libgcc/default.nix.
+  passthru.threadModel = "posix";
 }


### PR DESCRIPTION
A follow-up to https://github.com/NixOS/nixpkgs/pull/552087, except it doesn't change the default for MinGW.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
