### PR TITLE
python3Packages.trectools: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/trectools/default.nix
+++ b/pkgs/development/python-modules/trectools/default.nix
@@ -30,11 +30,6 @@ buildPythonPackage {
     hash = "sha256-p8BvLO+rD/l+ATE4+u3I6k25R1RVKlk2dn+RLQZTLDs=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "bs4 >= 0.0.0.1" "beautifulsoup4 >= 4.11.1"
-  '';
-
   build-system = [ setuptools ];
 
   dependencies = [
@@ -48,6 +43,8 @@ buildPythonPackage {
     sarge
   ];
 
+  pythonRemoveDeps = [ "bs4" ];
+
   nativeCheckInputs = [
     unittestCheckHook
   ];
@@ -57,7 +54,7 @@ buildPythonPackage {
     rm unittests/testtreceval.py
   '';
 
-  unittestFlagsArray = [
+  unittestFlags = [
     "unittests/"
   ];
 

--- a/pkgs/development/python-modules/trectools/default.nix
+++ b/pkgs/development/python-modules/trectools/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage {
   version = "0.0.50";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "joaopalotti";
     repo = "trectools";

--- a/pkgs/development/python-modules/trectools/default.nix
+++ b/pkgs/development/python-modules/trectools/default.nix
@@ -18,7 +18,7 @@
 buildPythonPackage {
   pname = "trectools";
   version = "0.0.50";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joaopalotti";


### PR DESCRIPTION
As part of #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
