### PR TITLE
emacs.pkgs.swift-mode: 20260801.1244 -> 20260827.1241

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -127462,11 +127462,11 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20260801,
-    1244
+    20260827,
+    1241
    ],
-   "commit": "610b2c24433c11c30a39a6799af69b10cd3bec97",
-   "sha256": "1qjkka6fx9sw14gzjqmyiny0z1mvcyyzmr74a96vndfbx576i9xp"
+   "commit": "bb4ef3a344a04ec97c8707ad8c5aadc2f446ad02",
+   "sha256": "1kv2m8lbdv71p7b6nqwfi5cbmda29faf24lx9hn472lkil95x5sx"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
This includes a workaround[1] for Emacs bug#81717[2] which sometimes crashes Emacs 31.

[1]: https://github.com/swift-emacs/swift-mode/pull/204
[2]: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81717

This also fixes packages listed [here][3] that depend on `swift-mode`.

[3]: https://github.com/NixOS/nixpkgs/pull/556299#issuecomment-5408839513



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
