### PR TITLE
linux-builder-vz: fix nixdb retention; harden registration against gc

### DIFF
--- a/nixos/lib/store-registration-info.nix
+++ b/nixos/lib/store-registration-info.nix
@@ -1,0 +1,12 @@
+{
+  hostPkgs,
+  rootPaths,
+}:
+
+let
+  regInfo = hostPkgs.closureInfo { inherit rootPaths; };
+in
+{
+  inherit regInfo;
+  regInfoPath = "/nix/.ro-store/${baseNameOf regInfo}/registration";
+}

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -351,11 +351,10 @@ let
   '';
 
   regInfo = hostPkgs.closureInfo { rootPaths = config.virtualisation.additionalPaths; };
-  regInfoPath =
-    if cfg.useNixStoreImage || cfg.mountHostNixStore then
-      "/nix/.ro-store/${baseNameOf regInfo}/registration"
-    else
-      "${regInfo}/registration";
+  regInfoPath = "/nix/.ro-store/${baseNameOf regInfo}/registration";
+  regInfoParam = optionalString (
+    cfg.useNixStoreImage || cfg.mountHostNixStore
+  ) " regInfo=${regInfoPath}";
 
   # Use well-defined and persistent filesystem labels to identify block devices.
   rootFilesystemLabel = "nixos";
@@ -1319,7 +1318,7 @@ in
         mkIf cfg.directBoot.enable [
           "-kernel \${NIXPKGS_QEMU_KERNEL_${sanitizeShellIdent config.system.name}:-${config.system.build.toplevel}/kernel}"
           "-initrd ${cfg.directBoot.initrd}"
-          ''-append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init regInfo=${regInfoPath} ${consoles} $QEMU_KERNEL_PARAMS"''
+          ''-append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init${regInfoParam} ${consoles} $QEMU_KERNEL_PARAMS"''
         ]
       )
       (mkIf cfg.useEFIBoot [

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -350,8 +350,14 @@ let
         "$@"
   '';
 
-  regInfo = hostPkgs.closureInfo { rootPaths = config.virtualisation.additionalPaths; };
-  regInfoPath = "/nix/.ro-store/${baseNameOf regInfo}/registration";
+  inherit
+    (import ../../lib/store-registration-info.nix {
+      inherit hostPkgs;
+      rootPaths = config.virtualisation.additionalPaths;
+    })
+    regInfo
+    regInfoPath
+    ;
   regInfoParam = optionalString (
     cfg.useNixStoreImage || cfg.mountHostNixStore
   ) " regInfo=${regInfoPath}";

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -351,6 +351,11 @@ let
   '';
 
   regInfo = hostPkgs.closureInfo { rootPaths = config.virtualisation.additionalPaths; };
+  regInfoPath =
+    if cfg.useNixStoreImage || cfg.mountHostNixStore then
+      "/nix/.ro-store/${baseNameOf regInfo}/registration"
+    else
+      "${regInfo}/registration";
 
   # Use well-defined and persistent filesystem labels to identify block devices.
   rootFilesystemLabel = "nixos";
@@ -1314,7 +1319,7 @@ in
         mkIf cfg.directBoot.enable [
           "-kernel \${NIXPKGS_QEMU_KERNEL_${sanitizeShellIdent config.system.name}:-${config.system.build.toplevel}/kernel}"
           "-initrd ${cfg.directBoot.initrd}"
-          ''-append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init regInfo=${regInfo}/registration ${consoles} $QEMU_KERNEL_PARAMS"''
+          ''-append "$(cat ${config.system.build.toplevel}/kernel-params) init=${config.system.build.toplevel}/init regInfo=${regInfoPath} ${consoles} $QEMU_KERNEL_PARAMS"''
         ]
       )
       (mkIf cfg.useEFIBoot [

--- a/nixos/modules/virtualisation/vm-base.nix
+++ b/nixos/modules/virtualisation/vm-base.nix
@@ -136,7 +136,7 @@ in
     systemd.services.register-nix-paths = lib.mkIf config.nix.enable {
       # Runs early so the store DB is populated first; `--load-db` needs no daemon.
       unitConfig.DefaultDependencies = false;
-      wantedBy = [ "sysinit.target" ];
+      requiredBy = [ "sysinit.target" ];
       before = [
         "sysinit.target"
         "shutdown.target"

--- a/nixos/modules/virtualisation/vm-base.nix
+++ b/nixos/modules/virtualisation/vm-base.nix
@@ -143,7 +143,11 @@ in
         "nix-daemon.socket"
         "nix-daemon.service"
       ];
-      after = [ "local-fs.target" ];
+      after = [
+        "local-fs.target"
+        "systemd-tmpfiles-setup.service"
+      ];
+      requires = [ "systemd-tmpfiles-setup.service" ];
       conflicts = [ "shutdown.target" ];
       restartIfChanged = false;
       serviceConfig = {

--- a/nixos/modules/virtualisation/vz-vm-file-systems.nix
+++ b/nixos/modules/virtualisation/vz-vm-file-systems.nix
@@ -1,0 +1,34 @@
+{
+  diskImage,
+  lib,
+  sharedDirectories,
+  writableStoreUseTmpfs,
+}:
+
+{
+  "/" = lib.mkVMOverride {
+    device = "tmpfs";
+    fsType = "tmpfs";
+    neededForBoot = true;
+    options = [ "mode=0755" ];
+  };
+}
+// lib.optionalAttrs (!writableStoreUseTmpfs && diskImage != null) {
+  # Second disk, hence /dev/vdb: store image is always first. Mount all of
+  # /nix so the Nix database persists together with the writable store.
+  "/nix" = lib.mkVMOverride {
+    device = "/dev/vdb";
+    fsType = "ext4";
+    autoFormat = true;
+    neededForBoot = true;
+  };
+}
+// lib.mapAttrs' (
+  _: share:
+  lib.nameValuePair share.target (
+    lib.mkVMOverride {
+      device = share.tag;
+      fsType = "virtiofs";
+    }
+  )
+) sharedDirectories

--- a/nixos/modules/virtualisation/vz-vm.nix
+++ b/nixos/modules/virtualisation/vz-vm.nix
@@ -253,33 +253,11 @@ in
       ];
 
       # Override per entry and not as a whole: see note in vm-base.nix.
-      fileSystems = {
-        "/" = lib.mkVMOverride {
-          device = "tmpfs";
-          fsType = "tmpfs";
-          neededForBoot = true;
-          options = [ "mode=0755" ];
-        };
-      }
-      // lib.optionalAttrs (!cfg.writableStoreUseTmpfs && vzCfg.diskImage != null) {
-        # Second disk, hence /dev/vdb: store image is always first. Mount all of
-        # /nix so the Nix database persists together with the writable store.
-        "/nix" = lib.mkVMOverride {
-          device = "/dev/vdb";
-          fsType = "ext4";
-          autoFormat = true;
-          neededForBoot = true;
-        };
-      }
-      // lib.mapAttrs' (
-        _: share:
-        lib.nameValuePair share.target (
-          lib.mkVMOverride {
-            device = share.tag;
-            fsType = "virtiofs";
-          }
-        )
-      ) cfg.sharedDirectories;
+      fileSystems = import ./vz-vm-file-systems.nix {
+        inherit lib;
+        inherit (cfg) sharedDirectories writableStoreUseTmpfs;
+        diskImage = vzCfg.diskImage;
+      };
 
       # DHCP and DNS come from host NAT
       networking.useDHCP = lib.mkDefault true;

--- a/nixos/modules/virtualisation/vz-vm.nix
+++ b/nixos/modules/virtualisation/vz-vm.nix
@@ -13,8 +13,14 @@ let
 
   hostPkgs = cfg.host.pkgs;
 
-  regInfo = hostPkgs.closureInfo { rootPaths = cfg.additionalPaths; };
-  regInfoPath = "/nix/.ro-store/${baseNameOf regInfo}/registration";
+  inherit
+    (import ../../lib/store-registration-info.nix {
+      inherit hostPkgs;
+      rootPaths = cfg.additionalPaths;
+    })
+    regInfo
+    regInfoPath
+    ;
 
   # Host-built erofs store image, named by closure hash so only a changed guest rebuilds it.
   # A derivation is not an option: it would need the Linux builder this VM provides.

--- a/nixos/modules/virtualisation/vz-vm.nix
+++ b/nixos/modules/virtualisation/vz-vm.nix
@@ -255,8 +255,9 @@ in
         };
       }
       // lib.optionalAttrs (!cfg.writableStoreUseTmpfs && vzCfg.diskImage != null) {
-        # Second disk, hence /dev/vdb: store image is always first.
-        "/nix/.rw-store" = lib.mkVMOverride {
+        # Second disk, hence /dev/vdb: store image is always first. Mount all of
+        # /nix so the Nix database persists together with the writable store.
+        "/nix" = lib.mkVMOverride {
           device = "/dev/vdb";
           fsType = "ext4";
           autoFormat = true;

--- a/nixos/modules/virtualisation/vz-vm.nix
+++ b/nixos/modules/virtualisation/vz-vm.nix
@@ -14,6 +14,7 @@ let
   hostPkgs = cfg.host.pkgs;
 
   regInfo = hostPkgs.closureInfo { rootPaths = cfg.additionalPaths; };
+  regInfoPath = "/nix/.ro-store/${baseNameOf regInfo}/registration";
 
   # Host-built erofs store image, named by closure hash so only a changed guest rebuilds it.
   # A derivation is not an option: it would need the Linux builder this VM provides.
@@ -31,7 +32,7 @@ let
     # Virtualization.framework offers a virtio console
     "console=hvc0"
     "init=${toplevel}/init"
-    "regInfo=${regInfo}/registration"
+    "regInfo=${regInfoPath}"
   ]
   ++ config.boot.kernelParams;
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -982,6 +982,7 @@ in
   linkding = runTest ./web-apps/linkding.nix;
   linkding-postgres = runTest ./web-apps/linkding-postgres.nix;
   linkwarden = runTest ./web-apps/linkwarden.nix;
+  linux-builder-vz-store-gc = runTest ./linux-builder-vz-store-gc.nix;
   listmonk = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./listmonk.nix { };
   litellm = runTest ./litellm.nix;
   litestream = runTest ./litestream.nix;

--- a/nixos/tests/linux-builder-vz-store-gc.nix
+++ b/nixos/tests/linux-builder-vz-store-gc.nix
@@ -1,0 +1,65 @@
+{ lib, ... }:
+
+{
+  # Strictly speaking, this is not a precise test for VZ builder, but we don't
+  # have vzvm backend for nixos tests, so we use qemu here, with config that
+  # matches linux-builder-vz disk layout.
+  name = "linux-builder-vz-store-gc";
+
+  nodes.machine = {
+    virtualisation = {
+      # Match the vz-vm drive order: the read-only store image is /dev/vda,
+      # followed by the writable data disk at /dev/vdb.
+      diskImage = null;
+      useNixStoreImage = true;
+      writableStore = true;
+      writableStoreUseTmpfs = false;
+      emptyDiskImages = [ 1024 ];
+
+      fileSystems = import ../modules/virtualisation/vz-vm-file-systems.nix {
+        inherit lib;
+        diskImage = "./nixos.qcow2";
+        sharedDirectories = { };
+        writableStoreUseTmpfs = false;
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start(allow_reboot=True)
+    machine.wait_for_unit("multi-user.target")
+
+    def kernel_param(name):
+        return machine.succeed(
+            f"grep -oE '(^| ){name}=[^ ]+' /proc/cmdline | cut -d= -f2-"
+        ).strip()
+
+    reg_info = kernel_param("regInfo")
+    init = kernel_param("init")
+
+    def boot_path_status():
+        return {
+            "regInfo": machine.execute(f"test -f {reg_info}")[0] == 0,
+            "init": machine.execute(f"test -x {init}")[0] == 0,
+        }
+
+    assert all(boot_path_status().values())
+
+    with subtest("garbage collection before reboot"):
+        machine.succeed("nix-collect-garbage")
+        before_reboot = boot_path_status()
+
+    machine.reboot()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("garbage collection after reboot"):
+        machine.succeed("nix-collect-garbage")
+        after_reboot = boot_path_status()
+
+    results = {
+        "before reboot": before_reboot,
+        "after reboot": after_reboot,
+    }
+    assert all(all(paths.values()) for paths in results.values()), results
+  '';
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -10,6 +10,7 @@ in
   libc,
   llvmPackages,
   makeScopeWithSplicing',
+  nixosTests,
   pkgs,
   preLibcHeaders,
   stdenv,
@@ -202,7 +203,13 @@ makeScopeWithSplicing' {
             system = null;
           };
         in
-        nixos.config.system.build.macos-builder-installer
+        nixos.config.system.build.macos-builder-installer.overrideAttrs (oldAttrs: {
+          passthru = oldAttrs.passthru // {
+            tests = (oldAttrs.passthru.tests or { }) // {
+              store-gc = nixosTests.linux-builder-vz-store-gc;
+            };
+          };
+        })
       ) { modules = [ ]; };
     }
   );


### PR DESCRIPTION
The primary goal of this PR is to fix the following VZ builder issue:

1. Registration file is gc'd because it doesn't register itself.
2. Builder reboots.
3. Since /nix/var is not persistent across reboots, database is lost.
4. Registration fails because its file is gone.
5. Still, machine boots because registration service is not blocking.
6. Later, another gc wipes everything else, including system closure.
7. Another reboot fails because init is gone.

This is not theoretical: I am drive-testing this builder for a few weeks and
I hit sudden builder inaccessibility due to this issue - where I couldn't ssh
into the builder, even after I reboot it. Disk image inspection revealed lots
of whiteouts on expected store paths.

---

The core changes are:
1. Persist complete `/nix` out of tmpfs, making store state survive reboot.
2. Load registration file from .ro-store that is whiteout-resistant.

The rest are just hardening adjustments for the registration service.

The branch also includes a new nixos test designed to catch regressions for
a configuration that resembles -vz builder (but using qemu), as well as a few
small refactoring patches to make it possible.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
