### PR TITLE
rewritefs: 0-unstable-2021-10-03 -> 0-unstable-2026-08-24

### DIFF
--- a/pkgs/by-name/re/rewritefs/package.nix
+++ b/pkgs/by-name/re/rewritefs/package.nix
@@ -4,24 +4,24 @@
   fetchFromGitHub,
   pkg-config,
   fuse3,
-  pcre,
+  pcre2,
 }:
 
 stdenv.mkDerivation {
   pname = "rewritefs";
-  version = "0-unstable-2021-10-03";
+  version = "0-unstable-2026-08-24";
 
   src = fetchFromGitHub {
     owner = "sloonz";
     repo = "rewritefs";
-    rev = "3a56de8b5a2d44968b8bc3885c7d661d46367306";
-    sha256 = "1w2rik0lhqm3wr68x51zs45gqfx79l7fi4p0sqznlfq7sz5s8xxn";
+    rev = "7a4f971ed4c3e8c838c01c924340a0eed22d3b0f";
+    sha256 = "sha256-Vv9W7zQIILwxfFZmdZcUnJlMYGeHFt9WUXcliACnNoE=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     fuse3
-    pcre
+    pcre2
   ];
 
   prePatch = ''


### PR DESCRIPTION
Part of #356387
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
