### PR TITLE
python3Packages.dissononce: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/dissononce/default.nix
+++ b/pkgs/development/python-modules/dissononce/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
+  setuptools,
   pytest,
   cryptography,
   transitions,
@@ -10,7 +11,7 @@
 buildPythonPackage rec {
   pname = "dissononce";
   version = "0.34.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tgalal";
@@ -19,12 +20,14 @@ buildPythonPackage rec {
     sha256 = "0hn64qfr0d5npmza6rjyxwwp12k2z2y1ma40zpl104ghac6g3mbs";
   };
 
+  build-system = [ setuptools ];
+
   nativeCheckInputs = [ pytest ];
   checkPhase = ''
     HOME=$(mktemp -d) py.test tests/
   '';
 
-  propagatedBuildInputs = [
+  dependencies = [
     cryptography
     transitions
   ];

--- a/pkgs/development/python-modules/dissononce/default.nix
+++ b/pkgs/development/python-modules/dissononce/default.nix
@@ -8,16 +8,18 @@
   transitions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dissononce";
   version = "0.34.3";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "tgalal";
     repo = "dissononce";
-    rev = version;
-    sha256 = "0hn64qfr0d5npmza6rjyxwwp12k2z2y1ma40zpl104ghac6g3mbs";
+    tag = finalAttrs.version;
+    hash = "sha256-etXxDFPwERDo/YCoGrz4YopwOe9eZqN+vbY0kB0mxkI=";
   };
 
   build-system = [ setuptools ];
@@ -32,9 +34,11 @@ buildPythonPackage rec {
     transitions
   ];
 
+  pythonImportsCheck = [ "dissononce" ];
+
   meta = {
     homepage = "https://pypi.org/project/dissononce/";
     license = lib.licenses.mit;
     description = "Python implementation for Noise Protocol Framework";
   };
-}
+})

--- a/pkgs/development/python-modules/dissononce/default.nix
+++ b/pkgs/development/python-modules/dissononce/default.nix
@@ -3,7 +3,8 @@
   fetchFromGitHub,
   lib,
   setuptools,
-  pytest,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
   cryptography,
   transitions,
 }:
@@ -24,14 +25,14 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  nativeCheckInputs = [ pytest ];
-  checkPhase = ''
-    HOME=$(mktemp -d) py.test tests/
-  '';
-
   dependencies = [
     cryptography
     transitions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
   pythonImportsCheck = [ "dissononce" ];


### PR DESCRIPTION
As part of #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
