### PR TITLE
nixos/tests/systemd-timesyncd-nscd-dnssec: bind tinydns to loopback

### DIFF
--- a/nixos/tests/systemd-timesyncd-nscd-dnssec.nix
+++ b/nixos/tests/systemd-timesyncd-nscd-dnssec.nix
@@ -4,7 +4,7 @@
 # correct time, we need to connect to an NTP server, which usually requires resolving its hostname.
 #
 # This test does the following:
-# - Sets up a DNS server (tinydns) listening on the eth1 ip address, serving .ntp and fake.ntp records.
+# - Sets up a DNS server (tinydns) listening on loopback, serving .ntp and fake.ntp records.
 # - Configures that DNS server as a resolver and enables DNSSEC in systemd-resolved settings.
 # - Configures systemd-timesyncd to use fake.ntp hostname as an NTP server.
 # - Performs a regular DNS lookup, to ensure it fails due to broken DNSSEC.
@@ -13,31 +13,22 @@
 #   server running. For this test to succeed, we only need to ensure that systemd-timesyncd
 #   resolves the IP address of the fake.ntp host.
 
-{ pkgs, ... }:
-
 let
   ntpHostname = "fake.ntp";
   ntpIP = "192.0.2.1";
+  dnsIP = "127.0.0.1";
 in
 {
   name = "systemd-timesyncd-nscd-dnssec";
   nodes.machine =
+    { lib, ... }:
     {
-      pkgs,
-      lib,
-      config,
-      ...
-    }:
-    let
-      eth1IP = (lib.head config.networking.interfaces.eth1.ipv4.addresses).address;
-    in
-    {
-      # Setup a local DNS server for the NTP domain on the eth1 IP address
+      # Setup a local DNS server for the NTP domain on loopback
       services.tinydns = {
         enable = true;
-        ip = eth1IP;
+        ip = dnsIP;
         data = ''
-          .ntp:${eth1IP}
+          .ntp:${dnsIP}
           +.${ntpHostname}:${ntpIP}
         '';
       };
@@ -45,7 +36,7 @@ in
       # Enable systemd-resolved with DNSSEC and use the local DNS as a name server
       services.resolved.enable = true;
       services.resolved.settings.Resolve.DNSSEC = true;
-      networking.nameservers = [ eth1IP ];
+      networking.nameservers = [ dnsIP ];
 
       # Configure systemd-timesyncd to use our NTP hostname
       services.timesyncd.enable = lib.mkForce true;


### PR DESCRIPTION
Nothing orders tinydns.service after network-addresses-eth1.service, so
tinydns could start before eth1's address was assigned and fail with
"unable to bind UDP socket".

Assisted-by: Claude:claude-fable-5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
