### PR TITLE
binutils-unwrapped.plugin-api-header: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -344,14 +344,20 @@ stdenv.mkDerivation (finalAttrs: {
     # The plugin API is not a function of any targets. Expose it separately,
     # currently only used by LLVM for enabling BFD to do LTO with LLVM bitcode.
     # (Tar will exit with an error if there are no matches).
-    plugin-api-header = runCommand "libbfd-plugin-api-header" { } ''
-      mkdir -p $out
-      tar --directory=$out \
-      --extract \
-      --file=${finalAttrs.src} \
-      --strip-components=1 \
-        --wildcards '*'/include/plugin-api.h
-    '';
+    plugin-api-header =
+      runCommand "libbfd-plugin-api-header"
+        {
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        ''
+          mkdir -p $out
+          tar --directory=$out \
+          --extract \
+          --file=${finalAttrs.src} \
+          --strip-components=1 \
+            --wildcards '*'/include/plugin-api.h
+        '';
   };
 
   __structuredAttrs = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
