### PR TITLE
python3Packages.optuna-dashboard: fix missing bundle.js

### DIFF
--- a/pkgs/development/python-modules/optuna-dashboard/default.nix
+++ b/pkgs/development/python-modules/optuna-dashboard/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   alembic,
   boto3,
   botorch,
@@ -8,7 +7,6 @@
   buildPythonPackage,
   cmaes,
   colorlog,
-  fetchFromGitHub,
   httpx,
   moto,
   numpy,
@@ -23,6 +21,7 @@
   setuptools,
   streamlit,
   tqdm,
+  fetchPypi,
 }:
 
 buildPythonPackage rec {
@@ -30,11 +29,11 @@ buildPythonPackage rec {
   version = "0.20.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "optuna";
-    repo = "optuna-dashboard";
-    tag = "v${version}";
-    hash = "sha256-pg1R8tZjfLDDzDWiLRmaU1a1mKDzeZliPC2X0UV+xEw=";
+  # bundle.js cannot be built with nix in 0.20.0. This should be fixed in the next release.
+  src = fetchPypi {
+    pname = "optuna_dashboard";
+    inherit version;
+    sha256 = "52a6da480a2500b6993c8fa61c81063b0dbe730edbd9f651c81b318393cca71d";
   };
 
   dependencies = [
@@ -64,30 +63,15 @@ buildPythonPackage rec {
     streamlit
   ];
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # AttributeError: module 'numpy' has no attribute 'float128' ==> not available on 64-bit Darwin
-    "test_infer_sortable"
-    "test_serialize_numpy_floating"
-  ];
-
-  # Disable tests that use playwright (needs network)
-  disabledTestPaths = [
-    "e2e_tests/test_dashboard/test_usecases/test_preferential_optimization.py"
-    "e2e_tests/test_dashboard/test_usecases/test_study_history.py"
-    "e2e_tests/test_dashboard/visual_regression_test.py"
-    "e2e_tests/test_standalone/test_study_list.py"
-  ];
-
   pythonImportsCheck = [ "optuna_dashboard" ];
 
-  # Temporarily disable tests as they hang due to a torch bug on darwin
-  # Will revert in https://github.com/NixOS/nixpkgs/pull/424873
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  # the source distribution ships without tests
+  doCheck = false;
 
   meta = {
     description = "Real-time Web Dashboard for Optuna";
     homepage = "https://github.com/optuna/optuna-dashboard";
-    changelog = "https://github.com/optuna/optuna-dashboard/releases/tag/${src.tag}";
+    changelog = "https://github.com/optuna/optuna-dashboard/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jherland ];
     mainProgram = "optuna-dashboard";


### PR DESCRIPTION
As described in Issue #441996, `optuna-dashboard` does not ship the `bundle.js` file required for it to load.

I was unable to build the file with nix, so I made the package use the pypi source distribution, which includes the required file.

This workaround can likely be reverted with the next `optuna-dashboard` release, since the current upstream `main` branch has switched to `pnpm` for building `bundle.js`, and I was able to build it with nix.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
