### PR TITLE
windows.sdk: fix 'fetchWinSdk' by adding the package 'cacert' to nativeBuildInputs

### DIFF
--- a/pkgs/os-specific/windows/msvcSdk/fetchWinSdk.nix
+++ b/pkgs/os-specific/windows/msvcSdk/fetchWinSdk.nix
@@ -3,6 +3,7 @@
   config,
   stdenvNoCC,
   xwin,
+  cacert,
 }:
 let
   host = stdenvNoCC.hostPlatform;
@@ -45,7 +46,10 @@ lib.extendMkDerivation {
 
       strictDeps = true;
 
-      nativeBuildInputs = [ xwin ];
+      nativeBuildInputs = [
+        xwin
+        cacert
+      ];
 
       outputHashAlgo = "sha256";
       outputHashMode = "recursive";


### PR DESCRIPTION
This PR fixes the `windows.sdk` package. Right now it does not build, as the `fetchWinSdk` derivation fails in buildPhase, when trying to download the SDK from Microsoft servers:
```
       > Error: HTTP GET request for https://download.visualstudio.microsoft.com/download/pr/2ae938ff-cbb6-4e4d-990c-7794a7a03745/47f47e4a9ff1ffd7a08a04a519e4bfdc7f95769ec93a9b0db74f30b2af21b255/VisualStudio.vsman failed
       >
       > Caused by:
       >     rustls: unexpected error: No CA certificates were loaded from the system
```

This issue is fixed by including the `cacert` package in the nativeBuildInputs of `fetchWinSdk`. It still produces the correct FOD hash after finishing the download, and everything works again.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
