### PR TITLE
python3Packages.u-msgpack-python: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/u-msgpack-python/default.nix
+++ b/pkgs/development/python-modules/u-msgpack-python/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
+  setuptools,
   glibcLocales,
   unittestCheckHook,
 }:
@@ -9,12 +10,14 @@
 buildPythonPackage rec {
   pname = "u-msgpack-python";
   version = "2.8.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-uAGoPW7XXm30HkRRi08qnCIdwtpLzVOA46D+2lILxho=";
   };
+
+  build-system = [ setuptools ];
 
   env.LC_ALL = "en_US.UTF-8";
 

--- a/pkgs/development/python-modules/u-msgpack-python/default.nix
+++ b/pkgs/development/python-modules/u-msgpack-python/default.nix
@@ -23,9 +23,10 @@ buildPythonPackage (finalAttrs: {
 
   env.LC_ALL = "en_US.UTF-8";
 
-  buildInputs = [ glibcLocales ];
-
-  nativeCheckInputs = [ unittestCheckHook ];
+  nativeCheckInputs = [
+    glibcLocales
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [ "umsgpack" ];
 

--- a/pkgs/development/python-modules/u-msgpack-python/default.nix
+++ b/pkgs/development/python-modules/u-msgpack-python/default.nix
@@ -7,13 +7,15 @@
   unittestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "u-msgpack-python";
   version = "2.8.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-uAGoPW7XXm30HkRRi08qnCIdwtpLzVOA46D+2lILxho=";
   };
 
@@ -25,10 +27,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ unittestCheckHook ];
 
+  pythonImportsCheck = [ "umsgpack" ];
+
   meta = {
     description = "Portable, lightweight MessagePack serializer and deserializer written in pure Python";
     homepage = "https://github.com/vsergeev/u-msgpack-python";
-    changelog = "https://github.com/vsergeev/u-msgpack-python/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/vsergeev/u-msgpack-python/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
As part of #515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
