### PR TITLE
bpfvet: init at 0.2.1

### DIFF
--- a/pkgs/by-name/bp/bpfvet/package.nix
+++ b/pkgs/by-name/bp/bpfvet/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "bpfvet";
+  version = "0.2.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "boratanrikulu";
+    repo = "bpfvet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-++vCltHBmy0JPzNjZ7qe1I9eValBcw2V+j9WRZKVAG8=";
+  };
+
+  vendorHash = "sha256-hnkmkHUS5QzhnlDXB6CF683aDBTnJC86J4//IBcJLOA=";
+
+  ldflags = [ "-s" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "BPF portability analyzer for compiled eBPF object files";
+    homepage = "https://github.com/boratanrikulu/bpfvet";
+    changelog = "https://github.com/boratanrikulu/bpfvet/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stepbrobd ];
+    mainProgram = "bpfvet";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

upstreaming some of my own overlayed packages https://github.com/stepbrobd/inc/tree/master/pkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
