### PR TITLE
opencode: use production channel

### DIFF
--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -4,7 +4,7 @@
   bun,
   darwin,
   fetchFromGitHub,
-  makeBinaryWrapper,
+  makeWrapper,
   models-dev,
   nodejs,
   nix-update-script,
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     bun
     nodejs
     installShellFiles
-    makeBinaryWrapper
+    makeWrapper
     writableTmpDirAsHomeHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -136,7 +136,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.MODELS_DEV_API_JSON = "${models-dev}/dist/_api.json";
   env.OPENCODE_DISABLE_MODELS_FETCH = true;
   env.OPENCODE_VERSION = finalAttrs.version;
-  env.OPENCODE_CHANNEL = "stable";
+  env.OPENCODE_CHANNEL = "prod";
 
   buildPhase = ''
     runHook preBuild
@@ -166,7 +166,39 @@ stdenv.mkDerivation (finalAttrs: {
          ]
        )
      } \
-    --set OPENCODE_DISABLE_AUTOUPDATE true
+    --set OPENCODE_DISABLE_AUTOUPDATE true \
+    --run '
+      # NOTE: Once this workaround is removed we should switch back to using
+      # makeBinaryWrapper here.
+
+      # nixpkgs previously built OpenCode with OPENCODE_CHANNEL=stable. "stable"
+      # is no longer an upstream channel, so it caused OpenCode to store its database
+      # as opencode-stable.db. After switching to the upstream production channel,
+      # OpenCode would normally use opencode.db instead, making existing sessions
+      # appear to be lost. Keep using the legacy database until the user migrates
+      # it, unless they explicitly configured OPENCODE_DB or disabled this workaround.
+
+      data_home="''${XDG_DATA_HOME:-$HOME/.local/share}"
+      legacy="$data_home/opencode/opencode-stable.db"
+      canonical="$data_home/opencode/opencode.db"
+
+      if [ -z "''${OPENCODE_DB:-}" ] \
+        && [ -z "''${NIXPKGS_OPENCODE_DISABLE_LEGACY_DB_WORKAROUND:-}" ] \
+        && [ -e "$legacy" ] \
+        && [ ! -e "$canonical" ]; then
+        export OPENCODE_DB="opencode-stable.db"
+
+        # Only show migration guidance when stderr is attached to a terminal.
+        # Non-interactive uses such as `opencode web`, services, or scripts
+        # should continue starting normally with the legacy database selected.
+        if [ -t 2 ]; then
+          echo "Detected legacy nixpkgs OpenCode database at $legacy." >&2
+          echo "Continuing to use it for compatibility." >&2
+          echo "See https://github.com/NixOS/nixpkgs/pull/558549 for migration instructions." >&2
+          echo "Set NIXPKGS_OPENCODE_DISABLE_LEGACY_DB_WORKAROUND=1 to disable this workaround." >&2
+        fi
+      fi
+    '
 
     install -Dm644 ${models-dev.jsonschema} $out/share/model-schema.json
     install -Dm644 config.json $out/share/config.json


### PR DESCRIPTION
OpenCode only recognizes `dev`, `beta`, `prod`, and `latest` as channel
values. Unknown values fall back to `dev`, while `latest` maps to
`prod`. The selected channel controls channel-gated behavior, e.g.
workspaces, is exposed as a `dev` marker in `opencode web`, and affects
the database path.

Nixpkgs currently sets `OPENCODE_CHANNEL = "stable"`, so the package
unintentionally uses development-channel behavior. It also causes
OpenCode to use the nixpkgs-specific `opencode-stable.db` database path.

Change the channel to `prod`, which uses the upstream production
behavior and canonical `opencode.db` path.

To avoid making existing sessions appear lost after upgrading, switch
from `makeBinaryWrapper` to `makeWrapper` and add a temporary wrapper
workaround. When `opencode-stable.db` exists and `opencode.db` does not,
the wrapper continues using the legacy database and points the user at
migration instructions. Explicit `OPENCODE_DB` configuration takes
precedence, and the workaround can be disabled with
`NIXPKGS_OPENCODE_DISABLE_LEGACY_DB_WORKAROUND=1`.

The wrapper does not rename or modify the database.

Relevant upstream code:

- https://github.com/anomalyco/opencode/blob/v1.18.25/packages/app/vite.js#L8-L13
- https://github.com/anomalyco/opencode/blob/v1.18.25/packages/core/src/database/database.ts

## Migration instructions

> [!NOTE]
> The wrapper does not modify or rename the existing database. Until migration,
> it continues using `opencode-stable.db` when that file exists and the canonical
> `opencode.db` does not.

1. Stop all running OpenCode processes, including `opencode web` instances.
2. Back up the OpenCode data directory:

   * `${XDG_DATA_HOME:-$HOME/.local/share}/opencode`
3. Rename the legacy database:

   * `opencode-stable.db` → `opencode.db`
4. Start OpenCode again and verify the expected sessions are present.

OpenCode uses SQLite and may have `-wal` and `-shm` sidecar files while running,
which is why all OpenCode processes should be stopped before migrating.

If you explicitly set `OPENCODE_DB`, the nixpkgs workaround is not used.

The workaround can also be bypassed with:

```sh
NIXPKGS_OPENCODE_DISABLE_LEGACY_DB_WORKAROUND=1 opencode ...
```

This makes OpenCode use its normal upstream database selection without modifying
the legacy database.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].