### PR TITLE
nix-fast-build: 1.6.0 -> 2.0.1

### DIFF
--- a/pkgs/by-name/ni/nix-fast-build/package.nix
+++ b/pkgs/by-name/ni/nix-fast-build/package.nix
@@ -1,55 +1,61 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   python3Packages,
   nix-eval-jobs,
-  nix-output-monitor,
   nix-update-script,
   bashInteractive,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "nix-fast-build";
-  version = "1.6.0";
+  version = "2.0.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "nix-fast-build";
     tag = finalAttrs.version;
-    hash = "sha256-PMBbenLBvn/0pSFOhwPVn171Vw7kU5YmBUNDhxllZ7c=";
+    hash = "sha256-VOzpaf8Si/c7B5xXwxZi+i34LKoDaMgPNZbSMZkpXP4=";
   };
 
   build-system = [ python3Packages.setuptools ];
 
   makeWrapperArgs = [
-    "--prefix PATH : ${
-      lib.makeBinPath (
-        [
-          nix-eval-jobs
-          nix-eval-jobs.nix
-          bashInteractive
-        ]
-        ++ lib.optional (lib.meta.availableOn stdenv.buildPlatform nix-output-monitor.compiler) nix-output-monitor
-      )
-    }"
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      nix-eval-jobs
+      nix-eval-jobs.nix
+      bashInteractive
+    ])
   ];
 
-  # Don't run integration tests as they try to run nix
-  # to build stuff, which we cannot do inside the sandbox.
-  checkPhase = ''
-    PYTHONPATH= $out/bin/nix-fast-build --help
-  '';
+  nativeCheckInputs = with python3Packages; [
+    pyte
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    # The other test files run nix, which fails in the sandbox
+    "tests/test_ci_renderer.py"
+    "tests/test_log_format.py"
+    "tests/test_term.py"
+    "tests/test_tty_renderer.py"
+  ];
+
+  pythonImportsCheck = [ "nix_fast_build" ];
 
   passthru = {
     updateScript = nix-update-script { };
   };
 
   meta = {
-    description = "Combine the power of nix-eval-jobs with nix-output-monitor to speed-up your evaluation and building process";
+    description = "Speed-up your Nix evaluation and building process by running them in parallel";
     homepage = "https://github.com/Mic92/nix-fast-build";
-    changelog = "https://github.com/Mic92/nix-fast-build/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/Mic92/nix-fast-build/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       getchoo


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/Mic92/nix-fast-build/compare/1.6.0...2.0.1
Changelog: https://github.com/Mic92/nix-fast-build/releases/tag/2.0.1

cc @getchoo @Mic92

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test