### PR TITLE
antigravity-acp: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1456,6 +1456,12 @@
     githubId = 30437811;
     name = "Alex Andrews";
   };
+  aliheidary1381 = {
+    email = "aliheidary1381@gmail.com";
+    github = "aliheidary1381";
+    githubId = 31212739;
+    name = "Ali Heydari";
+  };
   alikaansun = {
     github = "alikaansun";
     githubId = 77810345;

--- a/pkgs/by-name/an/antigravity-acp/package.nix
+++ b/pkgs/by-name/an/antigravity-acp/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+  autoPatchelfHook,
+}:
+let
+  sources = {
+    x86_64-linux = {
+      url = "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_20260818_01_RC01-linux-x86_64.zip";
+      hash = "sha256-zj8JYoV1slSXz1o8GdBztJrLgPHasf+FkpGenJuHmeE="; # Run `nix store prefetch-file <url>`
+    };
+    aarch64-linux = {
+      url = "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_20260818_01_RC01-linux-arm64.zip";
+      hash = "sha256-cPzaxwaE3mD3oOsW6kl9bMRJhyhCDwYOCFDPyakym0A=";
+    };
+    aarch64-darwin = {
+      url = "https://dl.google.com/agy-extensions/releases/macos/agy-acp-server-agy_acp_server_20260818_01_RC01-darwin-arm64.zip";
+      hash = "sha256-8SLKfnAwon+WSdpM8afYDhLEjF9hGP81r/w01Wy/g90=";
+    };
+  };
+
+  srcInfo =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported platform for antigravity-acp: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "antigravity-acp";
+  version = "1.0.0";
+
+  src = fetchurl {
+    inherit (srcInfo) url hash;
+  };
+
+  nativeBuildInputs = [
+    unzip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  sourceRoot = ".";
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m755 agy_acp_server.par $out/bin/agy_acp_server.par
+    install -m555 localharness_external $out/bin/localharness_external
+
+    ln -s $out/bin/agy_acp_server.par $out/bin/agy_acp_server
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Google's AI coding agent. Official ACP server powered by Antigravity";
+    homepage = "https://antigravity.google/docs/ide/extensions";
+    license = lib.licenses.unfree;
+    maintainers = [
+      lib.maintainers.aliheidary1381
+      lib.maintainers.johnrtitor
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    mainProgram = "agy_acp_server";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

antigravity-acp ([official](https://antigravity.google/docs/ide/extensions)) brings the power of Google Antigravity to IDEs like Zed, VS Code, and Jetbrains products.

Metedata (version and description) are from [here](https://github.com/agentclientprotocol/registry/tree/main/antigravity-acp) and [here](https://agentclientprotocol.com/get-started/registry).

## Things done

I've only tested the `x86_64-linux` build by using it in the Zed editor.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
