### PR TITLE
turingplus: add bootstrap test to `passthru.tests`

### DIFF
--- a/pkgs/by-name/tu/turingplus/package.nix
+++ b/pkgs/by-name/tu/turingplus/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
+  turingplus,
   bootstrap ? callPackage ./bootstrap.nix { },
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -58,6 +59,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  # Try to compile Turing+ itself using the Nix-built version of the compiler.
+  # Note that `turingplus.override` has to be used since `finalPackage.override`
+  # does not exist
+  passthru.tests.bootstrap = turingplus.override {
+    bootstrap = finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Extended version of the Turing programming language with concurrency and systems programming features";


### PR DESCRIPTION
Adds a `passthru.tests` test to make sure that the Nix derivation builds successfully when the Nix-built compiler itself is used as the `bootstrap` input, rather than the upstream release binary.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
