### PR TITLE
ggshield: 1.53.0 -> 1.54.0

### DIFF
--- a/pkgs/by-name/gg/ggshield/package.nix
+++ b/pkgs/by-name/gg/ggshield/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "ggshield";
-  version = "1.52.2";
+  version = "1.53.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GitGuardian";
     repo = "ggshield";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bz3R1ylmkaYF3Wt/ylzeE2IsWKvZ8bmoF39Xu4tVzFU=";
+    hash = "sha256-1LyO5zcd5ueiWSZcwel5JqhdS9UKtESoNxYyY9z+Rbc=";
   };
 
   pythonRelaxDeps = true;
@@ -44,6 +44,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     tomli
     truststore
     typing-extensions
+    unearth
     urllib3
   ];
 

--- a/pkgs/by-name/gg/ggshield/package.nix
+++ b/pkgs/by-name/gg/ggshield/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "ggshield";
-  version = "1.53.0";
+  version = "1.54.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GitGuardian";
     repo = "ggshield";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1LyO5zcd5ueiWSZcwel5JqhdS9UKtESoNxYyY9z+Rbc=";
+    hash = "sha256-8U8kY8IiYM1NXL30cRHrh3Sy5UWIiS8eATKhiugHVik=";
   };
 
   pythonRelaxDeps = true;
@@ -42,6 +42,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     rich
     sigstore
     tomli
+    tomlkit
     truststore
     typing-extensions
     unearth
@@ -89,6 +90,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "test_get_file_sha_in_ref"
     # Generated hooks config references pytest binary, instead of ggshield CLI. Odd!
     "test_install_cursor_local_fresh"
+    "test_install_vibe_global"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
