### PR TITLE
fff-mcp: init at 0.10.5

### DIFF
--- a/pkgs/by-name/ff/fff-mcp/package.nix
+++ b/pkgs/by-name/ff/fff-mcp/package.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  lib,
+  libgit2,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fff-mcp";
+  version = "0.10.6";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dmtrKovalenko";
+    repo = "fff";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IR8w57VPiCerh8tEUhzNjd2A7BMY1Dvs0Yl0rIIoj1E=";
+  };
+
+  cargoHash = "sha256-mt5T9Cs174pc1CtrPZE6hwYZ3eSaGhCRL94trcoZn4Q=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libgit2 ];
+
+  env.LIBGIT2_NO_VENDOR = "1";
+
+  # The workspace also holds a Neovim FFI crate, a C library and Python/Node
+  # bindings; none of them are wanted here.
+  cargoBuildFlags = [
+    "--package"
+    "fff-mcp"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  # The parent-death watchdog only ticks fast enough to meet the test's 5s
+  # deadline under `debug_assertions`; in a release build it ticks once a minute.
+  checkFlags = [ "--skip=exits_when_parent_dies_even_without_idle_timeout" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "MCP server for the fff file search engine";
+    homepage = "https://github.com/dmtrKovalenko/fff";
+    changelog = "https://github.com/dmtrKovalenko/fff/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "fff-mcp";
+    maintainers = with lib.maintainers; [ happysalada ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
init the fff mcp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
