### PR TITLE
blindfold: init at 1.1.0

### DIFF
--- a/pkgs/by-name/bl/blindfold/package.nix
+++ b/pkgs/by-name/bl/blindfold/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "blindfold";
+  version = "1.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Eoin-McMahon";
+    repo = "blindfold";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-faSuaeOlFu7cw6WJxsHn/dQOfIzvxJNIadacgTfan7w=";
+  };
+
+  cargoHash = "sha256-Wwpl1U96CYt5WDEaiibP/ZiJyDDaPfrd1g8/qFOENDg=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "A simple and lightwheight .gitignore generator";
+    mainProgram = "blindfold";
+    maintainers = with lib.maintainers; [ idkdontaskm3 ];
+    license = with lib.licenses; [ mit ];
+  };
+})


### PR DESCRIPTION
## Things done
pulled blindfold rust repo, built (requiring openssl and pkg-config) overall a simple package. doCheck is disabled due to a check that fails in some terminals due to coloring - if there is a better way to do this, please note it when reviewing! thx!

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].