### PR TITLE
uppy-companion: save 40mb on installation

### DIFF
--- a/pkgs/by-name/up/uppy-companion/package.nix
+++ b/pkgs/by-name/up/uppy-companion/package.nix
@@ -52,19 +52,23 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/packages/@uppy
-    mkdir $out/bin
-    mv packages/@uppy/companion $out/lib/packages/@uppy/companion
-    # Remove extra files
-    rm -rf $out/lib/packages/@uppy/companion/{*.md,LICENSE,Makefile,.*ignore,infra/,output/,test/,__mocks__/,*/json}
-    # Remove dev dependencies
-    rm -rf $out/lib/packages/@uppy/companion/node_modules/{.bin,webpack*,update*,tyepscript,jest*,eslint*,{@,}esbuild,{@,}rollup,terser,@types,execa,http-proxy,nock,supertest,vite*}
+    export yarnTmpDir=$(mktemp -d)
+    export yarnPack=$yarnTmpDir/yarn-pack.tgz
 
-    # Link final binary
-    ln -s $out/lib/packages/@uppy/companion/bin/companion $out/bin/companion
+    mkdir -p $out/lib/node_modules/@uppy/companion $out/bin
 
-    patchShebangs $out/bin/companion
+    pushd packages/@uppy/companion
 
+    yarn pack -o $yarnPack
+    tar xvf $yarnPack -C $out/lib/node_modules/@uppy/companion --strip-components 1 package/
+
+    rm -rf node_modules
+    yarn workspaces focus --production
+    find node_modules -maxdepth 1 -type d -empty -delete
+    cp -r node_modules $out/lib/node_modules/@uppy/companion/node_modules
+    popd
+
+    ln -s $out/lib/node_modules/@uppy/companion/bin/companion $out/bin/companion
     runHook postInstall
   '';
 


### PR DESCRIPTION
Instead of trimming deps after install, just prune before and then we don't have to manually filter either. Problem solved! Saves ~40mb of installation size with literally 0 downside.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
