### PR TITLE
outline: shrink output closure size

### DIFF
--- a/pkgs/by-name/ou/outline/package.nix
+++ b/pkgs/by-name/ou/outline/package.nix
@@ -49,8 +49,12 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
+    yarn workspaces focus --production
+
     mkdir -p $out/bin $out/share/outline
     mv build server public node_modules $out/share/outline/
+    find $out/share/outline/node_modules -name "*.map" -delete
+    find $out/share/outline/node_modules -name "*.d.ts" -delete
 
     node_modules=$out/share/outline/node_modules
     build=$out/share/outline/build


### PR DESCRIPTION
Shrinks the closure from 1.2GB to 627MB. Removes various unneeded files and runs yarn workspaces focus to go to only production dependencies instead of shipping devDependencies that are unneeded.

### Diff
* `before`: before changes
* `after`: trim to only prod deps
* `after-2`: remove all .map files
* `after-3`: remove all .d.ts files
<img width="601" height="482" alt="31-16-08-06-region" src="https://github.com/user-attachments/assets/16c1c83a-023f-44ec-a20b-2b551a0643c4" />

~~Have not run tests yet, will do so soon.~~ Run tests, no issues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
