### PR TITLE
deskflow: fix fd leaks in the Wayland wl-clipboard backend

### DIFF
--- a/pkgs/by-name/de/deskflow/deskflow-socket-cloexec.patch
+++ b/pkgs/by-name/de/deskflow/deskflow-socket-cloexec.patch
@@ -1,0 +1,31 @@
+Sockets created by ArchNetworkBSD lack FD_CLOEXEC, so helpers spawned by
+the Wayland wl-clipboard backend inherit the listening socket fd; wl-copy
+daemonizes and outlives deskflow, keeping the port bound. Every restart
+then fails with "cannot bind address: Address already in use" while no
+deskflow process is running.
+Upstream: no fix; the whole wl-clipboard backend was removed on master
+(deskflow/deskflow@df3746777, PR #9431, targeting 1.27). Drop this patch
+when the backend disappears.
+
+--- a/src/lib/arch/unix/ArchNetworkBSD.cpp	2026-08-24 17:15:22.522141220 +0200
++++ b/src/lib/arch/unix/ArchNetworkBSD.cpp	2026-08-24 17:15:32.442274780 +0200
+@@ -103,6 +103,9 @@
+   if (fd == -1) {
+     throwError(errno);
+   }
++  // Spawned helpers (wl-copy/wl-paste outlive us) must not inherit sockets:
++  // a leaked listen fd keeps the port bound and blocks the next server start.
++  fcntl(fd, F_SETFD, FD_CLOEXEC);
+   try {
+     setBlockingOnSocket(fd, false);
+   } catch (...) {
+@@ -220,6 +223,9 @@
+     throwError(err);
+   }
+ 
++  // See newSocket(): accepted connections must not leak into spawned helpers.
++  fcntl(fd, F_SETFD, FD_CLOEXEC);
++
+   try {
+     setBlockingOnSocket(fd, false);
+   } catch (...) {

--- a/pkgs/by-name/de/deskflow/deskflow-wlclipboard-no-fd-leak.patch
+++ b/pkgs/by-name/de/deskflow/deskflow-wlclipboard-no-fd-leak.patch
@@ -1,0 +1,60 @@
+WlClipboard::add()/empty() allocate a heap QProcess per clipboard write
+and never destroy it; no Qt event loop runs on that thread, so finished()
+is never delivered. Each write leaks 3 pipe fds + 1 forkfd and leaves a
+wl-copy zombie; the server hits EMFILE (1024 fds) after ~2 days of
+regular use ("QProcess: Cannot create pipe (Too many open files)").
+Measured live: 3 clipboard syncs = +48 pipes/+16 zombies unpatched, flat
+with this patch. QProcess::startDetached() creates no channels and needs
+no reaping.
+Upstream: deskflow/deskflow#9660 closed as duplicate without a fix; the
+backend was removed on master (df3746777). This patch fails loudly at the
+1.27 bump (file gone): drop it then.
+
+--- a/src/lib/platform/WlClipboard.cpp	2026-08-27 10:35:04.266493101 +0200
++++ b/src/lib/platform/WlClipboard.cpp	2026-08-27 10:35:19.402606051 +0200
+@@ -114,18 +114,14 @@
+   if (!m_open) {
+     return false;
+   }
+-  auto cmd = new QProcess(this);
+-  cmd->setProgram(s_copyApp);
+-  m_runningWlCopies.append(cmd);
+-  connect(cmd, &QProcess::finished, this, [&] { m_runningWlCopies.removeAll(cmd); });
+-
+   QStringList args = {s_noNewLine, ""};
+   if (!m_useClipboard)
+     args.prepend(s_isPrimary);
+ 
+-  cmd->setArguments(args);
+-  cmd->start();
+-  bool success = cmd->waitForStarted(100);
++  // Detached spawn: no channels created, no child to reap. A heap QProcess
++  // is never cleaned up here because no Qt event loop runs on this thread,
++  // so its pipes and forkfd leak until EMFILE (and children stay zombies).
++  bool success = QProcess::startDetached(s_copyApp, args);
+ 
+   if (success) {
+     // Update ownership and cache only if command succeeded
+@@ -153,20 +149,12 @@
+     return;
+   }
+ 
+-  auto cmd = new QProcess(this);
+-  cmd->setProgram(s_copyApp);
+-
+-  m_runningWlCopies.append(cmd);
+-  connect(cmd, &QProcess::finished, this, [&] { m_runningWlCopies.removeAll(cmd); });
+-
+   QStringList args = {s_noNewLine, s_readType.arg(mimeType), QString::fromStdString(data)};
+   if (!m_useClipboard)
+     args.prepend(s_isPrimary);
+ 
+-  cmd->setArguments(args);
+-  cmd->start();
+-
+-  if (cmd->waitForStarted(100)) {
++  // Detached spawn: see empty().
++  if (QProcess::startDetached(s_copyApp, args)) {
+     std::scoped_lock<std::mutex> lock(m_cacheMutex);
+     updateOwnership(true);
+     invalidateCache();

--- a/pkgs/by-name/de/deskflow/package.nix
+++ b/pkgs/by-name/de/deskflow/package.nix
@@ -41,6 +41,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-XcSG47Ysjn+wrJH5DC/XXGXcneXcW7xIhAn6sguuv+s=";
   };
 
+  patches = [
+    # wl-copy inherits the listening socket and keeps the port bound after exit
+    ./deskflow-socket-cloexec.patch
+    # one leaked QProcess (3 pipes + forkfd + zombie) per clipboard write -> EMFILE
+    ./deskflow-wlclipboard-no-fd-leak.patch
+  ];
+
   postPatch = ''
     substituteInPlace src/lib/deskflow/unix/AppUtilUnix.cpp \
       --replace-fail "/usr/share/X11/xkb/rules/evdev.xml" "${xkeyboard_config}/share/X11/xkb/rules/evdev.xml"


### PR DESCRIPTION
Two defects in deskflow's Wayland clipboard backend (`WlClipboard`, which spawns `wl-copy`/`wl-paste`) make a long-running server degrade and eventually break:

1. **Leaked listening socket into wl-copy** — sockets created by `ArchNetworkBSD` lack `FD_CLOEXEC`. `wl-copy` daemonizes and outlives deskflow, keeping the port (default 24800) bound: every restart then fails with `cannot bind address: Address already in use` while no deskflow process is running, and only `kill -9` of the orphaned `wl-copy` processes frees it.
2. **fd/zombie leak on every clipboard write** — `WlClipboard::add()`/`empty()` allocate a heap `QProcess` per write and never destroy it (the `finished` handler only removes it from a list, and no Qt event loop runs on that thread so `finished()` is never even delivered). Each write leaks 3 pipe fds + 1 forkfd and leaves a `wl-copy <defunct>` zombie. The server hits EMFILE (default 1024 fds) after a couple of days of regular use, printing `QProcess: Cannot create pipe (Too many open files)` — and restarting it then trips defect 1.

Measured on a live server (deskflow 1.25.0 under Hyprland, PC↔Mac sharing): 3 clipboard syncs = +48 pipe fds, +16 zombies unpatched; flat with these patches. `QProcess::startDetached()` creates no channels and needs no reaping, and matches the stack-allocated `QProcess` pattern the read paths of the same file already use.

### Why not upstream first

The wl-clipboard backend was removed entirely on deskflow master (deskflow/deskflow@df3746777, PR deskflow/deskflow#9431, targeting 1.27) in favor of a portal-only implementation (currently implemented by Mutter/KWin only). The zombie leak was reported as deskflow/deskflow#9660 and closed as duplicate without a targeted fix, and there is no 1.25/1.26 maintenance branch — so these fixes have no upstream landing branch, while the 1.26.0 that nixpkgs ships still contains the affected backend. The defects were diagnosed and measured on 1.25.0; both patches apply cleanly to v1.25.0 and v1.26.0 (`WlClipboard.cpp` is identical between the two tags). Both patch headers say to drop them when the backend disappears (1.27+); the WlClipboard patch will then fail loudly at build time rather than silently.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. — `nixpkgs-review rev HEAD` against current master: 1 package built (`deskflow`), no reverse dependencies affected.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` — the patched server runs in daily production use (PC↔Mac keyboard/mouse + clipboard sharing under Hyprland); upstream's unit test suite also runs in `checkPhase`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

**AI disclosure** (per the [automation/AI policy]): the diagnosis, the patches, and this summary were drafted with the assistance of Claude Code (model `claude-fable-5`); the commit carries the corresponding `Assisted-by:` trailer. I reviewed the patches, built the package locally, and run the patched builds in daily use; measurements quoted above were taken on my machines.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @flacks
