### PR TITLE
ziggity: init at 0.30.0

### DIFF
--- a/pkgs/by-name/zi/ziggity/package.nix
+++ b/pkgs/by-name/zi/ziggity/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  bash,
+  coreutils,
+  stdenv,
+  fetchFromGitHub,
+  git,
+  gnugrep,
+  makeWrapper,
+  nix-update-script,
+  versionCheckHook,
+  zig_0_16,
+}:
+
+let
+  zig = zig_0_16;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ziggity";
+  version = "0.30.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "simoarpe";
+    repo = "ziggity";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OssZNyfA1dQa578+IebQh5FenmU5TFcfX3ynUjg7sf0=";
+  };
+
+  zigDeps = zig.fetchDeps {
+    inherit (finalAttrs) src pname version;
+    fetchAll = true;
+    hash = "sha256-pe34plcSfNsvYytU/Gps7cPSUbyd2octV3/Fg9H9qcY=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/git.zig src/app.zig \
+      --replace-fail "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+        "${lib.makeBinPath finalAttrs.nativeCheckInputs}"
+  '';
+
+  postConfigure = ''
+    cp -rLT ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
+    chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    zig
+  ];
+
+  nativeCheckInputs = [
+    bash
+    coreutils
+    git
+    gnugrep
+  ];
+
+  doCheck = true;
+
+  postInstall = ''
+    wrapProgram "$out/bin/ziggity" \
+      --prefix PATH : ${lib.makeBinPath [ git ]}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/ziggity";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v(.*)$"
+      "--custom-dep"
+      "zigDeps"
+    ];
+  };
+
+  meta = {
+    description = "Fast, keyboard-driven terminal UI for Git";
+    homepage = "https://github.com/simoarpe/ziggity";
+    changelog = "https://github.com/simoarpe/ziggity/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbek ];
+    mainProgram = "ziggity";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Fast, keyboard-driven terminal UI for Git.
https://github.com/simoarpe/ziggity

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
