### PR TITLE
python3Packages.graph-tool: 3.6 -> 3.7

### DIFF
--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -5,12 +5,11 @@
   stdenv,
 
   boost191,
-  cairomm_1_0,
+  cairomm_1_16,
   cgal,
   expat,
   fontconfig,
   gobject-introspection,
-  graphviz,
   gtk3,
   llvmPackages,
   matplotlib,
@@ -36,7 +35,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "graph-tool";
-  version = "3.6";
+  version = "3.7";
   pyproject = false;
 
   strictDeps = true;
@@ -45,7 +44,7 @@ buildPythonPackage (finalAttrs: {
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-KFKitvz3zFEQAi8hkvIBC0c5QTRmOJRamdV0cyMbejU=";
+    hash = "sha256-oEupn8h0X0QPx326ygfaTQXNjUqW5qr6vfXFfjgJhn0=";
   };
 
   postPatch =
@@ -54,14 +53,6 @@ buildPythonPackage (finalAttrs: {
       substituteInPlace configure \
         --replace-fail 'tput setaf $1' : \
         --replace-fail 'tput sgr0' :
-    ''
-    +
-    # hardcode path to graphviz library to avoid find_library, which would require setting LD_LIBRARY_PATH
-    ''
-      substituteInPlace src/graph_tool/draw/graphviz_draw.py \
-        --replace-fail \
-          'ctypes.util.find_library("gvc")' \
-          '"${lib.getLib graphviz}/lib/libgvc${stdenv.hostPlatform.extensions.sharedLibrary}"'
     '';
 
   configureFlags =
@@ -94,7 +85,7 @@ buildPythonPackage (finalAttrs: {
   # https://graph-tool.skewed.de/installation.html#manual-compilation
   buildInputs = [
     boost'
-    cairomm_1_0
+    cairomm_1_16
     cgal
     expat
     mpfr

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7220,7 +7220,7 @@ self: super: with self; {
 
   granian = callPackage ../development/python-modules/granian { };
 
-  graph-tool = callPackage ../development/python-modules/graph-tool { inherit (pkgs) cgal graphviz; };
+  graph-tool = callPackage ../development/python-modules/graph-tool { inherit (pkgs) cgal; };
 
   graphemeu = callPackage ../development/python-modules/graphemeu { };
 


### PR DESCRIPTION
https://git.skewed.de/count0/graph-tool/-/compare/refs/tags/release-3.6..refs/tags/release-3.7

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test