### PR TITLE
fiji: moved wrapGAppsHook - bugfix for issue #370030

### DIFF
--- a/pkgs/by-name/fi/fiji/package.nix
+++ b/pkgs/by-name/fi/fiji/package.nix
@@ -74,11 +74,14 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper $out/bin/.fiji-launcher-hack $out/bin/fiji \
       --prefix PATH : ${lib.makeBinPath [ jdk11 ]} \
       --set JAVA_HOME ${jdk11.home} \
-      ''${gappsWrapperArgs[@]}
 
     ln $out/fiji/images/icon.png $out/share/icons/hicolor/256x256/apps/fiji.png
 
     runHook postInstall
+  '';
+
+  preFixup = ''
+    wrapProgram $out/bin/fiji ''${gappsWrapperArgs[@]}
   '';
 
   meta = {


### PR DESCRIPTION
I experienced crashes when trying to open files with the following error message:

`(java:82676): GLib-GIO-ERROR **: $TIME: No GSettings schemas are installed on the system`

same as PR #363577 and open Issue: Fiji/ImageJ crashing with File > Open #370030

the Issues with #370030 started shortly after PR #363577

found XDG_DATA_DIRS where not set by wrapGAppsHook3, since dontWrapGApps = true

## Things done
moved the in #363577 applied `${gappsWrapperArgs[@]}`  from installPhase to  preFixup, so it builds later 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
