### PR TITLE
uzdoom: 4.14.3 -> 5.0.0, modernize

### DIFF
--- a/pkgs/by-name/uz/uzdoom/package.nix
+++ b/pkgs/by-name/uz/uzdoom/package.nix
@@ -9,17 +9,17 @@
   libsndfile,
   libvpx,
   libwebp,
+  libx11,
   makeWrapper,
+  moltenvk,
   mpg123,
   ninja,
   openal,
   pkg-config,
   python3,
   sdl2-compat,
-  vulkan-loader,
-  moltenvk,
   vulkan-headers,
-  libx11,
+  vulkan-loader,
   zlib,
 }:
 
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "uzdoom";
   version = "5.0.0";
 
-  strictDeps = true;
   __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "UZDoom";
@@ -38,6 +38,11 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   outputs = [ "out" ] ++ lib.optionals stdenv.hostPlatform.isLinux [ "doc" ];
+
+  postPatch = ''
+    substituteInPlace cmake/UpdateRevision.cmake \
+      --replace-fail "unknown" "${finalAttrs.src.tag}"
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -65,11 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     moltenvk
     vulkan-headers
   ];
-
-  postPatch = ''
-    substituteInPlace cmake/UpdateRevision.cmake \
-      --replace-fail "unknown" "${finalAttrs.src.tag}"
-  '';
 
   cmakeFlags = [
     (lib.cmakeBool "DYN_OPENAL" false)
@@ -108,19 +108,19 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://zdoom.org";
-    changelog = "https://github.com/UZDoom/UZDoom/releases/tag/${finalAttrs.version}";
     description = "Modern, feature-rich source port for the classic game DOOM";
-    mainProgram = "uzdoom";
     longDescription = ''
       UZDoom is a feature centric port for all Doom engine games, based on
       GZDoom, adding an advanced renderer and powerful scripting capabilities
     '';
+    homepage = "https://zdoom.org";
+    changelog = "https://github.com/UZDoom/UZDoom/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [
       Gliczy
       keenanweaver
     ];
+    platforms = with lib.platforms; linux ++ darwin;
+    mainProgram = "uzdoom";
   };
 })

--- a/pkgs/by-name/uz/uzdoom/package.nix
+++ b/pkgs/by-name/uz/uzdoom/package.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "uzdoom";
   version = "5.0.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "UZDoom";
     repo = "UZDoom";

--- a/pkgs/by-name/uz/uzdoom/package.nix
+++ b/pkgs/by-name/uz/uzdoom/package.nix
@@ -4,29 +4,34 @@
   fetchFromGitHub,
   bzip2,
   cmake,
-  gtk3,
+  glib,
   libGL,
+  libsndfile,
   libvpx,
   libwebp,
   makeWrapper,
+  mpg123,
   ninja,
   openal,
   pkg-config,
-  SDL2,
+  python3,
+  sdl2-compat,
   vulkan-loader,
+  moltenvk,
+  vulkan-headers,
+  libx11,
   zlib,
-  zmusic,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uzdoom";
-  version = "4.14.3";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "UZDoom";
     repo = "UZDoom";
     tag = finalAttrs.version;
-    hash = "sha256-vMynousxc2k7jSa6ScYNeZ9/ozRnDXTyKwgcYQcf87M=";
+    hash = "sha256-iNPpkAV1ED+BRqa2WmB6R0PFaCqpmTWDCZT9USbmZuY=";
   };
 
   outputs = [ "out" ] ++ lib.optionals stdenv.hostPlatform.isLinux [ "doc" ];
@@ -36,33 +41,42 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     ninja
     pkg-config
+    python3
   ];
 
   buildInputs = [
     bzip2
-    gtk3
+    glib
     libGL
     libvpx
     libwebp
     openal
-    SDL2
+    sdl2-compat
     vulkan-loader
     zlib
-    zmusic
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libx11
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    moltenvk
+    vulkan-headers
   ];
 
   postPatch = ''
-    substituteInPlace tools/updaterevision/UpdateRevision.cmake \
+    substituteInPlace cmake/UpdateRevision.cmake \
       --replace-fail "unknown" "${finalAttrs.src.tag}"
   '';
 
   cmakeFlags = [
-    (lib.cmakeBool "DYN_GTK" false)
     (lib.cmakeBool "DYN_OPENAL" false)
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeFeature "OPENAL_INCLUDE_DIR" "${openal}/include/AL")
     (lib.cmakeFeature "OPENAL_LIBRARY" "${openal}/lib/libopenal.dylib")
+    (lib.cmakeFeature "Vulkan_INCLUDE_DIR" "${vulkan-headers}/include")
+    (lib.cmakeFeature "Vulkan_MoltenVK_INCLUDE_DIR" "${lib.getDev moltenvk}/include")
+    (lib.cmakeFeature "Vulkan_MoltenVK_LIBRARY" "${moltenvk}/lib/libMoltenVK.dylib")
     (lib.cmakeBool "HAVE_VULKAN" true)
     (lib.cmakeBool "HAVE_GLES2" false)
   ];
@@ -81,7 +95,13 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     mv $out/bin/uzdoom $out/share/games/uzdoom/uzdoom
     makeWrapper $out/share/games/uzdoom/uzdoom $out/bin/uzdoom \
-      --set LD_LIBRARY_PATH ${lib.makeLibraryPath [ vulkan-loader ]}
+      --set LD_LIBRARY_PATH ${
+        lib.makeLibraryPath [
+          libsndfile
+          mpg123
+          vulkan-loader
+        ]
+      }
   '';
 
   meta = {

--- a/pkgs/by-name/uz/uzdoom/package.nix
+++ b/pkgs/by-name/uz/uzdoom/package.nix
@@ -105,8 +105,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/UZDoom/UZDoom";
-    description = "Modder-friendly OpenGL and Vulkan source port based on the DOOM engine";
+    homepage = "https://zdoom.org";
+    changelog = "https://github.com/UZDoom/UZDoom/releases/tag/${finalAttrs.version}";
+    description = "Modern, feature-rich source port for the classic game DOOM";
     mainProgram = "uzdoom";
     longDescription = ''
       UZDoom is a feature centric port for all Doom engine games, based on


### PR DESCRIPTION
- Bumped to latest version
- ZMusic is vendored, so we can drop it now. Add `libsndfile` and `mpg123` for it to work in the wrapper
- `python3` is now required
- Swap to `sdl2-compat` to match upstream CI
- Drop GTK3/`DYN_GTK` var, add `glib` and `libx11` instead
- Add `strictDeps` & `__structuredAttrs`
- Update meta info and run `pedantix` cleanup

Changelog: https://github.com/UZDoom/UZDoom/releases/tag/5.0.0
Diff: https://github.com/UZDoom/UZDoom/compare/4.14.3...5.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
