### PR TITLE
nixos/activation: warn about deprecated activation scripts

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -116,6 +116,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @Artturin @Ericson2314 @lo
 /nixos/lib/eval-config.nix                            @infinisil
 /nixos/modules/misc/ids.nix                           @R-VdP
 /nixos/modules/system/activation/bootspec.nix         @grahamc @cole-h @raitobezarius
+/nixos/modules/system/activation/restrict-activation-scripts.nix @R-VdP
 /nixos/modules/system/activation/bootspec.cue         @grahamc @cole-h @raitobezarius
 
 # NixOS Render Docs

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -229,6 +229,9 @@
 
 - `programs.regreet` has been renamed to `services.displayManager.regreet`.
 
+- Activation scripts (`system.activationScripts`) are deprecated and now emit a warning.
+  See [the tracking issue](https://github.com/NixOS/nixpkgs/issues/475305) for alternative approaches.
+
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
 - `temporal` has been updated to the 1.31 release line. Always consult the [upstream upgrade

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1955,6 +1955,7 @@
   ./system/activation/bootspec.nix
   ./system/activation/nixos-init.nix
   ./system/activation/pre-switch-check.nix
+  ./system/activation/restrict-activation-scripts.nix
   ./system/activation/specialisation.nix
   ./system/activation/switchable-system.nix
   ./system/activation/top-level.nix

--- a/nixos/modules/system/activation/restrict-activation-scripts.nix
+++ b/nixos/modules/system/activation/restrict-activation-scripts.nix
@@ -1,0 +1,45 @@
+# Activation scripts are deprecated, see
+# https://github.com/NixOS/nixpkgs/issues/475305
+#
+# This module warns about any activation script that is not on the
+# exemption list below. The list contains the scripts that are still
+# defined by NixOS itself, it should only ever shrink. Do NOT add new
+# entries, add a systemd unit instead.
+#
+# The warning will eventually become an assertion.
+{ config, lib, ... }:
+
+let
+  exemptions = [
+    "binsh"
+    "etc"
+    "groups"
+    "hashes"
+    "modprobe"
+    "specialfs"
+    "udevd"
+    "users"
+    "usrbinenv"
+  ];
+
+  scriptText = value: if lib.isString value then value else value.text;
+
+  offenders = lib.attrNames (
+    lib.filterAttrs (name: value: !(lib.elem name exemptions) && scriptText value != "") (
+      lib.removeAttrs config.system.activationScripts [ "script" ]
+    )
+  );
+in
+
+{
+  meta.maintainers = with lib.maintainers; [ rvdp ];
+
+  config = {
+    warnings = lib.optional (offenders != [ ]) ''
+      Activation scripts are deprecated and will be removed soon.
+      See https://github.com/NixOS/nixpkgs/issues/475305 for alternatives.
+      The following activation scripts are defined:
+      ${lib.concatMapStringsSep "\n" (name: "- system.activationScripts.${name}") offenders}
+    '';
+  };
+}


### PR DESCRIPTION
Activation scripts are deprecated, see #475305.

This adds a module that warns about any non-empty script in `system.activationScripts` that is not on the exemption list of scripts still defined by NixOS itself. The exemption list lives in a dedicated module with a `ci/OWNERS` entry, so additions to it get flagged in review. The list should only ever shrink.

We allow empty definitions since those are used to disable a script or to add ordering dependencies.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
