### PR TITLE
nixos/tests/tor: replace activation script with ExecStartPre

### DIFF
--- a/nixos/tests/tor.nix
+++ b/nixos/tests/tor.nix
@@ -160,14 +160,17 @@ let
 
     # Deploy pre-generated relay and authority keys before Tor starts.
     # This ensures the relay fingerprint matches what's in DirAuthority lines.
-    system.activationScripts.tor-keys = lib.stringAfter [ "users" "groups" ] ''
-      mkdir -p /var/lib/tor/keys
-      cp ${daKeysets.${name}}/keys/* /var/lib/tor/keys/
-      touch /var/lib/tor/sr-state
-      chown -R tor:tor /var/lib/tor
-      chmod 700 /var/lib/tor /var/lib/tor/keys
-      chmod 600 /var/lib/tor/keys/*
-    '';
+    # Runs as root (`+` prefix) so it can chown to tor:tor.
+    systemd.services.tor.serviceConfig.ExecStartPre = lib.mkBefore [
+      "+${pkgs.writeShellScript "tor-keys-${name}" ''
+        mkdir -p /var/lib/tor/keys
+        cp ${daKeysets.${name}}/keys/* /var/lib/tor/keys/
+        touch /var/lib/tor/sr-state
+        chown -R tor:tor /var/lib/tor
+        chmod 700 /var/lib/tor /var/lib/tor/keys
+        chmod 600 /var/lib/tor/keys/*
+      ''}"
+    ];
 
     services.tor = {
       enable = true;


### PR DESCRIPTION
Part of #475305.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
