### PR TITLE
sforzando: init at 1.982

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12170,6 +12170,11 @@
     github = "Inarizxc";
     githubId = 128096405;
   };
+  Incand = {
+    github = "Incand";
+    githubId = 11589690;
+    name = "Armin Schaare";
+  };
   inclyc = {
     email = "i@lyc.dev";
     github = "inclyc";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -323,6 +323,7 @@
   ./programs/screen.nix
   ./programs/seahorse.nix
   ./programs/sedutil.nix
+  ./programs/sforzando.nix
   ./programs/shadow.nix
   ./programs/sharing.nix
   ./programs/singularity.nix

--- a/nixos/modules/programs/sforzando.nix
+++ b/nixos/modules/programs/sforzando.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.sforzando;
+in
+{
+  options.programs.sforzando = {
+    enable = lib.mkEnableOption "sforzando, a free SFZ 2.0 sample player by Plogue";
+
+    createSymlinks = lib.mkEnableOption ''
+      system-level symlinks required for sforzando's VST3/CLAP plugins.
+      Enable this alongside the home-manager module when you do not want a
+      system-wide install but still need VST3/CLAP support in a DAW
+    '';
+  };
+
+  config = lib.mkIf (cfg.enable || cfg.createSymlinks) {
+    # sforzando's VST3/CLAP plugins dlopen "/opt/Plogue/Aria/libAria.so" as a
+    # hardcoded string — autoPatchelf can't fix string constants. Symlink the
+    # Plogue tree from the nix store so the path resolves without a manual install.
+    systemd.tmpfiles.rules = [
+      "d /opt 0755 root root - -"
+      "L+ /opt/Plogue - - - - ${pkgs.sforzando}/Plogue"
+      # Plogue hardcodes access("/usr/bin/zenity") — ignores PATH entirely.
+      "L+ /usr/bin/zenity - - - - ${pkgs.zenity}/bin/zenity"
+    ];
+
+    # zenity provides the dialog Plogue products need for license acceptance;
+    # works on KDE, GNOME, and any other desktop.
+    environment.systemPackages = lib.mkIf cfg.enable [
+      pkgs.sforzando
+      pkgs.zenity
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1609,6 +1609,7 @@ in
   send = runTest ./send.nix;
   service-runner = runTest ./service-runner.nix;
   servo = runTest ./servo.nix;
+  sforzando = runTestOn [ "x86_64-linux" ] ./sforzando.nix;
   sftpgo = runTest ./sftpgo.nix;
   sfxr-qt = runTest ./sfxr-qt.nix;
   sgt-puzzles = runTest ./sgt-puzzles.nix;

--- a/nixos/tests/sforzando.nix
+++ b/nixos/tests/sforzando.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+{
+  name = "sforzando";
+  meta.maintainers = with lib.maintainers; [ Incand ];
+
+  nodes.machine =
+    { ... }:
+    {
+      programs.sforzando.enable = true;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("systemd-tmpfiles-setup.service")
+
+    with subtest("system symlinks are created"):
+        machine.succeed("test -L /opt/Plogue")
+        machine.succeed("test -e /opt/Plogue/Aria/libAria.so")
+        machine.succeed("test -L /usr/bin/zenity")
+
+    with subtest("sforzando binary is on PATH"):
+        machine.succeed("sforzando --help || true")
+  '';
+}

--- a/pkgs/by-name/sf/sforzando/package.nix
+++ b/pkgs/by-name/sf/sforzando/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  dpkg,
+  nixosTests,
+  autoPatchelfHook,
+  makeWrapper,
+  alsa-lib,
+  cairo,
+  curl,
+  glib,
+  gtk3,
+  gtkmm3,
+  libpulseaudio,
+  pango,
+  libxcb-util,
+  zenity,
+}:
+
+let
+  version = "1.982";
+in
+stdenv.mkDerivation {
+  pname = "sforzando";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchzip {
+    url = "https://sforzando.s3.us-east-1.amazonaws.com/LINUX_plogue-sforzando_${version}_x86_64.zip";
+    hash = "sha256-Qcwv5DgReNxA68CWosvIwZkhDAxnc5/A15lmlc/Mr3M=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    cairo
+    curl
+    glib
+    gtk3
+    gtkmm3
+    libpulseaudio
+    pango
+    libxcb-util
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    for deb in $src/*.deb; do
+      dpkg-deb -x "$deb" pkgs
+    done
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Plogue"
+    cp -r pkgs/opt/Plogue/Aria      "$out/Plogue/"
+    cp -r pkgs/opt/Plogue/sforzando "$out/Plogue/"
+    cp -r pkgs/opt/Plogue/TableWarp2 "$out/Plogue/"
+
+    # Patch hardcoded /opt/Plogue paths inside the .config JSON files.
+    # The Aria engine reads these to locate libAria.so and its resources.
+    sed -i "s|/opt/Plogue/Aria|$out/Plogue/Aria|g"           "$out/Plogue/Aria/.config"
+    sed -i "s|/opt/Plogue/sforzando|$out/Plogue/sforzando|g" "$out/Plogue/sforzando/.config"
+
+    mkdir -p "$out/lib/vst3"
+    cp -r pkgs/usr/lib/vst3/sforzando.vst3 "$out/lib/vst3/"
+
+    mkdir -p "$out/lib/clap"
+    cp pkgs/usr/lib/clap/sforzando.clap "$out/lib/clap/"
+
+    mkdir -p "$out/share/applications" "$out/share/icons/hicolor/256x256/apps"
+    cp pkgs/usr/share/applications/plogue-sforzando.desktop \
+       "$out/share/applications/"
+    cp pkgs/usr/share/icons/hicolor/256x256/apps/plogue-sforzando.png \
+       "$out/share/icons/hicolor/256x256/apps/"
+    substituteInPlace "$out/share/applications/plogue-sforzando.desktop" \
+      --replace 'Exec=/opt/Plogue/sforzando/sforzando' "Exec=$out/bin/sforzando"
+
+    mkdir -p "$out/bin"
+    makeWrapper "$out/Plogue/sforzando/sforzando" "$out/bin/sforzando" \
+      --prefix PATH : ${lib.makeBinPath [ zenity ]}
+
+    runHook postInstall
+  '';
+
+  # Teach autoPatchelfHook to find libAria.so when patching the VST3/CLAP plugins.
+  preFixup = ''
+    addAutoPatchelfSearchPath "$out/Plogue/Aria"
+  '';
+
+  passthru.tests = {
+    inherit (nixosTests) sforzando;
+  };
+
+  meta = {
+    description = "Free, highly SFZ 2.0 compliant sample player";
+    homepage = "https://plogue.com/products/sforzando.html";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ Incand ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "sforzando";
+  };
+}


### PR DESCRIPTION
# Description

Adds Plogue sforzando, a free SFZ 2.0 compliant SFZ sample player. Ships a standalone binary plus VST3 and CLAP plugins.

The binaries contain hardcoded `dlopen("/opt/Plogue/Aria/libAria.so")` and `access("/usr/bin/zenity", X_OK)` calls that `autoPatchelfHook` cannot fix (string constants vs `DT_NEEDED` entries). The NixOS module creates the required system-level symlinks via `systemd.tmpfiles.rules`.

# Checklist

- [x] Package built on `x86_64-linux`
- [x] `meta.license` set to `unfree`
- [x] `meta.sourceProvenance` set to `binaryNativeCode`
- [x] NixOS module added with `programs.sforzando.enable` and `programs.sforzando.createSymlinks` options
- [x] NixOS test added
- [x] Added myself to `maintainer-list.nix`