### PR TITLE
jitsi-meet: 1.0.8792 -> 1.0.9365

### DIFF
--- a/nixos/modules/services/networking/jibri/default.nix
+++ b/nixos/modules/services/networking/jibri/default.nix
@@ -405,7 +405,7 @@ in
           '') cfg.xmppEnvironments
         ))
         + ''
-          ${pkgs.jdk11_headless}/bin/java -Djava.util.logging.config.file=${./logging.properties-journal} -Dconfig.file=${configFile} -jar ${pkgs.jibri}/opt/jitsi/jibri/jibri.jar --config /var/lib/jibri/jibri.json
+          ${getExe pkgs.jdk17_headless} -Dwebdriver.chrome.driver=${getExe pkgs.chromedriver} -Djava.util.logging.config.file=${./logging.properties-journal} -Dconfig.file=${configFile} -jar ${pkgs.jibri}/opt/jitsi/jibri/jibri.jar --config /var/lib/jibri/jibri.json
         '';
 
       environment.HOME = "/var/lib/jibri";

--- a/nixos/modules/services/networking/jibri/default.nix
+++ b/nixos/modules/services/networking/jibri/default.nix
@@ -91,7 +91,13 @@ let
 in
 {
   options.services.jibri = with types; {
-    enable = mkEnableOption "Jitsi BRoadcasting Infrastructure. Currently Jibri must be run on a host that is also running {option}`services.jitsi-meet.enable`, so for most use cases it will be simpler to run {option}`services.jitsi-meet.jibri.enable`";
+    enable = mkEnableOption "Jitsi BRoadcasting Infrastructure" // {
+      description = ''
+        Whether to enable Jibri.
+        Jibri must run on a host where {option}`services.jitsi-meet.enable` is enabled.
+        It installs a system-wide Chromium policy that disables security warnings for every Chromium user.
+      '';
+    };
     config = mkOption {
       type = format.type;
       default = { };
@@ -432,10 +438,6 @@ in
     environment.etc."chromium/policies/managed/managed_policies.json".text = builtins.toJSON {
       CommandLineFlagSecurityWarningsEnabled = false;
     };
-    warnings = [
-      "All security warnings for Chromium have been disabled. This is necessary for Jibri, but it also impacts all other uses of Chromium on this system."
-    ];
-
     boot = {
       extraModprobeConfig = ''
         options snd-aloop enable=1,1,1,1,1,1,1,1

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -422,6 +422,11 @@ let
         default = "en";
         description = "Default room language.";
       };
+      extraModules = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Additional modules to load on this MUC component.";
+      };
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -584,7 +589,15 @@ let
 
       ${lib.concatMapStrings (muc: ''
         Component ${toLua muc.domain} "muc"
-            modules_enabled = {${optionalString cfg.modules.mam ''"muc_mam",''}${optionalString muc.allowners_muc ''"muc_allowners",''}${optionalString muc.moderation ''"muc_moderation",''}${optionalString (lib.elem "muc_notifications" cfg.package.communityModules) ''"muc_notifications",''} }
+            modules_enabled = ${
+              toLua (
+                optional cfg.modules.mam "muc_mam"
+                ++ optional muc.allowners_muc "muc_allowners"
+                ++ optional muc.moderation "muc_moderation"
+                ++ optional (lib.elem "muc_notifications" cfg.package.communityModules) "muc_notifications"
+                ++ muc.extraModules
+              )
+            }
             name = ${toLua muc.name}
             restrict_room_creation = ${toLua muc.restrictRoomCreation}
             max_history_messages = ${toLua muc.maxHistoryMessages}

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -457,6 +457,20 @@ in
       "d '/var/lib/jitsi-meet' 0750 root jitsi-meet - -"
     ];
 
+    systemd.services.jicofo = mkIf (cfg.jicofo.enable && cfg.prosody.enable) {
+      partOf = [ "prosody.service" ];
+      after = [ "prosody.service" ];
+    };
+    systemd.services.jibri =
+      mkIf ((config.services.jibri.enable || cfg.jibri.enable) && cfg.prosody.enable)
+        {
+          partOf = [ "prosody.service" ];
+          after = [
+            "jicofo.service"
+            "prosody.service"
+          ];
+        };
+
     systemd.services.jitsi-meet-init-secrets = {
       wantedBy = [ "multi-user.target" ];
       before = [

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -262,6 +262,8 @@ in
           allowners_muc = cfg.prosody.allowners_muc;
           roomLocking = false;
           roomDefaultPublicJids = true;
+          # muc_meeting_id loads jitsi_permissions for moderator features
+          extraModules = [ "muc_meeting_id" ];
           extraConfig = ''
             restrict_room_creation = true
             storage = "memory"
@@ -273,6 +275,7 @@ in
           name = "Jitsi Meet Breakout MUC";
           roomLocking = false;
           roomDefaultPublicJids = true;
+          extraModules = [ "muc_meeting_id" ];
           extraConfig = ''
             restrict_room_creation = true
             storage = "memory"

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -449,7 +449,7 @@ in
         EnvironmentFile = [ "/var/lib/jitsi-meet/secrets-env" ];
         SupplementaryGroups = [ "jitsi-meet" ];
       };
-      reloadIfChanged = true;
+      reloadIfChanged = false;
     };
 
     users.groups.jitsi-meet = { };

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -323,6 +323,7 @@ in
       ];
       extraPluginPaths = [ "${pkgs.jitsi-meet-prosody}/share/prosody-plugins" ];
       extraConfig = lib.mkMerge [
+        (mkBefore "component_admins_as_room_owners = true")
         (mkAfter ''
           Component "focus.${cfg.hostName}" "client_proxy"
             target_address = "focus@auth.${cfg.hostName}"

--- a/nixos/tests/jibri.nix
+++ b/nixos/tests/jibri.nix
@@ -5,10 +5,15 @@
     maintainers = pkgs.lib.teams.jitsi.members;
   };
 
+  node.pkgsReadOnly = false;
+
   nodes.machine =
-    { config, pkgs, ... }:
+    { config, ... }:
     {
       virtualisation.memorySize = 5120;
+
+      # jitsi-meet inherits olm's known vulnerabilities
+      nixpkgs.config.permittedInsecurePackages = [ pkgs.jitsi-meet.name ];
 
       services.jitsi-meet = {
         enable = true;
@@ -54,7 +59,7 @@
     )
 
     assert '"busyStatus":"IDLE","health":{"healthStatus":"HEALTHY"' in machine.succeed(
-        "curl -X GET http://machine:2222/jibri/api/v1.0/health"
+        "curl -X GET http://localhost:2222/jibri/api/v1.0/health"
     )
     machine.succeed(
         """curl -H "Content-Type: application/json" -X POST http://localhost:2222/jibri/api/v1.0/startService -d '{"sessionId": "RecordTest","callParams":{"callUrlInfo":{"baseUrl": "https://machine","callName": "TestCall"}},"callLoginParams":{"domain": "recorder.machine", "username": "recorder", "password": "'"$(cat /var/lib/jitsi-meet/jibri-recorder-secret)"'" },"sinkType": "file"}'"""

--- a/nixos/tests/jitsi-meet.nix
+++ b/nixos/tests/jitsi-meet.nix
@@ -5,14 +5,19 @@
     maintainers = pkgs.lib.teams.jitsi.members;
   };
 
+  node.pkgsReadOnly = false;
+
   nodes = {
     client =
       { nodes, pkgs, ... }:
       {
       };
     server =
-      { config, pkgs, ... }:
+      { config, ... }:
       {
+        # jitsi-meet inherits olm's known vulnerabilities
+        nixpkgs.config.permittedInsecurePackages = [ pkgs.jitsi-meet.name ];
+
         services.jitsi-meet = {
           enable = true;
           hostName = "server";

--- a/nixos/tests/jitsi-meet.nix
+++ b/nixos/tests/jitsi-meet.nix
@@ -21,6 +21,7 @@
         services.jitsi-meet = {
           enable = true;
           hostName = "server";
+          jigasi.enable = true;
         };
         services.jitsi-videobridge.openFirewall = true;
 
@@ -58,6 +59,7 @@
     ''
       server.wait_for_unit("jitsi-videobridge2.service")
       server.wait_for_unit("jicofo.service")
+      server.wait_for_unit("jigasi.service")
       server.wait_for_unit("nginx.service")
       server.wait_for_unit("prosody.service")
 

--- a/pkgs/by-name/ji/jibri/package.nix
+++ b/pkgs/by-name/ji/jibri/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   dpkg,
-  jdk11_headless,
+  jdk17_headless,
   makeWrapper,
   writeText,
   xorg-server,
@@ -24,10 +24,10 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jibri";
-  version = "8.0-183-g7b406bf";
+  version = "8.0-205-g206e038";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/jibri_${finalAttrs.version}-1_all.deb";
-    sha256 = "QF7BkLizAsEzjC6PdTyPFAFf82AzukTnxHxLHyz5Kco=";
+    hash = "sha256-DJyBNjCgesg0P1SSU8mi3vVN9TK5sU/eLS1PLzEsIRE=";
   };
 
   dontBuild = true;
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     cat '${xorgModulePaths}' >> $out/etc/jitsi/jibri/xorg-video-dummy.conf
 
-    makeWrapper ${jdk11_headless}/bin/java $out/bin/jibri --add-flags "-jar $out/opt/jitsi/jibri/jibri.jar"
+    makeWrapper ${lib.getExe jdk17_headless} $out/bin/jibri --add-flags "-jar $out/opt/jitsi/jibri/jibri.jar"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ji/jicofo/package.nix
+++ b/pkgs/by-name/ji/jicofo/package.nix
@@ -7,16 +7,13 @@
   nixosTests,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "jicofo";
-  version = "1.0-1153";
+  version = "1.0-1189";
   src = fetchurl {
-    url = "https://download.jitsi.org/stable/jicofo_${version}-1_all.deb";
-    sha256 = "tBvaXyRqNg8VeIy3aI1HbrZNlelsYowLOVlsXyap+gA=";
+    url = "https://download.jitsi.org/stable/jicofo_${finalAttrs.version}-1_all.deb";
+    hash = "sha256-c6YQT/okrB/PZmD7jHPte+qWpevfKqnXm4oAtTVjm7s=";
   };
-in
-stdenv.mkDerivation {
-  inherit pname version src;
 
   dontBuild = true;
 
@@ -52,4 +49,4 @@ stdenv.mkDerivation {
     teams = [ lib.teams.jitsi ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ji/jigasi/package.nix
+++ b/pkgs/by-name/ji/jigasi/package.nix
@@ -3,20 +3,17 @@
   stdenv,
   fetchurl,
   dpkg,
-  jdk11,
+  jdk17_headless,
   nixosTests,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "jigasi";
-  version = "1.1-395-g3bb4143";
+  version = "1.1-412-ge9a3acc";
   src = fetchurl {
-    url = "https://download.jitsi.org/stable/jigasi_${version}-1_all.deb";
-    hash = "sha256-kBUo9TZZs3/OUrV1t813jk8Pf2vNrKEP7hZL2L2oMNE=";
+    url = "https://download.jitsi.org/stable/jigasi_${finalAttrs.version}-1_all.deb";
+    hash = "sha256-NlJxfUyUGUqyk8rQAtykZhyAhMapmTvca42HaG1MRJU=";
   };
-in
-stdenv.mkDerivation {
-  inherit pname version src;
 
   nativeBuildInputs = [ dpkg ];
 
@@ -25,7 +22,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     substituteInPlace usr/share/jigasi/jigasi.sh \
-      --replace-fail "exec java" "exec ${jdk11}/bin/java"
+      --replace-fail "exec java" "exec ${lib.getExe jdk17_headless}"
 
     mkdir -p $out/{share,bin}
     mv usr/share/jigasi $out/share/
@@ -49,4 +46,4 @@ stdenv.mkDerivation {
     teams = [ lib.teams.jitsi ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ji/jitsi-meet-prosody/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet-prosody/package.nix
@@ -8,10 +8,10 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jitsi-meet-prosody";
-  version = "1.0.8737";
+  version = "1.0.9365";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/jitsi-meet-prosody_${finalAttrs.version}-1_all.deb";
-    sha256 = "fZs1ng1mtxwXgJAQqxAlrNrqUQJc9fGlxJKwuTJLENc=";
+    hash = "sha256-tgRYD4Ip+QAbOKCFTXVbou5Qv+Us+pNtzi5xlT/bFIc=";
   };
 
   nativeBuildInputs = [ dpkg ];

--- a/pkgs/by-name/ji/jitsi-meet/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet/package.nix
@@ -15,21 +15,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jitsi-meet";
-  version = "1.0.8792";
+  version = "1.0.9365";
 
   src = fetchFromGitHub {
     owner = "jitsi";
     repo = "jitsi-meet";
     tag = lib.last (lib.splitVersion finalAttrs.version);
-    hash = "sha256-K4Xrse1kpNqlUChbQnAjP5lRCRuDfJKiN/022tCmMVQ=";
+    hash = "sha256-gAXY40jvQjGhitbpWjJ+C8GZwuRu/zyJw2NN5yf/l6o=";
   };
 
   env = {
     makeFlags = "source-package";
     makeCacheWritable = true;
+    forceGitDeps = true;
     npmDeps = fetchNpmDeps {
       inherit (finalAttrs) src;
-      hash = "sha256-2NPfr3gskHz9zSGs//uzyCCuE+CZ295hhitDPlS9xuY=";
+      hash = "sha256-5fGaX8VFCCMkTeQuhFPwd9W7cBNVML/bVYLODq07s5w=";
+      forceGitDeps = true;
     };
   };
 

--- a/pkgs/by-name/ji/jitsi-videobridge/package.nix
+++ b/pkgs/by-name/ji/jitsi-videobridge/package.nix
@@ -9,16 +9,13 @@
   nixosTests,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "jitsi-videobridge2";
-  version = "2.3-249-g9a2123ad4";
+  version = "2.3-307-g4bb0aead1";
   src = fetchurl {
-    url = "https://download.jitsi.org/stable/jitsi-videobridge2_${version}-1_all.deb";
-    sha256 = "b8hYuDyweRLAagaehHMzC2/XjZHNlxMchM8za8zPtj4=";
+    url = "https://download.jitsi.org/stable/jitsi-videobridge2_${finalAttrs.version}-1_all.deb";
+    hash = "sha256-5im9MH8xwJMH3PklZX/Tli641HmmxV6df5jWfsBYxDo=";
   };
-in
-stdenv.mkDerivation {
-  inherit pname version src;
 
   dontBuild = true;
 
@@ -67,4 +64,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     mainProgram = "jitsi-videobridge";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

jitsi hasn't been updated for a very long time... i wanted to set it up for grenoble nix user group meetup streaming

i have tried this in my deployment at https://meet.ysun.co/ with https://github.com/stepbrobd/inc/commit/058eb9dedd2e2a9869101e60f2519c1812d562a2 and this is a PR upstreaming my local changes

superseds:
- https://github.com/NixOS/nixpkgs/pull/449276
- https://github.com/NixOS/nixpkgs/pull/548655
- https://github.com/NixOS/nixpkgs/pull/548654
- https://github.com/NixOS/nixpkgs/pull/448775
- https://github.com/NixOS/nixpkgs/pull/548651
- https://github.com/NixOS/nixpkgs/pull/447966
- https://github.com/NixOS/nixpkgs/pull/448130
- https://github.com/NixOS/nixpkgs/pull/548649
- https://github.com/NixOS/nixpkgs/pull/548652

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
