### PR TITLE
draupnir: hostfix for broken nodejs 24.19

### DIFF
--- a/pkgs/by-name/dr/draupnir/package.nix
+++ b/pkgs/by-name/dr/draupnir/package.nix
@@ -78,7 +78,7 @@ buildNpmPackage (finalAttrs: {
     mkdir -p $out/lib/node_modules/draupnir
     mkdir $out/bin
     # Install outputs
-    mv ./node_modules ./packages ./apps/draupnir/dist ./apps/draupnir/version.txt ./apps/draupnir/package.json $out/lib/node_modules/draupnir
+    mv ./node_modules ./packages ./apps/draupnir/dist ./apps/draupnir/branch.txt ./apps/draupnir/version.txt ./apps/draupnir/package.json $out/lib/node_modules/draupnir
     # Fix dangling symlink pointing to relative path ../apps/draupnir
     rm $out/lib/node_modules/draupnir/node_modules/draupnir
 

--- a/pkgs/by-name/dr/draupnir/package.nix
+++ b/pkgs/by-name/dr/draupnir/package.nix
@@ -2,7 +2,9 @@
   lib,
   fetchFromGitHub,
   makeBinaryWrapper,
-  nodejs_24,
+  # use nodejs_22 as there is currently an upstream bug in nodejs_24.19
+  # see https://github.com/nodejs/node/issues/65446
+  nodejs_22,
   matrix-sdk-crypto-nodejs,
   python3,
   sqlite,
@@ -16,7 +18,7 @@
   fetchpatch2,
 }:
 let
-  nodeSources = srcOnly nodejs_24;
+  nodeSources = srcOnly nodejs_22;
 in
 
 buildNpmPackage (finalAttrs: {
@@ -81,7 +83,7 @@ buildNpmPackage (finalAttrs: {
     rm $out/lib/node_modules/draupnir/node_modules/draupnir
 
     # Create wrapper executable
-    makeWrapper ${lib.getExe nodejs_24} $out/bin/draupnir \
+    makeWrapper ${lib.getExe nodejs_22} $out/bin/draupnir \
       --add-flags "--enable-source-maps" \
       --add-flags "$out/lib/node_modules/draupnir/dist/index.js"
 


### PR DESCRIPTION
Change nodejs version to v22:

This prevents an upstream bug introduced in https://github.com/NixOS/nixpkgs/pull/548826
and still open here https://github.com/nodejs/node/issues/65446


Add `branch.txt` to the runtime folder:

This fixes an error while startup of the daemon that files is not found.

## Things done

I only tested this patch live against nixos 26.05 stable.
Runs currently on milliways.info and looks good to me.
tested branch: https://github.com/TuxCoder/nixpkgs/tree/draupnir_nodejs_hotfix_26_05

Maintainer: @TheArcaneBrony 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
