### PR TITLE
nixosTests: test tpm2-totp CLI usage & Plymouth integration

### DIFF
--- a/nixos/modules/system/boot/plymouth-tpm2-totp.nix
+++ b/nixos/modules/system/boot/plymouth-tpm2-totp.nix
@@ -20,6 +20,7 @@ in
   meta = {
     maintainers = with lib.maintainers; [ majiir ];
     doc = ./plymouth-tpm2-totp.md;
+    # tested by nixosTests.tpm2-totp.plymouth
   };
 
   config = lib.mkIf cfg.enable {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1818,6 +1818,7 @@ in
   tor = runTest ./tor.nix;
   tpm-ek = handleTest ./tpm-ek { };
   tpm2 = import ./tpm2 { inherit runTest; };
+  tpm2-totp = import ./tpm2-totp { inherit runTest; };
   traccar = runTest ./traccar.nix;
   # tracee requires bpf
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };

--- a/nixos/tests/tpm2-totp/_common.nix
+++ b/nixos/tests/tpm2-totp/_common.nix
@@ -1,0 +1,89 @@
+# common test properties shared across the tpm2-totp tests
+{
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (builtins) concatStringsSep;
+  inherit (lib) types;
+  inherit (lib.options) mkOption;
+  inherit (lib.strings) escapeShellArgs;
+
+  cfg = config.test-tpm2-totp;
+in
+{
+
+  _class = "nixosTest";
+
+  # for shared test properties
+  # (makes it easier to reuse tests externally with different PCRs)
+  options.test-tpm2-totp = {
+
+    banks = mkOption {
+      type = with types; listOf str;
+      default = [
+        "SHA1"
+        "SHA256"
+      ];
+      description = "PCR banks to seal secret of tpm2-totp against";
+    };
+
+    bankToHexLength = mkOption {
+      type = with types; attrsOf int;
+      default = {
+        SHA1 = 40;
+        SHA256 = 64;
+      };
+      description = "Length of hex-encoded PCR value for each supported bank";
+    };
+
+    sealArgs = mkOption {
+      type = types.str;
+      internal = true;
+      readOnly = true;
+      default = escapeShellArgs [
+        "--banks"
+        (concatStringsSep "," cfg.banks)
+        "--pcrs"
+        (concatStringsSep "," cfg.pcrs)
+      ];
+      description = "Arguments for tpm2-totp when generating a secret";
+    };
+
+    pcrs = mkOption {
+      type = with types; listOf str;
+      default = [
+        "0"
+        "1"
+        "2"
+        "3"
+        "4"
+        "5"
+        "6"
+      ];
+      description = "PCRs to seal secret of tpm2-totp against";
+    };
+
+  };
+
+  config = {
+
+    # tests are similar enough to share maintainers
+    meta.maintainers = with lib.maintainers; [
+      Zocker1999NET
+    ];
+
+    nodes.machine.virtualisation = {
+
+      # obviously required
+      tpm.enable = true;
+
+      # interestingly not actually required for tests to pass
+      # but is a more realistic setup than legacy boot
+      useEFIBoot = true;
+
+    };
+
+  };
+}

--- a/nixos/tests/tpm2-totp/cli.nix
+++ b/nixos/tests/tpm2-totp/cli.nix
@@ -1,0 +1,106 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (builtins) head;
+  inherit (lib.strings)
+    escapeShellArgs
+    replicate
+    toLower
+    ;
+
+  cfg = config.test-tpm2-totp;
+
+  # extend a used PCR to invalidate the TOTP
+  pcrExtendCmd =
+    let
+      bank = head cfg.banks;
+      pcr = head cfg.pcrs;
+      bankLength = cfg.bankToHexLength.${bank};
+    in
+    escapeShellArgs [
+      "tpm2_pcrextend"
+      "${pcr}:${toLower bank}=${replicate bankLength "0"}"
+    ];
+
+  totpPassword = "-P abcdef";
+  totpInvalidPassword = "-P wrong";
+in
+{
+
+  _class = "nixosTest";
+
+  imports = [
+    ./_common.nix
+  ];
+
+  name = "tpm2-totp-cli";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [
+        tpm2-tools # for tpm2_pcrextend
+        tpm2-totp # manually test the CLI commands (without using module)
+        oath-toolkit # for oathtool, to independently verify the TOTP
+      ];
+    };
+
+  testScript = ''
+    import re
+
+    def extract_secret(out: str) -> str:
+      """extract TOTP secret from tpm2-totp output"""
+      url = next(l for l in out.splitlines() if l.startswith("otpauth://"))
+      return url.split("secret=")[1]
+
+    # wait for systemd finished booting, otherwise PCRs might still change
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("calculate fails when no secret is stored"):
+      machine.fail("tpm2-totp calculate")
+
+    with subtest("typical tpm2-totp setup flow"):
+      out = machine.succeed("tpm2-totp ${totpPassword} ${cfg.sealArgs} generate")
+      secret = extract_secret(out)
+      print(f"secret: {secret!r}")
+
+    with subtest("calculate produces a TOTP that matches oathtool"):
+      totp = machine.succeed("tpm2-totp calculate").strip()
+      # check ±30s step to avoid flakiness around step boundaries
+      now = int(machine.succeed("date +%s").strip())
+      codes = []
+      for offset in (-30, 0, 30):
+        t = machine.succeed(f"date -d @{now + offset} +%Y-%m-%dT%H:%M:%S").strip()
+        code = machine.succeed(f"oathtool --totp --base32 --now {t} {secret}").strip()
+        codes.append(code)
+      assert totp in codes, f"{totp} not in {codes!r} at epoch {now!r}"
+
+    with subtest("calculate with --time prints the calculation time"):
+      out = machine.succeed("tpm2-totp -t calculate").strip()
+      assert re.search(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}: \d{6}$", out)
+
+    with subtest("changing a sealed PCR invalidates the TOTP"):
+      machine.succeed("${pcrExtendCmd}")
+      machine.fail("tpm2-totp calculate")
+
+    with subtest("recover with the correct password returns the original secret"):
+      out = machine.succeed("tpm2-totp ${totpPassword} recover")
+      recovered_secret = extract_secret(out)
+      assert recovered_secret == secret, f"recovered secret {recovered_secret!r} != original secret {secret!r}"
+
+    with subtest("recover with a wrong password fails"):
+      machine.fail("tpm2-totp ${totpInvalidPassword} recover")
+
+    with subtest("reseal to the current PCR values restores calculate"):
+      machine.succeed("tpm2-totp ${totpPassword} ${cfg.sealArgs} reseal")
+      machine.succeed("tpm2-totp calculate")
+
+    with subtest("clean removes the secret and calculate fails"):
+      machine.succeed("tpm2-totp clean")
+      machine.fail("tpm2-totp calculate")
+  '';
+
+}

--- a/nixos/tests/tpm2-totp/default.nix
+++ b/nixos/tests/tpm2-totp/default.nix
@@ -1,0 +1,5 @@
+{ runTest }:
+{
+  cli = runTest ./cli.nix;
+  plymouth = runTest ./plymouth.nix;
+}

--- a/nixos/tests/tpm2-totp/plymouth.nix
+++ b/nixos/tests/tpm2-totp/plymouth.nix
@@ -1,0 +1,76 @@
+{
+  config,
+  ...
+}:
+let
+  cfg = config.test-tpm2-totp;
+in
+{
+
+  _class = "nixosTest";
+
+  imports = [
+    ./_common.nix
+  ];
+
+  name = "tpm2-totp-plymouth";
+
+  # to verify TOTP digits on the plymouth screen
+  enableOCR = true;
+
+  nodes.machine =
+    { config, ... }:
+    {
+
+      # minimal enablement of tpm2-totp module
+      boot = {
+        initrd.systemd.enable = true;
+        plymouth = {
+          enable = true;
+          tpm2-totp.enable = true;
+        };
+      };
+
+      # required for manual TOTP calculation in initrd by testScript
+      boot.initrd.systemd.extraBin.tpm2-totp = "${config.boot.plymouth.tpm2-totp.package}/bin/tpm2-totp";
+
+      # pause boot for test inspection
+      testing.initrdBackdoor = true;
+
+    };
+
+  testScript = ''
+    import re
+
+    # required for later reboot
+    machine.start(allow_reboot=True)
+
+    with subtest("mirror typical tpm2-totp setup flow"):
+      machine.wait_for_unit("initrd.target")
+      machine.switch_root()
+      machine.wait_for_unit("multi-user.target")
+      # seal without password for recovery should also work
+      machine.succeed("tpm2-totp ${cfg.sealArgs} generate")
+
+    with subtest("reboot into initrd"):
+      machine.reboot()
+      machine.wait_for_unit("initrd.target")
+
+    with subtest("plymouth-tpm2-totp.service runs in initrd"):
+      machine.wait_for_unit("plymouth-tpm2-totp.service")
+      machine.succeed("systemctl is-active plymouth-tpm2-totp.service")
+
+    with subtest("TOTP can be calculated in initrd"):
+      out = machine.succeed("tpm2-totp calculate").strip()
+      assert re.search(r"^\d{6}$", out), f"no 6-digit TOTP found in: {out!r}"
+
+    with subtest("plymouth displays TOTP digits on the screen"):
+      # not match against exact expected TOTP as may have already changed by the time OCR was successful
+      machine.wait_for_text(r"\d{6}")
+
+    with subtest("confirm full boot still works"): # test just in case
+      machine.switch_root()
+      machine.wait_for_unit("multi-user.target")
+  '';
+
+}

--- a/pkgs/by-name/tp/tpm2-totp/package.nix
+++ b/pkgs/by-name/tp/tpm2-totp/package.nix
@@ -10,6 +10,7 @@
   withPlymouth ? false,
   plymouth,
   qrencode,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,6 +40,13 @@ stdenv.mkDerivation (finalAttrs: {
     qrencode
   ]
   ++ lib.optional withPlymouth plymouth;
+
+  passthru.tests = {
+    inherit (nixosTests.tpm2-totp) cli;
+  }
+  // lib.optionalAttrs withPlymouth {
+    inherit (nixosTests.tpm2-totp) plymouth;
+  };
 
   meta = {
     description = "Attest the trustworthiness of a device against a human using time-based one-time passwords";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tests were missing, so I decided to write them. TL;DR on the tests:
- `nixosTests.tpm2-totp.cli` tests the CLI usage of `tpm2-totp` against its expected security-related behavior:
	- generated TOTP is as expected (compared to `oathtool`)
	- changing a PCR sealed against breaks TOTP calculation
	- secret can be resealed & can be cleared
- `nixosTests.tpm2-totp.plymouth` tests that TOTP is visibly presented to the user
	- does not compare TOTP value in case OCR fails or takes longer than expected

I decided to insert me as maintainer for these tests, as I have designed them.

Pinging maintainers of package & module: @Majiir @RaitoBezarius 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
