### PR TITLE
modprobed-db: 2.50 -> 2.51

### DIFF
--- a/pkgs/by-name/mo/modprobed-db/package.nix
+++ b/pkgs/by-name/mo/modprobed-db/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "modprobed-db";
-  version = "2.50";
+  version = "2.51";
 
   src = fetchFromGitHub {
     owner = "graysky2";
     repo = "modprobed-db";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-JcotyXFrxE9DmrGS8cx/+BvHeQ8rLd+0h4jIYD2NZmY=";
+    hash = "sha256-C73qDaY+I0bypaZqEipAuj4CAX1wIWhIMOzYpRiaGPE=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Updated the package, confirmed it runs and that it moved my config to the new xdg dirs. Warning for people using hjem or home manager for the config the database and config are now in their relevent xdg dirs which if u use the defaults are:

```
~/.config/modprobed.db -> ~/.local/share/modprobed-db/modprobed.db
~/.config/modprobed-db.conf -> ~/.config/modprobed-db/modprobed-db.conf
```
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package modprobed-db`
Commit: `623904488774eae40a4758f74380017e40d5393c`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>modprobed-db</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>modprobed-db</li>
  </ul>
</details>

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
