### PR TITLE
python3Packages.fast-depends: init at 3.0.7

### DIFF
--- a/pkgs/development/python-modules/fast-depends/default.nix
+++ b/pkgs/development/python-modules/fast-depends/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  uv-build,
+  anyio,
+  typing-extensions,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "fast-depends";
+  version = "3.0.7";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "Lancetnik";
+    repo = "FastDepends";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-AjQS7aqz0/CojwHlyD6ZU575SdhxGcaA6unE62gzxnE=";
+  };
+  dependencies = [
+    anyio
+    typing-extensions
+  ];
+  build-system = [ uv-build ];
+  meta = {
+    description = "Dependency injection system extracted from FastAPI, with async and sync support";
+    homepage = "https://github.com/Lancetnik/FastDepends";
+    changelog = "https://github.com/Lancetnik/FastDepends/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5872,6 +5872,8 @@ self: super: with self; {
 
   fast-colorthief = callPackage ../development/python-modules/fast-colorthief { };
 
+  fast-depends = callPackage ../development/python-modules/fast-depends { };
+
   fast-histogram = callPackage ../development/python-modules/fast-histogram { };
 
   fast-query-parsers = callPackage ../development/python-modules/fast-query-parsers { };


### PR DESCRIPTION
Adding fast-depends python package

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
