### PR TITLE
ratspeak: 1.0.25 -> 1.0.31

### DIFF
--- a/pkgs/by-name/ra/ratspeak/package.nix
+++ b/pkgs/by-name/ra/ratspeak/package.nix
@@ -26,38 +26,38 @@ let
   rsReticulum = fetchFromGitHub {
     owner = "ratspeak";
     repo = "rsReticulum";
-    rev = "17e6107aa8fb9a5b0c2cac2f4fe4b68655593bd8";
-    hash = "sha256-0HjeGZ57eiz9z9akc+ESdZLAN+/uR9LyNaMLgYiTPO8=";
+    tag = "v1.2.0";
+    hash = "sha256-gdup7PaYOQnBE3Mm4adpjQh5W3DaXWrdmuUhj5cF0ZE=";
   };
   rsLXMF = fetchFromGitHub {
     owner = "ratspeak";
     repo = "rsLXMF";
-    rev = "393478019b3a076abc7af5f0d2c7b980b3329550";
-    hash = "sha256-uCoU4HtdRy6sB8vi5BtifKFAy0a7FPuHuuRb1EJTJ2c=";
+    tag = "v1.2.0";
+    hash = "sha256-5YV/XHpBoqN+XoE6Nf/zqq9JRAcMZKqWLsseRqZVt6o=";
   };
   rsLXST = fetchFromGitHub {
     owner = "ratspeak";
     repo = "rsLXST";
-    rev = "e3f80815bcf1c1d6af1c07135dfe05b6163d596a";
-    hash = "sha256-921xMNdneOTurUoUR5ImPEB8ztfEQLl9jCZY+s9Cjuo=";
+    tag = "v0.2.0";
+    hash = "sha256-XLdA0kprtPEkJmnKJM4dhzoN0wb/jWzk1qP0jNyFw7I=";
   };
   lrgp-rs = fetchFromGitHub {
     owner = "ratspeak";
     repo = "lrgp-rs";
-    rev = "0b55361ebf91c1caa09d5ed8ab88ac0a6d955de6";
-    hash = "sha256-MZGWGCWLc+suHCD9NFV6m8A4EP4pLfogaqm93pMk/ss=";
+    tag = "v0.4.1";
+    hash = "sha256-SgdQZpVmJjB/g1OnW2/Gx3fwtrcUC+2UQy88gvMTDUw=";
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ratspeak";
-  version = "1.0.25";
+  version = "1.0.31";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ratspeak";
     repo = "Ratspeak";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HJH31dAnmSK85AkX+ufvmo+Nmd9X6xmLO06Lys8kces=";
+    hash = "sha256-cvvjZNr0b9Q9PX6UqKFIHoPArWQGZ7fwFRgh5uJPQdg=";
   };
 
   # The app expects the protocol repos next to its own checkout.
@@ -69,7 +69,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     chmod -R u+w rsReticulum rsLXMF rsLXST lrgp-rs
   '';
 
-  cargoHash = "sha256-XumEJazJux0FFLS6qcruaXdOLsZ9hfn8Q/hA9Ot4RzM=";
+  cargoHash = "sha256-zf3582SkmrWdWYoTIyN3tGNGF5PhxyU1ZpTwf8uKDvo=";
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 


### PR DESCRIPTION
The build is currently failing:

```
   Compiling notify-rust v4.17.0
   Compiling async-fs v2.2.0
   Compiling async-net v2.0.0
   Compiling ogg v0.9.2
   Compiling rfd v0.15.4
   Compiling ratspeak-tauri v1.0.31 (/build/source/crates/ratspeak-tauri)
   Compiling ratspeak-runtime v1.0.31 (/build/source/crates/ratspeak-runtime)
error[E0432]: unresolved import `lxmf_core::router::RouterStateSnapshot`
  --> /build/source/crates/ratspeak-runtime/src/lxmf.rs:29:46
   |
29 |     LxmRouter, OutboundAction, RouterConfig, RouterStateSnapshot, plan_direct_delivery,
   |                                              ^^^^^^^^^^^^^^^^^^^ no `RouterStateSnapshot` in `router`

   Compiling ashpd v0.11.1
error[E0599]: no method named `state_snapshot` found for struct `LxmRouter` in the current scope
    --> /build/source/crates/ratspeak-runtime/src/lxmf.rs:3166:39
     |
3166 |             router_state: self.router.state_snapshot(),
     |                                       ^^^^^^^^^^^^^^ method not found in `LxmRouter`

error[E0599]: no method named `state_snapshot` found for struct `LxmRouter` in the current scope
    --> /build/source/crates/ratspeak-runtime/src/lxmf.rs:3201:70
     |
3201 |                 .then(|| (self.lxmf_storage_dir.clone(), self.router.state_snapshot())),
     |                                                                      ^^^^^^^^^^^^^^ method not found in `LxmRouter`

error[E0599]: no method named `with_persisted_bluetooth_enabled` found for struct `RNodeStartupOptions` in the current scope
  --> /build/source/crates/ratspeak-runtime/src/rns.rs:31:36
   |
31 |     RNodeStartupOptions::default().with_persisted_bluetooth_enabled()
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `RNodeStartupOptions`

   Compiling sharded-slab v0.1.7
   Compiling ratspeak v1.0.31 (/build/source/src-tauri)
   Compiling matchers v0.2.0
   Compiling tracing-log v0.2.0
   Compiling thread_local v1.1.10
   Compiling nu-ansi-term v0.50.3
   Compiling pollster v0.4.0
   Compiling urlencoding v2.1.3
   Compiling tracing-subscriber v0.3.23
   Compiling tauri-plugin-single-instance v2.4.3
Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `ratspeak-runtime` (lib) due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
