### PR TITLE
gtest: Fix for or-conf

### DIFF
--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -50,8 +50,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-  ]
-  ++ lib.optionals withAbseil [
+  ];
+
+  buildInputs = lib.optionals withAbseil [
     abseil-cpp
     re2
   ];


### PR DESCRIPTION
## Summary

`withAbseil = true` puts `abseil-cpp`/`re2` under `nativeBuildInputs`. CMake's
`find_package(absl)` locates Abseil's package config via `CMAKE_PREFIX_PATH`,
which nixpkgs' cmake setup-hook populates from `buildInputs` -- not
`nativeBuildInputs`. So `-DGTEST_HAS_ABSL=ON` fails configure:

```
CMake Error at CMakeLists.txt:25 (find_package):
  Could not find a package configuration file provided by "absl"
```

`or-tools` is the only caller in nixpkgs that sets `withAbseil = true` (via
its `checkInputs`' `gtest' = gtest.override { withAbseil = true; }`), so this
latent bug was never triggered until now -- found while getting or-tools'
Python 3.14 fix (#551898) to build cleanly under `nixpkgs-review`.

## Fix

Move `abseil-cpp`/`re2` from `nativeBuildInputs` to `buildInputs`, gated the
same way (`lib.optionals withAbseil [...]`).

## Verified

- `nix build --expr 'pkgs.gtest.override { withAbseil = true; }'` succeeds
  (previously failed at configure).
- `nix build --expr 'pkgs.or-tools'` (which uses `gtest'` in `checkInputs`,
  `doCheck = true` on Linux) now succeeds end to end, including its
  checkPhase.

## Related

Related to #551898 (or-tools: fix Python 3.14 support) -- that PR's own
`nixpkgs-review` build was failing on this, not on anything in its own
diff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
