### PR TITLE
envoy-bin: 1.37.4 -> 1.37.6

### DIFF
--- a/pkgs/by-name/en/envoy-bin/package.nix
+++ b/pkgs/by-name/en/envoy-bin/package.nix
@@ -7,7 +7,7 @@
   versionCheckHook,
 }:
 let
-  version = "1.37.4";
+  version = "1.37.6";
   inherit (stdenvNoCC.hostPlatform) system;
   throwSystem = throw "envoy-bin is not available for ${system}.";
 
@@ -20,8 +20,8 @@ let
 
   hash =
     {
-      aarch64-linux = "sha256-y5WLtcHpEkYoPHOcCPDpE+d5nJd5Hn26G6znsd6ljuA=";
-      x86_64-linux = "sha256-i8e/dn5revJhxLboUYk1bzC8fmx4ERnp2RHfHXRfgKg=";
+      aarch64-linux = "sha256-dX/hh6gIPwNF6x7q5pS3+09b54sAVCxCy4SfWhaMSBg=";
+      x86_64-linux = "sha256-gQWRigH5aMbPx9EIk4xQgEYuKRMyrxeB0NEUtqBk+U8=";
     }
     .${system} or throwSystem;
 in


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/releases
https://github.com/envoyproxy/envoy/releases/tag/v1.37.6 
https://github.com/envoyproxy/envoy/releases/tag/v1.37.5
Fixes: CVE-2026-73511
Fixes: CVE-2026-73512
Fixes: CVE-2026-73513
Fixes: CVE-2026-73546
Fixes: CVE-2026-73547
Fixes: CVE-2026-73548
Fixes: CVE-2026-73549
Fixes: CVE-2026-73550
Fixes: CVE-2026-73551
Fixes: CVE-2026-73552
Fixes: CVE-2026-73553
Fixes: CVE-2026-73572
Fixes: CVE-2026-73521
Fixes: CVE-2026-47205
Fixes: CVE-2026-47207
Fixes: CVE-2026-47221
Fixes: CVE-2026-47220
Fixes: CVE-2026-47775
Fixes: CVE-2026-48044
Fixes: CVE-2026-47204
Fixes: CVE-2026-47692
Fixes: CVE-2026-47778
Fixes: CVE-2026-48042
Fixes: CVE-2026-48090
Fixes: CVE-2026-48497
Fixes: CVE-2026-48743
Fixes: CVE-2026-48706
Fixes: GHSA-p7c7-7c47-pwch

Not-cherry-picked-because: security fix, not a backport


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
