### PR TITLE
tinycast: init at 0.10.3-beta.72

### DIFF
--- a/pkgs/by-name/ti/tinycast/package.nix
+++ b/pkgs/by-name/ti/tinycast/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+}:
+
+let
+  sources = lib.importJSON ./sources.json;
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tinycast";
+  inherit (sources) version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/abue-ammar/tinycast/releases/download/${sources.tag}/Tinycast-${sources.version}.dmg";
+    inherit (sources) hash;
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  # Tinycast.dmg is APFS formatted, which is unsupported by undmg.
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = "Tinycast Beta.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Tinycast Beta.app"
+    cp -R . "$out/Applications/Tinycast Beta.app"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Beta release of Tinycast, a native macOS launcher, hotkeys, and clipboard history";
+    homepage = "https://github.com/abue-ammar/tinycast";
+    changelog = "https://github.com/abue-ammar/tinycast/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ pwnwriter ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ti/tinycast/sources.json
+++ b/pkgs/by-name/ti/tinycast/sources.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.10.3-beta.72",
+  "tag": "v0.10.3-beta.72",
+  "hash": "sha256-MMayl8yMZApInUH2SGzIycmvvgUWAR0E951pqwKEHQY="
+}

--- a/pkgs/by-name/ti/tinycast/update.sh
+++ b/pkgs/by-name/ti/tinycast/update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+repo="abue-ammar/tinycast"
+old_version=$(jq -r ".version" sources.json)
+
+release=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+  "https://api.github.com/repos/${repo}/releases?per_page=100" \
+  | jq '
+    [
+      .[]
+      | select(.prerelease == true)
+      | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.[0-9]+$"))
+    ]
+    | sort_by(.published_at)
+    | last
+  ')
+
+tag=$(jq -r ".tag_name" <<< "$release")
+version="${tag#v}"
+
+if [[ -z "$tag" || "$tag" == "null" ]]; then
+  echo "No Tinycast beta release found"
+  exit 1
+fi
+
+if [[ "$old_version" == "$version" ]]; then
+  echo "tinycast is already up to date at $version"
+  exit 0
+fi
+
+echo "Updating tinycast from $old_version to $version"
+
+asset_url=$(jq -r --arg name "Tinycast-${version}.dmg" '.assets[] | select(.name == $name) | .browser_download_url' <<< "$release")
+
+if [[ -z "$asset_url" || "$asset_url" == "null" ]]; then
+  echo "No Tinycast Beta DMG asset found for $tag"
+  exit 1
+fi
+
+sha256hash="$(nix-prefetch-url --type sha256 "$asset_url")"
+hash="$(nix hash convert --to sri --hash-algo sha256 "$sha256hash")"
+
+jq -n \
+  --arg version "$version" \
+  --arg tag "$tag" \
+  --arg hash "$hash" \
+  '{version: $version, tag: $tag, hash: $hash}' \
+  > sources.json
+
+echo "Updated tinycast to $version (tag: $tag)"


### PR DESCRIPTION
tinycast: init at 0.10.3-beta.72

Tinycast, a native macOS launcher with hotkeys and clipboard history: https://github.com/abue-ammar/tinycast

Changelog: https://github.com/abue-ammar/tinycast/releases/tag/v0.10.3-beta.72

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows [the automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[the automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
