### PR TITLE
libhwy: split in several outputs and enable shared libs

### DIFF
--- a/pkgs/by-name/li/libhwy/move-contrib-to-its-own-output.patch
+++ b/pkgs/by-name/li/libhwy/move-contrib-to-its-own-output.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -657,4 +657,4 @@
+ install(TARGETS hwy_contrib EXPORT hwy_targets
+-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++  LIBRARY DESTINATION "${CMAKE_CONTRIB_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
++  ARCHIVE DESTINATION "${CMAKE_CONTRIB_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
++  RUNTIME DESTINATION "${CMAKE_CONTRIB_PREFIX}/${CMAKE_INSTALL_BINDIR}")
+diff --git a/libhwy-contrib.pc.in b/libhwy-contrib.pc.in
+--- a/libhwy-contrib.pc.in
++++ b/libhwy-contrib.pc.in
+@@ -1,3 +1,3 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=${prefix}
++exec_prefix=@CMAKE_CONTRIB_PREFIX@
+ libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@

--- a/pkgs/by-name/li/libhwy/package.nix
+++ b/pkgs/by-name/li/libhwy/package.nix
@@ -5,18 +5,31 @@
   ninja,
   gtest,
   fetchFromGitHub,
+  testers,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libhwy";
   version = "1.4.0";
+
+  __structuredAttrs = true;
+  outputs = [
+    "out"
+    "dev"
+    "contrib"
+  ];
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "highway";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-YUYZO9KLffczjwIz3mBBceD6oM1giLCFLDHgDCevdRA=";
   };
+
+  patches = [
+    ./move-contrib-to-its-own-output.patch
+  ];
 
   hardeningDisable = lib.optionals stdenv.hostPlatform.isAarch64 [
     # aarch64-specific code gets:
@@ -29,45 +42,55 @@ stdenv.mkDerivation rec {
     ninja
   ];
 
+  checkInputs = [
+    gtest
+  ];
+
   # Required for case-insensitive filesystems ("BUILD" exists)
   dontUseCmakeBuildDir = true;
 
-  cmakeFlags =
-    let
-      libExt = stdenv.hostPlatform.extensions.library;
-    in
-    [
-      "-GNinja"
-      "-DCMAKE_INSTALL_LIBDIR=lib"
-      "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    ]
-    ++ lib.optionals doCheck [
-      "-DHWY_SYSTEM_GTEST:BOOL=ON"
-      "-DGTEST_INCLUDE_DIR=${lib.getDev gtest}/include"
-      "-DGTEST_LIBRARY=${lib.getLib gtest}/lib/libgtest${libExt}"
-      "-DGTEST_MAIN_LIBRARY=${lib.getLib gtest}/lib/libgtest_main${libExt}"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isAarch32 [
-      "-DHWY_CMAKE_ARM7=ON"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isx86_32 [
-      # Quoting CMakelists.txt:
-      #   This must be set on 32-bit x86 with GCC < 13.1, otherwise math_test will be
-      #   skipped. For GCC 13.1+, you can also build with -fexcess-precision=standard.
-      # Fixes tests:
-      #   HwyMathTestGroup/HwyMathTest.TestAllAtanh/EMU128
-      #   HwyMathTestGroup/HwyMathTest.TestAllLog1p/EMU128
-      "-DHWY_CMAKE_SSE2=ON"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isRiscV [
-      # Runtime dispatch is not implemented https://github.com/google/highway/issues/838
-      # so tests (and likely normal operation) fail with SIGILL on processors without V.
-      # Until the issue is resolved, we disable RVV completely.
-      "-DHWY_CMAKE_RVV=OFF"
-    ];
+  cmakeFlags = [
+    "-GNinja"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_CONTRIB_PREFIX=${placeholder "contrib"}"
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "HWY_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+  ]
+  ++ lib.optional finalAttrs.finalPackage.doCheck (lib.cmakeBool "HWY_SYSTEM_GTEST" true)
+  ++ lib.optionals stdenv.hostPlatform.isAarch32 [
+    "-DHWY_CMAKE_ARM7=ON"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isx86_32 [
+    # Quoting CMakelists.txt:
+    #   This must be set on 32-bit x86 with GCC < 13.1, otherwise math_test will be
+    #   skipped. For GCC 13.1+, you can also build with -fexcess-precision=standard.
+    # Fixes tests:
+    #   HwyMathTestGroup/HwyMathTest.TestAllAtanh/EMU128
+    #   HwyMathTestGroup/HwyMathTest.TestAllLog1p/EMU128
+    "-DHWY_CMAKE_SSE2=ON"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isRiscV [
+    # Runtime dispatch is not implemented https://github.com/google/highway/issues/838
+    # so tests (and likely normal operation) fail with SIGILL on processors without V.
+    # Until the issue is resolved, we disable RVV completely.
+    "-DHWY_CMAKE_RVV=OFF"
+  ];
+
+  # Consumers rely on test headers being exported, but CMake install them only when tests are enabled.
+  postInstall = lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+    install -Dm644 hwy/tests/*.h -t $out/include/hwy/tests/
+  '';
 
   # hydra's darwin machines run into https://github.com/libjxl/libjxl/issues/408
   doCheck = !stdenv.hostPlatform.isDarwin;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
 
   meta = {
     description = "Performance-portable, length-agnostic SIMD with runtime dispatch";
@@ -78,5 +101,9 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ zhaofengli ];
+    pkgConfigModules = [
+      "libhwy"
+      "libhwy-contrib"
+    ];
   };
-}
+})

--- a/pkgs/by-name/ss/ssimulacra2/package.nix
+++ b/pkgs/by-name/ss/ssimulacra2/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
         rev = version;
         hash = "sha256-v2HyyHtBydr7QiI83DW1yRv2kWjUOGxFT6mmdrN9XPo=";
       };
+      outputs = [ "out" ];
       patches = [ ];
       postPatch = ''
         substituteInPlace CMakeLists.txt --replace-fail "set(CMAKE_CXX_STANDARD 11)" "set(CMAKE_CXX_STANDARD 17)"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Before this change:

```console
$ du -sh "$(nix-build -A libhwy)"        
8.9M    /nix/store/l71xwd2dvawcswgpi64pmpvki33fm8bh-libhwy-1.4.0
```

After this change:

```console
$ du -sh "$(nix-build -A libhwy)"
96K     /nix/store/crf9pyb85047d7ra3fkk9phw6md305yn-libhwy-1.4.0
$ du -sh "$(nix-build -A libhwy.contrib)" 
3.3M    /nix/store/s9xgg32g3dj3187xrm8a47j6j8rsg8bh-libhwy-1.4.0-contrib
$ du -sh "$(nix-build -A libhwy.dev)" 
4.6M    /nix/store/4jlrw2cy0q0grs7851hgh583by8166kc-libhwy-1.4.0-dev
```

Users who only need the core library can avoid downloading the heavy contrib extension.

I'm also removing the `GTEST_*` CMake flags that were reported as unused.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
