### PR TITLE
cwal: 0.9.0 -> 0.10.1

### DIFF
--- a/pkgs/by-name/cw/cwal/package.nix
+++ b/pkgs/by-name/cw/cwal/package.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  cmake,
-  pkg-config,
+  pkgconf,
   imagemagick,
   libimagequant,
   luajit,
@@ -12,20 +11,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cwal";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "nitinbhat972";
     repo = "cwal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-RDtYBgqTG3Ycn1D6QtaHGZVXKxw8UqhzssxXA4temYo=";
+    hash = "sha256-hQ2N/lSUp1FduYG0tPOVP68QeOQyi7luEkys3A697LU=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
-    cmake
-    pkg-config
+    pkgconf
     makeBinaryWrapper
   ];
 
@@ -34,6 +32,25 @@ stdenv.mkDerivation (finalAttrs: {
     libimagequant
     luajit
   ];
+
+  postPatch = ''
+    substituteInPlace config.h \
+      --replace-fail '#define INSTALL_DIR "/usr"' \
+      "#define INSTALL_DIR \"$out\""
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    cc nob.c -o nob
+    ./nob build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    ./nob install
+    runHook postInstall
+  '';
 
   postFixup = ''
     wrapProgram $out/bin/cwal \

--- a/pkgs/by-name/cw/cwal/package.nix
+++ b/pkgs/by-name/cw/cwal/package.nix
@@ -6,25 +6,23 @@
   imagemagick,
   libimagequant,
   luajit,
-  makeBinaryWrapper,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cwal";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "nitinbhat972";
     repo = "cwal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-hQ2N/lSUp1FduYG0tPOVP68QeOQyi7luEkys3A697LU=";
+    hash = "sha256-n9v2EiW1wRMsYoNk+m20qQao52vvmD6NDM8Z/oEyjbU=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
     pkgconf
-    makeBinaryWrapper
   ];
 
   buildInputs = [
@@ -50,11 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
     ./nob install
     runHook postInstall
-  '';
-
-  postFixup = ''
-    wrapProgram $out/bin/cwal \
-      --prefix XDG_DATA_DIRS : $out/share
   '';
 
   meta = {


### PR DESCRIPTION
- migrate build from cmake to nob (CMakeLists removed upstream)
- remove cmake from nativeBuildInputs, use cc nob.c -o nob && ./nob build
- patch INSTALL_DIR to $out and use nob install


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
