### PR TITLE
python3Packages.otter-grader: 6.1.6 -> 7.0.0

### DIFF
--- a/pkgs/development/python-modules/otter-grader/default.nix
+++ b/pkgs/development/python-modules/otter-grader/default.nix
@@ -3,7 +3,11 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   poetry-core,
+
+  # dependencies
   click,
   dill,
   fica,
@@ -15,43 +19,57 @@
   nbconvert,
   nbformat,
   pandas,
+  python-frontmatter,
   python-on-whales,
   pyyaml,
   requests,
   wrapt,
+
+  # optional-dependencies
+  # grading:
   ipykernel,
   jupyter-client,
   pypdf,
+  # plugins:
   google-api-python-client,
   google-auth-oauthlib,
   gspread,
   six,
+  # r:
   rpy2,
-  pytestCheckHook,
-  writableTmpDirAsHomeHook,
-  pytest-html,
-  matplotlib,
-  tqdm,
+
+  # tests
   R,
+  matplotlib,
+  pytest-html,
+  pytestCheckHook,
+  quarto,
+  tqdm,
+  writableTmpDirAsHomeHook,
   rPackages,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "otter-grader";
-  version = "6.1.6";
+  version = "7.0.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ucbds-infra";
     repo = "otter-grader";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bqBwDbxnvRm7W9r87YK9vwi3sSyoyqbdnqVs5HxOzsg=";
+    hash = "sha256-1YevahUFesCDEfmMTIGa6qO7DwBYmGFivWFJFap/Djw=";
   };
 
   build-system = [
     poetry-core
   ];
 
+  pythonRelaxDeps = [
+    "fica"
+    "wrapt"
+  ];
   dependencies = [
     click
     dill
@@ -64,6 +82,7 @@ buildPythonPackage (finalAttrs: {
     nbconvert
     nbformat
     pandas
+    python-frontmatter
     python-on-whales
     pyyaml
     requests
@@ -87,21 +106,16 @@ buildPythonPackage (finalAttrs: {
     ];
   };
 
-  pythonRelaxDeps = [
-    "fica"
-  ];
-
-  pythonImportsCheck = [
-    "otter"
-  ];
+  pythonImportsCheck = [ "otter" ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    writableTmpDirAsHomeHook
-    pytest-html
-    matplotlib
-    tqdm
     R
+    matplotlib
+    pytest-html
+    pytestCheckHook
+    quarto
+    tqdm
+    writableTmpDirAsHomeHook
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
@@ -118,9 +132,17 @@ buildPythonPackage (finalAttrs: {
     "test_notebooks_with_pdfs"
     "test_config_overrides_integration"
     "test_queue"
+
     # testthat 3.x assertion message format differs from the expected results in
     # this R Markdown test, causing a partial credit output mismatch
     "test_rmd"
+
+    # pandas 3 renamed the public classes' `__module__` to `pandas`:
+    # AssertionError: assert 'pandas.DataFrame' == 'pandas.core.frame.DataFrame'
+    "test_get_variable_type"
+
+    # Grading qmd files requires ottr>=1.6.0, but rPackages.ottr is 1.5.3
+    "test_qmd"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # socket.bind() fails under macOS sandbox


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/ucbds-infra/otter-grader/compare/v6.1.6...v7.0.0
Changelog: https://github.com/ucbds-infra/otter-grader/blob/refs/tags/v7.0.0/CHANGELOG.md

cc @HHR2020

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test