### PR TITLE
python3Packages.pyopencl: 2026.1.2 -> 2026.1.4

### DIFF
--- a/pkgs/development/python-modules/pyopencl/default.nix
+++ b/pkgs/development/python-modules/pyopencl/default.nix
@@ -30,16 +30,24 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyopencl";
-  version = "2026.1.2";
+  version = "2026.1.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "inducer";
     repo = "pyopencl";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-n1xdJbq+RPW2p8MNc6YA9+GlYokSbW8llbCFFv1wCcE=";
+    hash = "sha256-jYonctlEmvfZoY8n5eNfh5XQdUPrZRGcKzFVUP78eUk=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        "nanobind >=3.0" \
+        "nanobind"
+  '';
 
   build-system = [
     cmake
@@ -72,9 +80,9 @@ buildPythonPackage (finalAttrs: {
   ];
 
   env = {
-    CL_INC_DIR = "${opencl-headers}/include";
-    CL_LIB_DIR = "${ocl-icd}/lib";
-    CL_LIBNAME = "${ocl-icd}/lib/libOpenCL${stdenv.hostPlatform.extensions.sharedLibrary}";
+    CL_INC_DIR = "${lib.getInclude opencl-headers}/include";
+    CL_LIB_DIR = "${lib.getLib ocl-icd}/lib";
+    CL_LIBNAME = "${lib.getLib ocl-icd}/lib/libOpenCL${stdenv.hostPlatform.extensions.sharedLibrary}";
   };
 
   preCheck = ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/inducer/pyopencl/compare/v2026.1.2...v2026.1.4
Changelog: https://github.com/inducer/pyopencl/releases/tag/v2026.1.4

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test