### PR TITLE
treewide: use nix-instantiate --eval --raw in update scripts

### DIFF
--- a/pkgs/by-name/au/audiobookshelf/update.sh
+++ b/pkgs/by-name/au/audiobookshelf/update.sh
@@ -13,7 +13,7 @@ fi
 REPO="advplyr/audiobookshelf"
 
 NEW_VER=$(list-git-tags --url=https://github.com/$REPO | rg 'v[0-9\.]*$' | sed -e 's/^v//' | sort -V | tail -n 1)
-OLD_VER=$(nix-instantiate --eval -A audiobookshelf.version | jq --exit-status --raw-output)
+OLD_VER=$(nix-instantiate --eval --raw -A audiobookshelf.version)
 
 if [ "$NEW_VER" == "$OLD_VER" ]; then
   echo "No update needed."

--- a/pkgs/by-name/au/audiothekar/update.sh
+++ b/pkgs/by-name/au/audiothekar/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/fxsth/audiothekar/releases/latest | jq -e -r .tag_name | tail -c +2)
-old_version=$(nix-instantiate --eval -A audiothekar.version | jq -e -r)
+old_version=$(nix-instantiate --eval --raw -A audiothekar.version)
 
 if [[ $version == "$old_version" ]]; then
     echo "New version same as old version, nothing to do." >&2

--- a/pkgs/by-name/ca/cavalier/update.sh
+++ b/pkgs/by-name/ca/cavalier/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/NickvisionApps/Cavalier/releases/latest | jq -e -r .tag_name)
-old_version=$(nix-instantiate --eval -A cavalier.version | jq -e -r)
+old_version=$(nix-instantiate --eval --raw -A cavalier.version)
 
 if [[ $version == "$old_version" ]]; then
     echo "New version same as old version, nothing to do." >&2

--- a/pkgs/by-name/da/dawarich/update.sh
+++ b/pkgs/by-name/da/dawarich/update.sh
@@ -6,7 +6,7 @@ set -o pipefail
 OWNER="Freika"
 REPO="dawarich"
 
-old_version=$(nix-instantiate --eval -A 'dawarich.version' default.nix | tr -d '"')
+old_version=$(nix-instantiate --eval --raw -A dawarich.version)
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/$OWNER/$REPO/releases/latest" | jq -r ".tag_name")
 
 echo "Updating to $version"

--- a/pkgs/by-name/de/denaro/update.sh
+++ b/pkgs/by-name/de/denaro/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/NickvisionApps/Denaro/releases/latest | jq -e -r .tag_name)
-old_version=$(nix-instantiate --eval -A denaro.version | jq -e -r)
+old_version=$(nix-instantiate --eval --raw -A denaro.version)
 
 if [[ $version == "$old_version" ]]; then
     echo "New version same as old version, nothing to do." >&2

--- a/pkgs/by-name/ej/ejabberd/update.sh
+++ b/pkgs/by-name/ej/ejabberd/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/processone/ejabberd/releases/latest | jq -e -r .tag_name)
-old_version=$(nix-instantiate --eval -A ejabberd.version | jq -e -r)
+old_version=$(nix-instantiate --eval --raw -A ejabberd.version)
 
 if [[ $version == "$old_version" ]]; then
     echo "New version same as old version, nothing to do." >&2

--- a/pkgs/by-name/gh/ghostty/update.nu
+++ b/pkgs/by-name/gh/ghostty/update.nu
@@ -7,7 +7,7 @@ let latest = ^list-git-tags --url=https://github.com/ghostty-org/ghostty
   | last
   | str trim --left --char "v"
 
-let current = ^nix-instantiate --eval -A ghostty.version | str trim -c '"'
+let current = ^nix-instantiate --eval --raw -A ghostty.version
 
 if $latest == $current {
   print "Up to date!"

--- a/pkgs/by-name/gn/gnucash/update.sh
+++ b/pkgs/by-name/gn/gnucash/update.sh
@@ -10,8 +10,8 @@ if [[ "$latest_version" = "$UPDATE_NIX_OLD_VERSION" ]]; then
     exit 0
 fi
 
-old_src_hash=$(nix-instantiate --eval -A gnucash.src.outputHash | tr -d '"')
-old_src_doc_hash=$(nix-instantiate --eval -A gnucash.docs.src.outputHash | tr -d '"')
+old_src_hash=$(nix-instantiate --eval --raw -A gnucash.src.outputHash)
+old_src_doc_hash=$(nix-instantiate --eval --raw -A gnucash.docs.src.outputHash)
 
 src_hash=$(nix-prefetch-url "https://github.com/Gnucash/gnucash/releases/download/$latest_version/gnucash-$latest_version.tar.bz2")
 src_hash=$(nix-hash --to-sri --type sha256 "$src_hash")

--- a/pkgs/by-name/ir/ironcalc/update.sh
+++ b/pkgs/by-name/ir/ironcalc/update.sh
@@ -10,7 +10,7 @@ branch="main"
 commit=$(curl -s "https://api.github.com/repos/$owner/$repo/branches/$branch" | jq -r .commit.sha)
 date=$(curl -s "https://api.github.com/repos/$owner/$repo/commits/$commit" | jq -r .commit.committer.date | cut -d'T' -f1)
 
-current_version=$(nix-instantiate --eval -A ironcalc.version 2>/dev/null | tr -d '"' || echo "0.0.0")
+current_version=$(nix-instantiate --eval --raw -A ironcalc.version)
 base_version=$(echo "$current_version" | sed -E 's/-unstable-.*//')
 new_version="$base_version-unstable-$date"
 

--- a/pkgs/by-name/ko/koito/update.sh
+++ b/pkgs/by-name/ko/koito/update.sh
@@ -26,7 +26,7 @@ yarn-berry-fetcher missing-hashes "${src_path}/client/yarn.lock" >"${package_dir
 
 echo "Updating offline cache hash…"
 offline_cache_hash=$(yarn-berry-fetcher prefetch "${src_path}/client/yarn.lock" "${package_dir}/missing-hashes.json")
-old_hash=$(nix-instantiate --eval --expr "with import ./. {}; koito.client.offlineCache.outputHash" --raw)
+old_hash=$(nix-instantiate --eval --raw -A koito.client.offlineCache.outputHash)
 sed -i "s|${old_hash}|${offline_cache_hash}|" "${package_dir}/client.nix"
 
 echo "Done."

--- a/pkgs/by-name/le/legends-of-equestria/update.sh
+++ b/pkgs/by-name/le/legends-of-equestria/update.sh
@@ -4,8 +4,8 @@
 set -eu -o pipefail
 
 ATTR=legends-of-equestria
-DOWNLOADS_PAGE="$(curl -s "$(nix-instantiate --eval -A "$ATTR.meta.downloadPage" | tr -d '"')")"
-OLD_VERSION="$(nix-instantiate --eval -A "$ATTR.version" | tr -d '"')"
+DOWNLOADS_PAGE="$(curl -s "$(nix-instantiate --eval --raw -A "$ATTR.meta.downloadPage")")"
+OLD_VERSION="$(nix-instantiate --eval --raw -A "$ATTR.version")"
 NIX_FILE="$(nix-instantiate --eval -A "$ATTR.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')"
 TMP=$(mktemp -d)
 

--- a/pkgs/by-name/ma/mailpit/update.sh
+++ b/pkgs/by-name/ma/mailpit/update.sh
@@ -47,7 +47,7 @@ cat > $SOURCE_NIX <<-EOF
 }
 EOF
 
-GO_HASH="$(nix-instantiate --eval -A mailpit.vendorHash | tr -d '"')"
+GO_HASH="$(nix-instantiate --eval --raw -A mailpit.vendorHash)"
 VENDOR_HASH=$(extractVendorHash "$GO_HASH")
 
 cat > $SOURCE_NIX <<-EOF

--- a/pkgs/by-name/me/melonloader-installer/update.sh
+++ b/pkgs/by-name/me/melonloader-installer/update.sh
@@ -8,7 +8,7 @@ set -eu -o pipefail
 
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/LavaGang/MelonLoader.Installer/releases/latest | jq -e -r .tag_name)
-old_version=$(nix-instantiate --eval -A melonloader-installer.version | jq -e -r)
+old_version=$(nix-instantiate --eval --raw -A melonloader-installer.version)
 
 if [[ $version == "$old_version" ]]; then
     echo "New version same as old version, nothing to do." >&2

--- a/pkgs/by-name/mu/musicfree-desktop/update.sh
+++ b/pkgs/by-name/mu/musicfree-desktop/update.sh
@@ -3,14 +3,14 @@
 
 set -euo pipefail
 
-old_version=$(nix-instantiate --eval -A musicfree-desktop.version | tr -d '"')
+old_version=$(nix-instantiate --eval --raw -A musicfree-desktop.version)
 new_version=$(curl -sL ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} https://api.github.com/repos/maotoumao/MusicFreeDesktop/releases/latest | jq -r .tag_name | tr -d v)
 if [ "$old_version" == "$new_version" ]; then
   echo "Already up to date" >&2
   exit
 fi
 
-patch=$(dirname $(nix-instantiate --eval -A musicfree-desktop.meta.position | tr -d '"' | cut -d : -f 1))/bump-deps.patch
+patch=$(dirname $(nix-instantiate --eval --raw -A musicfree-desktop.meta.position | cut -d : -f 1))/bump-deps.patch
 
 export HOME=$(mktemp -d)
 pushd $HOME

--- a/pkgs/by-name/pl/plasticity/update.sh
+++ b/pkgs/by-name/pl/plasticity/update.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/nkallen/plasticity/releases/latest | jq -e -r ".tag_name | .[1:]")
-old_version=$(nix-instantiate --eval -A plasticity.version | jq -e -r)
+old_version=$(nix-instantiate --eval --raw -A plasticity.version)
 
 if [[ $version == "$old_version" ]]; then
     echo "New version same as old version, nothing to do." >&2

--- a/pkgs/by-name/ra/ramalama/update.sh
+++ b/pkgs/by-name/ra/ramalama/update.sh
@@ -13,7 +13,7 @@ else
   nix-update --format --use-github-releases ramalama
 fi
 
-version="$(nix-instantiate --eval -A ramalama.version | jq --raw-output .)"
+version="$(nix-instantiate --eval --raw -A ramalama.version)"
 
 image_name="quay.io/ramalama/ramalama"
 image_tag="${version%.*}"

--- a/pkgs/by-name/re/renpy/update.sh
+++ b/pkgs/by-name/re/renpy/update.sh
@@ -4,12 +4,12 @@
 set -euo pipefail
 
 # so that update bot doesn't try to update renpyMinimal
-if [[ -n "${UPDATE_NIX_ATTR_PATH:-}" ]] && [[ "${UPDATE_NIX_ATTR_PATH:-}" != renpy ]];
+if [[ -n "${UPDATE_NIX_ATTR_PATH:-}" ]] && [[ "${UPDATE_NIX_ATTR_PATH:-}" != renpy ]]; then
   exit
 fi
 
 attr() {
-  nix-instantiate --eval -A renpy.$1 | tr -d '"'
+  nix-instantiate --eval --raw -A renpy."$1"
 }
 
 old_version="$(attr version)"

--- a/pkgs/by-name/re/retrospy/update.sh
+++ b/pkgs/by-name/re/retrospy/update.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 new_version="$(curl -s "https://api.github.com/repos/retrospy/RetroSpy/releases?per_page=1" | jq -r '.[0].tag_name')"
 new_version=${new_version#v}
-old_version=$(nix-instantiate --eval -A retrospy.version | jq -e -r)
+old_version=$(nix-instantiate --eval --raw -A retrospy.version)
 
 if [[ "$new_version" == "$old_version" ]]; then
     echo "Up to date"

--- a/pkgs/by-name/ri/river-bedload/update-build-zig-zon.sh
+++ b/pkgs/by-name/ri/river-bedload/update-build-zig-zon.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p bash jq zon2nix wget
 
-commit=$(nix-instantiate --eval -A river-bedload.src.rev | jq --raw-output)
+commit=$(nix-instantiate --eval --raw -A river-bedload.src.rev)
 
 wget "https://git.sr.ht/~novakane/river-bedload/blob/${commit}/build.zig.zon"
 zon2nix build.zig.zon >pkgs/by-name/ri/river-bedload/build.zig.zon.nix

--- a/pkgs/by-name/um/umami/update.sh
+++ b/pkgs/by-name/um/umami/update.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
-old_version=$(nix-instantiate --eval -A 'umami.version' default.nix | tr -d '"' || echo "0.0.1")
+old_version=$(nix-instantiate --eval --raw -A umami.version)
 version=$(curl -s "https://api.github.com/repos/umami-software/umami/releases/latest" | jq -r ".tag_name")
 version="${version#v}"
 


### PR DESCRIPTION
Various update scripts used hacks like jq -e -r or tr -d '"' to strip quotes from strings, instead of simply adding the --raw flag to nix-instantiate.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
