### PR TITLE
python3Packages.lunr: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/lunr/default.nix
+++ b/pkgs/development/python-modules/lunr/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  hatchling,
+  typing-extensions,
+  importlib-metadata,
+  hatch-fancy-pypi-readme,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "lunr";
+  version = "0.8.0";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "yeraydiazdiaz";
+    repo = "lunr.py";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-47gLvelEiPuOC/OvQBy+Es1zCt+NfdC0AFTISviHn6k=";
+  };
+  dependencies = [ hatch-fancy-pypi-readme ];
+  build-system = [
+    hatchling
+  ];
+  meta = {
+    description = "Python implementation of Lunr.js";
+    homepage = "https://github.com/yeraydiazdiaz/lunr.py";
+    changelog = "https://github.com/yeraydiazdiaz/lunr.py/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10279,6 +10279,8 @@ self: super: with self; {
 
   lunatone-rest-api-client = callPackage ../development/python-modules/lunatone-rest-api-client { };
 
+  lunr = callPackage ../development/python-modules/lunr { };
+
   lupa = callPackage ../development/python-modules/lupa { };
 
   lupupy = callPackage ../development/python-modules/lupupy { };


### PR DESCRIPTION
Adding lunr python package

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
