### PR TITLE
python3Packages.pillow-jxl-plugin: enable tests

### DIFF
--- a/pkgs/development/python-modules/pillow-jxl-plugin/default.nix
+++ b/pkgs/development/python-modules/pillow-jxl-plugin/default.nix
@@ -9,6 +9,8 @@
   packaging,
   pillow,
   numpy,
+  openexr,
+  pyexiv2,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -44,12 +46,17 @@ buildPythonPackage (finalAttrs: {
     pillow
   ];
 
-  doCheck = false;
-
   nativeCheckInputs = [
     pytestCheckHook
     numpy
+    openexr
+    pyexiv2
   ];
+
+  # Remove source so tests don't try to import from it
+  preCheck = ''
+    rm -r pillow_jxl
+  '';
 
   pythonImportsCheck = [
     "pillow_jxl"


### PR DESCRIPTION
Enables the tests of `python3Packages.pillow-jxl-plugin` now that #546021 and #546026 have been merged. As announced in https://github.com/NixOS/nixpkgs/pull/543307#issuecomment-5254534575.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
