### PR TITLE
python3Packages.scanpy: 1.12.3 -> 1.12.4

### DIFF
--- a/pkgs/development/python-modules/scanpy/default.nix
+++ b/pkgs/development/python-modules/scanpy/default.nix
@@ -64,7 +64,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "scanpy";
-  version = "1.12.3";
+  version = "1.12.4";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -72,7 +72,7 @@ buildPythonPackage (finalAttrs: {
     owner = "scverse";
     repo = "scanpy";
     tag = finalAttrs.version;
-    hash = "sha256-/QkkKNwc8RS4dYSkptqJDwRmmP9WDBpBoPtufqKvwqw=";
+    hash = "sha256-TToqDM4Ze5zdt9hQ/0G2SXsTmtZmzyZ7+etn1dqfH/U=";
   };
 
   # Otherwise, several tests fail to be collected:
@@ -191,15 +191,18 @@ buildPythonPackage (finalAttrs: {
 
   disabledTestPaths = [
     # try to download data:
+    "tests/plotting/legacy/test_plotting.py"
     "tests/test_aggregated.py"
     "tests/test_highly_variable_genes.py"
     "tests/test_normalization.py"
     "tests/test_pca.py"
-    "tests/test_plotting.py"
-    "tests/test_plotting_embedded/"
 
     # fixture 'backed_adata' not found
     "tests/test_backed.py"
+
+    # Need `docs/`, which is resolved relatively to the installed package:
+    #   FileNotFoundError: .../docs/_static/img/Scanpy_Logo_RGB.png
+    "tests/plotting/legacy/embedded/"
   ];
 
   disabledTests = [


### PR DESCRIPTION


## Things done

Diff: https://github.com/scverse/scanpy/compare/1.12.3...1.12.4
Changelog: https://github.com/scverse/scanpy/releases/tag/1.12.4

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test