### PR TITLE
atlas-file-manager: init at 1.2.0

### DIFF
--- a/pkgs/by-name/at/atlas-file-manager/package.nix
+++ b/pkgs/by-name/at/atlas-file-manager/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  qt6,
+  exiv2,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "atlas-file-manager";
+  version = "1.2.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "AstraSuite";
+    repo = "Atlas";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l/jdB90oPVxFG5LlylQxYskYJN+av+MGjiy4jh5Il6s=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/main.cpp \
+      --replace-fail 'app.setApplicationVersion("1.0.0");' 'app.setApplicationVersion("${finalAttrs.version}");'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    qt6.qtmultimedia
+    exiv2
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "ATLAS_VERSION" finalAttrs.version)
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "QT_QPA_PLATFORM=offscreen atlas --version";
+    };
+  };
+
+  meta = {
+    description = "File manager for Caelestia";
+    homepage = "https://github.com/AstraSuite/Atlas";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "atlas";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[Atlas](https://github.com/AstraSuite/Atlas) is a fast, lightweight Native Caelestia File Manager built with Qt 6 and Material Design 3.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test