### PR TITLE
yopass: init services.yopass

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -36,6 +36,8 @@
 
 - [Cardwire](https://github.com/OpenGamingCollective/cardwire), a GPU manager for Linux that uses eBPF+LSM hooks to control GPUs. Available as [services.cardwired](#opt-services.cardwired.enable).
 
+- [Yopass](https://yopass.se/), a secure way to share secrets, passwords and files. Available as [services.yopass](#opt-services.yopass.enable).
+
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).
 
 - [udp514-journal](https://github.com/eworm-de/udp514-journal), a service to forward remote syslog messages to systemd-journal. Available as [services.udp514-journal](#opt-services.udp514-journal.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1867,6 +1867,7 @@
   ./services/web-apps/windmill.nix
   ./services/web-apps/wordpress.nix
   ./services/web-apps/writefreely.nix
+  ./services/web-apps/yopass.nix
   ./services/web-apps/your_spotify.nix
   ./services/web-apps/youtrack.nix
   ./services/web-apps/zabbix.nix

--- a/nixos/modules/services/web-apps/yopass.nix
+++ b/nixos/modules/services/web-apps/yopass.nix
@@ -1,0 +1,478 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.yopass;
+
+  defaultUser = "yopass";
+  defaultGroup = "yopass";
+
+  toEnvValue =
+    v:
+    if lib.isBool v then
+      lib.boolToString v
+    else if lib.isAttrs v || lib.isList v then
+      builtins.toJSON v
+    else
+      toString v;
+
+  # Named options below map 1:1 onto yopass-server's env vars (see
+  # upstream docs/server-options.md).
+  namedEnv = {
+    ADDRESS = cfg.address;
+    PORT = toString cfg.port;
+    LOG_LEVEL = cfg.logLevel;
+    METRICS_PORT = if cfg.metricsPort == null then null else toString cfg.metricsPort;
+    HEALTH_CHECK = lib.boolToString cfg.healthCheck;
+
+    DATABASE = cfg.database.backend;
+    MEMCACHED = if cfg.database.backend == "memcached" then cfg.database.memcached else null;
+    REDIS = if cfg.database.backend == "redis" then cfg.database.redis else null;
+
+    MAX_LENGTH = toString cfg.maxLength;
+    DEFAULT_EXPIRY = cfg.defaultExpiry;
+    FORCE_EXPIRATION = cfg.forceExpiration;
+    FORCE_ONETIME_SECRETS = lib.boolToString cfg.forceOnetimeSecrets;
+    PREFETCH_SECRET = lib.boolToString cfg.prefetchSecret;
+    ARGON2 = lib.boolToString cfg.argon2;
+
+    MAX_FILE_SIZE = cfg.fileStorage.maxFileSize;
+    DISABLE_UPLOAD = lib.boolToString cfg.fileStorage.disableUpload;
+    FILE_STORE = cfg.fileStorage.backend;
+    FILE_STORE_PATH = if cfg.fileStorage.backend == "disk" then cfg.fileStorage.path else null;
+    FILE_STORE_S3_BUCKET = cfg.fileStorage.s3.bucket;
+    FILE_STORE_S3_PREFIX = cfg.fileStorage.s3.prefix;
+    FILE_STORE_S3_ENDPOINT = cfg.fileStorage.s3.endpoint;
+    FILE_STORE_S3_REGION = cfg.fileStorage.s3.region;
+    CLEANUP_INTERVAL = toString cfg.fileStorage.cleanupInterval;
+    DISABLE_FILE_CLEANUP = lib.boolToString cfg.fileStorage.disableCleanup;
+
+    TLS_CERT = cfg.tls.cert;
+    TLS_KEY = cfg.tls.key;
+
+    CORS_ALLOW_ORIGIN = cfg.corsAllowOrigin;
+    TRUSTED_PROXIES =
+      if cfg.trustedProxies == [ ] then null else lib.concatStringsSep "," cfg.trustedProxies;
+
+    READ_ONLY = lib.boolToString cfg.readOnly;
+    DISABLE_FEATURES = lib.boolToString cfg.disableFeatures;
+    NO_LANGUAGE_SWITCHER = lib.boolToString cfg.noLanguageSwitcher;
+    PRIVACY_NOTICE_URL = cfg.privacyNoticeUrl;
+    IMPRINT_URL = cfg.imprintUrl;
+    PUBLIC_URL = cfg.publicUrl;
+  };
+
+  # `null` in namedEnv means "let yopass-server use its own default"
+  # and is filtered out here rather than exported empty; settings has
+  # no such convention since its freeform type excludes null.
+  env = lib.filterAttrs (_: v: v != null) namedEnv // lib.mapAttrs (_: toEnvValue) cfg.settings;
+in
+{
+  options.services.yopass = {
+    enable = lib.mkEnableOption "Yopass, a secure way to share secrets and files";
+
+    package = lib.mkPackageOption pkgs "yopass" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = defaultUser;
+      description = "User account under which yopass-server runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = defaultGroup;
+      description = "Group under which yopass-server runs.";
+    };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "Listen address.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 1337;
+      description = "Listen port.";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "debug"
+        "info"
+        "warn"
+        "error"
+      ];
+      default = "info";
+      description = "Log level.";
+    };
+
+    metricsPort = lib.mkOption {
+      type = lib.types.nullOr lib.types.port;
+      default = null;
+      description = ''
+        Port for the Prometheus metrics server. Left unset (`null`)
+        disables the metrics server, matching upstream's `-1` default.
+      '';
+    };
+
+    healthCheck = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Check database connectivity and exit, rather than serving requests.";
+    };
+
+    database = {
+      backend = lib.mkOption {
+        type = lib.types.enum [
+          "memcached"
+          "redis"
+        ];
+        default = "memcached";
+        description = "Storage backend for secrets.";
+      };
+
+      memcached = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost:11211";
+        description = "Memcached address (`host:port`), used when `database.backend` is `memcached`.";
+      };
+
+      redis = lib.mkOption {
+        type = lib.types.str;
+        default = "redis://localhost:6379/0";
+        description = ''
+          Redis connection URL, used when `database.backend` is `redis`.
+
+          If this points at a local `services.redis.servers.<name>`,
+          add `systemd.services.yopass.after = [ "redis-<name>.service" ];`
+          yourself to avoid a startup race -- this module doesn't
+          create or own the backend, so it can't infer that ordering.
+        '';
+      };
+    };
+
+    maxLength = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 10000;
+      description = "Maximum encrypted secret size in bytes.";
+    };
+
+    defaultExpiry = lib.mkOption {
+      type = lib.types.enum [
+        "1h"
+        "1d"
+        "1w"
+      ];
+      default = "1h";
+      description = "Default expiration pre-selected in the UI.";
+    };
+
+    forceExpiration = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "1h"
+          "1d"
+          "1w"
+        ]
+      );
+      default = null;
+      description = ''
+        Force all secrets and file uploads to this fixed expiration.
+        The server rejects any create request specifying a different
+        value.
+      '';
+    };
+
+    forceOnetimeSecrets = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Reject secrets that are not set to one-time viewing.";
+    };
+
+    prefetchSecret = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Show a warning that the secret may be one-time use before revealing it.";
+    };
+
+    argon2 = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Use Argon2id for password key derivation instead of iterated
+        SHA-256. Loosens the Content-Security-Policy to allow
+        WebAssembly compilation (`'wasm-unsafe-eval'`) — a reverse
+        proxy that overrides the CSP header must add that keyword
+        itself, or decryption breaks in the browser.
+      '';
+    };
+
+    fileStorage = {
+      maxFileSize = lib.mkOption {
+        type = lib.types.str;
+        default = "512KB";
+        example = "10MB";
+        description = ''
+          Maximum file upload size. Capped at 1 MB without a license
+          key regardless of this setting.
+        '';
+      };
+
+      disableUpload = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Disable the `/create/file` upload endpoint entirely.";
+      };
+
+      backend = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "disk"
+            "s3"
+          ]
+        );
+        default = null;
+        description = ''
+          File storage backend. Left unset (`null`) stores files in
+          the same database backend used for text secrets.
+        '';
+      };
+
+      path = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/yopass/files";
+        description = "Base directory for the disk file store, used when `fileStorage.backend` is `disk`.";
+      };
+
+      s3 = {
+        bucket = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "S3 bucket name. Required when `fileStorage.backend` is `s3`.";
+        };
+
+        prefix = lib.mkOption {
+          type = lib.types.str;
+          default = "yopass/";
+          description = "Key prefix for objects stored in S3.";
+        };
+
+        endpoint = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "http://minio:9000";
+          description = "S3-compatible endpoint URL.";
+        };
+
+        region = lib.mkOption {
+          type = lib.types.str;
+          default = "us-east-1";
+          description = "S3 region.";
+        };
+      };
+
+      cleanupInterval = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 60;
+        description = "How often (seconds) the built-in file cleanup runs.";
+      };
+
+      disableCleanup = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Disable the built-in cleanup goroutine, e.g. when relying on S3 lifecycle rules instead.";
+      };
+    };
+
+    tls = {
+      cert = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Path to the TLS certificate file.";
+      };
+
+      key = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Path to the TLS private key file.";
+      };
+    };
+
+    corsAllowOrigin = lib.mkOption {
+      type = lib.types.str;
+      default = "*";
+      description = "Value for the `Access-Control-Allow-Origin` response header.";
+    };
+
+    trustedProxies = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "192.168.1.0/24"
+        "10.0.0.0/8"
+      ];
+      description = "IP addresses or CIDR ranges whose `X-Forwarded-For` headers are trusted.";
+    };
+
+    readOnly = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Disable secret creation endpoints. Retrieval and deletion remain active.";
+    };
+
+    disableFeatures = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Hide the features section on the homepage.";
+    };
+
+    noLanguageSwitcher = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Hide the language switcher in the navigation bar.";
+    };
+
+    privacyNoticeUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "URL linked from the privacy notice in the footer.";
+    };
+
+    imprintUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "URL linked from the imprint / legal notice in the footer.";
+    };
+
+    publicUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Base URL of the public read-only instance. Secret links
+        generated by the creation instance use this URL instead.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/yopass";
+      description = ''
+        Path to a file in systemd `EnvironmentFile` format, for
+        settings that shouldn't land in the Nix store: `API_TOKEN`,
+        `WEBHOOK_SECRET`, `LICENSE_KEY`, `OIDC_CLIENT_SECRET`,
+        `OIDC_SESSION_KEY`.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType =
+          with lib.types;
+          attrsOf (
+            let
+              typeList = [
+                bool
+                float
+                int
+                str
+                path
+              ];
+            in
+            oneOf (typeList ++ [ (listOf (oneOf typeList)) ])
+          );
+      };
+      default = { };
+      description = ''
+        Extra yopass-server settings, as environment variables. See
+        [the upstream documentation](https://github.com/jhaals/yopass/blob/master/docs/server-options.md)
+        for available flags — this option takes their env var form
+        (e.g. `--oidc-issuer` is `OIDC_ISSUER`). Prefer the type-checked
+        options above where one exists; use this for anything not yet
+        modeled, including license-gated settings like OIDC and
+        branding.
+      '';
+      example = {
+        OIDC_ISSUER = "https://accounts.google.com";
+        OIDC_ALLOWED_DOMAINS = "example.com";
+        APP_NAME = "Secrets";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.yopass = {
+      description = "Yopass - Share secrets securely";
+      documentation = [ "https://github.com/jhaals/yopass" ];
+      wantedBy = [ "multi-user.target" ];
+      # memcached.service is always that exact unit name in nixpkgs, so
+      # it's safe to order after unconditionally when used. redis has no
+      # equivalent default here -- see database.redis's description.
+      after = [
+        "network.target"
+      ]
+      ++ lib.optional (cfg.database.backend == "memcached") "memcached.service";
+
+      environment = env;
+
+      serviceConfig = {
+        ExecStart = lib.getExe' cfg.package "yopass-server";
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "on-failure";
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+        StateDirectory = "yopass";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged @setuid @keyring"
+        ];
+        UMask = "0077";
+      };
+    };
+
+    users.users = lib.mkIf (cfg.user == defaultUser) {
+      ${defaultUser} = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = "/var/lib/yopass";
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == defaultGroup) {
+      ${defaultGroup} = { };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1966,6 +1966,7 @@ in
     inherit runTest;
   };
   yggdrasil = runTest ./yggdrasil.nix;
+  yopass = import ./web-apps/yopass.nix { inherit pkgs runTest; };
   your_spotify = runTest ./your_spotify.nix;
   zammad = runTest ./zammad.nix;
   zapret2 = runTest ./zapret2.nix;

--- a/nixos/tests/web-apps/yopass.nix
+++ b/nixos/tests/web-apps/yopass.nix
@@ -1,0 +1,73 @@
+{
+  runTest,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (pkgs) lib;
+  yopassCli = lib.getExe pkgs.yopass;
+
+  yopassTest =
+    { name, backend }:
+    runTest {
+      name = "yopass-${name}";
+
+      nodes.machine =
+        { ... }:
+        {
+          services.memcached.enable = backend == "memcached";
+          services.redis.servers.yopass = lib.mkIf (backend == "redis") {
+            enable = true;
+            # Named instances default to port 0 (Unix socket only); yopass
+            # connects over TCP via a redis:// URL, so this needs enabling.
+            port = 6379;
+          };
+
+          services.yopass = {
+            enable = true;
+            database.backend = backend;
+            # "localhost" resolves to the IPv6 loopback first in this VM,
+            # but services.redis.servers binds 127.0.0.1 (IPv4) only by
+            # default; point at it explicitly rather than fight DNS order.
+            database.redis = lib.mkIf (backend == "redis") "redis://127.0.0.1:6379/0";
+          };
+
+          # The module can't infer this itself (see database.redis's
+          # description) since it doesn't own the backend -- wire it here,
+          # where the actual unit name (for this *named* redis instance)
+          # is known, to avoid a startup race.
+          systemd.services.yopass.after = lib.mkIf (backend == "redis") [ "redis-yopass.service" ];
+          systemd.services.yopass.requires = lib.mkIf (backend == "redis") [ "redis-yopass.service" ];
+        };
+
+      testScript = ''
+        start_all()
+        machine.wait_for_unit("yopass.service")
+        machine.wait_for_open_port(1337)
+        machine.succeed("curl --fail http://localhost:1337 | grep -qi yopass")
+
+        # Round-trip a secret through the real yopass CLI (ships in the
+        # same package as yopass-server), exercising create + retrieve
+        # against the running server rather than guessing the HTTP API.
+        link = machine.succeed(
+            "printf 'hello from the nixos test' |"
+            " ${yopassCli} --api http://localhost:1337 --url http://localhost:1337"
+        ).strip()
+        machine.succeed(
+            "${yopassCli} --api http://localhost:1337 --url http://localhost:1337"
+            f" --decrypt '{link}' | grep -q 'hello from the nixos test'"
+        )
+      '';
+    };
+in
+{
+  memcached = yopassTest {
+    name = "memcached";
+    backend = "memcached";
+  };
+  redis = yopassTest {
+    name = "redis";
+    backend = "redis";
+  };
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Adds a NixOS module `services.yopass` for [Yopass](https://yopass.se/) (the package itself landed in #551500), a secure way to share secrets, passwords and files.

yopass-server has no config file format — every flag documented in its [server-options docs](https://github.com/jhaals/yopass/blob/master/docs/server-options.md) has a 1:1 environment variable equivalent, so the module generates environment variables rather than a config file. Named, type-checked options cover the documented flags grouped by category (core, database, secrets, file storage, TLS, security, frontend/UI), plus a freeform `settings` escape hatch for anything not yet modeled — notably the license-gated OIDC/branding/audit-log flags.

Options:
- `database.backend` (`memcached` or `redis`) plus the matching connection option — the module doesn't own or create the backend, so if you point it at a local `services.redis.servers.<name>`, you need to add the matching `systemd.services.yopass.after`/`wants` yourself (a named redis instance produces the unit `redis-<name>.service`, not `redis.service`, so this can't be inferred in general). Memcached's ordering is handled automatically, since nixpkgs' memcached module always uses the single unit name `memcached.service`.
- `environmentFile` (optional) — supplies secrets (`API_TOKEN`, `WEBHOOK_SECRET`, `LICENSE_KEY`, `OIDC_CLIENT_SECRET`) via a systemd `EnvironmentFile`, keeping them out of the world-readable Nix store.
- Standard options for the rest of the documented flags (`port`, default `1337`; `maxLength`; `defaultExpiry`; `fileStorage.*`; `tls.*`; …).

Includes a NixOS test in `nixos/tests/web-apps/yopass.nix` with one variant per storage backend (memcached, redis). Each variant does a real functional round-trip through the actual `yopass` CLI (create a secret, decrypt it back) rather than hand-guessing the HTTP API.

> Disclosure: this pull request summary was drafted with assistance from Claude Code (Claude Sonnet 5 / Fable 5). All changes were reviewed and tested by me, and the commit carries an `Assisted-by:` trailer.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
