### PR TITLE
bmputil: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/bm/bmputil/package.nix
+++ b/pkgs/by-name/bm/bmputil/package.nix
@@ -11,16 +11,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "bmputil";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromCodeberg {
     owner = "blackmagic-debug";
     repo = "bmputil";
     tag = "v${version}";
-    hash = "sha256-ZD/JXsx52U+O3FazRc9xnShx34fxTXcD2zhW5mgSYtU=";
+    hash = "sha256-WX26rDFLWtEG/BvVwPjsY3X1ebvNseEpdgJRGMynyBo=";
   };
 
-  cargoHash = "sha256-/I1chzqnhgky/+cKGhFrdgZvoLGM9P75ga5UDTMOI3Q=";
+  cargoHash = "sha256-Uj+TLD1SGx5lFFhSDKRr6iMg4QnjgE1+1KbXTi/5iCI=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -32,8 +32,6 @@ rustPlatform.buildRustPackage rec {
     install -Dm 444 ${blackmagic.src}/driver/99-blackmagic-plugdev.rules $out/lib/udev/rules.d/99-blackmagic-plugdev.rules
   '';
 
-  doCheck = false; # fails at least 1 test
-
   nativeInstallCheckInputs = [
     versionCheckHook
     udevCheckHook
@@ -41,8 +39,8 @@ rustPlatform.buildRustPackage rec {
   doInstallCheck = true;
 
   meta = {
-    description = "Black Magic Probe Firmware Manager";
-    homepage = "https://github.com/blackmagic-debug/bmputil";
+    description = "Black Magic Probe companion utility";
+    homepage = "https://codeberg.org/blackmagic-debug/bmputil";
     license = with lib.licenses; [
       mit
       asl20


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
