### PR TITLE
nixos/openbao-agent: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -24,6 +24,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [openbao-agent](https://openbao.org/docs/agent/), the agent side of OpenBao, rendering templated secrets to disk and reacting to a re-render. Available as [services.openbao-agent](#opt-services.openbao-agent.instances).
+
 - [Portmaster](https://safing.io/portmaster/), a privacy-focused application
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).

--- a/nixos/modules/services/security/vault-agent.nix
+++ b/nixos/modules/services/security/vault-agent.nix
@@ -68,6 +68,8 @@ let
                       upstreamDocs =
                         if flavour == "vault-agent" then
                           "https://developer.hashicorp.com/vault/docs/agent#configuration-file-options"
+                        else if flavour == "openbao-agent" then
+                          "https://openbao.org/docs/agent/"
                         else
                           "https://github.com/hashicorp/consul-template/blob/main/docs/configuration.md#configuration-file";
                     in
@@ -92,6 +94,7 @@ let
       instance,
       name,
       flavour,
+      subcommand ? null,
     }:
     let
       configFile = format.generate "${name}.json" instance.settings;
@@ -107,8 +110,8 @@ let
         User = instance.user;
         Group = instance.group;
         RuntimeDirectory = flavour;
-        ExecStart = "${lib.getExe instance.package} ${
-          lib.optionalString (flavour == "vault-agent") "agent"
+        ExecStart = "${lib.getExe instance.package}${
+          lib.optionalString (subcommand != null) " ${subcommand}"
         } -config ${configFile}";
         ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
         KillSignal = "SIGINT";
@@ -124,12 +127,19 @@ in
       pkgName = "vault";
       flavour = "vault-agent";
     };
+    services.openbao-agent.instances = commonOptions {
+      pkgName = "openbao";
+      flavour = "openbao-agent";
+    };
   };
 
   config = lib.mkMerge (
     map
       (
-        flavour:
+        {
+          flavour,
+          subcommand ? null,
+        }:
         let
           cfg = config.services.${flavour};
         in
@@ -137,19 +147,32 @@ in
           systemd.services = lib.mapAttrs' (
             name: instance:
             lib.nameValuePair "${flavour}-${name}" (createAgentInstance {
-              inherit name instance flavour;
+              inherit
+                name
+                instance
+                flavour
+                subcommand
+                ;
             })
           ) cfg.instances;
         }
       )
       [
-        "consul-template"
-        "vault-agent"
+        { flavour = "consul-template"; }
+        {
+          flavour = "vault-agent";
+          subcommand = "agent";
+        }
+        {
+          flavour = "openbao-agent";
+          subcommand = "agent";
+        }
       ]
   );
 
   meta.maintainers = with lib.maintainers; [
     emilylange
+    kiara
     tcheronneau
   ];
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1313,6 +1313,7 @@ in
   openafs = runTest ./openafs.nix;
   openarena = runTest ./openarena.nix;
   openbao = runTest ./openbao.nix;
+  openbao-agent = runTest ./openbao-agent.nix;
   opencloud = runTest ./opencloud.nix;
   openldap = runTest ./openldap.nix;
   openresty-lua = runTest ./openresty-lua.nix;

--- a/nixos/tests/openbao-agent.nix
+++ b/nixos/tests/openbao-agent.nix
@@ -1,0 +1,68 @@
+{ lib, ... }:
+{
+  name = "openbao-agent";
+
+  meta.maintainers = with lib.maintainers; [ kiara ];
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      services.openbao-agent.instances.example.settings = {
+        vault.address = config.environment.variables.BAO_ADDR;
+
+        auto_auth.method = [
+          {
+            type = "token_file";
+            config.token_file_path = pkgs.writeText "bao-token" config.environment.variables.BAO_TOKEN;
+          }
+        ];
+
+        template = [
+          {
+            contents = ''
+              {{- with secret "secret/example" }}
+              {{ .Data.data.key }}
+              {{- end }}
+            '';
+            perms = "0600";
+            destination = "/example";
+          }
+        ];
+      };
+
+      # skip init/unseal - `services.openbao` lacks dev mode
+      systemd.services.openbao-dev = {
+        description = "OpenBao dev server";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        path = [ pkgs.bash ];
+        environment.HOME = "/root";
+        serviceConfig.ExecStart = ''
+          ${lib.getExe pkgs.openbao} server -dev \
+            -dev-root-token-id=${config.environment.variables.BAO_TOKEN} \
+            -dev-listen-address=127.0.0.1:8200
+        '';
+      };
+
+      environment = {
+        systemPackages = [ pkgs.openbao ];
+        variables = {
+          # dev mode binds 127.0.0.1 only, and the client tries `::1` first
+          BAO_ADDR = "http://127.0.0.1:8200";
+          BAO_TOKEN = "root";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("openbao-dev.service")
+    machine.wait_for_open_port(8200)
+
+    machine.wait_until_succeeds('bao kv put secret/example key=example')
+
+    machine.wait_for_unit("openbao-agent-example.service")
+
+    machine.wait_for_file("/example")
+    machine.succeed('grep "example" /example')
+  '';
+}


### PR DESCRIPTION
Add a `services.openbao-agent` to interact with secrets client [OpenBao Agent](https://openbao.org/docs/agent-and-proxy/agent/).
Code is shared with `services.vault-agent`.

Assisted-by: Claude:claude-opus-5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
