### PR TITLE
cargo-group-imports: init at 0.1.5

### DIFF
--- a/pkgs/by-name/ca/cargo-group-imports/package.nix
+++ b/pkgs/by-name/ca/cargo-group-imports/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchpatch2,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "cargo-group-imports";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "cpg314";
+    repo = "cargo-group-imports";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y4/un5Z0MdnDPfPmWXtDRxXNdIEpGAC4x+2TY//cAVs=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      name = "adjust-tests.patch";
+      url = "https://github.com/cpg314/cargo-group-imports/commit/5816db94f9b36c4157d71f8dfa22392e718a084a.patch?full_index=1";
+      hash = "sha256-gHre9i+k7sIUwNgZqNNstybeabE2+HqAPkom9mkd67Q=";
+    })
+    # https://github.com/cpg314/cargo-group-imports/pull/5
+    (fetchpatch2 {
+      name = "fixup-warning.patch";
+      url = "https://github.com/cpg314/cargo-group-imports/commit/64a90b6b308950062eafcfffa975e70c2d9a6201.patch?full_index=1";
+      hash = "sha256-S4QUmHPm2bDJA1GzCUaAFVJKtR0FO6ZDESiH8Xe+cMg=";
+    })
+  ];
+
+  cargoHash = "sha256-r9/Lhf3vJLC+F6a4alVtdCiodV/uLLMXUjh2xx58kPg=";
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Group imports in Rust workspaces";
+    homepage = "https://github.com/cpg314/cargo-group-imports";
+    changelog = "https://github.com/cpg314/cargo-group-imports/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      baloo
+    ];
+    mainProgram = "cargo-group-imports";
+  };
+})


### PR DESCRIPTION
cargo-group-import is a tool to group rust imports

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
