### PR TITLE
henkan: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14506,6 +14506,11 @@
     githubId = 386765;
     matrix = "@k900:0upti.me";
   };
+  kaanreal = {
+    name = "Kaan";
+    github = "kaanreal";
+    githubId = 167336594;
+  };
   kaasboteram = {
     name = "Luuk Machielse";
     github = "kaasboteram";

--- a/pkgs/by-name/he/henkan/package.nix
+++ b/pkgs/by-name/he/henkan/package.nix
@@ -1,0 +1,41 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+}:
+
+let
+  pname = "henkan";
+  version = "1.6.1";
+  src = fetchurl {
+    url = "https://github.com/kaanreal/henkan/releases/download/v${version}/Henkan-v${version}-linux.AppImage";
+    hash = "sha256-T3zOuSM8daRFW3I/kVIDRuGHo02AP+Fn9axWrNi54cQ=";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm644 ${appimageContents}/usr/share/applications/Henkan.desktop \
+      $out/share/applications/henkan.desktop
+    substituteInPlace $out/share/applications/henkan.desktop \
+      --replace-fail "Exec=henkan" "Exec=$out/bin/henkan"
+
+    for icon in ${appimageContents}/usr/share/icons/hicolor/*/apps/henkan.png; do
+      destination="''${icon#${appimageContents}/}"
+      install -Dm644 "$icon" "$out/$destination"
+    done
+  '';
+
+  meta = {
+    description = "osu!mania to Etterna and StepMania converter";
+    homepage = "https://henkan.kaanreal.me/";
+    downloadPage = "https://github.com/kaanreal/henkan/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "henkan";
+    maintainers = with lib.maintainers; [ kaanreal ];
+  };
+}


### PR DESCRIPTION
Adds Henkan, an open-source osu!mania to Etterna and StepMania map and skin converter.

The package wraps the upstream x86_64 AppImage and declares binary native-code provenance. The SHA-256 matches the v1.6.1 GitHub release asset. I could not execute a Nix build locally; this was validated structurally and the AppImage was extracted and exercised during the AUR package build.

Assisted by OpenAI Codex (GPT-5).