### PR TITLE
firelink: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1456,6 +1456,12 @@
     githubId = 30437811;
     name = "Alex Andrews";
   };
+  aliheidary1381 = {
+    email = "aliheidary1381@gmail.com";
+    github = "aliheidary1381";
+    githubId = 31212739;
+    name = "Ali Heydari";
+  };
   alikaansun = {
     github = "alikaansun";
     githubId = 77810345;

--- a/pkgs/by-name/fi/firelink/package.nix
+++ b/pkgs/by-name/fi/firelink/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  cargo-tauri,
+  nodejs_22,
+  npmHooks,
+  pkg-config,
+  wrapGAppsHook3,
+  glib-networking,
+  openssl,
+  webkitgtk_4_1,
+  gtk3,
+  libsoup_3,
+  libayatana-appindicator,
+
+  aria2,
+  deno,
+  ffmpeg,
+  yt-dlp,
+}:
+let
+  targetTriple = stdenv.hostPlatform.rust.rustcTarget;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "firelink";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "nimbold";
+    repo = "Firelink";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tXNaQ2AxuvONCBKz5IgJicGShui/1TgMyZoLi3g2AOA=";
+  };
+
+  cargoHash = "sha256-OkgYW83o4hxZs6JPPcczQ1O+pT6YcEEsWof95aN0Rv0=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-9/3M/d/XOwnKjA2J7vy/C7iVlbFAIbC1y7jZ6/RDduE=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs_22
+    npmHooks.npmConfigHook
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+    gtk3
+    libsoup_3
+    libayatana-appindicator
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  tauriBuildFlags = [
+    "--config"
+    (builtins.toJSON {
+      build.beforeBuildCommand = "";
+    })
+  ];
+
+  preBuild = ''
+    export VITE_BUILD_ID="nixpkgs-firelink-${finalAttrs.version}"
+    npm run build
+
+    mkdir -p "src-tauri/engine-dist/${targetTriple}"
+    ln -s "${aria2}/bin/aria2c" "src-tauri/engine-dist/${targetTriple}/aria2c-${targetTriple}"
+    ln -s "${deno}/bin/deno" "src-tauri/engine-dist/${targetTriple}/deno-${targetTriple}"
+    ln -s "${ffmpeg}/bin/ffmpeg" "src-tauri/engine-dist/${targetTriple}/ffmpeg-${targetTriple}"
+    ln -s "${yt-dlp}/bin/yt-dlp" "src-tauri/engine-dist/${targetTriple}/yt-dlp-${targetTriple}"
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libayatana-appindicator ]}
+    )
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "A fast cross-platform desktop download manager powered by Rust and Tauri";
+    homepage = "https://github.com/nimbold/Firelink";
+    license = lib.licenses.mit;
+    mainProgram = "firelink";
+    maintainers = [ lib.maintainers.aliheidary1381 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Firelink](https://github.com/nimbold/Firelink) is a download manager.

Firelink tries to bundle (copy) its runtime deps (aria2, etc.) into its package. I skipped that, and instead symlinked them into the package instead. This breaks the tests, but this is the Nix way.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
