### PR TITLE
libretroPackages: remove meta.hydraPlatforms = [ ];

### DIFF
--- a/pkgs/by-name/li/libretroPackages/package.nix
+++ b/pkgs/by-name/li/libretroPackages/package.nix
@@ -15,19 +15,20 @@ stdenvNoCC.mkDerivation {
   dontUnpack = true;
 
   installPhase = ''
-    echo >&2 "'libretroPackages' is a package set, not an installable package."
-    echo >&2 "Use an individual core instead, e.g., 'libretro.mgba'."
-    exit 1
+    runHook preInstall
+
+    mkdir -p $out
+
+    runHook postInstall
   '';
 
   meta = {
     description = "Dummy package for the libretro package set";
-    hydraPlatforms = [ ];
     # XXX: nixpkgs-merge-bot needs this package to evaluate clearly to allow
     # the individual cores to be merged, and that members that want to merge
     # via bot to be added to this list instead of each individual core.
     platforms = lib.platforms.all;
     teams = [ lib.teams.libretro ];
-    members = [ ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/558134#issuecomment-5482618341

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
