### PR TITLE
Draupnir: include missed file, fix tests flow

### DIFF
--- a/nixos/tests/matrix/draupnir.nix
+++ b/nixos/tests/matrix/draupnir.nix
@@ -78,6 +78,7 @@
 
                   async def member_callback(room: MatrixRoom, event: RoomMemberEvent) -> None:
                       if event.membership == "join" and event.sender == "@draupnir:homeserver":
+                          print("Got draupnir join event, sending '!draupnir status'")
                           await client.room_send(
                               room_id=room.room_id,
                               message_type="m.room.message",
@@ -89,7 +90,7 @@
 
                   async def message_callback(room: MatrixRoom, event: RoomMessageNotice) -> None:
                       print(f"{event.sender}: {event.body}")
-                      if event.sender == "@draupnir:homeserver":
+                      if event.sender == "@draupnir:homeserver" and "Repository: " in event.source["content"]["body"] and "Version: " in event.source["content"]["body"]:
                           await client.close()
                           exit(0)
 
@@ -135,9 +136,9 @@
       homeserver.succeed("matrix-synapse-register_new_matrix_user -u moderator -p password --no-admin")
 
       # get draupnir access token
-      payload = json.dumps({ "type": "m.login.password", "user": "draupnir", "password": "password" })
+      draupnir_login_payload = json.dumps({ "type": "m.login.password", "user": "draupnir", "password": "password" })
       homeserver.succeed(
-          f"curl --fail --json '{payload}' http://localhost:8008/_matrix/client/v3/login"
+          f"curl --fail --json '{draupnir_login_payload}' http://localhost:8008/_matrix/client/v3/login"
           + " | jq -r .access_token"
           + " | tee /tmp/draupnir-access-token"
        )

--- a/nixos/tests/matrix/draupnir.nix
+++ b/nixos/tests/matrix/draupnir.nix
@@ -70,6 +70,7 @@
             }
             ''
               import asyncio
+              import time
               from nio import AsyncClient, MatrixRoom, RoomMemberEvent, RoomMessageNotice
 
 
@@ -78,7 +79,13 @@
 
                   async def member_callback(room: MatrixRoom, event: RoomMemberEvent) -> None:
                       if event.membership == "join" and event.sender == "@draupnir:homeserver":
-                          print("Got draupnir join event, sending '!draupnir status'")
+                          print("Got draupnir join event!")
+
+                  async def message_callback(room: MatrixRoom, event: RoomMessageNotice) -> None:
+                      print(f"{event.sender}:\n{event.body}" if "\n" in event.body else f"{event.sender}: {event.body}")
+
+                      if event.sender == "@draupnir:homeserver" and "Startup complete." in event.body:
+                          print("Draupnir reported ready, sending '!draupnir status'")
                           await client.room_send(
                               room_id=room.room_id,
                               message_type="m.room.message",
@@ -88,9 +95,53 @@
                               }
                           )
 
-                  async def message_callback(room: MatrixRoom, event: RoomMessageNotice) -> None:
-                      print(f"{event.sender}: {event.body}")
-                      if event.sender == "@draupnir:homeserver" and "Repository: " in event.source["content"]["body"] and "Version: " in event.source["content"]["body"]:
+                      if event.sender == "@draupnir:homeserver" and "Repository: " in event.body and "Version: " in event.body:
+                          print("Got status reply, creating policy list")
+                          await client.room_send(
+                              room_id=room.room_id,
+                              message_type="m.room.message",
+                              content={
+                                  "msgtype": "m.text",
+                                  "body": "!draupnir list create test test"
+                              }
+                          )
+
+                          time.sleep(3)
+                          print("Surely it's done by now (couldnt find a good way to trigger the next step), protecting a room")
+
+                          await client.room_send(
+                              room_id=room.room_id,
+                              message_type="m.room.message",
+                              content={
+                                  "msgtype": "m.text",
+                                  "body": "!draupnir rooms add #protected:homeserver"
+                              }
+                          )
+                          time.sleep(3)
+                          print("Surely it's done by now (there's no text reply), sending a ban command")
+
+                          await client.room_send(
+                              room_id=room.room_id,
+                              message_type="m.room.message",
+                              content={
+                                  "msgtype": "m.text",
+                                  "body": "!draupnir ban @bad:homeserver test spam"
+                              }
+                          )
+                          time.sleep(3)
+                          print("Surely it's done by now (there's no text reply), sending a server ban command")
+
+                          await client.room_send(
+                              room_id=room.room_id,
+                              message_type="m.room.message",
+                              content={
+                                  "msgtype": "m.text",
+                                  "body": "!draupnir ban meow test spam"
+                              }
+                          )
+                          time.sleep(3)
+                          print("Surely it's done by now (there's no text reply), assuming all is good")
+
                           await client.close()
                           exit(0)
 
@@ -111,6 +162,19 @@
                       }
                   )
                   print(room)
+
+                  protectedRoom = await client.room_create(
+                      name="Protected",
+                      alias="protected",
+                      invite=["@draupnir:homeserver"],
+                      power_level_override={
+                          "users": {
+                              "@draupnir:homeserver": 100,
+                              "@moderator:homeserver": 100,
+                          }
+                      }
+                  )
+                  print(protectedRoom)
 
                   print(await client.join(room.room_id))
 

--- a/pkgs/by-name/dr/draupnir/package.nix
+++ b/pkgs/by-name/dr/draupnir/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   makeBinaryWrapper,
-  nodejs_24,
+  nodejs_26,
   matrix-sdk-crypto-nodejs,
   python3,
   sqlite,
@@ -16,7 +16,7 @@
   fetchpatch2,
 }:
 let
-  nodeSources = srcOnly nodejs_24;
+  nodeSources = srcOnly nodejs_26;
 in
 
 buildNpmPackage (finalAttrs: {
@@ -81,7 +81,7 @@ buildNpmPackage (finalAttrs: {
     rm $out/lib/node_modules/draupnir/node_modules/draupnir
 
     # Create wrapper executable
-    makeWrapper ${lib.getExe nodejs_24} $out/bin/draupnir \
+    makeWrapper ${lib.getExe nodejs_26} $out/bin/draupnir \
       --add-flags "--enable-source-maps" \
       --add-flags "$out/lib/node_modules/draupnir/dist/index.js"
 

--- a/pkgs/by-name/dr/draupnir/package.nix
+++ b/pkgs/by-name/dr/draupnir/package.nix
@@ -76,7 +76,7 @@ buildNpmPackage (finalAttrs: {
     mkdir -p $out/lib/node_modules/draupnir
     mkdir $out/bin
     # Install outputs
-    mv ./node_modules ./packages ./apps/draupnir/dist ./apps/draupnir/version.txt ./apps/draupnir/package.json $out/lib/node_modules/draupnir
+    mv ./node_modules ./packages ./apps/draupnir/dist ./apps/draupnir/version.txt ./apps/draupnir/branch.txt ./apps/draupnir/package.json $out/lib/node_modules/draupnir
     # Fix dangling symlink pointing to relative path ../apps/draupnir
     rm $out/lib/node_modules/draupnir/node_modules/draupnir
 


### PR DESCRIPTION
Fixed the packaging to include the branch.txt that we're generating, as it seems to have been forgotten.
Also fixed the nixos test script to check for the message content directly, rather than exiting on "Startup complete. Now monitoring rooms." before `!draupnir status` is processed.

Also includes a bump to node26 as it appears to run, given that 22 was too far gone as far as upstream was concerned.

This effort is part of figuring out what's going on with #557949 as I'm not able to reproduce it so far.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
