### PR TITLE
nixos-render-docs: mention documentation.nixos.checkRedirects in redirect error

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/redirects.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/redirects.py
@@ -76,6 +76,13 @@ This can happen when an identifier was added, renamed, or removed.
         $ nix-shell doc
         NixOS:
         $ nix-shell nixos/doc/manual
+
+    NOTE: Building a NixOS configuration rather than working on nixpkgs itself?
+        An out-of-tree module that sets `meta.doc` contributes identifiers that
+        nixos/doc/manual/redirects.json cannot list. Skip this check with the
+        NixOS option:
+
+            documentation.nixos.checkRedirects = false;
 """)
         error_messages.append("NOTE: If your build passes locally and you see this message in CI, you probably need a rebase.")
         return "\n".join(error_messages)


### PR DESCRIPTION
## Description of changes

When the redirect check fails, every remedy the error message offers assumes the
reader is working inside a nixpkgs checkout:

```
    Added new content?
        $ redirects add-content <identifier> <path>
...
    NOTE: Run the right nix-shell to make this command available.
        Nixpkgs:
        $ nix-shell doc
        NixOS:
        $ nix-shell nixos/doc/manual

NOTE: If your build passes locally and you see this message in CI, you probably
need a rebase.
```

But the check is also reachable from an ordinary NixOS configuration: any
out-of-tree module setting `meta.doc` contributes an identifier that
`nixos/doc/manual/redirects.json` cannot list, so `nixos-manual-html` fails and
`nixos-rebuild` stops. This was reported in #412451 and resolved in #412731 by
adding `documentation.nixos.checkRedirects`.

That option is the right escape hatch, but nothing in the error message points
to it, so a user who hits this has no way to get from the failure to the fix.
This adds one note:

```
    NOTE: Building a NixOS configuration rather than working on nixpkgs itself?
        An out-of-tree module that sets `meta.doc` contributes identifiers that
        nixos/doc/manual/redirects.json cannot list. Skip this check with the
        NixOS option:

            documentation.nixos.checkRedirects = false;
```

No behaviour change -- the text of one existing error message only.

## Reproducer

`mymod.md`:

```markdown
# My Fake Thing {#module-services-myfakething}
```

`mymod.nix`:

```nix
{ lib, ... }:
{
  options.services.myFakeThing.enable = lib.mkEnableOption "my fake thing";
  meta.doc = ./mymod.md;
}
```

Adding `mymod.nix` to a configuration and building
`config.system.build.manual.manualHTML` fails with
`module-services-myfakething`. Confirmed on `nixos-26.05` (`a9e6d84`) and
`nixos-unstable` (`2c423e0`).

## Things done

- Built on platform(s): x86_64-linux
- Text-only change to an existing diagnostic; no functional change.
