### PR TITLE
nixos/forgejo-runner: fix typo in migration instructions

### DIFF
--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -89,7 +89,7 @@ in
                     to extract two values from it. Given the instance name of "${name}", you should
                     be able to find it at `/var/lib/gitea-runner/${name}/.runner'.
 
-                 2. Read the contents of it, for example using `cat /var/lib/gitea-runner/native/.runner'.
+                 2. Read the contents of it, for example using `cat /var/lib/gitea-runner/${name}/.runner'.
 
                  3. Take note of the "uuid" and set the option `${options.settings}.server.connections.default.uuid'
                     to that value. For example "c9e50be9-a7c3-4aee-ba35-624c4ff8c519".
@@ -110,7 +110,7 @@ in
                     to extract two values from it. Given the instance name of "${name}", you should
                     be able to find it at `/var/lib/gitea-runner/${name}/.runner'.
 
-                 2. Read the contents of it, for example using `cat /var/lib/gitea-runner/native/.runner'.
+                 2. Read the contents of it, for example using `cat /var/lib/gitea-runner/${name}/.runner'.
 
                  3. Take note of the "uuid" and set the option `${options.settings}.server.connections.default.uuid'
                     to that value. For example "c9e50be9-a7c3-4aee-ba35-624c4ff8c519".


### PR DESCRIPTION
The hard-coded value "native" is a leftover from my testing, as one of my instances has a runner called "native".

Ref: #529621

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` (`forgejo-runner.tests`, no-op).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
