### PR TITLE
gccNGPackages_16: Init

### DIFF
--- a/pkgs/development/compilers/gcc/ng/15/libgcc/darwin-detection.patch
+++ b/pkgs/development/compilers/gcc/ng/15/libgcc/darwin-detection.patch
@@ -1,0 +1,12 @@
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -236,7 +236,7 @@
+   esac
+   tmake_file="$tmake_file t-slibgcc-darwin"
+   case ${host} in
+-    *-*-darwin2*)
+-      tmake_file="t-darwin-min-11 $tmake_file"
++    *-*-darwin2* | *-*-darwin)
++      tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
+       ;;
+     *-*-darwin1[89]*)

--- a/pkgs/development/compilers/gcc/ng/16/gcc/fix-collect2-paths.diff
+++ b/pkgs/development/compilers/gcc/ng/16/gcc/fix-collect2-paths.diff
@@ -1,0 +1,315 @@
+diff --git a/gcc/collect2.cc b/gcc/collect2.cc
+index 4353be6e3..7cd646905 100644
+--- a/gcc/collect2.cc
++++ b/gcc/collect2.cc
+@@ -327,7 +327,7 @@ static void write_aix_file (FILE *, struct id *);
+ static char *resolve_lib_name (const char *);
+ #endif
+ static char *extract_string (const char **);
+-static void post_ld_pass (bool);
++static void post_ld_pass (bool, bool);
+ static void process_args (int *argcp, char **argv);
+ 
+ /* Enumerations describing which pass this is for scanning the
+@@ -513,12 +513,10 @@ is_ctor_dtor (const char *s)
+ 
+ static struct path_prefix cpath, path;
+ 
+-#ifdef CROSS_DIRECTORY_STRUCTURE
+ /* This is the name of the target machine.  We use it to form the name
+    of the files to execute.  */
+ 
+ static const char *const target_machine = TARGET_MACHINE;
+-#endif
+ 
+ /* Search for NAME using prefix list PPREFIX.  We only look for executable
+    files.
+@@ -577,7 +575,7 @@ add_lto_object (struct lto_object_list *list, const char *name)
+ 
+ static void
+ maybe_run_lto_and_relink (char **lto_ld_argv, char **object_lst,
+-			  const char **object, bool force)
++			  const char **object, bool force, bool is_cross_compiler)
+ {
+   const char **object_file = const_cast<const char **> (object_lst);
+ 
+@@ -722,7 +720,7 @@ maybe_run_lto_and_relink (char **lto_ld_argv, char **object_lst,
+ 		    "ld_args");
+       /* We assume that temp files were created, and therefore we need to take
+          that into account (maybe run dsymutil).  */
+-      post_ld_pass (/*temp_file*/true);
++      post_ld_pass (/*temp_file*/true, is_cross_compiler);
+       free (lto_ld_argv);
+ 
+       maybe_unlink_list (lto_o_files);
+@@ -734,10 +732,10 @@ maybe_run_lto_and_relink (char **lto_ld_argv, char **object_lst,
+       fork_execute ("ld", lto_ld_argv, HAVE_GNU_LD && at_file_supplied,
+ 		    "ld_args");
+       /* No LTO objects were found, so no new temp file.  */
+-      post_ld_pass (/*temp_file*/false);
++      post_ld_pass (/*temp_file*/false, is_cross_compiler);
+     }
+   else
+-    post_ld_pass (false); /* No LTO objects were found, no temp file.  */
++    post_ld_pass (false, is_cross_compiler); /* No LTO objects were found, no temp file.  */
+ }
+ /* Entry point for linker invoation.  Called from main in collect2.cc.
+    LD_ARGV is an array of arguments for the linker.  */
+@@ -801,33 +799,14 @@ main (int argc, char **argv)
+   static const char *const gstrip_suffix = "gstrip";
+ 
+   const char *full_ld_suffixes[USE_LD_MAX];
+-#ifdef CROSS_DIRECTORY_STRUCTURE
+-  /* If we look for a program in the compiler directories, we just use
+-     the short name, since these directories are already system-specific.
+-     But it we look for a program in the system directories, we need to
+-     qualify the program name with the target machine.  */
+-
+-  const char *const full_nm_suffix =
+-    concat (target_machine, "-", nm_suffix, NULL);
+-  const char *const full_gnm_suffix =
+-    concat (target_machine, "-", gnm_suffix, NULL);
+-#ifdef LDD_SUFFIX
+-  const char *const full_ldd_suffix =
+-    concat (target_machine, "-", ldd_suffix, NULL);
+-#endif
+-  const char *const full_strip_suffix =
+-    concat (target_machine, "-", strip_suffix, NULL);
+-  const char *const full_gstrip_suffix =
+-    concat (target_machine, "-", gstrip_suffix, NULL);
+-#else
++  const char *full_nm_suffix;
++  const char *full_gnm_suffix;
++  const char *full_strip_suffix;
++  const char *full_gstrip_suffix;
++
+ #ifdef LDD_SUFFIX
+-  const char *const full_ldd_suffix	= ldd_suffix;
++  const char *full_ldd_suffix;
+ #endif
+-  const char *const full_nm_suffix	= nm_suffix;
+-  const char *const full_gnm_suffix	= gnm_suffix;
+-  const char *const full_strip_suffix	= strip_suffix;
+-  const char *const full_gstrip_suffix	= gstrip_suffix;
+-#endif /* CROSS_DIRECTORY_STRUCTURE */
+ 
+   const char *arg;
+   FILE *outf;
+@@ -842,6 +821,7 @@ main (int argc, char **argv)
+   const char **ld1;
+   bool use_plugin = false;
+   bool use_collect_ld = false;
++  bool is_cross_compiler = false;
+ 
+   /* The kinds of symbols we will have to consider when scanning the
+      outcome of a first pass link.  This is ALL to start with, then might
+@@ -866,17 +846,6 @@ main (int argc, char **argv)
+ #endif
+   int i;
+ 
+-  for (i = 0; i < USE_LD_MAX; i++)
+-#ifdef CROSS_DIRECTORY_STRUCTURE
+-    /* lld and mold are platform-agnostic and not prefixed with target
+-       triple.  */
+-    if (!(i == USE_LLD_LD || i == USE_MOLD_LD || i == USE_WILD_LD))
+-      full_ld_suffixes[i] = concat (target_machine, "-", ld_suffixes[i],
+-				    NULL);
+-    else
+-#endif
+-      full_ld_suffixes[i] = ld_suffixes[i];
+-
+   p = argv[0] + strlen (argv[0]);
+   while (p != argv[0] && !IS_DIR_SEPARATOR (p[-1]))
+     --p;
+@@ -1054,6 +1023,65 @@ main (int argc, char **argv)
+   prefix_from_env ("COMPILER_PATH", &cpath);
+   prefix_from_env ("PATH", &path);
+ 
++  /* Determine the full path name of the C compiler to use.  */
++  c_file_name = getenv ("COLLECT_GCC");
++  if (c_file_name == 0)
++    {
++      c_file_name = concat (target_machine, "-gcc", NULL);
++      p = find_a_file (&cpath, c_file_name, X_OK);
++      if (p == 0)
++        p = find_a_file (&path, c_file_name, X_OK);
++
++      if (p == 0) {
++        c_file_name = "gcc";
++        p = find_a_file (&cpath, c_file_name, X_OK);
++        if (p == 0)
++          p = find_a_file (&path, c_file_name, X_OK);
++      }
++    }
++  else
++    {
++      p = find_a_file (&cpath, c_file_name, X_OK);
++
++      /* Here it should be safe to use the system search path since we should have
++        already qualified the name of the compiler when it is needed.  */
++      if (p == 0)
++        p = find_a_file (&path, c_file_name, X_OK);
++    }
++
++  if (p)
++    c_file_name = p;
++
++  if (c_file_name) {
++    is_cross_compiler = strncmp(basename(c_file_name), target_machine, strlen(target_machine)) == 0;
++  }
++
++  for (i = 0; i < USE_LD_MAX; i++)
++    /* lld and mold are platform-agnostic and not prefixed with target
++       triple.  */
++    if (!(i == USE_LLD_LD || i == USE_MOLD_LD || i == USE_WILD_LD) && is_cross_compiler)
++      full_ld_suffixes[i] = concat (target_machine, "-", ld_suffixes[i],
++				    NULL);
++    else
++      full_ld_suffixes[i] = ld_suffixes[i];
++
++  full_nm_suffix =
++    is_cross_compiler ? concat (target_machine, "-", nm_suffix, NULL) : nm_suffix;
++
++  full_gnm_suffix =
++    is_cross_compiler ? concat (target_machine, "-", gnm_suffix, NULL) : gnm_suffix;
++
++  full_strip_suffix =
++    is_cross_compiler ? concat (target_machine, "-", strip_suffix, NULL) : strip_suffix;
++
++  full_gstrip_suffix =
++    is_cross_compiler ? concat (target_machine, "-", gstrip_suffix, NULL) : gstrip_suffix;
++
++#ifdef LDD_SUFFIX
++  full_ldd_suffix =
++    is_cross_compiler ? concat (target_machine, "-", ldd_suffix, NULL) : ldd_suffix;
++#endif
++
+   /* Try to discover a valid linker/nm/strip to use.  */
+ 
+   /* Maybe we know the right file to use (if not cross).  */
+@@ -1144,27 +1172,6 @@ main (int argc, char **argv)
+   if (strip_file_name == 0)
+     strip_file_name = find_a_file (&path, full_strip_suffix, X_OK);
+ 
+-  /* Determine the full path name of the C compiler to use.  */
+-  c_file_name = getenv ("COLLECT_GCC");
+-  if (c_file_name == 0)
+-    {
+-#ifdef CROSS_DIRECTORY_STRUCTURE
+-      c_file_name = concat (target_machine, "-gcc", NULL);
+-#else
+-      c_file_name = "gcc";
+-#endif
+-    }
+-
+-  p = find_a_file (&cpath, c_file_name, X_OK);
+-
+-  /* Here it should be safe to use the system search path since we should have
+-     already qualified the name of the compiler when it is needed.  */
+-  if (p == 0)
+-    p = find_a_file (&path, c_file_name, X_OK);
+-
+-  if (p)
+-    c_file_name = p;
+-
+   *ld1++ = *ld2++ = ld_file_name;
+ 
+   /* Make temp file names.  */
+@@ -1598,6 +1605,8 @@ main (int argc, char **argv)
+ 	       (c_file ? c_file : "not found"));
+       fprintf (stderr, "o_file              = %s\n",
+ 	       (o_file ? o_file : "not found"));
++      fprintf (stderr, "is_cross_compiler   = %s\n",
++          (is_cross_compiler ? "yes" : "no"));
+ 
+       ptr = getenv ("COLLECT_GCC_OPTIONS");
+       if (ptr)
+@@ -1647,9 +1656,9 @@ main (int argc, char **argv)
+ 	  maybe_unlink (export_file);
+ #endif
+ 	if (lto_mode != LTO_MODE_NONE)
+-	  maybe_run_lto_and_relink (ld1_argv, object_lst, object, false);
++	  maybe_run_lto_and_relink (ld1_argv, object_lst, object, false, is_cross_compiler);
+ 	else
+-	  post_ld_pass (/*temp_file*/false);
++	  post_ld_pass (/*temp_file*/false, is_cross_compiler);
+ 
+ 	return 0;
+       }
+@@ -1701,7 +1710,7 @@ main (int argc, char **argv)
+ 	do_link (ld1_argv, "ld1_args");
+ 
+       if (lto_mode)
+-        maybe_run_lto_and_relink (ld1_argv, object_lst, object, false);
++        maybe_run_lto_and_relink (ld1_argv, object_lst, object, false, is_cross_compiler);
+ 
+       /* Strip now if it was requested on the command line.  */
+       if (strip_flag)
+@@ -1719,7 +1728,7 @@ main (int argc, char **argv)
+ #ifdef COLLECT_EXPORT_LIST
+       maybe_unlink (export_file);
+ #endif
+-      post_ld_pass (/*temp_file*/false);
++      post_ld_pass (/*temp_file*/false, is_cross_compiler);
+       return 0;
+     }
+ 
+@@ -1802,15 +1811,15 @@ main (int argc, char **argv)
+   do_link (ld2_argv, "ld2_args");
+ 
+   if (lto_mode)
+-    maybe_run_lto_and_relink (ld2_argv, object_lst, object, false);
++    maybe_run_lto_and_relink (ld2_argv, object_lst, object, false, is_cross_compiler);
+ #else
+   /* Otherwise, simply call ld because link is already done.  */
+   if (lto_mode)
+-    maybe_run_lto_and_relink (ld2_argv, object_lst, object, true);
++    maybe_run_lto_and_relink (ld2_argv, object_lst, object, true, is_cross_compiler);
+   else
+     {
+       fork_execute ("ld", ld2_argv, HAVE_GNU_LD && at_file_supplied, "ld_args");
+-      post_ld_pass (/*temp_file*/false);
++      post_ld_pass (/*temp_file*/false, is_cross_compiler);
+     }
+ 
+   /* Let scan_prog_file do any final mods (OSF/rose needs this for
+@@ -3023,7 +3032,7 @@ process_args (int *argcp, char **argv) {
+ }
+ 
+ static void
+-do_dsymutil (const char *output_file) {
++do_dsymutil (const char *output_file, bool is_cross_compiler) {
+   const char *dsymutil = 0;
+   struct pex_obj *pex;
+   char **real_argv = XCNEWVEC (char *, verbose ? 4 : 3);
+@@ -3034,11 +3043,7 @@ do_dsymutil (const char *output_file) {
+    here is consistent with the way other installations work (and one can
+    always symlink a multitarget dsymutil with a target-specific name).  */
+   const char *dsname = "dsymutil";
+-#ifdef CROSS_DIRECTORY_STRUCTURE
+-  const char *qname = concat (target_machine, "-", dsname, NULL);
+-#else
+-  const char *qname = dsname;
+-#endif
++  const char *qname = is_cross_compiler ? concat (target_machine, "-", dsname, NULL) : dsname;
+ #ifdef DEFAULT_DSYMUTIL
+   /* Configured default takes priority.  */
+   if (dsymutil == 0 && access (DEFAULT_DSYMUTIL, X_OK) == 0)
+@@ -3073,14 +3078,14 @@ do_dsymutil (const char *output_file) {
+ }
+ 
+ static void
+-post_ld_pass (bool temp_file) {
++post_ld_pass (bool temp_file, bool is_cross_compiler) {
+   if (!(temp_file && flag_idsym) && !flag_dsym)
+     return;
+ 
+-  do_dsymutil (output_file);
++  do_dsymutil (output_file, is_cross_compiler);
+ }
+ #else
+ static void
+ process_args (int *argcp ATTRIBUTE_UNUSED, char **argv ATTRIBUTE_UNUSED) { }
+-static void post_ld_pass (bool temp_file ATTRIBUTE_UNUSED) { }
++static void post_ld_pass (bool temp_file ATTRIBUTE_UNUSED, bool is_cross_compiler ATTRIBUTE_UNUSED) { }
+ #endif

--- a/pkgs/development/compilers/gcc/ng/16/libatomic/no-gcc-objdir-install.patch
+++ b/pkgs/development/compilers/gcc/ng/16/libatomic/no-gcc-objdir-install.patch
@@ -1,0 +1,26 @@
+From: John Ericson <git@JohnEricson.me>
+Subject: [PATCH] libatomic: Do not install into the toplevel gcc objdir
+
+GCC 16 added an `all-local` hook that copies `libatomic.la` into
+`../../gcc/`, so that the compiler being built in the same object tree can
+link `-latomic`.  There is no such tree here: each runtime library is built
+on its own, against an already-finished compiler, which is given the library
+through the wrapper instead.  The rule just fails:
+
+    install: cannot create regular file '/build/build/../../gcc/libatomic.so.1.2.0'
+
+Drop the hook rather than the rule, so the difference from upstream stays as
+small as possible.
+---
+diff --git a/libatomic/Makefile.am b/libatomic/Makefile.am
+index 49689d451..c389e8cd6 100644
+--- a/libatomic/Makefile.am
++++ b/libatomic/Makefile.am
+@@ -181,7 +181,6 @@ all-multi: $(libatomic_la_LIBADD)
+ # from $gcc_objdir seems to fix the issue.
+ 
+ gcc_objdir = `pwd`/$(MULTIBUILDTOP)../../gcc/
+-all-local: stmp-libatomic
+ stmp-libatomic: libatomic.la
+ 	$(LIBTOOL) --mode=install $(INSTALL_DATA) libatomic.la $(gcc_objdir)$(MULTISUBDIR)/
+ if LIBAT_BUILD_ASNEEDED_SOLINK

--- a/pkgs/development/compilers/gcc/ng/16/libgcc/darwin-detection.patch
+++ b/pkgs/development/compilers/gcc/ng/16/libgcc/darwin-detection.patch
@@ -1,0 +1,12 @@
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -239,7 +239,7 @@ case ${host} in
+     x86_64-*-darwin2[0-2]*)
+       tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
+       ;;
+-    *-*-darwin2*)
+-      tmake_file="t-darwin-min-11 $tmake_file"
++    *-*-darwin2* | *-*-darwin)
++      tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
+       ;;
+     *-*-darwin1[89]*)

--- a/pkgs/development/compilers/gcc/ng/16/libgfortran/force-regular-dirs.patch
+++ b/pkgs/development/compilers/gcc/ng/16/libgfortran/force-regular-dirs.patch
@@ -1,0 +1,64 @@
+From 7a0c8ca8872a73c6886940448ba9b3203b13268d Mon Sep 17 00:00:00 2001
+From: John Ericson <git@JohnEricson.me>
+Date: Mon, 21 Jul 2025 11:42:13 -0400
+Subject: [PATCH] libgfortran: Force regular include/lib dir
+
+Rebased for GCC 16, which grew a second coarray library (libcaf_shmem)
+sharing the `cafexeclib` prefix this removes.
+---
+ libgfortran/Makefile.am | 16 ++++++----------
+ 1 file changed, 6 insertions(+), 10 deletions(-)
+
+diff --git a/libgfortran/Makefile.am b/libgfortran/Makefile.am
+index 2862326db..f97bfc9b5 100644
+--- a/libgfortran/Makefile.am
++++ b/libgfortran/Makefile.am
+@@ -42,8 +42,7 @@ extra_darwin_ldflags_libgfortran += -Wc,-nodefaultrpaths
+ extra_darwin_ldflags_libgfortran += -Wl,-rpath,@loader_path
+ endif
+ 
+-gfor_c_HEADERS = ISO_Fortran_binding.h
+-gfor_cdir = $(libdir)/gcc/$(target_alias)/$(gcc_version)/include
++include_HEADERS = ISO_Fortran_binding.h
+ 
+ LTLDFLAGS = $(shell $(SHELL) $(top_srcdir)/../libtool-ldflags $(LDFLAGS)) \
+ 	    $(lt_host_flags)
+@@ -58,8 +57,8 @@ LIBBACKTRACE_INCLUDE = -I$(srcdir)/$(MULTISRCTOP)../libbacktrace \
+ 	      -I../libbacktrace
+ endif
+ 
+-toolexeclib_LTLIBRARIES = libgfortran.la
+-toolexeclib_DATA = libgfortran.spec
++lib_LTLIBRARIES = libgfortran.la
++toolexeclib_DATA = libgfortran.spec # needs "exec" in name
+ libgfortran_la_LINK = $(LINK) $(libgfortran_la_LDFLAGS)
+ libgfortran_la_LDFLAGS = -version-info `grep -v '^\#' $(srcdir)/libtool-version` \
+ 	$(LTLDFLAGS) $(LIBQUADLIB) $(LIBBACKTRACE_LIB) \
+@@ -71,15 +70,14 @@ libgfortran_la_DEPENDENCIES = $(version_dep) libgfortran.spec $(LIBQUADLIB_DEP)
+ libcaf_shared_DEPS = caf/libcaf.h caf/caf_error.h
+ libcaf_shared_SRCS = caf/caf_error.c
+ 
+-cafexeclib_LTLIBRARIES = libcaf_single.la
+-cafexeclibdir = $(libdir)/gcc/$(target_alias)/$(gcc_version)$(MULTISUBDIR)
++lib_LTLIBRARIES += libcaf_single.la
+ libcaf_single_la_SOURCES = caf/single.c $(libcaf_shared_SRCS)
+ libcaf_single_la_LDFLAGS = -static
+ libcaf_single_la_DEPENDENCIES = $(libcaf_shared_DEPS)
+ libcaf_single_la_LINK = $(LINK) $(libcaf_single_la_LDFLAGS)
+ 
+ if ENABLE_CAF_SHMEM
+-cafexeclib_LTLIBRARIES += libcaf_shmem.la
++lib_LTLIBRARIES += libcaf_shmem.la
+ libcaf_shmem_la_CFLAGS = $(CAF_SHMEM_CFLAGS)
+ libcaf_shmem_la_SOURCES = $(libcaf_shared_SRCS) \
+ 	caf/shmem.c caf/shmem/alloc.c caf/shmem/allocator.c \
+@@ -97,8 +95,7 @@ libcaf_shmem_la_LINK = $(LINK) $(libcaf_shmem_la_LDFLAGS) $(CAF_SHMEM_LIBS)
+ endif
+ 
+ if IEEE_SUPPORT
+-fincludedir = $(libdir)/gcc/$(target_alias)/$(gcc_version)$(MULTISUBDIR)/finclude
+-nodist_finclude_HEADERS = ieee_arithmetic.mod ieee_exceptions.mod ieee_features.mod
++nodist_include_HEADERS = ieee_arithmetic.mod ieee_exceptions.mod ieee_features.mod
+ endif
+ 
+ ## io.h conflicts with a system header on some platforms, so

--- a/pkgs/development/compilers/gcc/ng/16/libgomp/uid-buffer-size.patch
+++ b/pkgs/development/compilers/gcc/ng/16/libgomp/uid-buffer-size.patch
@@ -1,0 +1,29 @@
+From: John Ericson <git@JohnEricson.me>
+Subject: [PATCH] libgomp: Size the device UID buffer for a negative int
+
+`gomp_get_uid_for_device` allows ten digits for the `%d`, but `device_num`
+is a plain `int`, whose widest rendering is `-2147483648` -- eleven.  With
+the eight-character prefix that is twenty bytes plus the NUL into a
+nineteen-byte buffer, so `snprintf` truncates.  GCC 16 notices, and
+`libgomp` builds with `-Werror`:
+
+    target.c:5956:31: error: 'snprintf' output may be truncated before the
+    last format character [-Werror=format-truncation=]
+
+Allow the sign.
+
+TODO: send upstream.
+---
+diff --git a/libgomp/target.c b/libgomp/target.c
+index d562b0493..526875504 100644
+--- a/libgomp/target.c
++++ b/libgomp/target.c
+@@ -5950,7 +5950,7 @@ gomp_get_uid_for_device (struct gomp_device_descr *devicep, int device_num)
+     devicep->uid = devicep->get_uid_func (devicep->target_id);
+   if (!devicep->uid)
+     {
+-      size_t ln = strlen (STR_OMP_DEV_PREFIX) + 10 + 1;
++      size_t ln = strlen (STR_OMP_DEV_PREFIX) + 11 + 1;
+       char *uid;
+       uid = gomp_malloc (ln);
+       snprintf (uid, ln, "%s%d", STR_OMP_DEV_PREFIX, device_num);

--- a/pkgs/development/compilers/gcc/ng/README.md
+++ b/pkgs/development/compilers/gcc/ng/README.md
@@ -64,3 +64,23 @@ Both are packaged from the same sources and, for now, the same version: `gccNGPa
 Nothing selects GGN NG yet by default.
 The plan is for very exotic package sets to switch to this first.
 The main tier-1 native Linux package sets cached on `cache.nixos.org` will come later.
+
+### Patches the monolithic set has and this one does not
+
+None of `../patches/default.nix` is applied here.
+Some of it this set does not need, some of it is a real gap; the ones that have been looked at:
+
+| patch | verdict | why |
+|---|---|---|
+| `gcc-12-no-sys-dirs.patch`, `13/no-sys-dirs-riscv.patch` | needed | Needed for a native build, not a cross one. `cppdefault.cc` drops `LOCAL_INCLUDE_DIR` and `NATIVE_SYSTEM_HEADER_DIR` by itself when `CROSS_DIRECTORY_STRUCTURE` is defined and no sysroot is, and `/lib/` and `/usr/lib/` reach `startfile_prefixes` only under `*cross_compile == '0' \|\| target_system_root`. We pass no sysroot, so a cross compiler is already clean and a native one searches all four. |
+| `13/mangle-NIX_STORE-in-__FILE__.patch` | needed | `cc-wrapper` sets `useMacroPrefixMap = !isGNU`, and this set's `gcc` is `isGNU`, so nothing else keeps store paths out of `__FILE__`. |
+| `cfi_startproc-reorder-label-14-1.diff` | needed, in `libgcc` | Needed on aarch64, and belongs to `libgcc` rather than `gcc`: it patches `libgcc/config/aarch64/lse.S`, whose output clang 18 and later refuse to assemble. |
+| `libstdc-fix-compilation-in-freestanding-win32.patch` | believed unnecessary | Only takes effect under `!_GLIBCXX_HOSTED`, and `libstdcxx` is built against a real libc here. The monolithic set needs it because its `withoutTargetLibc` stage builds a freestanding libstdc++. |
+| the Darwin set (`iains` and Homebrew) | needed | Darwin is in scope; it is just not tested yet. Two of the three are `libgcc` patches rather than `gcc` ones, as `cfi_startproc` was: `libgcc-darwin-fix-reexport` (`libgcc/config/t-slibgcc-darwin`) and `libgcc-darwin-detection` (`libgcc/config.host`). Only the large `gcc-16-darwin-aarch64-support` diff belongs to `gcc`. |
+| `c++tools-dont-check-enable-default-pie.patch` | needed | `--enable-default-pie` is about the target, but `c++tools` is built for the host, so it should follow `--enable-host-pie` instead. We pass `--enable-default-pie` and we do build `c++tools` -- there is a `g++-mapper-server` in the output -- so the mis-scoped flag applies here too. Upstream only in 14 and 15, and 15 is the default here, so this does not go away soon. |
+| `ppc-musl.patch` | needed | Needed on powerpc+musl, and `no-sys-dirs` does not subsume it: that one `#undef`s `LOCAL_INCLUDE_DIR` in `cppdefault.cc`, but `rs6000/sysv4.h` tests the macro earlier, where it builds `INCLUDE_DEFAULTS_MUSL_LOCAL`, so `/usr/local/include` survives there. |
+| `gcc-12-gfortran-driving.patch` | needed | Needed wherever libtool parses `gfortran -v`, which `libgfortran` does. Gate it on `langFortran` as the monolithic set does. |
+| the two Cygwin patches | needed, but elsewhere | Neither is upstream in 15 or 16. They belong with whatever enables Cygwin here rather than with this set's own bootstrap. |
+| `libssp-noshared-musl32.patch` | undecided | Makes `LINK_SSP_SPEC` link `-lssp_nonshared` unconditionally, which is an Alpine assumption about what the libc ships, and this set builds its own `libssp`. Worth settling against a real musl x86_32 target rather than on paper. |
+
+All four apply cleanly to 15.3.0 and 16.2.0; none is applied here yet.

--- a/pkgs/development/compilers/gcc/ng/README.md
+++ b/pkgs/development/compilers/gcc/ng/README.md
@@ -1,5 +1,7 @@
 # GCC Next-Generation
 
+> This read-me assisted by: Claude Code (Claude Opus 5)
+
 Experimental split GCC package set, based on the LLVM package set design.
 
 The monolithic `gcc` derivation builds the compiler and every runtime library in one go, so a change to the target libc rebuilds the compiler too.
@@ -65,22 +67,37 @@ Nothing selects GGN NG yet by default.
 The plan is for very exotic package sets to switch to this first.
 The main tier-1 native Linux package sets cached on `cache.nixos.org` will come later.
 
+### Patches
+
+Several of these are conditional on the target platform, following the monolithic set.
+General Nixpkgs policy is to apply patches unconditionally where possible, and we probably should too.
+But out of an abundance of caution we're matching the monolithic GCC for now.
+
+TODO: apply them whatever the target.
+The ones that are gated touch files no other target compiles -- `gcc/config/i386/cygwin.h`, `libgcc/config.host` -- so it should just work.
+
+`libssp-noshared-musl32.patch` is the exception either way: it rewrites `LINK_SSP_SPEC` in `gcc/gcc.cc`, which every target compiles, so it cannot become unconditional without changing what every other target links.
+
 ### Patches the monolithic set has and this one does not
 
-None of `../patches/default.nix` is applied here.
-Some of it this set does not need, some of it is a real gap; the ones that have been looked at:
+Most of `../patches/default.nix` is not applied here.
+Some of it this set does not need; three were real gaps and have since been copied in.
+The ones that have been looked at:
 
-| patch | verdict | why |
+| patch | status | why |
 |---|---|---|
-| `gcc-12-no-sys-dirs.patch`, `13/no-sys-dirs-riscv.patch` | needed | Needed for a native build, not a cross one. `cppdefault.cc` drops `LOCAL_INCLUDE_DIR` and `NATIVE_SYSTEM_HEADER_DIR` by itself when `CROSS_DIRECTORY_STRUCTURE` is defined and no sysroot is, and `/lib/` and `/usr/lib/` reach `startfile_prefixes` only under `*cross_compile == '0' \|\| target_system_root`. We pass no sysroot, so a cross compiler is already clean and a native one searches all four. |
-| `13/mangle-NIX_STORE-in-__FILE__.patch` | needed | `cc-wrapper` sets `useMacroPrefixMap = !isGNU`, and this set's `gcc` is `isGNU`, so nothing else keeps store paths out of `__FILE__`. |
-| `cfi_startproc-reorder-label-14-1.diff` | needed, in `libgcc` | Needed on aarch64, and belongs to `libgcc` rather than `gcc`: it patches `libgcc/config/aarch64/lse.S`, whose output clang 18 and later refuse to assemble. |
+| `gcc-12-no-sys-dirs.patch`, `13/no-sys-dirs-riscv.patch` | applied | Needed for a native build, not a cross one. `cppdefault.cc` drops `LOCAL_INCLUDE_DIR` and `NATIVE_SYSTEM_HEADER_DIR` by itself when `CROSS_DIRECTORY_STRUCTURE` is defined and no sysroot is, and `/lib/` and `/usr/lib/` reach `startfile_prefixes` only under `*cross_compile == '0' \|\| target_system_root`. We pass no sysroot, so a cross compiler is already clean and a native one searches all four. |
+| `13/mangle-NIX_STORE-in-__FILE__.patch` | applied | `cc-wrapper` sets `useMacroPrefixMap = !isGNU`, and this set's `gcc` is `isGNU`, so nothing else keeps store paths out of `__FILE__`. |
+| `cfi_startproc-reorder-label-14-1.diff` | applied, in `libgcc`, off Darwin | Needed on aarch64, and belongs to `libgcc` rather than `gcc`: it patches `libgcc/config/aarch64/lse.S`, whose output clang 18 and later refuse to assemble. Held back on Darwin, where the `iains` branch replaces `STARTFN` with an `ENTRY` macro that already writes the label ahead of `.cfi_startproc`. |
 | `libstdc-fix-compilation-in-freestanding-win32.patch` | believed unnecessary | Only takes effect under `!_GLIBCXX_HOSTED`, and `libstdcxx` is built against a real libc here. The monolithic set needs it because its `withoutTargetLibc` stage builds a freestanding libstdc++. |
-| the Darwin set (`iains` and Homebrew) | needed | Darwin is in scope; it is just not tested yet. Two of the three are `libgcc` patches rather than `gcc` ones, as `cfi_startproc` was: `libgcc-darwin-fix-reexport` (`libgcc/config/t-slibgcc-darwin`) and `libgcc-darwin-detection` (`libgcc/config.host`). Only the large `gcc-16-darwin-aarch64-support` diff belongs to `gcc`. |
-| `c++tools-dont-check-enable-default-pie.patch` | needed | `--enable-default-pie` is about the target, but `c++tools` is built for the host, so it should follow `--enable-host-pie` instead. We pass `--enable-default-pie` and we do build `c++tools` -- there is a `g++-mapper-server` in the output -- so the mis-scoped flag applies here too. Upstream only in 14 and 15, and 15 is the default here, so this does not go away soon. |
-| `ppc-musl.patch` | needed | Needed on powerpc+musl, and `no-sys-dirs` does not subsume it: that one `#undef`s `LOCAL_INCLUDE_DIR` in `cppdefault.cc`, but `rs6000/sysv4.h` tests the macro earlier, where it builds `INCLUDE_DEFAULTS_MUSL_LOCAL`, so `/usr/local/include` survives there. |
-| `gcc-12-gfortran-driving.patch` | needed | Needed wherever libtool parses `gfortran -v`, which `libgfortran` does. Gate it on `langFortran` as the monolithic set does. |
-| the two Cygwin patches | needed, but elsewhere | Neither is upstream in 15 or 16. They belong with whatever enables Cygwin here rather than with this set's own bootstrap. |
+| the Darwin set (`iains` and Homebrew) | applied | Darwin is in scope; it is just not tested yet. Two of the three are `libgcc` patches rather than `gcc` ones, as `cfi_startproc` was: `libgcc-darwin-fix-reexport` (`libgcc/config/t-slibgcc-darwin`) and `libgcc-darwin-detection` (`libgcc/config.host`). The third, `gcc-16-darwin-aarch64-support`, spans the monorepo, so each package takes the files it builds -- `gcc`, `libgcc` and `libsanitizer` -- as `system-libbacktrace.patch` already is. `libitm` and `libgcobol` are not packaged here, so their three files are dropped. It also supersedes two of our own patches, which are held back on Darwin: `cfi_startproc-reorder-label` and `fix-collect2-paths`. |
+| `c++tools-dont-check-enable-default-pie.patch` | applied, below 16 | `--enable-default-pie` is about the target, but `c++tools` is built for the host, so it should follow `--enable-host-pie` instead. We pass `--enable-default-pie` and we do build `c++tools` -- there is a `g++-mapper-server` in the output -- so the mis-scoped flag applies here too. Upstream only in 14 and 15, and 15 is the default here, so this does not go away soon. |
+| `ppc-musl.patch` | applied | Needed on powerpc+musl, and `no-sys-dirs` does not subsume it: that one `#undef`s `LOCAL_INCLUDE_DIR` in `cppdefault.cc`, but `rs6000/sysv4.h` tests the macro earlier, where it builds `INCLUDE_DEFAULTS_MUSL_LOCAL`, so `/usr/local/include` survives there. |
+| `gcc-12-gfortran-driving.patch` | applied, on `langFortran` | Needed wherever libtool parses `gfortran -v`, which `libgfortran` does. Gate it on `langFortran` as the monolithic set does. |
+| the two Cygwin patches | applied, on `isCygwin` | Neither is upstream in 15 or 16. They belong with whatever enables Cygwin here rather than with this set's own bootstrap. |
 | `libssp-noshared-musl32.patch` | undecided | Makes `LINK_SSP_SPEC` link `-lssp_nonshared` unconditionally, which is an Alpine assumption about what the libc ships, and this set builds its own `libssp`. Worth settling against a real musl x86_32 target rather than on paper. |
 
-All four apply cleanly to 15.3.0 and 16.2.0; none is applied here yet.
+Everything the monolithic set has is now applied here, bar `libssp-noshared-musl32.patch`, which is undecided for the reason above.
+
+None of the Darwin ones is tested: there is no Darwin machine here.
+What is checked is that each component's list applies in order, with `patch(1)`, on a pristine tree, and that nothing off Darwin changes.

--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -187,6 +187,9 @@ makeScopeWithSplicing' {
           ++ [
             "-B${targetGccPackages.libstdcxx}/lib"
             "-B${targetGccPackages.libgfortran}/lib/"
+            # `libgfortran.spec`, which the driver reads from the directory
+            # above, links `-lquadmath` unconditionally.
+            "-B${targetGccPackages.libquadmath}/lib"
           ]
           ++ threadsCflags;
         };

--- a/pkgs/development/compilers/gcc/ng/common/gcc/c++tools-dont-check-enable-default-pie.patch
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/c++tools-dont-check-enable-default-pie.patch
@@ -1,0 +1,80 @@
+From 3f1f99ef82a65d66e3aaa429bf4fb746b93da0db Mon Sep 17 00:00:00 2001
+From: Kito Cheng <kito.cheng@sifive.com>
+Date: Tue, 27 May 2025 10:10:15 +0800
+Subject: [PATCH] c++tools: Don't check --enable-default-pie.
+
+`--enable-default-pie` is an option to specify whether to enable
+position-independent executables by default for `target`.
+
+However c++tools is build for `host`, so it should just follow
+`--enable-host-pie` option to determine whether to build with
+position-independent executables or not.
+
+NOTE:
+
+I checked PR 98324 and build with same configure option
+(`--enable-default-pie` and lto bootstrap) on x86-64 linux to make sure
+it won't cause same problem.
+
+c++tools/ChangeLog:
+
+	* configure.ac: Don't check `--enable-default-pie`.
+	* configure: Regen.
+---
+ c++tools/configure    | 11 -----------
+ c++tools/configure.ac |  6 ------
+ 2 files changed, 17 deletions(-)
+
+diff --git a/c++tools/configure b/c++tools/configure
+index 1353479becaf4..6df4a2f0dfaed 100755
+--- a/c++tools/configure
++++ b/c++tools/configure
+@@ -700,7 +700,6 @@ enable_option_checking
+ enable_c___tools
+ enable_maintainer_mode
+ enable_checking
+-enable_default_pie
+ enable_host_pie
+ enable_host_bind_now
+ with_gcc_major_version_only
+@@ -1335,7 +1334,6 @@ Optional Features:
+                           enable expensive run-time checks. With LIST, enable
+                           only specific categories of checks. Categories are:
+                           yes,no,all,none,release.
+-  --enable-default-pie    enable Position Independent Executable as default
+   --enable-host-pie       build host code as PIE
+   --enable-host-bind-now  link host code as BIND_NOW
+ 
+@@ -2946,15 +2944,6 @@ $as_echo "#define ENABLE_ASSERT_CHECKING 1" >>confdefs.h
+ 
+ fi
+ 
+-# Check whether --enable-default-pie was given.
+-# Check whether --enable-default-pie was given.
+-if test "${enable_default_pie+set}" = set; then :
+-  enableval=$enable_default_pie; PICFLAG=-fPIE
+-else
+-  PICFLAG=
+-fi
+-
+-
+ # Enable --enable-host-pie
+ # Check whether --enable-host-pie was given.
+ if test "${enable_host_pie+set}" = set; then :
+diff --git a/c++tools/configure.ac b/c++tools/configure.ac
+index db34ee678e033..8c4b72a8023a8 100644
+--- a/c++tools/configure.ac
++++ b/c++tools/configure.ac
+@@ -97,12 +97,6 @@ if test x$ac_assert_checking != x ; then
+ [Define if you want assertions enabled.  This is a cheap check.])
+ fi
+ 
+-# Check whether --enable-default-pie was given.
+-AC_ARG_ENABLE(default-pie,
+-[AS_HELP_STRING([--enable-default-pie],
+-		  [enable Position Independent Executable as default])],
+-[PICFLAG=-fPIE], [PICFLAG=])
+-
+ # Enable --enable-host-pie
+ AC_ARG_ENABLE(host-pie,
+ [AS_HELP_STRING([--enable-host-pie],

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -59,92 +59,98 @@ stdenv.mkDerivation (finalAttrs: {
     "info"
   ];
 
-  patches = [
-    (fetchpatch {
-      name = "for_each_path-functional-programming.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/f23bac62f46fc296a4d0526ef54824d406c3756c.diff";
-      hash = "sha256-J7SrypmVSbvYUzxWWvK2EwEbRsfGGLg4vNZuLEe6Xe0=";
-    })
-    (fetchpatch {
-      name = "find_a_program-separate-from-find_a_file.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/948eb02800777d0318ee2a38bf32076afee739f2.diff";
-      hash = "sha256-doXak3VfdWR/BP9XiJaU7uJz7rex78N1oaW6CqYwKaQ=";
-    })
-    (fetchpatch {
-      name = "simplify-find_a_program-and-find_a_file.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/073b4656d07e40f83a1db7f4462ab2d68b1875a2.diff";
-      hash = "sha256-kW6ZHyMzsn7snUBuDx4XLriaFGWZ1fixNc9UH8O5els=";
-    })
-    (fetchpatch {
-      name = "for_each_path-fix-uninitialized-ret-PR121806.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/6b008944e7bc3a342a734c4fcf1001d63fd0a6f8.diff";
-      hash = "sha256-preG5DdRX+a0NIebsapAVnqiLYtPjsR4H5BkAXL/65g=";
-    })
-    (fetchpatch {
-      name = "for_each_path-pass-machine-specific.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/f62f68e7c4bde0385fbd2dba3e926586dd2f1281.diff";
-      hash = "sha256-NsgGnTMQTnz1c4urr6jeoGOzQ4xeJ/p+F53osNDYDCA=";
-    })
-    (fetchpatch {
-      name = "find_a_program-search-with-machine-prefix.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/a514707ffd7d58b140686036c2dece43ecb7d33c.diff";
-      hash = "sha256-54/HzM+aeWq8CTkQu8Pualqc/LgRLS0+8EY8uPUsD+s=";
-    })
+  patches =
+    # Backports of commits that are in the GCC 16 release branch already.
+    lib.optionals (lib.versionOlder release_version "16") [
+      (fetchpatch {
+        name = "for_each_path-functional-programming.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/f23bac62f46fc296a4d0526ef54824d406c3756c.diff";
+        hash = "sha256-J7SrypmVSbvYUzxWWvK2EwEbRsfGGLg4vNZuLEe6Xe0=";
+      })
+      (fetchpatch {
+        name = "for_each_path-fix-uninitialized-ret-PR121806.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/6b008944e7bc3a342a734c4fcf1001d63fd0a6f8.diff";
+        hash = "sha256-preG5DdRX+a0NIebsapAVnqiLYtPjsR4H5BkAXL/65g=";
+      })
 
-    # Make --disable-fixinclude compatible with Cygwin
-    (fetchpatch {
-      name = "mingw-drop-obsolete-STMP_FIXINC-override.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/7fb73dd7bb8aabab1416f0b28e6df45131a8e8ab.diff";
-      hash = "sha256-FmFJISfXt+/TCRcd4rYfwacBiTqu+/OKw0VvLh46Hz0=";
-    })
+      # Make --disable-fixinclude compatible with Cygwin
+      (fetchpatch {
+        name = "mingw-drop-obsolete-STMP_FIXINC-override.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/7fb73dd7bb8aabab1416f0b28e6df45131a8e8ab.diff";
+        hash = "sha256-FmFJISfXt+/TCRcd4rYfwacBiTqu+/OKw0VvLh46Hz0=";
+      })
+    ]
+    # Backports of commits that are on trunk only, and so are still needed for
+    # GCC 16.
+    ++ [
+      (fetchpatch {
+        name = "find_a_program-separate-from-find_a_file.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/948eb02800777d0318ee2a38bf32076afee739f2.diff";
+        hash = "sha256-doXak3VfdWR/BP9XiJaU7uJz7rex78N1oaW6CqYwKaQ=";
+      })
+      (fetchpatch {
+        name = "simplify-find_a_program-and-find_a_file.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/073b4656d07e40f83a1db7f4462ab2d68b1875a2.diff";
+        hash = "sha256-kW6ZHyMzsn7snUBuDx4XLriaFGWZ1fixNc9UH8O5els=";
+      })
+      (fetchpatch {
+        name = "for_each_path-pass-machine-specific.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/f62f68e7c4bde0385fbd2dba3e926586dd2f1281.diff";
+        hash = "sha256-NsgGnTMQTnz1c4urr6jeoGOzQ4xeJ/p+F53osNDYDCA=";
+      })
+      (fetchpatch {
+        name = "find_a_program-search-with-machine-prefix.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/a514707ffd7d58b140686036c2dece43ecb7d33c.diff";
+        hash = "sha256-54/HzM+aeWq8CTkQu8Pualqc/LgRLS0+8EY8uPUsD+s=";
+      })
 
-    # Not upstream yet; a follow-up to the series above (drop the `/raw` to
-    # read them). They extend that series' `<target>-as` preference to `PATH`,
-    # where we put the cross toolchain, so a cross compiler finds its tools
-    # the way a native one does. See below for the problems `--with-as` and
-    # `--with-ld` cause, and thus why we want to avoid them.
-    (fetchpatch {
-      name = "driver-factor-out-env-path-parsing.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-1-git@JohnEricson.me/raw";
-      hash = "sha256-2qUUMWuyxX4mVaBPeNnHIiMl/aN7ejWM5stTSFWxD7g=";
-    })
-    (fetchpatch {
-      name = "driver-search-PATH-ourselves.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-2-git@JohnEricson.me/raw";
-      # The posted patch is against trunk, which spells this cast with the C++
-      # operator.  GCC 15 still uses the CONST_CAST macro, and the line is
-      # context rather than a change, so it cannot fuzz-match.  Rewrite it
-      # here rather than keeping a forked copy of the whole patch.
-      postFetch = ''
-        substituteInPlace "$out" \
-          --replace-fail 'string, const_cast<char **> (commands[i].argv),' \
-                         'string, CONST_CAST (char **, commands[i].argv),'
-      '';
-      hash = "sha256-uD8xJxQus2qyNgNDN/63WnURNuUJFDkhaXPph7g/DIk=";
-    })
-    (fetchpatch {
-      name = "driver-search-PATH-machine-prefix.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-3-git@JohnEricson.me/raw";
-      hash = "sha256-Q5CJpJKD11kadIKselQdHgNe26GqojpyAAmlAyHnsB0=";
-    })
+      # Not upstream yet; a follow-up to the series above (drop the `/raw` to
+      # read them). They extend that series' `<target>-as` preference to `PATH`,
+      # where we put the cross toolchain, so a cross compiler finds its tools
+      # the way a native one does. See below for the problems `--with-as` and
+      # `--with-ld` cause, and thus why we want to avoid them.
+      (fetchpatch {
+        name = "driver-factor-out-env-path-parsing.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-1-git@JohnEricson.me/raw";
+        hash = "sha256-2qUUMWuyxX4mVaBPeNnHIiMl/aN7ejWM5stTSFWxD7g=";
+      })
+      (fetchpatch {
+        name = "driver-search-PATH-ourselves.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-2-git@JohnEricson.me/raw";
+        # The posted patch is against trunk, which spells this cast with the C++
+        # operator.  GCC 15 still uses the CONST_CAST macro, and the line is
+        # context rather than a change, so it cannot fuzz-match.  Rewrite it
+        # here rather than keeping a forked copy of the whole patch.
+        postFetch = ''
+          substituteInPlace "$out" \
+            --replace-fail 'string, const_cast<char **> (commands[i].argv),' \
+                           'string, CONST_CAST (char **, commands[i].argv),'
+        '';
+        hash = "sha256-uD8xJxQus2qyNgNDN/63WnURNuUJFDkhaXPph7g/DIk=";
+      })
+      (fetchpatch {
+        name = "driver-search-PATH-machine-prefix.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-3-git@JohnEricson.me/raw";
+        hash = "sha256-Q5CJpJKD11kadIKselQdHgNe26GqojpyAAmlAyHnsB0=";
+      })
 
-    (getVersionFile "gcc/fix-collect2-paths.diff")
+      (getVersionFile "gcc/fix-collect2-paths.diff")
 
-    # From the posting to gcc-patches, which covers every component that links
-    # libbacktrace. Take only this component's non-generated files: the
-    # generated ones are rebuilt by `autoreconfHook269` below, against a GCC
-    # slightly different from the one the patch was made against.
-    (fetchpatch {
-      name = "system-libbacktrace.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20260814013206.3818461-1-git@JohnEricson.me/raw";
-      includes = [
-        "config/libbacktrace.m4"
-        "gcc/configure.ac"
-        "gcc/Makefile.in"
-      ];
-      hash = "sha256-i+J4B5f+zrXERPqJxwjEm/JHZhDsV6Gmxx/n9+G0shM=";
-    })
-  ];
+      # From the posting to gcc-patches, which covers every component that links
+      # libbacktrace. Take only this component's non-generated files: the
+      # generated ones are rebuilt by `autoreconfHook269` below, against a GCC
+      # slightly different from the one the patch was made against.
+      (fetchpatch {
+        name = "system-libbacktrace.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20260814013206.3818461-1-git@JohnEricson.me/raw";
+        includes = [
+          "config/libbacktrace.m4"
+          "gcc/configure.ac"
+          "gcc/Makefile.in"
+        ];
+        hash = "sha256-i+J4B5f+zrXERPqJxwjEm/JHZhDsV6Gmxx/n9+G0shM=";
+      })
+    ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -60,8 +60,84 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches =
+    # Kept out of the version-dependent blocks below because they are about
+    # nixpkgs rather than about any GCC version, and applied first so that the
+    # driver series, which rewrites much of `gcc.cc`, does not move their
+    # context out from under them.
+    [
+      # Do not look for headers and libraries in `/usr/local/include`, `/lib`
+      # and `/usr/lib`. GCC drops these itself for a cross compiler with no
+      # sysroot, which is what most of this set is, but not for a native one.
+      ./no-sys-dirs.patch
+      ./no-sys-dirs-riscv.patch
+
+      # Keep store hashes out of `__FILE__`, which would otherwise put `-dev`
+      # outputs in runtime closures. `cc-wrapper` leaves this to the compiler
+      # for GNU: it sets `useMacroPrefixMap = !isGNU`, so nothing else covers
+      # it. See <https://gcc.gnu.org/PR111527>.
+      ./mangle-NIX_STORE-in-__FILE__.patch
+
+      # `rs6000/sysv4.h` builds its own `INCLUDE_DEFAULTS` for musl, testing
+      # `LOCAL_INCLUDE_DIR` before the `#undef` above is reached, so
+      # `/usr/local/include` survives there without this.
+      ./ppc-musl.patch
+
+    ]
+    # Keep `-l` and its argument together in the `Driving:` line, which is
+    # what libtool parses out of `gfortran -v`.
+    ++ lib.optionals langFortran [
+      ./gfortran-driving.patch
+    ]
+    # `--enable-default-pie` is a target option, but `c++tools` is built for
+    # the host and should follow `--enable-host-pie`. We pass the former and
+    # do build `c++tools`. Fixed upstream in 16.
+    ++ lib.optionals (lib.versionOlder release_version "16") [
+      ./c++tools-dont-check-enable-default-pie.patch
+    ]
+    # Cygwin's `abort` comes in through `windows.h` and collides with the
+    # `tsystem.h` macro on the `inhibit_libc` path, which this set's bootstrap
+    # goes through by design; and `unix` should be defined the conforming way.
+    # Neither is upstream in 15 or 16.
+    #
+    # Iain Sandoe's Darwin branch, as the monolithic set takes it: from
+    # Homebrew, because GitHub's compare API gives unstable diffs. It spans
+    # the monorepo, so each package takes the files it builds -- `libgcc` and
+    # `libsanitizer` take theirs the same way.
+    ++ lib.optionals stdenv.targetPlatform.isDarwin [
+      (fetchpatch {
+        name = "darwin-aarch64-support.patch";
+        url =
+          if lib.versionAtLeast release_version "16" then
+            "https://raw.githubusercontent.com/Homebrew/homebrew-core/70e2a9e1d072fa3bc34cf41d97f4b65bede2b01e/Patches/gcc/gcc-16.1.0.diff"
+          else
+            "https://raw.githubusercontent.com/Homebrew/homebrew-core/70e2a9e1d072fa3bc34cf41d97f4b65bede2b01e/Patches/gcc/gcc-15.3.0.diff";
+        includes = [
+          "gcc/*"
+          "fixincludes/*"
+          "configure"
+          "configure.ac"
+        ];
+        hash =
+          if lib.versionAtLeast release_version "16" then
+            "sha256-iaWuT6zNxmGH/8hwlzZZTGO4EiozNFGRr8o80dmKY3U="
+          else
+            "sha256-W4O+cRcuKpRKG3JW5CZf20pXbKeugVQYVFgPnDzQO+E=";
+      })
+    ]
+    ++ lib.optionals stdenv.targetPlatform.isCygwin [
+      (fetchpatch {
+        name = "cygwin-fix-compilation-with-inhibit_libc.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20250926170154.2222977-1-corngood@gmail.com/raw";
+        hash = "sha256-mgzMRvgPdhj+Q2VRsFhpE2WQzg0CvWsc5/FRAsSU1Es=";
+      })
+      (fetchpatch {
+        name = "cygwin-use-builtin_define_std-for-unix.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20250922182808.2599390-3-corngood@gmail.com/raw";
+        hash = "sha256-8I2G4430gkYoWgUued4unqhk8ZCajHf1dcivAeuLZ0E=";
+      })
+    ]
     # Backports of commits that are in the GCC 16 release branch already.
-    lib.optionals (lib.versionOlder release_version "16") [
+    ++ lib.optionals (lib.versionOlder release_version "16") [
       (fetchpatch {
         name = "for_each_path-functional-programming.patch";
         url = "https://github.com/gcc-mirror/gcc/commit/f23bac62f46fc296a4d0526ef54824d406c3756c.diff";
@@ -146,9 +222,16 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-3-git@JohnEricson.me/raw";
         hash = "sha256-Q5CJpJKD11kadIKselQdHgNe26GqojpyAAmlAyHnsB0=";
       })
-
+    ]
+    # Held back on Darwin, like `cfi_startproc-reorder-label` in `libgcc`:
+    # Iain's branch below carries the same change -- `is_cross_compiler`, the
+    # extra `post_ld_pass` argument, dropping the `CROSS_DIRECTORY_STRUCTURE`
+    # guard on `target_machine` -- so all this would add there is deleting the
+    # loop his version leaves behind, and it does not apply on top of it.
+    ++ lib.optionals (!stdenv.targetPlatform.isDarwin) [
       (getVersionFile "gcc/fix-collect2-paths.diff")
-
+    ]
+    ++ [
       # From the posting to gcc-patches, which covers every component that links
       # libbacktrace. Take only this component's non-generated files: the
       # generated ones are rebuilt by `autoreconfHook269` below, against a GCC

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -114,20 +114,33 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-1-git@JohnEricson.me/raw";
         hash = "sha256-2qUUMWuyxX4mVaBPeNnHIiMl/aN7ejWM5stTSFWxD7g=";
       })
-      (fetchpatch {
-        name = "driver-search-PATH-ourselves.patch";
-        url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-2-git@JohnEricson.me/raw";
-        # The posted patch is against trunk, which spells this cast with the C++
-        # operator.  GCC 15 still uses the CONST_CAST macro, and the line is
-        # context rather than a change, so it cannot fuzz-match.  Rewrite it
-        # here rather than keeping a forked copy of the whole patch.
-        postFetch = ''
-          substituteInPlace "$out" \
-            --replace-fail 'string, const_cast<char **> (commands[i].argv),' \
-                           'string, CONST_CAST (char **, commands[i].argv),'
-        '';
-        hash = "sha256-uD8xJxQus2qyNgNDN/63WnURNuUJFDkhaXPph7g/DIk=";
-      })
+      (fetchpatch (
+        {
+          name = "driver-search-PATH-ourselves.patch";
+          url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-2-git@JohnEricson.me/raw";
+        }
+        // (
+          if lib.versionOlder release_version "16" then
+            {
+              # The posted patch is against trunk, which spells this cast with
+              # the C++ operator.  GCC 15 still uses the CONST_CAST macro, and
+              # the line is context rather than a change, so it cannot
+              # fuzz-match.  Rewrite it here rather than keeping a forked copy
+              # of the whole patch.
+              postFetch = ''
+                substituteInPlace "$out" \
+                  --replace-fail 'string, const_cast<char **> (commands[i].argv),' \
+                                 'string, CONST_CAST (char **, commands[i].argv),'
+              '';
+              hash = "sha256-uD8xJxQus2qyNgNDN/63WnURNuUJFDkhaXPph7g/DIk=";
+            }
+          else
+            {
+              # 16 switched to the C++ operator, so the patch is taken as posted.
+              hash = "sha256-ILH3oHsnPXZmwPWfZ7Pt5MfLs00ZBJ+vFHw3MRRh4Dw=";
+            }
+        )
+      ))
       (fetchpatch {
         name = "driver-search-PATH-machine-prefix.patch";
         url = "https://inbox.sourceware.org/gcc-patches/20260810065714.2215299-3-git@JohnEricson.me/raw";

--- a/pkgs/development/compilers/gcc/ng/common/gcc/gfortran-driving.patch
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/gfortran-driving.patch
@@ -1,0 +1,20 @@
+This patch fixes interaction with Libtool.
+See <http://thread.gmane.org/gmane.comp.gcc.patches/258777>, for details.
+
+--- a/gcc/fortran/gfortranspec.cc
++++ b/gcc/fortran/gfortranspec.cc
+@@ -461,8 +461,15 @@ For more information about these matters, see the file named COPYING\n\n"));
+     {
+       fprintf (stderr, _("Driving:"));
+       for (i = 0; i < g77_newargc; i++)
++	{
++	  if (g77_new_decoded_options[i].opt_index == OPT_l)
++	    /* Make sure no white space is inserted after `-l'.  */
++	    fprintf (stderr, " -l%s",
++		     g77_new_decoded_options[i].canonical_option[1]);
++	  else
+ 	fprintf (stderr, " %s",
+ 		 g77_new_decoded_options[i].orig_option_with_args_text);
++	}
+       fprintf (stderr, "\n");
+     }

--- a/pkgs/development/compilers/gcc/ng/common/gcc/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/mangle-NIX_STORE-in-__FILE__.patch
@@ -1,0 +1,97 @@
+From e160a8cd4a704f4b7724df02b62394f677cc4198 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <siarheit@google.com>
+Date: Fri, 22 Sep 2023 22:41:49 +0100
+Subject: [PATCH] gcc/file-prefix-map.cc: always mangle __FILE__ into invalid
+ store path
+
+Without the change `__FILE__` used in static inline functions in headers
+embed paths to header files into executable images. For local headers
+it's not a problem, but for headers in `/nix/store` this causes `-dev`
+inputs to be retained in runtime closure.
+
+Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
+`lttng-ust.dev`.
+
+For this reason we want to remove the occurrences of hashes in the
+expansion of `__FILE__`. `nuke-references` does it by replacing hashes
+by `eeeeee...`. It is handy to be able to invert the transformation to
+go back to the original store path. The chosen solution is to make the
+hash uppercase:
+- it does not trigger runtime references (except for all digit hashes,
+  which are unlikely enough)
+- it visually looks like a bogus store path
+- it is easy to find the original store path if required
+
+Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` as:
+
+  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/$HASH1-nlohmann-json-ver
+  -fmacro-prefix-map=/nix/...
+
+In practice it quickly exhausts argument length limit due to `gcc`
+deficiency: https://gcc.gnu.org/PR111527
+
+Until it's fixed let's hardcode header mangling if $NIX_STORE variable
+is present in the environment.
+
+Tested as:
+
+    $ printf "# 0 \"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
+    ...
+    .string "/nix/store/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-pppppp-vvvvvvv"
+    ...
+
+Mangled successfully.
+
+To reverse the effect of the mangle use new `NIX_GCC_DONT_MANGLE_PREFIX_MAP`
+environment variable. It should not normally be needed.
+--- a/gcc/file-prefix-map.cc
++++ b/gcc/file-prefix-map.cc
+@@ -74,7 +74,7 @@ add_prefix_map (file_prefix_map *&maps, const char *arg, const char *opt)
+    remapping was performed.  */
+ 
+ static const char *
+-remap_filename (file_prefix_map *maps, const char *filename)
++remap_filename (file_prefix_map *maps, const char *filename, bool mangle_nix_store = false)
+ {
+   file_prefix_map *map;
+   char *s;
+@@ -102,6 +102,30 @@ remap_filename (file_prefix_map *maps, const char *filename)
+       break;
+   if (!map)
+     {
++      if (mangle_nix_store && getenv("NIX_GCC_DONT_MANGLE_PREFIX_MAP") == NULL)
++	{
++	  /* Remap all fo $NIX_STORE/.{32} paths to uppercase
++	   *
++	   * That way we avoid argument parameters explosion
++	   * and still avoid embedding headers into runtime closure:
++	   *   https://gcc.gnu.org/PR111527
++	   */
++	   char * nix_store = getenv("NIX_STORE");
++	   size_t nix_store_len = nix_store ? strlen(nix_store) : 0;
++	   const char * name = realname ? realname : filename;
++	   size_t name_len = strlen(name);
++	   if (nix_store && name_len >= nix_store_len + 1 + 32 && memcmp(name, nix_store, nix_store_len) == 0)
++	     {
++		s = (char *) ggc_alloc_atomic (name_len + 1);
++		memcpy(s, name, name_len + 1);
++		for (size_t i = nix_store_len + 1; i < nix_store_len + 1 + 32; i++) {
++		  s[i] = TOUPPER(s[i]);
++		}
++		if (realname != filename)
++		  free (const_cast <char *> (realname));
++		return s;
++	     }
++	}
+       if (realname != filename)
+ 	free (const_cast <char *> (realname));
+       return filename;
+@@ -163,7 +187,7 @@ add_profile_prefix_map (const char *arg)
+ const char *
+ remap_macro_filename (const char *filename)
+ {
+-  return remap_filename (macro_prefix_maps, filename);
++  return remap_filename (macro_prefix_maps, filename, true);
+ }
+ 
+ /* Remap using -fdebug-prefix-map.  Return the GC-allocated new name

--- a/pkgs/development/compilers/gcc/ng/common/gcc/no-sys-dirs-riscv.patch
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/no-sys-dirs-riscv.patch
@@ -1,0 +1,13 @@
+--- a/gcc/config/riscv/linux.h
++++ b/gcc/config/riscv/linux.h
+@@ -69,9 +69,5 @@
+ 
+ #define TARGET_ASM_FILE_END file_end_indicate_exec_stack
+ 
+-#define STARTFILE_PREFIX_SPEC 			\
+-   "/lib" XLEN_SPEC "/" ABI_SPEC "/ "		\
+-   "/usr/lib" XLEN_SPEC "/" ABI_SPEC "/ "	\
+-   "/lib/ "					\
+-   "/usr/lib/ "
++#define STARTFILE_PREFIX_SPEC ""
+ 

--- a/pkgs/development/compilers/gcc/ng/common/gcc/no-sys-dirs.patch
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/no-sys-dirs.patch
@@ -1,0 +1,26 @@
+--- a/gcc/cppdefault.cc	2013-01-10 21:38:27.000000000 +0100
++++ b/gcc/cppdefault.cc	2014-08-18 16:20:32.893944536 +0200
+@@ -35,6 +35,8 @@
+ # undef CROSS_INCLUDE_DIR
+ #endif
+ 
++#undef LOCAL_INCLUDE_DIR
++
+ const struct default_include cpp_include_defaults[]
+ #ifdef INCLUDE_DEFAULTS
+ = INCLUDE_DEFAULTS;
+--- a/gcc/gcc.cc	2014-03-23 12:30:57.000000000 +0100
++++ b/gcc/gcc.cc	2014-08-18 13:19:32.689201690 +0200
+@@ -1162,10 +1162,10 @@
+ /* Default prefixes to attach to command names.  */
+ 
+ #ifndef STANDARD_STARTFILE_PREFIX_1
+-#define STANDARD_STARTFILE_PREFIX_1 "/lib/"
++#define STANDARD_STARTFILE_PREFIX_1 ""
+ #endif
+ #ifndef STANDARD_STARTFILE_PREFIX_2
+-#define STANDARD_STARTFILE_PREFIX_2 "/usr/lib/"
++#define STANDARD_STARTFILE_PREFIX_2 ""
+ #endif
+ 
+ #ifdef CROSS_DIRECTORY_STRUCTURE  /* Don't use these prefixes for a cross compiler.  */

--- a/pkgs/development/compilers/gcc/ng/common/gcc/ppc-musl.patch
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/ppc-musl.patch
@@ -1,0 +1,18 @@
+diff --git a/gcc/config/rs6000/sysv4.h b/gcc/config/rs6000/sysv4.h
+index cbee89140dd..e1f26b0a096 100644
+--- a/gcc/config/rs6000/sysv4.h
++++ b/gcc/config/rs6000/sysv4.h
+@@ -996,13 +996,7 @@ ncrtn.o%s"
+     { GPLUSPLUS_BACKWARD_INCLUDE_DIR, "G++", 1, 1,	\
+       GPLUSPLUS_INCLUDE_DIR_ADD_SYSROOT, 0 },
+ 
+-#ifdef LOCAL_INCLUDE_DIR
+-#define INCLUDE_DEFAULTS_MUSL_LOCAL			\
+-    { LOCAL_INCLUDE_DIR, 0, 0, 1, 1, 2 },		\
+-    { LOCAL_INCLUDE_DIR, 0, 0, 1, 1, 0 },
+-#else
+ #define INCLUDE_DEFAULTS_MUSL_LOCAL
+-#endif
+ 
+ #ifdef PREFIX_INCLUDE_DIR
+ #define INCLUDE_DEFAULTS_MUSL_PREFIX			\

--- a/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
@@ -43,7 +43,11 @@ stdenv.mkDerivation (finalAttrs: {
     ''
   );
 
-  patches = [
+  # Both are the same upstream change, which is in the GCC 16 release branch:
+  # the backport itself, and the hand-edit of the generated `aclocal.m4` that
+  # `fetchpatch` cannot carry. GCC 16 already includes `../config/gthr.m4`
+  # there.
+  patches = lib.optionals (lib.versionOlder release_version "16") [
     (fetchpatch {
       name = "custom-threading-model.patch";
       url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";

--- a/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
@@ -43,22 +43,26 @@ stdenv.mkDerivation (finalAttrs: {
     ''
   );
 
-  # Both are the same upstream change, which is in the GCC 16 release branch:
-  # the backport itself, and the hand-edit of the generated `aclocal.m4` that
-  # `fetchpatch` cannot carry. GCC 16 already includes `../config/gthr.m4`
-  # there.
-  patches = lib.optionals (lib.versionOlder release_version "16") [
-    (fetchpatch {
-      name = "custom-threading-model.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
-      hash = "sha256-U1Eh6ByhmseHQigfHIyO4MlAQB3fECmpPEP/M00DOg0=";
-      includes = [
-        "config/*"
-        "libatomic/configure.ac"
-      ];
-    })
-    (getVersionFile "libatomic/gthr-include.patch")
-  ];
+  patches =
+    lib.optionals (lib.versionAtLeast release_version "16") [
+      (getVersionFile "libatomic/no-gcc-objdir-install.patch")
+    ]
+    # Both are the same upstream change, which is in the GCC 16 release
+    # branch: the backport itself, and the hand-edit of the generated
+    # `aclocal.m4` that `fetchpatch` cannot carry. GCC 16 already includes
+    # `../config/gthr.m4` there.
+    ++ lib.optionals (lib.versionOlder release_version "16") [
+      (fetchpatch {
+        name = "custom-threading-model.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+        hash = "sha256-U1Eh6ByhmseHQigfHIyO4MlAQB3fECmpPEP/M00DOg0=";
+        includes = [
+          "config/*"
+          "libatomic/configure.ac"
+        ];
+      })
+      (getVersionFile "libatomic/gthr-include.patch")
+    ];
 
   postUnpack = ''
     mkdir -p ./build
@@ -86,6 +90,15 @@ stdenv.mkDerivation (finalAttrs: {
     "cross_compiling=true"
     "--disable-multilib"
   ];
+
+  # GCC 16's `libatomic/configure.ac` refuses to run with an empty `CFLAGS`:
+  # it appends `-fno-link-libatomic` to them and needs `AC_PROG_CC`'s conftests
+  # to see it, so it will not let `AC_PROG_CC` supply the default instead. In
+  # the monorepo build the top level passes them down; each library is
+  # configured on its own here, so pass what `AC_PROG_CC` would have chosen.
+  env = lib.optionalAttrs (lib.versionAtLeast release_version "16") {
+    CFLAGS = "-g -O2";
+  };
 
   preConfigure = ''
     cd "$buildRoot"

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/cfi_startproc-reorder-label.diff
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/cfi_startproc-reorder-label.diff
@@ -1,0 +1,16 @@
+this patch fixes build for clang-18+
+
+diff --git a/libgcc/config/aarch64/lse.S b/libgcc/config/aarch64/lse.S
+index ecef47086..b478dd4d9 100644
+--- a/libgcc/config/aarch64/lse.S
++++ b/libgcc/config/aarch64/lse.S
+@@ -174,8 +174,8 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ 	.globl	\name
+ 	HIDDEN(\name)
+ 	SYMBOL_TYPE(\name, %function)
+-	.cfi_startproc
+ \name:
++	.cfi_startproc
+ .endm
+ 
+ .macro	ENDFN name

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/darwin-fix-reexport.patch
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/darwin-fix-reexport.patch
@@ -1,0 +1,11 @@
+--- a/libgcc/config/t-slibgcc-darwin
++++ b/libgcc/config/t-slibgcc-darwin
+@@ -139,8 +139,7 @@ libgcc_s.1.dylib: all-multi libgcc_s.$(SHLIB_SOVERSION)$(SHLIB_EXT)
+ 	  $(CC) -arch $${arch} -nodefaultlibs -dynamiclib -nodefaultrpaths \
+ 	    -o libgcc_s.1$(SHLIB_EXT)_T_$${mlib} \
+ 	    -Wl,-reexport_library,libgcc_s.$(SHLIB_SOVERSION)$(SHLIB_EXT)_T_$${mlib} \
+ 	    -lSystem \
+-	    -Wl,-reexported_symbols_list,$(srcdir)/config/darwin-unwind.ver \
+ 	    -install_name $(SHLIB_RPATH)/libgcc_s.1.dylib \
+ 	    -compatibility_version 1 -current_version 1.1 ; \
+ 	done

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -127,44 +127,49 @@ stdenv.mkDerivation (finalAttrs: {
   # library's own headers, and `libgcc_s` links against it.
   buildInputs = lib.optional (threads != null) threads;
 
-  patches = [
-    (fetchpatch {
-      name = "delete-MACHMODE_H.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/493aae4b034d62054d5e7e54dc06cd9a8be54e29.diff";
-      hash = "sha256-oEk0lnI96RlpALWpb7J+GnrtgQsFVqDO57I/zjiqqTk=";
-    })
-    (fetchpatch {
-      name = "custom-threading-model.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
-      hash = "sha256-92LIttIXdh12/lRhivb2JTPpqUmGBRn+uKmR5pzuveo=";
-      includes = [
-        "config/*"
-        "libgcc/configure.ac"
-      ];
-    })
-    (fetchpatch {
-      name = "no-pie-cflags.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/77144dd3b6736e0166156bb509590d924375a4f1.diff";
-      hash = "sha256-QlxlTkWAK1dB7JiU5wz2iOW24gj3bFaeBpwb90oWwns=";
-      includes = [
-        "gcc/Makefile.in"
-        "gcc/configure.ac"
-        "libgcc/Makefile.in"
-        "libgcc/configure.ac"
-      ];
-    })
-    (fetchpatch {
-      name = "no-target-system-root.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/9947930b7ae923010c5061fd8fa6b1ec4f22f161.diff";
-      hash = "sha256-BZmpHpJuuyDmQMwpQhSgCZO0Rg7kXt8rTiJAT+e0sUw=";
-    })
-    (fetchpatch {
-      name = "regular-libdir-includedir.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250717174911.1536129-1-git@JohnEricson.me/raw";
-      hash = "sha256-Cn7rvg1FI7H/26GzSe4pv5VW/gvwbwGqivAqEeawkwk=";
-    })
-    (getVersionFile "libgcc/force-regular-dirs.patch")
-  ];
+  patches =
+    # Backports of commits that are in the GCC 16 release branch already.
+    lib.optionals (lib.versionOlder release_version "16") [
+      (fetchpatch {
+        name = "delete-MACHMODE_H.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/493aae4b034d62054d5e7e54dc06cd9a8be54e29.diff";
+        hash = "sha256-oEk0lnI96RlpALWpb7J+GnrtgQsFVqDO57I/zjiqqTk=";
+      })
+      (fetchpatch {
+        name = "custom-threading-model.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+        hash = "sha256-92LIttIXdh12/lRhivb2JTPpqUmGBRn+uKmR5pzuveo=";
+        includes = [
+          "config/*"
+          "libgcc/configure.ac"
+        ];
+      })
+      (fetchpatch {
+        name = "no-pie-cflags.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/77144dd3b6736e0166156bb509590d924375a4f1.diff";
+        hash = "sha256-QlxlTkWAK1dB7JiU5wz2iOW24gj3bFaeBpwb90oWwns=";
+        includes = [
+          "gcc/Makefile.in"
+          "gcc/configure.ac"
+          "libgcc/Makefile.in"
+          "libgcc/configure.ac"
+        ];
+      })
+      (fetchpatch {
+        name = "no-target-system-root.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/9947930b7ae923010c5061fd8fa6b1ec4f22f161.diff";
+        hash = "sha256-BZmpHpJuuyDmQMwpQhSgCZO0Rg7kXt8rTiJAT+e0sUw=";
+      })
+    ]
+    # Not upstream anywhere yet.
+    ++ [
+      (fetchpatch {
+        name = "regular-libdir-includedir.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20250717174911.1536129-1-git@JohnEricson.me/raw";
+        hash = "sha256-Cn7rvg1FI7H/26GzSe4pv5VW/gvwbwGqivAqEeawkwk=";
+      })
+      (getVersionFile "libgcc/force-regular-dirs.patch")
+    ];
 
   autoreconfFlags = "--install --force --verbose . libgcc";
 

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -127,9 +127,44 @@ stdenv.mkDerivation (finalAttrs: {
   # library's own headers, and `libgcc_s` links against it.
   buildInputs = lib.optional (threads != null) threads;
 
+  # Move `.cfi_startproc` after the function label in the aarch64 LSE helpers.
+  # clang 18 and later refuse to assemble the output otherwise, which is what
+  # stops LLVM building against this libgcc. Not upstream in 16. Held back on
+  # Darwin as the monolithic set does.
   patches =
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      ./cfi_startproc-reorder-label.diff
+    ]
+    # Darwin is in scope but untested here. `darwin-detection` is paired by
+    # version in the monolithic set -- 14's variant for 16, 15's for 15 --
+    # which is what `getVersionFile` resolves to.
+    #
+    # The third is Iain Sandoe's branch, taken from Homebrew as the monolithic
+    # set takes it. It spans the monorepo, so this is only the part that lives
+    # here; `gcc` and `libsanitizer` take theirs the same way. It is also what
+    # makes `cfi_startproc-reorder-label` above redundant on Darwin: it drops
+    # `STARTFN` for an `ENTRY` macro that already writes the label ahead of
+    # `.cfi_startproc`.
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      ./darwin-fix-reexport.patch
+      (getVersionFile "libgcc/darwin-detection.patch")
+      (fetchpatch {
+        name = "darwin-aarch64-support.patch";
+        url =
+          if lib.versionAtLeast release_version "16" then
+            "https://raw.githubusercontent.com/Homebrew/homebrew-core/70e2a9e1d072fa3bc34cf41d97f4b65bede2b01e/Patches/gcc/gcc-16.1.0.diff"
+          else
+            "https://raw.githubusercontent.com/Homebrew/homebrew-core/70e2a9e1d072fa3bc34cf41d97f4b65bede2b01e/Patches/gcc/gcc-15.3.0.diff";
+        includes = [ "libgcc/*" ];
+        hash =
+          if lib.versionAtLeast release_version "16" then
+            "sha256-hDtEL/xAtavikWa1JYNbJLkyydc5H/iu2W7lvz+mRG0="
+          else
+            "sha256-5ctdSqxRJ445SSNao29WVurZsPbmgrCN+RmCAIEyUXw=";
+      })
+    ]
     # Backports of commits that are in the GCC 16 release branch already.
-    lib.optionals (lib.versionOlder release_version "16") [
+    ++ lib.optionals (lib.versionOlder release_version "16") [
       (fetchpatch {
         name = "delete-MACHMODE_H.patch";
         url = "https://github.com/gcc-mirror/gcc/commit/493aae4b034d62054d5e7e54dc06cd9a8be54e29.diff";

--- a/pkgs/development/compilers/gcc/ng/common/libgomp/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgomp/default.nix
@@ -58,6 +58,10 @@ stdenv.mkDerivation (finalAttrs: {
     cd $sourceRoot
   '';
 
+  patches = lib.optionals (lib.versionAtLeast release_version "16") [
+    (getVersionFile "libgomp/uid-buffer-size.patch")
+  ];
+
   enableParallelBuilding = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/gcc/ng/common/libquadmath/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libquadmath/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
 
       cp -r libquadmath "$out"
 
+      # `printf/gmp-impl.h` includes `longlong.h`, which lives here; the
+      # `Makefile` already looks in `../include` for it.
+      cp -r include "$out"
+
       cp config.guess "$out"
       cp config.rpath "$out"
       cp config.sub "$out"

--- a/pkgs/development/compilers/gcc/ng/common/libsanitizer/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libsanitizer/default.nix
@@ -6,6 +6,7 @@
   release_version,
   version,
   monorepoSrc ? null,
+  fetchpatch,
   runCommand,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -38,6 +39,30 @@ stdenv.mkDerivation (finalAttrs: {
   );
 
   sourceRoot = "${finalAttrs.src.name}/libsanitizer";
+
+  # This component's share of Iain Sandoe's Darwin branch, taken from Homebrew
+  # as the monolithic set takes it. One `configure.tgt` case; `gcc` and
+  # `libgcc` take their own parts of the same diff.
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    (fetchpatch {
+      name = "darwin-aarch64-support.patch";
+      url =
+        if lib.versionAtLeast release_version "16" then
+          "https://raw.githubusercontent.com/Homebrew/homebrew-core/70e2a9e1d072fa3bc34cf41d97f4b65bede2b01e/Patches/gcc/gcc-16.1.0.diff"
+        else
+          "https://raw.githubusercontent.com/Homebrew/homebrew-core/70e2a9e1d072fa3bc34cf41d97f4b65bede2b01e/Patches/gcc/gcc-15.3.0.diff";
+      includes = [ "libsanitizer/*" ];
+      hash =
+        if lib.versionAtLeast release_version "16" then
+          "sha256-NvDEjWfD2eEPJWtWOjtMeymdADPx9rm7Sn+6iGQg5EI="
+        else
+          "sha256-UF2p8qg7M6e4gsSC3TIyyE8+F+tPJUjiGF30fW53XeM=";
+    })
+  ];
+
+  # `sourceRoot` above puts `patchPhase` inside `libsanitizer`, but the patch
+  # names its files from the top of the monorepo.
+  patchFlags = [ "-p2" ];
 
   postUnpack = ''
     mkdir -p libstdc++-v3/src/

--- a/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
@@ -101,36 +101,40 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  patches = [
-    (fetchpatch {
-      name = "custom-threading-model.patch";
-      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
-      hash = "sha256-f0XAim3uzHnUx5lm/xO00IqBHu4YUEHF2WY+c0yCF6Y=";
-      includes = [
-        "config/*"
-        "libstdc++-v3/acinclude.m4"
-      ];
-    })
-    (getVersionFile "libstdcxx/force-regular-dirs.patch")
+  patches =
+    # A backport of a commit that is in the GCC 16 release branch already.
+    lib.optionals (lib.versionOlder release_version "16") [
+      (fetchpatch {
+        name = "custom-threading-model.patch";
+        url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+        hash = "sha256-f0XAim3uzHnUx5lm/xO00IqBHu4YUEHF2WY+c0yCF6Y=";
+        includes = [
+          "config/*"
+          "libstdc++-v3/acinclude.m4"
+        ];
+      })
+    ]
+    ++ [
+      (getVersionFile "libstdcxx/force-regular-dirs.patch")
 
-    # From the posting to gcc-patches, which covers every component that links
-    # libbacktrace. Take only this component's non-generated files: the
-    # generated ones are rebuilt by `autoreconfHook269` below, against a GCC
-    # slightly different from the one the patch was made against.
-    (fetchpatch {
-      name = "system-libbacktrace.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20260814013206.3818461-1-git@JohnEricson.me/raw";
-      includes = [
-        "config/libbacktrace.m4"
-        "libstdc++-v3/acinclude.m4"
-        "libstdc++-v3/src/Makefile.am"
-        "libstdc++-v3/src/c++23/Makefile.am"
-        "libstdc++-v3/src/c++23/stacktrace.cc"
-        "libstdc++-v3/src/experimental/Makefile.am"
-      ];
-      hash = "sha256-qcs5N+KgBs2FScqGUZRYbAKkI2oDnm+G/ZN9RCAgZpw=";
-    })
-  ];
+      # From the posting to gcc-patches, which covers every component that links
+      # libbacktrace. Take only this component's non-generated files: the
+      # generated ones are rebuilt by `autoreconfHook269` below, against a GCC
+      # slightly different from the one the patch was made against.
+      (fetchpatch {
+        name = "system-libbacktrace.patch";
+        url = "https://inbox.sourceware.org/gcc-patches/20260814013206.3818461-1-git@JohnEricson.me/raw";
+        includes = [
+          "config/libbacktrace.m4"
+          "libstdc++-v3/acinclude.m4"
+          "libstdc++-v3/src/Makefile.am"
+          "libstdc++-v3/src/c++23/Makefile.am"
+          "libstdc++-v3/src/c++23/stacktrace.cc"
+          "libstdc++-v3/src/experimental/Makefile.am"
+        ];
+        hash = "sha256-qcs5N+KgBs2FScqGUZRYbAKkI2oDnm+G/ZN9RCAgZpw=";
+      })
+    ];
 
   postUnpack = ''
     mkdir -p ./build

--- a/pkgs/development/compilers/gcc/ng/common/patches.nix
+++ b/pkgs/development/compilers/gcc/ng/common/patches.nix
@@ -1,6 +1,13 @@
 {
   # TODO: fix up and send to upstream
   "gcc/fix-collect2-paths.diff" = [
+    # GCC 16 spells one context line with the C++ `const_cast` operator rather
+    # than the `CONST_CAST2` macro, and excludes one more linker (`wild`) from
+    # the target-prefixed names, so the patch had to be rebased.
+    {
+      after = "16";
+      path = ../16;
+    }
     {
       after = "15";
       path = ../15;
@@ -30,6 +37,12 @@
   ];
   # In Git: https://github.com/Ericson2314/gcc/tree/libgfortran-force-regular-dirs-15
   "libgfortran/force-regular-dirs.patch" = [
+    # GCC 16 grew a second coarray library, `libcaf_shmem`, sharing the
+    # `cafexeclib` prefix this removes, so the patch had to be rebased.
+    {
+      after = "16";
+      path = ../16;
+    }
     {
       after = "15";
       path = ../15;

--- a/pkgs/development/compilers/gcc/ng/common/patches.nix
+++ b/pkgs/development/compilers/gcc/ng/common/patches.nix
@@ -31,6 +31,19 @@
     }
   ];
 
+  # Paired by version, as the monolithic set pairs them: 14's variant for 16,
+  # 15's for 15.
+  "libgcc/darwin-detection.patch" = [
+    {
+      after = "16";
+      path = ../16;
+    }
+    {
+      after = "15";
+      path = ../15;
+    }
+  ];
+
   # In Git: https://github.com/Ericson2314/gcc/tree/regular-dirs-in-libgcc-15
   "libgcc/force-regular-dirs.patch" = [
     {

--- a/pkgs/development/compilers/gcc/ng/common/patches.nix
+++ b/pkgs/development/compilers/gcc/ng/common/patches.nix
@@ -23,6 +23,14 @@
     }
   ];
 
+  # As above: only under `../16`, so name it for `gitRelease` builds too.
+  "libgomp/uid-buffer-size.patch" = [
+    {
+      after = "16";
+      path = ../16;
+    }
+  ];
+
   # In Git: https://github.com/Ericson2314/gcc/tree/regular-dirs-in-libgcc-15
   "libgcc/force-regular-dirs.patch" = [
     {

--- a/pkgs/development/compilers/gcc/ng/common/patches.nix
+++ b/pkgs/development/compilers/gcc/ng/common/patches.nix
@@ -14,6 +14,15 @@
     }
   ];
 
+  # Only present under `../16`, so a `gitRelease` build -- whose version
+  # directory is `../git` -- has to be pointed here too.
+  "libatomic/no-gcc-objdir-install.patch" = [
+    {
+      after = "16";
+      path = ../16;
+    }
+  ];
+
   # In Git: https://github.com/Ericson2314/gcc/tree/regular-dirs-in-libgcc-15
   "libgcc/force-regular-dirs.patch" = [
     {

--- a/pkgs/development/compilers/gcc/ng/default.nix
+++ b/pkgs/development/compilers/gcc/ng/default.nix
@@ -15,6 +15,7 @@
 let
   versions = {
     "15.3.0".officialRelease.sha256 = "sha256-+lnBvu+JlfJ8TXHB3yJ1hxiTFdPm+v8btDBuYbDFMOs=";
+    "16.2.0".officialRelease.sha256 = "sha256-5nOOKVl/czJwcxqpBgDzf/3ARQed/CfsfoGSzIEIXD4=";
   }
   // gccVersions;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3227,10 +3227,12 @@ with pkgs;
       # NOTE: keep this with the "NG" label until we're ready to drop the monolithic GCC
       gccNGPackagesSet = recurseIntoAttrs (callPackages ../development/compilers/gcc/ng { });
       gccNGPackages_15 = gccNGPackagesSet."15";
+      gccNGPackages_16 = gccNGPackagesSet."16";
       gccNGPackages = gccNGPackagesSet.${toString default-gcc-version};
       mkGCCNGPackages = gccNGPackagesSet.mkPackage;
     })
     gccNGPackages_15
+    gccNGPackages_16
     gccNGPackages
     mkGCCNGPackages
     ;


### PR DESCRIPTION
Add GCC 16 in addition to the GCC 15 that we already have with GCC NG.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
