### PR TITLE
home-assistant-custom-components.homematicip_local: 2.9.1 -> 2.10.0

### DIFF
--- a/pkgs/development/python-modules/aiohomematic/default.nix
+++ b/pkgs/development/python-modules/aiohomematic/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aiohomematic";
-  version = "2026.8.2";
+  version = "2026.8.5";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -29,7 +29,7 @@ buildPythonPackage (finalAttrs: {
     owner = "SukramJ";
     repo = "aiohomematic";
     tag = finalAttrs.version;
-    hash = "sha256-5jsIc/1zgDjHBlHtTQv23it+KbmQu3wEyCpWXdXe9ro=";
+    hash = "sha256-AmtDusw8pz+7OK6DMujlOcBn5yQ8K21YImb2aSohp78=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/openccu-loom-client/default.nix
+++ b/pkgs/development/python-modules/openccu-loom-client/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "openccu-loom-client";
-  version = "2026.8.9";
+  version = "2026.8.26";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
     owner = "SukramJ";
     repo = "openccu-loom-client";
     tag = finalAttrs.version;
-    hash = "sha256-wV9CVMBmztDHmg7kxYwELW+yDiJLBElvgnAvMGaGjoY=";
+    hash = "sha256-DjJqT13U2q7ubCWAWLd4Jcw/YShPcoIfVlK5KtbVtOg=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/openccu-loom-types/default.nix
+++ b/pkgs/development/python-modules/openccu-loom-types/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "openccu-loom-types";
-  version = "0.3.10";
+  version = "0.5.5";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     owner = "SukramJ";
     repo = "openccu-loom-types";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dEqDQW+WllrhE2bBzVflQSy39SeRGhBhNTBvi4OVxSw=";
+    hash = "sha256-zA/yLUwnmu4hmdWK1OuZ77mTnaM1p8ZEqSl41dN2a+w=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
@@ -17,13 +17,13 @@
 buildHomeAssistantComponent rec {
   owner = "SukramJ";
   domain = "homematicip_local";
-  version = "2.9.1";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "SukramJ";
     repo = "custom_homematic";
     tag = version;
-    hash = "sha256-zBtTqNxmOD844rBxPyHGCkE3GLYUH8mI5qBtPdxz24o=";
+    hash = "sha256-QJtINxZo0Lau8oNpZcjV3Cwt91c0T5WeD2O5RybhTAU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/SukramJ/homematicip_local/compare/2.9.1...2.10.0

Changelog: https://github.com/SukramJ/custom_homematic/blob/2.10.0/changelog.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
