### PR TITLE
httptoolkit: 1.26.0 -> 1.27.1, bump electron version to v42, httptoolkit-server: 1.26.1 -> 1.27.1

### DIFF
--- a/pkgs/by-name/ht/httptoolkit-server/package.nix
+++ b/pkgs/by-name/ht/httptoolkit-server/package.nix
@@ -21,13 +21,13 @@ let
 
   # update together with httptoolkit
   # nixpkgs-update: no auto update
-  version = "1.26.1";
+  version = "1.27.1";
 
   src = fetchFromGitHub {
     owner = "httptoolkit";
     repo = "httptoolkit-server";
     tag = "v${version}";
-    hash = "sha256-pCEz5bgpzEjGeBoOp3fb/WBW+loCzjvCckJTEwK0o7U=";
+    hash = "sha256-t7Rxh8BuzfhdBfMGMNWUV/xMtbhgw0yU9t97LbdKB9o=";
   };
 
   overridesNodeModules = buildNpmPackage' {
@@ -35,7 +35,7 @@ let
     inherit version src;
     sourceRoot = "${src.name}/overrides/js";
 
-    npmDepsHash = "sha256-B/W6kD6x10bfsuehRb9oObi+Gf3Hovm0jMNLcbuigeo=";
+    npmDepsHash = "sha256-oZcroK5zmQvvxBas9OmAXins+7+olGWwouUepprWFxk=";
 
     dontBuild = true;
 
@@ -45,6 +45,7 @@ let
     '';
   };
 
+  # Check update in package-lock.json
   nodeDatachannel = buildNpmPackage' {
     pname = "node-datachannel";
     version = "0.12.0";
@@ -105,7 +106,7 @@ buildNpmPackage' {
 
   patches = [ ./only-build-for-one-platform.patch ];
 
-  npmDepsHash = "sha256-OO1QI2KNbZo/2Bl6xC6oORVfDtBqjr2tuQmk6s70znM=";
+  npmDepsHash = "sha256-xICvMGB3RLsI0UDGPrtxkNrO1SgZqGGmfBzCQOFGJzY=";
 
   npmFlags = [ "--ignore-scripts" ];
 

--- a/pkgs/by-name/ht/httptoolkit/package.nix
+++ b/pkgs/by-name/ht/httptoolkit/package.nix
@@ -10,14 +10,14 @@
   makeWrapper,
   xcbuild,
 
-  electron_41,
+  electron_42,
   httptoolkit-server,
 }:
 
 let
-  electron = electron_41;
+  electron = electron_42;
 in
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "httptoolkit";
 
   # update together with httptoolkit-server
@@ -27,7 +27,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "httptoolkit";
     repo = "httptoolkit-desktop";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WEl0DGYdq1qa5zNEVO6L8TW6lgNTI0NdL0YXeR3Z0BI=";
   };
 
@@ -103,7 +103,7 @@ buildNpmPackage rec {
       terminal = false;
       icon = "httptoolkit";
       startupWMClass = "HTTP Toolkit";
-      comment = meta.description;
+      comment = finalAttrs.meta.description;
       categories = [ "Development" ];
       startupNotify = true;
     })
@@ -117,4 +117,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ tomasajt ];
     platforms = electron.meta.platforms;
   };
-}
+})

--- a/pkgs/by-name/ht/httptoolkit/package.nix
+++ b/pkgs/by-name/ht/httptoolkit/package.nix
@@ -22,13 +22,13 @@ buildNpmPackage (finalAttrs: {
 
   # update together with httptoolkit-server
   # nixpkgs-update: no auto update
-  version = "1.26.0";
+  version = "1.27.1";
 
   src = fetchFromGitHub {
     owner = "httptoolkit";
     repo = "httptoolkit-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WEl0DGYdq1qa5zNEVO6L8TW6lgNTI0NdL0YXeR3Z0BI=";
+    hash = "sha256-6DvfAjMIdLngwnBsUJywlFPUoKM8fgALYrmWu6QT5ow=";
   };
 
   patches = [
@@ -40,7 +40,7 @@ buildNpmPackage (finalAttrs: {
       --replace-fail "@out@" "$out"
   '';
 
-  npmDepsHash = "sha256-fGVxHhJU/1ZsRyX3AnP6jM/jkY0PZHKDA1tb2z06lLs=";
+  npmDepsHash = "sha256-NF1FVh86pQdgqcYzqTHEzjM5x4jJamOqsculkyHyVEM=";
 
   makeCacheWritable = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Work towards: #555100
Rewrite package to use finalAttrs
bump electron to v42
basic test passed in NixOS-WSL
Update desktop, server to 1.27.1
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
