### PR TITLE
atril: 1.28.6 -> 1.28.7

### DIFF
--- a/pkgs/by-name/at/atril/package.nix
+++ b/pkgs/by-name/at/atril/package.nix
@@ -12,6 +12,7 @@
   glib,
   libxml2,
   libarchive,
+  libgepub,
   libsecret,
   poppler,
   mate-desktop,
@@ -33,14 +34,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "atril";
-  version = "1.28.6";
+  version = "1.28.7";
 
   src = fetchFromGitHub {
     owner = "mate-desktop";
     repo = "atril";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-d5wkMsO3iR3qudL6JXmybDWkdvRgc53FFuf9S6wPEtU=";
+    hash = "sha256-fzmB3OKxbR1Wv7jVEGkDjqVxxDiKPEjyBVu9+RwW3v8=";
   };
 
   nativeBuildInputs = [
@@ -66,18 +67,17 @@ stdenv.mkDerivation (finalAttrs: {
     texlive.bin.core # for synctex, used by the pdf back-end
   ]
   ++ lib.optionals enableDjvu [ djvulibre ]
-  ++ lib.optionals enableEpub [ webkitgtk_4_1 ]
+  ++ lib.optionals enableEpub [
+    webkitgtk_4_1
+    libgepub
+  ]
   ++ lib.optionals enablePostScript [ libspectre ]
   ++ lib.optionals enableXps [ libgxps ];
 
   configureFlags =
     [ ]
     ++ lib.optionals enableDjvu [ "--enable-djvu" ]
-    ++ lib.optionals enableEpub [
-      # FIXME: We ship this with non-existent fallback mathjax-directory
-      # because `MathJax.js` is only available in MathJax 2.7.x.
-      "--enable-epub"
-    ]
+    ++ lib.optionals enableEpub [ "--enable-epub" ]
     ++ lib.optionals enablePostScript [ "--enable-ps" ]
     ++ lib.optionals enableXps [ "--enable-xps" ]
     ++ lib.optionals enableImages [ "--enable-pixbuf" ];


### PR DESCRIPTION
https://github.com/mate-desktop/atril/compare/v1.28.6...v1.28.7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
