### PR TITLE
Rename qobuz-player to qobine; qobine: 0.9.0 -> 2026-08-28

### DIFF
--- a/pkgs/by-name/qo/qobine/package.nix
+++ b/pkgs/by-name/qo/qobine/package.nix
@@ -9,12 +9,12 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "qobuz-player";
+  pname = "qobine";
   version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "SofusA";
-    repo = "qobuz-player";
+    repo = "qobine";
     tag = "v${finalAttrs.version}";
     hash = "sha256-uslU/HQognLMNz/w9hMdtpzby2neE+VC8Y+RV2XMd7Q=";
   };
@@ -36,8 +36,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Tui, web and rfid player for Qobuz";
-    homepage = "https://github.com/SofusA/qobuz-player";
-    changelog = "https://github.com/SofusA/qobuz-player/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/SofusA/qobine";
+    changelog = "https://github.com/SofusA/qobine/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       felixsinger

--- a/pkgs/by-name/qo/qobine/package.nix
+++ b/pkgs/by-name/qo/qobine/package.nix
@@ -6,23 +6,30 @@
   pkg-config,
   protobuf,
   rustPlatform,
+
+  # needed for GUI client
+  gtk4,
+  libadwaita,
+  webkitgtk_6_0,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qobine";
-  version = "0.9.0";
+  version = "2026-08-28";
 
   src = fetchFromGitHub {
     owner = "SofusA";
     repo = "qobine";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uslU/HQognLMNz/w9hMdtpzby2neE+VC8Y+RV2XMd7Q=";
+    hash = "sha256-C1GbLRuur1p5h/nGl9X5cYQCNAjai/u9Qo+XqkpJfzI=";
   };
 
   strictDeps = true;
   __structuredAttrs = true;
 
-  cargoHash = "sha256-vcII4SDE5zOgzS83CCLhffc7OEksmcMtXYb76r6M1JM=";
+  cargoHash = "sha256-OidPG2oJdr2IBZGYw46500//EdlmK8kDRFm6lPOeD3M=";
+
+  doCheck = false;
 
   nativeBuildInputs = [
     pkg-config
@@ -31,7 +38,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [
     alsa-lib
+    gtk4
+    libadwaita
     openssl
+    webkitgtk_6_0
   ];
 
   meta = {
@@ -43,6 +53,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       felixsinger
     ];
     platforms = lib.platforms.linux;
-    mainProgram = "qobuz-player";
+    mainProgram = "qobine-tui";
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2117,6 +2117,7 @@ mapAliases {
   qMasterPassword-wayland = warnAlias "'qMasterPassword-wayland' has been renamed to/replaced by 'qmasterpassword-wayland'" qmasterpassword-wayland; # Added 2026-02-01
   qmenumodel = warnAlias "'qmenumodel' has been renamed to 'libsForQt5.qmenumodel'" libsForQt5.qmenumodel; # Added 2026-03-26
   qnial = throw "'qnial' has been removed due to failing to build and being unmaintained"; # Added 2025-06-26
+  qobuz-player = throw "'qobuz-player' has been renamed to 'qobine'";
   qrscan = throw "qrscan has been removed, as it does not build with supported LLVM versions"; # Added 2025-08-19
   qscintilla = throw "'qscintilla' has been renamed to/replaced by 'libsForQt5.qscintilla'"; # Converted to throw 2025-10-27
   qscintilla-qt6 = throw "'qscintilla-qt6' has been renamed to/replaced by 'qt6Packages.qscintilla'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
