### PR TITLE
orc: 0.4.42 -> 0.4.44

### DIFF
--- a/pkgs/by-name/or/orc/package.nix
+++ b/pkgs/by-name/or/orc/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  testers,
   nix-update-script,
   fetchFromGitLab,
   meson,
@@ -70,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (gst_all_1) gst-plugins-good gst-plugins-bad gst-plugins-ugly;
       inherit gnuradio vips;
       qt6-qtmultimedia = qt6.qtmultimedia;
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
 
     updateScript = nix-update-script { };
@@ -79,6 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Oil Runtime Compiler";
     homepage = "https://gstreamer.freedesktop.org/projects/orc.html";
     changelog = "https://gitlab.freedesktop.org/gstreamer/orc/-/blob/${finalAttrs.version}/RELEASE";
+    pkgConfigModules = map (name: "${name}-${lib.versions.majorMinor finalAttrs.version}") [
+      "orc"
+      "orc-test"
+    ];
     # The source code implementing the Marsenne Twister algorithm is licensed
     # under the 3-clause BSD license. The rest is 2-clause BSD license.
     license = with lib.licenses; [

--- a/pkgs/by-name/or/orc/package.nix
+++ b/pkgs/by-name/or/orc/package.nix
@@ -6,10 +6,8 @@
   fetchFromGitLab,
   meson,
   ninja,
-  # FIXME: hotdoc errors out due to issues discovering libclang paths
-  # See https://github.com/NixOS/nixpkgs/issues/514723
   hotdoc,
-  buildDevDoc ? false,
+  buildDevDoc ? true,
 
   # for passthru.tests
   gnuradio,
@@ -28,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional buildDevDoc "devdoc";
   outputBin = "dev"; # compilation tools
+  outputDoc = lib.optionalString buildDevDoc "devdoc";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";

--- a/pkgs/by-name/or/orc/package.nix
+++ b/pkgs/by-name/or/orc/package.nix
@@ -91,6 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
       bsd3
       bsd2
     ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gstreamer" finalAttrs.version;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ tmarkus ];
   };

--- a/pkgs/by-name/or/orc/package.nix
+++ b/pkgs/by-name/or/orc/package.nix
@@ -41,12 +41,13 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i '/memcpy_speed/d' testsuite/meson.build
   '';
 
-  mesonFlags = [
-    (lib.mesonEnable "examples" false)
-    (lib.mesonEnable "benchmarks" false)
-    (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
-    (lib.mesonEnable "hotdoc" buildDevDoc)
-  ];
+  mesonFlags = lib.mapAttrsToList lib.mesonEnable {
+    examples = false;
+    benchmarks = false;
+    tests = finalAttrs.finalPackage.doCheck;
+    hotdoc = buildDevDoc;
+    tools = true;
+  };
 
   nativeBuildInputs = [
     meson

--- a/pkgs/by-name/or/orc/package.nix
+++ b/pkgs/by-name/or/orc/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  nix-update-script,
   fetchFromGitLab,
   meson,
   ninja,
@@ -64,10 +65,14 @@ stdenv.mkDerivation (finalAttrs: {
       && lib.versionAtLeast stdenv.cc.version "12"
     );
 
-  passthru.tests = {
-    inherit (gst_all_1) gst-plugins-good gst-plugins-bad gst-plugins-ugly;
-    inherit gnuradio vips;
-    qt6-qtmultimedia = qt6.qtmultimedia;
+  passthru = {
+    tests = {
+      inherit (gst_all_1) gst-plugins-good gst-plugins-bad gst-plugins-ugly;
+      inherit gnuradio vips;
+      qt6-qtmultimedia = qt6.qtmultimedia;
+    };
+
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/or/orc/package.nix
+++ b/pkgs/by-name/or/orc/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   meson,
   ninja,
   # FIXME: hotdoc errors out due to issues discovering libclang paths
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "orc";
-  version = "0.4.42";
+  version = "0.4.44";
 
   outputs = [
     "out"
@@ -27,9 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional buildDevDoc "devdoc";
   outputBin = "dev"; # compilation tools
 
-  src = fetchurl {
-    url = "https://gstreamer.freedesktop.org/src/orc/orc-${finalAttrs.version}.tar.xz";
-    hash = "sha256-fskSq1mvPMl4dMRWpWqK4e7FIMOF7ER+ihArK9EiyQw=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "gstreamer";
+    repo = "orc";
+    tag = finalAttrs.version;
+    hash = "sha256-/fWXR9LuINXwVMXCAGVm4H6I+Lut1u43rz+xmV+5cVs=";
   };
 
   postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''


### PR DESCRIPTION
Also includes the usual round of meson refactoring I currently do, and re-enables devdoc via hotdoc.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
