### PR TITLE
llvmPackages.*: enable strictDeps, structuredAttrs for monorepoSrc

### DIFF
--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -23,7 +23,11 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version;
 
   # Blank llvm dir just so relative path works
-  src = runCommand "bolt-src-${finalAttrs.version}" { inherit (monorepoSrc) passthru; } ''
+  src = runCommand "bolt-src-${finalAttrs.version}" {
+    inherit (monorepoSrc) passthru;
+    strictDeps = true;
+    __structuredAttrs = true;
+  } ''
     mkdir $out
     cp -r ${monorepoSrc}/cmake "$out"
     cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"

--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -23,20 +23,23 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version;
 
   # Blank llvm dir just so relative path works
-  src = runCommand "bolt-src-${finalAttrs.version}" {
-    inherit (monorepoSrc) passthru;
-    strictDeps = true;
-    __structuredAttrs = true;
-  } ''
-    mkdir $out
-    cp -r ${monorepoSrc}/cmake "$out"
-    cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
-    cp -r ${monorepoSrc}/third-party "$out"
+  src =
+    runCommand "bolt-src-${finalAttrs.version}"
+      {
+        inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
+      }
+      ''
+        mkdir $out
+        cp -r ${monorepoSrc}/cmake "$out"
+        cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
+        cp -r ${monorepoSrc}/third-party "$out"
 
-    # BOLT re-runs tablegen against LLVM sources, so needs them available.
-    cp -r ${monorepoSrc}/llvm/ "$out"
-    chmod -R +w $out/llvm
-  '';
+        # BOLT re-runs tablegen against LLVM sources, so needs them available.
+        cp -r ${monorepoSrc}/llvm/ "$out"
+        chmod -R +w $out/llvm
+      '';
 
   sourceRoot = "${finalAttrs.src.name}/bolt";
 

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -32,7 +32,11 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "clang-src-${version}" { inherit (monorepoSrc) passthru; } ''
+        runCommand "clang-src-${version}" {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        } ''
           mkdir -p "$out"
           cp -r ${monorepoSrc}/cmake "$out"
           cp -r ${monorepoSrc}/clang "$out"

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -32,16 +32,18 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "clang-src-${version}" {
-          inherit (monorepoSrc) passthru;
-          strictDeps = true;
-          __structuredAttrs = true;
-        } ''
-          mkdir -p "$out"
-          cp -r ${monorepoSrc}/cmake "$out"
-          cp -r ${monorepoSrc}/clang "$out"
-          ${lib.optionalString enableClangToolsExtra "cp -r ${monorepoSrc}/clang-tools-extra \"$out\""}
-        ''
+        runCommand "clang-src-${version}"
+          {
+            inherit (monorepoSrc) passthru;
+            strictDeps = true;
+            __structuredAttrs = true;
+          }
+          ''
+            mkdir -p "$out"
+            cp -r ${monorepoSrc}/cmake "$out"
+            cp -r ${monorepoSrc}/clang "$out"
+            ${lib.optionalString enableClangToolsExtra "cp -r ${monorepoSrc}/clang-tools-extra \"$out\""}
+          ''
       else
         src;
 

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -67,7 +67,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "compiler-rt-src-${version}" { inherit (monorepoSrc) passthru; } (
+      runCommand "compiler-rt-src-${version}" {
+        inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
+      } (
         ''
           mkdir -p "$out"
           cp -r ${monorepoSrc}/cmake "$out"

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -67,23 +67,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "compiler-rt-src-${version}" {
-        inherit (monorepoSrc) passthru;
-        strictDeps = true;
-        __structuredAttrs = true;
-      } (
-        ''
-          mkdir -p "$out"
-          cp -r ${monorepoSrc}/cmake "$out"
-        ''
-        + lib.optionalString (lib.versionAtLeast release_version "21") ''
-          cp -r ${monorepoSrc}/third-party "$out"
-        ''
-        + ''
-          cp -r ${monorepoSrc}/compiler-rt "$out"
-          cp -r ${monorepoSrc}/llvm "$out"
-        ''
-      )
+      runCommand "compiler-rt-src-${version}"
+        {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        (
+          ''
+            mkdir -p "$out"
+            cp -r ${monorepoSrc}/cmake "$out"
+          ''
+          + lib.optionalString (lib.versionAtLeast release_version "21") ''
+            cp -r ${monorepoSrc}/third-party "$out"
+          ''
+          + ''
+            cp -r ${monorepoSrc}/compiler-rt "$out"
+            cp -r ${monorepoSrc}/llvm "$out"
+          ''
+        )
     else
       src;
 

--- a/pkgs/development/compilers/llvm/common/flang-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang-rt/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
     runCommand "${finalAttrs.pname}-src-${version}"
       {
         inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
       }
       ''
         mkdir -p "$out"

--- a/pkgs/development/compilers/llvm/common/flang/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
     runCommand "${finalAttrs.pname}-src-${finalAttrs.version}"
       {
         inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
       }
       ''
         mkdir -p "$out"

--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -18,22 +18,25 @@
 let
   pname = "libc";
 
-  src' = runCommand "${pname}-src-${version}" {
-    strictDeps = true;
-    __structuredAttrs = true;
-  } (
-    ''
-      mkdir -p "$out"
-      cp -r ${monorepoSrc}/cmake "$out"
-      cp -r ${monorepoSrc}/runtimes "$out"
-      cp -r ${monorepoSrc}/llvm "$out"
-      cp -r ${monorepoSrc}/compiler-rt "$out"
-      cp -r ${monorepoSrc}/${pname} "$out"
-    ''
-    + lib.optionalString (lib.versionAtLeast release_version "21") ''
-      cp -r ${monorepoSrc}/third-party "$out"
-    ''
-  );
+  src' =
+    runCommand "${pname}-src-${version}"
+      {
+        strictDeps = true;
+        __structuredAttrs = true;
+      }
+      (
+        ''
+          mkdir -p "$out"
+          cp -r ${monorepoSrc}/cmake "$out"
+          cp -r ${monorepoSrc}/runtimes "$out"
+          cp -r ${monorepoSrc}/llvm "$out"
+          cp -r ${monorepoSrc}/compiler-rt "$out"
+          cp -r ${monorepoSrc}/${pname} "$out"
+        ''
+        + lib.optionalString (lib.versionAtLeast release_version "21") ''
+          cp -r ${monorepoSrc}/third-party "$out"
+        ''
+      );
 
   needHdrGen = isFullBuild || lib.versionAtLeast release_version "22";
 in

--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -18,7 +18,10 @@
 let
   pname = "libc";
 
-  src' = runCommand "${pname}-src-${version}" { } (
+  src' = runCommand "${pname}-src-${version}" {
+    strictDeps = true;
+    __structuredAttrs = true;
+  } (
     ''
       mkdir -p "$out"
       cp -r ${monorepoSrc}/cmake "$out"

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -112,29 +112,31 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "libcxx-src-${version}" {
-        inherit (monorepoSrc) passthru;
-        strictDeps = true;
-        __structuredAttrs = true;
-      } (
-        ''
-          mkdir -p "$out/llvm"
-          cp -r ${monorepoSrc}/cmake "$out"
-          cp -r ${monorepoSrc}/libcxx "$out"
-          cp -r ${monorepoSrc}/llvm/cmake "$out/llvm"
-          cp -r ${monorepoSrc}/llvm/utils "$out/llvm"
-          cp -r ${monorepoSrc}/third-party "$out"
-        ''
-        + (lib.optionalString (lib.versionAtLeast release_version "20") ''
-          cp -r ${monorepoSrc}/libc "$out"
-        '')
-        + ''
-          cp -r ${monorepoSrc}/runtimes "$out"
-        ''
-        + (lib.optionalString (cxxabi == null) ''
-          cp -r ${monorepoSrc}/libcxxabi "$out"
-        '')
-      )
+      runCommand "libcxx-src-${version}"
+        {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        (
+          ''
+            mkdir -p "$out/llvm"
+            cp -r ${monorepoSrc}/cmake "$out"
+            cp -r ${monorepoSrc}/libcxx "$out"
+            cp -r ${monorepoSrc}/llvm/cmake "$out/llvm"
+            cp -r ${monorepoSrc}/llvm/utils "$out/llvm"
+            cp -r ${monorepoSrc}/third-party "$out"
+          ''
+          + (lib.optionalString (lib.versionAtLeast release_version "20") ''
+            cp -r ${monorepoSrc}/libc "$out"
+          '')
+          + ''
+            cp -r ${monorepoSrc}/runtimes "$out"
+          ''
+          + (lib.optionalString (cxxabi == null) ''
+            cp -r ${monorepoSrc}/libcxxabi "$out"
+          '')
+        )
     else
       src;
 

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -112,7 +112,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "libcxx-src-${version}" { inherit (monorepoSrc) passthru; } (
+      runCommand "libcxx-src-${version}" {
+        inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
+      } (
         ''
           mkdir -p "$out/llvm"
           cp -r ${monorepoSrc}/cmake "$out"

--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -23,7 +23,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "libunwind-src-${version}" { inherit (monorepoSrc) passthru; } ''
+      runCommand "libunwind-src-${version}" {
+        inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
+      } ''
         mkdir -p "$out"
         cp -r ${monorepoSrc}/cmake "$out"
         cp -r ${monorepoSrc}/libunwind "$out"

--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -23,22 +23,24 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "libunwind-src-${version}" {
-        inherit (monorepoSrc) passthru;
-        strictDeps = true;
-        __structuredAttrs = true;
-      } ''
-        mkdir -p "$out"
-        cp -r ${monorepoSrc}/cmake "$out"
-        cp -r ${monorepoSrc}/libunwind "$out"
-        mkdir -p "$out/libcxx"
-        cp -r ${monorepoSrc}/libcxx/cmake "$out/libcxx"
-        cp -r ${monorepoSrc}/libcxx/utils "$out/libcxx"
-        mkdir -p "$out/llvm"
-        cp -r ${monorepoSrc}/llvm/cmake "$out/llvm"
-        cp -r ${monorepoSrc}/llvm/utils "$out/llvm"
-        cp -r ${monorepoSrc}/runtimes "$out"
-      ''
+      runCommand "libunwind-src-${version}"
+        {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        ''
+          mkdir -p "$out"
+          cp -r ${monorepoSrc}/cmake "$out"
+          cp -r ${monorepoSrc}/libunwind "$out"
+          mkdir -p "$out/libcxx"
+          cp -r ${monorepoSrc}/libcxx/cmake "$out/libcxx"
+          cp -r ${monorepoSrc}/libcxx/utils "$out/libcxx"
+          mkdir -p "$out/llvm"
+          cp -r ${monorepoSrc}/llvm/cmake "$out/llvm"
+          cp -r ${monorepoSrc}/llvm/utils "$out/llvm"
+          cp -r ${monorepoSrc}/runtimes "$out"
+        ''
     else
       src;
 

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -22,18 +22,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "lld-src-${version}" {
-        inherit (monorepoSrc) passthru;
-        strictDeps = true;
-        __structuredAttrs = true;
-      } ''
-        mkdir -p "$out"
-        cp -r ${monorepoSrc}/cmake "$out"
-        cp -r ${monorepoSrc}/lld "$out"
-        mkdir -p "$out/libunwind"
-        cp -r ${monorepoSrc}/libunwind/include "$out/libunwind"
-        mkdir -p "$out/llvm"
-      ''
+      runCommand "lld-src-${version}"
+        {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        ''
+          mkdir -p "$out"
+          cp -r ${monorepoSrc}/cmake "$out"
+          cp -r ${monorepoSrc}/lld "$out"
+          mkdir -p "$out/libunwind"
+          cp -r ${monorepoSrc}/libunwind/include "$out/libunwind"
+          mkdir -p "$out/llvm"
+        ''
     else
       src;
 

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -22,7 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "lld-src-${version}" { inherit (monorepoSrc) passthru; } ''
+      runCommand "lld-src-${version}" {
+        inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
+      } ''
         mkdir -p "$out"
         cp -r ${monorepoSrc}/cmake "$out"
         cp -r ${monorepoSrc}/lld "$out"

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -46,21 +46,23 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "lldb-src-${version}" {
-          inherit (monorepoSrc) passthru;
-          strictDeps = true;
-          __structuredAttrs = true;
-        } (
-          ''
-            mkdir -p "$out"
-            cp -r ${monorepoSrc}/cmake "$out"
-            cp -r ${monorepoSrc}/lldb "$out"
-          ''
-          + lib.optionalString (lib.versionAtLeast release_version "19" && enableManpages) ''
-            mkdir -p "$out/llvm"
-            cp -r ${monorepoSrc}/llvm/docs "$out/llvm/docs"
-          ''
-        )
+        runCommand "lldb-src-${version}"
+          {
+            inherit (monorepoSrc) passthru;
+            strictDeps = true;
+            __structuredAttrs = true;
+          }
+          (
+            ''
+              mkdir -p "$out"
+              cp -r ${monorepoSrc}/cmake "$out"
+              cp -r ${monorepoSrc}/lldb "$out"
+            ''
+            + lib.optionalString (lib.versionAtLeast release_version "19" && enableManpages) ''
+              mkdir -p "$out/llvm"
+              cp -r ${monorepoSrc}/llvm/docs "$out/llvm/docs"
+            ''
+          )
       else
         src;
 

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -46,7 +46,11 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "lldb-src-${version}" { inherit (monorepoSrc) passthru; } (
+        runCommand "lldb-src-${version}" {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        } (
           ''
             mkdir -p "$out"
             cp -r ${monorepoSrc}/cmake "$out"

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -87,25 +87,27 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "llvm-src-${version}" {
-          inherit (monorepoSrc) passthru;
-          strictDeps = true;
-          __structuredAttrs = true;
-        } (
-          ''
-            mkdir -p "$out"
-            cp -r ${monorepoSrc}/llvm "$out"
-            cp -r ${monorepoSrc}/cmake "$out"
-            cp -r ${monorepoSrc}/third-party "$out"
-          ''
-          + lib.optionalString enablePolly ''
-            chmod u+w "$out/llvm/tools"
-            cp -r ${monorepoSrc}/polly "$out/llvm/tools"
-          ''
-          + lib.optionalString (lib.versionAtLeast release_version "21") ''
-            cp -r ${monorepoSrc}/libc "$out"
-          ''
-        )
+        runCommand "llvm-src-${version}"
+          {
+            inherit (monorepoSrc) passthru;
+            strictDeps = true;
+            __structuredAttrs = true;
+          }
+          (
+            ''
+              mkdir -p "$out"
+              cp -r ${monorepoSrc}/llvm "$out"
+              cp -r ${monorepoSrc}/cmake "$out"
+              cp -r ${monorepoSrc}/third-party "$out"
+            ''
+            + lib.optionalString enablePolly ''
+              chmod u+w "$out/llvm/tools"
+              cp -r ${monorepoSrc}/polly "$out/llvm/tools"
+            ''
+            + lib.optionalString (lib.versionAtLeast release_version "21") ''
+              cp -r ${monorepoSrc}/libc "$out"
+            ''
+          )
       else
         src;
 

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -87,7 +87,11 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "llvm-src-${version}" { inherit (monorepoSrc) passthru; } (
+        runCommand "llvm-src-${version}" {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        } (
           ''
             mkdir -p "$out"
             cp -r ${monorepoSrc}/llvm "$out"

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -26,18 +26,21 @@ stdenv.mkDerivation (finalAttrs: {
     && (!stdenv.hostPlatform.isMusl);
 
   # Blank llvm dir just so relative path works
-  src = runCommand "${finalAttrs.pname}-src-${version}" {
-    inherit (monorepoSrc) passthru;
-    strictDeps = true;
-    __structuredAttrs = true;
-  } ''
-    mkdir -p "$out"
-    cp -r ${monorepoSrc}/cmake "$out"
-    cp -r ${monorepoSrc}/mlir "$out"
-    cp -r ${monorepoSrc}/third-party "$out/third-party"
+  src =
+    runCommand "${finalAttrs.pname}-src-${version}"
+      {
+        inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
+      }
+      ''
+        mkdir -p "$out"
+        cp -r ${monorepoSrc}/cmake "$out"
+        cp -r ${monorepoSrc}/mlir "$out"
+        cp -r ${monorepoSrc}/third-party "$out/third-party"
 
-    mkdir -p "$out/llvm"
-  '';
+        mkdir -p "$out/llvm"
+      '';
 
   sourceRoot = "${finalAttrs.src.name}/mlir";
 

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -26,7 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
     && (!stdenv.hostPlatform.isMusl);
 
   # Blank llvm dir just so relative path works
-  src = runCommand "${finalAttrs.pname}-src-${version}" { inherit (monorepoSrc) passthru; } ''
+  src = runCommand "${finalAttrs.pname}-src-${version}" {
+    inherit (monorepoSrc) passthru;
+    strictDeps = true;
+    __structuredAttrs = true;
+  } ''
     mkdir -p "$out"
     cp -r ${monorepoSrc}/cmake "$out"
     cp -r ${monorepoSrc}/mlir "$out"

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -30,7 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "openmp-src-${version}" { inherit (monorepoSrc) passthru; } ''
+      runCommand "openmp-src-${version}" {
+        inherit (monorepoSrc) passthru;
+        strictDeps = true;
+        __structuredAttrs = true;
+      } ''
         mkdir -p "$out"
         cp -r ${monorepoSrc}/cmake "$out"
         cp -r ${monorepoSrc}/openmp "$out"

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -30,15 +30,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "openmp-src-${version}" {
-        inherit (monorepoSrc) passthru;
-        strictDeps = true;
-        __structuredAttrs = true;
-      } ''
-        mkdir -p "$out"
-        cp -r ${monorepoSrc}/cmake "$out"
-        cp -r ${monorepoSrc}/openmp "$out"
-      ''
+      runCommand "openmp-src-${version}"
+        {
+          inherit (monorepoSrc) passthru;
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        ''
+          mkdir -p "$out"
+          cp -r ${monorepoSrc}/cmake "$out"
+          cp -r ${monorepoSrc}/openmp "$out"
+        ''
     else
       src;
 

--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -38,23 +38,25 @@ let
 
   src' =
     if monorepoSrc != null then
-      runCommand "${pname}-src-${version}" {
-        strictDeps = true;
-        __structuredAttrs = true;
-      } (
-        ''
-          mkdir -p "$out"
-          cp -r ${monorepoSrc}/cmake "$out"
-          cp -r ${monorepoSrc}/third-party "$out"
-          cp -r ${monorepoSrc}/llvm "$out"
-          cp -r ${monorepoSrc}/clang "$out"
-          cp -r ${monorepoSrc}/clang-tools-extra "$out"
-          cp -r ${monorepoSrc}/mlir "$out"
-        ''
-        + lib.optionalString (lib.versionAtLeast version "23") ''
-          cp -r ${monorepoSrc}/libc "$out"
-        ''
-      )
+      runCommand "${pname}-src-${version}"
+        {
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        (
+          ''
+            mkdir -p "$out"
+            cp -r ${monorepoSrc}/cmake "$out"
+            cp -r ${monorepoSrc}/third-party "$out"
+            cp -r ${monorepoSrc}/llvm "$out"
+            cp -r ${monorepoSrc}/clang "$out"
+            cp -r ${monorepoSrc}/clang-tools-extra "$out"
+            cp -r ${monorepoSrc}/mlir "$out"
+          ''
+          + lib.optionalString (lib.versionAtLeast version "23") ''
+            cp -r ${monorepoSrc}/libc "$out"
+          ''
+        )
     else
       src;
 

--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -38,7 +38,10 @@ let
 
   src' =
     if monorepoSrc != null then
-      runCommand "${pname}-src-${version}" { } (
+      runCommand "${pname}-src-${version}" {
+        strictDeps = true;
+        __structuredAttrs = true;
+      } (
         ''
           mkdir -p "$out"
           cp -r ${monorepoSrc}/cmake "$out"


### PR DESCRIPTION
These were not included in https://github.com/NixOS/nixpkgs/pull/553112 because I was testing with a branch that enabled `strictDeps`/`structuredAttrs` globally for `runCommandWith`.

At least some of these are on the path to the rust toolchain, but then we might as well update all of them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
