### PR TITLE
fluffychat: 2.8.0 -> 2.9.4

### DIFF
--- a/pkgs/by-name/fl/fluffychat/package.nix
+++ b/pkgs/by-name/fl/fluffychat/package.nix
@@ -39,13 +39,13 @@ in
 flutter344.buildFlutterApplication (
   rec {
     pname = "fluffychat-${targetFlutterPlatform}";
-    version = "2.8.0";
+    version = "2.9.4";
 
     src = fetchFromGitHub {
       owner = "krille-chan";
       repo = "fluffychat";
       tag = "v${version}";
-      hash = "sha256-+2srYuGNsCvxc89gq3zHgeCHrWTid7Oqtdno/Q/9hgk=";
+      hash = "sha256-nL0zyOg3pXbgg9hkXzq6B2igmUQ5jkTVlVi7k8TLggA=";
     };
 
     inherit pubspecLock;

--- a/pkgs/by-name/fl/fluffychat/pubspec.lock.json
+++ b/pkgs/by-name/fl/fluffychat/pubspec.lock.json
@@ -4,41 +4,41 @@
       "dependency": "transitive",
       "description": {
         "name": "_fe_analyzer_shared",
-        "sha256": "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d",
+        "sha256": "1dd467c7e56541bea70bbd35d537e3aa12dfba81f39e2a75bb6a61fc5595985b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "93.0.0"
+      "version": "97.0.0"
     },
     "analysis_server_plugin": {
       "dependency": "transitive",
       "description": {
         "name": "analysis_server_plugin",
-        "sha256": "5f3920acbd5765764ec9ef6c5bbdd102015424281232ee4fb4f5431c87abb4eb",
+        "sha256": "0dfddfb7e765a3d4583c185a0b755f59844c862affc88d2496ceac7a1a3d3659",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.7"
+      "version": "0.3.11"
     },
     "analyzer": {
       "dependency": "transitive",
       "description": {
         "name": "analyzer",
-        "sha256": "de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b",
+        "sha256": "041602214e3ec5a02ba85c08fe8e381aa25ac5367db17d03fbb6d22d851d4bba",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.0.1"
+      "version": "11.0.0"
     },
     "analyzer_plugin": {
       "dependency": "transitive",
       "description": {
         "name": "analyzer_plugin",
-        "sha256": "7df504f0c9d6891bacc9f73a5a8c5f6fe4fc49c90ec8e3379916372906ba0b32",
+        "sha256": "06d68a8c9e7302fa44c45aba77d792b6926430a47e0cf82abf6b90436a70d9f4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.14.1"
+      "version": "0.14.5"
     },
     "ansicolor": {
       "dependency": "transitive",
@@ -84,11 +84,11 @@
       "dependency": "transitive",
       "description": {
         "name": "audio_session",
-        "sha256": "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b",
+        "sha256": "f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.3"
+      "version": "0.2.4"
     },
     "badges": {
       "dependency": "direct main",
@@ -284,21 +284,31 @@
       "dependency": "transitive",
       "description": {
         "name": "coverage",
-        "sha256": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
+        "sha256": "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.15.0"
+      "version": "1.15.1"
+    },
+    "crop_image": {
+      "dependency": "direct main",
+      "description": {
+        "name": "crop_image",
+        "sha256": "27cbce1685a595efee62caab81c98b49b636f765c1da86353f58f5b2bf2775d8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.17"
     },
     "cross_file": {
       "dependency": "direct main",
       "description": {
         "name": "cross_file",
-        "sha256": "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937",
+        "sha256": "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.5+2"
+      "version": "0.3.5+4"
     },
     "crypto": {
       "dependency": "transitive",
@@ -334,11 +344,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "dart_code_linter",
-        "sha256": "44cce8527a2094201067b50aed97778930638cc43e8bb3cb0b40a90c36fb9c84",
+        "sha256": "83d8739948c5d1538240b80c26d94d1de648c143d7c26bfe80f4e3215e4b5096",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.1.6"
+      "version": "4.1.9"
     },
     "dart_earcut": {
       "dependency": "transitive",
@@ -384,11 +394,11 @@
       "dependency": "transitive",
       "description": {
         "name": "dbus",
-        "sha256": "d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270",
+        "sha256": "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.12"
+      "version": "0.7.14"
     },
     "desktop_drop": {
       "dependency": "direct main",
@@ -434,21 +444,21 @@
       "dependency": "direct main",
       "description": {
         "name": "dynamic_color",
-        "sha256": "43a5a6679649a7731ab860334a5812f2067c2d9ce6452cf069c5e0c25336c17c",
+        "sha256": "4aeb76de323e8eb660bab5557d826ad7ebbf1434a598f0c6aa8a11a9696a6757",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.8.1"
+      "version": "1.9.0"
     },
     "emoji_picker_flutter": {
       "dependency": "direct main",
       "description": {
         "name": "emoji_picker_flutter",
-        "sha256": "984d3e9b9cf3175df9a868ce4a2d9611491e80e5d3b8e2b1e8991a4998972885",
+        "sha256": "47794613fc533225bb506885e378e5b2c7097af06acbfd409a0bab444613a51e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.4.0"
+      "version": "4.5.3"
     },
     "fake_async": {
       "dependency": "transitive",
@@ -514,11 +524,11 @@
       "dependency": "transitive",
       "description": {
         "name": "file_selector_android",
-        "sha256": "89243030ea4b3463fb402b44d5eeacc4ccb1c46a88870cb2a5080d693200c1ed",
+        "sha256": "6a26687fa65cbc28a5345c7ae6f227e89f0b47740978a4c475b1a625da7a331b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.2+6"
+      "version": "0.5.2+8"
     },
     "file_selector_ios": {
       "dependency": "transitive",
@@ -564,11 +574,11 @@
       "dependency": "transitive",
       "description": {
         "name": "file_selector_web",
-        "sha256": "c4c0ea4224d97a60a7067eca0c8fd419e708ff830e0c83b11a48faf566cec3e7",
+        "sha256": "73181fbc5257776d8ecaa6a94ab3c8e920ad143b9132a6d984a9271dfc6928d3",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.9.4+2"
+      "version": "0.9.5"
     },
     "file_selector_windows": {
       "dependency": "transitive",
@@ -606,11 +616,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_foreground_task",
-        "sha256": "fc5c01a5e1b8f7bb51d0c737714f0c50440dbdf1aeddc5f8cbba313aa6fd4856",
+        "sha256": "0dad7e6a4ac57aeb0e680e35ec7ae997f1a2b8579fdb85b16dd16e299b634f4f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.2.2"
+      "version": "10.0.0"
     },
     "flutter_launcher_icons": {
       "dependency": "direct dev",
@@ -646,11 +656,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_local_notifications",
-        "sha256": "a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70",
+        "sha256": "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "22.0.1"
+      "version": "22.3.0"
     },
     "flutter_local_notifications_linux": {
       "dependency": "transitive",
@@ -666,11 +676,11 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_local_notifications_platform_interface",
-        "sha256": "ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814",
+        "sha256": "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "12.0.0"
+      "version": "12.2.0"
     },
     "flutter_local_notifications_web": {
       "dependency": "transitive",
@@ -712,51 +722,51 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_new_badger",
-        "sha256": "d3742ace8009663db1ac6ba0377b092f479c35deb33e05514ba05cc0b0a5aaaa",
+        "sha256": "586d4ea87d687d8e2bb3e9972381b4b0bedcd0b2b9fd9d13263dfd3398740746",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.1"
+      "version": "2.0.0"
     },
     "flutter_plugin_android_lifecycle": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_plugin_android_lifecycle",
-        "sha256": "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0",
+        "sha256": "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.34"
+      "version": "2.0.35"
     },
     "flutter_rust_bridge": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_rust_bridge",
-        "sha256": "37ef40bc6f863652e865f0b2563ea07f0d3c58d8efad803cc01933a4b2ee067e",
+        "sha256": "e87d6b9ee934dcd24a128ccb2bd91905d2d5fe5c06245d6a8f5477d4907a437a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.11.1"
+      "version": "2.12.0"
     },
     "flutter_secure_storage": {
       "dependency": "direct main",
       "description": {
         "name": "flutter_secure_storage",
-        "sha256": "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e",
+        "sha256": "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.3.1"
+      "version": "11.0.0"
     },
     "flutter_secure_storage_darwin": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_secure_storage_darwin",
-        "sha256": "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149",
+        "sha256": "ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.2"
+      "version": "0.4.0"
     },
     "flutter_secure_storage_linux": {
       "dependency": "transitive",
@@ -818,11 +828,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_vodozemac",
-        "sha256": "ef4c3580a7f2fe8eebb7602c6cba593a42b4a5e5466c372a022f77ccc14914a5",
+        "sha256": "7e893533d757501eba4aedeecb54586ac2f3fa5e4f28de3e5723b383d5293d7e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.0"
+      "version": "0.7.1"
     },
     "flutter_web_auth_2": {
       "dependency": "direct main",
@@ -930,11 +940,11 @@
       "dependency": "transitive",
       "description": {
         "name": "geolocator_platform_interface",
-        "sha256": "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67",
+        "sha256": "cdb082e4f048b69da244117b7914cc60d2a8897546ffaa4f2529c786ded7aee2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.2.6"
+      "version": "4.2.8"
     },
     "geolocator_web": {
       "dependency": "transitive",
@@ -1090,11 +1100,11 @@
       "dependency": "transitive",
       "description": {
         "name": "image_picker_android",
-        "sha256": "d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f",
+        "sha256": "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.8.13+17"
+      "version": "0.8.13+19"
     },
     "image_picker_for_web": {
       "dependency": "transitive",
@@ -1426,11 +1436,11 @@
       "dependency": "direct main",
       "description": {
         "name": "matrix",
-        "sha256": "25ab47abd6a98c5c1affd1c735b83dcd01844f49c60483d679ffb9463f0a3f61",
+        "sha256": "3d6c6b6dabbcca8e16a4ebfb19baddcd54a15654909d4b6a39fbc657f6727d01",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.1.0"
+      "version": "10.0.1"
     },
     "meta": {
       "dependency": "transitive",
@@ -1466,11 +1476,11 @@
       "dependency": "direct main",
       "description": {
         "name": "native_imaging",
-        "sha256": "ced7acb18b80a431578c9068eb9c3ee75f8df39491e8adaf471635bac282d651",
+        "sha256": "33efb2fb86f7e04f917969a5f61618b89765dd324a3683251d32349ff6338a2b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.4.0"
+      "version": "0.5.0"
     },
     "native_toolchain_c": {
       "dependency": "transitive",
@@ -1486,11 +1496,11 @@
       "dependency": "transitive",
       "description": {
         "name": "native_toolchain_cmake",
-        "sha256": "cd4865568c57f03c7ab1f138cc5032c5f77825d27083d6f5a3e9bbb3e8014a87",
+        "sha256": "de90e8952bad0684bdcff4d674c53d961f5cd1fdcf3a0255a669a35986c4ac1d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.5"
+      "version": "0.2.7"
     },
     "nested": {
       "dependency": "transitive",
@@ -1546,11 +1556,11 @@
       "dependency": "direct main",
       "description": {
         "name": "package_info_plus",
-        "sha256": "f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad",
+        "sha256": "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.2.0"
+      "version": "10.2.1"
     },
     "package_info_plus_platform_interface": {
       "dependency": "transitive",
@@ -1623,7 +1633,7 @@
       "version": "2.3.1"
     },
     "path_provider_foundation": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "path_provider_foundation",
         "sha256": "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699",
@@ -1636,21 +1646,21 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_linux",
-        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "sha256": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "path_provider_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_platform_interface",
-        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "sha256": "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     "path_provider_windows": {
       "dependency": "transitive",
@@ -1876,11 +1886,11 @@
       "dependency": "transitive",
       "description": {
         "name": "record_linux",
-        "sha256": "305526af0560866a0cc4219aa3726ef8541f819e14bd5f65b73ffdb7dc5911be",
+        "sha256": "b7484fdaf1f6d291543b9cf615e78096662b02df68d7a4728b13f352bde58d27",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.0"
+      "version": "2.1.1"
     },
     "record_macos": {
       "dependency": "transitive",
@@ -1926,11 +1936,11 @@
       "dependency": "transitive",
       "description": {
         "name": "record_windows",
-        "sha256": "39ca03e7ae4df5e2512bc3c92b0ef9a7b148d9295ae8ac92df6beb4daf939d94",
+        "sha256": "9cedfacee553a02b48977a5e1d74bf08a36cc5647eba56fb83e57da20552f443",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.0"
+      "version": "2.2.2"
     },
     "retry": {
       "dependency": "transitive",
@@ -1966,51 +1976,51 @@
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever",
-        "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+        "sha256": "ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_linux": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_linux",
-        "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "sha256": "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_macos": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_macos",
-        "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "sha256": "a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_platform_interface",
-        "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "sha256": "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "screen_retriever_windows": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_windows",
-        "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "sha256": "dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.2"
     },
     "scroll_to_index": {
       "dependency": "direct main",
@@ -2036,21 +2046,21 @@
       "dependency": "direct main",
       "description": {
         "name": "share_plus",
-        "sha256": "9eee8283462d91a7a1c8bdb67d08874abd75a2f8fae3bc0ca033035e375fb3d8",
+        "sha256": "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "13.2.0"
+      "version": "13.3.0"
     },
     "share_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "share_plus_platform_interface",
-        "sha256": "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9",
+        "sha256": "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.1.0"
+      "version": "7.2.0"
     },
     "shared_preferences": {
       "dependency": "direct main",
@@ -2066,11 +2076,11 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53",
+        "sha256": "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.23"
+      "version": "2.4.27"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
@@ -2222,41 +2232,31 @@
       "dependency": "transitive",
       "description": {
         "name": "sqflite_common",
-        "sha256": "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465",
+        "sha256": "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.8"
+      "version": "2.5.11"
     },
     "sqflite_common_ffi": {
       "dependency": "direct main",
       "description": {
         "name": "sqflite_common_ffi",
-        "sha256": "8d7b8749a516cbf6e9057f9b480b716ad14fc4f3d3873ca6938919cc626d9025",
+        "sha256": "5ccd38136edb9beb3213f6927775d52db70dfdadcdb28dad1f625ca9f2b9824f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.7+1"
-    },
-    "sqlcipher_flutter_libs": {
-      "dependency": "direct main",
-      "description": {
-        "name": "sqlcipher_flutter_libs",
-        "sha256": "dd1fcc74d5baf3c36ad53e2652b2d06c9f8747494a3ccde0076e88b159dfe622",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.6.8"
+      "version": "2.4.2"
     },
     "sqlite3": {
       "dependency": "transitive",
       "description": {
         "name": "sqlite3",
-        "sha256": "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2",
+        "sha256": "c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.9.4"
+      "version": "3.5.0"
     },
     "stack_trace": {
       "dependency": "transitive",
@@ -2322,11 +2322,11 @@
       "dependency": "transitive",
       "description": {
         "name": "synchronized",
-        "sha256": "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5",
+        "sha256": "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.4.0+1"
+      "version": "3.4.1"
     },
     "term_glyph": {
       "dependency": "transitive",
@@ -2372,11 +2372,11 @@
       "dependency": "transitive",
       "description": {
         "name": "timezone",
-        "sha256": "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b",
+        "sha256": "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.11.0"
+      "version": "0.11.1"
     },
     "typed_data": {
       "dependency": "transitive",
@@ -2512,11 +2512,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c",
+        "sha256": "b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.30"
+      "version": "6.3.32"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
@@ -2582,11 +2582,11 @@
       "dependency": "transitive",
       "description": {
         "name": "uuid",
-        "sha256": "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489",
+        "sha256": "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.5.3"
+      "version": "4.6.0"
     },
     "vector_math": {
       "dependency": "transitive",
@@ -2622,11 +2622,11 @@
       "dependency": "transitive",
       "description": {
         "name": "video_player_android",
-        "sha256": "5121de08444d00363efdda630a69ad4d27a208a9f7586482d4909a44a1cdbc63",
+        "sha256": "e229676f8fade3e0124482495aaa2b548872cc4018b6268adfca4868be16aa74",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.11.0"
+      "version": "2.12.0"
     },
     "video_player_avfoundation": {
       "dependency": "transitive",
@@ -2672,31 +2672,31 @@
       "dependency": "transitive",
       "description": {
         "name": "vodozemac",
-        "sha256": "bbe7dd31d7f623e2aeedb92e4b71a8b519e6109ce1e2911b5a220f6752b65cda",
+        "sha256": "7726f6c53bec7458b83820500b408a7d2d1804aae018c81bafae918d1a179313",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.0"
+      "version": "0.7.0"
     },
     "wakelock_plus": {
       "dependency": "direct main",
       "description": {
         "name": "wakelock_plus",
-        "sha256": "824c5bba0f800e86d32e57d3d1843c531f090005cc89d9a837933e6601093d53",
+        "sha256": "7253bca0fcf40d8413ddfcf4d2a1fa0a82475e79be25a4f2c564b695c9351486",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.6.1"
+      "version": "1.7.0"
     },
     "wakelock_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "wakelock_plus_platform_interface",
-        "sha256": "b13f99e992e7ae6a152e16c5559d3c07ff445b13330192662494e614ca3e7d7b",
+        "sha256": "0618d1799f0b28bcf98255b4ee8313e6fc4d38589dc4ee5fe5840d57d1aff6da",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.5.1"
+      "version": "1.6.0"
     },
     "watcher": {
       "dependency": "transitive",
@@ -2812,21 +2812,21 @@
       "dependency": "transitive",
       "description": {
         "name": "window_manager",
-        "sha256": "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd",
+        "sha256": "05c231fd7b23d2380f14c5cc10b7b93d60d4fa4a2fb4e0f032de27e44b5560e9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.1"
+      "version": "0.5.2"
     },
     "window_to_front": {
       "dependency": "transitive",
       "description": {
         "name": "window_to_front",
-        "sha256": "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee",
+        "sha256": "14fad8984db4415e2eeb30b04bb77140b180e260d6cb66b26de126a8657a9241",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.0.3"
+      "version": "0.0.4"
     },
     "wkt_parser": {
       "dependency": "transitive",

--- a/pkgs/development/compilers/dart/package-source-builders/flutter_vodozemac/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/flutter_vodozemac/default.nix
@@ -20,6 +20,7 @@ let
         _0_3_0 = "sha256-eKKrcroV2yl/FV2WmgZWFPO5MPAGz0xCvpr0fgIuGZ4=";
         _0_4_1 = "sha256-eKKrcroV2yl/FV2WmgZWFPO5MPAGz0xCvpr0fgIuGZ4=";
         _0_5_0 = "sha256-eKKrcroV2yl/FV2WmgZWFPO5MPAGz0xCvpr0fgIuGZ4=";
+        _0_7_1 = "sha256-KsOyQyz9TqcmkHwuf3iA0NQU+pOOtoBVKv1AxZCjxnw=";
       }
       .${"_" + (lib.replaceStrings [ "." ] [ "_" ] version)} or (throw ''
         Unsupported version of pub 'flutter_vodozemac': '${version}'

--- a/pkgs/development/compilers/dart/package-source-builders/sqlite3/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/sqlite3/default.nix
@@ -2,11 +2,40 @@
   stdenv,
   lib,
   writeScript,
+  fetchurl,
   sqlite,
 }:
-
 { version, src, ... }:
-
+let
+  sqlcipher =
+    let
+      system-alias = {
+        x86_64-linux = "x64.linux";
+      };
+    in
+    stdenv.mkDerivation {
+      name = "libsqlcipher.so";
+      src = fetchurl {
+        url = "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-${version}/libsqlcipher.${
+          system-alias.${stdenv.hostPlatform.system} or (throw ''
+            Unsupported system for pub 'sqlite3' ('sqlcipher' dependency)
+            Please add the system alias mapping if it exists, note that you will also have to add used version hashes for that system below'')
+        }.so";
+        sha256 =
+          {
+            _3_5_0-x86_64-linux = "sha256-GH+3MhYXTwWD7WmEHzc8wecYcaOcCXsy93UWiEjh6Eo=";
+          }
+          .${"_" + (lib.replaceStrings [ "." ] [ "_" ] version) + "-" + stdenv.hostPlatform.system}
+            or (throw ''
+              Unsupported version of pub 'sqlite3' ('sqlcipher' dependency '${version}')
+              Please add sha256 here. If the sha256
+              is the same with existing versions, add an alias here.
+            '');
+      };
+      unpackPhase = ":";
+      installPhase = "mkdir -p $out/lib && cp $src $out/lib/libsqlcipher.so";
+    };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sqlite3";
   inherit version src;
@@ -15,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   setupHook = writeScript "${finalAttrs.pname}-setup-hook" ''
     sqliteFixupHook() {
       runtimeDependencies+=('${lib.getLib sqlite}')
+      ${lib.optionalString (lib.versionAtLeast version "3.5.0") "runtimeDependencies+=('${lib.getLib sqlcipher}')"}
     }
 
     preFixupHooks+=(sqliteFixupHook)
@@ -25,6 +55,9 @@ stdenv.mkDerivation (finalAttrs: {
       ''
         substituteInPlace lib/src/hook/compile/description.dart \
           --replace-fail "return fromGitHub(LibraryType.sqlite3);" "return LookupSystem('sqlite3');"
+
+        substituteInPlace lib/src/hook/compile/description.dart \
+          --replace-fail "return fromGitHub(LibraryType.sqlcipher);" "return LookupSystem('sqlcipher');"
       ''
     else
       lib.optionalString (lib.versionAtLeast version "3.2.0") ''


### PR DESCRIPTION
Updates fluffychat, a matrix client, from v2.8.0 to the newest currently available version and adds extra build support features and dependency versions as needed.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- add flutter_vodozemac 0.7.1 source hash as fluffychat needs that (see https://github.com/NixOS/nixpkgs/pull/553485)
  - squashed into this commit since it is a very small change to avoid having to hold off this pr longer
- update sqlite3 build support to support fluffychat using the sqlcipher override
  - sqlcipher from nixpkgs was tried instead of fetching the prebuild source however fluffychat would build but segfault at startup using that. I will try to get it working if i have the time, but for now i think it is more important to get the package updated and this solution works.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `0f64b395be5d86d1779b15496ce3aae316d39e53`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>fluffychat</li>
    <li>fluffychat-web</li>
    <li>mhabit</li>
    <li>plezy</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
