### PR TITLE
github-runner: 2.336.0 -> 2.337.0

### DIFF
--- a/pkgs/by-name/gi/github-runner/deps.json
+++ b/pkgs/by-name/gi/github-runner/deps.json
@@ -1,18 +1,18 @@
 [
   {
     "pname": "Azure.Core",
-    "version": "1.50.0",
-    "hash": "sha256-8Pjz0/2wTLK5uY7G5qrxQr4CsmrjiR8gL4g6zJymj5s="
+    "version": "1.55.0",
+    "hash": "sha256-6lPqo+pNn0R1JOhlfg7KwD33Do43y2e1hxK0gX6fvhU="
   },
   {
     "pname": "Azure.Storage.Blobs",
-    "version": "12.27.0",
-    "hash": "sha256-Ag8kMe/NBfq+HSchFzm0VAAo9xVnrKHFHUjbQ4KpSh0="
+    "version": "12.29.2",
+    "hash": "sha256-eyEuuX8CjJfU5FCzxedc4F3oFMAAeIHcL28rurYCDc4="
   },
   {
     "pname": "Azure.Storage.Common",
-    "version": "12.26.0",
-    "hash": "sha256-GPiEPi/caj5z2cMFP5TUx/Jrj/zXZmA/xqC9CEoI+qQ="
+    "version": "12.28.0",
+    "hash": "sha256-I1LbKRdd9OLXZRP4jsp3A4WiI4ZVrEA640wqcPry81c="
   },
   {
     "pname": "Castle.Core",
@@ -31,13 +31,13 @@
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
-    "version": "8.0.0",
-    "hash": "sha256-9aWmiwMJKrKr9ohD1KSuol37y+jdDxPGJct3m2/Bknw="
+    "version": "10.0.3",
+    "hash": "sha256-+wTcmczUD1qSnnWZ1miijr62/glcRbNWRpEZh/OBU2g="
   },
   {
     "pname": "Microsoft.Bcl.Cryptography",
-    "version": "10.0.7",
-    "hash": "sha256-5hOu8j2jLhCj9m7MlBoCjq3Qo0ST+b8n6oG2lLHL24s="
+    "version": "10.0.11",
+    "hash": "sha256-+kdPkD18wpCVndcfoGinCINcr2Yk8Txl0RbJ3gYrNUc="
   },
   {
     "pname": "Microsoft.CodeCoverage",
@@ -46,43 +46,88 @@
   },
   {
     "pname": "Microsoft.DevTunnels.Connections",
-    "version": "1.3.48",
-    "hash": "sha256-/E7ik2riVOMUyPt/1pxU7laDHG1pG5JpLIf5cQ7x7K4="
+    "version": "1.3.51",
+    "hash": "sha256-0XsrCanwQ4E4BueU4njF0K8Ovczf9K4/mw9EhTxnzPM="
   },
   {
     "pname": "Microsoft.DevTunnels.Contracts",
-    "version": "1.3.48",
-    "hash": "sha256-YYmyZWmKv03BnOKAwbAeLrKqYDbBQ4ZS26jn92QkLSc="
+    "version": "1.3.51",
+    "hash": "sha256-O2JYXYxzjj4AooGdWsEQ8WgE8IxvPz9L58GJcIVPHF8="
   },
   {
     "pname": "Microsoft.DevTunnels.Management",
-    "version": "1.3.48",
-    "hash": "sha256-DyDPqIwQkKJESx5K9Y4nKtw05cHrTlTp56rg/JXuVag="
+    "version": "1.3.51",
+    "hash": "sha256-AA6t3lboBSdBYTON2QCEBOYoNW9GPh8OquUiQkBogeE="
   },
   {
     "pname": "Microsoft.DevTunnels.Ssh",
-    "version": "3.12.24",
-    "hash": "sha256-+GFTJiVQ5NZy3HeCiFIm4DggKAKPlEb90P/ZBB/rRxc="
+    "version": "3.12.40",
+    "hash": "sha256-EB/1D5evYbXJ/1jkeUeLgvOQtuPdT+xaJ4P6Na2vd+Q="
   },
   {
     "pname": "Microsoft.DevTunnels.Ssh.Tcp",
-    "version": "3.12.24",
-    "hash": "sha256-NCNAGmQ9ugp5ezJ8adujvP0HRtYkIn4Ly0AWq2nDH9M="
+    "version": "3.12.40",
+    "hash": "sha256-UrNqqNYxCNUUO4rCs4PsWX4naaJv3mD+eLf0Dxg1PSg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "10.0.3",
+    "hash": "sha256-OfcPeDv7RJvvv7ns+wCMAQCdG/He2KtxV6MRlwvp35I="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "8.0.2",
-    "hash": "sha256-UfLfEQAkXxDaVPC7foE/J3FVEXd31Pu6uQIhTic3JgY="
+    "version": "10.0.3",
+    "hash": "sha256-ShB94jEtsq5X5r6xDZQ+wotZYG3OPKOCHNGy4B7NVFs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "10.0.3",
+    "hash": "sha256-JglKtC6+jfiggRUU5AXC6mR0cW1t3M33wR7WXKyJjBs="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "10.0.3",
+    "hash": "sha256-uWAZh/RdMEiwTM2311KlDKK2LBo81tIYXPTUzJXbceA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "10.0.3",
+    "hash": "sha256-d8zXyTfgVdok+Cgg5EC04DH4iPQtLxlU9CsGy5+dr6s="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "8.0.3",
-    "hash": "sha256-5MSY1aEwUbRXehSPHYw0cBZyFcUH4jkgabddxhMiu3Q="
+    "version": "10.0.3",
+    "hash": "sha256-lIStSIPTxaoCRoUBHsBPXZbuVj5io02390Wkyepyflw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.3",
+    "hash": "sha256-KDYaVBSdNEuhs3U164RV0n20cjwrpi7uI71B0j/UFsA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.3",
+    "hash": "sha256-w0G+IW9kz70ug1BEuJTeS1N7werQhms3gQl6ODzNIpQ="
   },
   {
     "pname": "Microsoft.Extensions.Primitives",
     "version": "8.0.0",
     "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+  },
+  {
+    "pname": "Microsoft.Identity.Client",
+    "version": "4.83.1",
+    "hash": "sha256-WDt1xgK5hdxSYg6cIK5wXtY4/PB+BaT393gNLawzE8A="
+  },
+  {
+    "pname": "Microsoft.Identity.Client.Extensions.Msal",
+    "version": "4.83.1",
+    "hash": "sha256-t4hG5KSzfBfhfZ7dJDBS2wr7v2nnDwRjPs78ZziM/b8="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "8.14.0",
+    "hash": "sha256-bkCuz1Wj56N+LHWLvHKLcCtIRqBK+3k5vD2qfB7xXKk="
   },
   {
     "pname": "Microsoft.Net.Http.Headers",
@@ -481,8 +526,8 @@
   },
   {
     "pname": "System.ClientModel",
-    "version": "1.8.0",
-    "hash": "sha256-ZWVhuw3IRk9rZXkXERhesEET2KMMzHjUH/HDI288WK8="
+    "version": "1.11.0",
+    "hash": "sha256-wLbZlxAXOzKtjrdwrzvBdBTujt1QRwwGlbAa+Jx4PCc="
   },
   {
     "pname": "System.Collections",
@@ -526,6 +571,11 @@
   },
   {
     "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "10.0.3",
+    "hash": "sha256-YQzu50E7/1slw8IcFkVpQd33/IyWw1hJapTIscnoF5Q="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
     "version": "4.3.0",
     "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
   },
@@ -536,8 +586,8 @@
   },
   {
     "pname": "System.Diagnostics.EventLog",
-    "version": "10.0.7",
-    "hash": "sha256-fV+2RcEzBV/JUnPDOLce3VBQKqvo32zcTWMZeJcAAJg="
+    "version": "10.0.9",
+    "hash": "sha256-asuR1KqI8IdI83alSGSvPmcfNuPHK5WweZ2uAhuxe2U="
   },
   {
     "pname": "System.Diagnostics.EventLog",
@@ -561,8 +611,8 @@
   },
   {
     "pname": "System.Formats.Asn1",
-    "version": "10.0.7",
-    "hash": "sha256-s48DCef2td3qUMdsRRGFfzkZ/wl/kUaVseQBDDfWUzM="
+    "version": "10.0.11",
+    "hash": "sha256-AQ14gRr3Uyn/FsLbc1jUvIE9XzHaudYBiIy9HmOwuYc="
   },
   {
     "pname": "System.Globalization",
@@ -636,8 +686,13 @@
   },
   {
     "pname": "System.IO.Hashing",
-    "version": "10.0.1",
-    "hash": "sha256-k8EHcxnLitXo0CxoDZAxFmUlJJdKZVsZJ2+9zDMYB94="
+    "version": "10.0.3",
+    "hash": "sha256-IK2hZpaQysKYAoM0AbEVgTwla5hhqaop7360Tb2tZzk="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "10.0.3",
+    "hash": "sha256-+LsHlaUFMFVb60U7GFcvD1l7IpEcjdm1+Iw2g+qrUik="
   },
   {
     "pname": "System.IO.Pipelines",
@@ -661,8 +716,8 @@
   },
   {
     "pname": "System.Memory.Data",
-    "version": "8.0.1",
-    "hash": "sha256-cxYZL0Trr6RBplKmECv94ORuyjrOM6JB0D/EwmBSisg="
+    "version": "10.0.3",
+    "hash": "sha256-HefKyCuNJ7bONOVqGi2WScG6XIoFyfGSwTQM9Ol06+U="
   },
   {
     "pname": "System.Net.Http",
@@ -856,8 +911,8 @@
   },
   {
     "pname": "System.Security.Cryptography.Pkcs",
-    "version": "10.0.7",
-    "hash": "sha256-+3RdvoSme0k3FoutPdJLkbWPWsmqPVo80hMgpuH3FP0="
+    "version": "10.0.11",
+    "hash": "sha256-+L6ZL7/9VeyMlOJDcNjV/Rb7FMxXctLekfWROU0tMIM="
   },
   {
     "pname": "System.Security.Cryptography.Primitives",
@@ -866,8 +921,8 @@
   },
   {
     "pname": "System.Security.Cryptography.ProtectedData",
-    "version": "10.0.3",
-    "hash": "sha256-JF/WTKv00v/C4ml4g/VL3j4JMPpZa1HBmVMvUnphHr4="
+    "version": "10.0.11",
+    "hash": "sha256-YZi5wcj1Rfnt4SygMIWtdPNitbMwJeNEbtfpa0gPTtE="
   },
   {
     "pname": "System.Security.Cryptography.X509Certificates",
@@ -896,8 +951,8 @@
   },
   {
     "pname": "System.ServiceProcess.ServiceController",
-    "version": "10.0.7",
-    "hash": "sha256-koSlZI43JaCrG3ultJ6Sj7Ic9D9N878L+6HtRRGyJSA="
+    "version": "10.0.9",
+    "hash": "sha256-Z3M1YYCnY2dThtLcG7661EEXL3GgN3Ea5L2SXpnp32w="
   },
   {
     "pname": "System.Text.Encoding",
@@ -911,8 +966,8 @@
   },
   {
     "pname": "System.Text.Encoding.CodePages",
-    "version": "10.0.3",
-    "hash": "sha256-tDbCCtsmw1O8G9QvH2wyJtF7txxt6lpBy35w5rVZ800="
+    "version": "10.0.11",
+    "hash": "sha256-qkR7i03teRNMKtmSc0Ap4NnC3CMsuhfbCaDL/8c7U2E="
   },
   {
     "pname": "System.Text.Encoding.Extensions",
@@ -923,6 +978,16 @@
     "pname": "System.Text.Encoding.Extensions",
     "version": "4.3.0",
     "hash": "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
+    "version": "10.0.3",
+    "hash": "sha256-TuOSPfi9dfFnHvH5++zIi30JpRERp35HFpm2R0NWUAk="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "10.0.3",
+    "hash": "sha256-E1gPHMAuk2tR4cyScCfsSlDDerhlLAQCUZZMiByIk18="
   },
   {
     "pname": "System.Text.RegularExpressions",
@@ -941,8 +1006,8 @@
   },
   {
     "pname": "System.Threading.Channels",
-    "version": "10.0.3",
-    "hash": "sha256-JuimR9Phq1bx34EQzFxWINDyANQV8ZCP2zN2cBydGVI="
+    "version": "10.0.10",
+    "hash": "sha256-HCTjxLnKxalcdPZatq5/x1YZPcLExAR9cC8h4c2Ar3s="
   },
   {
     "pname": "System.Threading.Tasks",
@@ -973,6 +1038,11 @@
     "pname": "System.Threading.Timer",
     "version": "4.0.1-rc2-24027",
     "hash": "sha256-B3qiX7GvZ6wU9lyg4BEQhspVq0LGcF/W4H+4RwWJfBo="
+  },
+  {
+    "pname": "System.ValueTuple",
+    "version": "4.5.0",
+    "hash": "sha256-niH6l2fU52vAzuBlwdQMw0OEoRS/7E1w5smBFoqSaAI="
   },
   {
     "pname": "System.Xml.ReaderWriter",
@@ -1021,8 +1091,8 @@
   },
   {
     "pname": "xunit.runner.visualstudio",
-    "version": "2.8.2",
-    "hash": "sha256-UlfK348r8kJuraywfdCtpJJxHkv04wPNzpUaz4UM/60="
+    "version": "4.0.0",
+    "hash": "sha256-1CY2ZY7UEnMdeTFXW4dX4xHD1mB4VWuU1Rsa8ROHcQE="
   },
   {
     "pname": "YamlDotNet.Signed",

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -370,6 +370,7 @@ buildDotnetModule (finalAttrs: {
       aanderse
       zimbatm
       schmittlauch
+      osnyx
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -369,7 +369,6 @@ buildDotnetModule (finalAttrs: {
       kfollesdal
       aanderse
       zimbatm
-      schmittlauch
       osnyx
     ];
     platforms = [

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -33,13 +33,13 @@ assert builtins.all (
 
 buildDotnetModule (finalAttrs: {
   pname = "github-runner";
-  version = "2.336.0";
+  version = "2.337.0";
 
   src = fetchFromGitHub {
     owner = "actions";
     repo = "runner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QbenIEfOvISgXXlsalZa51y0m8ZG5uc/MpLnddpxXLo=";
+    hash = "sha256-aM8GmgCkjgaipEDBjC5v6U61WPjCAdKnPEGQypfTzmA=";
     leaveDotGit = true;
     postFetch = ''
       git -C $out rev-parse HEAD > $out/.git-revision


### PR DESCRIPTION
Changelog: https://github.com/actions/runner/releases/tag/v2.337.0

No breaking changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
