### PR TITLE
poetry: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/by-name/po/poetry/package.nix
+++ b/pkgs/by-name/po/poetry/package.nix
@@ -37,11 +37,11 @@ let
 
   plugins =
     ps: with ps; {
+      poeblix = callPackage ./plugins/poeblix.nix { };
       poetry-audit-plugin = callPackage ./plugins/poetry-audit-plugin.nix { };
       poetry-plugin-export = callPackage ./plugins/poetry-plugin-export.nix { };
       poetry-plugin-up = callPackage ./plugins/poetry-plugin-up.nix { };
       poetry-plugin-migrate = callPackage ./plugins/poetry-plugin-migrate.nix { };
-      poetry-plugin-poeblix = callPackage ./plugins/poetry-plugin-poeblix.nix { };
       poetry-plugin-shell = callPackage ./plugins/poetry-plugin-shell.nix { };
     };
 

--- a/pkgs/by-name/po/poetry/plugins/poeblix.nix
+++ b/pkgs/by-name/po/poetry/plugins/poeblix.nix
@@ -6,7 +6,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "poetry-plugin-poeblix";
+  pname = "poeblix";
   version = "0.10.0";
   pyproject = true;
 

--- a/pkgs/by-name/po/poetry/plugins/poeblix.nix
+++ b/pkgs/by-name/po/poetry/plugins/poeblix.nix
@@ -2,10 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  poetry,
   poetry-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "poeblix";
   version = "0.10.0";
   pyproject = true;
@@ -13,26 +14,30 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "spoorn";
     repo = "poeblix";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-TKadEOk9kM3ZYsQmE2ftzjHNGNKI17p0biMr+Nskigs=";
   };
 
-  postPatch = ''
-    sed -i '/poetry =/d' pyproject.toml
-  '';
-
-  nativeBuildInputs = [
+  build-system = [
     poetry-core
+  ];
+
+  pythonRelaxDeps = [
+    "poetry"
+  ];
+
+  buildInputs = [
+    poetry
   ];
 
   doCheck = false;
   pythonImportsCheck = [ "poeblix" ];
 
   meta = {
-    changelog = "https://github.com/spoorn/poeblix/releases/tag/${lib.removePrefix "refs/tags/" src.rev}";
+    changelog = "https://github.com/spoorn/poeblix/releases/tag/${finalAttrs.src.tag}";
     description = "Poetry Plugin that adds various features that extend the poetry command such as building wheel files with locked dependencies, and validations of wheel/docker containers";
     license = lib.licenses.mit;
     homepage = "https://github.com/spoorn/poeblix";
     maintainers = with lib.maintainers; [ hennk ];
   };
-}
+})

--- a/pkgs/by-name/po/poetry/unwrapped.nix
+++ b/pkgs/by-name/po/poetry/unwrapped.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "poetry";
-  version = "2.4.1";
+  version = "2.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = "poetry";
     tag = version;
-    hash = "sha256-Mb1etVmBm542q7FrcMU6pzXdMUDQSpI8DFg/gbOiG4U=";
+    hash = "sha256-/U3XZfGRPabE8xY8yPf/yol1BueqZ+theG0vXI1s2OA=";
   };
 
   patches = [


### PR DESCRIPTION
Diff: https://github.com/python-poetry/poetry/compare/2.4.1...2.4.2

Changelog: https://github.com/python-poetry/poetry/blob/2.4.2/CHANGELOG.md

closes https://github.com/NixOS/nixpkgs/pull/300432
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
