### PR TITLE
fastcrw: init at 0.32.0

### DIFF
--- a/pkgs/by-name/fa/fastcrw/package.nix
+++ b/pkgs/by-name/fa/fastcrw/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cacert,
+  cmake,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fastcrw";
+  version = "0.32.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "us";
+    repo = "crw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zk8xjKPPifNiHqx/B01ZG3r9xgoG1p1D1M7LhQoHD5Y=";
+  };
+
+  cargoHash = "sha256-yVh3B9Xl5yB9YWG0+lDOudnD1qi2VpAWBnItFZiRr3c=";
+
+  # aws-lc-sys drives its C build through cmake and generates its bindings.
+  nativeBuildInputs = [
+    cmake
+    rustPlatform.bindgenHook
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  # The crw-cli journeys drive the built binary against local mock servers, but
+  # rustls still refuses to construct a client without a system trust store.
+  nativeCheckInputs = [ cacert ];
+
+  cargoTestFlags = [ "--no-fail-fast" ];
+
+  checkFlags = [
+    # Dials a blackhole address to assert the error is a connect-phase timeout;
+    # the sandbox has no route at all, so it fails fast as "network unreachable".
+    "--skip=http_only::tests::connection_failure_catches_connect_timeout"
+
+    # The SSRF guard resolves the destination before a request is accepted, so
+    # in the sandbox these get "DNS resolution failed" instead of the response
+    # they assert on. CRW_ALLOW_LOOPBACK_FOR_TESTS=1 skips the resolve, but it
+    # is read process-wide and would neuter the SSRF tests in the same run.
+    "--skip=crawl_concurrent_start_unique_ids"
+    "--skip=crawl_concurrent_status_no_deadlock"
+    "--skip=crawl_start_returns_job_id"
+    "--skip=crawl_with_renderer_auto_accepted"
+    "--skip=crawl_with_renderer_unavailable_returns_400"
+    "--skip=mcp_crw_crawl_renderer_unavailable_returns_tool_error"
+    "--skip=scrape_with_renderer_unavailable_returns_400"
+    "--skip=v2_extract_blank_system_prompt_is_tolerated"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Web scraper, crawler and search API with an MCP server for AI agents";
+    homepage = "https://github.com/us/crw";
+    changelog = "https://github.com/us/crw/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ happysalada ];
+    mainProgram = "crw";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
