### PR TITLE
credsweeper: 1.17.4 -> 1.18.1

### DIFF
--- a/pkgs/development/python-modules/credsweeper/default.nix
+++ b/pkgs/development/python-modules/credsweeper/default.nix
@@ -1,22 +1,19 @@
 {
   lib,
   stdenv,
-  buildPythonPackage,
-  fetchFromGitHub,
-  pythonOlder,
-
-  # build-system
-  hatchling,
-
-  # dependencies
   base58,
   beautifulsoup4,
   bech32,
   brotli,
+  buildPythonPackage,
   colorama,
   cryptography,
+  deepdiff,
+  fetchFromGitHub,
   gitpython,
+  hatchling,
   humanfriendly,
+  hypothesis,
   lxml,
   numpy,
   odfpy,
@@ -24,32 +21,30 @@
   openpyxl,
   pandas,
   pdfminer-six,
+  psutil,
   pybase62,
+  pygments,
   pyjks,
   pysquashfsimage,
+  pytestCheckHook,
   python-dateutil,
   python-docx,
   python-pptx,
+  pythonOlder,
   pyxlsb,
   pyyaml,
   rpmfile,
   striprtf,
+  tqdm,
+  versionCheckHook,
   whatthepatch,
   xlrd,
-  # < python 3.14 only:
   zstandard,
-
-  # tests
-  deepdiff,
-  hypothesis,
-  psutil,
-  pytestCheckHook,
-  versionCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "credsweeper";
-  version = "1.17.4";
+  version = "1.18.1";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -58,7 +53,7 @@ buildPythonPackage (finalAttrs: {
     owner = "Samsung";
     repo = "CredSweeper";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JsKwmzC9kMF3dkYVFrLDxYsxOc5X13pFN9aealZEgqY=";
+    hash = "sha256-ktaCNgM0FJCdreIqhzYc21CjpLmp7vIbs9E5Q6yvWjc=";
   };
 
   build-system = [ hatchling ];
@@ -80,6 +75,7 @@ buildPythonPackage (finalAttrs: {
     pandas
     pdfminer-six
     pybase62
+    pygments
     pyjks
     pysquashfsimage
     python-dateutil
@@ -89,6 +85,7 @@ buildPythonPackage (finalAttrs: {
     pyyaml
     rpmfile
     striprtf
+    tqdm
     whatthepatch
     xlrd
   ]
@@ -109,6 +106,10 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # Probability tests
     "test_data_p"
+    "test_data_scan_depth_3_pedantic_p"
+    "test_data_scan_doc_p"
+    "test_data_scan_no_filters_p"
+    "test_data_scan_output_p"
     "test_depth_n"
     "test_depth_p"
     "test_match_n"


### PR DESCRIPTION
Diff: https://github.com/Samsung/CredSweeper/compare/v1.17.4...v1.18.1

Changelog: https://github.com/Samsung/CredSweeper/releases/tag/v1.18.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
