### PR TITLE
python3Packages.skops: skip failing test

### DIFF
--- a/pkgs/development/python-modules/skops/default.nix
+++ b/pkgs/development/python-modules/skops/default.nix
@@ -64,13 +64,15 @@ buildPythonPackage (finalAttrs: {
   # Override the overly strict pyproject.toml:tool.pytest.ini_options.filterwarnings
   # https://github.com/skops-dev/skops/issues/523
   pytestFlags = [
-    "-W"
-    "ignore::FutureWarning"
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::FutureWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [
+    # AssertionError
+    # assert result.count("sk-top-container") == 1
+    "test_no_overflow"
+
     # fairlearn is not available in nixpkgs
     "TestAddFairlearnMetricFrame"
   ]


### PR DESCRIPTION
## Things done

```
______________________ TestAddModelPlot.test_no_overflow _______________________

self = <test_card.TestAddModelPlot object at 0x7fffcab3e710>
model_card = Card(
  model=MyRegressor(),
  Model description/Training Procedure/Hyperparameters=TableSection(3x2),
  Model description/Training Procedure/Model Plot=<style>.sk-gl...script></body>,
)

    def test_no_overflow(self, model_card):
        result = model_card.select(
            "Model description/Training Procedure/Model Plot"
        ).format()
        # test if the model doesn't overflow the huggingface models page
>       assert result.count("sk-top-container") == 1
E       assert 2 == 1
E        +  where 2 = <built-in method count of str object at 0x5555595256d0>('sk-top-container')
E        +    where <built-in method count of str object at 0x5555595256d0> = "<style>.sk-global {/* Definition of color scheme common for light and dark mode */--sklearn-color-text: #000;--sklear...tectTheme(estimatorElement);estimatorElement.classList.add(theme);}\n}forceTheme('sk-container-id-7');</script></body>".count

skops/card/tests/test_card.py:243: AssertionError
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
