### PR TITLE
idle_detect: init at 0.9.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28297,6 +28297,14 @@
     githubId = 1552853;
     name = "Vincent Ambo";
   };
+  tb148 = {
+    name = "Tony Brown";
+    github = "tb148";
+    githubId = 28220642;
+    email = "me@tb148.net";
+    matrix = "@me:tb148.net";
+    keys = [ { fingerprint = "19FE 8C36 96B7 60FE 647D  7FF8 4E51 2749 E5D2 792E"; } ];
+  };
   tbaldwin = {
     email = "trent.baldwin@proton.me";
     matrix = "@tbaldwin:matrix.org";

--- a/pkgs/by-name/id/idle_detect/package.nix
+++ b/pkgs/by-name/id/idle_detect/package.nix
@@ -1,0 +1,64 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  coreutils,
+  cmake,
+  pkg-config,
+  ninja,
+  wayland-scanner,
+  dbus,
+  glib,
+  libevdev,
+  libx11,
+  libxscrnsaver,
+  wayland,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "idle_detect";
+  version = "0.9.2.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jamescowens";
+    repo = "idle_detect";
+    tag = finalAttrs.version;
+    hash = "sha256-gY9bLHsLE/1XGxe4WrF3CwMF2VIAenvfJvJmaqYvJxs=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \''${CMAKE_INSTALL_PREFIX}/\''${CMAKE_INSTALL_BINDIR} \''${CMAKE_INSTALL_BINDIR} \
+      --replace-fail /\''${CMAKE_INSTALL_SYSCONFDIR} \''${CMAKE_INSTALL_SYSCONFDIR} \
+      --replace-fail /etc/xdg/autostart \''${CMAKE_INSTALL_SYSCONFDIR}/xdg/autostart
+    substituteInPlace dc_event_detection.service.in \
+      --replace-fail /bin/sleep ${coreutils}/bin/sleep \
+      --replace-fail /etc/event_detect.conf $out/etc/event_detect.conf
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ninja
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    dbus
+    glib
+    libevdev
+    libx11
+    libxscrnsaver
+    wayland
+  ];
+
+  meta = {
+    description = "Compact C++ service for idle detection on a Linux workstation";
+    homepage = "https://github.com/jamescowens/idle_detect";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tb148 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

idle_detect is a compact C++ service for idle detection on a Linux workstation. BOINC recommends using it for idle detection support (see [here](https://github.com/BOINC/boinc/blob/89b2deb2ffca8bc1dd950808cbdc32c097e6ad46/client/hostinfo_unix.cpp#L2474)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
