### PR TITLE
nixos/tests/nextcloud: replace activation script with a tmpfs mount

### DIFF
--- a/nixos/tests/nextcloud/home-mount.nix
+++ b/nixos/tests/nextcloud/home-mount.nix
@@ -15,13 +15,10 @@ runTest (
 
     imports = [ testBase ];
 
-    nodes.nextcloud = { pkgs, ... }: {
-      system.activationScripts.nc-mock-mount = {
-        deps = [ "users" ];
-        text = ''
-          ${pkgs.coreutils}/bin/mkdir -p /mnt
-          ${pkgs.util-linux}/bin/mount -t tmpfs tmpfs /mnt
-        '';
+    nodes.nextcloud = {
+      fileSystems."/mnt" = {
+        fsType = "tmpfs";
+        device = "tmpfs";
       };
       services.nextcloud = {
         config.dbtype = "sqlite";


### PR DESCRIPTION
Part of #475305.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
