### PR TITLE
python3Packages.pybravia: 0.5.1 -> 0.5.3

### DIFF
--- a/pkgs/development/python-modules/pybravia/default.nix
+++ b/pkgs/development/python-modules/pybravia/default.nix
@@ -7,7 +7,7 @@
   pyprojectVersionPatchHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pybravia";
   version = "0.5.3";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Drafteed";
     repo = "pybravia";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dHc1jmwmLRXpxxIKPMyscDtyWB/UU8xyL7Uv4ioi2TY=";
   };
 
@@ -33,8 +33,8 @@ buildPythonPackage rec {
   meta = {
     description = "Library for remote control of Sony Bravia TVs 2013 and newer";
     homepage = "https://github.com/Drafteed/pybravia";
-    changelog = "https://github.com/Drafteed/pybravia/releases/tag/${src.tag}";
+    changelog = "https://github.com/Drafteed/pybravia/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/pybravia/default.nix
+++ b/pkgs/development/python-modules/pybravia/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "pybravia";
-  version = "0.5.1";
+  version = "0.5.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Drafteed";
     repo = "pybravia";
     tag = "v${version}";
-    hash = "sha256-Wx+YEEVZB0aGhgaQiC04GKwTY4yV0wj86b/8EJBs5yc=";
+    hash = "sha256-dHc1jmwmLRXpxxIKPMyscDtyWB/UU8xyL7Uv4ioi2TY=";
   };
 
   nativeBuildInputs = [ pyprojectVersionPatchHook ];


### PR DESCRIPTION
Diff: https://github.com/Drafteed/pybravia/compare/v0.5.1...v0.5.3

Changelog: https://github.com/Drafteed/pybravia/releases/tag/v0.5.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
