### PR TITLE
nixos-rebuild-ng: create custom profile directory on set_profile()

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -206,10 +206,16 @@ class Profile:
     path: Path
 
     @classmethod
+    def _is_custom_name(cls, name: str) -> bool:
+        return name != "system"
+
+    @classmethod
     def from_arg(cls, name: str) -> Self:
-        match name:
-            case "system":
-                return cls(name, Path("/nix/var/nix/profiles/system"))
-            case _:
-                path = Path("/nix/var/nix/profiles/system-profiles") / name
-                return cls(name, path)
+        if cls._is_custom_name(name):
+            path = Path("/nix/var/nix/profiles/system-profiles") / name
+            return cls(name, path)
+        else:
+            return cls(name, Path("/nix/var/nix/profiles/system"))
+
+    def is_custom(self) -> bool:
+        return self._is_custom_name(self.name)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -212,5 +212,4 @@ class Profile:
                 return cls(name, Path("/nix/var/nix/profiles/system"))
             case _:
                 path = Path("/nix/var/nix/profiles/system-profiles") / name
-                path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
                 return cls(name, path)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -690,9 +690,9 @@ def set_profile(
             ).strip()
             raise NixOSRebuildError(msg)
 
-    # Using custom profile, the target profile directory may not exist so we
-    # need to create it first
-    if profile.name != "system":
+    if profile.is_custom():
+        # Using custom profile, the target profile directory may not exist yet,
+        # so we need to create it first
         run_wrapper(
             ["mkdir", "-p", profile.path.parent],
             remote=target_host,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -690,6 +690,15 @@ def set_profile(
             ).strip()
             raise NixOSRebuildError(msg)
 
+    # Using custom profile, the target profile directory may not exist so we
+    # need to create it first
+    if profile.name != "system":
+        run_wrapper(
+            ["mkdir", "-p", profile.path.parent],
+            remote=target_host,
+            elevate=elevate,
+        )
+
     run_wrapper(
         ["nix-env", "-p", profile.path, "--set", path_to_config],
         remote=target_host,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -610,7 +610,7 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
 @patch("subprocess.run", autospec=True)
 @patch("uuid.uuid4", autospec=True)
 @patch(get_qualified_name(nr.services.cleanup_ssh), autospec=True)
-def test_execute_nix_switch_build_target_host(
+def test_execute_nix_switch_build_target_host_custom_profile(
     mock_cleanup_ssh: Mock,
     mock_uuid4: Mock,
     mock_run: Mock,
@@ -654,10 +654,12 @@ def test_execute_nix_switch_build_target_host(
             "nixos-config=./configuration.nix",
             "-I",
             "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
+            "--profile-name",
+            "custom-profile",
         ]
     )
 
-    assert mock_run.call_count == 12
+    assert mock_run.call_count == 13
     mock_run.assert_has_calls(
         [
             call(
@@ -802,9 +804,27 @@ def test_execute_nix_switch_build_target_host(
                     "-c",
                     """'exec /usr/bin/env -i PATH="${PATH-}" "$@"'""",
                     "sh",
+                    "mkdir",
+                    "-p",
+                    "/nix/var/nix/profiles/system-profiles",
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@target-host",
+                    "--",
+                    "sudo",
+                    "/bin/sh",
+                    "-c",
+                    """'exec /usr/bin/env -i PATH="${PATH-}" "$@"'""",
+                    "sh",
                     "nix-env",
                     "-p",
-                    "/nix/var/nix/profiles/system",
+                    "/nix/var/nix/profiles/system-profiles/custom-profile",
                     "--set",
                     str(config_path),
                 ],

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -205,19 +205,16 @@ def test_flake_from_arg(
         ) == m.Flake("/path/to", 'nixosConfigurations."remote-hostname"')
 
 
-@patch("pathlib.Path.mkdir", autospec=True)
-def test_profile_from_arg(mock_mkdir: Mock) -> None:
+def test_profile_from_arg() -> None:
     assert m.Profile.from_arg("system") == m.Profile(
         "system",
         Path("/nix/var/nix/profiles/system"),
     )
-    mock_mkdir.assert_not_called()
 
     assert m.Profile.from_arg("something") == m.Profile(
         "something",
         Path("/nix/var/nix/profiles/system-profiles/something"),
     )
-    mock_mkdir.assert_called_once()
 
 
 def test_grouped_nix_args_flake_build_flags() -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -217,6 +217,11 @@ def test_profile_from_arg() -> None:
     )
 
 
+def test_profile_is_custom() -> None:
+    assert not m.Profile("system", Path()).is_custom()
+    assert m.Profile("something", Path()).is_custom()
+
+
 def test_grouped_nix_args_flake_build_flags() -> None:
     """Test that flake_build_flags excludes evaluation-only flags."""
     from argparse import Namespace

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -749,6 +749,32 @@ def test_set_profile(mock_run: Mock) -> None:
         elevate=e.NO_ELEVATOR,
     )
 
+    mock_run.reset_mock()
+    target_host = m.Remote("user@localhost", [], "ssh")
+
+    n.set_profile(
+        m.Profile("something", profile_path),
+        config_path,
+        target_host=target_host,
+        elevate=e.NO_ELEVATOR,
+    )
+
+    mock_run.assert_has_calls(
+        [
+            call(
+                ["mkdir", "-p", profile_path.parent],
+                remote=target_host,
+                elevate=e.NO_ELEVATOR,
+            ),
+            call(
+                ["nix-env", "-p", profile_path, "--set", config_path],
+                remote=target_host,
+                elevate=e.NO_ELEVATOR,
+            ),
+        ]
+    )
+
+    mock_run.reset_mock()
     mock_run.return_value = CompletedProcess([], 1)
 
     with pytest.raises(m.NixOSRebuildError) as exc:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix #557687.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
