### PR TITLE
python3Packages.jupyter-themes: change pname to jupyterthemes to fix metadata check

### DIFF
--- a/pkgs/development/python-modules/jupyter-themes/default.nix
+++ b/pkgs/development/python-modules/jupyter-themes/default.nix
@@ -13,7 +13,7 @@
 }:
 
 buildPythonPackage (finalAttrs: {
-  pname = "jupyter-themes";
+  pname = "jupyterthemes";
   version = "0.20.0";
   pyproject = true;
 

--- a/pkgs/development/python-modules/jupyter-themes/default.nix
+++ b/pkgs/development/python-modules/jupyter-themes/default.nix
@@ -2,13 +2,17 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   lesscpy,
   matplotlib,
   notebook,
-  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jupyter-themes";
   version = "0.20.0";
   pyproject = true;
@@ -16,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "dunovank";
     repo = "jupyter-themes";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-AWbUXMOA6k2LpZtcJOPxTZb1oL5vLDbBq4aEhXWvy9M=";
   };
 
@@ -30,12 +34,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jupyterthemes" ];
 
+  # No tests
+  doCheck = false;
+
   meta = {
     description = "Theme-ify your Jupyter Notebooks!";
     homepage = "https://github.com/dunovank/jupyter-themes";
-    changelog = "https://github.com/dunovank/jupyter-themes/blob/v${version}/CHANGES.md";
+    changelog = "https://github.com/dunovank/jupyter-themes/blob/${finalAttrs.src.rev}/CHANGES.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jherland ];
     mainProgram = "jupyter-theme";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.jupyter-themes: cleanup**
- **python3Packages.jupyter-themes: change pname to jupyterthemes to fix metadata check**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
