### PR TITLE
docling-serve: drop withCPU toggle

### DIFF
--- a/pkgs/by-name/do/docling-serve/package.nix
+++ b/pkgs/by-name/do/docling-serve/package.nix
@@ -4,7 +4,6 @@
   withUI ? false,
   withTesserocr ? false,
   withRapidocr ? false,
-  withCPU ? false,
 }:
 
 (python3Packages.toPythonApplication (
@@ -13,7 +12,6 @@
       withUI
       withTesserocr
       withRapidocr
-      withCPU
       ;
   }
 ))

--- a/pkgs/development/python-modules/docling-serve/default.nix
+++ b/pkgs/development/python-modules/docling-serve/default.nix
@@ -46,7 +46,6 @@
   withUI ? false,
   withTesserocr ? false,
   withRapidocr ? false,
-  withCPU ? false,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -104,8 +103,7 @@ buildPythonPackage (finalAttrs: {
   ++ uvicorn.optional-dependencies.standard
   ++ lib.optionals withUI finalAttrs.passthru.optional-dependencies.ui
   ++ lib.optionals withTesserocr finalAttrs.passthru.optional-dependencies.tesserocr
-  ++ lib.optionals withRapidocr finalAttrs.passthru.optional-dependencies.rapidocr
-  ++ lib.optionals withCPU finalAttrs.passthru.optional-dependencies.cpu;
+  ++ lib.optionals withRapidocr finalAttrs.passthru.optional-dependencies.rapidocr;
 
   optional-dependencies = {
     ui = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Address https://github.com/NixOS/nixpkgs/pull/549079#issuecomment-5422131199

`withCPU` was a no-op in nixpkgs anyway (it only propagated to `torch`).

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
