### PR TITLE
airlock: init at 1.3.0, nixos/airlock: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -640,6 +640,7 @@
   ./services/development/turborepo-remote-cache.nix
   ./services/development/vsmartcard-vpcd.nix
   ./services/development/zammad.nix
+  ./services/display-managers/airlock.nix
   ./services/display-managers/cosmic-greeter.nix
   ./services/display-managers/default.nix
   ./services/display-managers/dms-greeter.nix

--- a/nixos/modules/services/display-managers/airlock.nix
+++ b/nixos/modules/services/display-managers/airlock.nix
@@ -1,0 +1,128 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.displayManager.airlock;
+  user = config.services.greetd.settings.default_session.user;
+  group =
+    let
+      g = config.users.users.${user}.group or "";
+    in
+    if g != "" then g else "greeter";
+in
+{
+  options.services.displayManager.airlock = {
+    enable = lib.mkEnableOption "Airlock, a clean and modern Material Design 3 Quickshell greeter for greetd";
+
+    package = lib.mkPackageOption pkgs "airlock" { };
+
+    compositor = {
+      package = lib.mkPackageOption pkgs "cage" { };
+
+      extraArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "-s" ];
+        example = [
+          "-s"
+          "-m"
+          "last"
+        ];
+        description = ''
+          Arguments to pass to the compositor (defaults to cage).
+        '';
+      };
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--only"
+        "DP-1"
+      ];
+      description = ''
+        Extra command-line arguments to pass to {command}`astra-airlock` (e.g. display output options).
+      '';
+    };
+
+    syncDynamicScheme = {
+      enable = lib.mkEnableOption "sudoers permissions for wheel users to sync active desktop themes to the greeter non-interactively";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = (config.users.users.${user} or { }) != { };
+        message = "airlock: user ${user} does not exist. Please create it before referencing it.";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    services.accounts-daemon.enable = lib.mkDefault true;
+    hardware.graphics.enable = lib.mkDefault true;
+
+    fonts.packages = with pkgs; [
+      material-symbols
+    ];
+
+    systemd.tmpfiles.settings."10-airlock" = {
+      "/var/cache/astra-airlock".d = {
+        inherit user group;
+        mode = "0755";
+      };
+      "/var/cache/astra-airlock/schemes".d = {
+        inherit user group;
+        mode = "0755";
+      };
+      "/var/cache/astra-airlock/schemes/dynamic".d = {
+        inherit user group;
+        mode = "0777";
+      };
+    };
+
+    services.greetd = {
+      enable = lib.mkDefault true;
+      settings.default_session = {
+        command = lib.mkDefault (
+          lib.escapeShellArgs (
+            [
+              (lib.getExe cfg.compositor.package)
+            ]
+            ++ cfg.compositor.extraArgs
+            ++ [
+              "--"
+              (lib.getExe cfg.package)
+            ]
+            ++ cfg.extraArgs
+          )
+        );
+      };
+    };
+
+    security.sudo.extraRules = lib.mkIf cfg.syncDynamicScheme.enable [
+      {
+        commands = [
+          {
+            command = "${lib.getExe cfg.package} --sync";
+            options = [ "NOPASSWD" ];
+          }
+          {
+            command = "${lib.getExe cfg.package} -s";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+        groups = [ "wheel" ];
+      }
+    ];
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    rachalaraj
+  ];
+}

--- a/pkgs/by-name/ai/airlock/package.nix
+++ b/pkgs/by-name/ai/airlock/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  qt6,
+  quickshell,
+  wlr-randr,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "airlock";
+  version = "1.3.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "AstraSuite";
+    repo = "Airlock";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sSYL/7IBtxp6GPfqV0lDGlIz4JMD70dyA4szeJXceh0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "ASTRA_AIRLOCK_VERSION" finalAttrs.version)
+    (lib.cmakeFeature "INSTALL_QSCONFDIR" "${placeholder "out"}/etc/xdg/quickshell/astra-airlock")
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix PATH : ${
+        lib.makeBinPath [
+          quickshell
+          wlr-randr
+        ]
+      }
+      --prefix QML2_IMPORT_PATH : "$out/lib/qt6/qml"
+      --set CAELESTIA_GREETER_DIR "$out/etc/xdg/quickshell/astra-airlock"
+    )
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "astra-airlock --version";
+    };
+  };
+
+  meta = {
+    description = "Greetd frontend for Caelestia Shell";
+    homepage = "https://github.com/AstraSuite/Airlock";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "astra-airlock";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[Airlock](https://github.com/AstraSuite/Airlock) is a clean, modern Material Design 3 Quickshell frontend for greetd built on Caelestia.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test