### PR TITLE
python3Packages.fontbakery: cleanup and refactor

### DIFF
--- a/pkgs/development/python-modules/fontbakery/default.nix
+++ b/pkgs/development/python-modules/fontbakery/default.nix
@@ -169,6 +169,9 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/fonttools/fontbakery/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     mainProgram = "fontbakery";
-    maintainers = with lib.maintainers; [ danc86 ];
+    maintainers = with lib.maintainers; [
+      danc86
+      jopejoe1
+    ];
   };
 })

--- a/pkgs/development/python-modules/fontbakery/default.nix
+++ b/pkgs/development/python-modules/fontbakery/default.nix
@@ -10,8 +10,8 @@
   collidoscope,
   defcon,
   dehinter,
-  fetchPypi,
   font-v,
+  fetchFromGitHub,
   fonttools,
   freetype-py,
   gflanguages,
@@ -45,14 +45,16 @@
   vharfbuzz,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fontbakery";
   version = "1.1.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-cLQNjrpk8m3Rm1VBC4FNGB7e/E+hjIqcStFSDqfVIk4=";
+  src = fetchFromGitHub {
+    owner = "fonttools";
+    repo = "fontbakery";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IkGcaRW8RjwR/foACR38HtCuETyXTyCjpIUaY+awMQo=";
   };
 
   env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
@@ -164,9 +166,9 @@ buildPythonPackage rec {
   meta = {
     description = "Tool for checking the quality of font projects";
     homepage = "https://github.com/googlefonts/fontbakery";
-    changelog = "https://github.com/fonttools/fontbakery/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/fonttools/fontbakery/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     mainProgram = "fontbakery";
     maintainers = with lib.maintainers; [ danc86 ];
   };
-}
+})

--- a/pkgs/development/python-modules/fontbakery/default.nix
+++ b/pkgs/development/python-modules/fontbakery/default.nix
@@ -14,7 +14,6 @@
   freetype-py,
   gflanguages,
   gfsubsets,
-  gitMinimal,
   glyphsets,
   installShellFiles,
   jinja2,
@@ -104,7 +103,6 @@ buildPythonPackage (finalAttrs: {
   ++ fonttools.optional-dependencies.ufo;
 
   nativeCheckInputs = [
-    gitMinimal
     pytestCheckHook
     pytest-xdist
     ufolint
@@ -167,38 +165,12 @@ buildPythonPackage (finalAttrs: {
   preCheck = ''
     # Let the tests invoke 'fontbakery' command.
     export PATH="$out/bin:$PATH"
-    # font-v tests assume they are running from a git checkout, although they
-    # don't care which one. Create a dummy git repo to satisfy the tests:
-    git init -b main
-    git config user.email test@example.invalid
-    git config user.name Test
-    git commit --allow-empty --message 'Dummy commit for tests'
   '';
 
   disabledTests = [
     # These require network access
     "test_check_axes_match"
-    "test_check_description_broken_links"
-    "test_check_description_family_update"
-    "test_check_metadata_designer_profiles"
-    "test_check_metadata_has_tags"
-    "test_check_metadata_includes_production_subsets"
-    "test_check_vertical_metrics"
     "test_check_vertical_metrics_regressions"
-    "test_check_cjk_vertical_metrics"
-    "test_check_cjk_vertical_metrics_regressions"
-    "test_check_fontbakery_version_live_apis"
-    "test_command_check_googlefonts"
-    # AssertionError
-    "test_check_shape_languages"
-    "test_command_config_file"
-    "test_config_override"
-  ];
-
-  disabledTestPaths = [
-    # ValueError: Check 'googlefonts/glyphsets/shape_languages' not found
-    "tests/test_checks_filesize.py"
-    "tests/test_checks_googlefonts_overrides.py"
   ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/fontbakery/default.nix
+++ b/pkgs/development/python-modules/fontbakery/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   axisregistry,
-  babelfont,
   beautifulsoup4,
   beziers,
   buildPythonPackage,
@@ -10,7 +9,6 @@
   collidoscope,
   defcon,
   dehinter,
-  font-v,
   fetchFromGitHub,
   fonttools,
   freetype-py,
@@ -40,9 +38,15 @@
   toml,
   ufo2ft,
   ufolint,
-  ufomerge,
   unicodedata2,
+  uharfbuzz,
   vharfbuzz,
+  myst-parser,
+  sphinx,
+  sphinx-rtd-theme,
+  pytest-cov-stub,
+  pylint,
+  black,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -76,48 +80,89 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
-    axisregistry
-    babelfont
-    beautifulsoup4
     beziers
     cmarkgfm
-    collidoscope
     defcon
     dehinter
-    font-v
     fonttools
     freetype-py
-    gflanguages
-    gfsubsets
-    glyphsets
     jinja2
-    lxml
     munkres
     opentypespec
     ots-python
     packaging
     pip-api
-    protobuf
     pyyaml
     requests
     rich
-    shaperglot
-    stringbrewer
     toml
     ufo2ft
     ufolint
-    ufomerge
-    unicodedata2
+    uharfbuzz
     vharfbuzz
-  ];
+  ]
+  ++ fonttools.optional-dependencies.ufo;
 
   nativeCheckInputs = [
     gitMinimal
     pytestCheckHook
     pytest-xdist
-    requests-mock
     ufolint
-  ];
+    pytest-cov-stub
+    requests-mock
+    pylint
+    black
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.all;
+
+  optional-dependencies = {
+    beautifulsoup4 = [ beautifulsoup4 ];
+    shaperglot = [ shaperglot ];
+    googlefontsalwayslatest = [
+      axisregistry
+      gflanguages
+      gfsubsets
+      glyphsets
+      shaperglot
+    ];
+    adobefonts = [ ];
+    fontval = [ lxml ];
+    fontwerk = finalAttrs.passthru.optional-dependencies.googlefonts;
+    googlefonts = [
+      collidoscope
+      fonttools
+      protobuf
+      stringbrewer
+      unicodedata2
+    ]
+    ++ fonttools.optional-dependencies.lxml
+    ++ fonttools.optional-dependencies.unicode
+    ++ finalAttrs.passthru.optional-dependencies.beautifulsoup4
+    ++ finalAttrs.passthru.optional-dependencies.googlefontsalwayslatest
+    ++ finalAttrs.passthru.optional-dependencies.shaperglot;
+    iso15008 = [ ];
+    microsoft = [ ];
+    notofonts = finalAttrs.passthru.optional-dependencies.googlefonts;
+    typenetwork = [
+      unicodedata2
+    ]
+    ++ finalAttrs.passthru.optional-dependencies.beautifulsoup4
+    ++ finalAttrs.passthru.optional-dependencies.shaperglot;
+    docs = [
+      myst-parser
+      sphinx
+      sphinx-rtd-theme
+    ];
+    all =
+      finalAttrs.passthru.optional-dependencies.docs
+      ++ finalAttrs.passthru.optional-dependencies.adobefonts
+      ++ finalAttrs.passthru.optional-dependencies.fontval
+      ++ finalAttrs.passthru.optional-dependencies.fontwerk
+      ++ finalAttrs.passthru.optional-dependencies.googlefonts
+      ++ finalAttrs.passthru.optional-dependencies.iso15008
+      ++ finalAttrs.passthru.optional-dependencies.notofonts
+      ++ finalAttrs.passthru.optional-dependencies.typenetwork;
+  };
 
   preCheck = ''
     # Let the tests invoke 'fontbakery' command.


### PR DESCRIPTION
Depends on #557333
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
