### PR TITLE
dotnetCorePackages: add riscv64-linux support

### DIFF
--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -142,7 +142,10 @@ buildDotnetModule (finalAttrs: {
 
   dotnetFlags = [
     "-p:PackageRuntime=${dotnetCorePackages.systemToDotnetRid stdenv.hostPlatform.system}"
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isRiscV64 [ "-p:UseAppHost=false" ];
+
+  useAppHost = !stdenv.hostPlatform.isRiscV64;
 
   # As given here: https://github.com/actions/runner/blob/0befa62/src/dir.proj#L33-L41
   projectFile = [
@@ -156,7 +159,7 @@ buildDotnetModule (finalAttrs: {
   ];
   nugetDeps = ./deps.json;
 
-  doCheck = true;
+  doCheck = !stdenv.hostPlatform.isRiscV64;
 
   # tests fail with sandboxing under darwin
   __darwinAllowLocalNetworking = true;
@@ -318,6 +321,15 @@ buildDotnetModule (finalAttrs: {
       --run 'mkdir -p "$RUNNER_ROOT"'
       --chdir "$out"
     )
+  ''
+  + lib.optionalString stdenv.hostPlatform.isRiscV64 ''
+    for bin in Runner.Listener Runner.PluginHost Runner.Worker; do
+      printf '%s\n' \
+        '#!${runtimeShell}' \
+        "exec ${dotnetCorePackages.runtime_8_0}/bin/dotnet \"$out/lib/github-runner/$bin.dll\" \"\$@\"" \
+        > "$out/lib/github-runner/$bin"
+      chmod +x "$out/lib/github-runner/$bin"
+    done
   '';
 
   # List of files to wrap
@@ -375,6 +387,7 @@ buildDotnetModule (finalAttrs: {
       "x86_64-linux"
       "aarch64-linux"
       "aarch64-darwin"
+      "riscv64-linux"
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/development/compilers/dotnet/10.0/releases.nix
+++ b/pkgs/development/compilers/dotnet/10.0/releases.nix
@@ -42,6 +42,7 @@ let
   ];
 
   hostPackages = {
+    linux-riscv64 = [ ];
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-arm";
@@ -162,6 +163,7 @@ let
   };
 
   targetPackages = {
+    linux-riscv64 = [ ];
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-arm";
@@ -468,6 +470,10 @@ rec {
   aspnetcore_10_0 = buildAspNetCore {
     version = "10.0.11";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/10.0.111/dotnet-sdk-10.0.111-linux-riscv64.tar.gz";
+        hash = "sha512-+dA0vf63mVr1JREoVfK4c+qE8vgAdm/6jAFAyLGPiAPnbgUS8IjANEVolug/xPks3/bjpYEFx9+cRA3UWi0inA==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/10.0.11/aspnetcore-runtime-10.0.11-linux-arm.tar.gz";
         hash = "sha512-cW3SeY9EVwevUiDQycVYfv1bJ5IF3NhcT81IZtKkOUKiZmJzTnq4zHTSfDn0eCU+o2XQeNhixw+w+Rfxhk+yYw==";
@@ -506,6 +512,10 @@ rec {
   runtime_10_0 = buildNetRuntime {
     version = "10.0.11";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/10.0.111/dotnet-sdk-10.0.111-linux-riscv64.tar.gz";
+        hash = "sha512-+dA0vf63mVr1JREoVfK4c+qE8vgAdm/6jAFAyLGPiAPnbgUS8IjANEVolug/xPks3/bjpYEFx9+cRA3UWi0inA==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.11/dotnet-runtime-10.0.11-linux-arm.tar.gz";
         hash = "sha512-fC8Ke9QjELjQnbzJDs5iI5fbw4622jokmzAibWPQEZMwQRyv/z3pUNghtc60mUBLR9tV/aqFKbBN0UxjI5ZhnQ==";
@@ -626,6 +636,10 @@ rec {
   sdk_10_0_1xx = buildNetSdk {
     version = "10.0.111";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/10.0.111/dotnet-sdk-10.0.111-linux-riscv64.tar.gz";
+        hash = "sha512-+dA0vf63mVr1JREoVfK4c+qE8vgAdm/6jAFAyLGPiAPnbgUS8IjANEVolug/xPks3/bjpYEFx9+cRA3UWi0inA==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.111/dotnet-sdk-10.0.111-linux-arm.tar.gz";
         hash = "sha512-bO1NgOUKKzueqFnvD/LGOAGL4hlQdIckm6F4O78v1uq8G9jtYKVlKIkNbrNvSEu1tk5KcmViMh+mrvaIy6CC4g==";

--- a/pkgs/development/compilers/dotnet/8.0/releases.nix
+++ b/pkgs/development/compilers/dotnet/8.0/releases.nix
@@ -52,6 +52,7 @@ let
   ];
 
   hostPackages = {
+    linux-riscv64 = [ ];
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-arm";
@@ -172,6 +173,7 @@ let
   };
 
   targetPackages = {
+    linux-riscv64 = [ ];
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-arm";
@@ -628,6 +630,10 @@ rec {
   aspnetcore_8_0 = buildAspNetCore {
     version = "8.0.30";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/8.0.130/dotnet-sdk-8.0.130-linux-riscv64.tar.gz";
+        hash = "sha512-Wy9bhKmSiRZNUqxx0+i1hqWOhsDNIOIhwKQYXouDG5LnjrPpd2f236h3lqGWX9a3rZUHTxzAZVEOXvJh7iEAEQ==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.30/aspnetcore-runtime-8.0.30-linux-arm.tar.gz";
         hash = "sha512-1n1IhT7KriFvuwKIE9cAMBMAR+QkWB1Fi17pg7rUsQsClh+ErNhOnsMIP5N7IsjY2LsCIjfEV+xru3TtYJDwpg==";
@@ -666,6 +672,10 @@ rec {
   runtime_8_0 = buildNetRuntime {
     version = "8.0.30";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/8.0.130/dotnet-sdk-8.0.130-linux-riscv64.tar.gz";
+        hash = "sha512-Wy9bhKmSiRZNUqxx0+i1hqWOhsDNIOIhwKQYXouDG5LnjrPpd2f236h3lqGWX9a3rZUHTxzAZVEOXvJh7iEAEQ==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0.30/dotnet-runtime-8.0.30-linux-arm.tar.gz";
         hash = "sha512-pDlq9mts7ub5U1TxNRlGMJHeR0kzBQcUYJhM4Jv7sa6+x5B7LqAfHbEiXk8ZRIHD0X3QXxc1wCgbnRd4spVChQ==";
@@ -745,6 +755,10 @@ rec {
   sdk_8_0_1xx = buildNetSdk {
     version = "8.0.130";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/8.0.130/dotnet-sdk-8.0.130-linux-riscv64.tar.gz";
+        hash = "sha512-Wy9bhKmSiRZNUqxx0+i1hqWOhsDNIOIhwKQYXouDG5LnjrPpd2f236h3lqGWX9a3rZUHTxzAZVEOXvJh7iEAEQ==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.130/dotnet-sdk-8.0.130-linux-arm.tar.gz";
         hash = "sha512-P3Bz0urrJh025M+03V9DpGJuw17CLci5zHrE1ukQ6l6gsKfJxnG3/v0EARDnURUlzHt+VG8Kd25NTeek8WDQkw==";

--- a/pkgs/development/compilers/dotnet/9.0/releases.nix
+++ b/pkgs/development/compilers/dotnet/9.0/releases.nix
@@ -37,6 +37,7 @@ let
   ];
 
   hostPackages = {
+    linux-riscv64 = [ ];
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.NETCore.App.Crossgen2.linux-arm";
@@ -157,6 +158,7 @@ let
   };
 
   targetPackages = {
+    linux-riscv64 = [ ];
     linux-arm = [
       (fetchNupkg {
         pname = "Microsoft.AspNetCore.App.Runtime.linux-arm";
@@ -408,6 +410,10 @@ rec {
   aspnetcore_9_0 = buildAspNetCore {
     version = "9.0.19";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/9.0.120/dotnet-sdk-9.0.120-linux-riscv64.tar.gz";
+        hash = "sha512-qbSFjTAQMOPKCla5J3jTVzqmpWWXoWIUWkTphzgE1chO9sk9+GMhYtenWF2V35U7UrwKOa/qPcc538XAYHyrpg==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.19/aspnetcore-runtime-9.0.19-linux-arm.tar.gz";
         hash = "sha512-JB8TWsTOuOuLLRNfWY+NHrvoOSfiPD8Q5MgFlc32cll29/cC8pIOTcbIPaikOugHjrCPPCuMtxqqNbDxodsgRw==";
@@ -446,6 +452,10 @@ rec {
   runtime_9_0 = buildNetRuntime {
     version = "9.0.19";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/9.0.120/dotnet-sdk-9.0.120-linux-riscv64.tar.gz";
+        hash = "sha512-qbSFjTAQMOPKCla5J3jTVzqmpWWXoWIUWkTphzgE1chO9sk9+GMhYtenWF2V35U7UrwKOa/qPcc538XAYHyrpg==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.19/dotnet-runtime-9.0.19-linux-arm.tar.gz";
         hash = "sha512-lHne1saaCRY1mdK1+1X28u+4lii2+4qq9riCpzkfBlpTc5N4HwzW3Vo4AmkKWnRnjU5piqnhHj2uhwBKKs/NWg==";
@@ -525,6 +535,10 @@ rec {
   sdk_9_0_1xx = buildNetSdk {
     version = "9.0.120";
     srcs = {
+      linux-riscv64 = {
+        url = "https://github.com/liberodark/dotnet_riscv/releases/download/9.0.120/dotnet-sdk-9.0.120-linux-riscv64.tar.gz";
+        hash = "sha512-qbSFjTAQMOPKCla5J3jTVzqmpWWXoWIUWkTphzgE1chO9sk9+GMhYtenWF2V35U7UrwKOa/qPcc538XAYHyrpg==";
+      };
       linux-arm = {
         url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.120/dotnet-sdk-9.0.120-linux-arm.tar.gz";
         hash = "sha512-xOkQu0a7qzVyCTJQcCm8h9ibcEu65PCzxIRNeBHRsWtg45tNX6InLRTLEIQceZkMQ3YqO2kNlf4e/i3Xd+5acA==";

--- a/pkgs/development/compilers/dotnet/binary/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/binary/build-dotnet.nix
@@ -38,6 +38,7 @@ assert
   libkrb5,
   openssl,
   curl,
+  lttng-ust,
   lttng-ust_2_12,
   testers,
   runCommand,
@@ -119,7 +120,8 @@ mkWrapper type (
       curl
       xmlstarlet
     ]
-    ++ lib.optional stdenv.hostPlatform.isLinux lttng-ust_2_12;
+    ++ lib.optional stdenv.hostPlatform.isLinux lttng-ust_2_12
+    ++ lib.optional stdenv.hostPlatform.isRiscV64 lttng-ust;
 
     src = fetchurl (
       srcs.${hostRid} or (throw "Missing source (url and hash) for host RID: ${hostRid}")
@@ -208,7 +210,7 @@ mkWrapper type (
       in
       {
         packages = map forceSDKEval (
-          commonPackages ++ hostPackages.${hostRid} ++ targetPackages.${targetRid}
+          commonPackages ++ hostPackages.${hostRid} or [ ] ++ targetPackages.${targetRid} or [ ]
         );
         targetPackages = lib.mapAttrs (_: map forceSDKEval) targetPackages;
         inherit runtime aspnetcore;

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -39,6 +39,7 @@ makeScopeWithSplicing' {
       runtimeIdentifierMap = {
         "x86_64-linux" = "linux-x64";
         "aarch64-linux" = "linux-arm64";
+        "riscv64-linux" = "linux-riscv64";
         "aarch64-darwin" = "osx-arm64";
         "x86_64-windows" = "win-x64";
         "i686-windows" = "win-x86";

--- a/pkgs/development/compilers/dotnet/dotnet.nix
+++ b/pkgs/development/compilers/dotnet/dotnet.nix
@@ -1,6 +1,7 @@
 {
   config,
   callPackage,
+  stdenv,
   lib,
   channel,
   dir ? ./. + ("/" + channel),
@@ -17,12 +18,23 @@ let
 
   withVMR = lib.pathExists (dir + "/release.json");
 
-  sourcePackages = lib.optionalAttrs withVMR (callPackage ./source (attrs // { inherit binary; }));
+  sourcePackages = lib.optionalAttrs withVMR (
+    callPackage ./source (removeAttrs attrs [ "stdenv" ] // { inherit binary; })
+  );
 
   pkgs =
     lib.optionalAttrs config.allowAliases binary
     // lib.mapAttrs' (k: v: lib.nameValuePair "${k}-bin" v) binary
-    // sourcePackages;
+    // lib.mapAttrs (
+      k: v:
+      if lib.meta.availableOn stdenv.hostPlatform v then
+        v
+      else
+        lib.findFirst (c: c != null && lib.meta.availableOn stdenv.hostPlatform c) v [
+          (binary.${k} or null)
+          (binary."${k}_1xx" or null)
+        ]
+    ) sourcePackages;
 
   suffix = lib.replaceStrings [ "." ] [ "_" ] channel;
   sdkAttr = "sdk_${suffix}" + lib.optionalString (!withVMR) "-bin";

--- a/pkgs/development/compilers/dotnet/source/default.nix
+++ b/pkgs/development/compilers/dotnet/source/default.nix
@@ -75,11 +75,14 @@ let
           tarballHash
           depsFile
           ;
-        bootstrapSdk = (buildDotnetSdk bootstrapSdkFile).sdk.overrideAttrs (old: {
-          passthru = old.passthru or { } // {
-            inherit artifacts;
-          };
-        });
+        # the bootstrap sdk runs on the build machine
+        bootstrapSdk =
+          (pkgsBuildHost.dotnetCorePackages.buildDotnetSdk bootstrapSdkFile).sdk.overrideAttrs
+            (old: {
+              passthru = old.passthru or { } // {
+                inherit artifacts;
+              };
+            });
       };
 
   fallbackSdk = binary.${"sdk_${suffix.sdk}"};

--- a/pkgs/development/compilers/dotnet/source/vmr.nix
+++ b/pkgs/development/compilers/dotnet/source/vmr.nix
@@ -147,6 +147,7 @@ stdenv.mkDerivation {
     ++ lib.optionals (lib.versionOlder version "9") [
       ./fix-aspnetcore-portable-build.patch
       ./vmr-compiler-opt-v8.patch
+      ./vmr8-riscv64-no-crossgen.patch
     ]
     # see passthru.hasCrossTargetBug
     ++ lib.optional (

--- a/pkgs/development/compilers/dotnet/source/vmr8-riscv64-no-crossgen.patch
+++ b/pkgs/development/compilers/dotnet/source/vmr8-riscv64-no-crossgen.patch
@@ -1,0 +1,24 @@
+--- a/src/runtime/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
++++ b/src/runtime/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+@@ -22,6 +22,9 @@
+     <PublishReadyToRun Condition="'$(TargetOS)' == 'netbsd' Or '$(TargetOS)' == 'illumos' Or '$(TargetOS)' == 'solaris'">false</PublishReadyToRun>
+     <!-- Disable crossgen on FreeBSD when cross building from Linux. -->
+     <PublishReadyToRun Condition="'$(TargetOS)' == 'freebsd' and '$(CrossBuild)' == 'true'">false</PublishReadyToRun>
++    <!-- crossgen is not supported on riscv64 yet -->
++    <PublishReadyToRun Condition="'$(TargetArchitecture)' == 'riscv64'">false</PublishReadyToRun>
++    <PublishSingleFile Condition="'$(TargetArchitecture)' == 'riscv64'">false</PublishSingleFile>
+     <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
+   </PropertyGroup>
+ 
+--- a/src/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
++++ b/src/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+@@ -19,6 +19,9 @@
+     <SysRoot Condition="'$(NativeAotSupported)' == 'true' and '$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
+     <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
+     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
++    <!-- crossgen is not supported on riscv64 yet -->
++    <PublishReadyToRun Condition="'$(TargetArchitecture)' == 'riscv64'">false</PublishReadyToRun>
++    <PublishSingleFile Condition="'$(TargetArchitecture)' == 'riscv64'">false</PublishSingleFile>
+     <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
+     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
+     <!-- Compute host package name (taken from Microsoft.DotNet.ILCompiler.SingleEntry.targets) -->


### PR DESCRIPTION
Hi,

Have initiated https://github.com/liberodark/dotnet_riscv for unlock riscv64 support for dotnet on nixpkgs.
I hope to create or migrate this repository in nix-community for example.
And create immutable release for use in nixpkgs for help riscv64 support.
PS: I am fully prepared to maintain support for riscv64 builds and keep up with updates accordingly.

Best Regards

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
