### PR TITLE
libmirisdr-4: init at 2.0.0

### DIFF
--- a/pkgs/by-name/li/libmirisdr-4/package.nix
+++ b/pkgs/by-name/li/libmirisdr-4/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libusb1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libmirisdr";
+  version = "2.0.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "f4exb";
+    repo = "libmirisdr-4";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-HH9FEBcZdHvl5mEPduaIojQtFEIZaA2c4qUcHd7EVvk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libusb1
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
+  meta = {
+    description = "Driver and utilities for Mirics MSI2500/MSI001 SDR devices";
+    homepage = "https://github.com/f4exb/libmirisdr-4";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.db8le ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [libmirisdr-4](https://github.com/f4exb/libmirisdr-4), a driver for MSi001/MSi2500 based SDRs. Requires the kernel modules msi2500 and msi001 to be blacklisted at runtime to function properly, but it seems like that should be handled by the user.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
