### PR TITLE
nixos/sillytavern: support declarative extension, restart when configFile changes

### DIFF
--- a/nixos/modules/services/web-apps/sillytavern.nix
+++ b/nixos/modules/services/web-apps/sillytavern.nix
@@ -43,6 +43,28 @@ in
         '';
       };
 
+      extensions = lib.mkOption {
+        type = lib.types.attrsOf lib.types.pathInStore;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            MyExtension = pkgs.fetchFromGitHub {
+              owner = "";
+              repo = "MyExtension";
+              # ...
+            };
+          }
+        '';
+        description = ''
+          Attrset of extension names to extension paths, for declaratively
+          managing extensions. Ad-hoc extension management via the web UI will
+          no longer function if this is non-empty.
+
+          The name will be used as the extension directory name, and should
+          match the basename of the Git repository URL's pathname.
+        '';
+      };
+
       port = lib.mkOption {
         type = lib.types.nullOr lib.types.port;
         default = null;
@@ -119,9 +141,19 @@ in
         Group = cfg.group;
         Restart = "always";
         StateDirectory = "SillyTavern";
-        BindPaths = [
-          "%S/SillyTavern/extensions:${cfg.package}/lib/node_modules/sillytavern/public/scripts/extensions/third-party"
-        ];
+        BindPaths =
+          let
+            extensionsPath =
+              if cfg.extensions == { } then
+                "%S/SillyTavern/extensions"
+              else
+                pkgs.linkFarm "sillytavern-extensions" (
+                  lib.mapAttrsToList (name: path: { inherit name path; }) cfg.extensions
+                );
+          in
+          [
+            "${extensionsPath}:${cfg.package}/lib/node_modules/sillytavern/public/scripts/extensions/third-party"
+          ];
 
         # Security hardening
         CapabilityBoundingSet = [ "" ];
@@ -154,13 +186,15 @@ in
         mode = "0700";
         inherit (cfg) user group;
       };
-      "/var/lib/SillyTavern/extensions".d = {
-        mode = "0700";
-        inherit (cfg) user group;
-      };
       "/var/lib/SillyTavern/config.yaml"."L+" = {
         mode = "0600";
         argument = cfg.configFile;
+        inherit (cfg) user group;
+      };
+    }
+    // lib.optionalAttrs (cfg.extensions == { }) {
+      "/var/lib/SillyTavern/extensions".d = {
+        mode = "0700";
         inherit (cfg) user group;
       };
     };

--- a/nixos/modules/services/web-apps/sillytavern.nix
+++ b/nixos/modules/services/web-apps/sillytavern.nix
@@ -95,6 +95,7 @@ in
       description = "Silly Tavern";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ cfg.configFile ];
       # required by sillytavern's extension manager
       path = [ pkgs.gitMinimal ];
       environment.XDG_DATA_HOME = "%S";


### PR DESCRIPTION
See individual commits for details. Can split in two PRs if desired.

## Things done

Tested declarative extension works, config restart works, tested non-declarative starts (but not install).

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
