### PR TITLE
python3Packages.nc_py_api: init at 0.30.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26126,6 +26126,12 @@
     githubId = 5791019;
     name = "Jiuyang Liu";
   };
+  ser = {
+    email = "nixos-github@random.re";
+    github = "ser";
+    githubId = 231537;
+    name = "ᎠᎡ. Ѕϵrgϵ Ѵictor";
+  };
   Sereja313 = {
     name = "Sergey Gulin";
     github = "Sereja313";

--- a/pkgs/development/python-modules/nc_py_api/default.nix
+++ b/pkgs/development/python-modules/nc_py_api/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+
+  # runtime dependencies
+  fastapi,
+  filelock,
+  niquests,
+  pydantic,
+  python-dotenv,
+  starlette,
+  xmltodict,
+
+  # optional dependencies
+  uvicorn,
+  caldav,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "nc_py_api";
+  version = "0.30.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cloud-py-api";
+    repo = "nc_py_api";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MXL8fgMsmZ1UOJoUyeun6WVol1PjsEpfxqDZtofuqZ0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    fastapi
+    filelock
+    niquests
+    pydantic
+    python-dotenv
+    starlette
+    xmltodict
+  ];
+
+  optional-dependencies = {
+    app = [ uvicorn ];
+    calendar = [ caldav ];
+  };
+
+  # The integration tests under `tests/` require a live Nextcloud
+  # instance (upstream `conftest.py` connects at module load and raises
+  # `EnvironmentError` if no server is reachable).  Strip that
+  # directory and run only the offline `tests_unit/` subset.
+  postPatch = ''
+    rm -rf tests
+  '';
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "nc_py_api" ];
+
+  meta = {
+    description = "Nextcloud Python Framework";
+    homepage = "https://github.com/cloud-py-api/nc_py_api";
+    changelog = "https://github.com/cloud-py-api/nc_py_api/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ser ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11841,6 +11841,8 @@ self: super: with self; {
 
   nc-dnsapi = callPackage ../development/python-modules/nc-dnsapi { };
 
+  nc_py_api = callPackage ../development/python-modules/nc_py_api { };
+
   nccl4py = callPackage ../development/python-modules/nccl4py { };
 
   ncclient = callPackage ../development/python-modules/ncclient { };


### PR DESCRIPTION
# Nextcloud Python Framework

Python library that provides a robust and well-documented API that allows developers to interact with and extend Nextcloud's functionality.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
