### PR TITLE
ultrastar-manager: use top-level callPackage

### DIFF
--- a/pkgs/tools/misc/ultrastar-manager/default.nix
+++ b/pkgs/tools/misc/ultrastar-manager/default.nix
@@ -3,12 +3,9 @@
   stdenv,
   fetchFromGitHub,
   pkg-config,
-  wrapQtAppsHook,
+  qt5,
   symlinkJoin,
-  qmake,
   diffPlugins,
-  qtbase,
-  qtmultimedia,
   taglib,
   libmediainfo,
   libzen,
@@ -20,8 +17,8 @@ let
   rev = "ef4524e2239ddbb60f26e05bfba1f4f28cb7b54f";
   sha256 = "0dl2qp686vbs160b3i9qypb7sv37phy2wn21kgzljbk3wnci3yv4";
   buildInputs = [
-    qtbase
-    qtmultimedia
+    qt5.qtbase
+    qt5.qtmultimedia
     taglib
     libmediainfo
     libzen
@@ -51,7 +48,7 @@ let
       name = "${src.name}-patched";
       inherit src;
 
-      nativeBuildInputs = [ wrapQtAppsHook ];
+      nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
       dontInstall = true;
 
@@ -87,9 +84,9 @@ let
       name = "ultrastar-manager-${name}-plugin-${version}";
       src = patchedSrc;
 
-      nativeBuildInputs = [ wrapQtAppsHook ];
+      nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
-      buildInputs = [ qmake ] ++ buildInputs;
+      buildInputs = [ qt5.qmake ] ++ buildInputs;
 
       postPatch = ''
         sed -e "s|DESTDIR = .*$|DESTDIR = $out|" \
@@ -141,7 +138,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pkg-config
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
   ];
 
   inherit buildInputs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9895,7 +9895,7 @@ with pkgs;
 
   ultrastar-creator = callPackage ../tools/misc/ultrastar-creator { };
 
-  ultrastar-manager = libsForQt5.callPackage ../tools/misc/ultrastar-manager { };
+  ultrastar-manager = callPackage ../tools/misc/ultrastar-manager { };
 
   # To ensure vdrift's code is built on hydra
   vdrift-bin = vdrift.bin;


### PR DESCRIPTION
Should have no rebuilds (tested on my x86-64_linux machine).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
