### PR TITLE
agent-client-protocol: 0.12.0 -> 0.12.1

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -151,6 +151,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
   versionCheckKeepEnvironment = [ "HOME" ];
 
   disabledTests = [
+    # The finite stdio input closes before all responses are flushed in the sandbox.
+    "test_stdio_server_uses_the_same_json_rpc_lifecycle"
+
     # AssertionError: assert <MCPSourceStatus.UNAVAILABLE: 'unavailable'> is <MCPSourceStatus.ENABLED: 'enabled'>
     "test_mcp_catalog_read_refresh_toggle_remove_and_compatibility_aliases"
 
@@ -158,9 +161,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # ModuleNotFoundError: No module named 'mcp'
     "test_aclose_terminates_real_subprocess"
     "test_persists_real_subprocess_state_across_calls"
-
-    # AssertionError: assert '32:2617357:1782120467963161870:7' != '32:2617357:1782120467963161870:7'
-    "test_changes_when_file_changes"
 
     # vibe.core.llm.exceptions.BackendError: LLM backend error [mock-provider]
     # reason: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
@@ -184,10 +184,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   disabledTestPaths = [
-    # This tests the install_script and fails. This is not relevant for nixpkgs.
-    "tests/test_install_script.py"
-
-    # All snapshot tests fail with AssertionError
+    # All snapshot tests use syrupy 4.8.0, which is not packaged here.
     "tests/snapshots/"
 
     # These tests invoke uv run and fail to import the packaged pydantic extension.

--- a/pkgs/development/python-modules/agent-client-protocol/default.nix
+++ b/pkgs/development/python-modules/agent-client-protocol/default.nix
@@ -10,16 +10,20 @@
   pydantic,
 
   # optional-dependencies
+  h2,
+  httpx,
   opentelemetry-sdk,
+  websockets,
 
   # tests
   pytest-asyncio,
   pytestCheckHook,
+  uvicorn,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "agent-client-protocol";
-  version = "0.12.0";
+  version = "0.12.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -27,7 +31,7 @@ buildPythonPackage (finalAttrs: {
     owner = "agentclientprotocol";
     repo = "python-sdk";
     tag = finalAttrs.version;
-    hash = "sha256-IJJ4zgwkLP7CnU330X1K6p/We3A+tm/Veu64C2XhPS8=";
+    hash = "sha256-GBMzhDHOiXGQDyHtDEBpGL4SH/I16Zh/QMePhiLHJSE=";
   };
 
   build-system = [
@@ -39,6 +43,11 @@ buildPythonPackage (finalAttrs: {
   ];
 
   optional-dependencies = {
+    http = [
+      h2
+      httpx
+      websockets
+    ];
     logfire = [
       # logfire (unpackaged)
       opentelemetry-sdk
@@ -50,16 +59,13 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
-  ];
+    uvicorn
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.http;
 
   disabledTests = [
-    # Hangs forever
+    # Agent subprocess cannot complete in the sandbox.
     "test_spawn_agent_process_roundtrip"
-  ];
-
-  disabledTestPaths = [
-    # Optional HTTP transport dependencies are not packaged here.
-    "tests/http"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/mistralai/default.nix
+++ b/pkgs/development/python-modules/mistralai/default.nix
@@ -21,11 +21,14 @@
   griffe,
   mcp,
   google-auth,
+  msgpack,
   requests,
   websockets,
+  zstandard,
   opentelemetry-exporter-otlp-proto-http,
 
   # tests
+  opentelemetry-instrumentation-httpx,
   opentelemetry-sdk,
   pytest-asyncio,
   pytestCheckHook,
@@ -83,26 +86,31 @@ buildPythonPackage (finalAttrs: {
       opentelemetry-sdk
       opentelemetry-exporter-otlp-proto-http
     ];
+    workflow_payload_compression = [
+      msgpack
+      zstandard
+    ];
   };
 
   pythonImportsCheck = [ "mistralai" ];
 
   nativeCheckInputs = [
+    opentelemetry-instrumentation-httpx
     pytest-asyncio
     pytestCheckHook
   ]
   ++ finalAttrs.passthru.optional-dependencies.agents
   ++ finalAttrs.passthru.optional-dependencies.gcp
   ++ finalAttrs.passthru.optional-dependencies.realtime
-  ++ finalAttrs.passthru.optional-dependencies.telemetry;
+  ++ finalAttrs.passthru.optional-dependencies.telemetry
+  ++ finalAttrs.passthru.optional-dependencies.workflow_payload_compression;
 
   disabledTestPaths = [
-    # ModuleNotFoundError: No module named 'opentelemetry.instrumentation'
-    "src/mistralai/extra/tests/test_otel_tracing.py"
-    # ModuleNotFoundError: No module named 'msgpack'
-    "src/mistralai/extra/tests/test_workflow_encoding.py"
-    # '062f2cad7f1fee8c3e409b73d431e71b' not found in '00-e5d29cde482d5d796428c10d13e86060-468fe44f7efdb086-01'
-    "src/mistralai/extra/tests/test_traceparent_hook.py::TestTraceparentInjectionHook::test_propagates_sampled_active_span"
+    # Local test servers cannot bind in the Nix sandbox.
+    "src/mistralai/extra/tests/test_otel_tracing.py::TestOtelTracing::test_app_otel_does_not_enable_mistral_span_without_mistral_telemetry"
+    "src/mistralai/extra/tests/test_otel_tracing.py::TestOtelTracing::test_concurrent_async_httpx_auto_instrumented_spans_are_genai_children"
+    "src/mistralai/extra/tests/test_otel_tracing.py::TestOtelTracing::test_httpx_auto_instrumented_span_is_child_of_genai_span"
+    "src/mistralai/extra/tests/test_otel_tracing.py::TestPerInstanceTracerProvider::test_get_telemetry_tracer_dedicated_provider_captures_app_spans"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Diff: [agentclientprotocol/python-sdk@0.12.0...0.12.1](https://github.com/agentclientprotocol/python-sdk/compare/0.12.0...0.12.1)
Changelog: [https://github.com/agentclientprotocol/python-sdk/releases/tag/0.12.1](https://github.com/agentclientprotocol/python-sdk/releases/tag/0.12.1)

cc @GaetanLepage @shikanime @mana-byte

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at passthru.tests.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and core functionality.
- [x] Ran [nixpkgs-review](https://github.com/Mic92/nixpkgs-review#usage). See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [ ] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [ ] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).
