### PR TITLE
python3Packages.tensordict: 0.13.0 -> 0.14.1

### DIFF
--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -29,7 +29,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "tensordict";
-  version = "0.13.0";
+  version = "0.14.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -37,7 +37,7 @@ buildPythonPackage (finalAttrs: {
     owner = "pytorch";
     repo = "tensordict";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JL6S3Wc9PJbskOPhsr+0QFunZBkMcJCsvhLlz6ggAQ4=";
+    hash = "sha256-p1h1JqstEwkrzhEIe3bxGVNBZRy8NS4wUzCRwQ8Aitk=";
   };
 
   postPatch = ''
@@ -79,6 +79,11 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Hangs forever
+    "test/distributed/test_distributed.py"
+  ];
+
   disabledTests = [
     # TypeError: not all arguments converted during string formatting
     "test_dtensor"
@@ -106,18 +111,6 @@ buildPythonPackage (finalAttrs: {
     "test_map_exception"
     "test_map"
     "test_multiprocessing"
-  ];
-
-  disabledTestPaths = [
-    # torch._dynamo.exc.Unsupported: Graph break due to unsupported builtin None.ReferenceType.__new__.
-    "test/test_compile.py"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Hangs forever
-    "test/test_distributed.py"
-    # Hangs after testing due to pool usage
-    "test/test_h5.py"
-    "test/test_memmap.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -69,6 +69,7 @@
   # tests
   imageio,
   pytest-rerunfailures,
+  pytest-xdist,
   pytestCheckHook,
   pyyaml,
   scipy,
@@ -193,11 +194,18 @@ buildPythonPackage (finalAttrs: {
     export XDG_RUNTIME_DIR=$(mktemp -d)
   '';
 
+  pytestFlags = [
+    # Tests memory consumption grows significantly with the number of parallel processes
+    # -> Limit the number of parallel jobs to prevent OOMing
+    "--maxprocesses=16"
+  ];
+
   nativeCheckInputs = [
     gymnasium
     h5py
     imageio
     pytest-rerunfailures
+    pytest-xdist
     pytestCheckHook
     pyyaml
     scipy

--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -76,15 +76,18 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "torchrl";
-  version = "0.13.3";
+  version = "0.14.0";
   pyproject = true;
   __structuredAttrs = true;
 
+  # No tags have been made for 0.14.0
+  # https://github.com/pytorch/rl/pull/4108#issuecomment-5558175190
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "rl";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-GdiGZZlx8olRMzl4CJD11S1+q0+pOeCD2wrDPcji5p0=";
+    # tag = "v${finalAttrs.version}";
+    rev = "6e18e35b2c68be1a56afebfb0676d217925114cd";
+    hash = "sha256-a1Ehbr6N5w9sVH1ygFhlPEm8J51zIrXB37N18OQqiDM=";
   };
 
   postPatch = ''
@@ -191,8 +194,8 @@ buildPythonPackage (finalAttrs: {
   '';
 
   nativeCheckInputs = [
-    h5py
     gymnasium
+    h5py
     imageio
     pytest-rerunfailures
     pytestCheckHook
@@ -310,7 +313,8 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Modular, primitive-first, python-first PyTorch library for Reinforcement Learning";
     homepage = "https://github.com/pytorch/rl";
-    changelog = "https://github.com/pytorch/rl/releases/tag/${finalAttrs.src.tag}";
+    # TODO: uncomment when src is using a git tag again
+    # changelog = "https://github.com/pytorch/rl/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };


### PR DESCRIPTION
## Things done

- **python3Packages.tensordict: 0.13.0 -> 0.14.1** ([Diff](https://github.com/pytorch/tensordict/compare/v0.13.0...v0.14.1), [Changelog](https://github.com/pytorch/tensordict/releases/tag/v0.14.1))
- **python3Packages.torchrl: 0.13.3 -> 0.14.0** ([Diff](https://github.com/pytorch/rl/compare/v0.13.3...6e18e35b2c68be1a56afebfb0676d217925114cd))
- **python3Packages.torchrl: use pytest-xdist to speed up tests**

Diff: https://github.com/pytorch/tensordict/compare/v0.13.0...v0.14.0
Changelogs:
- https://github.com/pytorch/tensordict/releases/tag/v0.14.0
- https://github.com/pytorch/tensordict/releases/tag/v0.14.1

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test