### PR TITLE
maintainers: remove dduan

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6722,12 +6722,6 @@
     githubId = 25856103;
     name = "DDoSolitary";
   };
-  dduan = {
-    email = "daniel@duan.ca";
-    github = "dduan";
-    githubId = 75067;
-    name = "Daniel Duan";
-  };
   de11n = {
     email = "nixpkgs-commits@deshaw.com";
     github = "de11n";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -757,7 +757,6 @@ with lib.maintainers;
 
   swift = {
     members = [
-      dduan
       samasaur
       stephank
     ];

--- a/pkgs/by-name/tr/tre-command/package.nix
+++ b/pkgs/by-name/tr/tre-command/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Tree command, improved";
     homepage = "https://github.com/dduan/tre";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.dduan ];
+    maintainers = [ ];
     mainProgram = "tre";
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [August 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Adduan)
- Hasn't created any PRs / Issues since [June 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Adduan)
- About 74 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Adduan%20-commenter%3Adduan%20-author%3Adduan%20-reviewed-by%3Adduan) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] tre-command
