### PR TITLE
sm64ap: init at 0-unstable-2026-07-27

### DIFF
--- a/pkgs/by-name/ap/apcpp/package.nix
+++ b/pkgs/by-name/ap/apcpp/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  ixwebsocket,
+  jsoncpp,
+  openssl,
+  zlib,
+}:
+
+stdenv.mkDerivation {
+  pname = "apcpp";
+  version = "0-unstable-2026-08-25";
+
+  src = fetchFromGitHub {
+    owner = "N00byKing";
+    repo = "APCpp";
+    rev = "172f683d4306b4fa209949419993198f87d881ed";
+    hash = "sha256-kcVZQlKl6DVWKkOxnduv+XezISYP1q8YKkClS/rmn1M=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    ixwebsocket
+    jsoncpp
+    openssl
+    zlib
+  ];
+
+  patches = [ ./prefer-system-version-of-ixwebsocket.patch ];
+
+  meta = {
+    description = "C++ Library for Clients interfacing with the Archipelago Multi-Game Randomizer";
+    homepage = "https://github.com/N00byKing/APCpp";
+    maintainers = [ lib.maintainers.SchweGELBin ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/by-name/ap/apcpp/prefer-system-version-of-ixwebsocket.patch
+++ b/pkgs/by-name/ap/apcpp/prefer-system-version-of-ixwebsocket.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d9ba2f0..a353d60 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -67,15 +67,28 @@ if (MINGW OR NOT ZLIB_FOUND)
+     add_library(ZLIB::ZLIB ALIAS zlibstatic)
+ endif (MINGW OR NOT ZLIB_FOUND)
+ 
+-set(IXWEBSOCKET_INSTALL OFF CACHE BOOL "" FORCE)
+-add_subdirectory(IXWebSocket)
+-include_directories(IXWebSocket)
+-target_link_libraries(APCpp ixwebsocket)
+-
+ if (MINGW)
+     target_link_libraries(APCpp -static -static-libstdc++ -static-libgcc)
+ endif(MINGW)
+ 
++# Attempt finding system version of IXWebSocket
++find_package(PkgConfig)
++if (PKGCONFIG_FOUND AND (NOT MINGW) AND (NOT BUNDLED_IXWEBSOCKET))
++    pkg_check_modules(IXWEBSOCKET ixwebsocket)
++    if (IXWEBSOCKET_FOUND)
++        include_directories(${IXWEBSOCKET_INCLUDE_DIRS})
++        target_link_libraries(APCpp ${IXWEBSOCKET_LDFLAGS})
++    endif(IXWEBSOCKET_FOUND)
++endif(PKGCONFIG_FOUND AND (NOT MINGW) AND (NOT BUNDLED_IXWEBSOCKET))
++
++# No system version: Enable bundled
++if((NOT IXWEBSOCKET_FOUND) OR BUNDLED_IXWEBSOCKET)
++    set(IXWEBSOCKET_INSTALL OFF CACHE BOOL "" FORCE)
++    add_subdirectory(IXWebSocket)
++    include_directories(ixwebsocket/include)
++    target_link_libraries(APCpp ixwebsocket_static)
++endif((NOT IXWEBSOCKET_FOUND) OR BUNDLED_IXWEBSOCKET)
++
+ # Attempt finding system version of JsonCpp
+ find_package(PkgConfig)
+ if (PKGCONFIG_FOUND AND (NOT MINGW) AND (NOT BUNDLED_JSONCPP))

--- a/pkgs/by-name/ix/ixwebsocket/package.nix
+++ b/pkgs/by-name/ix/ixwebsocket/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ixwebsocket";
+  version = "12.0.1";
+
+  src = fetchFromGitHub {
+    owner = "machinezone";
+    repo = "IXWebSocket";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2QWIpLVIs2vGuMEhewDyihYdDQBz7SsOtfZ6pE67j2Q=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ zlib ];
+
+  meta = {
+    description = "C++ library for WebSocket client and server development";
+    homepage = "https://github.com/machinezone/IXWebSocket";
+    maintainers = [ lib.maintainers.SchweGELBin ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.bsd3;
+  };
+})

--- a/pkgs/by-name/sm/sm64ap/add-missing-help-options-to-cli.patch
+++ b/pkgs/by-name/sm/sm64ap/add-missing-help-options-to-cli.patch
@@ -1,0 +1,24 @@
+diff --git a/src/pc/cliopts.c b/src/pc/cliopts.c
+index c544579..b3e8fc6 100644
+--- a/src/pc/cliopts.c
++++ b/src/pc/cliopts.c
+@@ -16,7 +16,7 @@
+ struct PCCLIOptions gCLIOpts;
+ 
+ static void print_help(void) {
+-    printf("Super Mario 64 PC Port\n");
++    printf("Super Mario 64 PC Port for Archipelago\n");
+     printf("%-20s\tEnables the cheat menu.\n", "--cheats");
+     printf("%-20s\tSaves the configuration file as CONFIGNAME.\n", "--configfile CONFIGNAME");
+     printf("%-20s\tSets additional data directory name (only 'res' is used by default).\n", "--gamedir DIRNAME");
+@@ -24,6 +24,10 @@ static void print_help(void) {
+     printf("%-20s\tStarts the game in full screen mode.\n", "--fullscreen");
+     printf("%-20s\tSkips the Peach and Castle intro when starting a new game.\n", "--skip-intro");
+     printf("%-20s\tStarts the game in windowed mode.\n", "--windowed");
++    printf("%-20s\tSets the File path of the offline Archipelago room.\n", "--sm64ap_file");
++    printf("%-20s\tSets the IP and Port of the Archipelago server.\n", "--sm64ap_ip");
++    printf("%-20s\tSets the Name of the Archipelago user.\n", "--sm64ap_name");
++    printf("%-20s\tSets the Password of the Archipelago user.\n", "--sm64ap_passwd");
+ }
+ 
+ static inline int arg_string(const char *name, const char *value, char *target) {

--- a/pkgs/by-name/sm/sm64ap/package.nix
+++ b/pkgs/by-name/sm/sm64ap/package.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  sm64baserom,
+  hexdump,
+  pkg-config,
+  python3,
+  apcpp,
+  audiofile,
+  ixwebsocket,
+  libGL,
+  SDL2,
+  zlib,
+  fetchpatch,
+  cmake,
+  region ? "us",
+  bettercamera ? false,
+  nodrawingdistance ? false,
+  texture_fix ? false,
+  _60fps ? true,
+  always-nonstop ? false,
+  extended-moveset ? false,
+}:
+let
+  baseRom = (sm64baserom.override { inherit region; }).romPath;
+in
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "sm64ap";
+  version = "0-unstable-2026-07-27";
+
+  src = fetchFromGitHub {
+    owner = "N00byKing";
+    repo = "sm64ex";
+    rev = "d73bce2e046a87d3ce1e4ae5fb1979fb290cc684";
+    hash = "sha256-wCUfHSSGDn40/NGl1FuBBlqNVPn1HLSkx/VEIi/bna8=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    hexdump
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    apcpp
+    audiofile
+    ixwebsocket
+    libGL
+    SDL2
+    zlib
+  ];
+
+  env.APCPP_LD_PATH = "${apcpp}/lib";
+
+  makeFlags = [
+    "VERSION=${region}"
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin "OSX_BUILD=1"
+  ++ lib.optional bettercamera "BETTERCAMERA=1"
+  ++ lib.optional nodrawingdistance "NODRAWINGDISTANCE=1"
+  ++ lib.optional texture_fix "TEXTURE_FIX=1";
+
+  patches = [
+    # Adds the missing help options that are required to connect to an Archipelago room
+    ./add-missing-help-options-to-cli.patch
+    # Changes the Makefile to use the system version of apcpp if available
+    ./prefer-system-version-of-apcpp.patch
+  ]
+  ++ lib.optional _60fps (fetchpatch {
+    # Allows the game to be rendered at 60 FPS instead of 30 FPS by interpolation (game logic still runs at 30 FPS)
+    name = "60fps_ex.patch";
+    url = "file://${finalAttrs.src}/enhancements/60fps_ex.patch";
+    hash = "sha256-2V7WcZ8zG8Ef0bHmXVz2iaR48XRRDjTvynC4RPxMkcA=";
+  })
+  ++ lib.optional always-nonstop (fetchpatch {
+    # Allows Mario to stay within the level after collecting a star
+    name = "nonstop_mode_always_enabled.patch";
+    url = "file://${finalAttrs.src}/enhancements/nonstop_mode_always_enabled.patch";
+    hash = "sha256-s9V8UeIcjNyczfNPmgawgCmKJUkdCItSEr1cQ3ZyX/Q=";
+  })
+  ++ lib.optional extended-moveset (fetchpatch {
+    # Adds various new actions to Mario's moveset, including moves from Sunshine and Odyssey
+    name = "Extended.Moveset.v1.03b.sm64ex_archipelago.patch";
+    url = "file://${finalAttrs.src}/enhancements/Extended.Moveset.v1.03b.sm64ex_archipelago.patch";
+    hash = "sha256-kvsVZu5sXRJpya2BcnJOA+sgORBL3jK6YiZf/Gt3LlA=";
+  });
+
+  postPatch = ''
+    # Nix requires the real path to cmake, useful if you build with submodules
+    substituteInPlace Makefile --replace-fail " cmake " " ${lib.getExe cmake} "
+    # Use the sm64ap directory to save the preferences, for consistency
+    substituteInPlace src/pc/platform.c --replace-fail 'SDL_GetPrefPath("", "sm64ex")' 'SDL_GetPrefPath("", "sm64ap")'
+  '';
+
+  preBuild = ''
+    patchShebangs extract_assets.py
+    ln -s ${baseRom} ./baserom.${region}.z64
+  '';
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp "build/${region}_pc/sm64.${region}.f3dex2e" "$out/bin/sm64ap"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/N00byKing/sm64ex";
+    description = "Super Mario 64 PC Port for Archipelago";
+    longDescription = ''
+      Note that you must supply a baserom yourself to extract assets from.
+      If you are not using an US baserom, you must overwrite the "region" attribute with either "eu" or "jp".
+    '';
+    mainProgram = "sm64ap";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.SchweGELBin ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/sm/sm64ap/prefer-system-version-of-apcpp.patch
+++ b/pkgs/by-name/sm/sm64ap/prefer-system-version-of-apcpp.patch
@@ -1,0 +1,45 @@
+diff --git a/Makefile b/Makefile
+index fe65e47..5c7c73f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1017,17 +1017,22 @@ $(BUILD_DIR)/%.o: $(BUILD_DIR)/%.c
+ $(BUILD_DIR)/%.o: %.s
+ 	$(AS) $(ASFLAGS) -MD $(BUILD_DIR)/$*.d -o $@ $<
+ 
+-APCPP_LIB:=lib/APCpp/build/libAPCpp
++PKG_APCPP_LIB:=-L$(APCPP_LD_PATH) -lAPCpp $(shell pkg-config --libs ixwebsocket sdl2 zlib)
+ LDFLAGS_STATIC:=-static-libgcc -static-libstdc++
+-ifeq ($(WINDOWS_BUILD),1)
+-  APCPP_LIB:=$(APCPP_LIB).dll
+-else ifeq ($(OSX_BUILD),1)
+-  APCPP_LIB:=$(APCPP_LIB).dylib
+-else
+-  APCPP_LIB:=$(APCPP_LIB).so
+-  ifeq ($(IS_FLATPAK),1)
+-    LDFLAGS_STATIC=""
++ifeq ($(APCPP_LD_PATH),)
++  APCPP_LIB := $(shell pkg-config --libs apcpp)
++  ifeq ($(WINDOWS_BUILD),1)
++    APCPP_LIB:=$(APCPP_LIB).dll
++  else ifeq ($(OSX_BUILD),1)
++    APCPP_LIB:=$(APCPP_LIB).dylib
++  else
++    APCPP_LIB:=$(APCPP_LIB).so
++    ifeq ($(IS_FLATPAK),1)
++      LDFLAGS_STATIC=""
++    endif
+   endif
++else
++	LDFLAGS += $(PKG_APCPP_LIB)
+ endif
+ 
+ CMAKE_CFLAGS:="-fzero-init-padding-bits=unions"
+@@ -1043,7 +1048,7 @@ $(APCPP_LIB): lib/APCpp/Archipelago.cpp lib/APCpp/Archipelago.h
+ 
+ $(EXE): $(O_FILES) $(MIO0_FILES:.mio0=.o) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES) $(if $(RPC_LIBS),$(BUILD_DIR)/$(RPC_LIBS),) $(APCPP_LIB)
+ 	$(LD) $(LDFLAGS_STATIC) -L $(BUILD_DIR) -o $@ $(O_FILES) $(SOUND_OBJ_FILES) $(ULTRA_O_FILES) $(GODDARD_O_FILES) $(LDFLAGS) $(APCPP_LIB) -Wl,-rpath,.
+-	cp $(APCPP_LIB) $(BUILD_DIR)
++	$(ifnot $(APCPP_LD_PATH),cp $(APCPP_LIB) $(BUILD_DIR))
+ 
+ .PHONY: all clean distclean default diff test load libultra res
+ .PRECIOUS: $(BUILD_DIR)/bin/%.elf $(SOUND_BIN_DIR)/%.ctl $(SOUND_BIN_DIR)/%.tbl $(SOUND_SAMPLE_TABLES) $(SOUND_BIN_DIR)/%.s $(BUILD_DIR)/%


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hey, I've created a package for the Archipelago version of Super Mario 64.
It is heavily inspired by sm64ex, but needed some changes to differentiate the packages and to include the archipelago library (from a submodule).
I've also added missing command line help options that the users won't get confused, when launching the app for the first time or looking at --help.
For convinience, I've added the enhancement patches and build flags as package attributes.
Have a great day!

P.S. Oops, I wasn't aware of #556081. But these PRs differ a bit, so let's take the best from both.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
