### PR TITLE
networkmanager: Fix build of BPF stuff on powerpc64-linux

### DIFF
--- a/pkgs/by-name/ne/networkmanager/package.nix
+++ b/pkgs/by-name/ne/networkmanager/package.nix
@@ -1,5 +1,6 @@
 {
   fetchurl,
+  fetchpatch,
   gitUpdater,
   lib,
   nixosTests,
@@ -164,6 +165,14 @@ stdenv.mkDerivation (finalAttrs: {
     # Meson does not support using different directories during build and
     # for installation like Autotools did with flags passed to make install.
     ./fix-install-paths.patch
+
+    # Fixes BPF build on powerpc64-linux w/ ELFv1-targeting glibc
+    # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/2529
+    (fetchpatch {
+      name = "0001-networkmanager-bpf-Detect-ELF-ABI-version-on-ppc64.patch";
+      url = "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/3c28325b9c63386e5313ce006267144e7f63417a.patch";
+      hash = "sha256-SlyeykqL7Y11jEF+5l4aRXY2znHaSBhwV5lcmf88PGc=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/2529

NetworkManager seems to have adapted systemd's BPF stuff into their own codebase as a point at which https://github.com/systemd/systemd/pull/38307 wasn't part of systemd, so this is basically a port of that PR to this codebase.

Checking an ELFv2 target either natively or cross (i.e. `pkgsCross.powernv.networkmanager`) would be thorough, but if this hasn't caused any issues in systemd in the 1 year since that PR got merged, then I doubt that it'll break anything here…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native, glibc w/ ELFv1)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
