### PR TITLE
liquidwar: build with guile 3

### DIFF
--- a/pkgs/by-name/li/liquidwar/package.nix
+++ b/pkgs/by-name/li/liquidwar/package.nix
@@ -11,7 +11,7 @@
   expat,
   gettext,
   perl,
-  guile_2_0,
+  guile,
   SDL,
   SDL_image,
   SDL_mixer,
@@ -39,11 +39,30 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1976nnl83d8wspjhb5d5ivdvdxgb8lp34wp54jal60z4zad581fn";
   };
 
+  postPatch =
+    # configure: Liquid War 6 needs Guile 1.8 or 2.0
+    ''
+      substituteInPlace configure \
+        --replace-fail "guile/2.0" "guile/3.0" \
+        --replace-fail "guile-2.0" "guile-3.0" \
+        --replace-fail "LIBGUILE2" "LIBGUILE3"
+    ''
+    # error: 'SCM_LIST0' undeclared (first use in this function)
+    + ''
+      substituteInPlace src/lib/lw6-funcs{ldr,gui,pil,sys}.c \
+        --replace-fail "SCM_LIST0" "SCM_EOL"
+    ''
+    # ATTENTION! script returned false, something is wrong
+    + ''
+      substituteInPlace script/liquidwar6.scm \
+        --replace-fail "(lazy-catch #t" "(catch #t"
+    '';
+
   buildInputs = [
     xorgproto
     libx11
     gmp
-    guile_2_0
+    guile
     libjpeg
     libpng
     expat


### PR DESCRIPTION
Also, this PR removes the last reverse dependency of `guile_2_0` in Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
