### PR TITLE
python3Packages.torch-bin: 2.12.1 -> 2.13.0

### DIFF
--- a/pkgs/development/python-modules/torch/bin/binary-hashes.nix
+++ b/pkgs/development/python-modules/torch/bin/binary-hashes.nix
@@ -7,81 +7,81 @@
 
 version:
 builtins.getAttr version {
-  "2.12.1" = {
+  "2.13.0" = {
     x86_64-linux-310 = {
-      name = "torch-2.12.1+cu130-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
-      hash = "sha256-9/WsBh92dJF8rLqUIfChXo3zUQV/kBMs1GzMup36dyE=";
+      name = "torch-2.13.0+cu130-cp310-cp310-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
+      hash = "sha256-g3ZymBCRSPEN4SQoezkrxY10+ZOOlDDyb5/Wae+4r5w=";
     };
     x86_64-linux-311 = {
-      name = "torch-2.12.1+cu130-cp311-cp311-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
-      hash = "sha256-YjXzogtglMfoiCxlqGp/PG6MOsjb7AtX5XWTfQFm7Q8=";
+      name = "torch-2.13.0+cu130-cp311-cp311-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
+      hash = "sha256-eUZkwFo0cKXnOER7VElcxrvx78pIvyeUJwqJfZ9DVsQ=";
     };
     x86_64-linux-312 = {
-      name = "torch-2.12.1+cu130-cp312-cp312-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
-      hash = "sha256-S6/DVvu2IuJ1YXlAaCXDpWwXtAEZZDWhSHxbQMZXcGw=";
+      name = "torch-2.13.0+cu130-cp312-cp312-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+      hash = "sha256-jbczjmiVw9S9iaAv9CCVB9Hwzy/+s7iYU4taB9HqjB4=";
     };
     x86_64-linux-313 = {
-      name = "torch-2.12.1+cu130-cp313-cp313-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
-      hash = "sha256-1eGEBELSGClXs9L3eMwyXJD6XLQqqLGslJ8CnpvdfwY=";
+      name = "torch-2.13.0+cu130-cp313-cp313-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
+      hash = "sha256-lb260vB4a9RIky5LcqZASqIikNtuyVTiTt+m0zyDPI8=";
     };
     x86_64-linux-314 = {
-      name = "torch-2.12.1+cu130-cp314-cp314-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torch-2.12.1%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
-      hash = "sha256-yExZiLPkFmae03kNdyR5r1k00XiBGSiNi93ZxMsgcoU=";
+      name = "torch-2.13.0+cu130-cp314-cp314-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
+      hash = "sha256-4jEwKkVymNAjb3veMQglaPbNBhO2a060aEnorVPC440=";
     };
     aarch64-darwin-310 = {
-      name = "torch-2.12.1-cp310-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp310-cp310-macosx_14_0_arm64.whl";
-      hash = "sha256-7FboK+aosMA2dxp399Mq08KZdwVxr5gVs9r+YUNDidU=";
+      name = "torch-2.13.0-cp310-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl";
+      hash = "sha256-lPDeEpkW93uNwseo7/ZEz+3f5Z45yfVen24XVDQQKB0=";
     };
     aarch64-darwin-311 = {
-      name = "torch-2.12.1-cp311-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp311-cp311-macosx_14_0_arm64.whl";
-      hash = "sha256-74H1A5Eu/+os49mxKi46btSIlD6RJxyQx6gp9guvaqI=";
+      name = "torch-2.13.0-cp311-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl";
+      hash = "sha256-52+bzsxSuP9xEjmi91R9U1PflYeKsjLwdzwdlZKLkvg=";
     };
     aarch64-darwin-312 = {
-      name = "torch-2.12.1-cp312-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp312-cp312-macosx_14_0_arm64.whl";
-      hash = "sha256-0t0PLF98y92vNMreDer0doCDaPkCuc2382oqtCMBvA4=";
+      name = "torch-2.13.0-cp312-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl";
+      hash = "sha256-L+Ioq6KQ0UufMbBJvlUNvUacP9MBPXoZcFswRU2pcCc=";
     };
     aarch64-darwin-313 = {
-      name = "torch-2.12.1-cp313-none-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl";
-      hash = "sha256-x16TFzxwC8zWv8xKnRnOJCq22s0fF4FIMCehYjm55lA=";
+      name = "torch-2.13.0-cp313-none-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl";
+      hash = "sha256-M0SYmc5UlsG4S0hTF52U/RAgKK4UBzFNn7lWu3nnDQk=";
     };
     aarch64-darwin-314 = {
-      name = "torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl";
-      hash = "sha256-6bb30t1m6oejrmIAadMTNdWUwG7/saODvdIc/mHkTs4=";
+      name = "torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl";
+      hash = "sha256-2EmzkOB9jTM86OyvkbJzxlbFmDeaGcms8TGKiD9rORw=";
     };
     aarch64-linux-310 = {
-      name = "torch-2.12.1+cpu-cp310-cp310-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
-      hash = "sha256-k7jOs2ieNKkkZdTKx9COZd/PSdENbUfRXbXzkXuqEVI=";
+      name = "torch-2.13.0+cpu-cp310-cp310-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
+      hash = "sha256-8CjkKL3e6VzbhuJHAlTpXJr2KTYkiFUMIA7UeTElqBc=";
     };
     aarch64-linux-311 = {
-      name = "torch-2.12.1+cpu-cp311-cp311-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
-      hash = "sha256-bRth5TosAA4eXMSfyIrrxmW98CxjkQwkMRbTldfLwWQ=";
+      name = "torch-2.13.0+cpu-cp311-cp311-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
+      hash = "sha256-hEU7aVCOx5kC+JnF7ZSVrLniu+n9pfHV1vGePDhC4ac=";
     };
     aarch64-linux-312 = {
-      name = "torch-2.12.1+cpu-cp312-cp312-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
-      hash = "sha256-0WILx7z4CH8+SIIbXbmUoD4y3bCD1YwAC44DL4puLRU=";
+      name = "torch-2.13.0+cpu-cp312-cp312-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
+      hash = "sha256-bzB8LDLXZP/G/2iTuAH61tR1Lz5nlmy4q/GENCfAJgQ=";
     };
     aarch64-linux-313 = {
-      name = "torch-2.12.1+cpu-cp313-cp313-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
-      hash = "sha256-jUfgz8WWedTjZ2RsPfTPQzx9FZWzEwfg57I5HFjKIWA=";
+      name = "torch-2.13.0+cpu-cp313-cp313-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
+      hash = "sha256-C499BCMCeui5DHl3xifzN58yU2OggiTf+tm0staEqD0=";
     };
     aarch64-linux-314 = {
-      name = "torch-2.12.1+cpu-cp314-cp314-manylinux_2_28_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
-      hash = "sha256-G5rXDQowDWvYg//8FTpsD5vGS/QZBRmu7tA3OAe/+8w=";
+      name = "torch-2.13.0+cpu-cp314-cp314-manylinux_2_28_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
+      hash = "sha256-ygIfnrL4NFyD+gPjoEWHMIr7jfcb1HJnCz7OAN9YYhw=";
     };
   };
 }

--- a/pkgs/development/python-modules/torch/bin/default.nix
+++ b/pkgs/development/python-modules/torch/bin/default.nix
@@ -38,7 +38,7 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "2.12.1";
+  version = "2.13.0";
 in
 buildPythonPackage {
   inherit version;

--- a/pkgs/development/python-modules/torchvision/bin.nix
+++ b/pkgs/development/python-modules/torchvision/bin.nix
@@ -22,14 +22,13 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "0.27.1";
+  version = "0.28.0";
 in
 buildPythonPackage {
-  inherit version;
-
   pname = "torchvision";
-
+  inherit version;
   format = "wheel";
+  __structuredAttrs = true;
 
   src = fetchurl srcs."${stdenv.system}-${pyVerNoDot}" or unsupported;
 

--- a/pkgs/development/python-modules/torchvision/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchvision/binary-hashes.nix
@@ -7,81 +7,81 @@
 
 version:
 builtins.getAttr version {
-  "0.27.1" = {
+  "0.28.0" = {
     x86_64-linux-310 = {
-      name = "torchvision-0.27.1-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
-      hash = "sha256-RtNxOnPEU70t8DM0DAWkz0Rh1v25IUMm6GAJGDT9oMo=";
+      name = "torchvision-0.28.0-cp310-cp310-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.28.0%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl";
+      hash = "sha256-GcLRi7yMOxpmbw1B+R2PYk+RL6/61CE3EGHd3aUrqOo=";
     };
     x86_64-linux-311 = {
-      name = "torchvision-0.27.1-cp311-cp311-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
-      hash = "sha256-VRS3+oog7QcwEHsQi/Lpb8iIEOsIMJRua7U9aF4SnU4=";
+      name = "torchvision-0.28.0-cp311-cp311-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.28.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl";
+      hash = "sha256-Z4k89PtKznPaYJaGN7Hra72MsyJplfEjIuwAQfuumKE=";
     };
     x86_64-linux-312 = {
-      name = "torchvision-0.27.1-cp312-cp312-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
-      hash = "sha256-q7/HJFl8FtoXcAKhaXmqjETEiYyXvLcxtkfMV1B/V3I=";
+      name = "torchvision-0.28.0-cp312-cp312-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.28.0%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl";
+      hash = "sha256-igAI00zMToEGa5f/CuWjTGdr/fNGS69AwBsyDcmkXOA=";
     };
     x86_64-linux-313 = {
-      name = "torchvision-0.27.1-cp313-cp313-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
-      hash = "sha256-+fAI1LGy8BPq977Bqf8iEmNYHXdmjU4eDpw+01HVZGU=";
+      name = "torchvision-0.28.0-cp313-cp313-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.28.0%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl";
+      hash = "sha256-+jwfh/hmZ1YjgOPORn4AA3H6iK3vrsclErOdECGi9YE=";
     };
     x86_64-linux-314 = {
-      name = "torchvision-0.27.1-cp314-cp314-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu130/torchvision-0.27.1%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
-      hash = "sha256-xS179F2vZqghkWYOf4VSB0bCca097xQXzngnlnT+Q6A=";
+      name = "torchvision-0.28.0-cp314-cp314-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu130/torchvision-0.28.0%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl";
+      hash = "sha256-RV66sGSBmOBryBc5VprZtOpsj6bNncVFmBUsbOYoXc0=";
     };
     aarch64-darwin-310 = {
-      name = "torchvision-0.27.1-cp310-cp310-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp310-cp310-macosx_14_0_arm64.whl";
-      hash = "sha256-aLpjtIr5LwbbmVrbI9hBGZPbod7nBaTpJBG4OgCTC38=";
+      name = "torchvision-0.28.0-cp310-cp310-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0-cp310-cp310-macosx_14_0_arm64.whl";
+      hash = "sha256-Kh70tvS/WCi0jPrZc3LImC25BoMIhLKGi6XD35N6fYE=";
     };
     aarch64-darwin-311 = {
-      name = "torchvision-0.27.1-cp311-cp311-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp311-cp311-macosx_14_0_arm64.whl";
-      hash = "sha256-rYdDqcEsjBJK0KFJHlTDygx0npHjdOPZITYGCyLJ4PQ=";
+      name = "torchvision-0.28.0-cp311-cp311-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0-cp311-cp311-macosx_14_0_arm64.whl";
+      hash = "sha256-g/5sAghmqFrNfZfezMRf8R1m2vQpFtBDlqQwnGbAzLg=";
     };
     aarch64-darwin-312 = {
-      name = "torchvision-0.27.1-cp312-cp312-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp312-cp312-macosx_14_0_arm64.whl";
-      hash = "sha256-RIq/w7q6mE2kV39zcgnkRdpr6T47X0eZ2QFiv2Hj9IU=";
+      name = "torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl";
+      hash = "sha256-6fVMMM1S4+9/0DTMabe7fglk4cj4dD4BirkulbQPnu4=";
     };
     aarch64-darwin-313 = {
-      name = "torchvision-0.27.1-cp313-cp313-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp313-cp313-macosx_14_0_arm64.whl";
-      hash = "sha256-1gMRptCN+QX5ZWo6MS8Kj1Xw1GMhvHN7rTCo3slkQwk=";
+      name = "torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl";
+      hash = "sha256-1IO0qj9SN1aQU/dJzRorW7VIykVuQEYaXdCH8hFJ0SM=";
     };
     aarch64-darwin-314 = {
-      name = "torchvision-0.27.1-cp314-cp314-macosx_14_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1-cp314-cp314-macosx_14_0_arm64.whl";
-      hash = "sha256-n171mtYOaVeW7Ka2TpfLmyG51UY8rFrA74bPtytuXbk=";
+      name = "torchvision-0.28.0-cp314-cp314-macosx_14_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0-cp314-cp314-macosx_14_0_arm64.whl";
+      hash = "sha256-O9nbpVIkqdtKLXf2/qpWUXcNjI6G09DdsPpr7FTIcSs=";
     };
     aarch64-linux-310 = {
-      name = "torchvision-0.27.1-cp310-cp310-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
-      hash = "sha256-MyPtuQDKRtKduiZ+6AnlX+X+Cc09n1QSSnxe0zpqLb4=";
+      name = "torchvision-0.28.0-cp310-cp310-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl";
+      hash = "sha256-fYHaKATaUsl4jy1ajQqt3Oqfzm6118bhmjK0C07Qt1o=";
     };
     aarch64-linux-311 = {
-      name = "torchvision-0.27.1-cp311-cp311-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
-      hash = "sha256-P6NBdGcak08Wb5UnrLd4ctjKFs1ewh76o4VkYDPgUG4=";
+      name = "torchvision-0.28.0-cp311-cp311-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl";
+      hash = "sha256-IpWBk9ckRO18vMZlukghox5SefnE0a0IUgkYswiWt4o=";
     };
     aarch64-linux-312 = {
-      name = "torchvision-0.27.1-cp312-cp312-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
-      hash = "sha256-Y3g4M4sGCC8h/T9A1Lxw+H+MtcQXUwx06J2COVKAS8c=";
+      name = "torchvision-0.28.0-cp312-cp312-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl";
+      hash = "sha256-L3aMT21a321VNQYf1p7ESCdgi6wOluEhFJQqb9/OEQc=";
     };
     aarch64-linux-313 = {
-      name = "torchvision-0.27.1-cp313-cp313-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
-      hash = "sha256-fV0JoOmEQREdAm6pJMIC43UtYkJbhLB2jZjAuwdHR/8=";
+      name = "torchvision-0.28.0-cp313-cp313-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl";
+      hash = "sha256-h5rm1OLjZRWC+3GH6v1TVgHLXQGVldR+LIdCYqAA6I4=";
     };
     aarch64-linux-314 = {
-      name = "torchvision-0.27.1-cp314-cp314-linux_aarch64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torchvision-0.27.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
-      hash = "sha256-KQ67FCiA38qh/uw7RI3NPHBMLwORIyoe7Z7/XqXGWzU=";
+      name = "torchvision-0.28.0-cp314-cp314-linux_aarch64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl";
+      hash = "sha256-Ohp2yN7LHXu+3TWIvMyQ+yaZRLcyGnc9sYFzW0IRVCI=";
     };
   };
 }


### PR DESCRIPTION
## Things done

- **python3Packages.torch-bin: 2.12.1 -> 2.13.0** ([Changelog](https://github.com/pytorch/pytorch/releases/tag/v2.13.0), [Diff](https://github.com/pytorch/pytorch/compare/v2.12.1...v2.13.0))
- **python3Packages.torchvision-bin: 0.27.1 -> 0.28.0** ([Changelog](https://github.com/pytorch/vision/releases/tag/v0.28.0), [Diff](https://github.com/pytorch/vision/compare/v0.27.1...v0.28.0))

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
