### PR TITLE
python3Packages.liboqs-python: init at 0.16.0

### DIFF
--- a/pkgs/development/python-modules/liboqs-python/default.nix
+++ b/pkgs/development/python-modules/liboqs-python/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  liboqs,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Python dependencies
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "liboqs-python";
+  version = "0.16.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "open-quantum-safe";
+    repo = "liboqs-python";
+    rev = finalAttrs.version;
+    hash = "sha256-P3zlHQK0s3urvWy/tPJ2wZLDzvn79gFjBLg2PcnoNeU=";
+  };
+
+  postPatch = ''
+    substituteInPlace oqs/oqs.py --replace-fail \
+        'oqs_install_dir = home_dir / "_oqs"' \
+        'oqs_install_dir = Path("${liboqs}")'
+  '';
+
+  build-system = [
+    hatchling
+  ];
+
+  runtimeDependencies = [
+    liboqs
+  ];
+
+  pythonImportsCheck = [
+    "oqs"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python 3 bindings for liboqs";
+    homepage = "https://github.com/open-quantum-safe/liboqs-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wishfort36 ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9634,6 +9634,8 @@ self: super: with self; {
     }
   );
 
+  liboqs-python = callPackage ../development/python-modules/liboqs-python { };
+
   libparse-python = callPackage ../development/python-modules/libparse-python/package.nix { };
 
   libpass = callPackage ../development/python-modules/libpass { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

These are the official Python bindings for `liboqs`, which has been in nixpkgs since 2023.

I don't know if the right choice is to patch `liboqs-python` to facilitate finding `liboqs` as I've done here. As it is now, the original code (excerpt of `oqs/oqs.py`) is

```python
def _load_liboqs() -> ct.CDLL:
    if "OQS_INSTALL_PATH" in environ:
        oqs_install_dir = Path(environ["OQS_INSTALL_PATH"])
    else:
        home_dir = Path.home()
        oqs_install_dir = home_dir / "_oqs"
    # (...)
```

and we patch the last line to point to the right directory. We could alternatively patch [this line](https://github.com/open-quantum-safe/liboqs-python/blob/0f9e50bea240792b802a6e56f5e4d33a9ec0a6b0/oqs/oqs.py#L274) and add the right path as an 'additional searching path'.

Other comments:

- `liboqs-python` (version `0.16`) complains if it isn't given `liboqs` version `0.16`, although it doesn't decide to abort. Perhaps we should wait for #543164 to be merged?

- The dependency `tomli` is only used for Python < 3.11, while I believe nixpkgs only has Python >= 3.11, so there is no need to add it as a dependency.

- Regarding tests: I enabled pytestCheckHook, which required a new package, `pyasn1-alt-modules`. After packaging it, pytest gave some errors about some `yield`-s in test functions in `tests/test_kem.py`, so I ended up removing pytestCheckHook. I also got the same errors on Ubuntu in a container, so it seems like the library currently fails its tests.

- I haven't tested it on Darwin, although the bindings' readme says it should work fine there, too.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (NixOS 26.05)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
