### PR TITLE
clojure-lsp: switch updater to nix-update-script

### DIFF
--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  stdenvNoCC,
   buildGraalvmNativeImage,
   fetchurl,
-  writeScript,
   writableTmpDirAsHomeHook,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildGraalvmNativeImage (finalAttrs: {
@@ -34,30 +33,7 @@ buildGraalvmNativeImage (finalAttrs: {
     versionCheckHook
   ];
 
-  passthru.updateScript = writeScript "update-clojure-lsp" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl common-updater-scripts gnused jq nix
-
-    set -eu -o pipefail
-    source "${stdenvNoCC}/setup"
-
-    old_version="$(nix-instantiate --strict --json --eval -A clojure-lsp.version | jq -r .)"
-    latest_version="$(curl -s https://api.github.com/repos/clojure-lsp/clojure-lsp/releases/latest | jq -r .tag_name)"
-
-    if [[ $latest_version == $old_version ]]; then
-      echo "Already at latest version $old_version"
-      exit 0
-    fi
-
-    old_jar_hash="$(nix-instantiate --strict --json --eval -A clojure-lsp.jar.drvAttrs.outputHash | jq -r .)"
-
-    curl -o clojure-lsp-standalone.jar -sL "https://github.com/clojure-lsp/clojure-lsp/releases/download/$latest_version/clojure-lsp-standalone.jar"
-    new_jar_hash="$(nix-hash --flat --type sha256 clojure-lsp-standalone.jar | xargs -n1 nix --extra-experimental-features nix-command hash convert --hash-algo sha256)"
-
-    rm -f clojure-lsp-standalone.jar
-
-    update-source-version clojure-lsp "$latest_version" "$new_jar_hash"
-  '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Language Server Protocol (LSP) for Clojure";
@@ -65,7 +41,10 @@ buildGraalvmNativeImage (finalAttrs: {
     changelog = "https://github.com/clojure-lsp/clojure-lsp/releases/tag/${finalAttrs.version}";
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.ericdallo ];
+    maintainers = with lib.maintainers; [
+      ericdallo
+      jlesquembre
+    ];
     mainProgram = "clojure-lsp";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The update script is failing (see https://nixpkgs-update-logs.nix-community.org/clojure-lsp/2026-08-24.log), switching to `nix-update-script` resolves the issue.

Also adding myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
