### PR TITLE
credwolf: init at 1.2.1

### DIFF
--- a/pkgs/by-name/cr/credwolf/package.nix
+++ b/pkgs/by-name/cr/credwolf/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "credwolf";
+  version = "1.2.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "StrongWind1";
+    repo = "CredWolf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-R6yqaWX7RB+jElFfWec5dpBpQvlvQULEpgiiVTUzPWU=";
+  };
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    impacket
+    pyasn1
+  ];
+
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "credwolf" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to validate AD credentials over NTLM and Kerberos";
+    homepage = "https://github.com/StrongWind1/CredWolf";
+    changelog = "https://github.com/StrongWind1/CredWolf/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "credwolf";
+  };
+})


### PR DESCRIPTION
Tool to validate AD credentials over NTLM and Kerberos

https://github.com/StrongWind1/CredWolf

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
