### PR TITLE
claurst: init at 0.1.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23999,10 +23999,10 @@
     name = "David McKay";
   };
   rayhem = {
-    email = "glosser1@gmail.com";
+    email = "me@rayhem.dev";
     github = "rayhem";
     githubId = 49202382;
-    name = "Connor Glosser";
+    name = "rayhem";
   };
   raylas = {
     email = "r@raymond.sh";

--- a/pkgs/by-name/cl/claurst/package.nix
+++ b/pkgs/by-name/cl/claurst/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  gitMinimal,
+  cacert,
+  versionCheckHook,
+  nix-update-script,
+  alsa-lib,
+  dbus,
+  libxcb,
+  libxkbcommon,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "claurst";
+  version = "0.1.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kuberwastaken";
+    repo = "claurst";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-36U4Wh99sEK/iJfYo914OkREEhwys6zZQz1tIwIPfpc=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src-rust";
+
+  cargoHash = "sha256-Xr9AuV5hp9DuyMBeSAv+3hOuC0P2lkli837FA+FJHw0=";
+
+  # acp_smoke.rs spawns the built binary, which eagerly constructs a Bedrock
+  # reqwest client on startup (crates/api/src/providers/bedrock.rs); rustls
+  # needs a real CA bundle for that or it panics before it can speak ACP.
+  nativeCheckInputs = [ cacert ];
+  preCheck = ''
+    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+  '';
+
+  # aws-lc-sys (rustls' default crypto provider) and btls-sys (BoringSSL fork
+  # behind wreq, used for Anthropic TLS fingerprint impersonation) each vendor
+  # and build a BoringSSL-family C/C++ tree via cmake, with btls-sys also
+  # generating its FFI bindings with bindgen.
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    gitMinimal # btls-sys runs `git init`/`git apply` to patch its vendored BoringSSL tree
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    alsa-lib # cpal, behind the default `voice` feature
+    dbus # xcap's Wayland portal / D-Bus screenshot backend
+    libxcb # xcap's X11 screenshot backend
+    libxkbcommon # enigo's keysym translation
+  ];
+
+  checkFlags = [
+    # asserts no tracked file path contains the substring "build/"; false-positives
+    # in the Nix build sandbox because its build root is literally /build, so every
+    # tempfile::tempdir() path starts with /build/... regardless of gitignore matching
+    "--skip=gitignore_respected"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open-source multi-provider terminal coding agent";
+    homepage = "https://github.com/kuberwastaken/claurst";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.rayhem ];
+    mainProgram = "claurst";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add claurst, an open-source, multi-provider terminal coding agent built from the ground up in Rust.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [  ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].