### PR TITLE
tea-dash: init at 0.3.7

### DIFF
--- a/pkgs/by-name/te/tea-dash/package.nix
+++ b/pkgs/by-name/te/tea-dash/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+  nix-update-script,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tea-dash";
+  version = "0.3.7";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gbarany";
+    repo = "tea-dash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SbbrPWL33PrD02S58c50Gk9xOiu/5pRuccK9vrKViqE=";
+  };
+
+  vendorHash = "sha256-pnZbFXZX34xUUUMCR8zSplbBnwdYfrPDRssHQDcBA6o=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/gbarany/tea-dash/internal/build.Version=${finalAttrs.version}"
+    "-X=github.com/gbarany/tea-dash/internal/build.Commit=${finalAttrs.src.rev}"
+    "-X=github.com/gbarany/tea-dash/internal/build.Date=1970-01-01T00:00:00Z"
+  ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
+  meta = {
+    description = "gh-dash-style terminal dashboard (TUI) for Gitea & Forgejo — PRs, issues, notifications, Actions runs, and branches";
+    homepage = "https://github.com/gbarany/tea-dash";
+    changelog = "https://github.com/gbarany/tea-dash/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ frantathefranta ];
+    mainProgram = "tea-dash";
+  };
+})


### PR DESCRIPTION
https://github.com/gbarany/tea-dash

Assisted-by: nix-init


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
