### PR TITLE
pandora-launcher: create macOS .app bundle

### DIFF
--- a/pkgs/by-name/pa/pandora-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/pa/pandora-launcher-unwrapped/package.nix
@@ -51,11 +51,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
-
     imagemagick
     patchelf
-    pkg-config
   ];
 
   buildInputs = [
@@ -82,22 +83,46 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoVendorDir = "vendor"; # everything is vendored in-tree
   dontCargoSetupPostUnpack = true;
 
-  desktopItems = lib.singleton (makeDesktopItem {
-    name = "com.moulberry.pandoralauncher";
-    desktopName = "Pandora Launcher";
-    genericName = "Unofficial Minecraft Launcher";
-    exec = "pandora_launcher";
-    icon = "pandora_launcher";
-  });
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+    (makeDesktopItem {
+      name = "com.moulberry.pandoralauncher";
+      desktopName = "Pandora Launcher";
+      genericName = "Unofficial Minecraft Launcher";
+      exec = "pandora_launcher";
+      icon = "pandora_launcher";
+    })
+  ];
 
-  postInstall = ''
-    for size in 16 24 32 48 64 128 256; do
-      geometry="$size"x"$size"
-      mkdir -p "$out/share/icons/hicolor/$geometry/apps"
-      magick package/windows.svg -resize "$geometry" \
-        "$out/share/icons/hicolor/$geometry/apps/pandora_launcher.png"
-    done
-  '';
+  infoPlist = lib.generators.toPlist { escape = true; } {
+    CFBundleDevelopmentRegion = "en";
+    CFBundleDisplayName = "Pandora Launcher";
+    CFBundleExecutable = "pandora_launcher";
+    CFBundleIconFile = "mac.icns";
+    CFBundleIdentifier = "com.moulberry.pandoralauncher";
+    CFBundleInfoDictionaryVersion = "6.0";
+    CFBundleName = "Pandora Launcher";
+    CFBundlePackageType = "APPL";
+    CFBundleShortVersionString = finalAttrs.version;
+    CFBundleVersion = finalAttrs.version;
+    NSHighResolutionCapable = true;
+    NSMicrophoneUsageDescription = "A Minecraft mod wants to access your microphone.";
+  };
+
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications/PandoraLauncher.app/Contents/{MacOS,Resources}
+      cp package/mac.icns $out/Applications/PandoraLauncher.app/Contents/Resources/
+      printf '%s' ${lib.escapeShellArg finalAttrs.infoPlist} > $out/Applications/PandoraLauncher.app/Contents/Info.plist
+      ln -s $out/bin/pandora_launcher $out/Applications/PandoraLauncher.app/Contents/MacOS/pandora_launcher
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      for size in 16 24 32 48 64 128 256; do
+        geometry="$size"x"$size"
+        mkdir -p "$out/share/icons/hicolor/$geometry/apps"
+        magick package/windows.svg -resize "$geometry" \
+          "$out/share/icons/hicolor/$geometry/apps/pandora_launcher.png"
+      done
+    '';
 
   doInstallCheck = true;
 

--- a/pkgs/by-name/pa/pandora-launcher/package.nix
+++ b/pkgs/by-name/pa/pandora-launcher/package.nix
@@ -128,6 +128,15 @@ symlinkJoin {
 
   postBuild = ''
     wrapProgram $out/bin/pandora_launcher "''${makeWrapperArgs[@]}"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    if [ -d $out/Applications/PandoraLauncher.app ]; then
+      rm -rf $out/Applications/PandoraLauncher.app
+      mkdir -p $out/Applications/PandoraLauncher.app/Contents/MacOS
+      ln -s ${pandora-launcher'}/Applications/PandoraLauncher.app/Contents/Info.plist $out/Applications/PandoraLauncher.app/Contents/Info.plist
+      ln -s ${pandora-launcher'}/Applications/PandoraLauncher.app/Contents/Resources $out/Applications/PandoraLauncher.app/Contents/Resources
+      ln -s $out/bin/pandora_launcher $out/Applications/PandoraLauncher.app/Contents/MacOS/pandora_launcher
+    fi
   '';
 
   meta = {


### PR DESCRIPTION
Generate PandoraLauncher.app on Darwin for pandora-launcher-unwrapped and ensure the wrapper symlinks the wrapped binary inside the bundle.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
