### PR TITLE
invoiceplane: 1.7.1 -> 1.7.2

### DIFF
--- a/nixos/modules/services/web-apps/invoiceplane.nix
+++ b/nixos/modules/services/web-apps/invoiceplane.nix
@@ -332,6 +332,18 @@ in
             assertion = cfg.cron.enable -> cfg.cron.key != null;
             message = ''services.invoiceplane.sites."${hostName}".cron.key must be set in order to use cron service.'';
           }
+          {
+            assertion =
+              (lib.versionAtLeast (pkg hostName cfg).version "1.7.2" && cfg.invoiceTemplates != [ ])
+              -> cfg.settings ? CUSTOM_INVOICE_TEMPLATES_PDF;
+            message = ''services.invoiceplane.sites."${hostName}".invoiceTemplates is set but settings.CUSTOM_INVOICE_TEMPLATES_PDF is not. Since InvoicePlane >= 1.7.2 (current: ${cfg.package.version}), the filename of the custom invoice template PHP file must be explicitly whitelisted via settings.CUSTOM_INVOICE_TEMPLATES_PDF, otherwise it will not be picked up.'';
+          }
+          {
+            assertion =
+              (lib.versionAtLeast (pkg hostName cfg).version "1.7.2" && cfg.quoteTemplates != [ ])
+              -> cfg.settings ? CUSTOM_QUOTE_TEMPLATES_PDF;
+            message = ''services.invoiceplane.sites."${hostName}".quoteTemplates is set but settings.CUSTOM_QUOTE_TEMPLATES_PDF is not. Since InvoicePlane >= 1.7.2 (current: ${cfg.package.version}), the filename of the custom quote template PHP file must be explicitly whitelisted via settings.CUSTOM_QUOTE_TEMPLATES_PDF, otherwise it will not be picked up.'';
+          }
         ]) eachSite
       );
 

--- a/pkgs/by-name/in/invoiceplane/package.nix
+++ b/pkgs/by-name/in/invoiceplane/package.nix
@@ -11,7 +11,7 @@
   fetchzip,
 }:
 let
-  version = "1.7.1";
+  version = "1.7.2";
   # Fetch release tarball which contains language files
   # https://github.com/InvoicePlane/InvoicePlane/issues/1170
   languages = fetchzip {
@@ -27,13 +27,13 @@ php.buildComposerProject2 (finalAttrs: {
     owner = "InvoicePlane";
     repo = "InvoicePlane";
     tag = "v${version}";
-    hash = "sha256-Nci5GaCMYIjewq0W5emE6TDgc6JPz4bVVF3okNtHUag=";
+    hash = "sha256-LC/c1wdVNguv8BrrY7ysVwomgG8uTPoY1Fw8/EPFk2I=";
   };
 
   # Composer.lock validation currently fails for unknown reason
   composerStrictValidation = true;
 
-  vendorHash = "sha256-adKvKWo55SSbEKpgMJzR9vJQA8DnNXOTfSzp7t8s2Nk=";
+  vendorHash = "sha256-BRNglvJMREFD9iHPqXycw1WYlxuV9fL8/Zoba2Z3p8w=";
 
   nativeBuildInputs = [
     yarnConfigHook
@@ -45,7 +45,7 @@ php.buildComposerProject2 (finalAttrs: {
 
   offlineCache = fetchYarnDeps {
     inherit (finalAttrs) src patches;
-    hash = "sha256-rJlOYMnzFKui+caIFD4d82Q/RcDYnadeJ1G56fcNNQY=";
+    hash = "sha256-faEq9sVsE5xcqL07IIEmXcavcWPZicb7asmuhuBI+h4=";
   };
 
   postBuild = ''
@@ -57,7 +57,7 @@ php.buildComposerProject2 (finalAttrs: {
     chmod -R u+w $out/share
     mv $out/share/php/invoiceplane/* $out/
     cp -r ${languages}/application/language $out/application/
-    rm -r $out/{composer.json,composer.lock,CONTRIBUTING.md,docker-compose.yml,Gruntfile.js,package.json,node_modules,yarn.lock,share}
+    rm -r $out/{composer.json,composer.lock,docker-compose.yml,Gruntfile.js,package.json,node_modules,yarn.lock,share}
   '';
 
   passthru.tests = {


### PR DESCRIPTION
Changelog: https://github.com/InvoicePlane/InvoicePlane/releases/tag/v1.7.2

This is update contains high security fixes but is also breaking.

Custom template file names need to get whitelisted with the `CUSTOM_INVOICE_TEMPLATES_PDF` and might also need to get updated to match the new helper functions used in the [upstream default template](https://github.com/InvoicePlane/InvoicePlane/blob/develop/application/views/invoice_templates/pdf/InvoicePlane.php).

```
services.invoiceplane = {
  webserver = "nginx";
  sites."localhost" = {
    enable = true;
    invoiceTemplates = [ invoiceplane-template-vtdirektmarketing ];
    settings = {
      IP_URL = "http://localhost:8080";
      CUSTOM_INVOICE_TEMPLATES_PDF = "vtdirektmarketing";
    };
  };
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
