### PR TITLE
strace-tui: init at 1.0.1

### DIFF
--- a/pkgs/by-name/st/strace-tui/package.nix
+++ b/pkgs/by-name/st/strace-tui/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "strace-tui";
+  version = "1.0.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Rodrigodd";
+    repo = "strace-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VHBXZ1b5emqroFI5OswxXXq1BFNbm6iJlAAso93+Nr4=";
+  };
+
+  cargoHash = "sha256-8911bjw1v4pq/84L+B+x+WnKxGbTi5Og1xOxcwn9vHI=";
+
+  checkFlags = [
+    "--skip=test_cli_parse_subcommand"
+    "--skip=test_cli_trace_subcommand"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A terminal user interface (TUI) for visualizing and exploring strace output";
+    homepage = "https://github.com/Rodrigodd/strace-tui";
+    changelog = "https://github.com/Rodrigodd/strace-tui/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "strace-tui";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
