### PR TITLE
python3Packages.pysyncobj: 0.3.16 -> 0.3.17

### DIFF
--- a/pkgs/development/python-modules/pysyncobj/default.nix
+++ b/pkgs/development/python-modules/pysyncobj/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pysyncobj";
-  version = "0.3.16";
+  version = "0.3.17";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bakwc";
     repo = "PySyncObj";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/+vWvUe5oMdEJhqwmK89SE/P9zvpdhuB4qPTjgTR1kM=";
+    hash = "sha256-p4Jmyf/Y/pyHFn0lAACqaZCqXWdmmDMJwgyM5DDNJd4=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Diff: https://github.com/bakwc/PySyncObj/compare/v0.3.16...v0.3.17

Changelog: https://github.com/bakwc/PySyncObj/releases/tag/v0.3.17


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
