### PR TITLE
intel-graphics-compiler: avoid git gc data race

### DIFF
--- a/pkgs/by-name/in/intel-graphics-compiler/package.nix
+++ b/pkgs/by-name/in/intel-graphics-compiler/package.nix
@@ -109,6 +109,7 @@ stdenv.mkDerivation rec {
     export HOME=$(mktemp -d)
     git config --global user.email ""
     git config --global user.name nixbld
+    git config --global gc.auto 0
     git -C llvm-project init
     git -C llvm-project add .
     git -C llvm-project commit -m stub >/dev/null


### PR DESCRIPTION
Building the package on ZFS was 100% of the time broken for me, due to a `.git` directory corruption in the configure phase:

```log
...
-- [LLVM] : Copying stock LLVM sources /build/llvm-project to /build/build/IGC/llvm-deps-17.0.6/src/llvm
Error copying directory from "/build/llvm-project/.git" to "/build/build/IGC/llvm-deps-17.0.6/src/.git": No such file or directory
-- [LLVM] : Copying LLVM common CMake utils /build/llvm-project/cmake to /build/build/IGC/llvm-deps-17.0.6/src/cmake
...
```

It looks like committing many files into the newly created repository always triggers a background gc, which at least on ZFS (and maybe depending on the builder load) would run long enough, that the copy performed by cmake would abort in the middle, due to files and folders disappearing during the copy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

### `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --tests`
Commit: `73453610d85663dae6e42e796316ea2fc5899cf1`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 tests built:</summary>
  <ul>
    <li>intel-llvm.tests.sycl-compile-native_cpu</li>
    <li>intel-llvm.tests.sycl-compile-spir64</li>
    <li>intelLlvmStdenv.tests.succeedOnFailure</li>
    <li>intelLlvmStdenv.tests.inputDerivationRequiredSystemFeatures</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 7 packages built:</summary>
  <ul>
    <li>intel-graphics-compiler</li>
    <li>intel-compute-runtime (intel-graphics-compiler.tests.intel-compute-runtime)</li>
    <li>onedpl (intel-llvm.tests.onedpl)</li>
    <li>generic-sycl-components</li>
    <li>intel-llvm</li>
    <li>intelLlvmStdenv</li>
    <li>oneMath</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
