### PR TITLE
repath-studio: fix flaky tests in sandbox

### DIFF
--- a/nixos/tests/repath-studio.nix
+++ b/nixos/tests/repath-studio.nix
@@ -52,16 +52,28 @@
     machine.screenshot("Repath-Studio-GUI-Welcome")
     machine.send_key("kp_enter") # OK
 
-    # sleep is required it needs time to dismiss the dialog
+    # move the mouse to the "Save" icon on the toolbar
+    machine.execute("su - alice -c \"DISPLAY=:0 xdotool mousemove --sync 95 65\"")
+
+    # click the save icon until the GTK save dialog appears
+    for _ in range(30):
+        status, _ = machine.execute("su - alice -c \"DISPLAY=:0 xdotool search --name 'Save File'\"")
+        if status == 0:
+            break
+        machine.execute("su - alice -c \"DISPLAY=:0 xdotool click 1\"")
+        machine.sleep(1)
+
+    # wait for the GTK dialog to focus the text input field
+    machine.sleep(3)
+    machine.send_chars("saved.rps") # avoid using absolute path here, doesn't work for some reason
+    # wait for text to be typed
     machine.sleep(2)
-    machine.send_key("ctrl-shift-s")
-    machine.sleep(2)
-    machine.send_chars("/tmp/saved.rps")
-    machine.sleep(2)
-    machine.succeed("su - alice -c 'DISPLAY=:0 xdotool mousemove --sync 975 745 click 1'") # Save file dialog
-    machine.sleep(2)
-    print(machine.succeed("cat /tmp/saved.rps"))
-    assert "${pkgs.repath-studio.version}" in machine.succeed("cat /tmp/saved.rps")
+
+    machine.execute("su - alice -c \"DISPLAY=:0 xdotool key alt+s\"") # save file
+    machine.wait_until_succeeds("ls /home/alice/saved.rps")
+
+    machine.succeed("cat /home/alice/saved.rps")
+    assert "${pkgs.repath-studio.version}" in machine.succeed("cat /home/alice/saved.rps")
 
     machine.screenshot("Repath-Studio-GUI")
   '';

--- a/pkgs/by-name/re/repath-studio/fix-karma-sandbox.patch
+++ b/pkgs/by-name/re/repath-studio/fix-karma-sandbox.patch
@@ -1,0 +1,23 @@
+--- a/karma.conf.js
++++ b/karma.conf.js
+@@ -7,7 +7,7 @@
+     customLaunchers: {
+       ChromeHeadlessNoSandbox: {
+         base: 'ChromeHeadless',
+-        flags: ['--no-sandbox']
++        flags: ['--no-sandbox', '--disable-dev-shm-usage']
+       },
+       CustomElectron: {
+         base: 'Electron',
+@@ -42,6 +42,10 @@
+       outputDir: junitOutputDir + '/karma', // results will be saved as outputDir/browserName.xml
+       outputFile: undefined, // if included, results will be saved as outputDir/browserName/outputFile
+       suite: '' // suite will become the package name attribute in xml testsuite element
+-    }
++    },
++
++    browserDisconnectTimeout: 300000,
++    browserNoActivityTimeout: 300000,
++    pingTimeout: 300000
+   })
+ }

--- a/pkgs/by-name/re/repath-studio/package.nix
+++ b/pkgs/by-name/re/repath-studio/package.nix
@@ -36,6 +36,8 @@ buildNpmPackage (finalAttrs: {
     # outputHash of clojureHome changes each time `clojure` is updated
     # https://github.com/ngi-nix/ngipkgs/pull/1727#discussion_r2470180998
     ./pin-clojure.patch
+    # checks have become flaky in nix build sandbox, increase timeout and disable dev/shm for chrome
+    ./fix-karma-sandbox.patch
     ./0001-disable-auto-update-check.patch
   ];
 


### PR DESCRIPTION
It was failing recently https://hydra.nixos.org/job/nixpkgs/unstable/repath-studio.x86_64-linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
