### PR TITLE
stirling-pdf: skip tests failing due to expired certs

### DIFF
--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # tests require network facilities intentionally unavailable in the Nix sandbox
     ./skip-sandbox-incompatible-tests.patch
+
+    ./skip-tests-with-expired-certs.patch
   ];
 
   postPatch = lib.optionalString isDesktopVariant ''

--- a/pkgs/by-name/st/stirling-pdf/skip-tests-with-expired-certs.patch
+++ b/pkgs/by-name/st/stirling-pdf/skip-tests-with-expired-certs.patch
@@ -1,0 +1,18 @@
+diff --git a/build.gradle b/build.gradle
+index 3a967d1..f43fec0 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -278,6 +278,13 @@ subprojects {
+     tasks.withType(Test).configureEach {
+         useJUnitPlatform()
+         finalizedBy(jacocoReport)
++
++        filter {
++            excludeTestsMatching "*CertSignControllerTest"
++            excludeTestsMatching "*UntrustedSignerTests"
++            excludeTestsMatching "*SignWithKeystore"
++            excludeTestsMatching "*TrustedAnchorTests"
++        }
+     }
+ 
+     jacocoReport.configure {


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/557273


Apparently https://github.com/Stirling-Tools/Stirling-PDF/pull/7682 updated the certs, but things are still broken like that.
So I ended up disabling some tests instead.


Hopefully next release has it properly fixed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
