### PR TITLE
gradle: set to gradle_9 

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -47,6 +47,8 @@
 
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.
 
+- `gradle` has been upgraded to Gradle 9, which has breaking changes. See [upstream's migration guide](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html) for details.
+
 - The existing `wasm32-wasi` target has become `wasm32-wasip1` and `pkgsCross.wasi32` has become `pkgsCross.wasm32-wasip1`, aligning with LLVM's nomenclature. Aliases are in place and old forms will continue to be parsed but there might be some breakage if you're relying on the exact form of these (e.g., in sysroot paths).
 
 - `gotosocial` has been updated to 0.22.0. This release contains a very long database migration, which should not be cancelled or interrupted under any circumstances.

--- a/pkgs/by-name/al/alda/package.nix
+++ b/pkgs/by-name/al/alda/package.nix
@@ -3,12 +3,15 @@
   stdenv,
   fetchFromGitHub,
   buildGoModule,
-  gradle,
+  gradle_8,
   makeWrapper,
   jre,
   symlinkJoin,
 }:
 let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+
   pname = "alda";
   version = "2.3.2";
   src = fetchFromGitHub {

--- a/pkgs/by-name/ap/apkeditor/package.nix
+++ b/pkgs/by-name/ap/apkeditor/package.nix
@@ -6,11 +6,13 @@
   versionCheckHook,
 
   jre,
-  gradle,
+  gradle_8,
   makeWrapper,
 }:
 
 let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
   REAndroidLibrary =
     args:
     let

--- a/pkgs/by-name/co/coulomb/package.nix
+++ b/pkgs/by-name/co/coulomb/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  gradle,
+  gradle_8,
   jdk21_headless,
   fetchFromGitHub,
   stripJavaArchivesHook,
@@ -19,7 +19,10 @@
   adwaita-icon-theme,
   librsvg,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "coulomb";
   version = "0.6.1";

--- a/pkgs/by-name/cr/crossfire-gridarta/package.nix
+++ b/pkgs/by-name/cr/crossfire-gridarta/package.nix
@@ -4,9 +4,12 @@
   fetchgit,
   makeWrapper,
   jre,
-  gradle,
+  gradle_8,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation {
   pname = "crossfire-gridarta";
   version = "2025-04";

--- a/pkgs/by-name/cr/crossfire-jxclient/package.nix
+++ b/pkgs/by-name/cr/crossfire-jxclient/package.nix
@@ -3,11 +3,14 @@
   lib,
   fetchgit,
   makeWrapper,
-  gradle,
+  gradle_8,
   jre,
   ffmpeg,
 }:
-
+let
+  # A couple of deprecated features get used here; see git log for details
+  gradle = gradle_8;
+in
 stdenv.mkDerivation rec {
   pname = "crossfire-jxclient";
   version = "2025-01";

--- a/pkgs/by-name/gr/gradle-dependency-tree-diff/package.nix
+++ b/pkgs/by-name/gr/gradle-dependency-tree-diff/package.nix
@@ -2,12 +2,16 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   makeBinaryWrapper,
   jre_headless,
   zulu11,
   nix-update-script,
 }:
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gradle-dependency-tree-diff";
   version = "1.2.1";

--- a/pkgs/by-name/ja/java-hamcrest/package.nix
+++ b/pkgs/by-name/ja/java-hamcrest/package.nix
@@ -1,10 +1,14 @@
 {
   stdenvNoCC,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jdk,
   lib,
 }:
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "java-hamcrest";
   version = "3.0";

--- a/pkgs/by-name/jm/jmeter/package.nix
+++ b/pkgs/by-name/jm/jmeter/package.nix
@@ -3,14 +3,17 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
-  gradle,
+  gradle_8,
   jdk17,
   jre,
   makeWrapper,
   coreutils,
   gitMinimal,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jmeter";
   version = "5.6.3";

--- a/pkgs/by-name/js/jspecify/package.nix
+++ b/pkgs/by-name/js/jspecify/package.nix
@@ -4,11 +4,14 @@
   fetchFromGitHub,
   writeShellScript,
   nix-update,
-  gradle,
+  gradle_8,
   jdk21,
   jre_minimal,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jspecify";
   version = "1.0.0";

--- a/pkgs/by-name/kt/ktfmt/package.nix
+++ b/pkgs/by-name/kt/ktfmt/package.nix
@@ -5,9 +5,12 @@
   fetchFromGitHub,
   jre_headless,
   makeWrapper,
-  gradle,
+  gradle_8,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ktfmt";
   version = "0.63";

--- a/pkgs/by-name/pa/pakku/package.nix
+++ b/pkgs/by-name/pa/pakku/package.nix
@@ -2,14 +2,16 @@
   jre,
   lib,
   stdenv,
-  gradle,
+  gradle_8,
   makeWrapper,
   fetchFromGitHub,
   versionCheckHook,
   installShellFiles,
   stripJavaArchivesHook,
 }:
-
+let
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pakku";
   version = "1.5.0";

--- a/pkgs/by-name/pl/plantuml/package.nix
+++ b/pkgs/by-name/pl/plantuml/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jdk,
   jre,
   graphviz,
@@ -11,7 +11,9 @@
   versionCheckHook,
   nix-update-script,
 }:
-
+let
+  gradle = gradle_8;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "plantuml";
   version = "1.2026.6";

--- a/pkgs/by-name/pr/procyon/package.nix
+++ b/pkgs/by-name/pr/procyon/package.nix
@@ -5,7 +5,7 @@
   makeShellWrapper,
   jdk_headless,
   jre_minimal,
-  gradle,
+  gradle_8,
 }:
 
 let
@@ -22,6 +22,8 @@ let
     tag = "1.78";
     hash = "sha256-zoPymohdU8HhVmw7ACoPbgNGgzdsIDVD3bl7Fh3qf2g=";
   };
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/ra/ramus/package.nix
+++ b/pkgs/by-name/ra/ramus/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jre,
   makeWrapper,
   libx11,
@@ -10,6 +10,9 @@
   libGL,
 }:
 let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+
   self = stdenv.mkDerivation (finalAttrs: {
     pname = "ramus";
     version = "2.0.2";

--- a/pkgs/by-name/rh/rhino/package.nix
+++ b/pkgs/by-name/rh/rhino/package.nix
@@ -2,9 +2,12 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rhino";
   version = "1.8.0";

--- a/pkgs/by-name/si/simple-binary-encoding/package.nix
+++ b/pkgs/by-name/si/simple-binary-encoding/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jre,
   runtimeShell,
 
@@ -11,6 +11,9 @@
   html2text,
   txt2man,
 }:
+let
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "simple-binary-encoding";
   version = "1.39.0";

--- a/pkgs/by-name/sl/slimevr-server/package.nix
+++ b/pkgs/by-name/sl/slimevr-server/package.nix
@@ -5,7 +5,7 @@
   replaceVars,
   slimevr,
   jdk17,
-  gradle,
+  gradle_8,
   hidapi,
   makeWrapper,
 }:
@@ -29,6 +29,9 @@ let
         libhidapi
       ]
     }'";
+
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 in
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/sm/smithy-cli/package.nix
+++ b/pkgs/by-name/sm/smithy-cli/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gradle,
+  gradle_8,
   jre,
   makeWrapper,
   nix-update-script,
@@ -10,7 +10,10 @@
   versionCheckHook,
   writeText,
 }:
-
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "smithy-cli";
   version = "1.72.1";

--- a/pkgs/by-name/sm/smithy-language-server/package.nix
+++ b/pkgs/by-name/sm/smithy-language-server/package.nix
@@ -4,9 +4,13 @@
   fetchFromGitHub,
   makeWrapper,
   jre,
-  gradle,
+  gradle_8,
   runCommand,
 }:
+let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "smithy-language-server";
   version = "0.9.0";

--- a/pkgs/by-name/st/structurizr-cli/package.nix
+++ b/pkgs/by-name/st/structurizr-cli/package.nix
@@ -7,12 +7,14 @@
   findutils,
   gnused,
   jre,
-  gradle,
+  gradle_8,
   makeBinaryWrapper,
   gitMinimal,
   versionCheckHook,
 }:
-
+let
+  gradle = gradle_8;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "structurizr-cli";
   version = "2025.05.28";

--- a/pkgs/by-name/tr/traccar/package.nix
+++ b/pkgs/by-name/tr/traccar/package.nix
@@ -5,7 +5,7 @@
   fetchNpmDeps,
   makeWrapper,
   npmHooks,
-  gradle,
+  gradle_8,
   jdk_headless,
   jre_minimal,
   nodejs,
@@ -23,6 +23,7 @@ let
       "jdk.crypto.ec"
     ];
   };
+  gradle = gradle_8;
   protobuf = protobuf_35;
   protobufJavaVer = import ./protobuf-java-version.nix;
 in

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -392,5 +392,5 @@ rec {
   };
 
   # Default version of Gradle in nixpkgs.
-  gradle = gradle_8;
+  gradle = gradle_9;
 }

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   lib,
   callPackage,
-  gradle,
+  gradle_8,
   makeBinaryWrapper,
   openjdk21,
   unzip,
@@ -18,6 +18,9 @@
 }:
 
 let
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
+
   pkg_path = "$out/lib/ghidra";
   pname = "ghidra";
   version = "12.1.2";

--- a/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   buildGhidraExtension,
   z3,
-  gradle,
+  gradle_8,
 }:
 let
   ghidraPlatformName =
@@ -15,6 +15,9 @@ let
     }
     .${stdenv.hostPlatform.system}
       or (throw "${stdenv.hostPlatform.system} is an unsupported platform");
+
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle = gradle_8;
 
   z3_lib = (
     z3.override {


### PR DESCRIPTION
Update the default `gradle` to `gradle_9`. Where builds started failing because of this change, update those packages to continue to use `gradle_8`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
