### PR TITLE
nix-diff-rs: init at 0-unstable-2026-08-22

### DIFF
--- a/pkgs/by-name/ni/nix-diff-rs/package.nix
+++ b/pkgs/by-name/ni/nix-diff-rs/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage {
+  pname = "nix-diff-rs";
+  version = "0-unstable-2026-08-22";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "nix-diff-rs";
+    rev = "bc31a21022671f257285f9443cc9d595a079efbc";
+    hash = "sha256-3lOJ6E2HY865uhmDcCeM1pdtTFVq5vw/1erQrmjQ0cc=";
+  };
+
+  cargoHash = "sha256-DPHxOPBllnO6fyIRRElPo8WgZEWXL2Dq7qR4ePxiaH4=";
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  nativeCheckInputs = [ nix ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "branch"
+    ];
+  };
+
+  meta = {
+    description = "Explain why two Nix derivations differ";
+    homepage = "https://github.com/Mic92/nix-diff-rs";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      me-and
+      mic92
+    ];
+    mainProgram = "nix-diff";
+  };
+}


### PR DESCRIPTION
[nix-diff-rs](https://github.com/Mic92/nix-diff-rs) is a Rust reimplementation of [nix-diff](https://hackage.haskell.org/package/nix-diff).

@Mic92 I've added you as a maintainer since it's your project, but you obviously get to opt out if you'd rather!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
