### PR TITLE
make-derivation: cleanup structuredAttrs logic

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -879,10 +879,14 @@ let
                   inherit name;
                   value =
                     let
-                      raw = zipAttrsWith (_: concatLists) [
-                        attrsOutputChecks
-                        (makeOutputChecks (attrs.outputChecks.${name} or { }))
-                      ];
+                      raw =
+                        if attrs ? outputChecks.${name} then
+                          zipAttrsWith (_: concatLists) [
+                            attrsOutputChecks
+                            (makeOutputChecks attrs.outputChecks.${name})
+                          ]
+                        else
+                          attrsOutputChecks;
                     in
                     # separateDebugInfo = true will put all sorts of files in
                     # the debug output which could carry references, but

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -892,7 +892,7 @@ let
                     # the debug output which could carry references, but
                     # that's "normal". Notably it symlinks to the source.
                     # So disable reference checking for the debug output
-                    if separateDebugInfo' && name == "debug" then
+                    if raw != { } && separateDebugInfo' && name == "debug" then
                       removeAttrs raw referenceCheckingAttrsToRemove
                     else
                       raw;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -20,7 +20,6 @@ let
     elem
     extendDerivation
     filter
-    filterAttrs
     foldl'
     getDev
     head
@@ -165,14 +164,18 @@ let
     # having to wait while nix builds a derivation that might not be used.
     # See also https://github.com/NixOS/nix/issues/4629
     {
-      ${if (attrs ? disallowedReferences) then "disallowedReferences" else null} =
+      ${if attrs ? disallowedReferences then "disallowedReferences" else null} =
         map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
-      ${if (attrs ? disallowedRequisites) then "disallowedRequisites" else null} =
+      ${if attrs ? disallowedRequisites then "disallowedRequisites" else null} =
         map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
-      ${if (attrs ? allowedReferences) then "allowedReferences" else null} =
-        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
-      ${if (attrs ? allowedRequisites) then "allowedRequisites" else null} =
-        mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
+      ${
+        if attrs ? allowedReferences && attrs.allowedReferences != null then "allowedReferences" else null
+      } =
+        unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
+      ${
+        if attrs ? allowedRequisites && attrs.allowedRequisites != null then "allowedRequisites" else null
+      } =
+        unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
     };
 in
 config:
@@ -857,9 +860,8 @@ let
           ${if __structuredAttrs then "outputChecks" else null} =
             let
               attrsOutputChecks = makeOutputChecks attrs;
-              attrsOutputChecksFiltered = filterAttrs (_: v: v != null) attrsOutputChecks;
             in
-            if !attrs ? outputChecks && (attrsOutputChecks == { } || attrsOutputChecksFiltered == { }) then
+            if !attrs ? outputChecks && attrsOutputChecks == { } then
               { }
             else
               listToAttrs (
@@ -868,7 +870,7 @@ let
                   value =
                     let
                       raw = zipAttrsWith (_: concatLists) [
-                        attrsOutputChecksFiltered
+                        attrsOutputChecks
                         (makeOutputChecks (attrs.outputChecks.${name} or { }))
                       ];
                     in

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -135,14 +135,6 @@ let
 
   isSingularDependency = dep: dep == null || isDerivation dep || isString dep || isPath dep;
 
-  cachedOutputChecks = {
-    out = { };
-  };
-  debugCachedOutputChecks = {
-    out = { };
-    debug = { };
-  };
-
   # Turn a derivation into its outPath without a string context attached.
   # See the comment at the usage site.
   unsafeDerivationToUntrackedOutpath =
@@ -867,16 +859,8 @@ let
               attrsOutputChecks = makeOutputChecks attrs;
               attrsOutputChecksFiltered = filterAttrs (_: v: v != null) attrsOutputChecks;
             in
-            # to avoid the listToAttrs in most common situations, we replicate
-            # what it would produce for most derivations. this can be improved
-            # in the future at the cost of a mass rebuild - empty attrsets for
-            # each output is a noop
-            if
-              !attrs ? outputs
-              && !attrs ? outputChecks
-              && (attrsOutputChecks == { } || attrsOutputChecksFiltered == { })
-            then
-              if separateDebugInfo' then debugCachedOutputChecks else cachedOutputChecks
+            if !attrs ? outputChecks && (attrsOutputChecks == { } || attrsOutputChecksFiltered == { }) then
+              { }
             else
               listToAttrs (
                 map (name: {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -171,11 +171,11 @@ let
       ${
         if attrs ? allowedReferences && attrs.allowedReferences != null then "allowedReferences" else null
       } =
-        unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
+        map unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
       ${
         if attrs ? allowedRequisites && attrs.allowedRequisites != null then "allowedRequisites" else null
       } =
-        unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
+        map unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
     };
 in
 config:
@@ -853,10 +853,20 @@ let
             map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
           ${if !__structuredAttrs && attrs ? disallowedRequisites then "disallowedRequisites" else null} =
             map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
-          ${if !__structuredAttrs && attrs ? allowedReferences then "allowedReferences" else null} =
-            mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
-          ${if !__structuredAttrs && attrs ? allowedRequisites then "allowedRequisites" else null} =
-            mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
+          ${
+            if !__structuredAttrs && attrs ? allowedReferences && attrs.allowedReferences != null then
+              "allowedReferences"
+            else
+              null
+          } =
+            map unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
+          ${
+            if !__structuredAttrs && attrs ? allowedRequisites && attrs.allowedRequisites != null then
+              "allowedRequisites"
+            else
+              null
+          } =
+            map unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
           ${if __structuredAttrs then "outputChecks" else null} =
             let
               attrsOutputChecks = makeOutputChecks attrs;


### PR DESCRIPTION
Previously made some cleanups to how structuredAttrs is computed, to avoid logic in the common case. This was done carefully to avoid mass rebuilds. Here, I'm bundling together structuredAttrs cleanups that cause rebuilds, but allow us to do less work.

Stats diff for `pkgs.firefox`:
```json
{
  "attrset": {
    "lookups": "-0.14%",
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": "-0.13%"
  },
  "parser": {
    "expressions": "-0%"
  },
  "memoryBytes": {
    "envs": "-0.22%",
    "list": "-0.37%",
    "sets": "-0.04%",
    "symbols": "-0.01%",
    "values": "-0.16%",
    "total": "-0.08%"
  },
  "speed": {
    "primops": "-0.41%",
    "functionCalls": "-0.21%",
    "thunksMade": "-0.31%",
    "thunksAvoided": "-0.11%"
  }
}
```
Running `nix-diff` on firefox, only `libxcrypt` and `which` changed their hashes, and their diffs were trivial:
```jsonc
// before
"outputChecks":{"man":{},"out":{}}
// after
"outputChecks":{}
```
I also ran nix-diff on my own config, and the only diff was similar to this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
