### PR TITLE
nixos/pihole-ftl: rotate all configured log files

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -503,9 +503,32 @@ in
 
     environment.systemPackages = [ cfg.pihole ];
 
-    services.logrotate.settings.pihole-ftl = {
-      enable = true;
-      files = [ "${cfg.logDirectory}/FTL.log" ];
+    services.logrotate.settings = {
+      pihole-dnsmasq = {
+        files = [ "${cfg.logDirectory}/pihole.log" ];
+        frequency = "daily";
+        create = "640 ${cfg.user} ${cfg.group}";
+        rotate = 5;
+        compress = true;
+        delaycompress = true;
+        # FTL keeps this log open; SIGUSR2 closes and reopens it after rotation.
+        # https://docs.pi-hole.net/ftldns/signals/#sigusr2
+        postrotate = ''
+          ${getExe' pkgs.systemd "systemctl"} kill --kill-whom=main --signal=USR2 pihole-ftl.service 2>/dev/null || true
+        '';
+      };
+
+      pihole-ftl = {
+        files = [
+          "${cfg.logDirectory}/FTL.log"
+          "${cfg.logDirectory}/webserver.log"
+        ];
+        frequency = "weekly";
+        create = "640 ${cfg.user} ${cfg.group}";
+        rotate = 3;
+        compress = true;
+        delaycompress = true;
+      };
     };
   };
 


### PR DESCRIPTION
The Pi-hole FTL module configures three text log files:

- `pihole.log`
- `FTL.log`
- `webserver.log`

Its logrotate configuration currently includes only `FTL.log`. The DNS query and webserver logs are missed.

On a NixOS Pi-hole host, this was observed as an unbounded `pihole.log` (710 MB, 8.6 million lines in seven days), with the resulting file cache charged to `pihole-ftl.service`'s cgroup memory.

Configure rotation for all three files using the retention and reopen behavior from Pi-hole's upstream logrotate template:

https://github.com/pi-hole/pi-hole/blob/master/advanced/Templates/logrotate

- `pihole.log`: daily, five archives, `USR2` signal after rotation because FTL keeps the file open
- `FTL.log` and `webserver.log`: weekly, three archives; opened and closed per line, no signal needed

I verified the change by evaluating `services.logrotate.settings` for a minimal `services.pihole-ftl.enable = true` config and confirming the expected stanzas render (daily `pihole.log` with the `USR2` postrotate, weekly FTL/webserver stanzas). `nixosTests.pihole-ftl.basic` and `nixosTests.pihole-ftl.dnsmasq` pass on an x86_64-linux builder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Automation disclosure: this change was diagnosed and drafted with the assistance of an AI coding tool (OpenCode); I reviewed the implementation and verified the rendered module configuration.
