### PR TITLE
vanillatd: 0-unstable-2024-06-27 -> 0-unstable-2026-07-16; remove overrideable CMAKE_BUILD_TYPE; add passthru.updateScript; use 0-unstable-* version scheme

### DIFF
--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -23,6 +23,7 @@
   callPackage,
   symlinkJoin,
   rsync,
+  unstableGitUpdater,
 
   appName ? "vanillatd",
 }:
@@ -40,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     # FIXME: This version has format-security
     rev = "ebc8083d5d149f98abc20f460a512a2d16fdc59f";
     hash = "sha256-iUF9UFc0FMvOwLkGqSyLYGy5E8YqNySqDp5VVUa+u4o=";
+
   };
   # TODO: Remove this. Just add this flag to ignore the format-security error temporarily.
   env.NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
@@ -123,6 +125,13 @@ stdenv.mkDerivation (finalAttrs: {
     in
     {
       inherit packages;
+
+      updateScript = unstableGitUpdater {
+        # A 'latest' tag exists,
+        # but it appears to be there only for upstream to provide builds
+        # and might move around.
+        hardcodeZeroVersion = true;
+      };
 
       withPackages =
         cb:

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -25,7 +25,6 @@
   rsync,
 
   appName ? "vanillatd",
-  CMAKE_BUILD_TYPE ? "RelWithDebInfo", # "Choose the type of build, recommended options are: Debug Release RelWithDebInfo"
 }:
 assert lib.assertOneOf "appName" appName [
   "vanillatd"
@@ -69,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_VANILLARA" (appName == "vanillara"))
     (lib.cmakeBool "BUILD_REMASTERTD" (appName == "remastertd"))
     (lib.cmakeBool "BUILD_REMASTERRA" (appName == "remasterra"))
-    (lib.cmakeFeature "CMAKE_BUILD_TYPE" CMAKE_BUILD_TYPE)
   ];
 
   # TODO: Fix this from the upstream

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -33,18 +33,15 @@ assert lib.assertOneOf "appName" appName [
 ];
 stdenv.mkDerivation (finalAttrs: {
   pname = appName;
-  version = "0-unstable-2024-06-27";
+  version = "0-unstable-2026-07-16";
 
   src = fetchFromGitHub {
     owner = "TheAssemblyArmada";
     repo = "Vanilla-Conquer";
-    # FIXME: This version has format-security
-    rev = "ebc8083d5d149f98abc20f460a512a2d16fdc59f";
-    hash = "sha256-iUF9UFc0FMvOwLkGqSyLYGy5E8YqNySqDp5VVUa+u4o=";
+    rev = "ce83b59edd99cccac6cebaae054ca04962c744b7";
+    hash = "sha256-jjiqW3J1XQr4+cNd86yXO0dFpt5VEKmxtMywBjTceTc=";
 
   };
-  # TODO: Remove this. Just add this flag to ignore the format-security error temporarily.
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
 
   buildInputs = [
     SDL2

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -33,7 +33,7 @@ assert lib.assertOneOf "appName" appName [
 ];
 stdenv.mkDerivation (finalAttrs: {
   pname = appName;
-  version = "0.0.0";
+  version = "0-unstable-2024-06-27";
 
   src = fetchFromGitHub {
     owner = "TheAssemblyArmada";


### PR DESCRIPTION
Update the package, remove the manual overriding of CMAKE_BUILD_TYPE as part of #427019, and add an update script to make updates easier (r-ryantm can now update this semi-automatically).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
