### PR TITLE
digilent: init waveforms and adept

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11938,6 +11938,13 @@
     githubId = 52052910;
     name = "iivusly";
   };
+  iJustLeyxo = {
+    name = "Leo";
+    github = "iJustLeyxo";
+    githubId = 92861073;
+    email = "nix@l-pf.link";
+    matrix = "@ijustleyxo:matrix.org";
+  };
   ik-nz = {
     email = "me@igk.nz";
     github = "ik-nz";

--- a/pkgs/by-name/di/digilent-adept/package.nix
+++ b/pkgs/by-name/di/digilent-adept/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+
+  autoPatchelfHook,
+  fetchurl,
+
+  avahi,
+  libusb1,
+  openssl,
+}:
+let
+  version = "2.30.1";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://files.digilent.com/Software/Adept2%20Runtime/${version}/digilent.adept.runtime_${version}_amd64.deb";
+      hash = "sha256-5eUdJkDC/zTvO0NvO983g4EgsVFg1z37q4LpB3O2s3I=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://files.digilent.com/Software/Adept2%20Runtime/${version}/digilent.adept.runtime_${version}_arm64.deb";
+      hash = "sha256-jNRg4/vK+4ttctztRO3Mm6aOpy/+a7pJ4N+q1xugc5I=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "digilent-adept";
+  inherit version;
+  __structuredAttrs = true;
+
+  src =
+    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    avahi
+    libusb1
+    openssl
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    ar x "$src"
+    tar -xf data.tar.gz
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"/{bin,etc,lib/udev/rules.d,share}
+
+    cp usr/lib/udev/dftdrvdtch "$out/bin/"
+    cp -r usr/lib/digilent/adept/. "$out/lib/"
+    cp -r usr/share/. "$out/share/"
+
+    cat > "$out/etc/digilent-adept.conf" << EOF
+    DigilentPath=$out/share/digilent
+    DigilentDataPath=$out/share/digilent/adept/data
+    EOF
+
+    cat > "$out/lib/udev/rules.d/52-digilent-usb.rules" << EOF
+    ATTR{idVendor}=="1443", MODE:="666"
+    ACTION=="add", ATTR{idVendor}=="0403", ATTR{manufacturer}=="Digilent", MODE:="666", RUN+="$out/bin/dftdrvdtch %s{busnum} %s{devnum}"
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Communicate with Digilent system boards";
+    downloadPage = "https://digilent.com/shop/software/digilent-adept/download";
+    homepage = "https://digilent.com/reference/software/adept/start";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ iJustLeyxo ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/di/digilent-waveforms/package.nix
+++ b/pkgs/by-name/di/digilent-waveforms/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+
+  autoPatchelfHook,
+  buildFHSEnv,
+  fetchurl,
+  zstd,
+
+  digilent-adept,
+  pipewire,
+  qt6,
+}:
+let
+  version = "3.25.1";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://files.digilent.com/Software/Waveforms/${version}/digilent.waveforms_${version}_amd64.deb";
+      hash = "sha256-0peaq3JskgKkihxdKzFFMVExccC2L6Lyou3NKSAnJ9M=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://files.digilent.com/Software/Waveforms/${version}/digilent.waveforms_${version}_arm64.deb";
+      hash = "sha256-FP/EUD9znoepV+82P5lPVE5Jt33sxOPvS7ysODLIA0U=";
+    };
+  };
+
+  package = stdenv.mkDerivation (finalAttrs: {
+    pname = "digilent-waveforms";
+    inherit version;
+
+    src =
+      srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+    strictDeps = true;
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      qt6.wrapQtAppsHook
+      zstd
+    ];
+
+    buildInputs = [
+      digilent-adept
+      qt6.qtbase
+      qt6.qtconnectivity
+      qt6.qtdeclarative
+      qt6.qtmultimedia
+      qt6.qtserialport
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      ar x $src
+      tar -xf data.tar.*
+
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"/{bin,lib,share}
+
+      cp -r usr/bin/. "$out/bin/"
+      cp -r usr/lib/. "$out/lib/"
+      cp -r usr/share/. "$out/share/"
+
+      substituteInPlace "$out/share/applications/digilent.waveforms.desktop" \
+        --replace-fail "Exec=/usr/bin/waveforms %u" "Exec=digilent-waveforms %u"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Virtual instrument suite for Digilent Test and Measurement devices";
+      downloadPage = "https://cloud.digilent.com/myproducts/waveforms";
+      homepage = "https://digilent.com/reference/software/waveforms/waveforms-3/start";
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [ iJustLeyxo ];
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
+  });
+in
+buildFHSEnv {
+  inherit (package) pname version meta;
+
+  targetPkgs = pkgs: [
+    digilent-adept
+    pipewire
+
+    package
+  ];
+
+  runScript = "${package.outPath}/bin/waveforms";
+
+  extraInstallCommands = ''
+    mkdir -p "$out/share"/{applications,icons}
+    ln -sf "${package.outPath}/share/applications/"* "$out/share/applications/"
+    ln -sf "${package.outPath}/share/digilent/waveforms/pixmaps/256.png" "$out/share/icons/waveforms.png"
+  '';
+}


### PR DESCRIPTION
_This is my first contribution to nixpkgs. I kindly thank you for taking the time to review my pr and nix code. Please make sure to tell me in case you find any issues (no matter how small) — I am sure there will be a few._

Digilent WaveForms is a software used to interface with Digilent test and measurement equipment for electrical analysis. While WaveForms provides the gui, it depends on the Digilent Adept runtime for communication with the device via usb. Both are unfree software. Digilents "Analog Discovery" devices are very popular, especially among hobbyists and electrical engineers in hardware development and testing roles.

I am willing to maintain the packages for the forseeable future.
I can only test on x86_64-linux with the one Digilent device I own so the testing I can do is limited.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
