### PR TITLE
python3Packages.sv-ttk: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/sv-ttk/default.nix
+++ b/pkgs/development/python-modules/sv-ttk/default.nix
@@ -6,13 +6,15 @@
   tkinter,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "sv-ttk";
   version = "2.6.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "sv_ttk";
     hash = "sha256-R1idXiA5jPQE6DYvJPPtSPODDNCs4FbYM1T6Jdjk/kg=";
   };
@@ -29,8 +31,8 @@ buildPythonPackage rec {
   meta = {
     description = "Gorgeous theme for Tkinter/ttk, based on the Sun Valley visual style";
     homepage = "https://github.com/rdbende/Sun-Valley-ttk-theme";
-    changelog = "https://github.com/rdbende/Sun-Valley-ttk-theme/releases/tag/v${version}";
+    changelog = "https://github.com/rdbende/Sun-Valley-ttk-theme/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ AngryAnt ];
   };
-}
+})

--- a/pkgs/development/python-modules/sv-ttk/default.nix
+++ b/pkgs/development/python-modules/sv-ttk/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   tkinter,
 }:
 
 buildPythonPackage rec {
   pname = "sv-ttk";
   version = "2.6.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit version;
@@ -16,10 +17,12 @@ buildPythonPackage rec {
     hash = "sha256-R1idXiA5jPQE6DYvJPPtSPODDNCs4FbYM1T6Jdjk/kg=";
   };
 
+  build-system = [ setuptools ];
+
   # No tests available
   doCheck = false;
 
-  propagatedBuildInputs = [ tkinter ];
+  dependencies = [ tkinter ];
 
   pythonImportsCheck = [ "sv_ttk" ];
 


### PR DESCRIPTION
As part of #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
