### PR TITLE
doc/configuration: replace removed package from example

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -265,7 +265,7 @@ source: ../config-options.json
 
 ### Build an environment {#sec-building-environment}
 
-Using `packageOverrides`, it is possible to manage packages declaratively. This means that we can list all of our desired packages within a declarative Nix expression. For example, to have `aspell`, `bc`, `ffmpeg`, `coreutils`, `gdb`, `nix`, `emscripten`, `jq`, `nox`, and `silver-searcher`, we could use the following in `~/.config/nixpkgs/config.nix`:
+Using `packageOverrides`, it is possible to manage packages declaratively. This means that we can list all of our desired packages within a declarative Nix expression. For example, to have `aspell`, `bc`, `ffmpeg`, `coreutils`, `gdb`, `nix`, `emscripten`, `jq`, `nox`, and `ugrep`, we could use the following in `~/.config/nixpkgs/config.nix`:
 
 ```nix
 {
@@ -283,7 +283,7 @@ Using `packageOverrides`, it is possible to manage packages declaratively. This 
           emscripten
           jq
           nox
-          silver-searcher
+          ugrep
         ];
       };
     };
@@ -308,7 +308,7 @@ To install it into our environment, you can just run `nix-env -iA nixpkgs.myPack
           emscripten
           jq
           nox
-          silver-searcher
+          ugrep
         ];
         pathsToLink = [
           "/share"
@@ -340,7 +340,7 @@ After building that new environment, look through `~/.nix-profile` to make sure 
           emscripten
           jq
           nox
-          silver-searcher
+          ugrep
         ];
         pathsToLink = [
           "/share/man"
@@ -381,7 +381,7 @@ This provides us with some useful documentation for using our packages.  However
         emscripten
         jq
         nox
-        silver-searcher
+        ugrep
       ];
       pathsToLink = [
         "/share/man"
@@ -441,7 +441,7 @@ Configuring GNU info is a little bit trickier than man pages. To work correctly,
         emscripten
         jq
         nox
-        silver-searcher
+        ugrep
         texinfoInteractive
       ];
       pathsToLink = [


### PR DESCRIPTION
The package silver-searcher mentioned in the documentation was removed from nixpgks, which means following the instructions would result in errors confusing the prospective users. Replaced it with a similar programme.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
