### PR TITLE
Aiormq bump

### DIFF
--- a/pkgs/development/python-modules/aio-pika/default.nix
+++ b/pkgs/development/python-modules/aio-pika/default.nix
@@ -9,19 +9,19 @@
 
 buildPythonPackage rec {
   pname = "aio-pika";
-  version = "9.6.2";
+  version = "10.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mosquito";
     repo = "aio-pika";
     tag = version;
-    hash = "sha256-N5MjFIolMRTTn4aV1NskBwonB/8FSuEZETumUrAa02Y=";
+    hash = "sha256-bCpO2E8cfu96sTMN+aJfrEcPidbIgYSuEkpsbBtkFr4=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "uv_build>=0.9.26,<0.10.0" uv_build
+      --replace-fail "uv_build>=0.9.26,<0.12" uv_build
   '';
 
   build-system = [ uv-build ];

--- a/pkgs/development/python-modules/aiormq/default.nix
+++ b/pkgs/development/python-modules/aiormq/default.nix
@@ -9,22 +9,20 @@
 
 buildPythonPackage rec {
   pname = "aiormq";
-  version = "9.6.4";
+  version = "7.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mosquito";
     repo = "aiormq";
     tag = version;
-    hash = "sha256-GFeOwjSQ1+nxP9hgNoELoEInTmhhO0JnNeoe2qfWNcg=";
+    hash = "sha256-pSiue6DS+YvU3OS3Kyxqt/duGhZaBaDnFqP5CJZTgzk=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "uv_build>=0.10.4,<0.11.0" uv_build
+      --replace "uv_build>=0.10.4,<0.12" uv_build
   '';
-
-  pythonRelaxDeps = [ "pamqp" ];
 
   build-system = [ uv-build ];
 


### PR DESCRIPTION
<!--

^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`aiormq` was bumped to `9.6.4` in 4cd94659826a, but that tag was never
   published to PyPI and looks like a [typo'd/mistaken ](https://github.com/mosquito/aiormq/issues/229)release upstream: its
   `pyproject.toml` still hardcodes `version = "6.9.2"` (the previous
   release), so the derivation's `version` attribute and the built wheel's
   own metadata disagree, and the build fails `pythonMetadataCheckPhase`.

   The next two tags, `6.9.3` and `6.9.4`, have the same problem (still say
   `6.9.2` internally). See https://github.com/mosquito/aiormq/issues/229.

   `7.0.0` is the next tag where the internal version was actually bumped to
   match, so this moves there instead. `pythonRelaxDeps` for `pamqp` is no
   longer needed: `7.0.0` pins `pamqp>=4,<5`, which nixpkgs' current `pamqp`
   (4.0.1) already satisfies.

   `aio-pika` pins `aiormq<7,>=6.8`, so it needs a matching bump to `10.0.0`
   (not `10.0.1`, which has the same unbumped-`pyproject.toml` issue as the
   aiormq tags above -- still says `10.0.0` internally).

This PR description was drafted with the assistance of Claude Code (Sonnet 5).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
