### PR TITLE
llama-cpp: simplify derivation and update script, 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -45,7 +45,10 @@
 }:
 
 let
+  # Upstream reads these from git, which the release tarball does not ship.
+  # They are purely informational: `llama-server --version`, `/props`, and the web UI.
   buildNumber = "10566";
+  buildCommit = "bb4caa7";
 
   # It's necessary to consistently use backendStdenv when building with CUDA support,
   # otherwise we get libstdc++ errors downstream.
@@ -95,12 +98,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     owner = "ggml-org";
     repo = "llama.cpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6cK5BMCCEUWL+590+WbrRInH3eEnsZ/S5m71IIBgDsA=";
-    leaveDotGit = true;
-    postFetch = ''
-      git -C "$out" rev-parse --short HEAD > $out/COMMIT
-      find "$out" -name .git -print0 | xargs -0 rm -rf
-    '';
+    hash = "sha256-46b+5YWwF5k1vBBzsjSCrn6k8dkPuBYy2bqWhgFqCbQ=";
   };
 
   patches = [ ];
@@ -142,7 +140,6 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   };
 
   preConfigure = ''
-    prependToVar cmakeFlags "-DLLAMA_BUILD_COMMIT:STRING=$(cat COMMIT)"
     pushd ${finalAttrs.npmRoot}
     LLAMA_BUILD_NUMBER=${buildNumber} npm run build
     popd
@@ -164,6 +161,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "GGML_RPC" rpcSupport)
     (cmakeBool "GGML_VULKAN" vulkanSupport)
     (cmakeFeature "LLAMA_BUILD_NUMBER" buildNumber)
+    (cmakeFeature "LLAMA_BUILD_COMMIT" buildCommit)
   ]
   ++ optionals cpuArchDynamicDispatch [
     # Build all CPU backend variants for runtime dynamic dispatch.

--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -47,8 +47,8 @@
 let
   # Upstream reads these from git, which the release tarball does not ship.
   # They are purely informational: `llama-server --version`, `/props`, and the web UI.
-  buildNumber = "10566";
-  buildCommit = "bb4caa7";
+  buildNumber = "10621";
+  buildCommit = "c1d0e7a";
 
   # It's necessary to consistently use backendStdenv when building with CUDA support,
   # otherwise we get libstdc++ errors downstream.
@@ -84,7 +84,7 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp";
-  version = "0.2.0";
+  version = "0.3.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -98,7 +98,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     owner = "ggml-org";
     repo = "llama.cpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-46b+5YWwF5k1vBBzsjSCrn6k8dkPuBYy2bqWhgFqCbQ=";
+    hash = "sha256-vVq7+eUN6NXZuqm7Jwlr4iFDV1PjNzQ6nK9AR2zvZYM=";
   };
 
   patches = [ ];

--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -55,6 +55,7 @@ let
     cmakeBool
     cmakeFeature
     optionals
+    optionalString
     ;
 
   cudaBuildInputs = with cudaPackages; [
@@ -188,14 +189,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "LLAMA_METAL_EMBED_LIBRARY" true)
   ];
 
-  # upstream plans on adding targets at the cmakelevel, remove those
-  # additional steps after that
-  postInstall = ''
-    mkdir -p $out/include
-    cp $src/include/llama.h $out/include/
-
-  ''
-  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd llama-server --bash <($out/bin/llama-server --completion-bash)
   '';
 

--- a/pkgs/by-name/ll/llama-cpp/update.sh
+++ b/pkgs/by-name/ll/llama-cpp/update.sh
@@ -28,10 +28,12 @@ version="$(github "$api/releases/latest" | jq -er '.tag_name | ltrimstr("v") | s
   exit 1
 }
 
-# llama.cpp reads the build number from git, which the release tarball does not ship.
+# llama.cpp reads the build number and commit from git, which the release tarball does not ship.
 # Every release carries the matching nightly tag as an asset.
 build_number="$(github "https://github.com/$repo/releases/download/v$version/nightly-tag.txt")"
+build_commit="$(github -H "Accept: application/vnd.github.sha" "$api/commits/v$version")"
 
 cd "$(git rev-parse --show-toplevel)"
 nix-update "${UPDATE_NIX_ATTR_PATH:-llama-cpp}" --version "$version"
 set_attr buildNumber "${build_number#b}"
+set_attr buildCommit "${build_commit:0:7}"

--- a/pkgs/by-name/ll/llama-cpp/update.sh
+++ b/pkgs/by-name/ll/llama-cpp/update.sh
@@ -1,52 +1,37 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p coreutils gitMinimal gnused nix-update
+#!nix-shell -i bash -p curl gitMinimal gnused jq nix-update
 # shellcheck shell=bash
 
 set -euo pipefail
 
-repo_url="https://github.com/ggml-org/llama.cpp.git"
+repo="ggml-org/llama.cpp"
+api="https://api.github.com/repos/$repo"
+package="pkgs/by-name/ll/llama-cpp/package.nix"
 
-version="$({
-  git ls-remote --refs --tags "$repo_url" 'refs/tags/v*' \
-    | sed -nE 's|^[^[:space:]]+[[:space:]]+refs/tags/v([0-9]+\.[0-9]+\.[0-9]+)$|\1|p' \
-    | sort -V \
-    | tail -n1
-})"
+github() {
+  # shellcheck disable=SC2086
+  curl -sSfL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$@"
+}
 
-if [[ -z "$version" ]]; then
-  echo "Failed to find the latest semantic version tag" >&2
+set_attr() {
+  sed -i -E "s|($1 = \")[^\"]*|\1$2|" "$package"
+  grep -q "$1 = \"$2\";" "$package" || {
+    echo "failed to set $1 in $package" >&2
+    exit 1
+  }
+}
+
+# The bNNNNN nightly releases are pre-releases, so the latest release is the newest semantic version.
+# Upstream only started flagging them as such at the v0.2.0 cutover, hence the shape check.
+version="$(github "$api/releases/latest" | jq -er '.tag_name | ltrimstr("v") | select(test("^[0-9]+(\\.[0-9]+)+$"))')" || {
+  echo "latest release is not a semantic version" >&2
   exit 1
-fi
+}
 
-tag_refs="$(
-  git ls-remote --tags "$repo_url" \
-    "refs/tags/v$version" "refs/tags/v$version^{}" 'refs/tags/b*'
-)"
-release_commit="$(
-  awk -v ref="refs/tags/v$version^{}" '$2 == ref { print $1 }' <<<"$tag_refs"
-)"
-if [[ -z "$release_commit" ]]; then
-  release_commit="$(
-    awk -v ref="refs/tags/v$version" '$2 == ref { print $1 }' <<<"$tag_refs"
-  )"
-fi
-build_number="$({
-  awk -v commit="$release_commit" '
-    $1 == commit && $2 ~ /^refs\/tags\/b[0-9]+(\^\{\})?$/ {
-      sub(/^refs\/tags\/b/, "", $2)
-      sub(/\^\{\}$/, "", $2)
-      print $2
-    }
-  ' <<<"$tag_refs" | sort -n | tail -n1
-})"
-
-if [[ -z "$release_commit" || -z "$build_number" ]]; then
-  echo "Failed to find the build number for v$version" >&2
-  exit 1
-fi
+# llama.cpp reads the build number from git, which the release tarball does not ship.
+# Every release carries the matching nightly tag as an asset.
+build_number="$(github "https://github.com/$repo/releases/download/v$version/nightly-tag.txt")"
 
 cd "$(git rev-parse --show-toplevel)"
 nix-update "${UPDATE_NIX_ATTR_PATH:-llama-cpp}" --version "$version"
-sed -i -E \
-  's|(buildNumber = ")[0-9]+(";)|\1'"$build_number"'\2|' \
-  pkgs/by-name/ll/llama-cpp/package.nix
+set_attr buildNumber "${build_number#b}"


### PR DESCRIPTION
- Fetch release tarball instead of entire git repo. The commit is now pinned next to buildNumber and updated via the script instead of being derived from git. That leads to smaller downloads and removes the need for the prependToVar step.
- Simplify the update script by directly downloading the latest release together with the auto-published nightly tag file.
- Drop the manual headers copy as the mentioned todo has been added to upstream.
- Bump to 0.3.0: https://github.com/ggml-org/llama.cpp/releases/tag/v0.3.0

The code changes (not this description) have been produced with assistance from Claude Code with Opus 5 as indicated by the `Assisted-by` trailers. I created self-contained commits, so maybe it's best to review them sequentially. nixpkgs-review is taking some time, I'll comment here once it's finished.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
