### PR TITLE
pkgs/nixos-render-docs: add id-prefix to nav.json

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -617,6 +617,11 @@ document.addEventListener("DOMContentLoaded", createObserver);
 def _to_base26(n: int) -> str:
     return (_to_base26(n // 26) if n > 26 else "") + chr(ord("A") + n % 26)
 
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+def _id_segment(fname: str) -> str:
+    stem = fname.removesuffix(".md").lower()
+    return _NON_ALNUM.sub("-", stem).strip("-")
+
 @dataclass
 class ConfigLeaf:
     file: str
@@ -627,6 +632,9 @@ class ConfigGroup:
     label: str
     children: list["ConfigNode"]
     id: str | None = None
+    # migration support for 'auto-id-prefix'
+    # id-prefix can only be set on a group, matching the legacy "includes" behavior
+    id_prefix: str | None = None
 
 ConfigNode = ConfigLeaf | ConfigGroup
 
@@ -725,7 +733,10 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
         gid = item.get('id')
         if gid is not None and (not isinstance(gid, str) or not gid):
             raise SrcError(src=src, description=f"{where}: 'id' must be a non-empty string")
-        return ConfigGroup(label=label, children=self._parse_config_nodes(children, where, src), id=gid)
+        id_prefix = item.get('id-prefix')
+        if id_prefix is not None and (not isinstance(id_prefix, str)):
+            raise SrcError(src=src, description=f"{where}: 'id-prefix' must be a string when being set")
+        return ConfigGroup(label=label, children=self._parse_config_nodes(children, where, src), id=gid, id_prefix=id_prefix)
 
     def _prepend_config(self, infile: Path, tokens: list[Token]) -> None:
         if self._config is None:
@@ -737,21 +748,22 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
         # a change to the preamble must change this index too.
         tokens[6:6] = [include]
 
-    def _build_config_include(self, nodes: list[ConfigNode], config_file: Path) -> Token:
-        included = [self._build_config_item(node, config_file) for node in nodes]
+    def _build_config_include(self, nodes: list[ConfigNode], config_file: Path, id_prefix: str | None = None) -> Token:
+        included = [self._build_config_item(node, config_file, id_prefix) for node in nodes]
         token = Token('included_page', '', 0, map=[0, 1])
         token.meta['included'] = included
         token.meta['include-args'] = {}
         return token
 
-    def _build_config_item(self, node: ConfigNode, config_file: Path) -> tuple[list[Token], Path]:
+    def _build_config_item(self, node: ConfigNode, config_file: Path, id_prefix: str | None = None) -> tuple[list[Token], Path]:
         if isinstance(node, ConfigLeaf):
             path = (config_file.parent / node.file).resolve()
             leaf_src = path.read_text()
+            prefix = f"{id_prefix}-{_id_segment(node.file)}" if id_prefix is not None else None
             self._base_paths.append(path)
             self._current_type.append('page')
             try:
-                fragment = self._parse(leaf_src)
+                fragment = self._parse(leaf_src, auto_id_prefix=prefix)
             finally:
                 self._current_type.pop()
                 self._base_paths.pop()
@@ -761,7 +773,11 @@ class HTMLConverter(BaseConverter[ManualHTMLRenderer]):
 
         # TocEntry._collect_entries reads nav-label and nav-id.
         # it builds the sidebar group from them.
-        group = self._build_config_include(node.children, config_file)
+        group = self._build_config_include(
+            node.children,
+            config_file,
+            # use the current id_prefix if set; otherwise inherit whatever the parent defined
+            node.id_prefix if node.id_prefix is not None else id_prefix)
         group.meta['nav-label'] = node.label
         if node.id is not None:
             group.meta['nav-id'] = node.id

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manual.py
@@ -1,4 +1,5 @@
 import json
+import re
 import xml.parsers.expat as expat
 from html.entities import name2codepoint
 from pathlib import Path
@@ -379,3 +380,141 @@ def test_config_malformed_node_fails(tmp_path: Path) -> None:
             {"x.md": "# X {#x}\n\nB.\n"},
         )
     assert "a group requires a non-empty 'label'" in str(excinfo.value.__cause__)
+
+
+_NIXDOC_SNIPPET1 = (
+    "# lib.asserts: assertion functions {#sec-lib-asserts}\n\n"
+    "## `lib.asserts.assertMsg` {#function-library-assertMsg}\n\n"
+    "Body.\n\n"
+    "### Inputs\n\n"
+    "`pred`\n\n"
+    ": Predicate that needs to succeed\n"
+)
+_NIXDOC_SNIPPET2 = (
+    "# lib.attrsets: attribute set functions {#sec-lib-attrsets}\n\n"
+    "## `lib.attrsets.attrByPath` {#function-library-attrByPath}\n\n"
+    "Body.\n\n"
+    "### Inputs\n\n"
+    "`attrPath`\n\n"
+    ": A list of strings\n"
+)
+
+
+def _heading_ids(html: str) -> list[str]:
+    return re.findall(r'<h[1-6] id="([^"]+)"', html)
+
+
+def test_config_id_prefix(tmp_path: Path) -> None:
+    html = _render_with_config(
+        tmp_path,
+        {
+            "items": [
+                {
+                    "label": "Library",
+                    "id-prefix": "auto-generated",
+                    "children": [{"file": "functions/library/asserts.md"}],
+                }
+            ]
+        },
+        {"functions/library/asserts.md": _NIXDOC_SNIPPET1},
+    )
+    assert 'id="auto-generated-functions-library-asserts-1.1.1"' in html
+    assert "Predicate that needs to succeed" in html
+
+
+def test_config_id_prefix_keeps_explicit_ids(tmp_path: Path) -> None:
+    html = _render_with_config(
+        tmp_path,
+        {
+            "items": [
+                {
+                    "label": "Library",
+                    "id-prefix": "auto-generated",
+                    "children": [{"file": "asserts.md"}],
+                }
+            ]
+        },
+        {"asserts.md": _NIXDOC_SNIPPET1},
+    )
+    assert 'id="sec-lib-asserts"' in html
+    assert 'id="function-library-assertMsg"' in html
+    assert 'id="auto-generated-asserts-1"' not in html
+    assert 'id="auto-generated-asserts-1.1"' not in html
+
+
+def test_config_id_prefix_is_unique(tmp_path: Path) -> None:
+    html = _render_with_config(
+        tmp_path,
+        {
+            "items": [
+                {
+                    "label": "Library",
+                    "id-prefix": "auto-generated",
+                    "children": [
+                        {"file": "asserts.md"},
+                        {"file": "attrsets.md"},
+                    ],
+                }
+            ]
+        },
+        # Both snippets have "# Inputs" which would collide
+        {"asserts.md": _NIXDOC_SNIPPET1, "attrsets.md": _NIXDOC_SNIPPET2},
+    )
+    generated = [id for id in _heading_ids(html) if id.startswith("auto-generated-")]
+    assert len(generated) == 2
+    assert len(set(generated)) == 2
+
+
+def test_config_id_prefix_inherit(tmp_path: Path) -> None:
+    html = _render_with_config(
+        tmp_path,
+        {
+            "items": [
+                {
+                    "label": "Outer",
+                    "id-prefix": "outer",
+                    "children": [
+                        {"label": "Inner", "children": [{"file": "asserts.md"}]},
+                    ],
+                }
+            ]
+        },
+        {"asserts.md": _NIXDOC_SNIPPET1},
+    )
+    generated = [id for id in _heading_ids(html) if id.startswith("outer-")]
+    assert len(generated) == 1
+
+
+def test_config_id_prefix_nested_override(tmp_path: Path) -> None:
+    html = _render_with_config(
+        tmp_path,
+        {
+            "items": [
+                {
+                    "label": "Outer",
+                    "id-prefix": "outer",
+                    "children": [
+                        {
+                            "label": "Inner",
+                            "id-prefix": "inner",
+                            "children": [{"file": "asserts.md"}],
+                        },
+                    ],
+                }
+            ]
+        },
+        {"asserts.md": _NIXDOC_SNIPPET1},
+    )
+    generated = [id for id in _heading_ids(html) if id.startswith(("outer-", "inner-"))]
+    assert len(generated) == 1
+    assert generated[0].startswith("inner-")
+
+
+def test_config_id_prefix_fails(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        _render_with_config(
+            tmp_path,
+            {"items": [{"label": "Library", "children": [{"file": "asserts.md"}]}]},
+            {"asserts.md": _NIXDOC_SNIPPET1},
+        )
+    assert "heading does not have an id" in str(excinfo.value.__cause__)


### PR DESCRIPTION
reference docs have no explicit heading-ids. This change allows reference docs to be included via nav.json

auto_id_prefix is a pre-existing feature. This PR adds support for that in nav.json

See the example below

This came up during #554651 

After this is merged we can merge #554651; and then we can start using the nav.json for rendering content into docs.nixos.org

Tests are added in a seperate commit assisted by an LLM 

This change allows the following:

`nav.json` 
```jsonc
{
    "items": [
        {
            "label": "nixpkgs lib functions",
            // PR adds this: This is needed because nrd requires explicit heading ids
            "id-prefix": "lib-functions", 
            "children": [
                // generated from lib/attrsets.nix which does not have heading-ids
                {"file": "lib-attrsets.md"}
                ...
            ],
        }
    ]
}
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
