### PR TITLE
stamp: 0-unstable-2026-07-13 -> 0-unstable-2026-08-24

### DIFF
--- a/pkgs/by-name/st/stamp/package.nix
+++ b/pkgs/by-name/st/stamp/package.nix
@@ -12,6 +12,7 @@
   blueprint-compiler,
   evolution-data-server-gtk4,
   glib-networking,
+  gpgme,
   gst_all_1,
   libportal-gtk4,
   libpsl,
@@ -20,7 +21,7 @@
 
 stdenv.mkDerivation {
   pname = "stamp";
-  version = "0-unstable-2026-07-13";
+  version = "0-unstable-2026-08-24";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -28,8 +29,8 @@ stdenv.mkDerivation {
     domain = "gitlab.gnome.org";
     owner = "jbrummer";
     repo = "stamp";
-    rev = "9bce220c9e094c4d616009ebc87499a68ffc14aa";
-    hash = "sha256-mplowqsBTT9ibLxD8pbaIeLSd1pindgXLSPKBjseul8=";
+    rev = "7b40424fd5e3bb97b7be0fd8be3f2b1759ccefd4";
+    hash = "sha256-1RpYMe30ymkb9iy9RwYNahsYqAxPlGrDYy3HfYn/7nM=";
   };
 
   dontUseCmakeConfigure = true;
@@ -46,6 +47,7 @@ stdenv.mkDerivation {
   buildInputs = [
     evolution-data-server-gtk4
     glib-networking
+    gpgme
     gst_all_1.gstreamer
     libadwaita
     libportal-gtk4


### PR DESCRIPTION
There were some useful changes, e.g. the button to archive a message.

gpgme is required since [2d1496ff](https://gitlab.gnome.org/jbrummer/stamp/-/commit/2d1496ffed0d8b292d950aa363be3f8633b196d8).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
