### PR TITLE
python3Packages.midea-local: modernize

### DIFF
--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -6,24 +6,24 @@
   aiofiles,
   aiohttp,
   colorlog,
-  commonregex,
   defusedxml,
-  deprecated,
   ifaddr,
   pycryptodome,
   platformdirs,
+  typing-extensions,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "midea-local";
-  version = "7.0.0";
+  version = "10.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "midea-lan";
     repo = "midea-local";
-    tag = "midea-local-v${finalAttrs.version}";
-    hash = "sha256-Z/zycW57/hmDIQVBWZmREtsMLaXSJTqDfuUUyf+tpUI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aCQsA9N6s4r2x466DNTUFqxRP4dfXZBSD9rrC9Bvrb4=";
   };
 
   build-system = [ setuptools ];
@@ -32,13 +32,14 @@ buildPythonPackage (finalAttrs: {
     aiofiles
     aiohttp
     colorlog
-    commonregex
     defusedxml
-    deprecated
     ifaddr
     pycryptodome
     platformdirs
+    typing-extensions
   ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "midealocal" ];
 

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -14,7 +14,7 @@
   platformdirs,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "midea-local";
   version = "7.0.0";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "midea-lan";
     repo = "midea-local";
-    tag = "midea-local-v${version}";
+    tag = "midea-local-v${finalAttrs.version}";
     hash = "sha256-Z/zycW57/hmDIQVBWZmREtsMLaXSJTqDfuUUyf+tpUI=";
   };
 
@@ -45,8 +45,8 @@ buildPythonPackage rec {
   meta = {
     description = "Control your Midea M-Smart appliances via local area network";
     homepage = "https://github.com/midea-lan/midea-local";
-    changelog = "https://github.com/midea-lan/midea-local/releases/tag/${src.tag}";
+    changelog = "https://github.com/midea-lan/midea-local/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ k900 ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -40,6 +40,8 @@ buildPythonPackage rec {
     platformdirs
   ];
 
+  pythonImportsCheck = [ "midealocal" ];
+
   meta = {
     description = "Control your Midea M-Smart appliances via local area network";
     homepage = "https://github.com/midea-lan/midea-local";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
