### PR TITLE
Add zellij-no-web overwrite

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3051,6 +3051,10 @@ with pkgs;
     nvidiaSupport = true;
   };
 
+  zellij-no-web = zellij.override {
+    zellij-unwrapped = zellij-unwrapped.override { withWebServer = false; };
+  };
+
   zellijPlugins = recurseIntoAttrs (callPackage ../by-name/ze/zellij/plugins { });
 
   zstd = callPackage ../tools/compression/zstd {


### PR DESCRIPTION
In #552794 we discussed that we might want to have an attribute `zellij-no-web` which is exposed by nixpkgs, so that users can use that for their normal zellij installation if they do not want to have that web capability compiled into the binary on their system.

With this patch, we expose this variant, which now gets build for nixpkgs and put into the cache.

Users can overwrite their local zellij installation to use this package as `zellij-unwrapped`, to benefit from the precompiled package in the nixpkgs cache (pseudocode, untested):

    zellij.override { zellij-unwrapped = pkgs.zellij-no-web; }

or something like that.
