### PR TITLE
visidata: 3.3 -> 3.4

### DIFF
--- a/pkgs/by-name/vi/visidata/package.nix
+++ b/pkgs/by-name/vi/visidata/package.nix
@@ -2,8 +2,6 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  # other
-  gitMinimal,
   withPcap ? true,
   withXclip ? stdenv.hostPlatform.isLinux,
   xclip,
@@ -13,14 +11,14 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "visidata";
-  version = "3.3";
+  version = "3.4";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "saulpw";
     repo = "visidata";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-y+HqRww/Fm+YeiNYH0a2TcUYOc72qL+9tC0PRudptrA=";
+    hash = "sha256-h5utXfafQP6uZ7vXQAYXfV26y0qHbk6vulPl6DXbVX4=";
   };
 
   propagatedBuildInputs =
@@ -66,6 +64,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       sh
       psutil
       numpy
+      shapely
 
       #requests_cache
       beautifulsoup4
@@ -87,10 +86,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     )
     ++ lib.optional withXclip xclip;
 
-  nativeCheckInputs = [
-    gitMinimal
-  ];
-
   # check phase uses the output bin, which is not possible when cross-compiling
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
@@ -98,23 +93,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     runHook preCheck
 
     # disable some tests which require access to the network
-    rm -f tests/load-http.vd            # http
-    rm -f tests/graph-cursor-nosave.vd  # http
-    rm -f tests/messenger-nosave.vd     # dns
+    rm tests/load-http-flaky.vd       # http
+    rm tests/messenger-nosave.vd      # dns
 
     # tests to disable because we don't have a package to load such files
-    rm -f tests/load-conllu.vdj         # no 'pyconll'
-    rm -f tests/load-sav.vd             # no 'savReaderWriter'
-    rm -f tests/load-fec.vdj            # no 'fecfile'
+    rm tests/load-conllu.vdj          # no 'pyconll'
+    rm tests/load-fec.vdj             # no 'fecfile'
 
-    # tests use git to compare outputs to references
-    git init -b "test-reference"
-    git config user.name "nobody"
-    git config user.email "no@where"
-    git add .
-    git commit -m "test reference"
-
-    substituteInPlace dev/test.sh --replace "bin/vd" "$out/bin/vd"
+    patchShebangs tests/
+    substituteInPlace tests/test-vdx.sh --replace-fail "bin/vd" "$out/bin/vd"
     bash dev/test.sh
     runHook postCheck
   '';


### PR DESCRIPTION
Accidently closed https://github.com/NixOS/nixpkgs/pull/556896 while trying to git push --force . This one has the suggested fix!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
