### PR TITLE
 beamPackages.elixir_1_20: 1.20.3 -> 1.20.4, elixir_1_19: 1.19.5 -> 1.19.6,  elixir_1_18: 1.18.4 -> 1.18.5 

### DIFF
--- a/pkgs/development/interpreters/elixir/1.18.nix
+++ b/pkgs/development/interpreters/elixir/1.18.nix
@@ -1,6 +1,6 @@
 import ./generic-builder.nix {
-  version = "1.18.4";
-  hash = "sha256-PwogI+HfRXy5M7Xn/KyDjm5vUquTBoGxliSV0A2AwSA=";
+  version = "1.18.5";
+  hash = "sha256-C7RXBjZZbdSgz4jdoOCKv8xfM95ChrYjXIIS/ahX+3Y=";
   # https://hexdocs.pm/elixir/1.18.0/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   minimumOTPVersion = "25";
 }

--- a/pkgs/development/interpreters/elixir/1.19.nix
+++ b/pkgs/development/interpreters/elixir/1.19.nix
@@ -1,6 +1,6 @@
 import ./generic-builder.nix {
-  version = "1.19.5";
-  hash = "sha256-ph7zu0F5q+/QZcsVIwpdU1icN84Rn3nIVpnRelpRIMQ=";
+  version = "1.19.6";
+  hash = "sha256-IpC1w3vKCKvEtmYqeYScChNWL7RXn/PjypUnLQt7IZc=";
   # https://hexdocs.pm/elixir/1.19.5/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   minimumOTPVersion = "26";
   maximumOTPVersion = "28";

--- a/pkgs/development/interpreters/elixir/1.20.nix
+++ b/pkgs/development/interpreters/elixir/1.20.nix
@@ -1,6 +1,6 @@
 import ./generic-builder.nix {
-  version = "1.20.3";
-  hash = "sha256-60DlK+yocWcKnxcOtUOkRO69scaY35AADoKFCCF6QfQ=";
+  version = "1.20.4";
+  hash = "sha256-Z/lAmD3wyiTnX2e7n2gHELkTpZ3AgGSjqNmvDxCH91g=";
   # https://hexdocs.pm/elixir/1.20.3/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   minimumOTPVersion = "27";
   maximumOTPVersion = "29";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
