### PR TITLE
python3Packages.asgi-correlation-id: init at 5.0.1

### DIFF
--- a/pkgs/development/python-modules/asgi-correlation-id/default.nix
+++ b/pkgs/development/python-modules/asgi-correlation-id/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  uv-build,
+  starlette,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "asgi-correlation-id";
+  version = "5.0.1";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "snok";
+    repo = "asgi-correlation-id";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KLoc+MGgw+gcN5UfGXt2UMTK488voCsqxlhtVBG+kjM=";
+  };
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.7.2,<0.8' 'uv_build'
+  '';
+  dependencies = [ starlette ];
+  build-system = [ uv-build ];
+  meta = {
+    description = "Middleware correlating project logs to individual requests";
+    homepage = "https://github.com/snok/asgi-correlation-id";
+    changelog = "https://github.com/snok/asgi-correlation-id/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1387,6 +1387,8 @@ self: super: with self; {
 
   asf-search = callPackage ../development/python-modules/asf-search { };
 
+  asgi-correlation-id = callPackage ../development/python-modules/asgi-correlation-id { };
+
   asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };
 
   asgi-lifespan = callPackage ../development/python-modules/asgi-lifespan { };


### PR DESCRIPTION
Adding asgi-correlation-id python package
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
