### PR TITLE
python3Packages.tlv8: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/tlv8/default.nix
+++ b/pkgs/development/python-modules/tlv8/default.nix
@@ -6,17 +6,19 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tlv8";
   version = "0.10.0";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   # pypi does not contain test files
   src = fetchFromGitHub {
     owner = "jlusiardi";
     repo = "tlv8_python";
-    rev = "v${version}";
-    sha256 = "sha256-G35xMFYasKD3LnGi9q8wBmmFvqgtg0HPdC+y82nxRWA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-G35xMFYasKD3LnGi9q8wBmmFvqgtg0HPdC+y82nxRWA=";
   };
 
   build-system = [ setuptools ];
@@ -36,4 +38,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jojosch ];
   };
-}
+})

--- a/pkgs/development/python-modules/tlv8/default.nix
+++ b/pkgs/development/python-modules/tlv8/default.nix
@@ -23,7 +23,10 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # upstream mixes the `*_test.py` and `*_tests.py` suffixes
+  pytestFlags = [ "-opython_files=*_test.py *_tests.py" ];
 
   pythonImportsCheck = [ "tlv8" ];
 

--- a/pkgs/development/python-modules/tlv8/default.nix
+++ b/pkgs/development/python-modules/tlv8/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "tlv8";
   version = "0.10.0";
-  format = "setuptools";
+  pyproject = true;
 
   # pypi does not contain test files
   src = fetchFromGitHub {
@@ -17,6 +18,8 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "sha256-G35xMFYasKD3LnGi9q8wBmmFvqgtg0HPdC+y82nxRWA=";
   };
+
+  build-system = [ setuptools ];
 
   checkInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
As part of #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
