### PR TITLE
python3Packages.wandb: 0.28.2 -> 0.29.0

### DIFF
--- a/pkgs/development/python-modules/cwsandbox/default.nix
+++ b/pkgs/development/python-modules/cwsandbox/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cwsandbox";
-  version = "0.23.0";
+  version = "1.7.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -30,7 +30,7 @@ buildPythonPackage (finalAttrs: {
     owner = "coreweave";
     repo = "cwsandbox-client";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-y9rsuAXmpMok0ZqdLhAfavglXh5Hz4VPy1UByYMM1WA=";
+    hash = "sha256-D8Mklp9XKRWgVf8OCBZSfX7pngfBlG3jN1DasAQkVFg=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   cymem,
@@ -128,6 +129,12 @@ buildPythonPackage (finalAttrs: {
     # AssertionError: confection has different version in setup.cfg and in requirements.txt:
     # >=1.3.2,<2.0.0 and >=1.1.0,<2.0.0 respectively
     "test_build_dependencies"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AssertionError:
+    #   assert eval["nel_macro_f"] > 0
+    #   assert 0.0 > 0
+    "test_overfitting_IO_with_ner"
   ];
 
   pythonImportsCheck = [ "spacy" ];

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -5,7 +5,7 @@
   pythonAtLeast,
 
   ## wandb-core
-  buildGoModule,
+  buildGo127Module,
   gitMinimal,
   writableTmpDirAsHomeHook,
   versionCheckHook,
@@ -33,8 +33,8 @@
   requests,
   sentry-sdk,
   setproctitle,
-  pythonOlder,
   typing-extensions,
+  xxhash,
 
   # tests
   azure-containerregistry,
@@ -80,12 +80,12 @@
 }:
 
 let
-  version = "0.28.2";
+  version = "0.29.0";
   src = fetchFromGitHub {
     owner = "wandb";
     repo = "wandb";
     tag = "v${version}";
-    hash = "sha256-kmgLHb+1NjStqcjMOYPPU2v2js4m8O3b2OpM6BiSbXI=";
+    hash = "sha256-5YkJB5uS9GalNKL+MPf5GVQX/jgWM62nxMVmdnzOXGs=";
   };
 
   wandb-xpu = rustPlatform.buildRustPackage {
@@ -143,7 +143,7 @@ let
     __darwinAllowLocalNetworking = true;
   };
 
-  wandb-core = buildGoModule {
+  wandb-core = buildGo127Module {
     pname = "wandb-core";
     inherit src version;
 
@@ -247,9 +247,8 @@ buildPythonPackage (finalAttrs: {
     requests
     sentry-sdk
     setproctitle
-  ]
-  ++ lib.optionals (pythonOlder "3.12") [
     typing-extensions
+    xxhash
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/wandb/wandb/compare/v0.28.2...v0.29.0
Changelog: https://github.com/wandb/wandb/blob/v0.29.0/CHANGELOG.md

cc @samuela

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test