### PR TITLE
paperless-ngx: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -70,14 +70,14 @@ let
 in
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "paperless-ngx";
-  version = "3.1.0";
+  version = "3.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "paperless-ngx";
     repo = "paperless-ngx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SipdhPxnGpCM/U0K5O59fdaKUuMLWiaXRE+XS3lpb/c=";
+    hash = "sha256-IOGwlATlS4T90dXufxkwI/MJGFGLXmlbqNB/OJbPLrY=";
   };
 
   postPatch = ''
@@ -272,19 +272,17 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     # FileNotFoundError(2, 'No such file or directory'): /build/tmp...
     "test_script_with_output"
     "test_script_exit_non_zero"
-    # Something broken with new Tesseract and inline RTL/LTR overrides?
-    "test_rtl_language_detection"
-    # Favicon tests fail due to static file handling in the test environment
-    # https://github.com/NixOS/nixpkgs/issues/421393
-    "test_favicon_view"
-    "test_favicon_view_missing_file"
-    # Requires DNS
+    # Requires internet
     "test_send_webhook_data_or_json"
-    # execnet.gateway_base.DumpError: can't serialize <class 'pathlib._local.PosixPath'>
-    # https://github.com/pytest-dev/pytest-xdist/issues/384
-    "test_subdirectory_upload"
-    # AssertionError: 4 != 3
-    "testNormalOperation"
+  ];
+
+  disabledTestPaths = [
+    # flaky test
+    #   AssertionError: Expected 'apply_async' to not have been called.
+    "src/documents/tests/test_management_consumer.py::TestCommandWatchEdgeCases::test_handles_deleted_before_stable"
+    # flaky test:
+    #   ValueError: Failed to open file for read: 'FileDoesNotExist("meta.json")'
+    "src/documents/tests/test_permission_filtering_security.py::TestTrashRestorePermissionBoundary::test_restore_allows_document_with_explicit_delete_permission"
   ];
 
   doCheck = !stdenv.hostPlatform.isDarwin;


### PR DESCRIPTION
Diff: https://github.com/paperless-ngx/paperless-ngx/compare/v3.1.0...v3.1.1

Changelog: https://github.com/paperless-ngx/paperless-ngx/releases/tag/v3.1.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
