### PR TITLE
cjson: enable windows cross compilation

### DIFF
--- a/pkgs/by-name/cj/cjson/package.nix
+++ b/pkgs/by-name/cj/cjson/package.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Ultralightweight JSON parser in ANSI C";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.matthiasbeyer ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.windows ++ lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Wanted to build cjson for Windows using cross compilation. It cross compiles just fine. Added windows to the meta platforms.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
