### PR TITLE
nixos/nixosTests.firewall-nftables: fix race condition

### DIFF
--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -121,13 +121,13 @@
       walled.succeed("${reset}")
       attacker.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
 
+      # Check whether activation of a new configuration reloads the firewall.
+      walled.succeed(
+          "/run/booted-system/specialisation/different-config/bin/switch-to-configuration test 2>&1 | grep -F ${unit}.service"
+      )
+
       # If we stop the firewall, then connections should succeed.
       walled.stop_job("${unit}")
       attacker.succeed("curl -v http://walled/ >&2")
-
-      # Check whether activation of a new configuration reloads the firewall.
-      walled.succeed(
-          "/run/booted-system/specialisation/different-config/bin/switch-to-configuration test 2>&1 | grep -qF ${unit}.service"
-      )
     '';
 }


### PR DESCRIPTION
`nixosTests.firewall-nftables` occasionally fails in CI with:

```sh
!!! RequestedAssertionFailed: command `/run/booted-system/specialisation/different-config/bin/switch-to-configuration test 2>&1 | grep -qF nftables.service` failed (exit code 1)
```

Although the test file itself [did not change since two month](https://github.com/NixOS/nixpkgs/commits/master/nixos/tests/firewall.nix) the test [occasionally fails in hydra](https://hydra.nixos.org/job/nixos/unstable/nixos.tests.firewall-nftables.x86_64-linux/all) and it also occasionally failed on my machine. I investigated this and 

Two independent issues in the test caused this:

- Wrong check ordering: The `switch-to-configuration` test check ran after walled.stop_job("${unit}"). `switch-to-configuration-ng` only diffs unit files directly for units that are still active; once stopped, the unit is instead only picked up by a *timing-dependent* fallback (wait for D-Bus activity to settle, then re-check which units became newly active). Under CI load, that wait can finish before the unit is actually restarted, so the check misses it.
- grep -q: -q makes grep exit as soon as it finds a match, closing its end of the pipe early. `switch-to-configuration-ng` ignores SIGPIPE, so its next eprintln!/println! call panics on the broken pipe (exit code 101) instead of failing gracefully. 

To fix these issues this PR drops `-q` so `grep` drains the output to EOF, matching the style already used in [reload.nix](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/nebula/reload.nix#L81) and moves the check before `stop_job` (this makes it exercise the deterministic diff path instead). 

This should make the test deterministic.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
