### PR TITLE
python3Packages.python-crontab: 3.3.0 -> 3.4.0

### DIFF
--- a/pkgs/development/python-modules/python-crontab/default.nix
+++ b/pkgs/development/python-modules/python-crontab/default.nix
@@ -2,14 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
-  python-dateutil,
   pytestCheckHook,
+  python-dateutil,
   setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "python-crontab";
-  version = "3.3.0";
+  version = "3.4.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -18,8 +18,13 @@ buildPythonPackage (finalAttrs: {
     owner = "doctormo";
     repo = "python-crontab";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eJXtvTRwokbewWrTArHJ2FXGDLvlkGA/5ZZR01koMW8=";
+    hash = "sha256-MVQNZDCEsX8cjDQQviTfwOarul8+CkdCvWfJMc5Sbq0=";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "= '3.3.0'," "= '${finalAttrs.version}',"
+  '';
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Diff: https://gitlab.com/doctormo/python-crontab/-/compare/v3.3.0...v3.4.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
