### PR TITLE
machine0: init at 1.0.164

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -725,6 +725,12 @@
     githubId = 63286;
     name = "Adam Hose";
   };
+  adithayyil = {
+    email = "adithayyil@proton.me";
+    github = "adithayyil";
+    githubId = 90326965;
+    name = "Adithya Thayyil";
+  };
   adjacentresearch = {
     email = "nate@adjacentresearch.xyz";
     github = "0xperp";

--- a/pkgs/by-name/ma/machine0/package.nix
+++ b/pkgs/by-name/ma/machine0/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  nodejs,
+  openssh,
+  xdg-utils,
+  versionCheckHook,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "machine0";
+  version = "1.0.164";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@machine0/cli/-/cli-${finalAttrs.version}.tgz";
+    hash = "sha256-7BLWBUZcV7l4KTwf0RvIn2+z7P1w5Q4KWAwsiA1jHdw=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # The published package has no dependencies: it is a single prebundled ESM
+  # file plus the entrypoint that loads it, so npm is not needed to install it.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/machine0
+    cp -r bin dist package.json $out/lib/machine0/
+
+    # ssh/ssh-keygen are called for `machine0 ssh` and key management,
+    # xdg-open to open the browser when logging in.
+    makeWrapper ${lib.getExe nodejs} $out/bin/machine0 \
+      --add-flags $out/lib/machine0/bin/entry.cjs \
+      --prefix PATH : ${
+        lib.makeBinPath ([ openssh ] ++ lib.optional stdenvNoCC.hostPlatform.isLinux xdg-utils)
+      }
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Cloud VMs from the CLI";
+    homepage = "https://machine0.io";
+    downloadPage = "https://www.npmjs.com/package/@machine0/cli";
+    license = lib.licenses.unfree;
+    mainProgram = "machine0";
+    maintainers = with lib.maintainers; [ adithayyil ];
+    platforms = lib.platforms.unix;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+})

--- a/pkgs/by-name/ma/machine0/update.sh
+++ b/pkgs/by-name/ma/machine0/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nodejs nix-update
+
+set -euo pipefail
+
+nix-update machine0 --version "$(npm view @machine0/cli version)"


### PR DESCRIPTION
[machine0](https://machine0.io) is a CLI for creating, provisioning, and snapshotting persistent cloud VMs, with NixOS flake provisioning (`machine0 provision <vm> <flake-ref>`).

Notes:
- upstream ships no license, `license` is absent from the published `package.json` and there is no LICENSE file in the tarball. Same handling as `graphite-cli`.
- the published tarball has zero dependencies; a single prebundled ESM file (`dist/cli.bundle.mjs`) plus the entrypoint that loads it. There is nothing for npm to install and no lockfile to vendor, so this is `stdenvNoCC.mkDerivation` + a `nodejs` wrapper.
- The wrapper puts `openssh` on `PATH` (`machine0 ssh`, and `ssh-keygen` for key management) and `xdg-utils` on Linux (opens the browser on `login`).
- `passthru.updateScript` bumps via `npm view @machine0/cli version` + `nix-update`; `nix-update` alone can't discover npm registry versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
