### PR TITLE
radicle-artifact: init at 0.18.0

### DIFF
--- a/pkgs/by-name/ra/radicle-artifact/package.nix
+++ b/pkgs/by-name/ra/radicle-artifact/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromRadicle,
+  stdenv,
+  gitMinimal,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "radicle-artifact";
+  version = "0.18.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromRadicle {
+    seed = "radicle.norman.life";
+    repo = "z4VYyJ9KuwMNkXGQnmKuGPGKw3inv";
+    tag = "releases/${finalAttrs.version}";
+    hash = "sha256-KMu0d8+Nu7wJcaJWFzQXN7nfp+Z6np84JQL8RKbWkIQ=";
+  };
+
+  cargoHash = "sha256-MRUeVIl9ZNNTs2T7/uKIyLm0KBgsXHYTI19uXOFWypk=";
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  # tests segfault on darwin
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Secure artifact distribution for Radicle";
+    homepage = "https://radicle.network/nodes/radicle.norman.life/rad:z4VYyJ9KuwMNkXGQnmKuGPGKw3inv";
+    changelog = "https://radicle.network/nodes/radicle.norman.life/rad:z4VYyJ9KuwMNkXGQnmKuGPGKw3inv/tree/CHANGELOG.md";
+    license = [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    teams = [ lib.teams.radicle ];
+    mainProgram = "rad-artifact";
+  };
+})

--- a/pkgs/by-name/ra/radicle-artifact/update.sh
+++ b/pkgs/by-name/ra/radicle-artifact/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils gnugrep common-updater-scripts nix-update
+
+version=$(list-git-tags | grep -oP '^releases/\K\d+\.\d+\.\d+$' | sort -rV | head -1)
+nix-update --version="$version" radicle-artifact


### PR DESCRIPTION
> Secure artifact distribution for [Radicle](https://radicle.dev/)
>
> radicle-artifact helps you securely publish large files bound to git commits and tags, without bloating your repo.

https://radicle.network/nodes/radicle.norman.life/rad:z4VYyJ9KuwMNkXGQnmKuGPGKw3inv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
