### PR TITLE
[backport staging-26.05] openexr: 3.4.11 -> 3.4.15

### DIFF
--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openexr";
-  version = "3.4.13";
+  version = "3.4.15";
 
   src = fetchFromGitHub {
     owner = "AcademySoftwareFoundation";
     repo = "openexr";
     rev = "v${version}";
-    hash = "sha256-uzeppRB8vpTjAuqlpvoTehdGL/ng1rTm7kbYdaQHKUw=";
+    hash = "sha256-Z2o2ooDqAof5rnR5lX3RfWnklyD/c98HuwWF6uZA+78=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openexr";
-  version = "3.4.11";
+  version = "3.4.13";
 
   src = fetchFromGitHub {
     owner = "AcademySoftwareFoundation";
     repo = "openexr";
     rev = "v${version}";
-    hash = "sha256-5dx2tag6XyuJfNfJgc68X+VWKXaHOL3M7ZJEQbQwFDA=";
+    hash = "sha256-uzeppRB8vpTjAuqlpvoTehdGL/ng1rTm7kbYdaQHKUw=";
   };
 
   outputs = [


### PR DESCRIPTION
backport of #538962 and #552886

https://github.com/AcademySoftwareFoundation/openexr/releases/v3.4.12
https://github.com/AcademySoftwareFoundation/openexr/releases/v3.4.13
https://github.com/AcademySoftwareFoundation/openexr/releases/v3.4.14
https://github.com/AcademySoftwareFoundation/openexr/releases/v3.4.15

<details>
<summary>Fixes:</summary>

- [CVE-2026-45696](https://www.cve.org/CVERecord?id=CVE-2026-45696) OpenEXR ht_undo_impl heap-buffer-overflow READ via codestream/channel width mismatch in HTJ2K decode
- [CVE-2026-44663](https://www.cve.org/CVERecord?id=CVE-2026-44663) Integer overflow in HTJ2K decoder ( ht_undo_impl ) leading to heap-buffer-overflow
- [OSS-Fuzz 512895184](https://issues.oss-fuzz.com/issues/512895184) Null-dereference WRITE in Imf_4_0::TileProcess::run_decode
- [OSS-fuzz 512314697](https://issues.oss-fuzz.com/issues/512314697) Direct-leak in internal_exr_add_part
- [OSS-fuzz 508362159](https://issues.oss-fuzz.com/issues/508362159) Heap-buffer-overflow in DwaCompressor_uncompress
- [OSS-fuzz 507413960](https://issues.oss-fuzz.com/issues/507413960) Heap-buffer-overflow in generic_unpack
- [CVE-2026-55373](https://www.cve.org/CVERecord?id=CVE-2026-55373) OpenEXRUtil SampleCountChannel endEdit() can loop forever on UINT_MAX sample counts
- [CVE-2026-55371](https://www.cve.org/CVERecord?id=CVE-2026-55371) OpenEXRCore exr_attr_set_bytes() accepts NULL type_hint with positive hint_length
- [CVE-2026-55059](https://www.cve.org/CVERecord?id=CVE-2026-55059) OpenEXRUtil SampleCountChannel row setter heap out-of-bounds write
- [CVE-2026-54920](https://www.cve.org/CVERecord?id=CVE-2026-54920) Integer Overflow and Use of Uninitialized Pointer leading to Invalid Delete in OpenEXRUtil Image Resize
- [CVE-2026-53532](https://www.cve.org/CVERecord?id=CVE-2026-53532) Unhandled assert abort in HTJ2K decoder via crafted QCD marker (DoS)
- [CVE-2026-68514](https://www.cve.org/CVERecord?id=CVE-2026-68514) PyOpenEXR deep prefixed literal RGB key collision heap buffer overflow
- [CVE-2026-68513](https://www.cve.org/CVERecord?id=CVE-2026-68513) PyOpenEXR prefixed literal RGB key collision heap buffer overflow
- [CVE-2026-62986](https://www.cve.org/CVERecord?id=CVE-2026-62986) PyOpenEXR deep prefixed RGB stale lane disclosure
- [CVE-2026-61703](https://www.cve.org/CVERecord?id=CVE-2026-61703) PyOpenEXR deep mixed RGB heap buffer overflow
- [CVE-2026-61555](https://www.cve.org/CVERecord?id=CVE-2026-61555) empty multiView viewFromChannelName file crash
- [CVE-2026-59985](https://www.cve.org/CVERecord?id=CVE-2026-59985) ILP32 OpenEXRCore RLE decode heap OOB read DoS
- [CVE-2026-59984](https://www.cve.org/CVERecord?id=CVE-2026-59984) ILP32 B44 InputFile decode scratch buffer overflow
- [CVE-2026-59983](https://www.cve.org/CVERecord?id=CVE-2026-59983) ILP32 DeepTiledInputFile sample count table decode OOB read
- [CVE-2026-59982](https://www.cve.org/CVERecord?id=CVE-2026-59982) ILP32 DWAA InputFile packed AC buffer overflow
- [CVE-2026-59981](https://www.cve.org/CVERecord?id=CVE-2026-59981) OpenEXRUtil SampleCountChannel row nonzero dataWindow heap OOB read
- [CVE-2026-59189](https://www.cve.org/CVERecord?id=CVE-2026-59189) OpenEXRUtil DeepImageChannel row nonzero dataWindow heap OOB read
- [CVE-2026-59187](https://www.cve.org/CVERecord?id=CVE-2026-59187) OpenEXR exrmetrics deep pixelmode heap buffer overflow
- [CVE-2026-59186](https://www.cve.org/CVERecord?id=CVE-2026-59186) OpenEXR ILP32 TiledRgbaInputFile large tile Array2D heap OOB write
- [CVE-2026-59184](https://www.cve.org/CVERecord?id=CVE-2026-59184) OpenEXRUtil FlatImageChannel row nonzero dataWindow heap OOB write
- [CVE-2026-59183](https://www.cve.org/CVERecord?id=CVE-2026-59183) Signed Integer Overflow Leading to Out-of-Bounds Memory Access in Deep Tile Decoding

and some other unnumbered ones
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (x86_64-linux)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
