### PR TITLE
libidn2: enable strictDeps, structuredAttrs for non-bootstrap build, modernize

### DIFF
--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   strictDeps = true;
-  # Beware: non-bootstrap libidn2 is overridden by ./hack.nix
+  # Beware: non-bootstrap libidn2 is overridden by ./no-bootstrap-reference.nix
   outputs = [
     "bin"
     "dev"

--- a/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
+++ b/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
@@ -39,9 +39,9 @@ runCommandLocal "${libidn2.pname}-${libidn2.version}"
     cp -r '${libidn2.dev}' "$dev"
     chmod +w "$dev"/nix-support/propagated-build-inputs
     substituteInPlace "$dev"/nix-support/propagated-build-inputs \
-      --replace '${libidn2.bin}' "$bin"
+      --replace-fail '${libidn2.bin}' "$bin"
     substituteInPlace "$dev"/lib/pkgconfig/libidn2.pc \
-      --replace '${libidn2.dev}' "$dev"
+      --replace-fail '${libidn2.dev}' "$dev"
 
     ln -s '${libidn2.out}' "$out" # it's hard to be without any $out
   ''

--- a/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
+++ b/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
@@ -18,6 +18,9 @@ runCommandLocal "${libidn2.pname}-${libidn2.version}"
       inherit (libidn2) out info devdoc; # no need to touch these store paths
     };
     inherit (libidn2) meta pname version;
+
+    strictDeps = true;
+    __structuredAttrs = true;
   }
   ''
     cp -r '${libidn2.bin}' "$bin"


### PR DESCRIPTION
No changes in CA hashes of the outputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
