### PR TITLE
nixos/programs.proxychains: fix assertion logic

### DIFF
--- a/nixos/modules/programs/proxychains.nix
+++ b/nixos/modules/programs/proxychains.nix
@@ -163,7 +163,7 @@ in
   config = lib.mkIf cfg.enable {
 
     assertions = lib.singleton {
-      assertion = cfg.chain.type != "random" && cfg.chain.length == null;
+      assertion = cfg.chain.length == null || cfg.chain.type == "random";
       message = ''
         Option `programs.proxychains.chain.length`
         only makes sense with `programs.proxychains.chain.type` = "random".


### PR DESCRIPTION
<!--
The assertion in `programs.proxychains` is logically inverted: it rejects
`type = "random"` unconditionally, because `!= "random"` is `false` whenever
`type` is `"random"`, making the whole conjunction `false` regardless of
`length`. The only truly invalid combination is setting `chain.length` without
`chain.type = "random"`, which the config file handles by omitting the
`chain_len` line when `length` is `null`.

The correct assertion is:

```nix
assertion = cfg.chain.length == null || cfg.chain.type == "random";
```

| `chain.type` | `chain.length` | Old assertion | New assertion | Expected |
|---|---|---|---|---|
| `"strict"` | `null` | `true` | `true` | pass |
| `"strict"` | `3` | `false` | `false` | reject |
| `"dynamic"` | `null` | `true` | `true` | pass |
| `"random"` | `null` | `false` | `true` | pass |
| `"random"` | `3` | `false` | `true` | pass |

Meta-only: the assertion is evaluated at Nix evaluation time, not build time, so
this change causes zero rebuilds.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/557400.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

### Verification

The assertion is a pure boolean expression evaluated at Nix eval time, veried
with `nix-instantiate --eval` against a throwaway config:

```nix
# Should succeed, fails on the old condition:
{ config, lib, ... }:
{
  programs.proxychains = {
    enable = true;
    chain.type = "random";
  };
}
```

Before: assertion fails (`type != "random"` is `false`, whole conjunction
`false`). After: assertion passes, config file generated with `random_chain`
and no `chain_len` line. The reverse case, `chain.length = 3` with
`chain.type = "strict"`, is still rejected.

**Automation disclosure**: this pull request's changes and this summary were
prepared with Claude Code. I reviewed the diff and the assertion truth table
myself before submitting, and I am the person accountable for it.