### PR TITLE
junkie: build with guile 3

### DIFF
--- a/pkgs/by-name/ju/junkie/package.nix
+++ b/pkgs/by-name/ju/junkie/package.nix
@@ -6,7 +6,7 @@
   autoreconfHook,
   pkg-config,
   libpcap,
-  guile_2_2,
+  guile,
   openssl,
 }:
 
@@ -30,14 +30,18 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail "guile-2.2" "guile-3.0"
+  ''
   # IP_DONTFRAG is defined on macOS from Big Sur
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     sed -i '10i#undef IP_DONTFRAG' include/junkie/proto/ip.h
   '';
 
   buildInputs = [
     libpcap
-    guile_2_2
+    guile
     openssl
   ];
   nativeBuildInputs = [
@@ -45,8 +49,13 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
   configureFlags = [
-    "GUILELIBDIR=\${out}/${guile_2_2.siteDir}"
-    "GUILECACHEDIR=\${out}/${guile_2_2.siteCcacheDir}"
+    "GUILELIBDIR=\${out}/${guile.siteDir}"
+    "GUILECACHEDIR=\${out}/${guile.siteCcacheDir}"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=implicit-function-declaration"
+    "-Wno-error=int-conversion"
   ];
 
   meta = {


### PR DESCRIPTION
Also fixes darwin build: https://hydra.nixos.org/job/nixpkgs/unstable/junkie.aarch64-darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
