### PR TITLE
harper-desktop: 2.8.0 -> 2.9.1

### DIFF
--- a/pkgs/by-name/ha/harper-desktop/package.nix
+++ b/pkgs/by-name/ha/harper-desktop/package.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "harper-desktop";
-  version = "2.8.0";
+  version = "2.9.1";
 
   __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchurl {
     url = "https://github.com/Automattic/harper/releases/download/v${finalAttrs.version}/Harper_${finalAttrs.version}_universal.dmg";
-    hash = "sha256-qF9FGsSGzf9lD1jXutFgKTGmgKdgSDXKraFKPA3tvJY=";
+    hash = "sha256-4A5QGuCEC7oBW9TkkbqKKoQ8MjbrlFWFCNxn1o2KFDs=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
Update `harper-desktop` from `2.8.0` to `2.9.1`.

Upstream release: https://github.com/Automattic/harper/releases/tag/v2.9.1

Validation performed by the original update workflow:

- Ran the package's declared update script with `maintainers/scripts/update.nix`.
- Built `harper-desktop` with `nix-build --no-out-link -A harper-desktop` on `aarch64-darwin`.
- Ran the original workflow's `harper-signature` package check. This was not a `passthru.tests` build.

Nixpkgs base: `7a659f969382cb4f9044222f55e5e006f14e6565`.

Automation disclosure: the package update was generated by `tyce-darwin-maintainer-updates` on GitHub Actions. This PR description and commit message were revised with OpenAI Codex (`gpt-5`). The package contents are unchanged by that revision.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
