### PR TITLE
replibyte: fix `aarch64-darwin` build

### DIFF
--- a/pkgs/by-name/re/replibyte/package.nix
+++ b/pkgs/by-name/re/replibyte/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
@@ -29,7 +30,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Fix undefined reference to `__rust_probestack` from wasmer_vm.
   # Define it as a no-op since it's only needed for stack overflow detection.
-  env.RUSTFLAGS = "-C link-arg=-Wl,--defsym,__rust_probestack=0";
+  env.RUSTFLAGS =
+    let
+      linkArgs = [
+        "-Wl"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        "--defsym"
+        "__rust_probestack=0"
+      ];
+    in
+    "-C link-arg=${builtins.concatStringsSep "," linkArgs}";
 
   cargoBuildFlags = [ "--all-features" ];
 


### PR DESCRIPTION
* both `--defsym` and `__rust_probestack=0` are unknown/invalid options during link on darwin systems using clang

Resolves: #558280


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
