### PR TITLE
nixos/headplane: add server.proxy_auth option

### DIFF
--- a/nixos/modules/services/networking/headplane.nix
+++ b/nixos/modules/services/networking/headplane.nix
@@ -120,6 +120,93 @@ in
                   example = "/var/lib/headplane";
                 };
 
+                proxy_auth = mkOption {
+                  type = types.nullOr (
+                    types.submodule {
+                      options = {
+                        enabled = mkEnableOption ''
+                          delegating Headplane authentication to a trusted reverse proxy
+                          instead of logging in through Headplane directly. Identity
+                          headers are only trusted on requests whose client IP matches
+                          `allowed_cidrs`; all Headscale API calls then use
+                          `headscale.api_key_path`
+                        '';
+
+                        allowed_cidrs = mkOption {
+                          type = types.listOf types.str;
+                          default = [
+                            "127.0.0.1/32"
+                            "::1/128"
+                          ];
+                          description = ''
+                            Client CIDRs allowed to authenticate via the configured proxy
+                            headers.
+                          '';
+                          example = [ "10.0.0.0/8" ];
+                        };
+
+                        trusted_proxy_cidrs = mkOption {
+                          type = types.listOf types.str;
+                          default = [
+                            "127.0.0.1/32"
+                            "::1/128"
+                          ];
+                          description = ''
+                            Direct proxy CIDRs trusted to supply `ip_header`.
+                          '';
+                          example = [ "127.0.0.1/32" ];
+                        };
+
+                        ip_header = mkOption {
+                          type = types.nullOr types.str;
+                          default = null;
+                          description = ''
+                            Header containing the original client IP, such as
+                            `X-Forwarded-For` or `X-Real-IP`. Only read when the direct
+                            socket peer matches `trusted_proxy_cidrs`.
+                          '';
+                          example = "X-Forwarded-For";
+                        };
+
+                        user_header = mkOption {
+                          type = types.str;
+                          default = "Remote-User";
+                          description = ''
+                            Header containing the stable authenticated user identity.
+                          '';
+                          example = "Remote-User";
+                        };
+
+                        email_header = mkOption {
+                          type = types.nullOr types.str;
+                          default = null;
+                          description = "Optional header containing the authenticated user's email address.";
+                          example = "Remote-Email";
+                        };
+
+                        name_header = mkOption {
+                          type = types.nullOr types.str;
+                          default = null;
+                          description = "Optional header containing the authenticated user's display name.";
+                          example = "Remote-Name";
+                        };
+
+                        picture_header = mkOption {
+                          type = types.nullOr types.str;
+                          default = null;
+                          description = "Optional header containing the authenticated user's profile picture URL.";
+                          example = "Remote-Picture";
+                        };
+                      };
+                    }
+                  );
+                  default = null;
+                  description = ''
+                    Delegate Headplane authentication to a trusted reverse proxy. See the
+                    upstream [Proxy Authentication docs](https://github.com/tale/headplane/blob/main/docs/features/proxy-auth.md).
+                  '';
+                };
+
               };
             };
             default = { };
@@ -443,6 +530,18 @@ in
           agentSettings == null || !agentSettings.enabled || cfg.settings.headscale.api_key_path != null;
         message = ''
           services.headplane.settings.headscale.api_key_path must be set when the agent is enabled.
+        '';
+      }
+      {
+        assertion =
+          cfg.settings.server.proxy_auth == null
+          || !cfg.settings.server.proxy_auth.enabled
+          || cfg.settings.headscale.api_key_path != null;
+        message = ''
+          services.headplane.settings.headscale.api_key_path must be set
+          when services.headplane.settings.server.proxy_auth.enabled is true.
+          Proxy authentication requires a Headscale API key to make Headscale
+          API calls on behalf of proxy-authenticated users.
         '';
       }
     ];


### PR DESCRIPTION
Add missing options for proxy auth <https://github.com/tale/headplane/blob/96f2721272cb697bea4cbe34e70e5d2e032e03d0/docs/features/proxy-auth.md>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
