### PR TITLE
nixos/portmaster: replace activation script with preStart cleanup

### DIFF
--- a/nixos/modules/services/networking/portmaster.nix
+++ b/nixos/modules/services/networking/portmaster.nix
@@ -8,7 +8,6 @@
 
 let
   inherit (lib)
-    boolToString
     concatMapStringsSep
     concatStringsSep
     escapeRegex
@@ -670,18 +669,6 @@ in
       '';
     };
 
-    system.activationScripts.portmaster-cleanup = ''
-      if ${boolToString (!managesConfig)}; then
-        if [ -e ${escapeShellArg runtimeConfigManagedMarkerPath} ]; then
-          ${getExe' pkgs.coreutils "rm"} -f ${escapeShellArg runtimeConfigPath} ${escapeShellArg runtimeConfigManagedMarkerPath}
-        fi
-      fi
-
-      if ${boolToString (!profilesEnabled)}; then
-        ${getExe' pkgs.coreutils "rm"} -f ${escapeShellArg profilesApiKeyPath}
-      fi
-    '';
-
     environment.systemPackages = [ cfg.package ];
 
     boot.kernelModules = [ "nfnetlink_queue" ];
@@ -714,9 +701,18 @@ in
         wantedBy = [ "multi-user.target" ];
         requires = [ "systemd-tmpfiles-setup.service" ];
 
-        preStart = lib.optionalString managesConfig ''
-          ${mergeConfig}
-        '';
+        preStart =
+          lib.optionalString (!managesConfig) ''
+            if [ -e ${escapeShellArg runtimeConfigManagedMarkerPath} ]; then
+              ${getExe' pkgs.coreutils "rm"} -f ${escapeShellArg runtimeConfigPath} ${escapeShellArg runtimeConfigManagedMarkerPath}
+            fi
+          ''
+          + lib.optionalString (!profilesEnabled) ''
+            ${getExe' pkgs.coreutils "rm"} -f ${escapeShellArg profilesApiKeyPath}
+          ''
+          + lib.optionalString managesConfig ''
+            ${mergeConfig}
+          '';
 
         serviceConfig =
           let


### PR DESCRIPTION
Part of #475305.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
