### PR TITLE
gobject-introspection: don't abort builds when g-ir-scanner is absent

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -79,6 +79,10 @@ then
     # override the variable to use the absolute path to g_ir_X in PATH which can be run
     + ''
       cat >> $dev/nix-support/setup-hook <<-'EOF'
+        # Override when gobject-introspection is a build-time dependency. Otherwise its $dev/bin
+        # is not on PATH.
+        [[ -z ''${strictDeps-} ]] || (( "$hostOffset" < 0 )) || return 0
+
         override-pkg-config-gir-variables() {
           PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_SCANNER="$(type -p g-ir-scanner)"
           PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_G_IR_COMPILER="$(type -p g-ir-compiler)"


### PR DESCRIPTION
When cross-compiling, the wrapper appends override-pkg-config-gir-variables to preConfigureHooks. That function assigns from `$(type -p g-ir-scanner)` without a fallback.

The hook is sourced by any package that gets gobject-introspection propagated to it, anything depending on pygobject3, but in that case gobject-introspection arrives in the buildInputs offset, so its `$dev/bin` is never added to PATH.

Because the failing command is an assignment, bash prints nothing. The entire build log ends with no error just:

    Running phase: updateAutotoolsGnuConfigScriptsPhase
    Running phase: configurePhase

The hook became visible when  ("python3Packages.dbus-python: Re-enable tests", #540549) added pygobject3 to dbus-python's checkInputs. Since then every cross build of dbus-python fails:

    nix-build -A pkgsCross.aarch64-multiplatform.buildPackages.python3Packages.dbus-python



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
