### PR TITLE
minimal-bootstrap.bash: disable installing loadable builtins

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
@@ -128,6 +128,6 @@ bootBash.runCommand "${pname}-${version}"
     make -j $NIX_BUILD_CORES SHELL=bash
 
     # Install
-    make -j $NIX_BUILD_CORES install
+    make -j $NIX_BUILD_CORES install SHOBJ_STATUS=unsupported
     ln -s bash $out/bin/sh
   ''


### PR DESCRIPTION
`make install` builds and _attempts_ to install the example loadable builtins, which fails because they don't link under tcc.

The inner install runs as a sub-make with errors ignored, so this fails partway through without failing the derivation.

If NIX_BUILD_CORES != 1, this fails non-deterministically resulting in a different set of empty directories in $out depending on when it fails, breaking reproducibility.

NB: I think we should plausibly just be doing `make bash` and a manual install(1) invocation, since we don't get much out of having bashbug(1) available (and `support/man2html` built, discarded when the derivation exits, unused) in the bootstrap. To be quite honest, I find it kind of gross that `make install` even attempts a _build_ at all (the loadables are not included in `make all`!), and the recursive make swallowing errors doesn't exactly spark joy.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
