### PR TITLE
tether: init at 0.2.18

### DIFF
--- a/pkgs/by-name/te/tether/package.nix
+++ b/pkgs/by-name/te/tether/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  pkg-config,
+  wrapGAppsHook3,
+  avahi,
+  bluez,
+  gettext,
+  glib,
+  gtest,
+  gtk-layer-shell,
+  gtk3,
+  libnotify,
+  nlohmann_json,
+  openssl,
+  wayland,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tether";
+  version = "0.2.18";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "zackb";
+    repo = "tether";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ygevoa/gEt80HyRYeWmVGDIwi4Eyl8XVz/RABcGK03Q=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '"''${PROJECT_VERSION}-unknown"' '"${finalAttrs.version}"'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    avahi
+    glib
+    gtk-layer-shell
+    gtk3
+    libnotify
+    openssl
+    wayland
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_JSON" "${nlohmann_json.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_GOOGLETEST" "${gtest.src}")
+    (lib.cmakeFeature "CHROME_MESSAGING_DIR" "etc/chromium/native-messaging-hosts")
+    (lib.cmakeFeature "GOOGLE_CHROME_MESSAGING_DIR" "etc/opt/chrome/native-messaging-hosts")
+    (lib.cmakeFeature "BLUETOOTHD_PATH" "${bluez}/libexec/bluetooth/bluetoothd")
+    (lib.cmakeBool "TETHER_BUILD_EXTENSIONS" false)
+  ];
+
+  doCheck = true;
+  enableParallelChecking = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linux + iPhone Continuity / iMessage / SMS";
+    homepage = "https://github.com/zackb/tether";
+    changelog = "https://github.com/zackb/tether/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stepbrobd ];
+    mainProgram = "tether";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

upstreaming some of my own overlayed packages https://github.com/stepbrobd/inc/tree/master/pkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
