### PR TITLE
hdrhistogram_c: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/by-name/hd/hdrhistogram_c/package.nix
+++ b/pkgs/by-name/hd/hdrhistogram_c/package.nix
@@ -26,11 +26,13 @@ stdenv.mkDerivation (finalAttrs: {
     ./no-avx2-i386.patch
   ];
 
-  buildInputs = [ zlib ];
   nativeBuildInputs = [
     cmake
     validatePkgConfig
   ];
+  buildInputs = [ zlib ];
+
+  strictDeps = true;
 
   cmakeFlags = lib.optionals stdenv.hostPlatform.isStatic [
     (lib.cmakeBool "HDR_HISTOGRAM_BUILD_SHARED" false)

--- a/pkgs/by-name/hd/hdrhistogram_c/package.nix
+++ b/pkgs/by-name/hd/hdrhistogram_c/package.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   meta = {
     description = "C port or High Dynamic Range (HDR) Histogram";
     homepage = "https://github.com/HdrHistogram/HdrHistogram_c";


### PR DESCRIPTION
No change in CA hashes of the outputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
