### PR TITLE
[26.05] rsync: 3.4.4 -> 3.5.0

### DIFF
--- a/pkgs/by-name/rs/rsync/package.nix
+++ b/pkgs/by-name/rs/rsync/package.nix
@@ -124,6 +124,12 @@ stdenv.mkDerivation (finalAttrs: {
           "variety-symlink-traversal"
           "variety"
         ]
+        # The Darwin sandbox drops set-id bits, and Python's os.getgroups()
+        # reports account groups that may not be usable by this process.
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          "chmod-setid"
+          "daemon-groupmap-wild"
+        ]
         # This test assumes that every Linux libc provides glibc malloc stats.
         ++ lib.optional stdenv.hostPlatform.isMusl "misc-coverage"
         # These require a native compiler and dynamic interposition.

--- a/pkgs/by-name/rs/rsync/package.nix
+++ b/pkgs/by-name/rs/rsync/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
 
   updateAutotoolsGnuConfigScriptsHook,
   perl,
@@ -29,27 +28,33 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rsync";
-  version = "3.4.4";
+  version = "3.5.0";
 
   src = fetchurl {
     # signed with key 9FEF 112D CE19 A0DC 7E88  2CB8 1BB2 4997 A853 5F6F
     url = "mirror://samba/rsync/src/rsync-${finalAttrs.version}.tar.gz";
-    hash = "sha256-vYjPgvplPaMjFPsikTZAfFyQ+A0XWNj0sJF2eHfY+pY=";
+    hash = "sha256-x//R72U+mVQPZh5HywC3+crR7muXI5mxb5PWcmVuDTM=";
   };
 
-  patches = [
-    # Fixes test failure on darwin
-    (fetchpatch {
-      url = "https://github.com/RsyncProject/rsync/commit/e1c5f0e93a75dd45f32f3b92ba221ef158ac2e5f.patch";
-      hash = "sha256-pg65K9BCTq/WvS5icK6KT28ARccFKedp2445wLYdRsE=";
-      excludes = [
-        ".github/workflows/cygwin-build.yml"
-      ];
-    })
-  ];
+  patches = [ ];
+
+  # Remove with the first upstream release that links t_acl against the snprintf fallback.
+  postPatch = ''
+    substituteInPlace Makefile.in \
+      --replace-fail 'T_ACL_OBJ = t_acl.o lib/acl.o' 'T_ACL_OBJ = t_acl.o lib/acl.o lib/snprintf.o'
+  '';
 
   preBuild = ''
-    patchShebangs ./runtests.py
+    patchShebangs ./runtests.py ./support/rrsync
+
+    # patchShebangs ignores non-executable test sources and embedded shebangs.
+    substituteInPlace \
+      testsuite/{daemon-namecvt-{empty-response,newline-token},rrsync-{sender-parent-pin,symlink}}_test.py \
+      --replace-fail '#!/usr/bin/env python3' '#!${python3}/bin/python3'
+
+    substituteInPlace \
+      testsuite/rsync-ssl-stunnel-{ca-required,hostname-check}_test.py \
+      --replace-fail '#!/usr/bin/env bash' '#!${stdenv.shell}'
   '';
 
   nativeBuildInputs = [
@@ -103,9 +108,31 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  # Test fails when built in a chroot store
+  # These require set-id, chown, xattrs, or unrestricted /proc/self/fd,
+  # which the Linux Nix build sandbox does not provide.
   preCheck = ''
-    rm testsuite/chgrp.test
+    export RSYNC_EXCLUDE=${
+      lib.concatStringsSep "," (
+        lib.optionals stdenv.hostPlatform.isLinux [
+          "chmod-option"
+          "chmod-setid"
+          "chown-fake"
+          "fake-super-backup-fifo-regression"
+          "protected-regular"
+          "rrsync-backup-dir-inband-pivot"
+          "rrsync-pull-delivers-content"
+          "variety-symlink-traversal"
+          "variety"
+        ]
+        # This test assumes that every Linux libc provides glibc malloc stats.
+        ++ lib.optional stdenv.hostPlatform.isMusl "misc-coverage"
+        # These require a native compiler and dynamic interposition.
+        ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+          "link-dest-symlink-enotsup"
+          "partial-protected-regular-retry-linux"
+        ]
+      )
+    }
   '';
 
   doCheck = true;

--- a/pkgs/by-name/rs/rsync/package.nix
+++ b/pkgs/by-name/rs/rsync/package.nix
@@ -85,6 +85,14 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isx86_64) [
     # fix `multiversioning needs 'ifunc' which is not supported on this target` error
     "--disable-roll-simd"
+  ]
+  # Linux can hard-link symlinks; configure defaults this check to "no" when
+  # cross-compiling (e.g. pkgsStatic) because it cannot run the probe.
+  # That leaves hardlink_symlinks false while itemize still reports identical
+  # --copy-dest/--link-dest symlinks with blank attribute flags, so
+  # testsuite/itemize.test fails (https://github.com/NixOS/nixpkgs/issues/537437).
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform != stdenv.buildPlatform) [
+    "rsync_cv_can_hardlink_symlink=yes"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Backports rsync 3.5.0 to NixOS 26.05. This release fixes 33 public CVEs tracked in #553017 and #553018. Five of these CVEs are rated Critical by their CNAs.

Upstream changelog: https://download.samba.org/pub/rsync/NEWS#3.5.0

Backports https://redirect.github.com/NixOS/nixpkgs/pull/552582 and its Darwin build fix https://redirect.github.com/NixOS/nixpkgs/pull/555976.

Addresses #553017 and #553018.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
