### PR TITLE
g-wrap: build with guile 3

### DIFF
--- a/pkgs/by-name/g-/g-wrap/package.nix
+++ b/pkgs/by-name/g-/g-wrap/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  guile_2_2,
+  guile,
   guile-lib,
   libffi,
   pkg-config,
@@ -18,12 +18,23 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "0ak0bha37dfpj9kmyw1r8fj8nva639aw5xr66wr5gd3l1rqf5xhg";
   };
 
+  # https://lists.gnu.org/r/guix-patches/2022-11/msg01596.html
+  postPatch = ''
+    substituteInPlace configure \
+      --replace-fail "2.2 2.0" "3.0 2.2 2.0"
+    substituteInPlace guile/g-wrap/guile-runtime.c \
+      --replace-fail "scm_class_top" 'scm_c_public_ref ("oop goops", "<top>")' \
+      --replace-fail "scm_class_method" 'scm_c_public_ref ("oop goops", "<method>")' \
+      --replace-fail "scm_class_generic" 'scm_c_public_ref ("oop goops", "<generic>")' \
+      --replace-fail "scm_memory_error(func_name)" "scm_report_out_of_memory ()"
+  '';
+
   nativeBuildInputs = [ pkg-config ];
 
   # Note: Glib support is optional, but it's quite useful (e.g., it's used by
   # Guile-GNOME).
   buildInputs = [
-    guile_2_2
+    guile
     glib
     guile-lib
   ];


### PR DESCRIPTION
https://lists.gnu.org/r/guix-patches/2022-11/msg01596.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
