### PR TITLE
python3Packages.cachetools-async: init at 0.0.5

### DIFF
--- a/pkgs/development/python-modules/cachetools-async/default.nix
+++ b/pkgs/development/python-modules/cachetools-async/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  hatchling,
+  cachetools,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "cachetools-async";
+  version = "0.0.5";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "imnotjames";
+    repo = "cachetools-async";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mZrgVE9ctGdXIjBfazbg2kYwP0gV/j4qDfel4Oarldg=";
+  };
+  dependencies = [ cachetools ];
+  build-system = [ hatchling ];
+  meta = {
+    description = "Decorators for caching asyncio functions and methods, inspired by cachetools";
+    homepage = "https://github.com/imnotjames/cachetools-async";
+    changelog = "https://github.com/imnotjames/cachetools-async/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2790,6 +2790,8 @@ self: super: with self; {
 
   cachetools = callPackage ../development/python-modules/cachetools { };
 
+  cachetools-async = callPackage ../development/python-modules/cachetools-async { };
+
   cachey = callPackage ../development/python-modules/cachey { };
 
   cachier = callPackage ../development/python-modules/cachier { };


### PR DESCRIPTION
Adding cachetoools-async python package

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
