### PR TITLE
nixos/sd-image: Revert "use lsblk -npo PARTN to identify partition for sd-card expansion"

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -400,7 +400,7 @@ in
         # Figure out device names for the boot device and root filesystem.
         rootPart=$(${lib.getExe' pkgs.util-linux "findmnt"} -n -o SOURCE /)
         bootDevice=$(${lib.getExe' pkgs.util-linux "lsblk"} -npo PKNAME $rootPart)
-        partNum=$(${lib.getExe' pkgs.util-linux "lsblk"} -npo PARTN $rootPart)
+        partNum=$(${lib.getExe' pkgs.util-linux "lsblk"} -npo MAJ:MIN $rootPart | ${lib.getExe pkgs.gawk} -F: '{print $2}')
 
         # Resize the root partition and the filesystem to fit the disk
         echo ",+," | ${lib.getExe' pkgs.util-linux "sfdisk"} -N$partNum --no-reread $bootDevice


### PR DESCRIPTION
Reverts:

- #390183

See:

- https://github.com/NixOS/nixpkgs/issues/554294