### PR TITLE
pythonPackages.pandera: 0.32.1 -> 0.33.0

### DIFF
--- a/pkgs/by-name/pa/pandera/package.nix
+++ b/pkgs/by-name/pa/pandera/package.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  python3Packages,
+}:
+
+python3Packages.toPythonApplication (
+  python3Packages.pandera.overridePythonAttrs (oldAttrs: {
+    # The CLI's three subcommands each lazily import a different extra:
+    # validate/infer need a dataframe backend and the serialization formats,
+    # generate needs hypothesis.
+    dependencies =
+      oldAttrs.dependencies
+      ++ lib.concatMap (extra: oldAttrs.optional-dependencies.${extra}) [
+        "cli"
+        "io"
+        "narwhals"
+        "pandas"
+        "polars"
+        "pyarrow"
+        "strategies"
+      ];
+  })
+)

--- a/pkgs/development/python-modules/pandera/default.nix
+++ b/pkgs/development/python-modules/pandera/default.nix
@@ -28,25 +28,28 @@
   numpy,
   pandas-stubs,
   polars,
+  pyarrow,
+  pyarrow-hotfix,
   pyyaml,
+  rich,
   scipy,
   shapely,
+  typer,
   xarray,
 
   # tests
   duckdb,
   joblib,
-  pyarrow-hotfix,
-  pyarrow,
   pytest-asyncio,
   pytestCheckHook,
-  pythonAtLeast,
-  rich,
+  python-multipart,
+  requests,
+  uvicorn,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pandera";
-  version = "0.32.1";
+  version = "0.33.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -54,7 +57,7 @@ buildPythonPackage (finalAttrs: {
     owner = "unionai-oss";
     repo = "pandera";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6xLrLPFjU3BMw/G8T4O48S8Ntx8EN29OQvSv2pCjIJg=";
+    hash = "sha256-QW+od2owqkErtz8fZc+LFVtsVAdMZFtUnR+9eaAXPK4=";
   };
 
   build-system = [
@@ -74,6 +77,11 @@ buildPythonPackage (finalAttrs: {
     let
       dask-dataframe = [ dask ] ++ dask.optional-dependencies.dataframe;
       extras = {
+        cli = [
+          typer
+          rich
+          pyyaml
+        ];
         strategies = [ hypothesis ];
         hypotheses = [ scipy ];
         io = [
@@ -112,6 +120,10 @@ buildPythonPackage (finalAttrs: {
           pandas
         ];
         polars = [ polars ];
+        pyarrow = [
+          pyarrow
+          narwhals
+        ];
         xarray = [
           numpy
           xarray
@@ -123,57 +135,42 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     duckdb
     joblib
-    pyarrow
-    pyarrow-hotfix
     pytest-asyncio
     pytestCheckHook
-    rich
+    python-multipart
+    requests
+    uvicorn
   ]
   ++ finalAttrs.passthru.optional-dependencies.all;
 
   disabledTestPaths = [
-    "tests/fastapi/test_app.py" # tries to access network
     "tests/pandas/test_docs_setting_column_widths.py" # tests doc generation, requires sphinx
     "tests/modin" # requires modin, not in nixpkgs
-    "tests/mypy/test_pandas_static_type_checking.py" # some typing failures
-    "tests/pyspark" # requires pyspark, not in nixpkgs
-
-    # KeyError: 'dask'
-    "tests/dask/test_dask.py::test_series_schema"
-    "tests/dask/test_dask_accessor.py::test_dataframe_series_add_schema"
-    # mypy tests
+    "tests/pyspark" # requires pyspark[connect], which the nixpkgs pyspark does not provide
+    # asserts on exact mypy diagnostics against upstream's pinned mypy 1.19
     "tests/mypy/"
-    # Very time-consuming tests
-    "tests/strategies/test_strategies.py"
-    # Narwhals backend issues
+    # narwhals backend is broken upstream: 33 failures across 7 files
     "tests/narwhals/"
-    # Schema issues
+    # passes, but adds ~4 min to the check phase
+    "tests/strategies/test_strategies.py"
+    # BackendNotFoundError: passes alone, but the *_narwhals_register tests
+    # swap the backend registry process-wide and this runs after them
     "tests/strategies/test_no_filter_chain.py"
   ];
 
   disabledTests = [
-    # AssertionError: assert failure_cases.equals(expected_failure_cases)
+    # ibis returns None where pandas returns NaN in the failure cases
     "test_ibis_custom_check"
-
-    # TypeError: __class__ assignment: 'GeoDataFrame' object...
-    "test_schema_model"
-    "test_schema_from_dataframe"
-    "test_schema_no_geometry"
-    # Tests requires pyspark
-    "test_pyspark_pandas_does_not_route_to_pyspark_sql"
-    # Assertion error due to None vs. NaN
+    # ibis schemas still resolve to the ibis backend, not the narwhals one
     "test_ibis_backend_is_narwhals"
-    "test_ibis_custom_check"
+    # requires pyspark
+    "test_pyspark_pandas_does_not_route_to_pyspark_sql"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # OOM error on ofborg:
     "test_engine_geometry_coerce_crs"
     # pandera.errors.SchemaError: Error while coercing 'geometry' to type geometry
     "test_schema_dtype_crs_with_coerce"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.13") [
-    # AssertionError: assert DataType(Sparse[float64, nan]) == DataType(Sparse[float64, nan])
-    "test_legacy_default_pandas_extension_dtype"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
