### PR TITLE
python3Packages.pyasn1-alt-modules: init at 0.4.10

### DIFF
--- a/pkgs/development/python-modules/pyasn1-alt-modules/default.nix
+++ b/pkgs/development/python-modules/pyasn1-alt-modules/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pyasn1,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyasn1-alt-modules";
+  version = "0.4.10";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "russhousley";
+    repo = "pyasn1-alt-modules";
+    tag = finalAttrs.version;
+    hash = "sha256-LOD7gXv+CagAR8qzmkKEWtVFd1zZdpyC++xoU1P3HaY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pyasn1 ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pyasn1_alt_modules" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Alternative ASN.1 modules for pyasn1";
+    homepage = "https://github.com/russhousley/pyasn1-alt-modules";
+    changelog = "https://github.com/russhousley/pyasn1-alt-modules/blob/${finalAttrs.src.rev}/CHANGES.txt";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14393,6 +14393,8 @@ self: super: with self; {
 
   pyasn1 = callPackage ../development/python-modules/pyasn1 { };
 
+  pyasn1-alt-modules = callPackage ../development/python-modules/pyasn1-alt-modules { };
+
   pyasn1-modules = callPackage ../development/python-modules/pyasn1-modules { };
 
   pyasuswrt = callPackage ../development/python-modules/pyasuswrt { };


### PR DESCRIPTION
Alternative ASN.1 modules for pyasn1

https://github.com/russhousley/pyasn1-alt-modules


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
