### PR TITLE
zcode: init at 3.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16406,6 +16406,12 @@
     githubId = 667272;
     name = "Lincoln Lee";
   };
+  LingLambda = {
+    email = "abc1514671906@163.com";
+    name = "ling";
+    github = "LingLambda";
+    githubId = 101567686;
+  };
   linj = {
     name = "Lin Jian";
     email = "me@linj.tech";

--- a/pkgs/by-name/zc/zcode/package.nix
+++ b/pkgs/by-name/zc/zcode/package.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  alsa-lib,
+  at-spi2-core,
+  cairo,
+  cups,
+  dbus,
+  dpkg,
+  expat,
+  fetchurl,
+  glib,
+  gtk3,
+  libGL,
+  libdrm,
+  libgbm,
+  libnotify,
+  libsecret,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxkbcommon,
+  libxrandr,
+  libxscrnsaver,
+  libxtst,
+  makeWrapper,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  util-linux,
+  vulkan-loader,
+  writableTmpDirAsHomeHook,
+  xdg-utils,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zcode";
+  version = "3.10.1";
+
+  src =
+    {
+      x86_64-linux = fetchurl {
+        url = "https://cdn-zcode.z.ai/zcode/electron/releases/${finalAttrs.version}/linux-x64/ZCode-${finalAttrs.version}-linux-x64.deb";
+        hash = "sha256-HezuwB4FRaTH+OJlFiabHoRd/DUkWYsWVeOLxhrL8Is=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://cdn-zcode.z.ai/zcode/electron/releases/${finalAttrs.version}/linux-arm64/ZCode-${finalAttrs.version}-linux-arm64.deb";
+        hash = "sha256-Irebq+OwD7b7/PfcwDO3VkpzT1PfTyiZjBhVYHEoayw=";
+      };
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+  ];
+
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    gtk3
+    glib
+    libGL
+    libdrm
+    libgbm
+    libnotify
+    libsecret
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxkbcommon
+    libxscrnsaver
+    libxtst
+    nspr
+    nss
+    pango
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  runtimeDependencies = [
+    libGL
+    systemd
+  ];
+
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/bin
+    mv opt/ZCode $out/lib/zcode
+    mv usr/share $out/share
+
+    # dlopen()ed by ANGLE at runtime, so autoPatchelfHook's RUNPATH doesn't
+    # cover them; without this the GPU process falls back to software rendering.
+    makeWrapper $out/lib/zcode/zcode $out/bin/zcode \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          util-linux
+          xdg-utils
+        ]
+      } \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libGL
+          vulkan-loader
+        ]
+      } \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}"
+
+    substituteInPlace $out/share/applications/zcode.desktop \
+      --replace-fail 'Exec=/opt/ZCode/zcode' 'Exec=zcode'
+
+    install -d $out/share/licenses/zcode
+    ln -s $out/lib/zcode/LICENSE.electron.txt $out/share/licenses/zcode/LICENSE.electron.txt
+    ln -s $out/lib/zcode/LICENSES.chromium.html $out/share/licenses/zcode/LICENSES.chromium.html
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Desktop application for AI-assisted software development";
+    homepage = "https://zcode.z.ai";
+    changelog = "https://zcode.z.ai/en/changelog";
+    downloadPage = "https://zcode.z.ai/en";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ LingLambda ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "zcode";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds ZCode 3.10.1, the desktop application for AI-assisted
software development.

Homepage: https://zcode.z.ai
Download page: https://zcode.z.ai/en
Upstream changelog: https://zcode.z.ai/en/changelog

The package:

- packages the official upstream deb: <https://cdn-zcode.z.ai/zcode/electron/releases/3.10.1/linux-x64/ZCode-3.10.1-linux-x64.deb/>
- supports `x86_64-linux` and `aarch64-linux`;
- provides the required dependencies; 

The package was tested and confirmed to run successfully on
`x86_64-linux`.

I used Omp with `gpt-5.6-sol` to assist with extracting the upstream
binary package, identifying runtime dependencies, and implementing the
Nix package. I manually reviewed the resulting package definition.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
