### PR TITLE
cloudflare-speed-cli: init at 1.0.8

### DIFF
--- a/pkgs/by-name/cl/cloudflare-speed-cli/package.nix
+++ b/pkgs/by-name/cl/cloudflare-speed-cli/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cloudflare-speed-cli";
+  version = "1.0.8";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kavehtehrani";
+    repo = "cloudflare-speed-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zEnl8Xd23RzRzV2VhUUfMPubhT3SnvBpwDo4oNV/x98=";
+  };
+
+  cargoHash = "sha256-2kVzz86g+ctoHSpllB2n+jf1izSgixG0yaUtxWqYXCE=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "cloudflare-speed-cli";
+    description = "CLI for internet speed test via cloudflare";
+    longDescription = ''
+      A CLI tool that displays network speed test results from
+      Cloudflare's speed test service in a TUI interface.
+    '';
+    homepage = "https://github.com/kavehtehrani/cloudflare-speed-cli";
+    downloadPage = "https://github.com/kavehtehrani/cloudflare-speed-cli/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/kavehtehrani/cloudflare-speed-cli/commits/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    identifiers = {
+      cpeParts = lib.meta.cpeFullVersionWithVendor "kavehtehrani" finalAttrs.version;
+      purlParts = {
+        type = "github";
+        namespace = "kavehtehrani";
+        name = "cloudflare-speed-cli";
+        version = finalAttrs.version;
+      };
+    };
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added cloudflare-speed-cli at 1.0.8 from https://github.com/kavehtehrani/cloudflare-speed-cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
