### PR TITLE
python3Packages.prefect-redis: init at 0.2.11

### DIFF
--- a/pkgs/development/python-modules/prefect-redis/default.nix
+++ b/pkgs/development/python-modules/prefect-redis/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  setuptools-scm,
+  prefect,
+  redis,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "prefect-redis";
+  version = "0.2.11";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "PrefectHQ";
+    repo = "prefect";
+    tag = "prefect-redis-${finalAttrs.version}";
+    hash = "sha256-mYqQKebUDwTpELUmWDkEFSUmxwM69AOw7rJOxgUiYbM=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/src/integrations/prefect-redis";
+  dependencies = [
+    prefect
+    redis
+  ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+  meta = {
+    description = "Redis integration for Prefect";
+    homepage = "https://github.com/PrefectHQ/prefect/tree/main/src/integrations/prefect-redis";
+    changelog = "https://github.com/PrefectHQ/prefect/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13874,6 +13874,8 @@ self: super: with self; {
 
   prefect = callPackage ../development/python-modules/prefect { };
 
+  prefect-redis = callPackage ../development/python-modules/prefect-redis { };
+
   prefixed = callPackage ../development/python-modules/prefixed { };
 
   preggy = callPackage ../development/python-modules/preggy { };


### PR DESCRIPTION
Adding prefect-redis python package


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
