### PR TITLE
python3Packages.kivy: fix builds on `aarch64-darwin`

### DIFF
--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -11,10 +11,12 @@
   libGL,
   libx11,
   mtdev,
+  python3,
   SDL2,
   SDL2_image,
   SDL2_ttf,
   SDL2_mixer,
+  angle,
   withGstreamer ? true,
   gst_all_1,
   pygments,
@@ -66,6 +68,9 @@ buildPythonPackage (finalAttrs: {
     libx11
     mtdev
   ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    angle
+  ]
   ++ lib.optionals withGstreamer (
     with gst_all_1;
     [
@@ -99,9 +104,15 @@ buildPythonPackage (finalAttrs: {
         "-Wno-error=incompatible-pointer-types"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        # fatal error: 'Python.h' file not found
+        "-I${python3}/include/${python3.libPrefix}"
         "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
       ]
     );
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    KIVY_ANGLE_INCLUDE_DIR = "${lib.getInclude angle}/include";
+    KIVY_ANGLE_LIB_DIR = "${lib.getLib angle}/lib";
   };
 
   /*


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
