### PR TITLE
[Backport relase-26.05] ytdownloader: 3.19.3 -> 4.0.1, electron_41 -> electron_43

### DIFF
--- a/pkgs/by-name/yt/ytdownloader/config-dir.patch
+++ b/pkgs/by-name/yt/ytdownloader/config-dir.patch
@@ -1,10 +1,9 @@
 --- a/main.js
 +++ b/main.js
-@@ -13,6 +13,15 @@
- const fs = require("fs");
- const path = require("path");
+@@ -19,6 +19,14 @@ const { platform } = require("os");
+ process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = "true";
  autoUpdater.autoDownload = false;
-+
+ 
 +// Set the config directory to XDG_CONFIG_HOME/ytdownloader
 +const xdgConfigHome = process.env.XDG_CONFIG_HOME;
 +let configDir = app.getPath('home') + "/.config/ytdownloader";
@@ -13,6 +12,5 @@
 +}
 +app.setPath ('userData', configDir);
 +
- /**@type {BrowserWindow} */
- let win = null;
- let secondaryWindow = null;
+ const USER_DATA_PATH = app.getPath("userData");
+ const CONFIG_FILE_PATH = path.join(USER_DATA_PATH, "ytdownloader.json");

--- a/pkgs/by-name/yt/ytdownloader/package.nix
+++ b/pkgs/by-name/yt/ytdownloader/package.nix
@@ -7,23 +7,23 @@
   ffmpeg-headless,
   yt-dlp,
   makeDesktopItem,
-  electron_41,
+  electron_43,
 }:
 let
-  electron = electron_41;
+  electron = electron_43;
 in
 buildNpmPackage rec {
   pname = "ytDownloader";
-  version = "3.22.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "aandrew-me";
     repo = "ytDownloader";
     tag = "v${version}";
-    hash = "sha256-zAHDBLQJa0FFX2esz7jVRnIY6aBwnoGp6Kr2jWDX+lg=";
+    hash = "sha256-chTaQ0nHTtdIhMo4GBSoQ6YbqDy8HNj190JNUt5nDiE=";
   };
 
-  npmDepsHash = "sha256-J/3m6HN2/gndtTrxf4rwhZtBAQUv1oQYbo8HeNLV8Xw=";
+  npmDepsHash = "sha256-Czs09QnQ7lnNjgysvSb7TFKz6t8ChvoT+1KzHFJ87SA=";
   makeCacheWritable = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/yt/ytdownloader/package.nix
+++ b/pkgs/by-name/yt/ytdownloader/package.nix
@@ -14,16 +14,16 @@ let
 in
 buildNpmPackage rec {
   pname = "ytDownloader";
-  version = "3.19.3";
+  version = "3.22.0";
 
   src = fetchFromGitHub {
     owner = "aandrew-me";
     repo = "ytDownloader";
     tag = "v${version}";
-    hash = "sha256-6HYVNtjGOQICiby4je3iYG9mPGMEXWTY+87HuUMaA2A=";
+    hash = "sha256-zAHDBLQJa0FFX2esz7jVRnIY6aBwnoGp6Kr2jWDX+lg=";
   };
 
-  npmDepsHash = "sha256-FiWtZBixg7iz/9YgqnhIIG6MYNql7ITOUXH7aBBv7Co=";
+  npmDepsHash = "sha256-J/3m6HN2/gndtTrxf4rwhZtBAQUv1oQYbo8HeNLV8Xw=";
   makeCacheWritable = true;
 
   nativeBuildInputs = [
@@ -55,22 +55,24 @@ buildNpmPackage rec {
   # Otherwise it stores config in ~/.config/Electron
   patches = [ ./config-dir.patch ];
 
-  # Replace hardcoded ffmpeg and ytdlp paths
-  # Also stop it from downloading ytdlp
   postPatch = ''
-    substituteInPlace src/renderer.js \
-      --replace-fail $\{__dirname}/../ffmpeg '${lib.getExe ffmpeg-headless}' \
-      --replace-fail 'path.join(os.homedir(), ".ytDownloader", "ytdlp")' '`${lib.getExe yt-dlp}`' \
-      --replace-fail 'let ytDlpIsPresent = false;' 'let ytDlpIsPresent = true;'
     # Disable auto-updates
     substituteInPlace src/preferences.js \
       --replace-warn 'const autoUpdateDisabled = getId("autoUpdateDisabled");' 'const autoUpdateDisabled = "true";'
   '';
 
   postInstall = ''
+    # Set paths to use system ffmpeg and yt-dlp to prevent downloading
     makeWrapper ${electron}/bin/electron $out/bin/ytdownloader \
         --add-flags $out/lib/node_modules/ytdownloader/main.js \
-        --prefix PATH : ${lib.makeBinPath [ ffmpeg-headless ]}
+        --set YTDOWNLOADER_FFMPEG_PATH "${lib.getExe ffmpeg-headless}" \
+        --set YTDOWNLOADER_YTDLP_PATH "${lib.getExe yt-dlp}" \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            ffmpeg-headless
+            yt-dlp
+          ]
+        }
 
     install -Dm444 assets/images/icon.png $out/share/icons/hicolor/512x512/apps/ytdownloader.png
   '';


### PR DESCRIPTION
Manual backport of #552928 + #555148.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
