### PR TITLE
python3Packages.{pyqt6-,}qscintilla: use top-level callPackage

### DIFF
--- a/pkgs/development/python-modules/qscintilla/default.nix
+++ b/pkgs/development/python-modules/qscintilla/default.nix
@@ -2,25 +2,34 @@
   lib,
   stdenv,
 
-  pythonPackages,
-  qmake,
-  qscintilla,
-  qtbase,
-  qtmacextras ? null,
+  buildPythonPackage,
+  isPy3k,
+  python,
+  pyqt-builder,
+  pyqt5,
+  pyqt6,
+  setuptools,
+  sip,
+
+  libsForQt5,
+  qt6Packages,
+
+  useQt6 ? true,
 }:
 
 let
-  qtVersion = lib.versions.major qtbase.version;
-  pyQtPackage = pythonPackages."pyqt${qtVersion}";
+  qtPackages = if useQt6 then qt6Packages else libsForQt5;
 
-  inherit (pythonPackages)
-    isPy3k
-    python
-    sip
-    pyqt-builder
+  inherit (qtPackages)
+    qmake
+    qscintilla
+    qtbase
     ;
+
+  qtVersion = lib.versions.major qtbase.version;
+  pyQtPackage = if useQt6 then pyqt6 else pyqt5;
 in
-pythonPackages.buildPythonPackage {
+buildPythonPackage {
   # Matches the `name` declared in Python/pyproject-qt${qtVersion}.toml upstream,
   # which is inconsistent between Qt5 ("QScintilla") and Qt6 ("PyQt6-QScintilla").
   pname = if qtVersion == "5" then "qscintilla" else "pyqt${qtVersion}-qscintilla";
@@ -35,7 +44,7 @@ pythonPackages.buildPythonPackage {
     qmake
     pyqt-builder
     qscintilla
-    pythonPackages.setuptools
+    setuptools
   ];
 
   buildInputs = [ qtbase ];
@@ -43,7 +52,7 @@ pythonPackages.buildPythonPackage {
   propagatedBuildInputs = [
     pyQtPackage
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ qtmacextras ];
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && !useQt6) [ libsForQt5.qtmacextras ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15833,9 +15833,7 @@ self: super: with self; {
     inherit (pkgs) mesa;
   };
 
-  pyqt6-qscintilla = pkgs.qt6Packages.callPackage ../development/python-modules/qscintilla {
-    pythonPackages = self;
-  };
+  pyqt6-qscintilla = callPackage ../development/python-modules/qscintilla { };
 
   pyqt6-sip = callPackage ../development/python-modules/pyqt/pyqt6-sip.nix {
     inherit (pkgs) mesa;
@@ -17589,8 +17587,8 @@ self: super: with self; {
 
   qreactor = callPackage ../development/python-modules/qreactor { };
 
-  qscintilla = pkgs.libsForQt5.callPackage ../development/python-modules/qscintilla {
-    pythonPackages = self;
+  qscintilla = callPackage ../development/python-modules/qscintilla {
+    useQt6 = false;
   };
 
   qstylizer = callPackage ../development/python-modules/qstylizer { };


### PR DESCRIPTION
This PR removes yet another instance of `libsForQt5.callPackage`, in the spirit of https://github.com/NixOS/nixpkgs/issues/180841#issuecomment-2218221636.

Also, this is the first time I've used Claude Code (which I disclosed in the commit message); the diff already seems good to me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
