### PR TITLE
guile-xcb: build with guile 3

### DIFF
--- a/pkgs/by-name/gu/guile-xcb/package.nix
+++ b/pkgs/by-name/gu/guile-xcb/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
-  guile_2_2,
+  guile,
   pkg-config,
   texinfo,
 }:
@@ -22,19 +22,24 @@ stdenv.mkDerivation {
     hash = "sha256-zbIsEIPwNJ1YXMZTDw2DfzufC+IZWfcWgZHbuv7bhJs=";
   };
 
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail "2.0 2.2" "2.0 2.2 3.0"
+  '';
+
   nativeBuildInputs = [
     autoreconfHook
-    guile_2_2
+    guile
     pkg-config
     texinfo
   ];
   buildInputs = [
-    guile_2_2
+    guile
   ];
 
   configureFlags = [
-    "--with-guile-site-dir=$(out)/${guile_2_2.siteDir}"
-    "--with-guile-site-ccache-dir=$(out)/${guile_2_2.siteCcacheDir}"
+    "--with-guile-site-dir=$(out)/${guile.siteDir}"
+    "--with-guile-site-ccache-dir=$(out)/${guile.siteCcacheDir}"
   ];
 
   makeFlags = [
@@ -46,6 +51,6 @@ stdenv.mkDerivation {
     description = "XCB bindings for Guile";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
-    platforms = guile_2_2.meta.platforms;
+    platforms = guile.meta.platforms;
   };
 }


### PR DESCRIPTION
Adding 3.0 to `GUILE_PKG([2.0 2.2])` suffices, no other fix is needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
