### PR TITLE
ghost-cli: 1.29.1 -> 1.32.2

### DIFF
--- a/pkgs/by-name/gh/ghost-cli/package.nix
+++ b/pkgs/by-name/gh/ghost-cli/package.nix
@@ -2,33 +2,64 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchYarnDeps,
-  yarnConfigHook,
-  yarnInstallHook,
+  nodejs,
+  pnpm_11,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  npmHooks,
   versionCheckHook,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ghost-cli";
-  version = "1.29.1";
+  version = "1.32.2";
 
   src = fetchFromGitHub {
     owner = "TryGhost";
     repo = "Ghost-CLI";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Zwm1v5xY3jq5krbGFVmA6qmVsYY5RdMEnHcefzKj6V4=";
+    hash = "sha256-wXdMNREukjp3ozyBOM1JuAvEAcsTf+5mvWPTTNf2+o8=";
   };
 
-  yarnOfflineCache = fetchYarnDeps {
-    yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-MpgTPBQ/VCwWzCN/a/y1TJyB6rSjwAIKu/RbBXE6fos=";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-u9g/EupJEkgq7vJMh+hkwNXj8d7oD9/5y83x4fJhLII=";
   };
 
   nativeBuildInputs = [
-    yarnConfigHook
-    yarnInstallHook
+    nodejs
+    pnpmConfigHook
+    pnpm_11
+    npmHooks.npmInstallHook
   ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    pnpm exec vitest run \
+      extensions/nginx/test/migrations-spec.js \
+      extensions/nginx/test/extension-spec.js
+
+    runHook postCheck
+  '';
+
+  preInstall = ''
+    CI=true pnpm --ignore-scripts --prod prune
+
+    # https://github.com/pnpm/pnpm/issues/3645
+    find node_modules -xtype l -delete
+
+    # Remove build-directory references from pnpm metadata.
+    rm node_modules/{.modules.yaml,.pnpm-workspace-state-v1.json}
+  '';
+
+  # Production dependencies are pruned with pnpm above.
+  dontNpmPrune = true;
+
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
   versionCheckProgram = "${placeholder "out"}/bin/ghost";


### PR DESCRIPTION
Updates Ghost CLI to 1.32.2, fixing CVE-2026-25552 in generated Nginx proxy configurations and migrating existing vulnerable configurations. The packaging follows upstream's migration from Yarn to pnpm.

https://redirect.github.com/TryGhost/Ghost-CLI/blob/v1.32.2/CHANGELOG.md

Addresses #548033

Requires a manual backport to `release-26.05`.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
