### PR TITLE
nixos/xautolock: use escapeShellArg for ExecStart arguments

### DIFF
--- a/nixos/modules/services/x11/xautolock.nix
+++ b/nixos/modules/services/x11/xautolock.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 
@@ -108,24 +109,31 @@ in
       description = "xautolock service";
       wantedBy = [ "graphical-session.target" ];
       partOf = [ "graphical-session.target" ];
-      serviceConfig = with lib; {
-        ExecStart = strings.concatStringsSep " " (
+      serviceConfig = {
+        ExecStart = utils.escapeSystemdExecArgs (
           [
-            "${pkgs.xautolock}/bin/xautolock"
+            (getExe pkgs.xautolock)
             "-noclose"
-            "-time ${toString cfg.time}"
-            "-locker '${cfg.locker}'"
+            "-time"
+            (toString cfg.time)
+            "-locker"
+            cfg.locker
           ]
           ++ optionals cfg.enableNotifier [
-            "-notify ${toString cfg.notify}"
-            "-notifier '${cfg.notifier}'"
+            "-notify"
+            (toString cfg.notify)
+            "-notifier"
+            cfg.notifier
           ]
           ++ optionals (cfg.nowlocker != null) [
-            "-nowlocker '${cfg.nowlocker}'"
+            "-nowlocker"
+            cfg.nowlocker
           ]
           ++ optionals (cfg.killer != null) [
-            "-killer '${cfg.killer}'"
-            "-killtime ${toString cfg.killtime}"
+            "-killer"
+            cfg.killer
+            "-killtime"
+            (toString cfg.killtime)
           ]
           ++ cfg.extraOptions
         );


### PR DESCRIPTION
<!--
The xautolock module wraps command paths in manual single quotes for the
systemd `ExecStart` line:

```nix
"-notifier '${cfg.notifier}'"
```

When the notifier string itself contains single quotes, as in the documented
example `"${pkgs.libnotify}/bin/notify-send 'Locking in 10 seconds'"`, the
inner quotes break the outer quoting:

```
-notifier '/nix/store/.../notify-send 'Locking in 10 seconds''
```

Systemd sees the quote ending after `notify-send`, then `Locking in 10
seconds` as separate unquoted tokens, and the trailing `''` as an empty
string. The service fails to start.

Replace manual quoting with `utils.escapeSystemdExecArgs`, which uses
systemd-native escaping (JSON-based quoting with `%`/`$` escaping). `ExecStart`
is parsed by systemd's exec-line parser, not a POSIX shell, so systemd-native
escaping is the correct fit.

This also splits flag-value pairs into separate list elements (e.g. `"-time"`
`(toString cfg.time)` instead of `"-time ${toString cfg.time}"`) and adds
`utils` to the module arguments, matching the pattern used by `gpsd`, `glances`,
`pgscv` and `rtkit`.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/557627.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

### Verification

Checked `escapeSystemdExecArgs` output against key cases via `nix-instantiate
--eval`:

| Input | `escapeSystemdExecArgs` output |
|---|---|
| `/bin/slock` | `"/bin/slock"` |
| `lock'er` | `"lock'er"` |
| `100%` | `"100%%"` |

Each argument is individually double-quoted for systemd, `%` is escaped to
`%%`, and embedded single quotes are preserved without shell-style escaping.

**Automation disclosure**: this pull request's changes and this summary were
prepared with Claude Code. I reviewed the diff and the escape verification
myself before submitting, and I am the person accountable for it.