### PR TITLE
gotenberg: use upstreams forked unoconv

### DIFF
--- a/pkgs/by-name/go/gotenberg/5.patch
+++ b/pkgs/by-name/go/gotenberg/5.patch
@@ -1,0 +1,41 @@
+From 4d74bc8e315c92cd6b2d51b246e37ed07fb92f69 Mon Sep 17 00:00:00 2001
+From: Sandro <sandro.jaeckel@gmail.com>
+Date: Mon, 31 Aug 2026 01:20:37 +0200
+Subject: [PATCH] Remove compatibility fixes for very old LO/OO.
+
+Based on https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/un/unoconv/0001-Remove-compatibility-fixes-for-very-old-LO-OO.patch
+---
+ unoconv | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/unoconv b/unoconv
+index 40fb840..b95137a 100644
+--- a/unoconv
++++ b/unoconv
+@@ -16,7 +16,6 @@
+ 
+ from __future__ import print_function
+ 
+-from distutils.version import LooseVersion
+ import getopt
+ import glob
+ import os
+@@ -873,10 +872,7 @@ class Convertor:
+             info(3, "Launching our own listener using %s." % office.binary)
+             try:
+                 product = self.svcmgr.createInstance("com.sun.star.configuration.ConfigurationProvider").createInstanceWithArguments("com.sun.star.configuration.ConfigurationAccess", UnoProps(nodepath="/org.openoffice.Setup/Product"))
+-                if product.ooName not in ('LibreOffice', 'LOdev') or LooseVersion(product.ooSetupVersion) <= LooseVersion('3.3'):
+-                    args = [office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-accept=%s" % op.connection]
+-                else:
+-                    args = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection]
++                args = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection]
+                 if op.userProfile:
+                     args.append("-env:UserInstallation=file://" + realpath(op.userProfile))
+                 info(2, '%s listener arguments are %s.' % (product.ooName, args))
+@@ -1489,4 +1485,4 @@ if __name__ == '__main__':
+         main()
+     except KeyboardInterrupt:
+         die(6, 'Exiting on user request')
+-    die(exitcode)
+\ No newline at end of file
++    die(exitcode)

--- a/pkgs/by-name/go/gotenberg/package.nix
+++ b/pkgs/by-name/go/gotenberg/package.nix
@@ -7,20 +7,65 @@
   makeBinaryWrapper,
   pdftk,
   qpdf,
-  unoconv,
   mktemp,
   makeFontsConf,
   liberation_ttf_v2,
   exiftool,
   pdfcpu,
+  makeWrapper,
   nixosTests,
   nix-update-script,
+  stdenvNoCC,
 }:
 let
   fontsConf = makeFontsConf { fontDirectories = [ liberation_ttf_v2 ]; };
   jre' = libreoffice.unwrapped.jdk;
   libreoffice' = "${libreoffice}/lib/libreoffice/program/soffice.bin";
   inherit (lib) getExe;
+
+  unoconverter = stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "unoconverter";
+    version = "0.4.0";
+
+    src = fetchFromGitHub {
+      owner = "gotenberg";
+      repo = "unoconverter";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-K3d/6jvj0Tt1e83hVTHZ0N7FzPgJsjxlUBS1nbp82zw=";
+    };
+
+    patches = [
+      # Remove compatibility fixes for very old LO/OO
+      # https://github.com/gotenberg/unoconverter/pull/5
+      ./5.patch
+    ];
+
+    postPatch = ''
+      substituteInPlace unoconv \
+        --replace-fail "#!/usr/bin/env python" "#!${libreoffice.unwrapped.python.interpreter}"
+    '';
+
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dt $out/bin unoconv
+      wrapProgram "$out/bin/unoconv" \
+        --set-default UNO_PATH "${libreoffice.unwrapped}/lib/libreoffice/program/"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Python script for interacting with LibreOffice";
+      homepage = "https://github.com/gotenberg/unoconverter";
+      license = lib.licenses.mit;
+      mainProgram = "unoconv";
+    };
+  });
 in
 buildGo126Module (finalAttrs: {
   pname = "gotenberg";
@@ -42,6 +87,12 @@ buildGo126Module (finalAttrs: {
 
   postPatch = ''
     find ./pkg -name '*_test.go' -exec sed -i -e 's#/tests#${finalAttrs.src}#g' {} \;
+
+    if ! grep -q "https://raw.githubusercontent.com/gotenberg/unoconverter/v${unoconverter.version}/unoconv" build/Dockerfile; then
+      unoconverter_version=$(grep -oP 'https://raw\.githubusercontent\.com/gotenberg/unoconverter/v\K[0-9]+\.[0-9]+\.[0-9]+(?=/unoconv)' build/Dockerfile)
+      echo "Our unoconverter version ${unoconverter.version} does not match upstream's version $unoconverter_version"
+      exit 1
+    fi
   '';
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -57,7 +108,7 @@ buildGo126Module (finalAttrs: {
     libreoffice
     pdftk
     qpdf
-    unoconv
+    unoconverter
     pdfcpu
     mktemp
     jre'
@@ -67,7 +118,7 @@ buildGo126Module (finalAttrs: {
     export CHROMIUM_BIN_PATH=${getExe chromium}
     export PDFTK_BIN_PATH=${getExe pdftk}
     export QPDF_BIN_PATH=${getExe qpdf}
-    export UNOCONVERTER_BIN_PATH=${getExe unoconv}
+    export UNOCONVERTER_BIN_PATH=${getExe unoconverter}
     export EXIFTOOL_BIN_PATH=${getExe exiftool}
     export PDFCPU_BIN_PATH=${getExe pdfcpu}
     # LibreOffice needs all of these set to work properly
@@ -100,7 +151,7 @@ buildGo126Module (finalAttrs: {
       --set PDFCPU_BIN_PATH "${getExe pdfcpu}" \
       --set PDFTK_BIN_PATH "${getExe pdftk}" \
       --set QPDF_BIN_PATH "${getExe qpdf}" \
-      --set UNOCONVERTER_BIN_PATH "${getExe unoconv}"
+      --set UNOCONVERTER_BIN_PATH "${getExe unoconverter}"
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
This is a sister to #558206, but I switched to the canonical unoconv source upstreamed uses to also get some additional flags.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
