### PR TITLE
hunk: 0.19.0 -> 0.20.1

### DIFF
--- a/pkgs/by-name/hu/hunk/package.nix
+++ b/pkgs/by-name/hu/hunk/package.nix
@@ -10,13 +10,13 @@
 
 let
   pname = "hunk";
-  version = "0.19.0";
+  version = "0.20.1";
 
   src = fetchFromGitHub {
     owner = "modem-dev";
     repo = "hunk";
     tag = "v${version}";
-    hash = "sha256-PWblqDS86PaSl5ToFawCNGTxmrWcmoBAfq8R5lMDbyk=";
+    hash = "sha256-QPo9lPxbTUfBuWEzk2YViYSaJ8/7hTC+fAnTEnI0Y20=";
   };
 
   node_modules = stdenv.mkDerivation {
@@ -56,7 +56,7 @@ let
 
     dontFixup = true;
 
-    outputHash = "sha256-Ixsv2wXb39kSRck9ZbjJjRlzn4KS2fkfl3v4MEeD7cE=";
+    outputHash = "sha256-S8YE1Er15as5Z9Rmqxf7GcvfC5B+neddSbdsxe4/2mk=";
     outputHashMode = "recursive";
   };
 in
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
   # Teach `hunk skill path` to find the FHS layout under share/skills/$pname
   # (https://github.com/NixOS/nixpkgs/issues/547426) instead of $out/skills.
   postPatch = ''
-    substituteInPlace src/core/paths.ts \
+    substituteInPlace src/core/run/paths.ts \
       --replace-fail \
         'join("node_modules", "hunkdiff", skillRelativePath),' \
         'join("node_modules", "hunkdiff", skillRelativePath),


### PR DESCRIPTION
Bumps hunk to 0.20.1 and repairs the packaging break that blocked the automated bump.

The [nixpkgs-update log for 2026-08-27](https://nixpkgs-update-logs.nix-community.org/hunk/2026-08-27.log) shows r-ryantm rewriting the version and hashes for 0.20.0, then failing the build in `patchPhase`:

```text
substitute(): ERROR: file 'src/core/paths.ts' does not exist
```

Upstream [modem-dev/hunk#795](https://github.com/modem-dev/hunk/pull/795) reorganized `src/core` into modules and moved `paths.ts` to `src/core/run/paths.ts`. No exported symbols or behavior changed, so the FHS skill-path patch only needs to point at the new location - though I have to say that this is the 4th time we're doing a similar fix for `hunk` since v16.

### Changes

- `version`: 0.19.0 -> 0.20.1
- `src.hash` and `node_modules.outputHash` refreshed
- `postPatch` retargeted from `src/core/paths.ts` to `src/core/run/paths.ts`

I skipped 0.20.0 and went straight to 0.20.1 since it is the current release and carries session-reload security fixes; the same patch applies to both.

---

  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
