### PR TITLE
python3Packages.ua-parser-rs: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/ua-parser-rs/default.nix
+++ b/pkgs/development/python-modules/ua-parser-rs/default.nix
@@ -11,7 +11,7 @@
 buildPythonPackage rec {
   pname = "ua-parser-rs";
   version = "0.1.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ua-parser";

--- a/pkgs/development/python-modules/ua-parser-rs/default.nix
+++ b/pkgs/development/python-modules/ua-parser-rs/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Native accelerator for ua-parser";
-    homepage = "https://github.com/ua-parser/uap-rust/tree/main/ua-parser-py";
+    homepage = "https://github.com/ua-parser/uap-rust";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dotlambda ];
   };

--- a/pkgs/development/python-modules/ua-parser-rs/default.nix
+++ b/pkgs/development/python-modules/ua-parser-rs/default.nix
@@ -8,21 +8,23 @@
   rustPlatform,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ua-parser-rs";
   version = "0.1.4";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "ua-parser";
     repo = "uap-rust";
-    tag = "ua-parser-rs-${version}";
+    tag = "ua-parser-rs-${finalAttrs.version}";
     hash = "sha256-8IU4NNW0v2zl6COtL6o7FALxqYNVKBGhERugxpXIN5g=";
     fetchSubmodules = true;
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-PNkyd9/0DdIqEmXbnw3dZs5ajWSo0rLhjJwRu3H06Cc=";
   };
 
@@ -40,10 +42,12 @@ buildPythonPackage rec {
 
   passthru.updateScript = gitUpdater { rev-prefix = "ua-parser-rs-"; };
 
+  pythonImportsCheck = [ "ua_parser_rs" ];
+
   meta = {
     description = "Native accelerator for ua-parser";
     homepage = "https://github.com/ua-parser/uap-rust/tree/main/ua-parser-py";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
As part of https://github.com/NixOS/nixpkgs/issues/515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
