### PR TITLE
libfn: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4266,6 +4266,12 @@
     githubId = 40476330;
     name = "brokenpip3";
   };
+  bronek = {
+    email = "brok@incorrekt.com";
+    github = "Bronek";
+    githubId = 823856;
+    name = "Bronek Kozicki";
+  };
   BronzeDeer = {
     github = "BronzeDeer";
     githubId = 74385045;

--- a/pkgs/by-name/li/libfn/package.nix
+++ b/pkgs/by-name/li/libfn/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  catch2_3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libfn";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "libfn";
+    repo = "functional";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-T4pKqLXo3kaCCEwXpVkXrCGRFdperBJsKW6meqIf+Xs=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  checkInputs = [ catch2_3 ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "DISABLE_FETCH_CONTENT" true)
+    (lib.cmakeBool "DISABLE_CCACHE_DETECTION" true)
+    (lib.cmakeBool "LIBFN_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Functional programming in C++ using monadic composition";
+    homepage = "https://libfn.org";
+    changelog = "https://github.com/libfn/functional/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ bronek ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
New package: [libfn 0.1.0](https://github.com/libfn/functional) — a header-only C++20 functional-programming library providing monadic composition over `expected`- and `optional`-style vocabulary types, with selected C++23 and C++26 facilities polyfilled for C++20. See the [project homepage](https://libfn.org) for further details.

This PR also adds me, the upstream maintainer, to the Nixpkgs maintainer list.

The derivation runs the upstream Catch2 test suite in `checkPhase`; all 44 tests pass with the default `stdenv`.

Automation disclosure: prepared with assistance from Claude (model `claude-fable-5`). Both commits include `Assisted-by:` trailers, and all generated output was reviewed, built, and tested before submission.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review rev` before submitting this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. (Not applicable: this is a header-only library with no binaries; the upstream test suite runs in `checkPhase`.)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
