### PR TITLE
elk: init at 1.0.1

### DIFF
--- a/pkgs/by-name/el/elk/package.nix
+++ b/pkgs/by-name/el/elk/package.nix
@@ -1,0 +1,84 @@
+{
+  fetchFromGitHub,
+  nix-update-script,
+  lib,
+  makeDesktopItem,
+  nodejs,
+  pnpm_11,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  stdenvNoCC,
+  pnpmBuildHook,
+}:
+let
+  pnpm = pnpm_11;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "elk";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "elk-zone";
+    repo = "elk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QKylYdJ23QRIqvHtWObJLl05nkSpku+HravvAoAqs7I=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  postPatch = ''
+    # pnpm 11 verifies node_modules before every `pnpm run` which conflicts
+    # with --shamefully-hoist
+    substituteInPlace pnpm-workspace.yaml --replace-fail \
+      "verifyDepsBeforeRun: install" \
+      "verifyDepsBeforeRun: false"
+  '';
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmBuildHook
+    pnpmConfigHook
+    pnpm
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    fetcherVersion = 4;
+    hash = "sha256-JgIq9YSOcMJbkxMyzH+HcpaBgEtkxp5utwENn5rmJ90=";
+  };
+
+  env.NUXT_TELEMETRY_DISABLED = "1";
+
+  preBuild = ''
+    pnpm run prepare
+
+  #   # Remove dev dependencies.
+  #   CI=true pnpm --ignore-scripts prune --prod
+  #   # Clean up broken symlinks left behind by `pnpm prune`
+  #   [ -d node_modules/.bin ] && find node_modules/.bin -xtype l -delete
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/elk
+    cp -r . $out/share/elk
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A nimble Mastodon web client";
+    homepage = "https://github.com/elk-zone/elk";
+    changelog = "https://github.com/elk-zone/elk/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.onny ];
+  };
+})

--- a/pkgs/by-name/el/elk/runtime-jsdom.patch
+++ b/pkgs/by-name/el/elk/runtime-jsdom.patch
@@ -1,0 +1,29 @@
+diff --git a/package.json b/package.json
+index 35810cc..145d8aa 100644
+--- a/package.json
++++ b/package.json
+@@ -32,6 +32,9 @@
+     "test": "cross-env CI=1 pnpm --recursive run test",
+     "typecheck": "turbo typecheck"
+   },
++  "dependencies": {
++    "jsdom": "29.1.1"
++  },
+   "devDependencies": {
+     "@electron-toolkit/tsconfig": "2.0.0",
+     "@eslint/compat": "2.1.0",
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 98165cf..3d07d0a 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -82,6 +82,10 @@ importers:
+ 
+   .:
++    dependencies:
++      jsdom:
++        specifier: 29.1.1
++        version: 29.1.1(@noble/hashes@2.0.1)
+     devDependencies:
+       '@electron-toolkit/tsconfig':
+         specifier: 2.0.0
+         version: 2.0.0(@types/node@26.1.1)


### PR DESCRIPTION
Packaging the Mastodon web client [Elk](https://github.com/elk-zone/elk).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
