### PR TITLE
zennotes-desktop: 2.39.0 -> 2.45.0

### DIFF
--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -13,14 +13,14 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "zennotes-desktop";
-  version = "2.39.0";
-  npmDepsHash = "sha256-AawgTAl0goPI3mkIyHEuV7E4AYR33HNL6bFwqN+yASo=";
+  version = "2.45.0";
+  npmDepsHash = "sha256-+5eIwbSTpRupYj4gR33MDeJEEDBlt+K4idnlZFWG4Z4=";
 
   src = fetchFromGitHub {
     owner = "ZenNotes";
     repo = "zennotes";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-H+cD9Qhgg8BGTXBHI28WZPP40Gk+dMzCnbm2sK8kxqM=";
+    hash = "sha256-/HoSAgt7INT5Hharc+ltb2ya8InAuZmhS8Tmftl0VOo=";
   };
 
   npmWorkspace = "apps/desktop";


### PR DESCRIPTION
Update `zennotes-desktop` to v2.45.0 (this PR started at 2.40.0 and has been restacked as upstream released 2.41.0, 2.42.0, 2.43.0, 2.44.0 and 2.45.0; the diff is still the three-line version and hash bump against current master).

Changelog: https://github.com/ZenNotes/zennotes/releases/tag/v2.45.0

Verification:

- The source and npm fixed-output hashes were computed by the upstream Nix update workflow using `nix-prefetch-github` and `prefetch-npm-deps` (ZenNotes/zennotes run 33932421672).
- That workflow built the upstream desktop and server Nix packages successfully on x86_64-linux, and the upstream Nix build workflow rebuilt them from the committed hashes on the release commit (run 33932697424).
- The package diff was rebased onto current nixpkgs master and retains Electron 42; only `version`, `npmDepsHash`, and the source `hash` change.
- The exact nixpkgs package was not built locally because Nix is unavailable on the release host; this PR relies on nixpkgs CI for that final package build.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Automation disclosure: Claude Code (Anthropic) assisted with the version and hash update and with drafting this PR description, under the upstream maintainer's direction. The three-line package diff was reviewed directly, and the hashes were independently produced and build-verified by the deterministic ZenNotes Nix workflows linked above.
