### PR TITLE
stave: init at 0.0.3

### DIFF
--- a/pkgs/by-name/st/stave/package.nix
+++ b/pkgs/by-name/st/stave/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "stave";
+  version = "0.0.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sufield";
+    repo = "stave";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Lq3u5/M9jJl7KLWzu4LRsB1xTn9QjOB4SrlZoF3Ye40=";
+  };
+
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-X=github.com/sufield/stave/internal/version.Version=v${finalAttrs.version}"
+    "-X=github.com/sufield/stave/internal/version.Commit=${finalAttrs.src.rev}"
+    "-X=github.com/sufield/stave/internal/version.Date=1970-01-01T00:00:00Z"
+    "-X=github.com/sufield/stave/internal/version.BuiltBy=nixpkgs"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  checkFlags = [
+    "-skip=TestCapabilities_DefaultVersionFallback"
+  ];
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to find compound attack paths that single-resource scanners miss";
+    homepage = "https://github.com/sufield/stave";
+    changelog = "https://github.com/sufield/stave/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "stave";
+  };
+})


### PR DESCRIPTION
Tool to find compound attack paths that single-resource scanners miss

https://github.com/sufield/stave

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
