### PR TITLE
pinta: fix text tool on linux by adding pango dependency

### DIFF
--- a/pkgs/by-name/pi/pinta/package.nix
+++ b/pkgs/by-name/pi/pinta/package.nix
@@ -8,6 +8,7 @@
   gtk4,
   glib,
   libadwaita,
+  pango,
   intltool,
   wrapGAppsHook4,
   nix-update-script,
@@ -15,7 +16,6 @@
   # Darwin transitive deps
   graphene,
   gettext,
-  pango,
   gdk-pixbuf,
   cairo,
   harfbuzz,
@@ -46,13 +46,13 @@ buildDotnetModule rec {
     gtk4
     glib
     libadwaita
+    pango
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Transitive dylib deps that Pinta's NativeImportResolver dlopen's by bare name.
     # These are not pulled in by wrapGAppsHook4's LD_LIBRARY_PATH on Darwin, so symlink is needed.
     graphene
     gettext
-    pango
     gdk-pixbuf
     cairo
     harfbuzz


### PR DESCRIPTION
Fixes #527173

Added pango dependency on Linux. In Pinta 3.1 developers switched from `Gtk.FontButton` to `Gtk.FontDialogButton` which uses pango for font description. Previously #506692 added pango on darwin. This PR adds it on linux as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
