### PR TITLE
scs: 3.2.11 -> 3.3.0

### DIFF
--- a/pkgs/by-name/sc/scs/package.nix
+++ b/pkgs/by-name/sc/scs/package.nix
@@ -14,23 +14,21 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scs";
-  version = "3.2.11";
+  version = "3.3.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "cvxgrp";
     repo = "scs";
     tag = finalAttrs.version;
-    hash = "sha256-hF5BxCLscyUmNXIVFIAAjY0GDbcH7WjODC4116aQfIs=";
+    hash = "sha256-5Mq/mi2pW9DHXjhUEjflBeZMjJN+aJZRenVlRlloBcw=";
   };
 
-  # Actually link and add libgfortran to the rpath
-  postPatch = ''
-    substituteInPlace scs.mk \
-      --replace-fail "# -lgfortran" "-lgfortran" \
-      --replace-fail "gcc" "cc"
-  '';
-
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ];
 
   buildInputs = [
     blas

--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -99,6 +99,16 @@ buildPythonPackage (finalAttrs: {
     "test_oprelcone_1_m1_k3_complex"
     "test_oprelcone_1_m3_k1_complex"
     "test_oprelcone_2"
+
+    # `use_indirect` was dropped from the SCS python bindings in 3.3.0:
+    # https://github.com/bodono/scs-python/pull/189
+    "test_scs_options"
+
+    # Numerical assertions failing with scs 3.3.0.
+    "test_dist_ratio"
+    "test_sdp_problem"
+    "test_variable_name_conflict"
+    "test_vector2norm"
   ];
 
   pythonImportsCheck = [ "cvxpy" ];

--- a/pkgs/development/python-modules/pepit/default.nix
+++ b/pkgs/development/python-modules/pepit/default.nix
@@ -2,30 +2,37 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
+
+  # dependencies
   cvxpy,
   numpy,
   pandas,
   scipy,
   matplotlib,
+
+  # tests
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pepit";
   version = "0.5.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "PerformanceEstimation";
     repo = "PEPit";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-PCWYfJ1h4P0X4KLNdIivLrPVAR7205K1Ii5ROuGHULo=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace-fail "{{VERSION_PLACEHOLDER}}" "${version}"
+      --replace-fail "{{VERSION_PLACEHOLDER}}" "${finalAttrs.version}"
   '';
 
   build-system = [
@@ -44,15 +51,20 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
-    "PEPit"
+  # Fail since scs 3.3.0, which returns `optimal_inaccurate` where it used to return `optimal`.
+  disabledTests = [
+    "test_cyclic_coordinate_descent"
+    "test_gradient_descent_lc"
+    "test_inexact_gradient"
   ];
+
+  pythonImportsCheck = [ "PEPit" ];
 
   meta = {
     description = "Performance Estimation in Python";
-    changelog = "https://pepit.readthedocs.io/en/latest/whatsnew/${version}.html";
+    changelog = "https://pepit.readthedocs.io/en/latest/whatsnew/${finalAttrs.version}.html";
     homepage = "https://pepit.readthedocs.io/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ wegank ];
   };
-}
+})

--- a/pkgs/development/python-modules/qpsolvers/default.nix
+++ b/pkgs/development/python-modules/qpsolvers/default.nix
@@ -2,12 +2,15 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  unittestCheckHook,
+
+  # build-system
   flit-core,
+
+  # dependencies
   numpy,
   scipy,
 
-  # optional dependencies
+  # optional-dependencies
   clarabel,
   cvxopt,
   daqp,
@@ -20,29 +23,31 @@
   highspy,
   piqp,
   proxsuite,
+
+  # tests
+  pytestCheckHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "qpsolvers";
   version = "4.13.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "qpsolvers";
     repo = "qpsolvers";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-JgrfHyZ5bhD5XBuxZsASnmFU080XZs0EjdOOj5Lr1Hg=";
   };
 
   build-system = [ flit-core ];
-
-  pythonImportsCheck = [ "qpsolvers" ];
 
   dependencies = [
     numpy
     scipy
   ];
 
-  optional-dependencies = {
+  optional-dependencies = lib.fix (self: {
     # FIXME commented out solvers have not been packaged yet
     clarabel = [ clarabel ];
     cvxopt = [ cvxopt ];
@@ -59,7 +64,7 @@ buildPythonPackage rec {
     quadprog = [ quadprog ];
     scs = [ scs ];
     open_source_solvers =
-      with optional-dependencies;
+      with self;
       lib.flatten [
         clarabel
         cvxopt
@@ -73,15 +78,32 @@ buildPythonPackage rec {
         quadprog
         scs
       ];
-  };
+  });
 
-  nativeCheckInputs = [ unittestCheckHook ] ++ optional-dependencies.open_source_solvers;
+  pythonImportsCheck = [ "qpsolvers" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.open_source_solvers;
+
+  enabledTestPaths = [ "tests/" ];
+
+  pytestFlags = [
+    # Marginally exceed the hard-coded tolerances with scs 3.3.0.
+    # `disabledTests` cannot be used: `test_scs` is a substring of other, passing test IDs
+    "--deselect=tests/test_solve_ls.py::TestSolveLS::test_scs"
+    "--deselect=tests/test_solve_qp.py::TestSolveQP::test_bounds_scs"
+    "--deselect=tests/test_solve_qp.py::TestSolveQP::test_scs"
+    "--deselect=tests/test_solve_qp.py::TestSolveQP::test_sparse_bounds_scs"
+    "--deselect=tests/test_solve_qp.py::TestSolveQP::test_warmstart_scs"
+  ];
 
   meta = {
-    changelog = "https://github.com/qpsolvers/qpsolvers/blob/${src.tag}/CHANGELOG.md";
     description = "Quadratic programming solvers in Python with a unified API";
+    changelog = "https://github.com/qpsolvers/qpsolvers/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     homepage = "https://github.com/qpsolvers/qpsolvers";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ renesat ];
   };
-}
+})

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -28,14 +28,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "qutip";
-  version = "5.2.3.post1";
+  version = "5.3.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "qutip";
     repo = "qutip";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9OcRV3BmRdDOCmov2cK3eoFutQI3Bf6w2QRPpFTZKCU=";
+    hash = "sha256-MegIeAI1euGRV0MymhDp6/ncyvFHoIz0td68hZzhNGs=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/scs/default.nix
+++ b/pkgs/development/python-modules/scs/default.nix
@@ -24,13 +24,14 @@ buildPythonPackage (finalAttrs: {
   pname = "scs";
   inherit (pkgs.scs) version;
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "bodono";
     repo = "scs-python";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-ZB1A6613ZgwGsZ97MpK9c1vUfNe+0RkUULtzQxGKd88=";
+    hash = "sha256-k6G336VZPnbYU1GfZrS+f0vEshMKhSJMWcH2dgD0CaY=";
   };
 
   postPatch = ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **scs: 3.2.11 -> 3.3.0** ([Diff](https://github.com/cvxgrp/scs/compare/3.2.11...3.3.0), [Changelog](https://github.com/cvxgrp/scs/releases/tag/3.3.0))
- **python3Packages.qpsolvers: cleanup, skip failing tests**
- **python3Packages.cvxpy: fix build**
- **python3Packages.qutip: 5.2.3.post1 -> 5.3.1** ([Diff](https://github.com/qutip/qutip/compare/v5.2.3.post1...v5.3.1), [Changelog](https://github.com/qutip/qutip/releases/tag/v5.3.1))
- **python3Packages.pepit: cleanup, skip failing tests**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
