### PR TITLE
cachix: 1.12.0 -> 1.12.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3420,13 +3420,13 @@ with haskellLib;
 # Manually maintained
 // (
   let
-    version = "1.12.0";
+    version = "1.12.1";
 
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
-      rev = "e3609f93799354c50e4126d6423ede6dd317e2f2";
-      hash = "sha256-AOhHyBEk8LOiAU9tgmNJPJAKKUVDQFzTNSLe62FPxpY=";
+      tag = "v${version}";
+      hash = "sha256-OUB6hPlFBB9FRdZgZXSye4lDOg+fbrqKe8ePv2IM7NY=";
     };
   in
   {


### PR DESCRIPTION
Updates the Cachix CLI from 1.12.0 to 1.12.1. This patch release improves daemon failure handling and authentication guidance, preserves trusted public keys for existing substituters, and adds a timeout for secure deployment connection setup.

Release: https://github.com/cachix/cachix/releases/tag/v1.12.1

Assisted by OpenAI Codex (GPT-5) for the source update, verification, and PR drafting.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at passthru.tests.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and core functionality.
- [ ] Ran nixpkgs-review on this PR.
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.