### PR TITLE
python3Packages.starlette-exporter: init at 0.23.0

### DIFF
--- a/pkgs/development/python-modules/starlette-exporter/default.nix
+++ b/pkgs/development/python-modules/starlette-exporter/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  prometheus-client,
+  starlette,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "starlette-exporter";
+  version = "0.23.0";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "stephenhillier";
+    repo = "starlette_exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OfuiOBpyLQoiwTx/pz3md8dmbqo9vohkcXvudcZrk2U=";
+  };
+  dependencies = [
+    starlette
+    prometheus-client
+  ];
+  build-system = [ setuptools ];
+  meta = {
+    description = "Prometheus metrics exporter for Starlette applications";
+    homepage = "https://github.com/stephenhillier/starlette_exporter";
+    changelog = "https://github.com/stephenhillier/starlette_exporter/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19863,6 +19863,8 @@ self: super: with self; {
 
   starlette-context = callPackage ../development/python-modules/starlette-context { };
 
+  starlette-exporter = callPackage ../development/python-modules/starlette-exporter { };
+
   starlette-wtf = callPackage ../development/python-modules/starlette-wtf { };
 
   starline = callPackage ../development/python-modules/starline { };


### PR DESCRIPTION
Adding starlette-exporter python package


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
