### PR TITLE
ninjabrain-bot: fix icon lookup

### DIFF
--- a/pkgs/by-name/ni/ninjabrain-bot/package.nix
+++ b/pkgs/by-name/ni/ninjabrain-bot/package.nix
@@ -58,6 +58,7 @@ maven.buildMavenPackage (finalAttrs: {
 
     install -Dm444 target/ninjabrainbot-${finalAttrs.version}-jar-with-dependencies.jar $out/share/java/ninjabrain-bot.jar
 
+    install -Dm644 src/main/resources/icon.png $out/share/icons/hicolor/512x512/apps/ninjabrain-bot.png
     install -Dm644 src/main/resources/icon.png $out/share/icons/hicolor/640x640/apps/ninjabrain-bot.png
 
     # Swing text rendering varies outside full desktop environments.


### PR DESCRIPTION
`caelestia` ’s launcher could not find `ninjabrain-bot` ’s icon because it was only installed in `hicolor/640x640` which is not listed in hicolor/index.theme

<img width="627" height="540" alt="image" src="https://github.com/user-attachments/assets/39a42d34-7d50-45e9-99c8-9b123892f86f" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
