### PR TITLE
python313Packages.kfactory: relax typer dependency

### DIFF
--- a/pkgs/development/python-modules/kfactory/default.nix
+++ b/pkgs/development/python-modules/kfactory/default.nix
@@ -56,6 +56,7 @@ buildPythonPackage (finalAttrs: {
   pythonRelaxDeps = [
     "pydantic"
     "klayout"
+    "typer"
   ];
 
   dependencies = [


### PR DESCRIPTION
## Summary
- `kfactory` declares `typer<0.25,>=0.21.1`, but nixpkgs currently pins `python3Packages.typer` at `0.25.1` (see 1719162d8237, which reverted a `0.25.1 -> 0.26.8` bump). This makes `pythonRuntimeDepsCheckHook` fail, breaking `kfactory` and its dependent `gdsfactory`.
- Discovered while investigating why #557079 (klayout bump) reported `python313Packages.kfactory` and `python313Packages.gdsfactory` as failing in its pre-merge `nixpkgs-review` report — this is a pre-existing break unrelated to that klayout bump.

## Test plan
- [x] `nix build .#python313Packages.kfactory` — builds, test suite passes (303 passed, 2 skipped)
- [x] `nix build .#python313Packages.gdsfactory` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyTGCtHJHRXam4oFi7fnJX