### PR TITLE
sabiql: 1.15.1 -> 2.0.1

### DIFF
--- a/pkgs/by-name/sa/sabiql/package.nix
+++ b/pkgs/by-name/sa/sabiql/package.nix
@@ -6,6 +6,7 @@
   rustc,
   graphviz,
   postgresql,
+  sqlite,
   xdg-utils,
   makeBinaryWrapper,
   nix-update-script,
@@ -13,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sabiql";
-  version = "1.15.1";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "riii111";
     repo = "sabiql";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-vxkuYBakLzfZJyOPFD92kYB0QapfaLfwvw/La6kVQXY=";
+    hash = "sha256-QKc53tMxz9/+5fnDdBvxAj/CPB/UE4uWQ3Kh1haTyAk=";
   };
 
-  cargoHash = "sha256-UN/3VFGZdjZjBGqCxgdiWUCuDS3p+3z/WqQ9CCwwQAA=";
+  cargoHash = "sha256-ujT547EFdBxHWY6l1DDrTnMGAek26p3csGouJEk1Mwo=";
 
   # Upstream use latest rust version need to patch use nixpkgs version
   postPatch = ''
@@ -33,11 +34,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     makeBinaryWrapper
   ];
 
+  nativeCheckInputs = [
+    sqlite
+  ];
+
   postInstall =
     let
       runtimePathDeps = [
         graphviz
         postgresql
+        sqlite
       ]
       ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ];
     in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
