### PR TITLE
nixos/gitea-actions-runner: re-register on changed url or config file

### DIFF
--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -240,29 +240,25 @@ in
                   mkdir -vp "$INSTANCE_DIR"
                   cd "$INSTANCE_DIR"
 
-                  # force reregistration on changed token or labels
-                  export TOKEN_HASH_FILE="$INSTANCE_DIR/.token-hash"
-                  export TOKEN_HASH_CURRENT="$(printf '%s' "$TOKEN" | sha256sum | cut -d' ' -f1)"
-                  export TOKEN_HASH_STORED="$(cat "$TOKEN_HASH_FILE" 2>/dev/null || echo "")"
-                  export LABELS_FILE="$INSTANCE_DIR/.labels"
-                  export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
-                  export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
+                  REGISTER_ARGS=( "--instance=${escapeShellArg instance.url}" \
+                      "--token=$TOKEN" \
+                      "--name=${escapeShellArg instance.name}" \
+                      "--labels=${escapeShellArg (concatStringsSep "," instance.labels)}" \
+                      "--config=${configFile}" )
 
-                  if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED" != "$LABELS_CURRENT" ] || [ "$TOKEN_HASH_CURRENT" != "$TOKEN_HASH_STORED" ]; then
+                  # force re-registration on changed args
+                  REGISTER_ARGS_HASH_CURRENT="$(printf '%s' "''${REGISTER_ARGS[@]}" | sha256sum | cut -d' ' -f1)"]
+                  REGISTER_ARGS_HASH_FILE="$INSTANCE_DIR/.args-hash"
+                  REGISTER_ARGS_HASH_STORED="$(cat $REGISTER_ARGS_HASH_FILE 2>/dev/null || echo "")"
+
+                  if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$REGISTER_ARGS_HASH_CURRENT" != "$REGISTER_ARGS_HASH_STORED" ]; then
                     # remove existing registration file, so that changing the token or labels forces a re-registration
                     rm -v "$INSTANCE_DIR/.runner" || true
 
                     # perform the registration
-                    ${getExe cfg.package} register --no-interactive \
-                      --instance ${escapeShellArg instance.url} \
-                      --token "$TOKEN" \
-                      --name ${escapeShellArg instance.name} \
-                      --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
-                      --config ${configFile}
-
+                    ${getExe cfg.package} register --no-interactive ''${REGISTER_ARGS[@]}
                     # and write back the configured labels and token hash
-                    printf '%s' "$TOKEN_HASH_CURRENT" > "$TOKEN_HASH_FILE"
-                    echo "$LABELS_WANTED" > "$LABELS_FILE"
+                    printf '%s' "$REGISTER_ARGS_HASH_CURRENT" > "$REGISTER_ARGS_HASH_FILE"
                   fi
 
                 '')


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Before, the runner would only re-register if the token changed or the labels changed. It would not re-register if the url or other settings changed. Now it just takes all the register arguments and hashes them and re-registers if that hash changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
