### PR TITLE
haskell.packages.ghc914.enummapset: fix tests with containers 0.8, adopt

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -164,6 +164,16 @@ with haskellLib;
   # Test suite issues
   #
 
+  # Tests import containers internals which changed in containers-0.8
+  # https://github.com/Mikolaj/enummapset/issues/28
+  enummapset = appendPatches [
+    (pkgs.fetchpatch {
+      name = "enummapset-containers-0.8.patch";
+      url = "https://github.com/Mikolaj/enummapset/commit/601e862fbf93cf03ed297016920fa0c0110a5e4c.patch";
+      hash = "sha256-pxLW78lDB8ieoh0ZnR50NrZNUyTDkMaqzyy3V5PhlBo=";
+    })
+  ] super.enummapset;
+
   # Fails to compile with GHC 9.14 https://github.com/snoyberg/mono-traversable/pull/261
   mono-traversable = dontCheck super.mono-traversable;
   # doctests broke with GHC 9.14, something to do with error messages

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -225,6 +225,8 @@ package-maintainers:
     - located-base
   iblech:
     - Agda
+  ilkecan:
+    - enummapset
   jb55:
     # - bson-lens
     - cased

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -223971,6 +223971,7 @@ self: {
       ];
       description = "IntMap and IntSet with Enum keys/elements";
       license = lib.licenses.bsd3;
+      maintainers = [ lib.maintainers.ilkecan ];
     }
   ) { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport https://github.com/Mikolaj/enummapset/commit/601e862fbf93cf03ed297016920fa0c0110a5e4c.

I hope this is the correct branch to target.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
