### PR TITLE
quarto: Patch to ensure compatibility with pandoc <3.8

### DIFF
--- a/pkgs/by-name/qu/quarto/older-pandoc-compat.patch
+++ b/pkgs/by-name/qu/quarto/older-pandoc-compat.patch
@@ -1,0 +1,47 @@
+diff --git a/bin/quarto.js b/bin/quarto.js
+index b68ea22..dd311f1 100644
+--- a/bin/quarto.js
++++ b/bin/quarto.js
+@@ -19487,7 +19487,7 @@ var init_constants6 = __esm({
+     kPaperSize = "papersize";
+     kLogFile = "log-file";
+     kHighlightStyle = "highlight-style";
+-    kSyntaxHighlighting = "syntax-highlighting";
++    kSyntaxHighlighting = "highlight-style";
+     kDefaultImageExtension = "default-image-extension";
+     kLogo = "logo";
+     kLinkColor = "linkcolor";
+@@ -143675,7 +143675,7 @@ async function textPreviewHtml(file, req) {
+   const cmd = [pandocBinaryPath()];
+   cmd.push("--to", "html");
+   cmd.push(
+-    "--syntax-highlighting",
++    "--highlight-style",
+     textHighlightThemePath("atom-one", darkMode ? "dark" : "light")
+   );
+   cmd.push("--standalone");
+@@ -143746,7 +143746,7 @@ ${jsInit}`;
+     cmd.push("--lua-filter");
+     cmd.push(filter3);
+     if (highlightPath) {
+-      cmd.push("--syntax-highlighting");
++      cmd.push("--highlight-style");
+       cmd.push(highlightPath);
+     }
+     cmd.push("--mathjax");
+diff --git a/share/filters/modules/jog.lua b/share/filters/modules/jog.lua
+index a354757..160e75b 100644
+--- a/share/filters/modules/jog.lua
++++ b/share/filters/modules/jog.lua
+@@ -115,7 +115,10 @@ local function recurse (element, tp, jogger)
+     end
+   elseif tp == 'Row' or tp == 'pandoc Row' then
+     element.cells    = jogger(element.cells)
+-  elseif tp == 'pandoc TableHead' or tp == 'pandoc TableFoot' or
++  elseif tp == 'pandoc TableBody' or tp == 'TableBody' then
++    element.head = jogger(element.head)
++    element.body = jogger(element.body)
++elseif tp == 'pandoc TableHead' or tp == 'pandoc TableFoot' or
+          tp == 'TableHead' or tp == 'TableFoot' then
+     element.rows    = jogger(element.rows)
+   elseif tp == 'pandoc TableBody' or tp == 'TableBody' then

--- a/pkgs/by-name/qu/quarto/package.nix
+++ b/pkgs/by-name/qu/quarto/package.nix
@@ -78,6 +78,12 @@ stdenv.mkDerivation (finalAttrs: {
   # libgcc_s.so.1 for the retained typst-gather and deno_dom binaries
   ++ lib.optionals stdenv.hostPlatform.isLinux [ (stdenv.cc.cc.libgcc or null) ];
 
+  # Patches quarto to use older API's from pandoc 3.7
+  # Quarto upstream is built against, and expects pandoc 3.8+ .
+  patches = lib.optionals (lib.versionOlder pandoc.version "3.8") [
+    ./older-pandoc-compat.patch
+  ];
+
   dontStrip = true;
 
   preFixup = ''


### PR DESCRIPTION
Adds a patch that is only active when pandoc <  3.8, since it will no longer be needed when pandoc in nixpkgs updates.

(I have tested the compatibility with my own nix build of the newer pandoc: https://github.com/moonpiedumplings/pandoc-flake) 

Pandoc's Lua API has changed, and quarto expects the newer `syntax-highlighting option`, whereas Pandoc <3.8 only works with the older `highlight-style`


@SuperSandro2000 This is try 3 on my pr I guess, I closed the previous one you commented on and integrated your suggestions.

Edit: This fixes this issue: https://github.com/nixOS/nixpkgs/issues/519484


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
