### PR TITLE
nixos/flarum: don't overwrite `config.php` on installs not managed by this module

### DIFF
--- a/nixos/modules/services/web-apps/flarum.nix
+++ b/nixos/modules/services/web-apps/flarum.nix
@@ -195,6 +195,25 @@ in
         Only set this to true if you are certain you are working with a fresh, empty database.
       '';
     };
+
+    adoptConfig = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to let this module manage a pre-existing config.php,
+        such as a hand-maintained one (typically with
+        {option}`createDatabaseLocally` = false).
+
+        By default, a config.php this module didn't create is left alone:
+        {option}`baseUrl` and {option}`database` are not applied to it, so
+        real settings can't get silently overwritten by their defaults.
+
+        Before enabling this, make sure {option}`baseUrl` and
+        {option}`database` already match the file's real values. Once
+        enabled, config.php is regenerated from these options on every
+        activation, and anything in the file not covered by them is lost.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -287,6 +306,16 @@ in
         cp -f ${cfg.package}/share/php/flarum/{extend.php,site.php,flarum} .
         ln -sf ${cfg.package}/share/php/flarum/vendor .
         ln -sf ${cfg.package}/share/php/flarum/public/index.php public/
+
+        ${optionalString cfg.adoptConfig "touch .flarum-installed"}
+
+        # config.php with no marker means we didn't write it, so leave it alone.
+        # This check must come before the guard below: that guard also touches
+        # the marker, which would make this check pass for the wrong reason.
+        if [ ! -f .flarum-installed ] && [ -f config.php ]; then
+          echo "flarum-install: config.php exists but wasn't written by this module; leaving it untouched." >&2
+          echo "flarum-install: set services.flarum.adoptConfig = true to adopt it." >&2
+        else
       ''
       + optionalString (cfg.createDatabaseLocally && cfg.database.driver == "mysql") ''
         if [ ! -f .flarum-installed ]; then
@@ -306,14 +335,18 @@ in
         fi
       ''
       + ''
-        install -m 0600 ${configPhpFile} config.php
-        ${optionalString (cfg.databasePasswordFile != null) ''
-          ${pkgs.replace-secret}/bin/replace-secret '@databasePassword@' \
-            ${escapeShellArg cfg.databasePasswordFile} config.php
-        ''}
+          touch .flarum-installed
+          install -m 0600 ${configPhpFile} config.php
+          ${optionalString (cfg.databasePasswordFile != null) ''
+            ${pkgs.replace-secret}/bin/replace-secret '@databasePassword@' \
+              ${escapeShellArg cfg.databasePasswordFile} config.php
+          ''}
+        fi
 
-        php flarum migrate
-        php flarum cache:clear
+        if [ -f config.php ]; then
+          php flarum migrate
+          php flarum cache:clear
+        fi
       '';
     };
   };

--- a/nixos/tests/flarum.nix
+++ b/nixos/tests/flarum.nix
@@ -81,5 +81,18 @@
         "echo 'select id from nixos_test_marker;' | sudo -u flarum mysql -u flarum flarum -N | grep -q 1"
     )
     machine.succeed("[ -f /var/lib/flarum/.flarum-installed ]")
+
+    # A config.php present without the .flarum-installed marker (hand-maintained,
+    # or from before this module managed config.php) must be left untouched.
+    machine.succeed("rm /var/lib/flarum/.flarum-installed")
+    machine.succeed(
+        "echo '<?php return array (\"url\" => \"http://localhost\", \"database\" => "
+        + "array (\"driver\" => \"mysql\", \"host\" => \"localhost\", \"database\" => "
+        + "\"flarum\", \"username\" => \"flarum\", \"password\" => \"flarum-db-password\"), "
+        + "\"nixos_test_marker\" => \"foreign-config\");' "
+        + "| sudo -u flarum tee /var/lib/flarum/config.php"
+    )
+    machine.succeed("systemctl restart flarum-install.service")
+    machine.succeed("grep -q 'nixos_test_marker' /var/lib/flarum/config.php")
   '';
 }


### PR DESCRIPTION
Commit https://github.com/NixOS/nixpkgs/commit/62e1de51f3f8f73549f0510b64ded369680d337f introduced a breaking change in release branch for existing flarum deployments with self-maintained `config.php`.

This guards activation so a `config.php` this module didn't write is left untouched, and adds `services.flarum.adoptConfig` (default `false`) to opt in to letting the module manage and regenerate an existing `config.php`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
