### PR TITLE
python3Packages.vllm: tidy dependencies

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -35,21 +35,15 @@
 
   # dependencies
   aioprometheus,
-  apache-tvm-ffi,
-  amd-aiter,
-  amd-quark,
-  amdsmi,
   anthropic,
   bitsandbytes,
   blake3,
   cachetools,
   cbor2,
   compressed-tensors,
-  datasets,
   depyf,
   einops,
   fastapi,
-  gguf,
   grpcio,
   grpcio-reflection,
   ijson,
@@ -73,8 +67,8 @@
   outlines,
   pandas,
   partial-json-parser,
-  peft,
   prometheus-fastapi-instrumentator,
+  psutil,
   py-cpuinfo,
   pyarrow,
   pybase64,
@@ -86,25 +80,30 @@
   sentencepiece,
   setproctitle,
   tiktoken,
-  timm,
   tokenizers,
-  tokenspeed-mla,
   torch,
   torchaudio,
   torchvision,
   transformers,
   uvicorn,
-  xformers,
   xgrammar,
   # linux-only
-  psutil,
   py-libnuma,
   # cuda-only
   cupy,
   flashinfer-python,
   nvidia-ml-py,
+  tokenspeed-mla,
+  # cuda or rocm only
+  xformers,
   # rocm-only
+  amd-aiter,
+  amd-quark,
+  amdsmi,
   bash,
+  datasets,
+  peft,
+  timm,
 
   # optional-dependencies
   # audio
@@ -431,13 +430,12 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   pythonRelaxDeps = true;
 
   pythonRemoveDeps = [
+    # Not packaged in nixpkgs.
     "flashinfer-cubin"
     "nvidia-cudnn-frontend"
+    "apache-tvm-ffi" # vllm does not depend on it directly, its version is only pinned for compatibility with tilelang (also removed).
     "tilelang"
     "fastsafetensors"
-
-    # Optional on ROCm
-    "tokenspeed-mla"
 
     # QuACK and Cutlass DSL seem to be added only for FA4
     # which in our case handles its own deps
@@ -529,8 +527,6 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
 
   dependencies = [
     aioprometheus
-    apache-tvm-ffi
-    amd-quark
     anthropic
     bitsandbytes
     blake3
@@ -540,7 +536,6 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     depyf
     einops
     fastapi
-    gguf
     grpcio
     grpcio-reflection
     ijson
@@ -565,6 +560,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     pandas
     partial-json-parser
     prometheus-fastapi-instrumentator
+    psutil
     py-cpuinfo
     pyarrow
     pybase64
@@ -584,13 +580,11 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     torchvision
     transformers
     uvicorn
-    xformers
     xgrammar
   ]
   ++ uvicorn.optional-dependencies.standard
   ++ aioprometheus.optional-dependencies.starlette
   ++ lib.optionals stdenv.targetPlatform.isLinux [
-    psutil
     py-libnuma
   ]
   ++ lib.optionals cudaSupport [
@@ -599,8 +593,12 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     nvidia-ml-py
     tokenspeed-mla
   ]
+  ++ lib.optionals (cudaSupport || rocmSupport) [
+    xformers # Only depended on by Pixtral. Removed in vllm-project/vllm#52185.
+  ]
   ++ lib.optionals rocmSupport [
     amd-aiter
+    amd-quark
     rocmPackages.rocminfo
     amdsmi
     datasets


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Tidy inputs grouping
* Move `psutil` to unconditional dependencies instead of Linux only, so it works on Darwin (upstream it is in [common.txt](https://github.com/vllm-project/vllm/blob/v0.24.0/requirements/common.txt#L3))
* Move `amd-quark` to ROCm-only dependencies (upstream in [rocm.txt](https://github.com/vllm-project/vllm/blob/v0.24.0/requirements/rocm.txt#L24))
* Remove `gguf`. The support for the format has been moved to an optional plugin in vllm-project/vllm#39612 that we should package if we want to continue offering the feature
* Moved `xformers` to CUDA and ROCm only. The dependency was officially removed in vllm-project/vllm#29262. It only remains [without requirements for the Pixtral model](https://github.com/vllm-project/vllm/blob/v0.24.0/vllm/model_executor/models/pixtral.py#L89-L99), where with CPU support, it would erroneously be able to import `xformers` and crash because the `memory_efficient_attention` operation is not implemented for the CPU backend
* Remove `apache-tvm-ffi` for consistency with the current omission of `tilelang`. vLLM does not depend on it directly, its version is only pinned for compatibility with `tilelang`. If we decide to add `tilelang`, they could be both limited to CUDA and ROCm.
* Remove `tokenspeed-mla` from `pythonRemoveDeps`, ROCm does not depend on it (not in `rocm.txt`), it is unnecessary

Reducing the diff in #553128

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
