### PR TITLE
nix: Add `useDefaultCache` option to control using cache.nixos.org

### DIFF
--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -208,6 +208,12 @@ in
         '';
       };
 
+      useDefaultCache = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to add cache.nixos.org to `substituters` and `trusted-public-keys`.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = semanticConfType;
@@ -429,9 +435,11 @@ in
 
     environment.etc."nix/nix.conf".source = nixConf;
     nix.settings = {
-      trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" ];
+      trusted-public-keys = mkIf cfg.useDefaultCache [
+        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      ];
       trusted-users = [ "root" ];
-      substituters = mkAfter [ "https://cache.nixos.org/" ];
+      substituters = mkIf cfg.useDefaultCache (mkAfter [ "https://cache.nixos.org/" ]);
       system-features = defaultSystemFeatures;
     };
 


### PR DESCRIPTION
Adds a `nix.useDefaultCache` option (true by default) which allows opting out of using [cache.nixos.org](https://cache.nixos.org/). This is tricky to do currently because it is a hardcoded list option, so it requires an override. No diff to existing configurations:

```sh
% nix eval .#nixosTests.nix-serve
«derivation /nix/store/39l6hq00k0vsbay895r6x5ymc46ba09x-vm-test-run-nix-serve.drv»
% git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
% nix eval .#nixosTests.nix-serve
«derivation /nix/store/39l6hq00k0vsbay895r6x5ymc46ba09x-vm-test-run-nix-serve.drv»
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
