### PR TITLE
 gtest: fix build withAbseil 

### DIFF
--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -50,8 +50,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-  ]
-  ++ lib.optionals withAbseil [
+  ];
+
+  buildInputs = lib.optionals withAbseil [
     abseil-cpp
     re2
   ];

--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -74,6 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/google/googletest";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ stephen-huan ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Building with the `withAbseil = true` flag (as needed by `pkgs.or-tools`) leads to the following build error.

```
nix-repl> :b legacyPackages.x86_64-linux.gtest.override { withAbseil = true; }
error: Cannot build '/nix/store/izx3cj34wzsrgymld3hyylhwsylqdrja-gtest-1.17.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/a9wvgarxhaa60njqfz3yllwp1xr984hs-gtest-1.17.0-dev
         /nix/store/zyxlkn4mckgpjrc2m7phx04b8isqw8yn-gtest-1.17.0
       Last 25 log lines:
       > -- Detecting C compile features - done
       > -- Detecting CXX compiler ABI info
       > -- Detecting CXX compiler ABI info - done
       > -- Check for working CXX compiler: /nix/store/w88q44gqd1qg5wmkk7v0h97rpiqvam0l-gcc-wrapper-15.3.0/bin/g++ - skipped
       > -- Detecting CXX compile features
       > -- Detecting CXX compile features - done
       > CMake Error at CMakeLists.txt:25 (find_package):
       >   By not providing "Findabsl.cmake" in CMAKE_MODULE_PATH this project has
       >   asked CMake to find a package configuration file provided by "absl", but
       >   CMake did not find one.
       >
       >   Could not find a package configuration file provided by "absl" with any of
       >   the following names:
       >
       >     absl.cps
       >     abslConfig.cmake
       >     absl-config.cmake
       >
       >   Add the installation prefix of "absl" to CMAKE_PREFIX_PATH or set
       >   "absl_DIR" to a directory containing one of the above files.  If "absl"
       >   provides a separate development package or SDK, be sure it has been
       >   installed.
       >
       >
       > -- Configuring incomplete, errors occurred!
       For full logs, run:
         nix-store -l /nix/store/izx3cj34wzsrgymld3hyylhwsylqdrja-gtest-1.17.0.drv
```

This is because of enabling `strictDeps` (https://github.com/NixOS/nixpkgs/pull/551630) + the PR https://github.com/NixOS/nixpkgs/pull/484228 adding the flag mistakenly adding the dependencies to `nativeBuildInputs` instead of `buildInputs`. Indeed, `patchelf --print-rpath ./result/lib/libgtest.so` gives

```
/nix/store/l6gapc4fk3sk0jw4nl0a2vv5kg524pyp-abseil-cpp-20260107.1/lib:/nix/store/ia8ycxcfs23xblv3s18i4xgqxm5sbkri-icu4c-78.3/lib:/nix/store/3x5532sa2gihl6gqxmi38vrmax01cwxz-re2-2025-11-05/lib:/nix/store/n51dhmdbik1kfrsm62j5knavmigwrl1a-glibc-2.42-84/lib:/nix/store/0vqb1mcas5j8dv6bhbrshinlgsg6bvgi-gcc-15.3.0-lib/lib
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
