### PR TITLE
python3Packages.jupyter-server: disable failing test on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -122,6 +122,11 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     # Failed: DID NOT RAISE <class 'tornado.web.HTTPError'>
     "test_copy_big_dir"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # AssertionError
+    # assert datetime.datetime(2026, 8, 30, 8, 46, 39, 807851, tzinfo=datetime.timezone.utc) > datetime.datetime(2026, 8, 30, 8, 46, 39, 807851, tzinfo=datetime.timezone.utc)
+    "test_created_timestamp"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
=========================== short test summary info ============================
...
FAILED tests/services/contents/test_manager.py::test_created_timestamp[jp_contents_manager0] - assert datetime.datetime(2026, 8, 30, 8, 48, 51, 733448, tzinfo=datetime.ti...
FAILED tests/services/contents/test_manager.py::test_created_timestamp[jp_contents_manager1] - assert datetime.datetime(2026, 8, 30, 8, 48, 51, 813449, tzinfo=datetime.ti...
===== 2 failed, 944 passed, 26 skipped, 76 deselected in 95.96s (0:01:35) ======
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
