### PR TITLE
mcp-proxy: 0.10.0 -> 0.12.0

### DIFF
--- a/pkgs/by-name/mc/mcp-proxy/package.nix
+++ b/pkgs/by-name/mc/mcp-proxy/package.nix
@@ -2,16 +2,17 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mcp-proxy";
-  version = "0.10.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "sparfenyuk";
     repo = "mcp-proxy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Hig+ZDFdToiYGOjb/rpqxnu8MaLmQLgSh5WYcgJGA1I=";
+    hash = "sha256-rurNHP5TprhFUrg+0E6FnNxhCqQv2xtkfhUrGUdGod0=";
   };
 
   pyproject = true;
@@ -19,9 +20,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
   build-system = [ python3Packages.setuptools ];
 
   dependencies = with python3Packages; [
-    uvicorn
+    httpx-auth
     mcp
+    uvicorn
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook


### PR DESCRIPTION
The nix-update bot picked up the update but failed to build the package due to a missing dependency: https://nixpkgs-update-logs.nix-community.org/mcp-proxy/2026-08-28.log. `httpx-auth` was added in https://github.com/sparfenyuk/mcp-proxy/commit/113274056da007362730285508cace63d006d555

Also added `versionCheckHook` as an extra sanity check. Verified via logs:
```
@nix { "action": "setPhase", "phase": "installCheckPhase" }
Executing versionCheckPhase
Successfully managed to find version 0.12.0 in the output of the command /nix/store/8ly49ns6ka2ljcq4w6096g9mxl94vljj-mcp-proxy-0.12.0/bin/mcp-proxy --version
mcp-proxy 0.12.0
Finished versionCheckPhase
no Makefile or custom installCheckPhase, doing nothing

``` 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
