### PR TITLE
epkowa: fix iscan-data download

### DIFF
--- a/pkgs/by-name/ep/epkowa/package.nix
+++ b/pkgs/by-name/ep/epkowa/package.nix
@@ -25,22 +25,23 @@ let
     platforms = with lib.platforms; linux;
   };
   plugins' = lib.attrsets.filterAttrs (_: lib.isDerivation) plugins;
-in
-let
   fwdir = symlinkJoin {
     name = "esci-firmware-dir";
     paths = lib.mapAttrsToList (name: value: value + "/share/esci") plugins';
   };
-in
-let
   iscan-data = stdenv.mkDerivation rec {
     pname = "iscan-data";
     version = "1.39.2-1";
 
     src = fetchurl {
       urls = [
-        "http://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz"
+        "https://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz"
         "https://web.archive.org/web/http://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz"
+      ];
+      # HTTP 403 otherwise
+      curlOptsList = [
+        "--user-agent"
+        "Mozilla/5.0 Gecko/20100101 Firefox/150.0"
       ];
       sha256 = "092qhlnjjgz11ifx6mng7mz20i44gc0nlccrbmw18xr5hipbqqka";
     };


### PR DESCRIPTION
Via nixpkgs build, downloading `iscan-data` failed with 403. The same URL in the browser works fine. The other mirror, archive.org, is down right now.

```
trying https://support.epson.net/linux/src/scanner/iscan/iscan-data_1.39.2-1.tar.gz
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed

  0      0   0      0   0      0      0      0                              0
curl: (22) The requested URL returned error: 403
Warning: Problem (retrying all errors). Retrying in 1 second. 3 retries left.
```

Added Firefox user agent, build now succeeds.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test