### PR TITLE
gram: Add gram-extensions output

### DIFF
--- a/pkgs/by-name/gr/gram/package.nix
+++ b/pkgs/by-name/gr/gram/package.nix
@@ -26,6 +26,7 @@
   writableTmpDirAsHomeHook,
 
   buildRemoteServer ? true,
+  buildExtensionCli ? true,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -37,6 +38,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals buildRemoteServer [
     "remote_server"
+  ]
+  ++ lib.optionals buildExtensionCli [
+    "extension_cli"
   ];
 
   src = fetchFromCodeberg {
@@ -89,7 +93,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--package=gram"
     "--package=cli"
   ]
-  ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
+  ++ lib.optionals buildRemoteServer [ "--package=remote_server" ]
+  ++ lib.optionals buildExtensionCli [ "--package=extension_cli" ];
 
   env = {
     ALLOW_MISSING_LICENSES = true;
@@ -157,6 +162,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ''
   + lib.optionalString buildRemoteServer ''
     install -Dm755 $release_target/remote_server $remote_server/bin/${finalAttrs.remoteServerExecutableName}
+  ''
+  + lib.optionalString buildExtensionCli ''
+    install -Dm755 $release_target/gram-extension $extension_cli/bin/gram-extension
   ''
   + ''
     runHook postInstall


### PR DESCRIPTION
This package is needed if compiling extensions for gram. Adding this output should unlock creating packages for the extensions themselves later on, but for now it allows external experimentation for doing this outside of nixpkgs.

This is my first contribution here. I am unsure if anything else here needs to be done. I have run `nix-build -A gram` and verified that it builds.

Note that the gram-extension binary is put in `libexec/gram-extension`. I don't know if this would be the correct location, but the thought process is that it should mainly be used by other derivations and not by users that include the gram binary into their path.

I have some personal code for building extensions and setting them up in the editor config. But that code is not in a place right now where upstreaming it is doable. I may try to clean this code up for usage inside nixpkgs at a later point - but this change itself should unblock others from doing the same, while being relatively low impact.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
