### PR TITLE
python3Packages.spsdk: 3.9.0 -> 3.11.0

### DIFF
--- a/pkgs/development/python-modules/spsdk-mcu-link/default.nix
+++ b/pkgs/development/python-modules/spsdk-mcu-link/default.nix
@@ -20,16 +20,17 @@
   spsdk-mcu-link,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "spsdk-mcu-link";
-  version = "0.6.6";
+  version = "0.6.14";
   pyproject = true;
+  __structuredAttrs = true;
 
   # Latest tag missing on GitHub
   src = fetchPypi {
     pname = "spsdk_mcu_link";
-    inherit version;
-    hash = "sha256-KISqhJJFtHFCDOFs+Zx0ghX0lGK5tazVqEIOT9gyAQs=";
+    inherit (finalAttrs) version;
+    hash = "sha256-9zcBx/apHX1RG0HbVvl/KzfCi4FRC56U2iSt6l1Urh8=";
   };
 
   build-system = [
@@ -40,6 +41,9 @@ buildPythonPackage rec {
     # unpackaged
     "libusb_package"
     "wasmtime"
+
+    # cyclic dependency
+    "spsdk"
   ];
 
   pythonRelaxDeps = [
@@ -78,4 +82,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -43,15 +43,16 @@
   cookiecutter,
   ipykernel,
   pytest-notebook,
+  pytest-xdist,
   pytestCheckHook,
-  voluptuous,
   versionCheckHook,
+  voluptuous,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "spsdk";
-  version = "3.9.0";
+  version = "3.11.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -59,8 +60,15 @@ buildPythonPackage (finalAttrs: {
     owner = "nxp-mcuxpresso";
     repo = "spsdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eA18DvQ0IIZtseJXXXMiFYkaOwBIhVXNaWiAObIj55I=";
+    hash = "sha256-BIYCOwXMw0PuZDWj7x4EG+mUBo+7RNJs0hvNVwbxlIg=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        "setuptools_scm<10" \
+        "setuptools_scm"
+  '';
 
   build-system = [
     setuptools
@@ -68,13 +76,16 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonRelaxDeps = [
+    "chardet"
     "cryptography"
+    "deepmerge"
     "filelock"
     "importlib-metadata"
     "packaging"
     "prettytable"
     "requests"
     "ruamel.yaml.clib"
+    "setuptools"
     "setuptools_scm"
     "typing-extensions"
   ];
@@ -126,8 +137,9 @@ buildPythonPackage (finalAttrs: {
     ipykernel
     pytest-notebook
     pytestCheckHook
-    voluptuous
+    pytest-xdist
     versionCheckHook
+    voluptuous
     writableTmpDirAsHomeHook
   ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/nxp-mcuxpresso/spsdk/compare/v3.9.0...v3.11.0
Changelog: https://github.com/nxp-mcuxpresso/spsdk/blob/v3.11.0/docs/release_notes.rst

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test