### PR TITLE
python3Packages.streamcontroller-plugin-tools: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/streamcontroller-plugin-tools/default.nix
+++ b/pkgs/development/python-modules/streamcontroller-plugin-tools/default.nix
@@ -6,15 +6,17 @@
   loguru,
   rpyc,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "streamcontroller-plugin-tools";
   version = "2.0.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "StreamController";
     repo = "streamcontroller-plugin-tools";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-dQZPRSzHhI3X+Pf7miwJlECGFgUfp68PtvwXAmpq5/s=";
   };
 
@@ -34,4 +36,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ sifmelcara ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/development/python-modules/streamcontroller-plugin-tools/default.nix
+++ b/pkgs/development/python-modules/streamcontroller-plugin-tools/default.nix
@@ -2,13 +2,14 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
+  setuptools,
   loguru,
   rpyc,
 }:
 buildPythonPackage rec {
   pname = "streamcontroller-plugin-tools";
   version = "2.0.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "StreamController";
@@ -16,6 +17,8 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-dQZPRSzHhI3X+Pf7miwJlECGFgUfp68PtvwXAmpq5/s=";
   };
+
+  build-system = [ setuptools ];
 
   dependencies = [
     loguru


### PR DESCRIPTION
As part of #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
