### PR TITLE
xpra: 6.4.4 -> 6.5.3

### DIFF
--- a/pkgs/by-name/xp/xpra/fix-122159.patch
+++ b/pkgs/by-name/xp/xpra/fix-122159.patch
@@ -1,6 +1,6 @@
 --- a/xpra/scripts/main.py
 +++ b/xpra/scripts/main.py
-@@ -536,13 +536,7 @@
+@@ -526,13 +526,7 @@
              "upgrade", "upgrade-seamless", "upgrade-desktop",
              "encoder", "runner",
      ) and not display_is_remote and options.daemon and use_systemd_run(options.systemd_run):
@@ -8,9 +8,9 @@
 -        # inject it into the command line if we have to:
          argv = list(cmdline)
 -        if argv[0].find("python") < 0:
--            major, minor = sys.version_info.major, sys.version_info.minor
--            python = which("python%i.%i" % (major, minor)) or which("python%i" % major) or which("python") or "python"
--            argv.insert(0, python)
+-            from xpra.platform.paths import get_python_execfile_command
+-            for arg in reversed(get_python_execfile_command()):
+-                argv.insert(0, arg)
          return systemd_run_wrap(mode, argv, options.systemd_run_args, user=getuid() != 0)
      configure_env(options.env)
      configure_logging(options, mode)

--- a/pkgs/by-name/xp/xpra/package.nix
+++ b/pkgs/by-name/xp/xpra/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  nix-update-script,
   pkg-config,
   runCommand,
   writeText,
@@ -104,14 +105,14 @@ let
 in
 effectiveBuildPythonApplication rec {
   pname = "xpra";
-  version = "6.4.4";
+  version = "6.5.3";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Xpra-org";
     repo = "xpra";
     tag = "v${version}";
-    hash = "sha256-zDI6xksviTjsfsh5OJdkif24BGPW9zfDsxATC98eeX0=";
+    hash = "sha256-UDKnkynWoS1feUBRRHXl7emksUmufBL16gmVFslMHpM=";
   };
 
   patches = [
@@ -120,7 +121,7 @@ effectiveBuildPythonApplication rec {
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
-    substituteInPlace xpra/platform/posix/features.py \
+    substituteInPlace xpra/scripts/config.py \
       --replace-fail "/usr/bin/xdg-open" "${xdg-utils}/bin/xdg-open"
 
     patchShebangs --build fs/bin/build_cuda_kernels.py
@@ -290,7 +291,7 @@ effectiveBuildPythonApplication rec {
 
   passthru = {
     inherit xf86videodummy;
-    updateScript = ./update.sh;
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/xp/xpra/update.sh
+++ b/pkgs/by-name/xp/xpra/update.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl perl common-updater-scripts
-
-version=$(curl https://xpra.org/src/ | perl -ne 'print "$1\n" if /xpra-([[:digit:].]+)\./' | sort -V | tail -n1)
-update-source-version xpra "$version"


### PR DESCRIPTION
This PR updates xpra to [v6.5.3](https://github.com/Xpra-org/xpra/releases/tag/v6.5.3), since @r-ryantm has been failing to update it automatically.

- The attempts to update to [v6.5](https://nixpkgs-update-logs.nix-community.org/xpra/2026-06-23.log), [v6.5.1](https://nixpkgs-update-logs.nix-community.org/xpra/2026-07-11.log), and [v6.5.2](https://nixpkgs-update-logs.nix-community.org/xpra/2026-07-29.log) failed due to Xpra-org/xpra@8f3dc99d9bb37909aa4fcb039ec6a2994a362308 and Xpra-org/xpra@bead0bc37fb7181bba396dc63483f700057742b8. The fix here is to update `patches` and `postPatch` accordingly.

- The attempt to update to [v6.5.3](https://nixpkgs-update-logs.nix-community.org/xpra/2026-08-25.log) actually only saw v6.5.2 because https://xpra.org/src/ is missing the v6.5.3 release, just as the source tarballs from prior releases v5.1.5 and v6.2 are also missing. The fix here is to replace the custom update script with the standard `nix-update-script`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
