### PR TITLE
plezy: update aarch64 patch

### DIFF
--- a/pkgs/by-name/pl/plezy/aarch64-linux.patch
+++ b/pkgs/by-name/pl/plezy/aarch64-linux.patch
@@ -1,30 +1,30 @@
 diff --git a/lib/theme/mono_theme.dart b/lib/theme/mono_theme.dart
-index b423b4c6..04834360 100644
+index 5b87737c..3873fe84 100644
 --- a/lib/theme/mono_theme.dart
 +++ b/lib/theme/mono_theme.dart
-@@ -42,7 +42,7 @@ ThemeData monoTheme({required bool dark, bool oled = false}) {
-   );
+@@ -61,7 +61,7 @@ ThemeData _buildMonoTheme({required bool dark, required bool oled, required Targ
  
    final base = ThemeData(
+     platform: platform,
 -    useMaterial3: true,
 +    useMaterial3: true, fontFamily: 'NotoSans',
      brightness: isDark ? Brightness.dark : Brightness.light,
      colorScheme: ColorScheme(
        brightness: isDark ? Brightness.dark : Brightness.light,
-@@ -85,7 +85,7 @@ ThemeData monoTheme({required bool dark, bool oled = false}) {
-       titleTextStyle: TextStyle(color: c.text, fontSize: 18, fontWeight: FontWeight.w700, letterSpacing: -0.2),
+@@ -108,7 +108,7 @@ ThemeData _buildMonoTheme({required bool dark, required bool oled, required Targ
+       titleTextStyle: TextStyle(color: c.text, fontSize: 18, fontWeight: .w700, letterSpacing: -0.2),
      ),
      textTheme: Typography.englishLike2021
 -        .apply(bodyColor: c.text, displayColor: c.text)
 +        .apply(fontFamily: 'NotoSans', bodyColor: c.text, displayColor: c.text)
          .copyWith(
-           displayLarge: const TextStyle(fontWeight: FontWeight.w700, letterSpacing: -0.5),
-           titleMedium: const TextStyle(fontWeight: FontWeight.w600),
+           displayLarge: const TextStyle(fontWeight: .w700, letterSpacing: -0.5),
+           titleMedium: const TextStyle(fontWeight: .w600),
 diff --git a/pubspec.yaml b/pubspec.yaml
-index 8de9f2e3..5b6f1f14 100644
+index 68f20256..419cc1d6 100644
 --- a/pubspec.yaml
 +++ b/pubspec.yaml
-@@ -142,3 +142,8 @@ flutter:
+@@ -152,3 +152,8 @@ flutter:
      - assets/shaders/anime4k/
      - assets/player_icons/
      - assets/rating_icons/

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -22,9 +22,7 @@
   makeBinaryWrapper,
   runCommand,
   noto-fonts-cjk-sans ? null,
-  use16kPagesizeWorkaround ? false,
 }:
-
 let
   pname = "plezy";
   version = "2.17.0";
@@ -72,8 +70,8 @@ let
 
     gitHashes = lib.importJSON ./git-hashes.json;
 
-    patches = lib.optionals use16kPagesizeWorkaround [
-      ./16k-font-workaround.patch
+    patches = lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+      ./aarch64-linux.patch
     ];
 
     nativeBuildInputs = [
@@ -104,10 +102,9 @@ let
         --replace-fail "URL https://github.com/simdutf/simdutf/releases/download/v6.4.2/singleheader.zip" \
                        "URL file://${simdutf}"
     ''
-    + lib.optionalString use16kPagesizeWorkaround ''
-      # Opt-in workaround for invisible text on aarch64-linux systems with 16K page size kernels
-      # (e.g. Asahi Linux). Text was invisible; bundling the font as a Dart asset fixed it,
-      # likely related to libflutter_linux_gtk.so being compiled with 4K page alignment only.
+    + lib.optionalString (stdenv.hostPlatform.system == "aarch64-linux") ''
+      # Opt-in workaround for invisible text on aarch64-linux systems. Text was invisible; bundling the font as a Dart asset fixed it,
+      # unknown why.
       install -Dm644 ${noto-fonts-cjk-sans}/share/fonts/opentype/noto-cjk/NotoSansCJK-VF.otf.ttc assets/fonts/NotoSans.ttc
     '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
The patch got a tiny bit out of date causing the build to fail with the override so I've updated it. Also I decided to look a bit more into it and I also get the invisible font when building on a 4kib pagesize x86 device but building the arm version and running with qemu. Which means the pagesize is not the issue its just aarch64-linux in general, I do not know why but I removed the override and just made it apply to all aarch64-linux users. I can confirm it works and is still needed as without the patch font is still invisible.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package plezy`
Commit: `e603524a6e2e5bb7c0453a6e6eb082b7dab6b634`

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>plezy</li>
  </ul>
</details>

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
