### PR TITLE
sing-box: 1.13.21 -> 1.14.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -51,6 +51,8 @@
 
 - The existing `wasm32-wasi` target has become `wasm32-wasip1` and `pkgsCross.wasi32` has become `pkgsCross.wasm32-wasip1`, aligning with LLVM's nomenclature. Aliases are in place and old forms will continue to be parsed but there might be some breakage if you're relying on the exact form of these (e.g., in sysroot paths).
 
+- `sing-box` has been updated to 1.14.0, which has removed some deprecated options.  See [upstream documentation](https://sing-box.sagernet.org/migration/) for details and migration options.
+
 - `gotosocial` has been updated to 0.22.0. This release contains a very long database migration, which should not be cancelled or interrupted under any circumstances.
  -  Postgres users: Following the migration, if you encounter slowdown on Postgres specifically (ie., timing out while loading timelines) you may need to run some manual database maintenance steps. Please check https://docs.gotosocial.org/en/stable/admin/database_maintenance/#postgres.
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -207,6 +207,8 @@
 
 - `services.komodo-periphery` has been updated to support version 2.0.0. Some options have been renamed to match the new configuration structure; compatibility aliases are provided for the renamed options. The `passkeys` and `outbound.onboardingKey` options have been removed; use `passkeyFiles`, `auth.privateKey`/`auth.corePublicKeys`, or `outbound.onboardingKeyFile` instead. New outbound mode configuration is available under `outbound.*`.
 
+- `sing-box` has been updated to 1.14.0, which has removed some deprecated options.  See [upstream documentation](https://sing-box.sagernet.org/migration/) for details and migration options.
+
 - `services.pfix-srsd` and the supporting `pfixtools` package have been removed, as the project is dormant and does not support pcre2.  `services.postsrsd` is the recommended replacement for Sender Rewriting Scheme support with Postfix.
 
 - `services.quake3-server.port` has been removed in favor of the structured [](#opt-services.quake3-server.settings.net_port) option. Use `services.quake3-server.settings.net_port` to set any custom UDP port directly.

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -14,6 +14,11 @@ let
     value = lib.singleton k;
   }) hosts;
 
+  hostsDns = {
+    type = "hosts";
+    tag = "dns:hosts";
+  };
+
   vmessPort = 1080;
   vmessUUID = "bf000d23-0752-40b4-affe-68f7707a9661";
   vmessInbound = {
@@ -255,6 +260,10 @@ in
         services.sing-box = {
           enable = true;
           settings = {
+            dns = {
+              final = hostsDns.tag;
+              servers = [ hostsDns ];
+            };
             inbounds = [
               tunInbound
             ];
@@ -270,6 +279,7 @@ in
               vmessOutbound
             ];
             route = {
+              default_domain_resolver = hostsDns.tag;
               default_interface = "eth1";
               final = "outbound:block";
               rules = [
@@ -314,6 +324,10 @@ in
         services.sing-box = {
           enable = true;
           settings = {
+            dns = {
+              final = hostsDns.tag;
+              servers = [ hostsDns ];
+            };
             inbounds = [
               tunInbound
             ];
@@ -341,6 +355,7 @@ in
               }
             ];
             route = {
+              default_domain_resolver = hostsDns.tag;
               default_interface = "eth1";
               final = "outbound:block";
               rules = [
@@ -386,6 +401,10 @@ in
         services.sing-box = {
           enable = true;
           settings = {
+            dns = {
+              final = hostsDns.tag;
+              servers = [ hostsDns ];
+            };
             inbounds = [
               {
                 tag = "inbound:tproxy";
@@ -407,6 +426,7 @@ in
               vmessOutbound
             ];
             route = {
+              default_domain_resolver = hostsDns.tag;
               default_interface = "eth1";
               final = "outbound:block";
               rules = [

--- a/pkgs/by-name/cr/cronet-go/package.nix
+++ b/pkgs/by-name/cr/cronet-go/package.nix
@@ -29,15 +29,15 @@ in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cronet-go";
   # NOTE: https://github.com/SagerNet/sing-box/blob/stable/.github/CRONET_GO_VERSION
-  version = "150.0.7871.63-1";
+  version = "150.0.7871.63-2";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "SagerNet";
     repo = "cronet-go";
-    rev = "7e27f60f7f04a1c762b6bb69b4a44d7b24cd7a5d";
+    rev = "d9872d6dd0d39cc7e042d1199d736f16fc40cf8c";
     fetchSubmodules = true;
-    hash = "sha256-dTKKl32saIIVt8ue105Xw643TBNEf09H38GbSdEcmKQ=";
+    hash = "sha256-b7sOKn5d5BsZa73Jukw25fz3MVWHlQBteXrufWwszUk=";
   };
 
   patches = [

--- a/pkgs/by-name/si/sing-box/package.nix
+++ b/pkgs/by-name/si/sing-box/package.nix
@@ -19,7 +19,7 @@ assert lib.assertMsg (
 buildGoModule (finalAttrs: {
   pname = "sing-box";
   # NOTE: also update cronet-go
-  version = "1.13.21";
+  version = "1.14.0";
 
   __structuredAttrs = true;
 
@@ -28,10 +28,10 @@ buildGoModule (finalAttrs: {
     owner = "SagerNet";
     repo = "sing-box";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+sFpijsCxsA2yGtaDFpKKmGhInbkN95jS6TE5++eSOQ=";
+    hash = "sha256-1v9bgM2H439ZoSkomv5dmT5SNrkuyOJ1iFFPlYPsW/k=";
   };
 
-  vendorHash = "sha256-JCLpqLphEPZ9xkgh+xeKX2MUdDJySALwtOp6wHZfKR8=";
+  vendorHash = "sha256-Bl73SkmnOyh5kULctDaxcOzXsYXRY2DOt80ME2+lBJo=";
 
   tags = [
     "with_gvisor"
@@ -44,6 +44,10 @@ buildGoModule (finalAttrs: {
     "with_tailscale"
     "with_ccm"
     "with_ocm"
+    "with_cloudflared"
+    "with_usbip"
+    "with_openvpn"
+    "with_openconnect"
     "badlinkname"
     "tfogo_checklinkname0"
   ]
@@ -71,7 +75,7 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-X=github.com/sagernet/sing-box/constant.Version=${finalAttrs.version}"
-    "-X=internal/godebug.defaultGODEBUG=multipathtcp=0"
+    "-X=runtime.godebugDefault=multipathtcp=0,tlssha1=1"
     "-checklinkname=0"
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
