### PR TITLE
nixos/tests/common/torrent-tracker: init, nixos/tests/lidarr: extend

### DIFF
--- a/nixos/tests/common/torrent-tracker.nix
+++ b/nixos/tests/common/torrent-tracker.nix
@@ -1,0 +1,187 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.test-support.torrentTracker;
+in
+{
+  options.test-support.torrentTracker = {
+    enable = lib.mkEnableOption "a BitTorrent tracker to use for serving torrents in NixOS tests";
+
+    opentrackerPackage = lib.mkPackageOption pkgs "opentracker" { };
+
+    transmissionPackage = lib.mkPackageOption pkgs "transmission" {
+      default = [ "transmission_4" ];
+    };
+
+    trackerPort = lib.mkOption {
+      type = lib.types.port;
+      default = 7070;
+      description = "Port which the BitTorrent tracker listens on.";
+    };
+
+    webPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Port which the HTTP server serving `.torrent` files listens on.";
+    };
+
+    torrents = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { name, ... }: {
+            options = {
+              file = lib.mkOption {
+                type = lib.types.path;
+                description = "Path to the file to serve as a torrent.";
+                example = lib.literalExpression ''
+                  pkgs.writeText "hello.txt" "..."
+                '';
+              };
+
+              url = lib.mkOption {
+                type = lib.types.str;
+                readOnly = true;
+                default = "http://${config.networking.hostName}:${toString cfg.webPort}/${name}.torrent";
+                description = "URL other nodes' BitTorrent clients can use to download the torrent file.";
+              };
+            };
+          }
+        )
+      );
+      default = { };
+      description = ''
+        Files to serve as torrents.
+
+        Each is created and seedeed automatically as part of starting `transmission.service`.
+      '';
+    };
+
+    announceUrl = lib.mkOption {
+      type = lib.types.str;
+      readOnly = true;
+      default = "http://${config.networking.hostName}:${toString cfg.trackerPort}/announce";
+      description = "Announce URL other nodes' BitTorrent clients can use to reach this tracker.";
+    };
+  };
+
+  config =
+    let
+      torrentDir = "/var/lib/torrent-tracker/torrents";
+      dataDir = "/var/lib/torrent-tracker/data";
+    in
+    lib.mkIf cfg.enable {
+      services.opentracker = {
+        enable = true;
+        package = cfg.opentrackerPackage;
+        extraOptions = "-p ${toString cfg.trackerPort}";
+      };
+
+      services.transmission = {
+        enable = true;
+        package = cfg.transmissionPackage;
+        openPeerPorts = true;
+        settings = {
+          download-dir = dataDir;
+
+          # Disable all peer discovery, not applicable in an offline environment.
+          dht-enabled = false;
+          pex-enabled = false;
+          lpd-enabled = false;
+        };
+      };
+
+      systemd.services.transmission = {
+        after = [ "systemd-tmpfiles-setup.service" ];
+        requires = [ "systemd-tmpfiles-setup.service" ];
+        serviceConfig = {
+          BindPaths = [ torrentDir ];
+          ExecStartPost = lib.concatMap ({ name, value }: [
+            "${lib.getExe' pkgs.coreutils "install"} -Dm644 '${value.file}' '${dataDir}/${lib.baseNameOf name}'"
+            "${lib.getExe' cfg.transmissionPackage "transmission-create"} '${dataDir}/${lib.baseNameOf name}' --tracker '${cfg.announceUrl}' --outfile '${torrentDir}/${lib.baseNameOf name}.torrent'"
+            "${lib.getExe' pkgs.coreutils "chmod"} 644 '${torrentDir}/${lib.baseNameOf name}.torrent'"
+            "${lib.getExe' cfg.transmissionPackage "transmission-remote"} --add '${torrentDir}/${lib.baseNameOf name}.torrent' --download-dir '${dataDir}'"
+          ]) (lib.attrsToList cfg.torrents);
+        };
+      };
+
+      systemd.tmpfiles.settings."10-torrent-tracker" = {
+        ${torrentDir}.d = {
+          user = "transmission";
+          group = "transmission";
+          mode = "0755";
+        };
+        ${dataDir}.d = {
+          user = "transmission";
+          group = "transmission";
+          mode = "0755";
+        };
+      };
+
+      systemd.services.torrent-tracker-webserver =
+        let
+          webserver =
+            pkgs.writers.writePython3Bin "torrent-tracker-webserver"
+              {
+                libraries = [ pkgs.python3Packages.systemd-python ];
+              }
+              ''
+                import functools
+                import http.server
+                import socket
+                import sys
+
+                from systemd import daemon
+
+                http.server.HTTPServer.address_family = socket.AF_INET6
+
+                with http.server.HTTPServer(
+                    ("::", int(sys.argv[2])),
+                    functools.partial(
+                        http.server.SimpleHTTPRequestHandler,
+                        directory=sys.argv[1],
+                    ),
+                ) as httpd:
+                    daemon.notify("READY=1")
+                    httpd.serve_forever()
+              '';
+        in
+        {
+          description = "HTTP server for serving .torrent files";
+          after = [
+            "network.target"
+            "systemd-tmpfiles-setup.service"
+          ];
+          requires = [ "systemd-tmpfiles-setup.service" ];
+          serviceConfig = {
+            Type = "notify";
+            DynamicUser = true;
+            WorkingDirectory = torrentDir;
+            ExecStart = "${lib.getExe webserver} ${torrentDir} ${toString cfg.webPort}";
+          };
+        };
+
+      systemd.targets.torrent-tracker = {
+        wantedBy = [ "multi-user.target" ];
+        after = [
+          "opentracker.service"
+          "transmission.service"
+          "torrent-tracker-webserver.service"
+        ];
+        requires = [
+          "opentracker.service"
+          "transmission.service"
+          "torrent-tracker-webserver.service"
+        ];
+      };
+
+      networking.firewall.allowedTCPPorts = [
+        cfg.trackerPort
+        cfg.webPort
+      ];
+      networking.firewall.allowedUDPPorts = [ cfg.trackerPort ];
+    };
+}

--- a/nixos/tests/lidarr.nix
+++ b/nixos/tests/lidarr.nix
@@ -1,20 +1,107 @@
-{ lib, ... }:
+{ pkgs, lib, ... }:
 
+let
+in
 {
   name = "lidarr";
-  meta.maintainers = [ ];
+  meta.maintainers = [ lib.maintainers.h7x4 ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      services.lidarr.enable = true;
+  nodes = {
+    tracker = {
+      imports = [ ./common/torrent-tracker.nix ];
+      test-support.torrentTracker = {
+        enable = true;
+        torrents."track.flac".file = pkgs.writeText "track.flac" "not actually a flac, just test content";
+      };
     };
 
-  testScript = ''
-    start_all()
+    machine = {
+      services.lidarr.enable = true;
+      services.transmission.enable = true;
+      environment.systemPackages = [ pkgs.yq-go ];
+    };
+  };
 
-    machine.wait_for_unit("lidarr.service")
-    machine.wait_for_open_port(8686)
-    machine.succeed("curl --fail http://localhost:8686/")
-  '';
+  testScript =
+    { nodes, ... }:
+    let
+      trackName = "track.flac";
+      trackFile = nodes.tracker.test-support.torrentTracker.torrents."track.flac".file;
+      torrentUrl = nodes.tracker.test-support.torrentTracker.torrents."track.flac".url;
+
+      trackerPort = nodes.tracker.test-support.torrentTracker.trackerPort;
+      lidarrPort = nodes.machine.services.lidarr.settings.server.port;
+      transmissionPort = nodes.machine.services.transmission.settings.rpc-port;
+      lidarrConfigFile = "${nodes.machine.services.lidarr.dataDir}/config.xml";
+      transmissionCategoryDir = "${nodes.machine.services.transmission.settings.download-dir}/lidarr";
+      transmissionDownload = "${transmissionCategoryDir}/${trackName}";
+
+      jsonFile = (pkgs.formats.json { }).generate;
+    in
+    ''
+      import json
+
+
+      def lidarr_api(method, path, json_file=None):
+          command = (
+              f"curl --fail -sS -X {method} http://localhost:${toString lidarrPort}{path}"
+              f" -H 'X-Api-Key: {api_key}'"
+          )
+          if json_file is not None:
+              command += f" --json @{json_file}"
+          return json.loads(machine.succeed(command))
+
+      start_all()
+
+      tracker.wait_for_unit("torrent-tracker.target")
+      tracker.wait_for_open_port(${toString trackerPort})
+
+      machine.wait_for_unit("lidarr.service")
+      machine.wait_for_open_port(${toString lidarrPort})
+      machine.succeed("curl --fail http://localhost:${toString lidarrPort}/")
+      api_key = machine.succeed(
+          "yq -p xml -oy '.Config.ApiKey' ${lidarrConfigFile}"
+      ).strip()
+
+      machine.wait_for_unit("transmission.service")
+      machine.wait_for_open_port(${toString transmissionPort})
+
+      with subtest("Configure with a transmission as a download client"):
+          response = lidarr_api(
+              "POST",
+              "/api/v1/downloadclient",
+              "${
+                # https://lidarr.audio/docs/api/#/DownloadClient/post_api_v1_downloadclient
+                jsonFile "lidarr-download-client.json" {
+                  enable = true;
+                  protocol = "torrent";
+                  priority = 1;
+                  name = "Transmission";
+                  implementation = "Transmission";
+                  implementationName = "Transmission";
+                  configContract = "TransmissionSettings";
+                  fields = [ ];
+                }
+              }",
+          )
+          assert "id" in response
+
+      with subtest("Have transmission fetch a release from the tracker"):
+          machine.succeed("transmission-remote --add ${torrentUrl} --download-dir ${transmissionCategoryDir}")
+          machine.wait_for_file("${transmissionDownload}")
+          machine.succeed("cmp ${transmissionDownload} ${trackFile}")
+
+      with subtest("Lidarr's queue reports the download"):
+          lidarr_api(
+              "POST",
+              "/api/v1/command",
+              "${jsonFile "lidarr-refresh-downloads.json" { name = "RefreshMonitoredDownloads"; }}",
+          )
+
+          def download_in_queue(_last_try):
+              queue = lidarr_api("GET", "/api/v1/queue?includeUnknownArtistItems=true")
+              return any(record["downloadClient"] == "Transmission" for record in queue["records"])
+
+          retry(download_in_queue)
+    '';
 }


### PR DESCRIPTION
This PR introduces a new shared module for use in NixOS tests, which makes it easy to serve torrents to various services.

In order to test that the module works as expected (as well as testing #545384), I've extended the test for lidarr to use the transmission client to fetch a torrent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
