### PR TITLE
python3Packages.litellm: 1.97.0 -> 1.98.0

### DIFF
--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -65,14 +65,14 @@
 
 buildPythonPackage rec {
   pname = "litellm";
-  version = "1.97.0";
+  version = "1.98.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BerriAI";
     repo = "litellm";
     tag = "v${version}";
-    hash = "sha256-9nVVXRvtfxntAgSetCy66jfDpunR12DEIoQKAjSZn/4=";
+    hash = "sha256-eMquDSSlBo//huXXiys/F36O18VDjv7U1OUe7DrKhus=";
   };
 
   nativeBuildInputs = with rustPlatform; [
@@ -99,6 +99,7 @@ buildPythonPackage rec {
 
   dependencies = [
     aiohttp
+    boto3
     click
     fastuuid
     httpx
@@ -119,7 +120,6 @@ buildPythonPackage rec {
       azure-identity
       azure-storage-blob
       backoff
-      boto3
       cryptography
       expression
       fastapi
@@ -180,6 +180,7 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "aiohttp"
+    "boto3"
     "click"
     "importlib-metadata"
     "jsonschema"


### PR DESCRIPTION
Bump litellm to 1.98.0.


Fixes proxy breaking due to fastapi changes:
```
litellm[6929]: Traceback (most recent call last):
litellm[6929]:   File "/nix/store/51ny3cqc56a48008qbrn5zssjsh2773v-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/proxy_cli.py", line 1004, in run_server
litellm[6929]:     from .proxy_server import (
litellm[6929]:     ...<4 lines>...
litellm[6929]:     )
litellm[6929]:   File "/nix/store/51ny3cqc56a48008qbrn5zssjsh2773v-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/proxy_server.py", line 439, in <module>
litellm[6929]:     from litellm.proxy.management_endpoints.management_v1 import (
litellm[6929]:         router as management_v1_router,
litellm[6929]:     )
litellm[6929]:   File "/nix/store/51ny3cqc56a48008qbrn5zssjsh2773v-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/management_endpoints/management_v1/__init__.py", line 7, in <module>
litellm[6929]:     from litellm.proxy.management_endpoints.management_v1.budgets import (
litellm[6929]:         router as budgets_router,
litellm[6929]:     )
litellm[6929]:   File "/nix/store/51ny3cqc56a48008qbrn5zssjsh2773v-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/management_endpoints/management_v1/budgets.py", line 19, in <module>
litellm[6929]:     from litellm.proxy.management_endpoints.management_v1.common import (
litellm[6929]:     ...<3 lines>...
litellm[6929]:     )
litellm[6929]:   File "/nix/store/51ny3cqc56a48008qbrn5zssjsh2773v-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/management_endpoints/management_v1/common.py", line 7, in <module>
litellm[6929]:     from fastapi.dependencies.utils import get_flat_dependant
litellm[6929]: ImportError: cannot import name 'get_flat_dependant' from 'fastapi.dependencies.utils' (/nix/store/bk71siyzciw1ixab7fl5ra93d09qx48y-python3.14-fastapi-0.141.1/lib/python3.14/site-packages/fastapi/dependencies/utils.py)
litellm[6929]: During handling of the above exception, another exception occurred:
litellm[6929]: Traceback (most recent call last):
litellm[6929]:   File "/nix/store/51ny3cqc56a48008qbrn5zssjsh2773v-python3.14-litellm-1.97.0/bin/.litellm-wrapped", line 9, in <module>
litellm[6929]:     sys.exit(run_server())
litellm[6929]:              ~~~~~~~~~~^^
litellm[6929]:   File "/nix/store/mc5q10vi28zacxmq87caj8fzkn4bipr6-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 1514, in __call__
litellm[6929]:     return self.main(*args, **kwargs)
litellm[6929]:            ~~~~~~~~~^^^^^^^^^^^^^^^^^
litellm[6929]:   File "/nix/store/mc5q10vi28zacxmq87caj8fzkn4bipr6-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 1435, in main
litellm[6929]:     rv = self.invoke(ctx)
litellm[6929]:   File "/nix/store/mc5q10vi28zacxmq87caj8fzkn4bipr6-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 1298, in invoke
litellm[6929]:     return ctx.invoke(self.callback, **ctx.params)
litellm[6929]:            ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
litellm[6929]:   File "/nix/store/mc5q10vi28zacxmq87caj8fzkn4bipr6-python3.14-click-8.3.3/lib/python3.14/site-packages/click/core.py", line 853, in invoke
litellm[6929]:     return callback(*args, **kwargs)
litellm[6929]:   File "/nix/store/51ny3cqc56a48008qbrn5zssjsh2773v-python3.14-litellm-1.97.0/lib/python3.14/site-packages/litellm/proxy/proxy_cli.py", line 1018, in run_server
litellm[6929]:     from proxy_server import (
litellm[6929]:     ...<4 lines>...
litellm[6929]:     )
litellm[6929]: ModuleNotFoundError: No module named 'proxy_server'
systemd[1]: litellm.service: Main process exited, code=exited, status=1/FAILURE
```

Slightly relax the minimum boto3 dependency to get the damned thing building. I don't use Bedrock, so I cannot confirm if this breaks it.
```
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for litellm-1.98.0-cp314-cp314-linux_x86_64.whl
       >   - boto3<2.0,>=1.43.1 not satisfied by version 1.42.31
       For full logs, run:
         nix log /nix/store/hxwssk9szywds0hm9ds86plsxgwm76hl-python3.14-litellm-1.98.0.drv
```


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
