### PR TITLE
python3Packages.opentelemetry-instrumentation-aio-pika: init at 0.64b0

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-instrumentation-aio-pika/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-aio-pika/default.nix
@@ -1,0 +1,61 @@
+{
+  buildPythonPackage,
+  opentelemetry-instrumentation,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  opentelemetry-api,
+  opentelemetry-semantic-conventions,
+  wrapt,
+
+  # optional-dependencies
+  aio-pika,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-aio-pika";
+  pyproject = true;
+
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-aio-pika";
+
+  # Upstream hasn't released a version supporting aio-pika>=10 yet; a fix is
+  # open upstream (verified working against 10.0.1 by its author) but not
+  # yet merged: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4998
+  postPatch = ''
+    substituteInPlace src/opentelemetry/instrumentation/aio_pika/package.py \
+      --replace-fail "aio_pika >= 7.2.0, < 10.0.0" "aio_pika >= 7.2.0, < 11.0.0"
+  '';
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    opentelemetry-api
+    opentelemetry-instrumentation
+    opentelemetry-semantic-conventions
+    wrapt
+  ];
+
+  optional-dependencies = {
+    instruments = [
+      aio-pika
+    ];
+  };
+
+  nativeCheckInputs = [
+    aio-pika
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.aio_pika" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    description = "OpenTelemetry aio-pika instrumentation";
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-aio-pika";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12662,6 +12662,10 @@ self: super: with self; {
     callPackage ../development/python-modules/opentelemetry-instrumentation
       { };
 
+  opentelemetry-instrumentation-aio-pika =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-aio-pika
+      { };
+
   opentelemetry-instrumentation-aiohttp-client =
     callPackage ../development/python-modules/opentelemetry-instrumentation-aiohttp-client
       { };


### PR DESCRIPTION
Depends on aiormq being merged (#557968): tests pull in aio-pika -> aiormq.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
