### PR TITLE
linux_testing: 7.2-rc7 -> 7.3-rc1

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -409,6 +409,9 @@ let
       # HAM radio
       HAMRADIO = whenOlder "7.1" yes;
       AX25 = whenOlder "7.1" module;
+
+      # Gate for the DINGHAI_PF module
+      DINGHAI = whenAtLeast "7.3" yes;
     }
     // lib.optionalAttrs (stdenv.hostPlatform.system == "aarch64-linux") {
       # Not enabled by default, hides modules behind it
@@ -717,6 +720,7 @@ let
 
       NTFS_FS = whenBetween "5.15" "6.9" no;
       NTFS_FS_POSIX_ACL = whenAtLeast "7.1" yes;
+      NTFS_FS_WOF_COMPRESSION = whenAtLeast "7.3" yes;
       NTFS3_LZX_XPRESS = whenAtLeast "5.15" yes;
       NTFS3_FS_POSIX_ACL = whenAtLeast "5.15" yes;
 
@@ -1380,6 +1384,7 @@ let
         BINFMT_SCRIPT = yes;
         # For systemd-binfmt
         BINFMT_MISC = option yes;
+        BINFMT_MISC_BPF = whenAtLeast "7.3" (whenPlatformHasEBPFJit (option yes));
 
         # Required for EDID overriding
         FW_LOADER = yes;
@@ -1395,6 +1400,8 @@ let
         # Allows PCIe devices to report errors with Advanced Error Reporting (AER).
         PCIEAER = yes;
         ACPI_APEI_PCIEAER = yes;
+        # PCIe link training status, e.g. on Cix P1
+        PCIE_CADENCE_DEBUGFS = whenAtLeast "7.3" (option yes);
 
         # Enable all available thermal governors
         THERMAL_GOV_BANG_BANG = yes;

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -1,7 +1,7 @@
 {
     "testing": {
-        "version": "7.2-rc7",
-        "hash": "sha256:1qr0k903z5v5w9zm5xsmmzcgxmxgx9vwz32g6zhs14s4sn5s0dgw",
+        "version": "7.3-rc1",
+        "hash": "sha256:1wwg9m0fg3pibm3fvsf6jc31c4xd5wpisxpr0ycxn2sfizql94ff",
         "lts": false
     },
     "6.1": {


### PR DESCRIPTION
bump linux_testing to 7.3-rc1

- ran `pkgs/os-specific/linux/kernel/update.sh`
- updated common-config for the new 7.3 options

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
