### PR TITLE
screendrop: init at 0.31.3

### DIFF
--- a/pkgs/by-name/sc/screendrop/package.nix
+++ b/pkgs/by-name/sc/screendrop/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+}:
+
+let
+  sources = lib.importJSON ./sources.json;
+  platform =
+    sources.platforms.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported platform: ${stdenvNoCC.hostPlatform.system}");
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "screendrop";
+  inherit (sources) version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/fayazara/Screendrop/releases/download/${sources.tag}/${platform.filename}";
+    inherit (platform) hash;
+  };
+
+  sourceRoot = "Screendrop.app";
+
+  nativeBuildInputs = [
+    undmg
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Screendrop.app"
+    cp -R . "$out/Applications/Screendrop.app"
+
+    mkdir -p "$out/bin"
+    ln -s "$out/Applications/Screendrop.app/Contents/MacOS/Screendrop" "$out/bin/screendrop"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Native macOS screenshot and screen recording tool";
+    homepage = "https://github.com/fayazara/Screendrop";
+    changelog = "https://github.com/fayazara/Screendrop/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ pwnwriter ];
+    mainProgram = "screendrop";
+    platforms = lib.attrNames sources.platforms;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/sc/screendrop/sources.json
+++ b/pkgs/by-name/sc/screendrop/sources.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.31.3",
+  "tag": "v0.31.3",
+  "platforms": {
+    "x86_64-darwin": {
+      "filename": "Screendrop.dmg",
+      "hash": "sha256-Sh8GRKu51Bo4UFvyaxMfqcPnQaE7FNTwTG54Tnkr9ls="
+    },
+    "aarch64-darwin": {
+      "filename": "Screendrop.dmg",
+      "hash": "sha256-Sh8GRKu51Bo4UFvyaxMfqcPnQaE7FNTwTG54Tnkr9ls="
+    }
+  }
+}

--- a/pkgs/by-name/sc/screendrop/update.sh
+++ b/pkgs/by-name/sc/screendrop/update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+repo="fayazara/Screendrop"
+
+old_version=$(jq -r ".version" sources.json)
+
+release=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+  "https://api.github.com/repos/${repo}/releases/latest")
+
+tag=$(jq -r ".tag_name" <<< "$release")
+
+if [[ -z "$tag" || "$tag" == "null" ]]; then
+    echo "No Screendrop release found"
+    exit 1
+fi
+
+version="${tag#v}"
+
+if [[ "$old_version" == "$version" ]]; then
+    echo "screendrop is already up to date at $version"
+    exit 0
+fi
+
+echo "Updating screendrop from $old_version to $version"
+
+filename=$(jq -r '.assets[] | select(.name == "Screendrop.dmg") | .name' <<< "$release")
+
+if [[ -z "$filename" || "$filename" == "null" ]]; then
+    echo "No Screendrop.dmg release asset found for $tag"
+    exit 1
+fi
+
+url="https://github.com/${repo}/releases/download/${tag}/${filename}"
+sha256hash="$(nix-prefetch-url --type sha256 "$url")"
+hash="$(nix hash convert --to sri --hash-algo sha256 "$sha256hash")"
+
+sources_tmp="$(mktemp)"
+jq -n --arg v "$version" --arg t "$tag" '{version: $v, tag: $t, platforms: {}}' > "$sources_tmp"
+
+for platform in x86_64-darwin aarch64-darwin; do
+    jq --arg platform "$platform" \
+       --arg filename "$filename" \
+       --arg hash "$hash" \
+       '.platforms += {($platform): {filename: $filename, hash: $hash}}' \
+       "$sources_tmp" > "${sources_tmp}.tmp" && mv "${sources_tmp}.tmp" "$sources_tmp"
+done
+
+mv "$sources_tmp" sources.json
+
+echo "Updated screendrop to $version (tag: $tag)"


### PR DESCRIPTION
screendrop: init at 0.31.3

 Screendrop, a native macOS screenshot and screen recording tool: https://github.com/fayazara/Screendrop

  Changelog: https://github.com/fayazara/Screendrop/releases/tag/v0.31.3

  ## Things done

  - Built on platform:
    - [ ] x86_64-linux
    - [ ] aarch64-linux
    - [x] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows [the automation/AI policy].

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [the automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test