### PR TITLE
nixos/containers: allow separately configuring host and container iface name

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -92,7 +92,7 @@ let
     ''
   );
 
-  nspawnExtraVethArgs = (name: cfg: "--network-veth-extra=${name}");
+  nspawnExtraVethArgs = (name: cfg: "--network-veth-extra=${cfg.hostInterfaceName}:${name}");
 
   startScript = cfg: ''
     # Declare root explicitly to avoid shellcheck warnings, it comes from the env
@@ -242,7 +242,9 @@ let
     fi
 
     ${concatStringsSep "\n" (
-      mapAttrsToList (name: cfg: "ip link del dev ${name} 2> /dev/null || true ") cfg.extraVeths
+      mapAttrsToList (
+        name: cfg: "ip link del dev ${cfg.hostInterfaceName} 2> /dev/null || true "
+      ) cfg.extraVeths
     )}
   '';
 
@@ -263,25 +265,25 @@ let
         name: cfg:
         if cfg.hostBridge != null then
           ''
-            # Add ${name} to bridge ${cfg.hostBridge}
-            ip link set dev "${name}" master "${cfg.hostBridge}" up
+            # Add ${cfg.hostInterfaceName} to bridge ${cfg.hostBridge}
+            ip link set dev "${cfg.hostInterfaceName}" master "${cfg.hostBridge}" up
           ''
         else
           ''
-            echo "Bring ${name} up"
-            ip link set dev "${name}" up
-            # Set IPs and routes for ${name}
+            echo "Bring ${cfg.hostInterfaceName} up"
+            ip link set dev "${cfg.hostInterfaceName}" up
+            # Set IPs and routes for ${cfg.hostInterfaceName}
             ${optionalString (cfg.hostAddress != null) ''
-              ip addr add ${cfg.hostAddress} dev "${name}"
+              ip addr add ${cfg.hostAddress} dev "${cfg.hostInterfaceName}"
             ''}
             ${optionalString (cfg.hostAddress6 != null) ''
-              ip -6 addr add ${cfg.hostAddress6} dev "${name}"
+              ip -6 addr add ${cfg.hostAddress6} dev "${cfg.hostInterfaceName}"
             ''}
             ${optionalString (cfg.localAddress != null) ''
-              ip route add ${cfg.localAddress} dev "${name}"
+              ip route add ${cfg.localAddress} dev "${cfg.hostInterfaceName}"
             ''}
             ${optionalString (cfg.localAddress6 != null) ''
-              ip -6 route add ${cfg.localAddress6} dev "${name}"
+              ip -6 route add ${cfg.localAddress6} dev "${cfg.hostInterfaceName}"
             ''}
           '';
     in
@@ -818,9 +820,27 @@ in
               extraVeths = mkOption {
                 type =
                   with types;
-                  attrsOf (submodule {
-                    options = networkOptions;
-                  });
+                  attrsOf (
+                    submodule (
+                      { name, ... }:
+                      {
+                        options = networkOptions // {
+                          hostInterfaceName = mkOption {
+                            type = types.str;
+                            default = name;
+                            description = ''
+                              The name of the veth interface on the host side.
+                              This must be unique across the *entire host*.
+
+                              Set this explicitly when the attribute name isn't
+                              host-unique (e.g. several containers share the same
+                              `extraVeths` name.)
+                            '';
+                          };
+                        };
+                      }
+                    )
+                  );
                 default = { };
                 description = ''
                   Extra veth-pairs to be created for the container.


### PR DESCRIPTION
This allows separately configuring the `extraVeth` iface name on the host. This is important because the names have to be unique across every container on that host; so trying to have a link with the same name in every container would fail. Now, the name of the veth is used inside the container, and the new option (if configured) is used on the host.

There's no change here for users who don't set the option; the name of the veth is used by default for the host name, which is the same behavior as before (just explicitly instead of implicitly).

I've played around with my homelab config in a VM with this patch, and all seems fine.

Closes #557505.
Assisted-by: Claude Sonnet 5 (Medium)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
