### PR TITLE
klee: fix build, llvmPackages_18 -> llvmPackages_19

### DIFF
--- a/pkgs/by-name/kl/klee/package.nix
+++ b/pkgs/by-name/kl/klee/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
-  llvmPackages_18,
+  llvmPackages_19,
   callPackage,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   python3,
   z3,
@@ -51,8 +52,9 @@ let
   # Python used for KLEE tests.
   kleePython = python3.withPackages (ps: with ps; [ tabulate ]);
 
-  # The LLVM we're using. Note that KLEE doesn't yet support 18 but this is the minimum in nixpkgs.
-  llvmPackages = llvmPackages_18;
+  # The LLVM we're using. Note that KLEE only has partial support for LLVM 19
+  # but this is the minimum in Nixpkgs.
+  llvmPackages = llvmPackages_19;
 in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "klee";
@@ -64,6 +66,14 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-8DofxLyTV8Al7ys8vSJpzf6qQV3sw940lGIZBvZqe2c=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "missing-cstdint-include.patch";
+      url = "https://github.com/klee/klee/commit/efa1e0529499f954885489d30210dfc7a3697258.patch";
+      hash = "sha256-mhnyTG36iyVrCFxvP+2PWcacmRjZvGczMTto8xSrfhw=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -120,9 +130,12 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   env.LIT_XFAIL = lib.concatStringsSep ";" [
     "KLEE :: ArrayOpt/test_expr_arbitrary.c"
+    "KLEE :: CXX/ArrayNew.cpp"
+    "KLEE :: CXX/New.cpp"
     "KLEE :: CXX/SimpleVirtual.cpp"
     "KLEE :: CXX/StaticConstructor.cpp"
     "KLEE :: CXX/StaticDestructor.cpp"
+    "KLEE :: CXX/symex/basic_c++/reinterpret_cast.cpp"
     "KLEE :: Concrete/ConstantExpr.ll"
     "KLEE :: Concrete/OverlappingPhiNodes.ll"
     "KLEE :: Concrete/UnorderedPhiNodes.ll"
@@ -131,12 +144,14 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "KLEE :: DeterministicAllocation/use-after-free-loh.c"
     "KLEE :: DeterministicAllocation/use-after-free.c"
     "KLEE :: Dogfood/ImmutableSet.cpp"
+    "KLEE :: Feature/Alias.c"
     "KLEE :: Feature/Atomic.c"
     "KLEE :: Feature/DivCheck.c"
     "KLEE :: Feature/ExtCall.c"
     "KLEE :: Feature/ExtCallWarnings.c"
     "KLEE :: Feature/FunctionAlias.c"
     "KLEE :: Feature/FunctionAliasExit.c"
+    "KLEE :: Feature/GlobalVariable.ll"
     "KLEE :: Feature/LargeArrayBecomesSym.c"
     "KLEE :: Feature/LowerSwitch.c"
     "KLEE :: Feature/MakeSymbolicName.c"
@@ -212,6 +227,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "KLEE :: VectorInstructions/memset.c"
     "KLEE :: VectorInstructions/oob-write.c"
     "KLEE :: VectorInstructions/shuffle_element.c"
+    "KLEE :: klee-stats/KleeStats.c"
     "KLEE :: klee-stats/KleeStatsTermClasses.c"
     "KLEE :: regression/2008-03-11-free-of-malloc-zero.c"
     "KLEE :: regression/2014-07-04-unflushed-error-report.c"

--- a/pkgs/by-name/st/stp/package.nix
+++ b/pkgs/by-name/st/stp/package.nix
@@ -9,6 +9,7 @@
   fetchFromGitHub,
   fetchpatch,
   symlinkJoin,
+  gitMinimal,
   perl,
   python3,
   zlib,
@@ -18,6 +19,7 @@
   cadical_2,
   gtest,
   lit,
+  llvmPackages,
   outputcheck,
   nix-update-script,
   useCadical ? true,
@@ -25,21 +27,25 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "stp";
-  version = "2.3.4";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "stp";
     repo = "stp";
-    tag = "${finalAttrs.version}_cadical";
-    hash = "sha256-fNx3/VS2bimlVwCejEZtNGDqVKnwBm0O2YkIUQm6eDM=";
+    tag = finalAttrs.version;
+    hash = "sha256-rY5YE9VJz1YXf7W0BxVedZPMnlQ9wdcI2V0ta3WEV80=";
+    fetchSubmodules = true;
   };
+
   patches = [
-    # Python 3.12+ compatibility for build: https://github.com/stp/stp/pull/450
+    # https://github.com/stp/stp/pull/704
     (fetchpatch {
-      url = "https://github.com/stp/stp/commit/fb185479e760b6ff163512cb6c30ac9561aadc0e.patch";
-      hash = "sha256-guFgeWOrxRrxkU7kMvd5+nmML0rwLYW196m1usE2qiA=";
+      name = "python-3.14-ast-constant.patch";
+      url = "https://github.com/stp/stp/commit/e5ab190e872d669b8fcd0d76e432e982707fa706.patch";
+      hash = "sha256-EKeLny9sb2XVsJHzSDh2WVvIg8jPIr0MkEqCHvctbB8=";
     })
   ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail GIT-hash-notfound "$version"
@@ -58,8 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "src/cadical.hpp" "cadical.hpp"
 
     substituteInPlace CMakeLists.txt \
-      --replace-fail "build/libcadical.a" "lib/libcadical.a" \
-      --replace-fail 'include_directories(''${CADICAL_DIR}/)' 'include_directories(''${CADICAL_DIR}/include)'
+      --replace-fail \
+      'find_path(CADICAL_INCLUDE_DIR NAMES src/cadical.hpp HINTS ''${CADICAL_DIR})' \
+      'find_path(CADICAL_INCLUDE_DIR NAMES cadical.hpp HINTS ''${CADICAL_DIR}/include)' \
+      --replace-fail "''${CADICAL_DIR}/build" "''${CADICAL_DIR}/lib"
   '';
 
   buildInputs = [
@@ -75,6 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     bison
     flex
+    gitMinimal
     perl
     pkg-config
   ];
@@ -100,17 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional finalAttrs.finalPackage.doCheck (lib.cmakeFeature "LIT_ARGS" "-v")
     ++ lib.optional useCadical (lib.cmakeFeature "CADICAL_DIR" (toString cadicalDependency));
 
-  # Fixes the following warning in the aarch64 build on Linux:
-  # lib/extlib-abc/aig/cnf/cnfData.c:4591:25: warning: result of comparison of
-  # constant 255 with expression of type 'signed char' is always false [-Wtautological-constant-out-of-range-compare]
-  # 4591 |         if ( pMemory[k] == (char)(-1) )
-  #
-  # This seems to cause an infinite loop in tests on aarch64-linux platforms.
-  #
-  # TODO: Remove these CFLAGS when they update to the version that pulls `abc` in with a submodule.
-  # https://github.com/stp/stp/issues/498#issuecomment-2611251631
-  env.CFLAGS = toString [ "-fsigned-char" ];
-
   outputs = [
     "dev"
     "out"
@@ -133,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     gtest
     lit
+    llvmPackages.llvm # for the `not` binary
     outputcheck
   ];
 
@@ -145,10 +144,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Some of the gtest/gmock files were in the pkgconfig folders, which may now be empty.
     find $out/ -name pkgconfig -type d -empty -delete
-
-    # Python bindings are broken:
-    substituteInPlace $python_install_dir/**/stp.py \
-      --replace-fail "from library_path import PATHS" "from .library_path import PATHS"
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
stacked on top of #557496 just to be able to get to building `klee` at all, even with `NIXPKGS_ALLOW_BROKEN=1`. first commit is from that pr, second is new.

llvm 18 is on its way out from nixpkgs, likely prior to the 26.11 release. accordingly, klee needs to migrate off. it's already in a half-broken state and is marked `broken`, since support for llvm > 16 is very partial, but this is enough to at least get klee proper to build. many existing tests fail, as do a few new ones, which we now ignore. this isn't *great*, but with klee upstream lagging as far behind on llvm as it is, we're not sure what else we can do here.

we also pull in a quick patch to add a missing include that causes klee to fail to build, even on llvm 18.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
