### PR TITLE
forgejo-runner: 12.13.2 -> 13.1.0

### DIFF
--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -8,64 +8,36 @@
   nix-update-script,
   gitMinimal,
   makeWrapper,
+  writableTmpDirAsHomeHook,
 }:
 
 let
-  # tests which assume network access in some form
   disabledTests = [
-    "Test_runCreateRunnerFile"
-    "Test_ping"
-
-    # The following tests were introduced in 9.x with the inclusion of act
-    # the pkgs/by-name/ac/act/package.nix just sets doCheck = false;
-
-    # Requires running Docker daemon
-    "TestDocker"
-    "TestJobExecutor"
-    "TestRunContext_PrepareJobContainer/Overlapping"
-    "TestRunExec"
-    "TestRunner"
-    "Test_validateCmd"
-
-    # Docker network request for image
-    "TestImageExistsLocally"
-    "TestStepDockerMain"
-
-    # Reaches out to different websites
-    "TestFindGitRemoteURL"
-    "TestGitFindRef"
-    "TestClone"
-    "TestCloneIfRequired"
-    "TestActionCache"
-    "TestRunContext_GetGitHubContext"
-    "TestSetJobResult_SkipsBannerInChildReusableWorkflow"
-
-    # These tests rely on outbound IP address
+    # requires network
     "TestHandler"
-    "TestHandler_gcCache"
-
-    # Timeouts
-    "TestRunJob_WithConnectionFromCommandOptions"
+    "TestClone"
+    "TestRunner_ReusableWorkflowGitHubInstance"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Uses docker-specific options, unsupported on Darwin
-    "TestMergeJobOptions"
+    # listen tcp 127.0.0.1:0: bind: operation not permitted
+    "TestNewClient"
+    # httptest: failed to listen on a port: listen tcp6 [::1]:0: bind: operation not permitted
     "TestNewEndpointHonoursTLSEnv"
   ];
 in
 buildGoModule (finalAttrs: {
   pname = "forgejo-runner";
-  version = "12.13.2";
+  version = "13.1.0";
 
   src = fetchFromGitea {
     domain = "code.forgejo.org";
     owner = "forgejo";
     repo = "runner";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-6i87t8LXYYXyQ8UzyUiEOvQ+9wuRz4xeUBivk0VJ0S4=";
+    hash = "sha256-0LVia4B9n2zuuHDGFnBVM1mrbI7XBhMfy25kRSN5/WQ=";
   };
 
-  vendorHash = "sha256-du7fXehcxZ70Lsr5VCkz646G0Us/XwM4Sl98HXimoao=";
+  vendorHash = "sha256-2QwltVOR6MJO8rLNgktN1ulvP0YrnqQorNnfJXzRmJs=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -79,12 +51,25 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X code.forgejo.org/forgejo/runner/v12/internal/pkg/ver.version=${finalAttrs.src.rev}"
+    "-X code.forgejo.org/forgejo/runner/v13/internal/pkg/ver.version=${finalAttrs.src.rev}"
   ];
 
   checkFlags = [
     "-skip ${lib.concatStringsSep "|" disabledTests}"
   ];
+
+  # Upstream offers '-args -features "-"' as go test flag to skip tests that require either lxc or docker.
+  # Unfortunately, we cannot use this without patching buildGoModule, as -args passes the remainder of the
+  # command line to the test binary, and checkFlags are templated between go test and $dir, causing $dir (e.g.
+  # ./...) to be discarded, which in turn causes all tests to be skipped.
+  # TODO: Make our buildGoModule (go/module.nix) template $dir before checkFlags to allow use of -arg
+  # https://code.forgejo.org/forgejo/runner/pulls/1591
+  # https://pkg.go.dev/cmd/go/internal/test#:~:text=%2Dargs
+  preCheck = ''
+    substituteInPlace testutils/test_main.go \
+      --replace-fail 'TestFeatureDocker: {},' '// TestFeatureDocker: {},' \
+      --replace-fail 'TestFeatureLXC:    {},' '// TestFeatureLXC:    {},'
+  '';
 
   postInstall = ''
     # Fix up go-specific executable naming derived from package name, upstream
@@ -98,7 +83,10 @@ buildGoModule (finalAttrs: {
     ln -s $out/bin/forgejo-runner $out/bin/act_runner
   '';
 
-  nativeCheckInputs = [ gitMinimal ];
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
https://code.forgejo.org/forgejo/runner/releases/tag/v13.0.0
https://code.forgejo.org/forgejo/runner/releases/tag/v13.1.0

https://forgejo.org/2026-08-runner-release-v13/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
