### PR TITLE
 unoconv: patch to work with newest libreoffice, use tag in src

### DIFF
--- a/pkgs/by-name/un/unoconv/package.nix
+++ b/pkgs/by-name/un/unoconv/package.nix
@@ -16,11 +16,14 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "unoconv";
     repo = "unoconv";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "1akx64686in8j8arl6vsgp2n3bv770q48pfv283c6fz6wf9p8fvr";
   };
 
-  patches = [ ./0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch ];
+  patches = [
+    ./0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch
+    ./remove-unohelper-absolutize-usage.diff
+  ];
 
   nativeBuildInputs = [
     asciidoc

--- a/pkgs/by-name/un/unoconv/remove-unohelper-absolutize-usage.diff
+++ b/pkgs/by-name/un/unoconv/remove-unohelper-absolutize-usage.diff
@@ -1,0 +1,40 @@
+diff --git a/unoconv b/unoconv
+index 6aa1bfa..0e53113 100755
+--- a/unoconv
++++ b/unoconv
+@@ -1000,7 +1000,7 @@ class Convertor:
+                 inputurl = 'private:stream'
+             else:
+                 if os.path.exists(inputfn):
+-                    inputurl = unohelper.absolutize(self.cwd, unohelper.systemPathToFileUrl(inputfn))
++                    inputurl = pyuno.absolutize(self.cwd, unohelper.systemPathToFileUrl(inputfn))
+                 else:
+                     inputurl = inputfn
+             document = self.desktop.loadComponentFromURL( inputurl , "_blank", 0, inputprops )
+@@ -1014,7 +1014,7 @@ class Convertor:
+                 if os.path.exists(op.template):
+                     info(1, "Template file: %s" % op.template)
+                     templateprops = UnoProps(OverwriteStyles=True)
+-                    templateurl = unohelper.absolutize(self.cwd, unohelper.systemPathToFileUrl(op.template))
++                    templateurl = pyuno.absolutize(self.cwd, unohelper.systemPathToFileUrl(op.template))
+                     document.StyleFamilies.loadStylesFromURL(templateurl, templateprops)
+                 else:
+                     print('unoconv: template file `%s\' does not exist.' % op.template, file=sys.stderr)
+@@ -1157,7 +1157,7 @@ class Convertor:
+                 else:
+                     outputfn = realpath(inbase + os.extsep + outputfmt.extension)
+ 
+-                outputurl = unohelper.absolutize( self.cwd, unohelper.systemPathToFileUrl(outputfn) )
++                outputurl = pyuno.absolutize( self.cwd, unohelper.systemPathToFileUrl(outputfn) )
+ 
+             info(1, "Output file: %s" % outputurl)
+ 
+@@ -1376,7 +1376,7 @@ if __name__ == '__main__':
+         office_environ(of)
+ #       debug_office()
+         try:
+-            import uno, unohelper
++            import pyuno, uno, unohelper
+             office = of
+             break
+         except:


### PR DESCRIPTION
This PR fixes unoconv being broken with the latest libreoffice version.

see https://gerrit.libreoffice.org/c/core/+/194073 for the change

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
