### PR TITLE
tmuxPlugins: fix invalid unstable version scheme

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -95,7 +95,7 @@ in
 
   better-mouse-mode = mkTmuxPlugin {
     pluginName = "better-mouse-mode";
-    version = "unstable-2021-08-02";
+    version = "0-unstable-2017-10-16";
     src = fetchFromGitHub {
       owner = "NHDaly";
       repo = "tmux-better-mouse-mode";
@@ -142,7 +142,7 @@ in
 
   continuum = mkTmuxPlugin {
     pluginName = "continuum";
-    version = "unstable-2022-01-25";
+    version = "3.1.0-unstable-2022-01-25";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-continuum";
@@ -196,7 +196,7 @@ in
 
   copycat = mkTmuxPlugin {
     pluginName = "copycat";
-    version = "unstable-2020-01-09";
+    version = "3.0.0-unstable-2020-01-09";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-copycat";
@@ -210,7 +210,7 @@ in
 
   cpu = mkTmuxPlugin {
     pluginName = "cpu";
-    version = "unstable-2023-01-06";
+    version = "0-unstable-2023-01-06";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-cpu";
@@ -321,7 +321,7 @@ in
 
   fpp = mkTmuxPlugin {
     pluginName = "fpp";
-    version = "unstable-2016-03-08";
+    version = "0-unstable-2016-03-08";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-fpp";
@@ -338,7 +338,7 @@ in
 
   fuzzback = mkTmuxPlugin {
     pluginName = "fuzzback";
-    version = "unstable-2022-11-21";
+    version = "0-unstable-2022-11-21";
     src = fetchFromGitHub {
       owner = "roosta";
       repo = "tmux-fuzzback";
@@ -373,7 +373,7 @@ in
   fzf-tmux-url = mkTmuxPlugin {
     pluginName = "fzf-tmux-url";
     rtpFilePath = "fzf-url.tmux";
-    version = "unstable-2024-04-14";
+    version = "0-unstable-2024-04-14";
     src = fetchFromGitHub {
       owner = "wfxr";
       repo = "tmux-fzf-url";
@@ -507,7 +507,7 @@ in
 
   logging = mkTmuxPlugin {
     pluginName = "logging";
-    version = "unstable-2019-04-19";
+    version = "2.1.0-unstable-2019-04-19";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-logging";
@@ -548,7 +548,7 @@ in
 
   mode-indicator = mkTmuxPlugin {
     pluginName = "mode-indicator";
-    version = "unstable-2021-10-01";
+    version = "0-unstable-2021-10-01";
     src = fetchFromGitHub {
       owner = "MunifTanjim";
       repo = "tmux-mode-indicator";
@@ -566,7 +566,7 @@ in
 
   net-speed = mkTmuxPlugin {
     pluginName = "net-speed";
-    version = "unstable-2018-12-02";
+    version = "0.3-unstable-2018-12-02";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-net-speed";
@@ -604,7 +604,7 @@ in
 
   maildir-counter = mkTmuxPlugin {
     pluginName = "maildir-counter";
-    version = "unstable-2016-11-25";
+    version = "0-unstable-2016-11-25";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-maildir-counter";
@@ -618,7 +618,7 @@ in
 
   online-status = mkTmuxPlugin {
     pluginName = "online-status";
-    version = "unstable-2018-11-30";
+    version = "1.0.0-unstable-2017-12-14";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-online-status";
@@ -632,7 +632,7 @@ in
 
   open = mkTmuxPlugin {
     pluginName = "open";
-    version = "unstable-2019-12-02";
+    version = "3.0.0-unstable-2019-12-02";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-open";
@@ -647,7 +647,7 @@ in
   onedark-theme = mkTmuxPlugin {
     pluginName = "onedark-theme";
     rtpFilePath = "tmux-onedark-theme.tmux";
-    version = "unstable-2020-06-07";
+    version = "0-unstable-2020-02-25";
     src = fetchFromGitHub {
       owner = "odedlaz";
       repo = "tmux-onedark-theme";
@@ -661,7 +661,7 @@ in
 
   pain-control = mkTmuxPlugin {
     pluginName = "pain-control";
-    version = "unstable-2020-02-18";
+    version = "1.0.0-unstable-2020-02-18";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-pain-control";
@@ -732,7 +732,7 @@ in
   power-theme = mkTmuxPlugin {
     pluginName = "power";
     rtpFilePath = "tmux-power.tmux";
-    version = "unstable-2024-05-12";
+    version = "1.0-unstable-2024-04-14";
     src = pkgs.fetchFromGitHub {
       owner = "wfxr";
       repo = "tmux-power";
@@ -749,7 +749,7 @@ in
 
   prefix-highlight = mkTmuxPlugin {
     pluginName = "prefix-highlight";
-    version = "unstable-2021-03-30";
+    version = "0-unstable-2021-03-30";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-prefix-highlight";
@@ -763,7 +763,7 @@ in
 
   resurrect = mkTmuxPlugin {
     pluginName = "resurrect";
-    version = "unstable-2022-05-01";
+    version = "4.0.0-unstable-2022-05-01";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-resurrect";
@@ -800,7 +800,7 @@ in
 
   rose-pine = mkTmuxPlugin {
     pluginName = "rose-pine";
-    version = "unstable-2024-01-08";
+    version = "0-unstable-2024-01-08";
     rtpFilePath = "rose-pine.tmux";
     src = fetchFromGitHub {
       owner = "rose-pine";
@@ -853,7 +853,7 @@ in
 
   sensible = mkTmuxPlugin {
     pluginName = "sensible";
-    version = "unstable-2022-08-14";
+    version = "3.0.0-unstable-2022-08-14";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-sensible";
@@ -914,7 +914,7 @@ in
 
   sessionist = mkTmuxPlugin {
     pluginName = "sessionist";
-    version = "unstable-2023-05-02";
+    version = "2.3.0-unstable-2023-05-02";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-sessionist";
@@ -928,7 +928,7 @@ in
 
   sidebar = mkTmuxPlugin {
     pluginName = "sidebar";
-    version = "unstable-2018-11-30";
+    version = "0.7.0-unstable-2018-11-30";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-sidebar";
@@ -942,7 +942,7 @@ in
 
   sysstat = mkTmuxPlugin {
     pluginName = "sysstat";
-    version = "unstable-2017-12-12";
+    version = "0-unstable-2017-12-12";
     src = fetchFromGitHub {
       owner = "samoshkin";
       repo = "tmux-plugin-sysstat";
@@ -956,7 +956,7 @@ in
 
   tilish = mkTmuxPlugin {
     pluginName = "tilish";
-    version = "unstable-2023-09-20";
+    version = "0-unstable-2023-09-20";
     src = fetchFromGitHub {
       owner = "jabirali";
       repo = "tmux-tilish";
@@ -994,7 +994,7 @@ in
 
   tmux-colors-solarized = mkTmuxPlugin {
     pluginName = "tmuxcolors";
-    version = "unstable-2019-07-14";
+    version = "0-unstable-2019-07-14";
     src = fetchFromGitHub {
       owner = "seebi";
       repo = "tmux-colors-solarized";
@@ -1029,7 +1029,7 @@ in
   tmux-fzf = mkTmuxPlugin {
     pluginName = "tmux-fzf";
     rtpFilePath = "main.tmux";
-    version = "unstable-2025-09-24";
+    version = "0-unstable-2025-09-24";
     src = fetchFromGitHub {
       owner = "sainnhe";
       repo = "tmux-fzf";
@@ -1238,7 +1238,7 @@ in
 
   urlview = mkTmuxPlugin {
     pluginName = "urlview";
-    version = "unstable-2016-01-06";
+    version = "0-unstable-2016-01-06";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-urlview";
@@ -1255,7 +1255,7 @@ in
 
   vim-tmux-focus-events = mkTmuxPlugin {
     pluginName = "vim-tmux-focus-events";
-    version = "unstable-2020-10-05";
+    version = "1.0.0-unstable-2020-10-05";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "vim-tmux-focus-events";
@@ -1275,7 +1275,7 @@ in
   vim-tmux-navigator = mkTmuxPlugin {
     pluginName = "vim-tmux-navigator";
     rtpFilePath = "vim-tmux-navigator.tmux";
-    version = "unstable-2025-07-15";
+    version = "1.0-unstable-2025-07-15";
     src = fetchFromGitHub {
       owner = "christoomey";
       repo = "vim-tmux-navigator";
@@ -1290,7 +1290,7 @@ in
   weather = mkTmuxPlugin {
     pluginName = "weather";
     rtpFilePath = "tmux-weather.tmux";
-    version = "unstable-2020-02-08";
+    version = "0-unstable-2020-02-08";
     src = fetchFromGitHub {
       owner = "xamut";
       repo = "tmux-weather";
@@ -1313,7 +1313,7 @@ in
 
   yank = mkTmuxPlugin {
     pluginName = "yank";
-    version = "unstable-2023-07-19";
+    version = "2.3.0-unstable-2023-07-19";
     src = fetchFromGitHub {
       owner = "tmux-plugins";
       repo = "tmux-yank";


### PR DESCRIPTION
As part of https://github.com/NixOS/nixpkgs/issues/541820


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
