### PR TITLE
python3Packages.cvxopt: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -19,15 +19,17 @@
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cvxopt";
   version = "1.3.3";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   disabled = isPyPy; # hangs at [translation:info]
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-gFnO9B8fEVyHvJt1/sn4bblefwr88DpS1hm6Qz5EO8s=";
   };
 
@@ -73,6 +75,8 @@ buildPythonPackage rec {
     "tests"
   ];
 
+  pythonImportsCheck = [ "cvxopt" ];
+
   meta = {
     homepage = "https://cvxopt.org/";
     description = "Python Software for Convex Optimization";
@@ -89,4 +93,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ edwtjo ];
     license = lib.licenses.gpl3Plus;
   };
-}
+})

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   isPyPy,
   blas,
   lapack,
@@ -21,7 +22,7 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 buildPythonPackage rec {
   pname = "cvxopt";
   version = "1.3.3";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = isPyPy; # hangs at [translation:info]
 
@@ -35,7 +36,10 @@ buildPythonPackage rec {
     lapack
   ];
 
-  build-system = [ setuptools-scm ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   # similar to Gsl, glpk, fftw there is also a dsdp interface
   # but dsdp is not yet packaged in nixpkgs


### PR DESCRIPTION
As part of #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
