### PR TITLE
raind: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24814,6 +24814,12 @@
     githubId = 129837916;
     name = "Rohith S";
   };
+  rokuroo171 = {
+    email = "mrakkakhairilazwar@gmail.com";
+    github = "rokuroo171";
+    githubId = 238833795;
+    name = "rokuroo";
+  };
   rolfschr = {
     email = "rolf.schr@posteo.de";
     github = "rolfschr";

--- a/pkgs/by-name/ra/raind/package.nix
+++ b/pkgs/by-name/ra/raind/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "raind";
   version = "0.2.0";
   __structuredAttrs = true;

--- a/pkgs/by-name/ra/raind/package.nix
+++ b/pkgs/by-name/ra/raind/package.nix
@@ -26,4 +26,4 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [ rokuroo171 ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/by-name/ra/raind/package.nix
+++ b/pkgs/by-name/ra/raind/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "rokuroo171";
     repo = "raind";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-zH5RP1mCxLdyqcDLlMG8zwodsEsez2XePtiWO+m/ST4=";
   };
 

--- a/pkgs/by-name/ra/raind/package.nix
+++ b/pkgs/by-name/ra/raind/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "raind";
+  version = "0.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rokuroo171";
+    repo = "raind";
+    rev = "v${version}";
+    hash = "sha256-zH5RP1mCxLdyqcDLlMG8zwodsEsez2XePtiWO+m/ST4=";
+  };
+
+  vendorHash = "sha256-8UprJXRLFO3giWAm8k+vbNz7HPYwKW7cD36qc3hEkzE=";
+
+  meta = {
+    description = "Terminal weather screensaver with four modes: rain, thunder, snow, meteor";
+    homepage = "https://github.com/rokuroo171/raind";
+    license = lib.licenses.mit;
+    mainProgram = "raind";
+    maintainers = with lib.maintainers; [ rokuroo171 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Things done

Adds raind, a terminal weather screensaver, at v0.2.0 under
pkgs/by-name/ra/raind. Registers rokuroo171 as maintainer.

- [x] Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`