### PR TITLE
gnucobol: use autoreconfHook on darwin too

### DIFF
--- a/pkgs/by-name/gn/gnucobol/package.nix
+++ b/pkgs/by-name/gn/gnucobol/package.nix
@@ -3,8 +3,6 @@
   stdenv,
   fetchurl,
   autoreconfHook,
-  autoconf,
-  automake,
   libtool,
   pkg-config,
   # libs
@@ -13,6 +11,7 @@
   gmp,
   libxml2,
   ncurses,
+  unixodbc,
   # docs
   help2man,
   texinfo,
@@ -47,18 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     texinfo
     texliveBasic
-  ]
-  ++ (
-    if stdenv.hostPlatform.isDarwin then
-      # autoreconf runs aclocal before autoconf, which messes up some compiler
-      # definition and causes many tests to fail (with segfaults)
-      [
-        automake
-        autoconf
-      ]
-    else
-      [ autoreconfHook ]
-  );
+    autoreconfHook
+  ];
 
   buildInputs = [
     cjson
@@ -66,6 +55,9 @@ stdenv.mkDerivation (finalAttrs: {
     gmp
     libxml2
     ncurses
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isUnix [
+    unixodbc
   ];
 
   outputs = [
@@ -94,13 +86,14 @@ stdenv.mkDerivation (finalAttrs: {
              AT_SKIP_IF(\[true\])' tests/testsuite.src/run_file.at
   '';
 
+  preAutoreconf = ''
+    gettextize --force
+  '';
+
   preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    autoconf
-    aclocal
-    automake
     # when building with nix on darwin, configure will use GNU strip,
     # which fails due to using --strip-unneeded, which is not supported
-    substituteInPlace configure --replace-fail '"GNU strip"' 'FAKE GNU strip'
+    substituteInPlace configure --replace-fail '"GNU strip"' '"FAKE GNU strip"'
   '';
 
   # GCC 15 changed some warnings to errors, particularly around function pointer types
@@ -108,12 +101,21 @@ stdenv.mkDerivation (finalAttrs: {
   # until gnucobol is updated to compile cleanly with GCC 15+/latest LLVM.
   # See: https://gcc.gnu.org/gcc-15/porting_to.html
   env.CFLAGS = "-std=gnu17";
+  env.CPPFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-DREAD_WRITE_NEEDS_FLUSH";
   enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-cobc-internal-checks"
+    "--enable-hardening"
+    "--with-db"
+    "--with-indexed=db"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isUnix [
+    "--with-obdc"
+  ];
 
   installFlags = [
     "localedir=$out/share/locale"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
     "install-pdf"
     "install-html"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Use the details from the gnucobol CI to allow us to build on Darwin with autoreconfHook. Also fix the removed install-html and install-pdf for linux which needed a run of gettoolize. It's mainly just a few hardening flags, using odbc for text input and an extra CPPFLAG.

Draft for now while I try and fix the errors with building the gnucobol pre-release build the superbol-studio-oss needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
