### PR TITLE
infrahub: init at 1.11.0

### DIFF
--- a/pkgs/by-name/in/infrahub/package.nix
+++ b/pkgs/by-name/in/infrahub/package.nix
@@ -1,0 +1,167 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  python3,
+  python3Packages,
+  stdenvNoCC,
+  nodejs_24,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+}:
+
+let
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+    owner = "opsmill";
+    repo = "infrahub";
+    tag = "infrahub-v${version}";
+    hash = "sha256-icqTnPimDG2UaysLVqJ/AELXI/qFa1ZDFfiqeingpqI=";
+  };
+
+  schema-visualizer-src = fetchFromGitHub {
+    owner = "opsmill";
+    repo = "infrahub-schema-visualizer";
+    rev = "f7d3cc5af409e9db7916947e33b887737a626d4d";
+    hash = "sha256-tdKS+H9rUssbF3Pc0UECLELVMjbPIcRhuzosWXTFR9s=";
+  };
+
+  frontend = stdenvNoCC.mkDerivation (frontendFinalAttrs: {
+    pname = "infrahub-frontend";
+    inherit version src;
+    sourceRoot = "${src.name}/frontend";
+
+    postPatch = ''
+      rm -rf packages/schema-visualizer
+      cp -r --no-preserve=mode,ownership ${schema-visualizer-src} packages/schema-visualizer
+      chmod -R u+w packages/schema-visualizer
+    '';
+
+    nativeBuildInputs = [
+      nodejs_24
+      pnpm_10
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (frontendFinalAttrs)
+        pname
+        version
+        src
+        sourceRoot
+        postPatch
+        ;
+      pnpm = pnpm_10;
+      fetcherVersion = 3;
+      hash = "sha256-E28fPSe8J8ed/wixde5EzpgtpCJyWPlylpx6FDXyL4o=";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm --filter frontend build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r app/dist $out/dist
+      runHook postInstall
+    '';
+  });
+in
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "infrahub-server";
+  inherit version src;
+  pyproject = true;
+
+  build-system = [
+    python3Packages.hatchling
+    python3Packages.hatch-vcs
+  ];
+  dependencies = with python3Packages; [
+    neo4j
+    neo4j-rust-ext
+    pydantic
+    pydantic-settings
+    pytest
+    aio-pika
+    structlog
+    boto3
+    email-validator
+    redis
+    hiredis
+    typer
+    click
+    prefect
+    prefect-redis
+    ujson
+    jinja2
+    gitpython
+    pyyaml
+    tomli
+    deepdiff
+    httpx
+    fastapi
+    fastapi-storages
+    graphene
+    gunicorn
+    prometheus-client
+    lunr
+    starlette-exporter
+    python-multipart
+    asgi-correlation-id
+    bcrypt
+    pyjwt
+    uvicorn
+    opentelemetry-instrumentation-aio-pika
+    opentelemetry-instrumentation-fastapi
+    grpcio
+    opentelemetry-exporter-otlp-proto-grpc
+    opentelemetry-exporter-otlp-proto-http
+    nats-py
+    netaddr
+    authlib
+    aiodataloader
+    fast-depends
+    cachetools-async
+    puremagic
+    rich
+    pyarrow
+    numpy
+    dulwich
+    whenever
+    netutils
+    ariadne-codegen
+    infrahub-sdk
+  ];
+  nativeBuildInputs = [
+    makeWrapper
+    python3Packages.pythonRelaxDepsHook
+  ];
+  pythonRelaxDeps = true;
+
+  passthru.frontend = frontend;
+
+  postInstall = ''
+    pythonPath="${python3Packages.makePythonPath finalAttrs.propagatedBuildInputs}:$out/${python3.sitePackages}"
+    makeWrapper ${lib.getExe python3Packages.gunicorn} $out/bin/gunicorn \
+      --prefix PYTHONPATH : "$pythonPath" \
+      --set INFRAHUB_FRONTEND_DIRECTORY ${frontend}
+    makeWrapper ${lib.getExe python3Packages.prefect} $out/bin/prefect \
+      --prefix PYTHONPATH : "$pythonPath"
+    makeWrapper ${lib.getExe python3Packages.uvicorn} $out/bin/infrahub-prefect-server \
+      --prefix PYTHONPATH : "$pythonPath" \
+      --add-flags "infrahub.prefect_server.app:create_infrahub_prefect --factory"
+  '';
+
+  meta = {
+    description = "Infrastructure catalog and source of truth built on a graph database";
+    homepage = "https://github.com/opsmill/infrahub";
+    changelog = "https://github.com/opsmill/infrahub/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mhdask ];
+  };
+})


### PR DESCRIPTION
Adds the actual Infrahub application

 Depends on the following PRs, which need to merge first:

  - #558131 — python3Packages.infrahub-sdk: init at 1.23.1
  - #558067 — python3Packages.neo4j-rust-ext: init at 6.3.0.0
  - #558061 — python3Packages.opentelemetry-instrumentation-aio-pika: init at 0.64b0
  - #558058 — python3Packages.prefect-redis: init at 0.2.11
  - #558052 — python3Packages.ariadne-codegen: init at 0.19.0
  - #558051 — python3Packages.starlette-exporter: init at 0.23.0
  - #558050 — python3Packages.lunr: init at 0.8.0
  - #558049 — python3Packages.fastapi-storages: init at 0.5.0
  - #558048 — python3Packages.fast-depends: init at 3.0.7
  - #558047 — python3Packages.cachetools-async: init at 0.0.5
  - #558043 — python3Packages.asgi-correlation-id: init at 5.0.1
  - #558027 — python3Packages.aiodataloader: init
  - #557968 — python3Packages.aiormq: 6.9.2 -> 7.0.0 (+ cascaded aio-pika bump)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
