### PR TITLE
typst: resolve transitive dependencies correctly

### DIFF
--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -73,6 +73,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     packages = callPackage ./typst-packages.nix { };
     wrapper = callPackage ./wrapper.nix { };
     withPackages = ps: finalAttrs.passthru.wrapper { packages = ps; };
+    tests = {
+      transitive-deps = callPackage ./tests/transitive-deps.nix { };
+    };
   };
 
   meta = {

--- a/pkgs/by-name/ty/typst/tests/transitive-deps.nix
+++ b/pkgs/by-name/ty/typst/tests/transitive-deps.nix
@@ -1,0 +1,65 @@
+{
+  runCommand,
+  buildTypstPackage,
+  typst,
+}:
+
+let
+  mkPkg =
+    pname: typstDeps: entrypointContent:
+    buildTypstPackage {
+      inherit pname typstDeps;
+      version = "0.1.0";
+      src =
+        runCommand "typst-${pname}-src"
+          {
+            manifest = ''
+              [package]
+              name = "${pname}"
+              version = "0.1.0"
+              entrypoint = "lib.typ"
+            '';
+            inherit entrypointContent;
+          }
+          ''
+            mkdir -p "$out"
+            printf '%s' "$manifest" > "$out/typst.toml"
+            printf '%s' "$entrypointContent" > "$out/lib.typ"
+          '';
+    };
+
+  leaf = mkPkg "test-leaf" [ ] ''
+    #let leaf-value = "reached the leaf"
+  '';
+
+  mid = mkPkg "test-mid" [ leaf ] ''
+    #import "@preview/test-leaf:0.1.0": leaf-value
+    #let mid-value = leaf-value
+  '';
+
+  top = mkPkg "test-top" [ mid ] ''
+    #import "@preview/test-mid:0.1.0": mid-value
+    #let top-value = mid-value
+  '';
+
+  env =
+    (typst.passthru.wrapper.override {
+      typstPackages = { inherit leaf mid top; };
+    })
+      { packages = p: [ p.top ]; };
+in
+runCommand "typst-transitive-deps"
+  {
+    nativeBuildInputs = [ env ];
+    doc = ''
+      #import "@preview/test-top:0.1.0": top-value
+      #top-value
+    '';
+  }
+  ''
+    root="${env}/lib/typst/packages/preview"
+    printf '%s' "$doc" > doc.typ
+    mkdir -p $out
+    typst compile doc.typ "$out/doc.pdf"
+    test -s "$out/doc.pdf"
+  ''

--- a/pkgs/by-name/ty/typst/wrapper.nix
+++ b/pkgs/by-name/ty/typst/wrapper.nix
@@ -17,9 +17,24 @@ lib.makeOverridable (
     inherit (typst) meta;
     name = "${typst.name}-env";
 
-    paths = lib.foldl' (acc: p: acc ++ lib.singleton p ++ p.propagatedBuildInputs) [ ] (
-      packages typstPkgs
-    );
+    paths =
+      let
+        selected = packages typstPkgs;
+      in
+      map (e: e.pkg) (
+        builtins.genericClosure {
+          startSet = map (p: {
+            key = p.outPath;
+            pkg = p;
+          }) selected;
+          operator =
+            { pkg, ... }:
+            map (d: {
+              key = d.outPath;
+              pkg = d;
+            }) (pkg.propagatedBuildInputs or [ ]);
+        }
+      );
 
     pathsToLink = [ "/lib/typst-packages" ];
 


### PR DESCRIPTION
Previously `paths` was calculated using `fold'`, which didn't account for transitive depenendencies more than one level deep, e.g. `fletcher > cetz > oxifmt`. Replace with calculation using `genericClosure` (this
is also used by `build-tex-env`).

I developed this fix in collaboration with Claude Opus 5, though I checked all the code myself, and suggested the structure of the test. I ran the test with the unpatched version of `wrapper`, to verify it fails, and afterwards on the patched version, to verify it succeeds. This PR was inspired by this Mastodon thread: https://types.pl/@cxandru/117190735794480862

@RossSmyth @kanashimia 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
