### PR TITLE
gtk-frdp: reduce platform support to linux

### DIFF
--- a/pkgs/by-name/gt/gtk-frdp/package.nix
+++ b/pkgs/by-name/gt/gtk-frdp/package.nix
@@ -53,6 +53,6 @@ stdenv.mkDerivation {
     description = "RDP viewer widget for GTK";
     teams = [ lib.teams.gnome ];
     license = lib.licenses.lgpl3Plus;
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
`gnome.generate_gir` requires loading `libfuse3.4.dylib` at build time, but nixpkgs only provides stubs for macFUSE (macfuse-stubs) due to license restrictions.

To reproduce the failing library load, add

```
env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-function-pointer-types";
```

and then try to build the package on darwin.

This package has been broken on darwin for a long time (last succeeding build on Hydra was in 2023). It also has only one reverse dependency (gnome-connections), which has `meta.platforms = lib.platforms.linux`.

Hydra: https://hydra.nixos.org/build/343492759


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
