### PR TITLE
d2Minimal: init

### DIFF
--- a/pkgs/by-name/d2/d2/package.nix
+++ b/pkgs/by-name/d2/d2/package.nix
@@ -22,6 +22,8 @@ buildGoModule (finalAttrs: {
   pname = "d2";
   version = "0.8.1";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "d2lang";
     repo = "d2";

--- a/pkgs/by-name/d2/d2Minimal/package.nix
+++ b/pkgs/by-name/d2/d2Minimal/package.nix
@@ -1,0 +1,6 @@
+{
+  d2,
+}:
+d2.override {
+  withImageSupport = false;
+}


### PR DESCRIPTION
Output of `d2` derivaiton is not affected by `__structuredAttrs`.

`d2` closure size: 2.2 GiB. `d2Minimal` closure size: 98.6 MiB.
Sadly, the way it's packaged right now, it requires a full rebuild, so it would be nice if it was built by nixpkgs.

Seems like `d2` can actually be implemented as a wrapper around `d2Minimal` (even when https://github.com/NixOS/nixpkgs/pull/532664 is merged), but maybe another day.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
