### PR TITLE
pre-commit: 4.5.1 -> 4.6.2; cleanup

### DIFF
--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -68,7 +68,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pytest-env
     pytest-forked
     pytest-xdist
-    pytestCheckHook
     re-assert
   ])
   ++ lib.optionals (!i686Linux) [

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -62,7 +62,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     go
     nodejs
     perl
-    versionCheckHook
     writableTmpDirAsHomeHook
   ]
   ++ (with python3Packages; [
@@ -81,6 +80,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # i686-linux: dotnet-sdk not available
     dotnet-sdk
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   postPatch = ''
     substituteInPlace pre_commit/resources/hook-tmpl \

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -216,6 +216,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     changelog = "https://github.com/pre-commit/pre-commit/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      booxter
       borisbabic
       savtrip
     ];

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -96,26 +96,21 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "--forked"
   ];
 
-  preCheck =
-    lib.optionalString (!(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64)) ''
-      # Disable outline atomics for rust tests on aarch64-linux.
-      export RUSTFLAGS="-Ctarget-feature=-outline-atomics"
-    ''
-    + ''
-      export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \
-             GIT_AUTHOR_EMAIL=test@example.com GIT_COMMITTER_EMAIL=test@example.com \
-             VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1
-    ''
-    + lib.optionalString (!i686Linux) ''
-      # Resolve `.NET location: Not found` errors for dotnet tests
-      export DOTNET_ROOT="${dotnet-sdk}/share/dotnet"
-    ''
-    + ''
-      git init -b master
+  preCheck = ''
+    export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \
+           GIT_AUTHOR_EMAIL=test@example.com GIT_COMMITTER_EMAIL=test@example.com \
+           VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1
+  ''
+  + lib.optionalString (!i686Linux) ''
+    # Resolve `.NET location: Not found` errors for dotnet tests
+    export DOTNET_ROOT="${dotnet-sdk}/share/dotnet"
+  ''
+  + ''
+    git init -b master
 
-      python -m venv --system-site-packages venv
-      source "$PWD/venv/bin/activate"
-    '';
+    python -m venv --system-site-packages venv
+    source "$PWD/venv/bin/activate"
+  '';
 
   postCheck = ''
     deactivate

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -26,14 +26,14 @@ let
 in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pre-commit";
-  version = "4.5.1";
+  version = "4.6.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pre-commit";
     repo = "pre-commit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3E/haU7TzTr+Qj3KadC7BYwuECZPa2Q+NvG5e4SSKSA=";
+    hash = "sha256-aCEN9dVz/3lB2gy7U+6dVj3jSM7cmVsstOp+LHvYRsU=";
   };
 
   patches = [
@@ -165,6 +165,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_lua_additional_dependencies"
     "test_node_additional_deps"
     "test_node_hook_versions"
+    "test_npm_install_succeeds_with_build"
     "test_perl_additional_dependencies"
     "test_r_hook"
     "test_r_inline"

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -95,7 +95,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   preCheck = ''
     export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \
            GIT_AUTHOR_EMAIL=test@example.com GIT_COMMITTER_EMAIL=test@example.com \
-           VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1
+           PRE_COMMIT_NO_CONCURRENCY=1
   ''
   + lib.optionalString (!i686Linux) ''
     # Resolve `.NET location: Not found` errors for dotnet tests

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -66,7 +66,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ]
   ++ (with python3Packages; [
     pytest-env
-    pytest-forked
     pytest-xdist
     re-assert
   ])
@@ -92,10 +91,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
     patchShebangs pre_commit/resources/hook-tmpl
   '';
-
-  pytestFlags = [
-    "--forked"
-  ];
 
   preCheck = ''
     export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -59,6 +59,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     cargo
     gitMinimal
     go
+    nodejs
     perl
     versionCheckHook
     writableTmpDirAsHomeHook
@@ -78,11 +79,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     coursier
     # i686-linux: dotnet-sdk not available
     dotnet-sdk
-    # nodejs can be moved back to the main nativeCheckInputs list once this
-    # issue is fixed: <https://github.com/NixOS/nixpkgs/issues/387658>. When nodejs gets
-    # moved back to the main nativeCheckInputs list, don’t forget to re-enable the
-    # Node.js-related tests that are currently disabled on i686-linux.
-    nodejs
   ];
 
   postPatch = ''
@@ -211,11 +207,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_dotnet_"
     # From coursier_test.py:
     "test_error_if_no_deps_or_channel"
-    # From node_test.py:
-    "test_healthy_system_node"
-    "test_unhealthy_if_system_node_goes_missing"
-    "test_node_hook_system"
-    "test_node_with_user_config_set"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -96,14 +96,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
     export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \
            GIT_AUTHOR_EMAIL=test@example.com GIT_COMMITTER_EMAIL=test@example.com \
            PRE_COMMIT_NO_CONCURRENCY=1
+
+    # Some CLI tests expect to run in a Git repository.
+    git init
   ''
   + lib.optionalString (!i686Linux) ''
     # Resolve `.NET location: Not found` errors for dotnet tests
     export DOTNET_ROOT="${dotnet-sdk}/share/dotnet"
-  ''
-  + ''
-    # Some CLI tests expect to run in a Git repository.
-    git init
   '';
 
   disabledTests = [

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -108,13 +108,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ''
   + ''
     git init -b master
-
-    python -m venv --system-site-packages venv
-    source "$PWD/venv/bin/activate"
-  '';
-
-  postCheck = ''
-    deactivate
   '';
 
   disabledTests = [

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -107,7 +107,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     export DOTNET_ROOT="${dotnet-sdk}/share/dotnet"
   ''
   + ''
-    git init -b master
+    # Some CLI tests expect to run in a Git repository.
+    git init
   '';
 
   disabledTests = [

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -128,8 +128,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   disabledTests = [
     # ERROR: The install method you used for conda--probably either `pip install conda`
     # or `easy_install conda`--is not compatible with using conda as an application.
-    "test_conda_"
-    "test_local_conda_"
+    "test_conda_language"
+    "test_conda_additional_deps"
 
     # /build/pytest-of-nixbld/pytest-0/test_install_ruby_with_version0/rbenv-2.7.2/libexec/rbenv-init:
     # /usr/bin/env: bad interpreter: No such file or directory
@@ -137,10 +137,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
     # network
     "test_additional_dependencies_roll_forward"
-    "test_additional_golang_dependencies_installed"
-    "test_additional_node_dependencies_installed"
-    "test_additional_rust_cli_dependencies_installed"
-    "test_additional_rust_lib_dependencies_installed"
     "test_automatic_toolchain_switching"
     "test_coursier_hook"
     "test_coursier_hook_additional_dependencies"
@@ -168,12 +164,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_perl_additional_dependencies"
     "test_r_hook"
     "test_r_inline"
-    "test_r_inline_hook"
-    "test_r_local_with_additional_dependencies_hook"
-    "test_r_with_additional_dependencies_hook"
-    "test_run_a_node_hook_default_version"
     "test_run_lib_additional_dependencies"
-    "test_run_versioned_node_hook"
     "test_rust_cli_additional_dependencies"
     "test_swift_language"
     "test_run_example_executable"
@@ -199,11 +190,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_unhealthy_unexpected_pyvenv"
     "test_unhealthy_with_version_change"
 
-    # i don't know why these fail
-    "test_install_existing_hooks_no_overwrite"
-    "test_installed_from_venv"
-    "test_uninstall_restores_legacy_hooks"
-    "test_dotnet_"
+    # R required
     "test_health_check_"
 
     # Expects `git commit` to fail when `pre-commit` is not in the `$PATH`,
@@ -211,9 +198,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_environment_not_sourced"
 
     # Docker required
-    "test_docker_"
+    "test_docker_fallback_user"
+    "test_docker_hook"
+    "test_docker_image_"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "test_install_existing_hooks_no_overwrite"
+    "test_uninstall_restores_legacy_hooks"
   ]
   ++ lib.optionals i686Linux [
+    # i686-linux: dotnet-sdk not available
+    "test_dotnet_"
     # From coursier_test.py:
     "test_error_if_no_deps_or_channel"
     # From node_test.py:

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -18,6 +18,7 @@
 
   # passthru
   callPackage,
+  pkgsi686Linux,
   pre-commit,
 }:
 
@@ -213,9 +214,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
     makeWrapperArgs+=(--suffix PATH : ${lib.makeBinPath [ gitMinimal ]})
   '';
 
-  passthru.tests = callPackage ./tests.nix {
-    inherit gitMinimal pre-commit;
-  };
+  passthru.tests =
+    callPackage ./tests.nix {
+      inherit gitMinimal pre-commit;
+    }
+    // lib.optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux") {
+      i686 = pkgsi686Linux.pre-commit;
+    };
 
   meta = {
     description = "Framework for managing and maintaining multi-language pre-commit hooks";

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -51,7 +51,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     identify
     nodeenv
     pyyaml
-    toml
     virtualenv
   ];
 

--- a/pkgs/by-name/pr/pre-commit/tests.nix
+++ b/pkgs/by-name/pr/pre-commit/tests.nix
@@ -2,7 +2,6 @@
   gitMinimal,
   pre-commit,
   runCommand,
-  testers,
 }:
 {
   check-meta-hooks =
@@ -38,8 +37,4 @@
         pre-commit run --all-files
         touch $out
       '';
-
-  version = testers.testVersion {
-    package = pre-commit;
-  };
 }


### PR DESCRIPTION
- **pre-commit: 4.5.1 -> 4.6.2**
- **pre-commit: remove toml dependency**
- **pre-commit: enable more tests**
- **pre-commit: enable nodejs tests on i686-linux**
- **pre-commit: remove obsolete RUSTFLAGS workaround**
- **pre-commit: add i686 passthru test**
- **pre-commit: migrate version test to install check**
- **pre-commit: remove duplicate pytestCheckHook**
- **pre-commit: remove stale test virtualenv**
- **pre-commit: simplify test repository setup**
- **pre-commit: remove pytest-forked**
- **pre-commit: remove unused virtualenv setting**
- **pre-commit: consolidate preCheck setup**
- **pre-commit: add booxter as maintainer**

Tested build for x86_64-linux, aarch64-darwin and i686-linux. Ran pre-commit run on pre-commit repo checkout.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
