### PR TITLE
mhabit: fix missing libicui18n.so from native_natural_sort

### DIFF
--- a/pkgs/development/compilers/dart/package-source-builders/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/default.nix
@@ -11,6 +11,7 @@
   hotkey_manager_linux = callPackage ./hotkey_manager_linux { };
   matrix = callPackage ./matrix { };
   media_kit_libs_linux = callPackage ./media_kit_libs_linux { };
+  native_natural_sort = callPackage ./native_natural_sort { };
   olm = callPackage ./olm { };
   pdfium_dart = callPackage ./pdfium_dart { };
   pdfium_flutter = callPackage ./pdfium_flutter { };

--- a/pkgs/development/compilers/dart/package-source-builders/native_natural_sort/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/native_natural_sort/default.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  lib,
+  writeScript,
+  icu,
+}:
+
+{ version, src, ... }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "native_natural_sort";
+  inherit version src;
+  inherit (src) passthru;
+
+  # native_natural_sort's Linux backend (LinuxCollationLoader, see
+  # lib/src/linux/collation_ffi.dart) discovers libicui18n.so by listing only
+  # a few hard-coded system directories (/usr/lib/<triplet>, /lib/<triplet>,
+  # /app/lib) and never consults LD_LIBRARY_PATH for that listing.  On NixOS
+  # ICU lives in the store, so Flutter apps using this package crash with
+  # "LinuxCollationLoader: no libicui18n.so found on the system"
+  # (https://github.com/NixOS/nixpkgs/issues/556264).
+  #
+  # Patch the search path to include nixpkgs' ICU (the full store path is
+  # substituted in below and baked into the compiled snapshot), and inject
+  # ICU into consumers' runtimeDependencies so it ends up in the runtime
+  # closure (and the wrapper's LD_LIBRARY_PATH).
+  patches = [ ./icu.patch ];
+
+  setupHook = writeScript "${finalAttrs.pname}-setup-hook" ''
+    nativeNaturalSortIcuHook() {
+      runtimeDependencies+=('${lib.getLib icu}')
+    }
+
+    preFixupHooks+=(nativeNaturalSortIcuHook)
+  '';
+
+  postPatch = ''
+    substituteInPlace lib/src/linux/collation_ffi.dart \
+      --replace-fail '@icuLib@' '${lib.getLib icu}/lib'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r . "$out"
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/development/compilers/dart/package-source-builders/native_natural_sort/icu.patch
+++ b/pkgs/development/compilers/dart/package-source-builders/native_natural_sort/icu.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/src/linux/collation_ffi.dart b/lib/src/linux/collation_ffi.dart
+--- a/lib/src/linux/collation_ffi.dart
++++ b/lib/src/linux/collation_ffi.dart
+@@ -203,6 +203,7 @@
+     '/usr/lib/$multiarchTriplet',
+     '/lib/$multiarchTriplet',
+     '/app/lib', // Flatpak runtime layout
++    '@icuLib@',
+   ];
+
+   /// Candidate paths in resolution order: unversioned soname, then the


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

native_natural_sort only scans hard-coded system dirs for libicui18n and
crashes on NixOS. Add a package-source-builder pointing searchDirs at the
Nix store's ICU and injecting ICU into runtimeDependencies.

Resolves #556264

Prepared with assistance from an AI assistant (Doubao); the author has reviewed the changes.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
