### PR TITLE
otb: fix build with gdal 3.13

### DIFF
--- a/pkgs/by-name/ot/otb/2-otb-gdal-cslconstlist.diff
+++ b/pkgs/by-name/ot/otb/2-otb-gdal-cslconstlist.diff
@@ -1,0 +1,78 @@
+diff -ru a/Modules/Core/IO/IOGDAL/src/otbGDALImageIO.cxx b/Modules/Core/IO/IOGDAL/src/otbGDALImageIO.cxx
+--- a/Modules/Core/IO/IOGDAL/src/otbGDALImageIO.cxx
++++ b/Modules/Core/IO/IOGDAL/src/otbGDALImageIO.cxx
+@@ -278,7 +278,7 @@
+ bool GDALImageIO::GetSubDatasetInfo(std::vector<std::string>& names, std::vector<std::string>& desc)
+ {
+   // Note: we assume that the subdatasets are in order : SUBDATASET_ID_NAME, SUBDATASET_ID_DESC, SUBDATASET_ID+1_NAME, SUBDATASET_ID+1_DESC
+-  char** papszMetadata;
++  CSLConstList papszMetadata;
+   papszMetadata = m_Dataset->GetDataSet()->GetMetadata("SUBDATASETS");
+ 
+   // Have we find some dataSet ?
+@@ -436,7 +436,7 @@
+   {
+     // this happen in the case of a hdf file with SUBDATASETS
+     // Note: we assume that the datasets are in order
+-    char** papszMetadata;
++    CSLConstList papszMetadata;
+     papszMetadata = m_Dataset->GetDataSet()->GetMetadata("SUBDATASETS");
+     // TODO: we might want to keep the list of names somewhere, at least the number of datasets
+     std::vector<std::string> names;
+@@ -741,7 +741,7 @@
+ 
+   if (m_NumberOfDimensions == 3)
+     m_Spacing[2] = 1;
+-  char** papszMetadata = dataset->GetMetadata(nullptr);
++  CSLConstList papszMetadata = dataset->GetMetadata(nullptr);
+ 
+   /* -------------------------------------------------------------------- */
+   /*      Report general info.                                            */
+diff -ru a/Modules/Core/IO/IOGDAL/test/otbGDALImageIOTestWriteMetadata.cxx b/Modules/Core/IO/IOGDAL/test/otbGDALImageIOTestWriteMetadata.cxx
+--- a/Modules/Core/IO/IOGDAL/test/otbGDALImageIOTestWriteMetadata.cxx
++++ b/Modules/Core/IO/IOGDAL/test/otbGDALImageIOTestWriteMetadata.cxx
+@@ -457,7 +457,7 @@
+ 
+   // Check the driver used
+   GDALDriver* poDriver;
+-  char**      papszMetadata;
++  CSLConstList papszMetadata;
+ 
+   GDALAllRegister();
+   poDriver = GetGDALDriverManager()->GetDriverByName(pszFormat);
+diff -ru a/Modules/Core/Metadata/src/otbCosmoImageMetadataInterface.cxx b/Modules/Core/Metadata/src/otbCosmoImageMetadataInterface.cxx
+--- a/Modules/Core/Metadata/src/otbCosmoImageMetadataInterface.cxx
++++ b/Modules/Core/Metadata/src/otbCosmoImageMetadataInterface.cxx
+@@ -50,7 +50,7 @@
+   std::vector<std::map<std::string, std::string> > metadataBands;
+   GDALDataset * dataset = static_cast<GDALDataset*>(GDALOpen(file.c_str(), GA_ReadOnly));
+   // Metadata for dataset
+-  char** papszMetadata = dataset->GetMetadata(nullptr);
++  CSLConstList papszMetadata = dataset->GetMetadata(nullptr);
+   for (int cpt = 0; papszMetadata[cpt] != nullptr; ++cpt)
+     {
+     std::string key, value;
+diff -ru a/Modules/ThirdParty/GDAL/gdalCreateCopyTest.cxx b/Modules/ThirdParty/GDAL/gdalCreateCopyTest.cxx
+--- a/Modules/ThirdParty/GDAL/gdalCreateCopyTest.cxx
++++ b/Modules/ThirdParty/GDAL/gdalCreateCopyTest.cxx
+@@ -43,7 +43,7 @@
+   papszCreateOptions = CSLAddString( papszCreateOptions, argv[4] );
+   }
+ 
+-  char **papszMetadata;
++  CSLConstList papszMetadata;
+   papszMetadata = GDALGetMetadata( hDriver, NULL );
+   if( CSLFetchBoolean( papszMetadata, GDAL_DCAP_CREATECOPY, FALSE ) )
+     printf( "Driver %s supports CreateCopy() method.\n", pszFormat );
+diff -ru a/Modules/ThirdParty/GDAL/gdalCreateTest.cxx b/Modules/ThirdParty/GDAL/gdalCreateTest.cxx
+--- a/Modules/ThirdParty/GDAL/gdalCreateTest.cxx
++++ b/Modules/ThirdParty/GDAL/gdalCreateTest.cxx
+@@ -28,7 +28,7 @@
+ int main(int argc, char * argv[])
+ {
+   const char *pszFormat = argv[1];
+-  char **papszMetadata;
++  CSLConstList papszMetadata;
+ 
+ 	GDALAllRegister();
+ 

--- a/pkgs/by-name/ot/otb/package.nix
+++ b/pkgs/by-name/ot/otb/package.nix
@@ -238,6 +238,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./1-otb-swig-include-itk.diff
+    # GDAL >= 3.13 returns CSLConstList from GDALGetMetadata, which no longer converts to char**.
+    ./2-otb-gdal-cslconstlist.diff
   ];
 
   postPatch = ''


### PR DESCRIPTION
OTB is currently broken on `master`:

```
$ nix build .#otb
error: build of '/nix/store/9cfha8k77r323vwigfbiqm5gq027w90r-otb-10.0-unstable-2025-12-11.drv' on 'ssh...' failed: Cannot build '/nix/store/9cfha8k77r323vwigfbiqm5gq027w90r-otb-10.0-unstable-2025-12-11.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/w1gz6j5r0dl1bkzv8mg4i7wvxw8na5zv-otb-10.0-unstable-2025-12-11
       Last 25 log lines:
       > 
       > -- Found Boost components: unit_test_framework
       > -- Found GDAL: /nix/store/r03kr3gn9srv03r6nqmrhlczxjmw853h-gdal-3.13.2/lib/libgdal.so (found version "3.13.2")
       > -- Performing Test GDAL_VERSION
       > -- Performing Test GDAL_VERSION - Success
       > -- Performing Test COMPILE_GDAL_HAS_OGR - Success
       > -- Performing Test GDAL_FORMATS_LIST
       > -- Performing Test GDAL_FORMATS_LIST - Success
       > -- Performing Test GDAL_HAS_JPEG
       > -- Performing Test GDAL_HAS_JPEG - Success
       > -- Performing Test GDAL_HAS_GTiff
       > -- Performing Test GDAL_HAS_GTiff - Success
       > -- Performing Test GDAL_CAN_CREATE_GTiff
       > Setting GDAL_CONFIG_CHECKING to ON. (all GDAL tests will run again)
       > CMake Error at Modules/ThirdParty/GDAL/otb-module-init.cmake:51 (message):
       >   Compiling Test GDAL_CAN_CREATE_GTiff - Failed
       >
       > Call Stack (most recent call first):
       >   Modules/ThirdParty/GDAL/otb-module-init.cmake:66 (error_message)
       >   Modules/ThirdParty/GDAL/otb-module-init.cmake:125 (gdal_try_run)
       >   CMake/OTBModuleEnablement.cmake:290 (include)
       >   CMakeLists.txt:288 (include)
       >
       > 
       > -- Configuring incomplete, errors occurred!
       For full logs, run:
         nix log /nix/store/9cfha8k77r323vwigfbiqm5gq027w90r-otb-10.0-unstable-2025-12-11.drv
```

This branch fixes the errors. Looks like the update here https://github.com/NixOS/nixpkgs/pull/544627 or maybe even earlier broke `otb`, which builds without `-fpermissive`. I kept that convention and just replaced the few places where the updated interface doesn't match usage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
