### PR TITLE
gst_all_1: specify CPE identifier where applicable

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -443,5 +443,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = if enableGplPlugins then lib.licenses.gpl2Plus else lib.licenses.lgpl2Plus;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ tmarkus ];
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
   };
 })

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -240,5 +240,6 @@ stdenv.mkDerivation (finalAttrs: {
     );
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ tmarkus ];
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
   };
 })

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -146,6 +146,26 @@ stdenv.mkDerivation (finalAttrs: {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
     updateScript = directoryListingUpdater { odd-unstable = true; };
+
+    # From around version 1.12.0 on, there is a single CPE identifier for all of GStreamer.
+    # FIXME: Should gst-plugins-rs follow the main GStreamer versioning or its own deviating version?
+    gstreamerCpeParts =
+      let
+        commonGstreamerVersion = finalAttrs.version;
+      in
+      version:
+      lib.warnIf (version != commonGstreamerVersion)
+        ''
+          Detected mismatch between common GStreamer version (${commonGstreamerVersion}) and version used for gstreamerCpeParts (${version}).
+          Note that GStreamer uses a common CPE identifier for its components.
+          Having a deviating version is unusual, but may occur e.g. if overriding a subset of GStreamer libraries.
+        ''
+        (
+          lib.meta.cpeFullVersionWithVendor "gstreamer" version
+          // {
+            product = "gstreamer";
+          }
+        );
   };
 
   meta = {
@@ -159,5 +179,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       tmarkus
     ];
+    identifiers.cpeParts = finalAttrs.passthru.gstreamerCpeParts finalAttrs.version;
   };
 })

--- a/pkgs/development/libraries/gstreamer/devtools/default.nix
+++ b/pkgs/development/libraries/gstreamer/devtools/default.nix
@@ -132,5 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ tmarkus ];
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
   };
 })

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -14,6 +14,8 @@
   flex,
   gettext,
   gobject-introspection,
+  # for passthru.gstreamerCpeParts
+  gstreamer,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   hotdoc,
@@ -93,5 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ tmarkus ];
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
   };
 })

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -61,6 +61,8 @@
   wavpack,
   glib,
   openssl,
+  # for passthru.gstreamerCpeParts
+  gstreamer,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   hotdoc,
@@ -306,5 +308,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ tmarkus ];
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
   };
 })

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -75,5 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ tmarkus ];
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
   };
 })

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -10,6 +10,8 @@
   gobject-introspection,
   gst-plugins-base,
   gst-plugins-bad,
+  # only for passthru.gstreamerCpeParts
+  gstreamer,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   hotdoc,
@@ -82,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
       A library on top of GStreamer for building an RTSP server.
     '';
     license = lib.licenses.lgpl2Plus;
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ bkchr ];
   };

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -17,6 +17,8 @@
   libintl,
   lib,
   enableGplPlugins ? true,
+  # only for passthru.gstreamerCpeParts
+  gstreamer,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
   hotdoc,
@@ -122,6 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
       like. The code might be widely known to present patent problems.
     '';
     license = if enableGplPlugins then lib.licenses.gpl2Plus else lib.licenses.lgpl2Plus;
+    identifiers.cpeParts = gstreamer.passthru.gstreamerCpeParts finalAttrs.version;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ tmarkus ];
   };


### PR DESCRIPTION
Add CPE identifiers to GStreamer packages where applicable.

Example invocation for testing:
```shell
$ nix-instantiate --eval -A gst_all_1.gst-plugins-ugly.meta.identifiers.cpeParts
{ edition = "*"; language = "*"; other = "*"; part = "a"; product = "gstreamer"; sw_edition = "*"; target_hw = "*"; target_sw = "*"; update = "-"; vendor = "gstreamer"; version = "1.28.6"; }
$ nix-instantiate --eval -A gst_all_1.gst-plugins-ugly.meta.identifiers.cpe
"cpe:2.3:a:gstreamer:gstreamer:1.28.6:-:*:*:*:*:*:*"
```

Example NIST NVD CPE lookup: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:gstreamer:gstreamer:1.28.6:*:*:*:*:*:*:*

Note: I'm unsure about how to handle `gst-plugins-rs`. Should we specify the version specific to the gst-plugins-rs release itself (0.15.3 at the moment) or rather the "associated" GStreamer release (if I understand correctly GStreamer also does something like a complete SDK release, which would e.g. use the `gstreamer-1.28.6` branch in the gst-plugins-rs repository, which corresponds to version 0.15.3).
Since `gst-plugins-rs` doesn't have any entry of its own in the CPE database and I couldn't find any CVE related to `gst-plugins-rs` on the spot (which would have allowed checking its CPE entry in turn), it's hard to tell which CPE would be authoritative for `gst-plugins-rs`.
I'd personally simply use the version used for GStreamer overall (i.e. currently 1.28.6 in our case), that would just look a little weird in the gst-plugins-rs derivation itself as the version would essentially come out of nowhere.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
