### PR TITLE
wrapGAppsHook fixes

### DIFF
--- a/pkgs/by-name/an/antimicrox/package.nix
+++ b/pkgs/by-name/an/antimicrox/package.nix
@@ -4,6 +4,7 @@
   cmake,
   kdePackages,
   pkg-config,
+  wrapGAppsHook3,
   itstool,
   udevCheckHook,
   SDL2,
@@ -30,6 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     itstool
     udevCheckHook
     libsForQt5.wrapQtAppsHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [

--- a/pkgs/by-name/me/mediaelch/package.nix
+++ b/pkgs/by-name/me/mediaelch/package.nix
@@ -14,6 +14,8 @@
   qt6Packages,
 
   qtVersion ? 6,
+
+  wrapGAppsHook3,
 }:
 
 let
@@ -53,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     qt'.qttools
     qt'.wrapQtAppsHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have a found a few packages that crash when attempting to open file pickers with the following error
```
GLib-GIO-ERROR **: 06:51:14.382: No GSettings schemas are installed on the system
```

I'm a bit confused as to why MediaElch was not working given it had a wrap already but adding `wrapGAppsHook3` fixed my issue

Been following https://github.com/NixOS/nixpkgs/issues/16285
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
