### PR TITLE
python3Packages.django-ranged-response: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/django-ranged-response/default.nix
+++ b/pkgs/development/python-modules/django-ranged-response/default.nix
@@ -6,14 +6,16 @@
   django,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "django-ranged-response";
   version = "0.2.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "11gr3jpmb5rvg3scv026kjwwkmnxwivgq5ypxadnnc9p58szy7zp";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-9x//NSo3MWub6tcX/Hbk3dbJuZxGgM30eDuXVa8c+YU=";
   };
 
   build-system = [ setuptools ];
@@ -23,10 +25,12 @@ buildPythonPackage rec {
 
   dependencies = [ django ];
 
+  pythonImportsCheck = [ "ranged_response" ];
+
   meta = {
     description = "Modified FileResponse that returns `Content-Range` headers with the HTTP response, so browsers (read Safari 9+) that request the file, can stream the response properly";
     homepage = "https://github.com/wearespindle/django-ranged-fileresponse";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mrmebelman ];
   };
-}
+})

--- a/pkgs/development/python-modules/django-ranged-response/default.nix
+++ b/pkgs/development/python-modules/django-ranged-response/default.nix
@@ -2,23 +2,26 @@
   lib,
   fetchPypi,
   buildPythonPackage,
+  setuptools,
   django,
 }:
 
 buildPythonPackage rec {
   pname = "django-ranged-response";
   version = "0.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "11gr3jpmb5rvg3scv026kjwwkmnxwivgq5ypxadnnc9p58szy7zp";
   };
 
+  build-system = [ setuptools ];
+
   # tests not included in PyPi package, github source is not up to date with 0.2.0
   doCheck = false;
 
-  propagatedBuildInputs = [ django ];
+  dependencies = [ django ];
 
   meta = {
     description = "Modified FileResponse that returns `Content-Range` headers with the HTTP response, so browsers (read Safari 9+) that request the file, can stream the response properly";


### PR DESCRIPTION
As part of #515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
