### PR TITLE
reccStdenv: init

### DIFF
--- a/pkgs/by-name/ni/nixception/package.nix
+++ b/pkgs/by-name/ni/nixception/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  nlohmann_json,
+}:
+let
+  src = fetchFromGitHub {
+    owner = "layus";
+    repo = "nixception";
+    rev = "v0.5.0";
+    fetchSubmodules = true;
+    hash = "sha256-tjIhrGhsrmBTJ1OD/Fxao7z9+wn2JCE1S8ggYQIH9Ek=";
+  };
+
+  # Nixception relies on a runner derivation that must be built from its own
+  # tree. We build it here and pass it below.
+  runner = stdenv.mkDerivation {
+    name = "nixception-runner";
+    src = "${src}/tools/runner";
+    buildInputs = [ nlohmann_json ];
+    meta = with lib; {
+      description = "C++ runner for nixception REAPI action derivations";
+      platforms = platforms.linux;
+    };
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nixception";
+  version = "0.5.0";
+  __structuredAttrs = true;
+  inherit src;
+  cargoHash = "sha256-Nqv1dwh//Ph6CUIK73n3/NVuoSt0RGjpxKL0mjG0stc=";
+
+  # Version override (no git repo).
+  env.NIXCEPTION_VERSION = "v${finalAttrs.version}";
+
+  # Wire the runner into the binary.
+  env.NIXCEPTION_RUNNER_OUT = "${runner.out}";
+  env.NIXCEPTION_RUNNER_DRV = "${
+    # Plain `runner.drvPath` trips restricted eval in CI.
+    # We "only" need the .drv itself, not the full input closure.
+    builtins.unsafeDiscardOutputDependency runner.drvPath
+  }";
+
+  # For convenience.
+  passthru.runner = runner;
+
+  meta = with lib; {
+    description = "Remote execution API endpoint that builds every action as a Nix derivation";
+    homepage = "https://github.com/layus/nixception";
+    # The nixception sources are Apache-2.0 (based on the last Apache-licensed
+    # NativeLink commit); the binary also statically links the GPL-3.0
+    # nix-compat crate from tvix.
+    license = with licenses; [
+      asl20
+      gpl3Only
+    ];
+    maintainers = with maintainers; [ layus ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/by-name/ni/nixceptionHook/nixception-setup-hook.sh
+++ b/pkgs/by-name/ni/nixceptionHook/nixception-setup-hook.sh
@@ -1,0 +1,146 @@
+# Setup hook for the nixception package.
+# ======================================
+#
+# It registers one extra phase: nixceptionStartPhase, registered via
+# preConfigurePhases; starts the nixception server and waits until it is ready
+# to accept connections on 127.0.0.1:50051.  The server is stopped by hooking
+# into stdenv's failureHook and exitHook, which are called by exitHandler (the
+# EXIT trap) on failure and success respectively.
+#
+# The phase is registered before configurePhase (rather than before buildPhase)
+# because some build systems (e.g. CMake) probe the compiler during configure.
+# When the compiler is wrapped by recc, the nixception server must already be
+# listening or those probes will fail with connection-refused errors.
+#
+# ── Verbosity ────────────────────────────────────────────────────────────────
+#
+# By default the hook runs in quiet mode: the nixception server's output is
+# sent to a log file and lifecycle messages are suppressed.  Set
+# NIXCEPTION_VERBOSE=1 in the build environment to get all the debug messages
+#
+# On build *failure* the server log is always dumped to stderr regardless of
+# the verbosity setting, so you can still debug without re-running.
+#
+# ── Shutdown ─────────────────────────────────────────────────────────────────
+#
+# stdenv's exitHandler (set as the EXIT trap before any setup hook runs) calls:
+#   runHook failureHook   – on non-zero exit
+#   runHook exitHook      – on clean exit
+#
+# We append our stop command to both hooks so the server is always torn down,
+# whether the build succeeds or fails.
+#
+# ── Extra sandbox tools ──────────────────────────────────────────────────────
+#
+# To make extra tools available inside the reapi-action sandbox, export
+# NIXCEPTION_EXTRA_SANDBOX_PATHS (colon-separated /nix/store/… paths) in the
+# build environment *before* this phase runs.
+
+# shellcheck shell=bash
+
+# Helper: print a message only in verbose mode.
+_nixception_log() {
+    if [ "${NIXCEPTION_VERBOSE:-0}" = "1" ]; then
+        echo "nixception-hook: $*" >&2
+    fi
+}
+
+_nixception_pid=
+_nixception_logfile=
+
+_nixceptionStop() {
+    _nixception_log "stopping server (pid $_nixception_pid)..."
+    kill "$_nixception_pid" 2>/dev/null || true
+    wait "$_nixception_pid" 2>/dev/null || true
+
+    # Print timing summary
+    if [ -s "$NIXCEPTION_STATS_FILE" ]; then
+        echo '' >&2
+        echo 'nixception-hook: ── timing statistics ──' >&2
+        cat "$NIXCEPTION_STATS_FILE" >&2
+    else
+        _nixception_log "no timing statistics available"
+    fi
+    rm -f "$NIXCEPTION_STATS_FILE"
+}
+
+_nixceptionFailStop() {
+    _nixceptionStop
+
+    # In quiet mode, dump the server log on failure so the user can debug
+    # without re-running in verbose mode.
+    if [ "${NIXCEPTION_VERBOSE:-0}" != "1" ] && [ -s "$_nixception_logfile" ]; then
+        echo '' >&2
+        echo 'nixception-hook: ── server log (last 200 lines) ──' >&2
+        tail -n 200 "$_nixception_logfile" >&2
+        echo 'nixception-hook: ── end of server log ──' >&2
+        echo '(set NIXCEPTION_VERBOSE=1 for full real-time output)' >&2
+    fi
+    rm -f "$_nixception_logfile"
+}
+
+# Clean exit: just stop the server (and remove the log file).
+_nixceptionCleanStop() {
+    _nixceptionStop
+    rm -f "$_nixception_logfile"
+}
+
+nixceptionStartPhase() {
+    # ── Sanity-check: recursive-nix socket ───────────────────────────────────
+    # The Nix daemon socket is exposed at /build/.nix-socket when the sandbox
+    # is started with the recursive-nix system feature.  Fail fast so the
+    # error is obvious rather than a cryptic connection-refused from nixception.
+    test -S /build/.nix-socket || {
+        echo "nixception-hook: FAIL: recursive-nix daemon socket not found" \
+            '– is requiredSystemFeatures = ["recursive-nix"] set?' >&2
+        exit 1
+    }
+
+    local _verbose="${NIXCEPTION_VERBOSE:-0}"
+
+    # Stats file
+    export NIXCEPTION_STATS_FILE
+    NIXCEPTION_STATS_FILE="$(mktemp -p /build nixception-stats.XXXXXX)"
+
+    # Server log file (used in quiet mode)
+    _nixception_logfile="$(mktemp -p /build nixception-server.log.XXXXXX)"
+
+    # Verbosiy
+    # In verbose mode the default RUST_LOG level is "info" and server output is
+    # timestamped and forwarded to stderr.  In quiet mode the level drops to
+    # "warn" and output goes to a log file that is only shown on failure.
+    # If the caller already set RUST_LOG we never override it.
+    local _rust_log
+    if [ -n "${RUST_LOG:-}" ]; then
+        _rust_log="$RUST_LOG"
+    elif [ "$_verbose" = "1" ]; then
+        _rust_log="info"
+    else
+        _rust_log="warn"
+    fi
+
+    # Start the server
+    _nixception_log "starting nixception server..."
+    if [ "$_verbose" = "1" ]; then
+        RUST_LOG="$_rust_log" \
+            RUST_BACKTRACE=1 \
+            @nixception@/bin/nixception \
+            > >(@moreutils@/bin/ts -s '[nixception] %H:%M:%.S' >&2) 2>&1 &
+    else
+        RUST_LOG="$_rust_log" \
+            RUST_BACKTRACE=1 \
+            @nixception@/bin/nixception \
+            > "$_nixception_logfile" 2>&1 &
+    fi
+    _nixception_pid=$!
+
+    # Register exit hooks
+    exitHook+=$'\n_nixceptionCleanStop\n'
+    failureHook+=$'\n_nixceptionFailStop\n'
+
+    # Wait for the server to be ready
+    @wait4x@/bin/wait4x tcp 127.0.0.1:50051 --timeout 30s --quiet
+    _nixception_log "server is ready (pid $_nixception_pid)"
+}
+
+preConfigurePhases="${preConfigurePhases:-} nixceptionStartPhase"

--- a/pkgs/by-name/ni/nixceptionHook/package.nix
+++ b/pkgs/by-name/ni/nixceptionHook/package.nix
@@ -1,0 +1,112 @@
+# tools/nixception-hook.nix
+#
+# A setup hook that starts a nixception remote-execution server before the
+# build phase and stops it afterwards.  Consumers add it to nativeBuildInputs:
+#
+#   nativeBuildInputs = [ nixceptionHook ];
+#
+# See ./nixception-setup-hook.sh for details.
+
+{
+  lib,
+  stdenv,
+  nixception,
+  nixceptionHook,
+  buildbox,
+  wait4x,
+  moreutils,
+  makeSetupHook,
+  runCommandLocal,
+  shellcheck,
+}:
+let
+  # ── Pure packaging check ──────────────────────────────────────────────────
+  # No recursive-nix, no running server: just assert the installed hook script
+  # is well-formed.  Runs in ordinary CI.
+  packaging-check =
+    runCommandLocal "nixception-hook-test"
+      {
+        nativeBuildInputs = [ shellcheck ];
+        installedHook = "${nixceptionHook}/nix-support/setup-hook";
+      }
+      ''
+        # Every @token@ substitution must be resolved (no literal @…@ left)
+        if grep -oE '@[a-zA-Z0-9_]+@' "$installedHook"; then
+          echo "FAIL: unresolved substitution token(s) remain in the setup hook"; exit 1
+        fi
+
+        # Shellcheck
+        # SC2148: no shebang. Setup hooks are sourced by stdenv, not executed.
+        if ! shellcheck --shell=bash --exclude=SC2148 "$installedHook"; then
+          echo "FAIL: shellcheck reported problems"; exit 1
+        fi
+
+        touch $out
+      '';
+
+  # ── Runtime smoke test (recursive-nix gated) ─────────────────────────────
+  # Actually adds the hook to a build, lets it start the nixception server,
+  # routes one trivial C compile through it via `recc` and checks result.
+  smoke-test = stdenv.mkDerivation {
+    name = "nixception-hook-smoke-test";
+    dontUnpack = true;
+    nativeBuildInputs = [
+      nixceptionHook
+      buildbox
+    ];
+    requiredSystemFeatures = [ "recursive-nix" ];
+
+    # Point recc at the server the hook starts (recc otherwise defaults to
+    # localhost:8085 for CAS / action cache).
+    RECC_INSTANCE = "main";
+    RECC_SERVER = "127.0.0.1:50051";
+    RECC_VERBOSE = 1;
+
+    buildPhase = ''
+      runHook preBuild
+
+      cat > hello.c <<'EOF'
+      #include <stdio.h>
+      int main(void) { printf("nixception smoke ok\n"); return 0; }
+      EOF
+
+      echo "compiling hello.c through recc -> nixception ..."
+      # recc runs linking locally, so split compilation in two
+      recc "$CC" -c -O2 -o hello.o hello.c
+      recc "$CC" -o hello hello.o
+
+      test -x hello || { echo "FAIL: recc did not produce an executable"; exit 1; }
+      output="$(./hello)"
+      test "$output" = "nixception smoke ok" \
+        || { echo "FAIL: unexpected program output: $output"; exit 1; }
+      echo "ok: recc-built binary runs and prints the expected line"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/bin"
+      cp hello "$out/bin/"
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Runtime smoke test: one C compile routed through nixceptionHook + recc";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ layus ];
+      platforms = lib.platforms.linux;
+    };
+  };
+in
+makeSetupHook {
+  name = "nixception-hook";
+
+  substitutions = {
+    nixception = "${nixception}";
+    wait4x = "${wait4x}";
+    moreutils = "${moreutils}";
+  };
+
+  passthru.tests = { inherit packaging-check smoke-test; };
+} ./nixception-setup-hook.sh

--- a/pkgs/by-name/re/reccStdenv/package.nix
+++ b/pkgs/by-name/re/reccStdenv/package.nix
@@ -1,0 +1,184 @@
+# recc-wrapped compiler + stdenv: the Remote Execution analogue of
+# ccacheWrapper / ccacheStdenv.  Where ccache caches object files in a local
+# directory, `recc` (shipped in buildbox) offloads each compile — and its
+# caching — to a nixception Remote Execution endpoint, which builds it as a
+# Nix derivation via recursive-nix.
+#
+# Exposed as `pkgs.reccStdenv`.  Select it like ccacheStdenv:
+#    replaceStdenv = { pkgs }: pkgs.reccStdenv;
+# or per-package via `.override { stdenv = reccStdenv; }`.
+{
+  lib,
+  stdenv,
+  stdenvAdapters,
+  overrideCC,
+  reccStdenv,
+  runCommand,
+  runCommandLocal,
+  makeWrapper,
+  buildbox,
+  nixceptionHook,
+  hello,
+}:
+
+let
+  # The recc-links tree: an unwrapped-cc-shaped directory whose compiler
+  # drivers (cc/gcc/g++/c++) are `recc <real-driver>` wrappers and whose every
+  # other file is symlinked straight through, so the surrounding cc-wrapper's
+  # NIX_* handling and suffix-salt are unchanged.  `extraConfig` is shell run
+  # (via makeWrapper --run) right before recc execs; it is where the RECC_*
+  # endpoints are set.  Direct analogue of `ccache.links`.
+  reccLinks =
+    { unwrappedCC, extraConfig }:
+    runCommand "${unwrappedCC.name}-recc"
+      {
+        passthru = {
+          isClang = unwrappedCC.isClang or false;
+          isGNU = unwrappedCC.isGNU or false;
+          isRecc = true;
+        }
+        // builtins.intersectAttrs {
+          hardeningUnsupportedFlagsByTargetPlatform = null;
+          hardeningUnsupportedFlags = null;
+        } unwrappedCC;
+        lib = lib.getLib unwrappedCC;
+        nativeBuildInputs = [ makeWrapper ];
+        meta = { inherit (unwrappedCC.meta) mainProgram; };
+      }
+      (
+        let
+          targetPrefix = lib.optionalString (
+            unwrappedCC ? targetConfig && unwrappedCC.targetConfig != null && unwrappedCC.targetConfig != ""
+          ) "${unwrappedCC.targetConfig}-";
+        in
+        ''
+          mkdir -p $out/bin
+
+          wrap() {
+            local cname="${targetPrefix}$1"
+            if [ -x "${unwrappedCC}/bin/$cname" ]; then
+              makeWrapper ${buildbox}/bin/recc $out/bin/$cname \
+                --run ${lib.escapeShellArg extraConfig} \
+                --add-flags ${unwrappedCC}/bin/$cname
+            fi
+          }
+
+          wrap cc
+          wrap c++
+          wrap gcc
+          wrap g++
+          wrap clang
+          wrap clang++
+
+          # Every remaining tool and every non-bin file falls through to the
+          # real compiler, so the tree stays a drop-in replacement.
+          for executable in $(ls ${unwrappedCC}/bin); do
+            [ -x "$out/bin/$executable" ] || ln -s ${unwrappedCC}/bin/$executable $out/bin/$executable
+          done
+          for file in $(ls ${unwrappedCC} | grep -vw bin); do
+            ln -s ${unwrappedCC}/$file $out/$file
+          done
+        ''
+      );
+
+  # The RECC_* endpoint config baked into every wrapper.  Each value defers to
+  # anything already in the environment, so a dev shell or the nixceptionHook
+  # can point recc elsewhere without rebuilding the wrapper.
+  reccExtraConfig = ''
+    export RECC_SERVER="''${RECC_SERVER:-127.0.0.1:50051}"
+    export RECC_CAS_SERVER="''${RECC_CAS_SERVER:-$RECC_SERVER}"
+    export RECC_ACTION_CACHE_SERVER="''${RECC_ACTION_CACHE_SERVER:-$RECC_SERVER}"
+    export RECC_INSTANCE="''${RECC_INSTANCE:-main}"
+
+    # RECC_PROJECT_ROOT is the top-level source dir: recc uploads every
+    # input path inside it and reconstructs each remote output at
+    #   RECC_PROJECT_ROOT / <action working_directory> / <output_path>.
+    # It must be an ancestor of both the sources and the build directory.
+    # $NIX_BUILD_TOP (e.g. /build) is an ancestor of the unpacked source
+    # tree and every build dir under it, so out-of-tree cmake/meson builds
+    # get correct output placement and all sources still upload.  Keep any
+    # value a caller already exported.
+    export RECC_PROJECT_ROOT="''${RECC_PROJECT_ROOT:-''${NIX_BUILD_TOP:-$(cd .. && pwd)}}"
+  '';
+
+  # A cc-wrapper whose underlying compiler is the recc-links tree above.
+  reccWrapper = stdenv.cc.override {
+    cc = reccLinks {
+      unwrappedCC = stdenv.cc.cc;
+      extraConfig = reccExtraConfig;
+    };
+  };
+
+  # In addition to the recc-wrapped compiler, every derivation built with this
+  # stdenv gets `nixceptionHook` in nativeBuildInputs and the `recursive-nix`
+  # system feature.  Together they make a pure `nix build` self-contained: the
+  # hook starts a nixception server on the sandbox loopback (127.0.0.1:50051)
+  # before configurePhase, and recc — invoked through the wrapped compiler —
+  # connects to it.  No external server is needed; the Remote Execution actions
+  # are cached in the shared Nix store.  Requires `recursive-nix`
+  # (experimental-features + system-features in nix.conf); otherwise pure — the
+  # nixception package is fetched from a released tag — so no `--impure`.
+  base = lib.lowPrio (
+    stdenvAdapters.overrideMkDerivationArgs (args: {
+      nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ nixceptionHook ];
+      requiredSystemFeatures = (args.requiredSystemFeatures or [ ]) ++ [ "recursive-nix" ];
+    }) (overrideCC stdenv reccWrapper)
+  );
+
+  # Pure packaging check (ordinary CI, no recursive-nix): assert
+  # reccStdenv's compiler is genuinely recc-wrapped — the unwrapped cc
+  # carries the `isRecc` marker and its drivers forward to `recc`.
+  cc-is-recc-wrapped =
+    runCommandLocal "reccStdenv-cc-is-recc-wrapped-test"
+      {
+        reccCC = base.cc.cc;
+      }
+      ''
+        test "${lib.optionalString (base.cc.cc.isRecc or false) "1"}" = "1" \
+          || { echo "FAIL: reccStdenv.cc.cc is not recc-wrapped (isRecc unset)"; exit 1; }
+        echo "ok: reccStdenv.cc.cc.isRecc is set"
+
+        found=0
+        for tool in cc c++ gcc g++ clang clang++; do
+          [ -e "$reccCC/bin/$tool" ] || continue
+          grep -q "/bin/recc" "$reccCC/bin/$tool" \
+            || { echo "FAIL: $tool does not forward to recc"; exit 1; }
+          echo "  ok: $tool -> recc"
+          found=$((found + 1))
+        done
+        [ "$found" -ge 1 ] || { echo "FAIL: no recc-forwarding drivers"; exit 1; }
+
+        echo "reccStdenv cc-is-recc-wrapped assertions passed ($found drivers)"
+        touch $out
+      '';
+
+  # End-to-end check (recursive-nix gated; Hydra skips it via the
+  # inherited system feature).  Build GNU hello through reccStdenv: the
+  # recc-wrapped compiler dispatches every compile to the nixception
+  # server the hook starts in the sandbox, and the result must run.  A
+  # maintainer with `recursive-nix` can run it to exercise the whole
+  # REAPI→Nix path.
+  recc-hello = (hello.override { stdenv = reccStdenv; }).overrideAttrs (old: {
+    pname = "reccStdenv-recc-hello-test";
+    # hello sets doInstallCheck = true and drives it through
+    # versionCheckHook + postInstallCheck; append our assertion there so
+    # both run (an installCheckPhase override would silently not run).
+    postInstallCheck = (old.postInstallCheck or "") + ''
+      echo "running hello built through reccStdenv..."
+      greeting=$("''${!outputBin}/bin/${old.meta.mainProgram}")
+      echo "  output: $greeting"
+      [ "$greeting" = "Hello, world!" ] \
+        || { echo "FAIL: unexpected hello output"; exit 1; }
+      echo "reccStdenv recc-hello end-to-end assertion passed"
+    '';
+  });
+
+in
+base
+// {
+  tests = { inherit cc-is-recc-wrapped recc-hello; };
+
+  # Make nixpkgs-vet happy.
+  strictDeps = true;
+  __structuredAttrs = true;
+}


### PR DESCRIPTION
This introduces reccStdenv, a new stdenv that uses nixceptionHook under the
hood to spawn a nixception server (translating REAPIv2 calls to recursive-nix)
and wraps the compiler with buildbox recc so compiler invocations are
translated into recursive-nix builds.

The stdenv is intended to make it easier to use nixceptionHook, as it is a
drop-in replacement of stdenv. It should make it trivial to use recc both
inside the sandbox and in nix shells.

Built on top of https://github.com/NixOS/nixpkgs/pull/558150.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
