### PR TITLE
display-pilot-2: init at 1.1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14888,6 +14888,12 @@
     githubId = 59027018;
     name = "Andrey Khorokhorin";
   };
+  khssnv = {
+    email = "a.khssnv@gmail.com";
+    github = "khssnv";
+    githubId = 833019;
+    name = "Alisher Khassanov";
+  };
   khumba = {
     email = "bog@khumba.net";
     github = "khumba";

--- a/pkgs/by-name/di/display-pilot-2/package.nix
+++ b/pkgs/by-name/di/display-pilot-2/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenvNoCC,
+  appimageTools,
+  fetchurl,
+  unzip,
+}:
+
+let
+  pname = "display-pilot-2";
+  version = "1.1.4.0";
+
+  appimage = stdenvNoCC.mkDerivation {
+    pname = "${pname}-appimage";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://esupportdownload.benq.com/esupport/VERTICAL%20%26%20PROFESSIONAL%20DISPLAY/Software/Display%20Pilot%202/Display%20Pilot%202_Display%20Pilot%202%20for%20Linux_V${version}_Linux_260407094616.zip";
+      hash = "sha256-IWFIR5VpnZiNP11VQLTWmoezfLbcXKrGB7VWgaf/Fxo=";
+    };
+
+    nativeBuildInputs = [ unzip ];
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      unzip "$src"
+
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm555 "Display Pilot 2-${version}-release.AppImage" "$out"
+
+      runHook postInstall
+    '';
+  };
+in
+appimageTools.wrapType2 (finalAttrs: {
+  inherit pname version;
+  src = appimage;
+
+  extraInstallCommands = ''
+    install -Dm444 ${finalAttrs.contents}/usr/share/applications/com.benq.DisplayPilot2.desktop \
+      $out/share/applications/com.benq.DisplayPilot2.desktop
+    substituteInPlace $out/share/applications/com.benq.DisplayPilot2.desktop \
+      --replace-fail 'Exec=Display_Pilot_2' 'Exec=${pname}'
+
+    install -Dm444 ${finalAttrs.contents}/usr/share/icons/hicolor/scalable/apps/dp2_svg.svg \
+      $out/share/icons/hicolor/scalable/apps/dp2_svg.svg
+  '';
+
+  meta = {
+    description = "BenQ utility for controlling supported monitors";
+    longDescription = ''
+      Display Pilot 2 uses DDC/CI to control supported BenQ monitors. On NixOS,
+      enable i2c support and add your user to the configured i2c group:
+
+      ```
+      hardware.i2c.enable = true;
+      users.users.<name>.extraGroups = [ "i2c" ];
+      ```
+
+      BenQ supports the Linux version on Ubuntu 24.04.2 LTS with GNOME 46 and X11.
+    '';
+    homepage = "https://www.benq.com/en-us/monitor/software/display-pilot-2.html";
+    downloadPage = "https://www.benq.com/en-us/support/downloads-faq/products/monitor/display-pilot-2/software-driver.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ khssnv ];
+    mainProgram = "display-pilot-2";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Add BenQ Display Pilot 2, a utility for configuring BenQ monitor settings.

<https://www.benq.com/en-us/monitor/software/display-pilot-2.html>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
