### PR TITLE
fish: avoid replacing "awk" in store paths

### DIFF
--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -254,14 +254,16 @@ stdenv.mkDerivation (finalAttrs: {
     EOF
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
+    # Trailing space in 'awk ' to avoid matching store paths that coincidentally
+    # contain the string 'awk'. (Yes, this has happened before!)
     for cur in share/functions/*.fish; do
       substituteInPlace "$cur" \
         --replace-quiet '/usr/bin/getent' '${lib.getExe getent}' \
-        --replace-quiet 'awk' '${lib.getExe' gawk "awk"}'
+        --replace-quiet 'awk ' '${lib.getExe' gawk "awk"} '
     done
     for cur in share/completions/*.fish; do
       substituteInPlace "$cur" \
-        --replace-quiet 'awk' '${lib.getExe' gawk "awk"}'
+        --replace-quiet 'awk ' '${lib.getExe' gawk "awk"} '
     done
   ''
   + ''


### PR DESCRIPTION
We're encountering a [fish build failure](https://hydra.nixos.org/build/343861659) on `staging-next-26.05` caused by the store path for gnugrep coincidentally containing the string `awk`. A later substitution of `awk` replaces this substring with another store path in some files, resulting in a number of broken paths that look like this:

```
/nix/store/x3mmar/nix/store/l048yqk8sv2lpz14ww39bqc3vzcmlz6m-gawk-5.4.1/bin/awk8qkqf3257aidf7cljax6mc8-gnugrep-3.12/bin/grep
```

Extending the `awk` pattern to `awk ` solves this problem and should be relatively safe given that awk requires arguments to be passed. (Let me know if you have a better idea to match awk invocations!)

Planning to get this into `master` first, then cherry-pick to `staging-next-26.05`, where the build failure happens.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
