### PR TITLE
nixos/doc: add section about overriding systemd units

### DIFF
--- a/nixos/doc/manual/administration/service-mgmt.chapter.md
+++ b/nixos/doc/manual/administration/service-mgmt.chapter.md
@@ -171,3 +171,45 @@ example illustrates this:
   };
 }
 ```
+
+### Overriding a package-provided unit {#sect-nixos-systemd-overriding-vendored-units}
+
+When a unit of the same name is provided both by a package in
+[](#opt-systemd.packages) and by `systemd.services`/`systemd.sockets`/etc.,
+NixOS does not replace the package's unit file by default.
+With the default `overrideStrategy` of `asDropinIfExists`, it instead places
+its own unit fragment in `<unit-name>.d/overrides.conf`, a systemd
+[drop-in file](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#id-1.14.3).
+systemd loads the vendored unit file first, then merges each drop-in on top
+of it.
+
+Drop-ins only *replace* single-value directives, such as `Description=`.
+For directives that may be listed multiple times, such as `ExecStart=`,
+`Environment=`, `After=`, or `CapabilityBoundingSet=`, each assignment
+*adds* to the ones already collected from the vendored unit and from
+earlier drop-ins, rather than replacing them.
+So setting e.g. `serviceConfig.ExecStart` in a NixOS module does not
+replace the package's `ExecStart=`, but rather adds a second one to the
+list.
+
+To fully replace such a directive instead of extending it, assign an
+empty string as the first list element.
+This resets the directive, discarding every value collected so far,
+before the following elements are collected into it again:
+
+```nix
+{
+  systemd.packages = [ pkgs.someDaemon ];
+
+  systemd.services.someDaemon.serviceConfig = {
+    # Discard the package's ExecStart= and replace it with our own.
+    ExecStart = [
+      ""
+      "${lib.getExe pkgs.someDaemon} --config /etc/someDaemon.conf"
+    ];
+
+    # Discard the package's EnvironmentFile= entirely.
+    EnvironmentFile = [ "" ];
+  };
+}
+```

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -271,6 +271,9 @@
   "sec-test-vm-ssh-access": [
     "index.html#sec-test-vm-ssh-access"
   ],
+  "sect-nixos-systemd-overriding-vendored-units": [
+    "index.html#sect-nixos-systemd-overriding-vendored-units"
+  ],
   "ssec-all-machine-objects": [
     "index.html#ssec-all-machine-objects"
   ],


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a documentation section about overriding systemd units, commonly used around nixpkgs. While the idea of an override is an upstream concept, I think the way we use them so implicitly in the module system together with `systemd.packages` warrants its own section.

Built the nixos manual locally and verified that it looked sane.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
