### PR TITLE
mcp-victoria{metrics,logs,traces}: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -203,6 +203,12 @@
     github = "1nv0k32";
     githubId = 30079271;
   };
+  _1sixth = {
+    email = "1sixth@azc.moe";
+    github = "1sixth";
+    githubId = 67363572;
+    name = "1sixth";
+  };
   _21CSM = {
     name = "21CSM";
     email = "21CSM@tutanota.com";

--- a/pkgs/by-name/mc/mcp-victorialogs/package.nix
+++ b/pkgs/by-name/mc/mcp-victorialogs/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nix-update-script,
+  nodejs,
+  npmHooks,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mcp-victorialogs";
+  version = "1.9.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "VictoriaMetrics";
+    repo = "mcp-victorialogs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-esfd6Eg1j2BCgee1T5tiIdSPWVEBqhI4UGDKRFYyn3s=";
+  };
+
+  vendorHash = null;
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/mcp-victorialogs/..." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  npmDeps = fetchNpmDeps {
+    name = "mcp-victorialogs-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/web";
+    hash = "sha256-B8kEHH7vv1Mp1gLwsFLaFkUyNZsq2ZZHH9U6+a7JlOA=";
+  };
+
+  npmRoot = "web";
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  preBuild = ''
+    npm --prefix web run build
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "MCP server for VictoriaLogs";
+    homepage = "https://github.com/VictoriaMetrics/mcp-victorialogs";
+    changelog = "https://github.com/VictoriaMetrics/mcp-victorialogs/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers._1sixth ];
+    mainProgram = "mcp-victorialogs";
+  };
+})

--- a/pkgs/by-name/mc/mcp-victoriametrics/package.nix
+++ b/pkgs/by-name/mc/mcp-victoriametrics/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nix-update-script,
+  nodejs,
+  npmHooks,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mcp-victoriametrics";
+  version = "1.20.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "VictoriaMetrics";
+    repo = "mcp-victoriametrics";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7kN7qwsvTL0scfBxMO/nrvikiysUxPY8nSFkhJsgGDM=";
+  };
+
+  vendorHash = null;
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/mcp-victoriametrics/..." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  npmDeps = fetchNpmDeps {
+    name = "mcp-victoriametrics-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/web";
+    hash = "sha256-Q6Ljqtbwz0pEvUcz8keps8Nr8xzOUusW0zBZq1mkz/Q=";
+  };
+
+  npmRoot = "web";
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  preBuild = ''
+    npm --prefix web run build
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "MCP server for VictoriaMetrics";
+    homepage = "https://github.com/VictoriaMetrics/mcp-victoriametrics";
+    changelog = "https://github.com/VictoriaMetrics/mcp-victoriametrics/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers._1sixth ];
+    mainProgram = "mcp-victoriametrics";
+  };
+})

--- a/pkgs/by-name/mc/mcp-victoriatraces/package.nix
+++ b/pkgs/by-name/mc/mcp-victoriatraces/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mcp-victoriatraces";
+  version = "1.5.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "VictoriaMetrics";
+    repo = "mcp-victoriatraces";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-As1ERHKytCmFRqg3ndcSQFBFg0MBs6M5zyaGUmIntuU=";
+  };
+
+  vendorHash = null;
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/mcp-victoriatraces/..." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "MCP server for VictoriaTraces";
+    homepage = "https://github.com/VictoriaMetrics/mcp-victoriatraces";
+    changelog = "https://github.com/VictoriaMetrics/mcp-victoriatraces/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers._1sixth ];
+    mainProgram = "mcp-victoriatraces";
+  };
+})


### PR DESCRIPTION
Add 3 VictoriaMetrics MCP servers:

- [mcp-victoriametrics](https://github.com/VictoriaMetrics/mcp-victoriametrics) 1.20.2
- [mcp-victorialogs](https://github.com/VictoriaMetrics/mcp-victorialogs) 1.9.0
- [mcp-victoriatraces](https://github.com/VictoriaMetrics/mcp-victoriatraces) 1.5.0

Disclosure: This PR was assisted by OpenAI Codex (gpt-5.6-sol).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

