### PR TITLE
unisic: init at 0.8.4

### DIFF
--- a/pkgs/by-name/un/unisic/package.nix
+++ b/pkgs/by-name/un/unisic/package.nix
@@ -1,0 +1,117 @@
+{
+  cmake,
+  curl,
+  fetchFromGitHub,
+  ffmpeg,
+  grim,
+  kdePackages,
+  leptonica,
+  lib,
+  libarchive,
+  libinput,
+  libx11,
+  libxcb,
+  libxext,
+  libxfixes,
+  ninja,
+  pipewire,
+  pkg-config,
+  qt6,
+  stdenv,
+  tesseract,
+  udev,
+  wayland,
+  wayland-scanner,
+  wl-clipboard,
+  zxing-cpp,
+  zip,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "unisic";
+  version = "0.8.4";
+
+  src = fetchFromGitHub {
+    owner = "unisic";
+    repo = "unisic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3hPiXO607oF5rYNzt1R6XEP7AswhzxjtJ6+VsOvtSfk=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.qttools
+    qt6.wrapQtAppsHook
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    curl
+    kdePackages.kguiaddons
+    kdePackages.layer-shell-qt
+    kdePackages.plasma-wayland-protocols
+    leptonica
+    libarchive
+    libinput
+    libx11
+    libxcb
+    libxext
+    libxfixes
+    pipewire
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtmultimedia
+    qt6.qtsvg
+    qt6.qtwayland
+    tesseract
+    udev
+    wayland
+    zxing-cpp
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+    (lib.cmakeBool "UNISIC_DEV_BUILD" false)
+    (lib.cmakeBool "BUILD_TESTING" true)
+  ];
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        curl
+        ffmpeg
+        grim
+        pipewire
+        wl-clipboard
+        zip
+      ]
+    }"
+    "--set-default TESSDATA_PREFIX ${tesseract}/share/tessdata"
+  ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    export HOME=$(mktemp -d)
+    export XDG_RUNTIME_DIR=$(mktemp -d)
+    QT_QPA_PLATFORM=offscreen ctest --output-on-failure
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Screen capture, annotation, recording, and sharing tool";
+    homepage = "https://unisic.app/";
+    changelog = "https://github.com/unisic/unisic/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "unisic";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This adds unisic (https://unisic.app/). A screen capture, recorder and annotation tool, built for Wayland.

The application has its own `flake.nix`, but it is not as convenient as having it be part of nixpkgs in terms of following nixpkgs in lock-step.

I wanted to add package tests for this, but unisic 0.8.4 doesn't have cli options `--version`. It has been added on main (https://github.com/unisic/unisic/pull/110), but has not been released yet. In the next release it would make sense to add a version package test.

I tried to adhere to https://github.com/unisic/unisic/blob/main/docs/dev/packaging.md and have the package definition be aligned with https://github.com/unisic/unisic/blob/main/nix/package.nix.

I've explicitly opted to use `tesseract` without overrides, so that all languages are used instead of the ones from the upstream package definition:

```
      "eng"
      "pol"
      "osd"
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
