### PR TITLE
various: gnome-circle 2026-08-29 updates

### DIFF
--- a/pkgs/by-name/cu/curtail/package.nix
+++ b/pkgs/by-name/cu/curtail/package.nix
@@ -23,14 +23,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "curtail";
-  version = "1.16.1";
+  version = "1.16.2";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Huluti";
     repo = "Curtail";
     tag = finalAttrs.version;
-    hash = "sha256-vegtuuGyjfr0vJgaGLTkws/BysxHeVod/C9bz8lnJpo=";
+    hash = "sha256-Z4XY2/24FBdvPB3MeT7PPSXprf5HHlL1OdB6rknsL/w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cu/curtail/package.nix
+++ b/pkgs/by-name/cu/curtail/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   wrapGAppsHook4,
   appstream-glib,
@@ -21,7 +21,7 @@
   nix-update-script,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "curtail";
   version = "1.16.2";
   pyproject = false;
@@ -54,8 +54,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     libadwaita
   ];
 
-  propagatedBuildInputs = [
-    python3.pkgs.pygobject3
+  dependencies = [
+    python3Packages.pygobject3
   ];
 
   preInstall = ''
@@ -84,6 +84,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/Huluti/Curtail/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Simple & useful image compressor";
     mainProgram = "curtail";
     homepage = "https://github.com/Huluti/Curtail";

--- a/pkgs/by-name/ea/eartag/package.nix
+++ b/pkgs/by-name/ea/eartag/package.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "eartag";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-Iwfk0SqxYF2bzkKZNqGonJh8MQ2c+K1wN0o4GECR/Rw=";
   };
 
@@ -60,7 +60,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     libadwaita
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     aiofiles
     aiohttp
     pygobject3
@@ -86,12 +86,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://gitlab.gnome.org/World/eartag";
     description = "Simple music tag editor";
     changelog = "https://gitlab.gnome.org/World/eartag/-/releases/${finalAttrs.version}";
-    # This seems to be using ICU license but we're flagging it to MIT license
-    # since ICU license is a modified version of MIT and to prevent it from
-    # being incorrectly identified as unfree software.
     license = lib.licenses.mit;
     mainProgram = "eartag";
-    maintainers = [ ];
     teams = [ lib.teams.gnome-circle ];
   };
 })

--- a/pkgs/by-name/ea/eartag/package.nix
+++ b/pkgs/by-name/ea/eartag/package.nix
@@ -22,7 +22,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "eartag";
-  version = "1.0.2";
+  version = "1.0.3";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "World";
     repo = "eartag";
     tag = finalAttrs.version;
-    hash = "sha256-Iwfk0SqxYF2bzkKZNqGonJh8MQ2c+K1wN0o4GECR/Rw=";
+    hash = "sha256-XyVKqkeaxy8bhrN6AhbnJpUSYETbY4DGHU7s2O71Wpc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/gn/gnome-decoder/package.nix
+++ b/pkgs/by-name/gn/gnome-decoder/package.nix
@@ -23,19 +23,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-decoder";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "decoder";
     tag = finalAttrs.version;
-    hash = "sha256-ssbqtDuUpHDT0Q91YCWsvYS8T9cMl4ukOKuaIvnGg44=";
+    hash = "sha256-ZYjln/s3WVSacugSK3aB6LeIpaqSy0T2cMqHoV4ge9A=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Ue89/U4OXQVftuGtiYF2cr4UuFzrfz6DT52EQM1wd7s=";
+    hash = "sha256-0koEJg/VZtFNxfuUaYv6iooHRQ1qxTeJDcTbC4giZhI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/io/iotas/package.nix
+++ b/pkgs/by-name/io/iotas/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitLab,
   blueprint-compiler,
   meson,
@@ -19,7 +19,7 @@
   webkitgtk_6_0,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "iotas";
   version = "2026.7";
   pyproject = false;
@@ -53,7 +53,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     webkitgtk_6_0
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     pygobject3
     pygtkspellcheck
     requests
@@ -71,6 +71,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   '';
 
   meta = {
+    changelog = "https://gitlab.gnome.org/World/iotas/-/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Simple note taking with mobile-first design and Nextcloud sync";
     homepage = "https://gitlab.gnome.org/World/iotas";
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/io/iotas/package.nix
+++ b/pkgs/by-name/io/iotas/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3,
   fetchFromGitLab,
+  blueprint-compiler,
   meson,
   ninja,
   pkg-config,
@@ -20,7 +21,7 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "iotas";
-  version = "2026.6";
+  version = "2026.7";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -28,10 +29,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     owner = "World";
     repo = "iotas";
     tag = finalAttrs.version;
-    hash = "sha256-Zsfp5O6k8VMjF6Hl3lT+u9JingGq3XgCzc8h9PVAhLg=";
+    hash = "sha256-qJI1C5G8DGdIOHXVPiky7JK+Re+0WY18c868LY8/h4k=";
   };
 
   nativeBuildInputs = [
+    blueprint-compiler
     meson
     ninja
     pkg-config

--- a/pkgs/by-name/ke/keypunch/package.nix
+++ b/pkgs/by-name/ke/keypunch/package.nix
@@ -54,6 +54,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ libadwaita ];
 
+  # Required to avoid building with development assets.
+  # See https://github.com/bragefuglseth/keypunch/blob/v7.0/meson.build#L18-L21
+  mesonBuildType = "release";
+
   passthru = {
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/ke/keypunch/package.nix
+++ b/pkgs/by-name/ke/keypunch/package.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "keypunch";
-  version = "6.3";
+  version = "7.0";
 
   src = fetchFromGitHub {
     owner = "bragefuglseth";
     repo = "keypunch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NjPC7WbzOk0tDjM8la+TKGy+U2NNT2kwcrSkaG7TylQ=";
+    hash = "sha256-I6nHobhQqcUdfTXDP9oIx+0BJz/VKaQb/OD77VQsWek=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/by-name/ke/keypunch/package.nix
+++ b/pkgs/by-name/ke/keypunch/package.nix
@@ -70,7 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "keypunch";
     maintainers = with lib.maintainers; [
       tomasajt
-      getchoo
     ];
     teams = [ lib.teams.gnome-circle ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/vi/video-trimmer/package.nix
+++ b/pkgs/by-name/vi/video-trimmer/package.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "video-trimmer";
-  version = "26.03";
+  version = "26.03.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "YaLTeR";
     repo = "video-trimmer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ro7yOl+OZ4IZxIkRMjYf4IqOxfCAB4PdIlWUEuymOc8=";
+    hash = "sha256-qHhN/BOSFTTco+Hy7Nn0h2ZcQw0eR0VEW7oVftpSkEM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {


### PR DESCRIPTION
Look into each commit message for a changelog and diff. Did some small cleanup on some packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
