### PR TITLE
otelite: init at 0.1.105

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -32150,6 +32150,12 @@
     githubId = 48529745;
     name = "ZariTen";
   };
+  zatevakhin = {
+    email = "zatevaxin.ivan+nixpkgs@gmail.com";
+    github = "zatevakhin";
+    githubId = 12279112;
+    name = "Ivan Zatevakhin";
+  };
   zatm8 = {
     email = "maxis1191@gmail.com";
     github = "mourogurt";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1088,6 +1088,7 @@
   ./services/monitoring/opentelemetry-collector.nix
   ./services/monitoring/orbit.nix
   ./services/monitoring/osquery.nix
+  ./services/monitoring/otelite.nix
   ./services/monitoring/parsedmarc.nix
   ./services/monitoring/perses.nix
   ./services/monitoring/pgscv.nix

--- a/nixos/modules/services/monitoring/otelite.nix
+++ b/nixos/modules/services/monitoring/otelite.nix
@@ -1,0 +1,101 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.otelite;
+in
+{
+  meta.maintainers = [ lib.maintainers.zatevakhin ];
+
+  options.services.otelite = {
+    enable = lib.mkEnableOption "Otelite OpenTelemetry receiver and dashboard";
+
+    package = lib.mkPackageOption pkgs "otelite" { };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = "Address on which the dashboard, API, and OTLP receivers listen.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "Port on which the dashboard and API listen.";
+    };
+
+    otlpGrpcPort = lib.mkOption {
+      type = lib.types.port;
+      default = 4317;
+      description = "Port on which the OTLP gRPC receiver listens.";
+    };
+
+    otlpHttpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 4318;
+      description = "Port on which the OTLP HTTP receiver listens.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the dashboard and OTLP receiver ports in the firewall.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          cfg.port != cfg.otlpGrpcPort
+          && cfg.port != cfg.otlpHttpPort
+          && cfg.otlpGrpcPort != cfg.otlpHttpPort;
+        message = "services.otelite ports must be distinct";
+      }
+    ];
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      cfg.port
+      cfg.otlpGrpcPort
+      cfg.otlpHttpPort
+    ];
+
+    systemd.services.otelite = {
+      description = "Otelite OpenTelemetry receiver and dashboard";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      environment = {
+        HOME = "/var/lib/otelite";
+        OTELITE_OTLP_GRPC_PORT = toString cfg.otlpGrpcPort;
+        OTELITE_OTLP_HTTP_PORT = toString cfg.otlpHttpPort;
+      };
+
+      serviceConfig = {
+        ExecStart = utils.escapeSystemdExecArgs [
+          (lib.getExe cfg.package)
+          "serve"
+          "--addr"
+          "${cfg.address}:${toString cfg.port}"
+          "--storage-path"
+          "/var/lib/otelite"
+        ];
+        DynamicUser = true;
+        StateDirectory = "otelite";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = "/var/lib/otelite";
+        UMask = "0027";
+        Restart = "on-failure";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1337,6 +1337,7 @@ in
   os-prober = handleTestOn [ "x86_64-linux" ] ./os-prober.nix { };
   osquery = handleTestOn [ "x86_64-linux" ] ./osquery.nix { };
   osrm-backend = runTest ./osrm-backend.nix;
+  otelite = runTest ./otelite.nix;
   outline = runTest ./outline.nix;
   overlayfs = runTest ./overlayfs.nix;
   owi = runTest ./owi.nix;

--- a/nixos/tests/otelite.nix
+++ b/nixos/tests/otelite.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+
+{
+  name = "otelite";
+  meta.maintainers = [ lib.maintainers.zatevakhin ];
+
+  nodes.machine.services.otelite = {
+    enable = true;
+    otlpGrpcPort = 14317;
+    otlpHttpPort = 14318;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("otelite.service")
+    machine.wait_for_open_port(3000)
+    machine.wait_for_open_port(14317)
+    machine.wait_for_open_port(14318)
+    machine.succeed("curl --fail http://localhost:3000/api/health | grep -F '\"otlp_grpc_port\":14317'")
+    machine.succeed("curl --fail http://localhost:3000/api/health | grep -F '\"otlp_http_port\":14318'")
+    machine.succeed("test $(stat -Lc %a /var/lib/otelite) = 750")
+  '';
+}

--- a/pkgs/by-name/ot/otelite/package.nix
+++ b/pkgs/by-name/ot/otelite/package.nix
@@ -1,0 +1,95 @@
+{
+  darwin,
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  lsof,
+  nixosTests,
+  openssl,
+  pkg-config,
+  procps,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "otelite";
+  version = "0.1.105";
+
+  src = fetchFromGitHub {
+    owner = "planetf1";
+    repo = "otelite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-w3gIfNz+hXH2cu8Ckp9xcUtK3SrXUAu1vzhNCOZ5ewI=";
+  };
+
+  cargoHash = "sha256-HbTLG5Vk5zdNJTR5+kOKy2FhbLX0f2qh4RMN0AgWIZw=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  # Upstream service-discovery tests use lsof and ps to inspect running processes.
+  nativeCheckInputs = [
+    lsof
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ procps ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.ps ];
+
+  cargoBuildFlags = [
+    "-p"
+    "otelite"
+    "--bin"
+    "otelite"
+  ];
+
+  checkFlags = [
+    # The Nix build PTY is too narrow for these contiguous pretty-table assertions.
+    "--skip=display_renders_correlation_provenance_counts"
+    "--skip=display_reports_identity_and_counts"
+    # Timing-sensitive assertion occasionally observes the log file before it is flushed.
+    "--skip=test_serve_writes_rotating_log_file"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # These tests require launchctl, which is unavailable in the Darwin sandbox.
+    "--skip=test_discovery_finds_serve_without_pid_file"
+    "--skip=test_status_recovers_from_corrupt_pid_file"
+  ];
+
+  swaggerUi = fetchurl {
+    url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.12.zip";
+    hash = "sha256-HK4z/JI+1yq8BTBJveYXv9bpN/sXru7bn/8g5mf2B/I=";
+  };
+
+  preBuild = ''
+    install -m 0644 ${finalAttrs.swaggerUi} "$TMPDIR/swagger-ui.zip"
+    export SWAGGER_UI_DOWNLOAD_URL="file:$TMPDIR/swagger-ui.zip"
+  '';
+
+  preCheck = ''
+    install -m 0644 ${finalAttrs.swaggerUi} "$TMPDIR/swagger-ui.zip"
+    export SWAGGER_UI_DOWNLOAD_URL="file:$TMPDIR/swagger-ui.zip"
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    "$out/bin/otelite" --help
+    "$out/bin/otelite" --version
+    runHook postInstallCheck
+  '';
+
+  passthru.tests.nixos = nixosTests.otelite;
+
+  meta = {
+    description = "Lightweight OpenTelemetry receiver and dashboard for local development";
+    homepage = "https://github.com/planetf1/otelite";
+    changelog = "https://github.com/planetf1/otelite/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ zatevakhin ];
+    mainProgram = "otelite";
+  };
+})


### PR DESCRIPTION
Adds [otelite](https://github.com/planetf1/otelite) `0.1.105`, a lightweight opentelemetry receiver and dashboard for local development.

The package builds the tagged upstream release and includes install checks for the cli. a minimal NixOS module is included for running otelite as a hardened dynamic-user systemd service, together with a NixOS VM test.

Automation disclosure: this contribution and pull request description were prepared with assistance from QueryMT using codex/gpt-5.6-sol. i manually reviewed and tested the resulting changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
