### PR TITLE
Update pretalx plugins

### DIFF
--- a/pkgs/by-name/pr/pretalx/plugins/downstream.nix
+++ b/pkgs/by-name/pr/pretalx/plugins/downstream.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pretalx-downstream";
-  version = "1.5.0";
+  version = "1.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretalx";
     repo = "pretalx-downstream";
     rev = "v${version}";
-    hash = "sha256-sYdaG1F2jprSnzvVgxRyDrKzeQh9H7IKS/T3lObdvzc=";
+    hash = "sha256-exTfGUVQsPbv+oNmgM6e3Q+u3UjDbsjoCNbeOvyaEZo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/pr/pretalx/plugins/media-ccc-de.nix
+++ b/pkgs/by-name/pr/pretalx/plugins/media-ccc-de.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pretalx-media-ccc-de";
-  version = "1.7.0";
+  version = "1.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretalx";
     repo = "pretalx-media-ccc-de";
     rev = "v${version}";
-    hash = "sha256-2a8AHP7G30K7Y8skmKnyoy/I9bpwgsUChf7s7G2nBZE=";
+    hash = "sha256-6yX6XoEX8bVQer3E6oH9Dm9A6Sz0x9O4p8uD0RpLPvk=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/pr/pretalx/plugins/pages.nix
+++ b/pkgs/by-name/pr/pretalx/plugins/pages.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pretalx-pages";
-  version = "1.9.0";
+  version = "1.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretalx";
     repo = "pretalx-pages";
     tag = "v${version}";
-    hash = "sha256-2xrkUxOXLR8ccdpkTpDQOV75vkPzkKqodTGf9aqVU0Q=";
+    hash = "sha256-eTsADpAaXLtgvrSo6Dm1z4xCXEslty+vIepkeg3ccjs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/pr/pretalx/plugins/public-voting.nix
+++ b/pkgs/by-name/pr/pretalx/plugins/public-voting.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pretalx-public-voting";
-  version = "1.10.0";
+  version = "1.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretalx";
     repo = "pretalx-public-voting";
     rev = "v${version}";
-    hash = "sha256-nvMDOvxVJ97JBAQFi4BuMkdtWLODnopfFCoPzExbu00=";
+    hash = "sha256-WqiTLFhJBlFezp071leJCtVVxqZykLGTih50J6o776A=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/pr/pretalx/plugins/venueless.nix
+++ b/pkgs/by-name/pr/pretalx/plugins/venueless.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pretalx-venueless";
-  version = "1.8.0";
+  version = "1.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretalx";
     repo = "pretalx-venueless";
     rev = "v${version}";
-    hash = "sha256-DgS10Pc08CVzbNUSwJpNee+/2THgt3zQsBlBk+mla6M=";
+    hash = "sha256-E6fnOIeNnhryozoXjZQKDsA7TY+BGVRTNPv9+FP4Tac=";
   };
 
   nativeBuildInputs = [ gettext ];

--- a/pkgs/by-name/pr/pretalx/plugins/vimeo.nix
+++ b/pkgs/by-name/pr/pretalx/plugins/vimeo.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pretalx-vimeo";
-  version = "2.7.0";
+  version = "2.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretalx";
     repo = "pretalx-vimeo";
     rev = "v${version}";
-    hash = "sha256-ZohT6RLnvGINBkNuCBGonffzW2GdjYsYYy6B3di1bdo=";
+    hash = "sha256-ekQCqso1CJqXi7bpKlZwY1pADmbOJVN8lDr2l4ugaXs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/pr/pretalx/plugins/youtube.nix
+++ b/pkgs/by-name/pr/pretalx/plugins/youtube.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pretalx-youtube";
-  version = "2.6.0";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretalx";
     repo = "pretalx-youtube";
     rev = "v${version}";
-    hash = "sha256-mudTB2qyCUkLwQsbbPiQuBeEscJQROdPWdjWmfOY7Vw=";
+    hash = "sha256-Vz09XXSLHEQkV1uUj8FVoA66u9b9yvbgu29a3unIkwY=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
https://github.com/pretalx/pretalx-youtube/compare/v2.6.0...v3.0.0
https://github.com/pretalx/pretalx-vimeo/compare/v2.7.0...v2.8.0
https://github.com/pretalx/pretalx-venueless/compare/v1.8.0...v1.9.0
https://github.com/pretalx/pretalx-public-voting/compare/v1.10.0...v1.11.0
https://github.com/pretalx/pretalx-pages/compare/v1.9.0...v1.10.0
https://github.com/pretalx/pretalx-media-ccc-de/compare/v1.7.0...v1.8.0
https://github.com/pretalx/pretalx-downstream/compare/v1.5.0...v1.6.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
