### PR TITLE
python3Packages.ariadne-codegen: init at 0.19.0

### DIFF
--- a/pkgs/development/python-modules/ariadne-codegen/default.nix
+++ b/pkgs/development/python-modules/ariadne-codegen/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  hatchling,
+  pyprojectVersionPatchHook,
+  click,
+  graphql-core,
+  toml,
+  httpx,
+  pydantic,
+  ruff,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "ariadne-codegen";
+  version = "0.19.0";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "mirumee";
+    repo = "ariadne-codegen";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-Xo56rY9Vj2AIMC7o0+3eWQDiJhfVZ+LTr39lPUTW0yQ=";
+  };
+  nativeBuildInputs = [
+    pyprojectVersionPatchHook
+  ];
+  dependencies = [
+    click
+    graphql-core
+    toml
+    httpx
+    pydantic
+    ruff
+  ];
+  # Upstream pins ruff>=0.15.0,<0.16.0, but only ever calls it as a `ruff
+  # check`/`ruff format` subprocess with long-stable, basic CLI flags
+  # (--isolated, --select, --target-version, --line-length); nixpkgs' ruff
+  # (0.16.4) behaves identically for these.
+  pythonRelaxDeps = [ "ruff" ];
+  build-system = [ hatchling ];
+  meta = {
+    description = "Generate fully typed GraphQL client from schema, queries and mutations";
+    homepage = "https://github.com/mirumee/ariadne-codegen";
+    changelog = "https://github.com/mirumee/ariadne-codegen/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1323,6 +1323,8 @@ self: super: with self; {
 
   ariadne = callPackage ../development/python-modules/ariadne { };
 
+  ariadne-codegen = callPackage ../development/python-modules/ariadne-codegen { };
+
   arpeggio = callPackage ../development/python-modules/arpeggio { };
 
   arpy = callPackage ../development/python-modules/arpy { };


### PR DESCRIPTION
- pythonRelaxDeps for ruff: upstream pins <0.16.0, but only invokes it via stable, basic CLI flags; verified against nixpkgs' ruff (0.16.4).
- pyprojectVersionPatchHook: __about__.py ships an unbumped placeholder version that upstream's own CI/CD overwrites at release time.

Assisted-by: Claude Code (Sonnet 5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
