### PR TITLE
wmderland: unstable-2020-07-17 -> 1.0.5

### DIFF
--- a/pkgs/by-name/wm/wmderland/0001-remove-flto.patch
+++ b/pkgs/by-name/wm/wmderland/0001-remove-flto.patch
@@ -1,9 +1,7 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 17a4944..33406f3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -10,7 +10,7 @@ include(BuildType)
- # Request C++14 standard, using new CMake variables.
+@@ -9,7 +9,7 @@
+ 
  set(CMAKE_CXX_STANDARD 14)
  set(CMAKE_CXX_STANDARD_REQUIRED True)
 -set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -Wall")

--- a/pkgs/by-name/wm/wmderland/package.nix
+++ b/pkgs/by-name/wm/wmderland/package.nix
@@ -9,15 +9,15 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wmderland";
-  version = "unstable-2020-07-17";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "aesophor";
     repo = "wmderland";
-    rev = "a40a3505dd735b401d937203ab6d8d1978307d72";
-    sha256 = "0npmlnybblp82mfpinjbz7dhwqgpdqc1s63wc1zs8mlcs19pdh98";
+    tag = finalAttrs.version;
+    hash = "sha256-kzd5Wo+HruPC8R7UENyvjTOXBs0gmYWd5wVykr/DQHY=";
   };
 
   nativeBuildInputs = [
@@ -51,9 +51,10 @@ stdenv.mkDerivation {
   meta = {
     description = "Modern and minimal X11 tiling window manager";
     homepage = "https://github.com/aesophor/wmderland";
+    changelog = "https://github.com/aesophor/wmderland/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     platforms = libx11.meta.platforms;
     maintainers = with lib.maintainers; [ takagiy ];
     mainProgram = "wmderland";
   };
-}
+})


### PR DESCRIPTION
As part of https://github.com/NixOS/nixpkgs/issues/541820


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
