### PR TITLE
or-tools: fix for python 3.14

### DIFF
--- a/pkgs/by-name/or/or-tools/package.nix
+++ b/pkgs/by-name/or/or-tools/package.nix
@@ -100,6 +100,11 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-BNB3KlgjpWcZtb9e68Jkc/4xC4K0c+Iisw0eS6ltYXE=";
     })
     ./0001-Fix-up-broken-CMake-rules-for-bundled-pybind-stuff.patch
+    (fetchpatch {
+      name = "0001-contrib-remove-deprecated-check_dependencies.py.patch";
+      url = "https://github.com/google/or-tools/commit/957379e02204e04acb3da71b5431ea092e8e8a29.diff?full_index=1";
+      hash = "sha256-DPbe1br1EHJ/4F3p53Lr6rUNwAatN64x/Jsl5WZS3kk=";
+    })
   ];
 
   # or-tools normally attempts to build Protobuf for the build platform when
@@ -243,10 +248,5 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "fzn-cp-sat";
     maintainers = with lib.maintainers; [ andersk ];
     platforms = with lib.platforms; linux ++ darwin;
-
-    # Only version 9.15 adds support for Python 3.14: https://github.com/google/or-tools/releases/tag/v9.15
-    # Also this package is tied to pybind 2.13.6, and only 3.0.0 supports Python 3.14: https://github.com/pybind/pybind11/releases/tag/v3.0.0
-    # Also, nix review fails to build python314Packages.ortools
-    broken = python3.pythonAtLeast "3.14";
   };
 })

--- a/pkgs/by-name/or/or-tools/pybind11-2.13.6.nix
+++ b/pkgs/by-name/or/or-tools/pybind11-2.13.6.nix
@@ -96,6 +96,8 @@ buildPythonPackage (finalAttrs: {
     "tests/extra_python_package/test_files.py"
     # tests that try to parse setuptools stdout
     "tests/extra_setuptools/test_setuphelper.py"
+    # pytest change
+    "tests/test_operator_overloading.py"
   ];
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

or-tools has been upgraded to v9.15, which supports python 3.14 upstream (see https://github.com/google/or-tools/pull/4922, releases on [pypi](https://pypi.org/project/ortools/)). I am a bit confused how the pinned pybind works, but it builds and works in my testing (running [k-means-constrained](https://github.com/joshlk/k-means-constrained)). In addition, the pybind situation should improve in the next release (e.g. https://github.com/google/or-tools/pull/5094, https://github.com/google/or-tools/pull/5190).

Requires https://github.com/NixOS/nixpkgs/pull/557250 as well (but this is true also for Python 3.13).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
