### PR TITLE
nanobind-backend: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/nanobind-backend/default.nix
+++ b/pkgs/development/python-modules/nanobind-backend/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  isPyPy,
+
+  # build-system
+  cmake,
+  ninja,
+  scikit-build-core,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "nanobind-backend";
+  version = "1.0.0";
+  pyproject = true;
+
+  disabled = isPyPy;
+
+  src = fetchFromGitHub {
+    owner = "wjakob";
+    repo = "nanobind";
+    tag = "v3.0.1";
+    fetchSubmodules = true;
+    hash = "sha256-VjH2cxjWctd99puD4U1ebnkQZaXF/t3ydtIHroV3BAI=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/nanobind-backend";
+
+  build-system = [
+    cmake
+    ninja
+    scikit-build-core
+  ];
+
+  dontUseCmakeBuildDir = true;
+
+  pythonImportsCheck = [
+    "nanobind_backend"
+    "nanobind_backend._nb_backend_v1"
+  ];
+
+  meta = {
+    description = "Compiled nanobind backend for extensions built in split mode";
+    homepage = "https://github.com/wjakob/nanobind";
+    changelog = "https://github.com/wjakob/nanobind/blob/v3.0.1/docs/changelog.rst";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ parras ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11771,6 +11771,8 @@ self: super: with self; {
 
   nanobind = callPackage ../development/python-modules/nanobind { };
 
+  nanobind-backend = callPackage ../development/python-modules/nanobind-backend { };
+
   nanoeigenpy = callPackage ../development/python-modules/nanoeigenpy { };
 
   nanoemoji = callPackage ../development/python-modules/nanoemoji { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the `nanobind-backed` package, needed to use the new split-mode compilation model introduced in `nanobind>=3` https://nanobind.readthedocs.io/en/latest/split_mode.html

Assisted-by: Pi:gpt-5.6-sol

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
