### PR TITLE
therion: fix build with fmt 12

### DIFF
--- a/pkgs/by-name/th/therion/package.nix
+++ b/pkgs/by-name/th/therion/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   perl,
@@ -38,6 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-TiyoNYk+wWXyNytQwr5EfRSWzNc42LX3qjMV9M+dsx0=";
   };
+
+  patches = [
+    # fmt >= 12 no longer provides fmt::format via fmt/core.h
+    (fetchpatch {
+      url = "https://github.com/therion/therion/commit/6c7e3a8e82228db0f2c450b7a26c848809d24010.patch";
+      hash = "sha256-sSki7QPDWmmTd3nb97vhuxFm92nfphTrGJM4oJlX39E=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
`therion` build is broken on master due to a `fmt` version bump. The issue has been fixed upstream, so this just grabs the appropriate commit until the next release happens.

```
$ nix build .#therion
❌ git+file:///home/joe/worktrees/nixpkgs-master#therion
error: Cannot build '/nix/store/nysl4cvi5jqnglh08bpnmbssannhzc54-therion-6.4.0.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/22n8cxgv6wlsskpcl5hhs8820infsh0z-therion-6.4.0
       Last 25 log lines:
       >   136 |         throw thexception(fmt::format("invalid object context -- {} {}", args[0], args[1]));
       >       |                                ^~~~~~
       > /build/source/src/therion-core/th2ddataobject.cxx:147:32: error: 'format' is not a member of 'fmt'
       >   147 |         throw thexception(fmt::format("object context not allowed -- {} {}", args[0], args[1]));
       >       |                                ^~~~~~
       > /build/source/src/therion-core/th2ddataobject.cxx: In member function 'void th2ddataobject::parse_u_subtype(const char*)':
       > /build/source/src/therion-core/th2ddataobject.cxx:211:28: error: 'format' is not a member of 'fmt'
       >   211 |     throw thexception(fmt::format("invalid subtype name -- {}", subtype));
       >       |                            ^~~~~~
       > /build/source/src/therion-core/th2ddataobject.cxx: In function 'void th2dparse_scale(const char*, int&, double&)':
       > /build/source/src/therion-core/th2ddataobject.cxx:221:30: error: 'format' is not a member of 'fmt'
       >   221 |       throw thexception(fmt::format("invalid scale -- {}", spec));
       >       |                              ^~~~~~
       > make[2]: *** [src/therion-core/CMakeFiles/therion-core.dir/build.make:86: src/therion-core/CMakeFiles/therion-core.dir/th2ddataobject.cxx.o] Error 1
       > make[2]: *** Waiting for unfinished jobs....
       > /build/source/src/therion-core/tharea.cxx: In member function 'void tharea::parse_type(char*)':
       > /build/source/src/therion-core/tharea.cxx:131:28: error: 'format' is not a member of 'fmt'
       >   131 |     throw thexception(fmt::format("unknown area type -- {}", tstr));
       >       |                            ^~~~~~
       > make[2]: *** [src/therion-core/CMakeFiles/therion-core.dir/build.make:100: src/therion-core/CMakeFiles/therion-core.dir/tharea.cxx.o] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:5327: src/therion-core/CMakeFiles/therion-core.dir/all] Error 2
       > make[1]: *** Waiting for unfinished jobs....
       > [ 42%] Linking CXX executable loch
       > [ 42%] Built target loch
       > make: *** [Makefile:136: all] Error 2
       For full logs, run:
         nix log /nix/store/nysl4cvi5jqnglh08bpnmbssannhzc54-therion-6.4.0.drv
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
