### PR TITLE
python3.buildEnv: enable strictDeps, enable structuredAttrs

### DIFF
--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -24,9 +24,15 @@ let
   env =
     let
       paths = requiredPythonModules extraLibs ++ [
-        (runCommand "bin" { } ''
-          mkdir -p $out/bin
-        '')
+        (runCommand "bin"
+          {
+            strictDeps = true;
+            __structuredAttrs = true;
+          }
+          ''
+            mkdir -p $out/bin
+          ''
+        )
       ];
       pythonPath = "${placeholder "out"}/${python.sitePackages}";
       pythonExecutable = "${placeholder "out"}/bin/${python.executable}";
@@ -70,6 +76,8 @@ let
       ''
       + postBuild;
 
+      derivationArgs.strictDeps = true;
+
       inherit (python) meta;
 
       passthru = python.passthru // {
@@ -78,6 +86,7 @@ let
         env = stdenv.mkDerivation {
           name = "interactive-${python.name}-environment";
           nativeBuildInputs = [ env ];
+          strictDeps = true;
 
           buildCommand = ''
             echo >&2 ""
@@ -85,6 +94,8 @@ let
             echo >&2 ""
             exit 1
           '';
+
+          __structuredAttrs = true;
         };
       };
     };

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -24,7 +24,7 @@ let
   env =
     let
       paths = requiredPythonModules extraLibs ++ [
-        (runCommand "bin"
+        (runCommand "${python.name}-env-bin"
           {
             strictDeps = true;
             __structuredAttrs = true;


### PR DESCRIPTION
`buildEnv` already forces `__structuredAttrs = true`, but it would be nice to have this `buildEnv` use `strictDeps` as well when Hydra builds it, making steps towards `strictDepsByDefault` easier.

Enabling `strictDeps` should be safe since `buildEnv` doesn't accept arbitrary build inputs?

Enabling `__structuredAttrs` / `strictDeps` on the other two derivations looks trivial, there's not much going on in either.

Anecdotally, I've built complete system configurations with `strictDepsByDefault` / `structuredAttrsByDefault` and I never saw any issues related to this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
