### PR TITLE
ntdswolf: init at 0.6.1, python3Packages.dpapi-ng: init at 0.2.0

### DIFF
--- a/pkgs/by-name/nt/ntdswolf/package.nix
+++ b/pkgs/by-name/nt/ntdswolf/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ntdswolf";
+  version = "0.6.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "StrongWind1";
+    repo = "NTDSWolf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dPL8qnByz1ALyQLPAzQp0yaDLKYuqXVAlrdZ7lnrRNU=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    dissect-database
+    dissect-regf
+    dpapi-ng
+    pycryptodome
+    rich
+    typer
+    typing-extensions
+  ];
+
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "ntdswolf" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Offline NTDS.dit parser and credential extractor for Active Directory forensics";
+    homepage = "https://github.com/StrongWind1/NTDSWolf";
+    changelog = "https://github.com/StrongWind1/NTDSWolf/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "ntdswolf";
+  };
+})

--- a/pkgs/development/python-modules/dpapi-ng/default.nix
+++ b/pkgs/development/python-modules/dpapi-ng/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  cryptography,
+  dnspython,
+  fetchFromGitHub,
+  nix-update-script,
+  pyspnego,
+  pytest-asyncio,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dpapi-ng";
+  version = "0.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jborean93";
+    repo = "dpapi-ng";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1GeayLsY9qGwlfEbkLbyi524MAKEmb/F1fzQ0jzrzF8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    cryptography
+    dnspython
+    pyspnego
+  ];
+
+  optional-dependencies = {
+    kerberos = [ pyspnego ];
+  };
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "dpapi_ng" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python DPAPI NG Decryptor for non-Windows Platforms";
+    homepage = "https://github.com/jborean93/dpapi-ng";
+    changelog = "https://github.com/jborean93/dpapi-ng/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5144,6 +5144,8 @@ self: super: with self; {
 
   doxmlparser = callPackage ../development/python-modules/doxmlparser { };
 
+  dpapi-ng = callPackage ../development/python-modules/dpapi-ng { };
+
   dparse = callPackage ../development/python-modules/dparse { };
 
   dparse2 = callPackage ../development/python-modules/dparse2 { };


### PR DESCRIPTION
Offline NTDS.dit parser and credential extractor for Active
Directory forensics

https://github.com/StrongWind1/NTDSWolf

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
