### PR TITLE
jsluice: 0-unstable-2023-06-23 -> 0-unstable-2024-01-10

### DIFF
--- a/pkgs/by-name/js/jsluice/package.nix
+++ b/pkgs/by-name/js/jsluice/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule {
   pname = "jsluice";
-  version = "0-unstable-2023-06-23";
+  version = "0-unstable-2024-01-10";
 
   src = fetchFromGitHub {
     owner = "BishopFox";
     repo = "jsluice";
-    rev = "f10429e1016a9573da0157eacde8f7feb9deb8c7";
-    hash = "sha256-l9rwC1ljtt7Q+FYKdQFhtnLJDS8OwMJXIIpZgya0zwU=";
+    rev = "0ddfab153e060a9eeaded4d8669233f7c071e7e4";
+    hash = "sha256-8BgpUvdHcooB2Kll91OCWKV6mMZVyyxkfYQx/vWEo0o=";
   };
 
-  vendorHash = "sha256-u4E+b/vChXArovtaZ4LODaINWit86i5K4GyHLR0JSyU=";
+  vendorHash = "sha256-uecg0Oi1VCCi/pZqtdiKmJNKhpqDrhxe/HpWGymKlow=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
