### PR TITLE
check-if-email-exists: init at 0.11.7

### DIFF
--- a/pkgs/by-name/ch/check-if-email-exists/package.nix
+++ b/pkgs/by-name/ch/check-if-email-exists/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "check-if-email-exists";
+  version = "0.11.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "reacherhq";
+    repo = "check-if-email-exists";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KRnSTufgpmT6Yo+7NcaRARjtXOCwvbcXXX4or8YTmjo=";
+  };
+
+  cargoHash = "sha256-syuwY4qpnvWTXDZ6onnpFSmiEs1GCttSDtR5+vzuUDY=";
+
+  # upstream forgot to bump crate version
+  postPatch = ''
+    substituteInPlace cli/Cargo.toml \
+      --replace-fail 'version = "0.11.6"' 'version = "${finalAttrs.version}"'
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = 1;
+
+  # require network
+  checkFlags = [
+    "--skip=smtp::tests::should_timeout"
+    "--skip=tests::test_input_foo_bar_baz"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Check if an email address exists without sending any email";
+    homepage = "https://github.com/reacherhq/check-if-email-exists";
+    changelog = "https://github.com/reacherhq/check-if-email-exists/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ stepbrobd ];
+    mainProgram = "check_if_email_exists";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

upstreaming some of my own overlayed packages https://github.com/stepbrobd/inc/tree/master/pkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
