### PR TITLE
dusk: init at 0-unstable-2026-04-29

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -13,6 +13,7 @@ in
     ./cwm.nix
     ./clfswm.nix
     ./dk.nix
+    ./dusk.nix
     ./dwm.nix
     ./e16.nix
     ./evilwm.nix

--- a/nixos/modules/services/x11/window-managers/dusk.nix
+++ b/nixos/modules/services/x11/window-managers/dusk.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.dusk;
+in
+{
+  ###### interface
+  options = {
+    services.xserver.windowManager.dusk = {
+      enable = mkEnableOption "dusk";
+
+      package = mkPackageOption pkgs "dusk" { };
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "dusk";
+      start = ''
+        export _JAVA_AWT_WM_NONREPARENTING=1
+        ${cfg.package}/bin/dusk &
+        waitPID=$!
+      '';
+    };
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/pkgs/by-name/du/dusk/package.nix
+++ b/pkgs/by-name/du/dusk/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  dbus,
+  libxcb,
+  libxft,
+  libxinerama,
+  libconfig,
+  yajl,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dusk";
+  version = "0-unstable-2026-04-29";
+
+  src = fetchFromGitHub {
+    owner = "bakkeby";
+    repo = "dusk";
+    rev = "4775b91d88859cb314bc710369578eff8ac2a850";
+    hash = "sha256-D82ALoa7Tyquy9qHtavqct/vJq4S574P2ZUG/WGjIYc=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    dbus
+    libxcb
+    libxft
+    libxinerama
+    libconfig
+    yajl
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail /usr/share/xsessions "$out/share/xsessions"
+  '';
+
+  preBuild = ''
+    makeFlagsArray+=(
+      "PREFIX=$out"
+      "CC=$CC"
+      ${lib.optionalString stdenv.hostPlatform.isStatic ''
+        LDFLAGS="$(${stdenv.cc.targetPrefix}pkg-config --static --libs x11 xinerama xft)"
+      ''}
+    )
+  '';
+
+  meta = {
+    homepage = "https://github.com/bakkeby/dusk";
+    description = "DWM fork with workspaces and other features";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "dusk";
+    maintainers = with lib.maintainers; [ evanwporter ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the window manager dusk:

https://github.com/bakkeby/dusk

This is a fork of dwm with more features.

For the most part I copied the dwm nix build script from nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
