### PR TITLE
zerobyte: init at 0.42.0 and add module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -34,6 +34,8 @@
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
+- [Zerobyte](https://github.com/nicotsx/zerobyte), backup automation for self-hosters built on top of restic, with a web interface to schedule, manage and monitor encrypted backups. Available as [services.zerobyte](#opt-services.zerobyte.enable).
+
 - [Cardwire](https://github.com/OpenGamingCollective/cardwire), a GPU manager for Linux that uses eBPF+LSM hooks to control GPUs. Available as [services.cardwired](#opt-services.cardwired.enable).
 
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1871,6 +1871,7 @@
   ./services/web-apps/your_spotify.nix
   ./services/web-apps/youtrack.nix
   ./services/web-apps/zabbix.nix
+  ./services/web-apps/zerobyte.nix
   ./services/web-apps/zipline.nix
   ./services/web-apps/zitadel.nix
   ./services/web-servers/agate.nix

--- a/nixos/modules/services/web-apps/zerobyte.nix
+++ b/nixos/modules/services/web-apps/zerobyte.nix
@@ -1,0 +1,239 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.zerobyte;
+in
+{
+  meta.maintainers = with lib.maintainers; [ pbek ];
+
+  options.services.zerobyte = {
+    enable = lib.mkEnableOption "Zerobyte, backup automation for self-hosters built on top of restic";
+
+    package = lib.mkPackageOption pkgs "zerobyte" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "zerobyte";
+      description = "User account under which Zerobyte runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "zerobyte";
+      description = "Group under which Zerobyte runs.";
+    };
+
+    appSecretFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/zerobyte-app-secret";
+      description = ''
+        Path to a file containing the application secret (32–256 characters),
+        used to encrypt sensitive data in the database. Generate one with
+        `openssl rand -hex 32`.
+
+        This should not be a path in the Nix store. The file is passed to the
+        service via systemd credentials.
+      '';
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/zerobyte";
+      description = ''
+        Directory used to store the database, encryption keys, local
+        repositories, volume mounts and the restic cache.
+
+        Do not point this to a network share, this will cause permission
+        issues and strong performance degradation.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf (
+          lib.types.oneOf [
+            lib.types.bool
+            lib.types.int
+            lib.types.str
+          ]
+        );
+      };
+      default = { };
+      example = {
+        BASE_URL = "https://zerobyte.example.com";
+        LOG_LEVEL = "debug";
+        GOMAXPROCS = 2;
+        TRUST_PROXY = true;
+      };
+      description = ''
+        Zerobyte configuration passed as environment variables. See
+        <https://github.com/nicotsx/zerobyte#configuration> for the available
+        settings.
+
+        `BASE_URL` is required. It is highly discouraged to expose Zerobyte
+        directly to the internet; bind `HOST` to localhost and use a secure
+        tunnel or an authenticating reverse proxy instead.
+
+        Do not put secrets here; use
+        [](#opt-services.zerobyte.environmentFile) instead.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/zerobyte.env";
+      description = ''
+        Environment file loaded by systemd, which may be used to pass secrets
+        such as `APP_SECRET` to Zerobyte without putting them into the Nix
+        store.
+      '';
+    };
+
+    provisioningFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a JSON file with operator-managed repositories and volumes to
+        sync at startup. See
+        <https://zerobyte.app/docs/guides/provisioning> for the format.
+
+        This may contain secrets, so it should not be a path in the Nix store.
+        The file is passed to the service via systemd credentials.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = with pkgs; [
+        cifs-utils
+        davfs2
+        fuse3
+        nfs-utils
+        openssh
+        sshfs
+        util-linux
+      ];
+      defaultText = lib.literalExpression "with pkgs; [ cifs-utils davfs2 fuse3 nfs-utils openssh sshfs util-linux ]";
+      description = ''
+        Extra packages added to the `PATH` of the Zerobyte service. The
+        default contains the tools needed to mount NFS, SMB, WebDAV and SFTP
+        volumes. Add `shoutrrr` here if you want notifications to be
+        delivered.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the firewall for the Zerobyte web interface.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.zerobyte.settings = {
+      NODE_ENV = lib.mkDefault "production";
+      # The generated web server binds to all interfaces and port 3000 when
+      # these are unset. Bind to 127.0.0.1 and use port 4096 like upstream:
+      # https://github.com/nicotsx/zerobyte/blob/main/Dockerfile
+      HOST = lib.mkDefault "127.0.0.1";
+      PORT = lib.mkDefault 4096;
+      RESTIC_HOSTNAME = lib.mkDefault config.networking.hostName;
+      ZEROBYTE_DATABASE_URL = "${cfg.dataDir}/data/zerobyte.db";
+      RESTIC_PASS_FILE = "${cfg.dataDir}/data/restic.pass";
+      ZEROBYTE_REPOSITORIES_DIR = "${cfg.dataDir}/repositories";
+      ZEROBYTE_VOLUMES_DIR = "${cfg.dataDir}/volumes";
+      RESTIC_CACHE_DIR = "${cfg.dataDir}/restic/cache";
+      RCLONE_CONFIG_DIR = "${cfg.dataDir}/rclone";
+      ENABLE_LOCAL_AGENT = lib.mkDefault true;
+    }
+    // lib.optionalAttrs (cfg.provisioningFile != null) {
+      PROVISIONING_PATH = "%d/provisioning.json";
+    }
+    // lib.optionalAttrs (cfg.appSecretFile != null) {
+      APP_SECRET_FILE = "%d/app-secret";
+    };
+
+    assertions = [
+      {
+        assertion = cfg.settings ? BASE_URL;
+        message = "services.zerobyte.settings.BASE_URL must be set.";
+      }
+      {
+        assertion = cfg.appSecretFile != null || cfg.environmentFile != null || cfg.settings ? APP_SECRET;
+        message = ''
+          services.zerobyte: A secret is required to encrypt sensitive data in
+          the database. Set `services.zerobyte.appSecretFile` or provide
+          `APP_SECRET` via `services.zerobyte.environmentFile`.
+        '';
+      }
+      {
+        assertion = !(cfg.settings ? APP_SECRET);
+        message = ''
+          services.zerobyte.settings.APP_SECRET would expose the secret in the
+          Nix store. Use `services.zerobyte.appSecretFile` or
+          `services.zerobyte.environmentFile` instead.
+        '';
+      }
+    ];
+
+    systemd.services.zerobyte = {
+      description = "Zerobyte backup automation";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = lib.mapAttrs (
+        _: value: if lib.isBool value then lib.boolToString value else toString value
+      ) cfg.settings;
+
+      path = [ cfg.package ] ++ cfg.extraPackages;
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" cfg.dataDir) (
+          lib.removePrefix "/var/lib/" cfg.dataDir
+        );
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        LoadCredential =
+          lib.optional (cfg.appSecretFile != null) "app-secret:${cfg.appSecretFile}"
+          ++ lib.optional (cfg.provisioningFile != null) "provisioning.json:${cfg.provisioningFile}";
+
+        # The local agent and the volume mount backends need these to perform
+        # NFS, SMB, WebDAV and SFTP mounts.
+        AmbientCapabilities = [ "CAP_SYS_ADMIN" ];
+        CapabilityBoundingSet = [ "CAP_SYS_ADMIN" ];
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectHome = lib.mkDefault false;
+        ProtectSystem = lib.mkDefault "full";
+        RestartSec = "10s";
+        UMask = "0077";
+      };
+    };
+
+    users.users = lib.mkIf (cfg.user == "zerobyte") {
+      zerobyte = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "zerobyte") { zerobyte = { }; };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ (lib.toInt (toString cfg.settings.PORT)) ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1971,6 +1971,7 @@ in
   zammad = runTest ./zammad.nix;
   zapret2 = runTest ./zapret2.nix;
   zenohd = runTest ./zenohd.nix;
+  zerobyte = runTest ./zerobyte.nix;
   zeronet-conservancy = runTest ./zeronet-conservancy.nix;
   zfs = import ./zfs.nix { inherit system pkgs runTest; };
   zigbee2mqtt = runTest ./zigbee2mqtt.nix;

--- a/nixos/tests/zerobyte.nix
+++ b/nixos/tests/zerobyte.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+{
+  name = "zerobyte";
+  meta.maintainers = with lib.maintainers; [ pbek ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.zerobyte = {
+        enable = true;
+        settings.BASE_URL = "http://localhost:4096";
+        # Test-only secret; a real deployment would use sops/agenix instead of
+        # a file in the Nix store.
+        environmentFile = pkgs.writeText "zerobyte.env" ''
+          APP_SECRET=94bad469e4b4e7c7f5a2b6a8c0d2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b4c66e25
+        '';
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("zerobyte.service")
+    machine.wait_for_open_port(4096)
+    machine.succeed("curl --fail -o /dev/null http://localhost:4096/")
+  '';
+}

--- a/pkgs/by-name/ze/zerobyte/canonicalize-node-modules.ts
+++ b/pkgs/by-name/ze/zerobyte/canonicalize-node-modules.ts
@@ -1,0 +1,60 @@
+import { lstat, mkdir, readdir, rm, symlink } from "fs/promises";
+import { join, relative } from "path";
+
+type Entry = {
+  dir: string;
+  version: string;
+};
+
+async function isDirectory(path: string) {
+  try {
+    return (await lstat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+const root = process.cwd();
+const bunRoot = join(root, "node_modules/.bun");
+const linkRoot = join(bunRoot, "node_modules");
+const versions = new Map<string, Entry[]>();
+
+for (const label of (await readdir(bunRoot)).sort()) {
+  const dir = join(bunRoot, label);
+  if (!(await isDirectory(dir))) continue;
+
+  const marker = label.startsWith("@") ? label.indexOf("@", 1) : label.indexOf("@");
+  if (marker <= 0) continue;
+
+  const name = label.slice(0, marker).replaceAll("+", "/");
+  const version = label.slice(marker + 1);
+  const entries = versions.get(name) ?? [];
+  entries.push({ dir, version });
+  versions.set(name, entries);
+}
+
+await rm(linkRoot, { recursive: true, force: true });
+await mkdir(linkRoot, { recursive: true });
+
+for (const [name, entries] of Array.from(versions.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+  entries.sort((a, b) => {
+    const aValid = Bun.semver.satisfies(a.version, "x.x.x");
+    const bValid = Bun.semver.satisfies(b.version, "x.x.x");
+    if (aValid && bValid) return -Bun.semver.order(a.version, b.version);
+    if (aValid) return -1;
+    if (bValid) return 1;
+    return b.version.localeCompare(a.version);
+  });
+
+  const selected = entries[0];
+  const parts = name.split("/");
+  const leaf = parts.pop();
+  if (!selected || !leaf) continue;
+
+  const parent = join(linkRoot, ...parts);
+  const target = join(selected.dir, "node_modules", name);
+  if (!(await isDirectory(target))) continue;
+
+  await mkdir(parent, { recursive: true });
+  await symlink(relative(parent, target) || ".", join(parent, leaf));
+}

--- a/pkgs/by-name/ze/zerobyte/normalize-bun-binaries.ts
+++ b/pkgs/by-name/ze/zerobyte/normalize-bun-binaries.ts
@@ -1,0 +1,67 @@
+import { lstat, mkdir, readdir, rm, symlink } from "fs/promises";
+import { join, relative } from "path";
+
+type PackageManifest = {
+  name?: string;
+  bin?: string | Record<string, string>;
+};
+
+async function isDirectory(path: string) {
+  try {
+    return (await lstat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+const bunRoot = join(process.cwd(), "node_modules/.bun");
+
+for (const entry of (await readdir(bunRoot)).sort()) {
+  const modulesRoot = join(bunRoot, entry, "node_modules");
+  if (!(await isDirectory(modulesRoot))) continue;
+
+  const binRoot = join(modulesRoot, ".bin");
+  await rm(binRoot, { recursive: true, force: true });
+  await mkdir(binRoot, { recursive: true });
+
+  const packageDirs: string[] = [];
+  for (const name of (await readdir(modulesRoot)).sort()) {
+    if (name === ".bin" || name === ".bun") continue;
+
+    const dir = join(modulesRoot, name);
+    if (!(await isDirectory(dir))) continue;
+
+    if (name.startsWith("@")) {
+      for (const child of (await readdir(dir)).sort()) {
+        const scopedDir = join(dir, child);
+        if (await isDirectory(scopedDir)) packageDirs.push(scopedDir);
+      }
+    } else {
+      packageDirs.push(dir);
+    }
+  }
+
+  for (const packageDir of packageDirs.sort()) {
+    const manifestFile = Bun.file(join(packageDir, "package.json"));
+    if (!(await manifestFile.exists())) continue;
+
+    const manifest = (await manifestFile.json()) as PackageManifest;
+    if (!manifest.bin) continue;
+
+    const binaries =
+      typeof manifest.bin === "string"
+        ? [[manifest.name ?? packageDir.split("/").pop(), manifest.bin]]
+        : Object.entries(manifest.bin).sort((a, b) => a[0].localeCompare(b[0]));
+
+    for (const [name, target] of binaries) {
+      if (!name || !target) continue;
+
+      const source = join(packageDir, target);
+      if (!(await Bun.file(source).exists())) continue;
+
+      const destination = join(binRoot, name.slice(name.lastIndexOf("/") + 1));
+      await rm(destination, { force: true });
+      await symlink(relative(binRoot, source) || ".", destination);
+    }
+  }
+}

--- a/pkgs/by-name/ze/zerobyte/package.nix
+++ b/pkgs/by-name/ze/zerobyte/package.nix
@@ -1,0 +1,175 @@
+{
+  lib,
+  stdenv,
+  bun,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nix-update-script,
+  nodejs,
+  rclone,
+  restic,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  buildNodeModules =
+    finalAttrs:
+    stdenv.mkDerivation {
+      pname = "${finalAttrs.pname}-node_modules";
+      inherit (finalAttrs) version src;
+
+      __structuredAttrs = true;
+      strictDeps = true;
+
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+        "GIT_PROXY_COMMAND"
+        "SOCKS_SERVER"
+      ];
+
+      nativeBuildInputs = [
+        bun
+        writableTmpDirAsHomeHook
+      ];
+
+      dontConfigure = true;
+
+      buildPhase = ''
+        runHook preBuild
+
+        bun install \
+          --cpu="*" \
+          --os="*" \
+          --frozen-lockfile \
+          --ignore-scripts \
+          --no-progress
+        bun --bun ${./canonicalize-node-modules.ts}
+        bun --bun ${./normalize-bun-binaries.ts}
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -R ./node_modules $out/node_modules
+        # Keep workspace packages so the workspace symlinks inside
+        # node_modules keep resolving.
+        cp -R ./packages $out/packages
+
+        # Windows executables are never used on the supported platforms and
+        # can be quarantined by endpoint security software.
+        find $out -type f -name '*.exe' -delete
+
+        runHook postInstall
+      '';
+
+      # Required, otherwise the fixed-output derivation references store paths.
+      dontFixup = true;
+
+      outputHash = "sha256-4fMmwxknyj2jwDyooT3WAzHXW2J5uxi6LsHdOoFte0k=";
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+    };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zerobyte";
+  version = "0.42.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "nicotsx";
+    repo = "zerobyte";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gueZUwoEetsEuAG5QXvLgUUrib79sk2azcmD0XZMhQo=";
+  };
+
+  nativeBuildInputs = [
+    bun
+    makeBinaryWrapper
+    nodejs
+    writableTmpDirAsHomeHook
+  ];
+
+  # Displayed in the web interface.
+  env = {
+    VITE_APP_VERSION = finalAttrs.version;
+    VITE_RESTIC_VERSION = restic.version;
+    VITE_RCLONE_VERSION = rclone.version;
+  };
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${finalAttrs.passthru.node_modules}/node_modules ./node_modules
+    cp -R ${finalAttrs.passthru.node_modules}/packages ./packages
+    chmod -R u+w ./node_modules ./packages
+    patchShebangs --build ./node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    bun run build
+    bun build apps/agent/src/index.ts --outfile .output/agent/index.mjs --target bun
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/zerobyte
+    cp -R .output $out/lib/zerobyte/.output
+    cp package.json $out/lib/zerobyte/package.json
+    # Database migrations, loaded by the server at startup.
+    cp -R app/drizzle $out/lib/zerobyte/migrations
+
+    makeBinaryWrapper ${lib.getExe bun} $out/bin/zerobyte \
+      --chdir "$out/lib/zerobyte" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bun
+          restic
+          rclone
+        ]
+      } \
+      --set NODE_ENV "production" \
+      --set APP_VERSION "${finalAttrs.version}" \
+      --set-default MIGRATIONS_PATH "$out/lib/zerobyte/migrations" \
+      --add-flags "$out/lib/zerobyte/.output/server/index.mjs"
+
+    install -Dm644 LICENSE $out/share/doc/zerobyte/LICENSE
+    install -Dm644 NOTICES.md $out/share/doc/zerobyte/NOTICES.md
+    cp -R LICENSES $out/share/doc/zerobyte/LICENSES
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    node_modules = buildNodeModules finalAttrs;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "node_modules"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Backup automation for self-hosters, built on top of restic";
+    homepage = "https://github.com/nicotsx/zerobyte";
+    changelog = "https://github.com/nicotsx/zerobyte/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ pbek ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    mainProgram = "zerobyte";
+  };
+})

--- a/pkgs/by-name/ze/zerobyte/package.nix
+++ b/pkgs/by-name/ze/zerobyte/package.nix
@@ -9,6 +9,7 @@
   rclone,
   restic,
   writableTmpDirAsHomeHook,
+  nixosTests,
 }:
 
 let
@@ -157,6 +158,9 @@ stdenv.mkDerivation (finalAttrs: {
         "--subpackage"
         "node_modules"
       ];
+    };
+    tests = {
+      inherit (nixosTests) zerobyte;
     };
   };
 


### PR DESCRIPTION
Adds Zerobyte (https://github.com/nicotsx/zerobyte) - backup automation for self-hosters, built on top of restic. It provides a modern web interface to schedule, manage, and monitor encrypted backups across NFS, SMB, WebDAV, SFTP, and local storage.

This PR adds:

- Package (pkgs/by-name/ze/zerobyte): builds the bun monorepo from source (vite + nitro → .output), bundles the local backup agent, and wraps the binary with restic/rclone. Uses a fixed-output node_modules derivation with nix-update-script --subpackage node_modules for automated updates.
- NixOS module (services.zerobyte): systemd service with LoadCredential-based secret handling (appSecretFile, provisioningFile), configurable data dir, local agent support, and the mount tooling (cifs/davfs2/nfs/sshfs) needed for remote volume backends. Runs with CAP_SYS_ADMIN only where mounts require it.
- NixOS test: boots a VM, starts the service, and verifies the web UI responds.
- Release notes entry under New Modules.
Note: nixpkgs' shoutrrr is the old containrrr 0.8.0 while Zerobyte expects the nicholas-fedor fork ≥0.17, so shoutrrr is intentionally not in the default closure — users can add it via services.zerobyte.extraPackages once nixpkgs updates it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
