### PR TITLE
inngest: use upstream release binaries

### DIFF
--- a/pkgs/by-name/in/inngest/package.nix
+++ b/pkgs/by-name/in/inngest/package.nix
@@ -1,109 +1,69 @@
 {
   lib,
-  buildGoModule,
-  fetchFromGitHub,
-  fetchPnpmDeps,
-  pnpm_10,
-  pnpmConfigHook,
-  nodejs,
-  stdenv,
-  testers,
+  stdenvNoCC,
+  fetchurl,
+  versionCheckHook,
 }:
+
 let
-  version = "1.43.0";
-  websiteRev = "159c0ac611e85ec85ffe0a8c8bf2c4a0330bdb38";
-
-  src = fetchFromGitHub {
-    owner = "inngest";
-    repo = "inngest";
-    tag = "v${version}";
-    hash = "sha256-4/xKqjSeRV11kGi7MJFCRmm3+86vxmzj9QEQD144KJk=";
+  platforms = {
+    x86_64-linux = "linux_amd64";
+    aarch64-linux = "linux_arm64";
+    aarch64-darwin = "darwin_arm64";
   };
-
-  website = fetchFromGitHub {
-    owner = "inngest";
-    repo = "website";
-    rev = websiteRev;
-    hash = "sha256-EkTIv8jgcqzurz2M7PC6Kfh6x2Zxu7UmIhpTjlj8o88=";
-  };
-
-  ui = stdenv.mkDerivation (finalAttrs: {
-    inherit version src;
-    pname = "inngest-ui";
-
-    nativeBuildInputs = [
-      nodejs
-      pnpm_10
-      pnpmConfigHook
-    ];
-
-    pnpmDeps = fetchPnpmDeps {
-      inherit (finalAttrs) pname version src;
-      pnpm = pnpm_10;
-      sourceRoot = "${finalAttrs.src.name}/ui";
-      fetcherVersion = 4;
-      hash = "sha256-9Aud9JUj2C/Bow7lB+P/BgniQXJa2MVqI7TcPICgxrI=";
-    };
-    pnpmRoot = "ui";
-
-    buildPhase = ''
-      runHook preBuild
-      pnpm --filter dev-server-ui build
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/dist
-      cp -r ui/apps/dev-server-ui/dist/. $out/dist/
-      runHook postInstall
-    '';
-  });
 in
-buildGoModule (finalAttrs: {
-  inherit version src;
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "inngest";
+  version = "1.44.0";
 
   __structuredAttrs = true;
+  strictDeps = true;
 
-  vendorHash = null;
+  src = finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system};
+  sourceRoot = ".";
 
-  preBuild = ''
-    cp -r ${ui}/dist/. ./pkg/devserver/static/
-    cp -r ${website}/. ./internal/embeddocs/website/
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 inngest $out/bin/inngest
+
+    runHook postInstall
   '';
 
-  postInstall = ''
-    mv $out/bin/cmd $out/bin/inngest
-  '';
-
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/inngest/inngest/pkg/inngest/version.Version=${version}"
-  ];
-
-  env.CGO_ENABLED = 0;
-
-  subPackages = [ "cmd" ];
+  doInstallCheck = stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
-    inherit ui website websiteRev;
-    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    sources = lib.mapAttrs (
+      system: platform:
+      fetchurl {
+        url = "https://github.com/inngest/inngest/releases/download/v${finalAttrs.version}/inngest_${finalAttrs.version}_${platform}.tar.gz";
+        hash =
+          {
+            x86_64-linux = "sha256-vvtgP/PNefRpgM+TCdZbNe3NMj3rAAsjfpTGto2PW+I=";
+            aarch64-linux = "sha256-nCi7lDjidvcN3+CRTMNKlgMS7vN8iFd7SyHGSxLdCis=";
+            aarch64-darwin = "sha256-1Cbs7Y//XwUA10rUEeU0AdL5dtdSFAmzSQj3zVaN2mk=";
+          }
+          .${system};
+      }
+    ) platforms;
     updateScript = ./update.sh;
   };
 
   meta = {
     description = "CLI and dev server for Inngest durable workflows";
     homepage = "https://github.com/inngest/inngest";
-    changelog = "https://github.com/inngest/inngest/releases/tag/${finalAttrs.src.tag}";
+    downloadPage = "https://github.com/inngest/inngest/releases";
+    changelog = "https://github.com/inngest/inngest/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.sspl;
-    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [
       albertchae
       kikos0
     ];
     mainProgram = "inngest";
-    platforms = lib.lists.remove "x86_64-darwin" lib.platforms.all;
+    platforms = builtins.attrNames platforms;
   };
 })

--- a/pkgs/by-name/in/inngest/update.sh
+++ b/pkgs/by-name/in/inngest/update.sh
@@ -1,46 +1,19 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i bash -p gh jq
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts
 # shellcheck shell=bash
 set -euo pipefail
 
-nixpkgs="$(pwd)"
-cd "$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")"
+version=$(curl -fsSL https://api.github.com/repos/inngest/inngest/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 
-nix_attr() { nix eval --json --impure --expr "(import $nixpkgs {}).$1" | jq -r; }
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
-update_hash() {
-  old_hash="$(nix_attr "$1.outputHash")"
-  new_hash="$(nix-build --impure --expr "let src = (import $nixpkgs {}).$1; in (src.overrideAttrs or (f: src // f src)) (_: { outputHash = \"\"; outputHashAlgo = \"sha256\"; })" 2>&1 | tr -s ' ' | grep -Po "got: \K.+$")" || true
-  sed -i "s|${old_hash}|${new_hash}|g" package.nix
-  echo "$1: $old_hash -> $new_hash"
-}
-
-latest=$(gh api repos/inngest/inngest/releases/latest --jq '.tag_name' | tr -d 'v')
-current=$(nix_attr inngest.version)
-
-if [[ "$current" == "$latest" ]]; then
-  echo "inngest is already up to date: $current"
-  exit 0
-fi
-
-echo "Updating inngest $current -> $latest"
-
-sed -i "s|version = \"${current}\"|version = \"${latest}\"|" package.nix
-update_hash inngest.src
-
-old_lock=$(gh api "repos/inngest/inngest/contents/ui/pnpm-lock.yaml?ref=v${current}" --jq '.sha')
-new_lock=$(gh api "repos/inngest/inngest/contents/ui/pnpm-lock.yaml?ref=v${latest}" --jq '.sha')
-if [[ "$old_lock" != "$new_lock" ]]; then
-  update_hash inngest.ui.pnpmDeps
-else
-  echo "pnpm lockfile unchanged, skipping"
-fi
-
-new_rev=$(gh api "repos/inngest/inngest/contents/internal/embeddocs/website?ref=v${latest}" --jq '.sha')
-old_rev=$(nix_attr inngest.websiteRev)
-if [[ "$old_rev" != "$new_rev" ]]; then
-  sed -i "s|${old_rev}|${new_rev}|" package.nix
-  update_hash inngest.website
-else
-  echo "website unchanged, skipping"
-fi
+for system in \
+  x86_64-linux \
+  aarch64-linux \
+  aarch64-darwin
+do
+  update-source-version inngest "$version" \
+    --source-key="sources.$system" \
+    --ignore-same-version \
+    --ignore-same-hash
+done


### PR DESCRIPTION
Inngest is licensed under the SSPL and therefore is not built by the official
Nixpkgs cache. Users consequently have to build the Go application and its
large pnpm frontend dependency graph locally. The pnpm dependency set is
approximately 1.8 GiB, making installation slow and inconvenient, whereas the
official release archive is approximately 30 MiB.

This changes the package to install Inngest's official release binaries.
Nixpkgs already packages upstream binaries under a range of licensing models:

- [`mongodb-ce`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/mo/mongodb-ce/package.nix) (SSPL, source-available)
- [`mongodb-compass`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/mo/mongodb-compass/package.nix) (SSPL, source-available)
- [`boundary`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/bo/boundary/package.nix) (BSL-1.1, source-available)
- [`elasticsearch7`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/search/elasticsearch/7.x.nix) (Elastic-2.0, source-available)
- [`tigerbeetle`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ti/tigerbeetle/package.nix) (Apache-2.0, open source)
- [`bun`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/bu/bun/package.nix) (MIT/LGPL-2.1, open source)
- [`claude-code`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/cl/claude-code/package.nix) (unfree, source unavailable)
- [`amp-cli`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/am/amp-cli/package.nix) (unfree, source unavailable)

Inngest intends to [transition to Apache-2.0](https://github.com/inngest/inngest/blob/main/LICENSE.md).
Once that happens, we intend to return the package to a source build, allowing
it to be distributed by the official Nixpkgs cache.


Assisted by Amp (GPT-5.6).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in `lib/tests` or `pkgs/test` for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.
- [x] Follows the automation/AI policy.

