### PR TITLE
apm-cli: 0.21.0 -> 0.29.0

### DIFF
--- a/pkgs/by-name/ap/apm-cli/package.nix
+++ b/pkgs/by-name/ap/apm-cli/package.nix
@@ -78,11 +78,33 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "apm_cli"
   ];
 
+  postInstall = ''
+    install -Dm755 -t "$out/share/apm-cli/scripts/runtime" scripts/runtime/*
+    install -Dm755 -t "$out/share/apm-cli/scripts" scripts/github-token-helper.sh
+  '';
+
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
 
   doInstallCheck = true;
+
+  postInstallCheck = ''
+        test -f "$out/share/apm-cli/scripts/runtime/setup-common.sh"
+        test -f "$out/share/apm-cli/scripts/github-token-helper.sh"
+
+        ${python3Packages.python.interpreter} - <<'PY'
+    from apm_cli.runtime.manager import RuntimeManager
+
+    manager = RuntimeManager()
+
+    assert manager.get_common_script()
+    assert manager.get_token_helper_script()
+
+    for runtime_info in manager.supported_runtimes.values():
+        assert manager.get_embedded_script(runtime_info["script"])
+    PY
+  '';
 
   meta = {
     description = "Agent Package Manager";

--- a/pkgs/by-name/ap/apm-cli/package.nix
+++ b/pkgs/by-name/ap/apm-cli/package.nix
@@ -2,11 +2,12 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "apm-cli";
-  version = "0.21.0";
+  version = "0.29.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -15,13 +16,20 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "microsoft";
     repo = "apm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Wotyqsg/1nbjttMk+4wpGK76+kaL7j6oMH61NwsTuNc=";
+    hash = "sha256-0aVqPRRaVjV3qoE+Fh3L98HUmBlAtu3pMiTSxVDj4Ak=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail '"llm-github-models>=0.1.0",' ""
+    # The wheel does not include scripts/, so RuntimeManager's
+    # repository-relative fallback does not work after installation.
+    substituteInPlace src/apm_cli/runtime/manager.py \
+      --replace-fail 'repo_root = current_file.parent.parent.parent.parent  # Go up to repo root' 'repo_root = Path("${placeholder "out"}/share/apm-cli")'
   '';
+
+  pythonRemoveDeps = [
+    # Not packaged in nixpkgs.
+    "llm-github-models"
+  ];
 
   build-system = with python3Packages; [
     setuptools
@@ -33,8 +41,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     filelock
     gitpython
     llm
-    # Not in nixpkgs and the game is not worth the candle for this package.
-    # llm-github-models
     python-frontmatter
     pyyaml
     requests
@@ -42,8 +48,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     rich-click
     ruamel-yaml
     toml
-    tomli
+    tomlkit
+    truststore
     watchdog
+    websockets
   ];
 
   optional-dependencies = with python3Packages; {
@@ -51,12 +59,16 @@ python3Packages.buildPythonApplication (finalAttrs: {
       pyinstaller
     ];
     dev = [
+      hypothesis
       jsonschema
       mypy
+      # Not packaged in nixpkgs.
+      # mutmut
       pylint
       pytest
       pytest-cov
-      pytest-split
+      # Not packaged in nixpkgs.
+      # pytest-split
       pytest-xdist
       ruff
     ];
@@ -66,12 +78,18 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "apm_cli"
   ];
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
   meta = {
     description = "Agent Package Manager";
     homepage = "https://github.com/microsoft/apm";
     changelog = "https://github.com/microsoft/apm/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ drupol ];
-    mainProgram = "apm-cli";
+    mainProgram = "apm";
   };
 })


### PR DESCRIPTION
Update `apm-cli` from 0.21.0 to 0.29.0, the latest stable upstream release.

The update adds the newly required `tomlkit` and `truststore` dependencies and adds `websockets`, which was already required upstream but missing from the previous Nix expression. It removes `tomli`, which upstream now requires only on Python versions older than 3.11. Upstream raised its `llm` and `llm-github-models` dependency floors; the current Nixpkgs `llm` satisfies the new requirement. The update also adds `hypothesis` to the evaluable development extras while keeping the unavailable `pytest-split` and `mutmut` packages omitted.

`llm-github-models` remains omitted because it is not packaged in Nixpkgs. This is not a new omission: the previous expression already removed it. The package now uses `pythonRemoveDeps` instead of patching an exact requirement string in `pyproject.toml`. Consequently, the Nix-provided `llm` fallback has no `github/*` models. Upstream's `apm runtime setup llm` instead installs `llm-github-models` into an APM-managed virtual environment, which APM prefers over the fallback; that end-to-end setup path was not executed.

The upstream wheel does not include the runtime setup scripts expected by `RuntimeManager`. This change installs those scripts in the Nix output, patches the source-build lookup path, and verifies during the install check that every supported runtime setup script can be loaded. The setup scripts themselves were not executed: depending on the runtime, they download tools with npm, pip, or from GitHub Releases, write under `~/.apm/runtimes`, and may append a PATH entry to the user's shell configuration.

The package now also uses the actual `apm` executable as `meta.mainProgram` and checks its reported version during the build.

Upstream changelog: https://github.com/microsoft/apm/blob/v0.29.0/CHANGELOG.md

### Verification

- `nix eval --json .#apm-cli.optional-dependencies`
- `nix eval --json .#apm-cli.pythonRemoveDeps`
- `nix build --no-link .#apm-cli -L`
- `nixfmt --check pkgs/by-name/ap/apm-cli/package.nix`
- `git diff --check upstream/master...HEAD`
- Installed `.#apm-cli` into an isolated Nix profile
- Verified `apm --version` reports 0.29.0
- Verified `apm --help` and `apm runtime list` start successfully
- Verified all runtime setup scripts are present in the installed profile

### Automation disclosure

These changes and this PR summary were prepared with OpenAI Codex (GPT-5.4 and GPT-5.6-sol) and reviewed with Claude Code (Claude Opus 5). The generated changes were reviewed through diff inspection and the checks listed above.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
