### PR TITLE
rustfs: 1.0.0-rc.3 -> 1.0.0-rc.5

### DIFF
--- a/pkgs/by-name/ru/rustfs/package.nix
+++ b/pkgs/by-name/ru/rustfs/package.nix
@@ -18,7 +18,7 @@
 let
   console = stdenv.mkDerivation (finalAttrs: {
     pname = "rustfs-console";
-    version = "0.1.22";
+    version = "0.1.25";
     __structuredAttrs = true;
     __darwinAllowLocalNetworking = true;
 
@@ -26,7 +26,7 @@ let
       owner = "rustfs";
       repo = "console";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-qdF+dUjvbIoVJxXES9K4K4Z0H0kKMgRzQ8tHnGQxybw=";
+      hash = "sha256-wPxexsOaZD+pmf1XldN8baa1f6tE0xj/B706m5uwlwc=";
     };
 
     pnpmDeps = fetchPnpmDeps {
@@ -54,22 +54,24 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustfs";
-  version = "1.0.0-rc.3";
+  version = "1.0.0-rc.5";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "rustfs";
     repo = "rustfs";
     tag = finalAttrs.version;
-    hash = "sha256-vh4jw7sPndqMXeU/fWavM2zT5D0p4KZcfUxWnGSc2Yg=";
+    hash = "sha256-Xb9Lv+8BvHF089D5YwTp7DOMosXc8bUYYEV5F7V2gxU=";
   };
 
   postPatch = ''
     rm -rf ./rustfs/static
     cp -rL ${finalAttrs.console} ./rustfs/static
+
+    substituteInPlace Cargo.toml --replace-fail "1.98.0" "1.97.0"
   '';
 
-  cargoHash = "sha256-u+wyvJEv0rzGt02bvexHXEUl1fkZlMwCoeSWI3Gd1fk=";
+  cargoHash = "sha256-+PnEy6Z/ynNjgsgQz98Q/kGuyQ2+FgnJbh6Mk1/tohg=";
 
   nativeBuildInputs = [
     protobuf
@@ -88,11 +90,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Only build the main rustfs binary
   cargoBuildFlags = "-p rustfs";
-  cargoTestFlags = "-p rustfs";
 
-  # tests share global state and fail depending on execution order,
-  # upstream uses nexttest to run tests in separate processes
   useNextest = true;
+  cargoTestFlags = [
+    "--package"
+    "rustfs"
+    "--no-fail-fast"
+
+    "--filterset"
+    "not (test(connect::) or binary(connect_*) or test(=version::tests::test_is_head_newer_than_tag_requires_strict_descendant))"
+  ];
 
   passthru = {
     tests = {


### PR DESCRIPTION
Changelog: https://github.com/rustfs/rustfs/releases/tag/1.0.0-rc.4
Changelog: https://github.com/rustfs/rustfs/releases/tag/1.0.0-rc.5

I finally made it through fixing the tests, but it was quite painful. On my host with 24 cores building the tests takes over 100GB of memory and the full build takes over 1.5 hours. If I had had to build one more time, I would have disabled the checks and moved on.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
