### PR TITLE
rocqPackages.coquelicot: 3.4.4 -> 3.4.5

### DIFF
--- a/pkgs/development/rocq-modules/coquelicot/default.nix
+++ b/pkgs/development/rocq-modules/coquelicot/default.nix
@@ -20,6 +20,7 @@ let
       in
       with lib.versions;
       lib.switch coq.coq-version [
+        (case (range "8.12" "9.3") "3.4.5")
         (case (range "8.12" "9.1") "3.4.4")
         (case (range "8.12" "9.1") "3.4.3")
         (case (range "8.12" "8.20") "3.4.2")
@@ -29,6 +30,7 @@ let
         (case (range "8.8" "8.13") "3.1.0")
         (case (range "8.5" "8.9") "3.0.2")
       ] null;
+    release."3.4.5".hash = "sha256-cqlfyfNw04kg8x70dWmLi3+BwWBXoAirsNhXmwi7whU=";
     release."3.4.4".hash = "sha256-xuL1ZpAfiBvQwXGjS7aN2N7KqSZlw+ywB8HvL9/Bjqs=";
     release."3.4.3".hash = "sha256-bzzAIENU2OYTtmdBU9Xw8zyBvz9vqTiqjWSm7RnXXRA=";
     release."3.4.2".hash = "sha256-aBTF8ZKu67Rb3ryCqFyejUXf/65KgG8i5je/ZMFSrj4=";

--- a/pkgs/development/rocq-modules/mathcomp-zify/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-zify/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  mkCoqDerivation,
-  coq,
+  mkRocqDerivation,
+  rocq-core,
   mathcomp-boot,
   mathcomp-fingroup,
   mathcomp-algebra,
@@ -9,9 +9,9 @@
   version ? null,
 }:
 
-mkCoqDerivation {
+mkRocqDerivation {
   namePrefix = [
-    "coq"
+    "rocq"
     "mathcomp"
   ];
   pname = "zify";
@@ -21,9 +21,9 @@ mkCoqDerivation {
 
   defaultVersion =
     let
-      case = coq: mc: out: {
+      case = rocq: mc: out: {
         cases = [
-          coq
+          rocq
           mc
         ];
         inherit out;
@@ -31,8 +31,9 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch
-      [ coq.coq-version mathcomp-algebra.version ]
+      [ rocq-core.rocq-version mathcomp-algebra.version ]
       [
+        (case (range "9.0" "9.3") (range "2.4.0" "2.6.0") "1.7.0+2.4+9.0")
         (case (range "8.18" "9.1") (range "2.3.0" "2.5.0") "1.6.0+2.3+8.18")
         (case (range "8.16" "9.1") (range "2.0.0" "2.5.0") "1.5.0+2.0+8.16")
         (case (range "8.13" "8.20") (range "1.12" "1.19.0") "1.3.0+1.12+8.13")
@@ -45,6 +46,7 @@ mkCoqDerivation {
   release."1.3.0+1.12+8.13".hash = "sha256-ebfY8HatP4te44M6o84DSLpDCkMu4IroPCy+HqzOnTE=";
   release."1.5.0+2.0+8.16".hash = "sha256-boBYGvXdGFc6aPnjgSZYSoW4kmN5khtNrSV3DUv9DqM=";
   release."1.6.0+2.3+8.18".hash = "sha256-rI5ZWtgO0a2sxCVChTdASxWxhgYEbM4OhC0dnSMRzZ8=";
+  release."1.7.0+2.4+9.0".hash = "sha256-2dEIx/c0zLagT9jW1aDE/87ztg51HrY1wP7ioQYpUTQ=";
 
   propagatedBuildInputs = [
     mathcomp-boot
@@ -52,6 +54,8 @@ mkCoqDerivation {
     mathcomp-fingroup
     stdlib
   ];
+
+  useCoqifVersion = v: v != null && v != "dev" && lib.versions.isLe "1.6.0+2.3+8.18" v;
 
   meta = {
     description = "Micromega tactics for Mathematical Components";


### PR DESCRIPTION
Update a few rocqPackages:
* coquelicot: 3.4.4 -> 3.4.5
* mathcomp-zify: 1.6.0 -> 1.7.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
