### PR TITLE
plezy: 2.17.0 -> 2.19.0

### DIFF
--- a/pkgs/by-name/pl/plezy/git-hashes.json
+++ b/pkgs/by-name/pl/plezy/git-hashes.json
@@ -5,5 +5,5 @@
   "auto_updater_windows": "sha256-787cMkeT2BlfwVcy4y46XkWioNqLKJgQ/CCxQvERa+A=",
   "background_downloader": "sha256-x1Z+Nlyvy+cc1EdRUikqZMDjVKdGHe7FOH2Yx9K0zhE=",
   "connectivity_plus": "sha256-sVUG5/6GF0Eu47BgUCkgbGi8w1ip5o0yQS00NnNjAGs=",
-  "os_media_controls": "sha256-UkrBz52dkdlSJ+UJwC2E7RhuSOcXzJx+dVo0JcW8pEY="
+  "os_media_controls": "sha256-cNNTqIVJy9Yo7IrBAbIQFngOCT6ccWnOHVti7B/5jsQ="
 }

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -27,13 +27,13 @@
 
 let
   pname = "plezy";
-  version = "2.17.0";
+  version = "2.19.0";
 
   src = fetchFromGitHub {
     owner = "edde746";
     repo = "plezy";
     tag = version;
-    hash = "sha256-lY8uwz+OyrUFuFxRQ+2GuTLwJYigLy/JZYv4R5tRszM=";
+    hash = "sha256-gsC6ENRxgJxmF0//d98W73lFHeVpGmCBPIa/f1Q3hpw=";
   };
 
   simdutf = fetchurl {
@@ -146,7 +146,7 @@ let
 
     src = fetchurl {
       url = "https://github.com/edde746/plezy/releases/download/${version}/plezy-macos.dmg";
-      hash = "sha256-MYuawP8NI5s+261XpEwAjnqvDFYjvCxZVAf84ph7peQ=";
+      hash = "sha256-K5TXoU7ydxZ57RPv/OfyO7rvV5atj2bYLRFDhY7BuaA=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pl/plezy/pubspec.lock.json
+++ b/pkgs/by-name/pl/plezy/pubspec.lock.json
@@ -326,16 +326,6 @@
       "source": "hosted",
       "version": "3.1.2"
     },
-    "cronet_http": {
-      "dependency": "direct main",
-      "description": {
-        "name": "cronet_http",
-        "sha256": "07bfb4c6158aef72f8004631826abaeecdeaa2b6042f5f8916b8db20e1d01b4a",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.6.0"
-    },
     "cross_file": {
       "dependency": "transitive",
       "description": {
@@ -375,16 +365,6 @@
       },
       "source": "hosted",
       "version": "1.0.2"
-    },
-    "cupertino_http": {
-      "dependency": "direct main",
-      "description": {
-        "name": "cupertino_http",
-        "sha256": "3c8c69cc1b94b9c7570d9454bf1e11fa7010b248547a0760843adc71f0c08fbe",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.0.2"
     },
     "dart_code_linter": {
       "dependency": "direct dev",
@@ -710,16 +690,6 @@
       "source": "hosted",
       "version": "4.1.2"
     },
-    "http_profile": {
-      "dependency": "transitive",
-      "description": {
-        "name": "http_profile",
-        "sha256": "7e679e355b09aaee2ab5010915c932cce3f2d1c11c3b2dc177891687014ffa78",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.1.0"
-    },
     "injector": {
       "dependency": "transitive",
       "description": {
@@ -734,11 +704,11 @@
       "dependency": "direct main",
       "description": {
         "name": "intl",
-        "sha256": "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5",
+        "sha256": "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.20.2"
+      "version": "0.20.3"
     },
     "io": {
       "dependency": "transitive",
@@ -854,11 +824,11 @@
       "dependency": "transitive",
       "description": {
         "name": "matcher",
-        "sha256": "dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861",
+        "sha256": "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.12.19"
+      "version": "0.12.20"
     },
     "material_color_utilities": {
       "dependency": "transitive",
@@ -884,11 +854,11 @@
       "dependency": "transitive",
       "description": {
         "name": "meta",
-        "sha256": "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349",
+        "sha256": "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.18.0"
+      "version": "1.19.0"
     },
     "mgenware_dart_lints": {
       "dependency": "direct dev",
@@ -964,8 +934,8 @@
       "dependency": "direct main",
       "description": {
         "path": ".",
-        "ref": "75556a968a4a1ebc42fbb8c31942c2418d4326e1",
-        "resolved-ref": "75556a968a4a1ebc42fbb8c31942c2418d4326e1",
+        "ref": "a27208e641790029ac54d825b97508575caee1a7",
+        "resolved-ref": "a27208e641790029ac54d825b97508575caee1a7",
         "url": "https://github.com/edde746/media_controls"
       },
       "source": "git",
@@ -1588,11 +1558,11 @@
       "dependency": "transitive",
       "description": {
         "name": "test_api",
-        "sha256": "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e",
+        "sha256": "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.11"
+      "version": "0.7.12"
     },
     "typed_data": {
       "dependency": "transitive",
@@ -1748,11 +1718,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vector_math",
-        "sha256": "d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b",
+        "sha256": "f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.0"
+      "version": "2.4.2"
     },
     "vm_service": {
       "dependency": "transitive",
@@ -1906,6 +1876,6 @@
   },
   "sdks": {
     "dart": ">=3.12.0 <4.0.0",
-    "flutter": ">=3.44.0"
+    "flutter": ">=3.47.0"
   }
 }


### PR DESCRIPTION
Release: https://github.com/edde746/plezy/releases/tag/2.18.0 https://github.com/edde746/plezy/releases/tag/2.19.0
Diff: https://github.com/edde746/plezy/compare/2.17.0...2.19.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
