### PR TITLE
ardour: 9.7 -> 9.8

### DIFF
--- a/pkgs/by-name/ar/ardour/default-plugin-search-paths.patch
+++ b/pkgs/by-name/ar/ardour/default-plugin-search-paths.patch
@@ -30,8 +30,8 @@ index a572ed55dd..3dd6c2fda6 100644
  	std::string prog = PBD::get_win_special_folder_path (CSIDL_PROGRAM_FILES);
  	vst3_discover_from_path (Glib::build_filename (prog, "Common Files", "VST3"), cache_only);
  #else
--	vst3_discover_from_path ("~/.vst3:/usr/local/lib/vst3:/usr/lib/vst3", cache_only);
-+	vst3_discover_from_path ("~/.vst3:/usr/local/lib/vst3:/usr/lib/vst3:~/.nix-profile/lib/vst3:/run/current-system/sw/lib/vst3:/etc/profiles/per-user/$USER/lib/vst3", cache_only);
+-	vst3_discover_from_path ("~/.vst3:/usr/lib64/vst3:/usr/lib/vst3:/usr/local/lib64/vst3:/usr/local/lib/vst3", cache_only);
++	vst3_discover_from_path ("~/.vst3:/usr/lib64/vst3:/usr/lib/vst3:/usr/local/lib64/vst3:/usr/local/lib/vst3:/run/current-system/sw/lib/vst3:/etc/profiles/per-user/$USER/lib/vst3", cache_only);
  #endif
  }
  

--- a/pkgs/by-name/ar/ardour/package.nix
+++ b/pkgs/by-name/ar/ardour/package.nix
@@ -88,14 +88,14 @@ let
 
   generic = stdenv.mkDerivation (finalAttrs: {
     pname = "ardour";
-    version = "9.7";
+    version = "9.8";
 
     # We can't use `fetchFromGitea` here, as attempting to fetch release archives from git.ardour.org
     # result in an empty archive. See https://tracker.ardour.org/view.php?id=7328 for more info.
     src = fetchgit {
       url = "git://git.ardour.org/ardour/ardour.git";
       tag = finalAttrs.version;
-      hash = "sha256-6gtlnk/oPXWJcN5tcb1r7dXyLpHPTSJwd8VfOjjFnWQ=";
+      hash = "sha256-h+JS3T2pr/VOtR9E2NMY4gd3IxL0leWATUV52u459iM=";
     };
 
     patches = [
@@ -294,15 +294,6 @@ let
       majorVersion = lib.versions.major finalAttrs.version;
     in
     {
-      patches = finalAttrs.patches ++ [
-        (fetchpatch {
-          # TODO: Remove with the next release of Ardour
-          url = "https://github.com/Ardour/ardour/commit/bff1ebbca2f50f1a0d2285efcf6e0c8237a07d8f.diff";
-          hash = "sha256-Ye22S2bmRt+c/GrrvgWCDlzUqSwaOdAh5vFuJb/BqV8=";
-          name = "fix-path-to-mo-files.diff";
-        })
-      ];
-
       postPatch = finalAttrs.postPatch + ''
         substituteInPlace wscript \
           --replace-fail '-DMAC_OS_X_VERSION_MAX_ALLOWED=110000' '-DMAC_OS_X_VERSION_MAX_ALLOWED=140000' \


### PR DESCRIPTION
https://ardour.org/whatsnew.html
Diff: https://github.com/Ardour/ardour/compare/9.7...9.8

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
