### PR TITLE
interpreter-workstation: init at latest (beta)

### DIFF
--- a/pkgs/by-name/in/interpreter-workstation/package.nix
+++ b/pkgs/by-name/in/interpreter-workstation/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  pname = "interpreter-workstation";
+  version = "latest";
+
+  src = fetchurl {
+    url = "https://openinterpreter.com/download/linux/appimage";
+    hash = "sha256-fJXSmrT/UaEjK+OUaqQt/jGkE/8gKXTi1qv9EOawQGk=";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  profile = ''
+    export APPIMAGE=true
+  '';
+
+  # Dependencies needed at runtime by the AppImage binary
+  extraPkgs =
+    pkgs: with pkgs; [
+      bubblewrap
+      ripgrep
+    ];
+
+  extraInstallCommands =
+    let
+      appimageContents = appimageTools.extract { inherit pname version src; };
+    in
+    ''
+      install -m 444 -D ${appimageContents}/interpreter.desktop -t $out/share/applications/
+
+      if [ -f "${appimageContents}/interpreter.png" ]; then
+        install -m 444 -D ${appimageContents}/interpreter.png $out/share/icons/hicolor/512x512/apps/${pname}.png
+      elif [ -f "${appimageContents}/.DirIcon" ]; then
+        install -m 444 -D ${appimageContents}/.DirIcon $out/share/icons/hicolor/512x512/apps/${pname}.png
+      fi
+
+      substituteInPlace $out/share/applications/interpreter.desktop \
+        --replace-fail "Exec=AppRun" "Exec=${pname}"
+    '';
+
+  meta = {
+    description = "The desktop agent. Interpreter lets you work alongside agents that can edit your documents, fill PDF forms, and more.";
+    homepage = "https://www.openinterpreter.com/desktop";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ _2hexed ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "interpreter-workstation";
+  };
+}


### PR DESCRIPTION
This PR inits Interpreter Workstation desktop app.

Link: https://www.openinterpreter.com/desktop
Repo: https://github.com/openinterpreter/interpreter-workstation

Built directly using their appimage to avoid complexity, dynamic linking and dependency issues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
