### PR TITLE
open-design: init at 0.21.1

### DIFF
--- a/pkgs/by-name/op/open-design/package.nix
+++ b/pkgs/by-name/op/open-design/package.nix
@@ -10,6 +10,8 @@
   python3,
   pkg-config,
   nix-update-script,
+  cctools,
+  xcbuild,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "open-design";
@@ -74,6 +76,10 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     python3
     pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+    xcbuild
   ];
 
   env = {

--- a/pkgs/by-name/op/open-design/package.nix
+++ b/pkgs/by-name/op/open-design/package.nix
@@ -1,0 +1,230 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs_24,
+  pnpm_10,
+  pnpmConfigHook,
+  makeWrapper,
+  python3,
+  pkg-config,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "open-design";
+  version = "0.21.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "nexu-io";
+    repo = "open-design";
+    rev = "open-design-v${finalAttrs.version}";
+    hash = "sha256-0aG4hyv+HnTQBcs3SxAgPJerDv6KJNQaZm3W8xd4lx8=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    pnpmWorkspaces = [
+      "./packages/release"
+      "./packages/contracts"
+      "./packages/registry-protocol"
+      "./packages/agui-adapter"
+      "./packages/plugin-runtime"
+      "./packages/sidecar-proto"
+      "./packages/launcher-proto"
+      "./packages/sidecar"
+      "./packages/platform"
+      "./packages/diagnostics"
+      "./packages/components"
+      "./packages/host"
+      "./packages/download"
+      "./apps/daemon"
+      "./apps/web"
+    ];
+    hash = "sha256-yymPSQqi4Atq8CyOy2w5upo+kihyUVwfFkXnj/q7rSo=";
+  };
+
+  pnpmWorkspaces = [
+    "./packages/release"
+    "./packages/contracts"
+    "./packages/registry-protocol"
+    "./packages/agui-adapter"
+    "./packages/plugin-runtime"
+    "./packages/sidecar-proto"
+    "./packages/launcher-proto"
+    "./packages/sidecar"
+    "./packages/platform"
+    "./packages/diagnostics"
+    "./packages/components"
+    "./packages/host"
+    "./packages/download"
+    "./apps/daemon"
+    "./apps/web"
+  ];
+
+  nativeBuildInputs = [
+    nodejs_24
+    pnpm_10
+    pnpmConfigHook
+    makeWrapper
+    python3
+    pkg-config
+  ];
+
+  env = {
+    NODE_ENV = "production";
+    OD_DAEMON_URL = "";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    export npm_config_nodedir=${nodejs_24}
+    export npm_config_build_from_source=true
+    export PATH="${nodejs_24}/lib/node_modules/npm/bin/node-gyp-bin:$PATH"
+
+    bsq_dir=$(find node_modules/.pnpm -mindepth 2 -maxdepth 4 \
+      -type d -path '*/better-sqlite3@*/node_modules/better-sqlite3' \
+      -print -quit || true)
+    if [ -n "$bsq_dir" ]; then
+      echo "Building better-sqlite3 from source at $bsq_dir"
+      ( cd "$bsq_dir" && node-gyp rebuild --release --build-from-source )
+      if [ ! -f "$bsq_dir/build/Release/better_sqlite3.node" ]; then
+        echo "ERROR: better_sqlite3.node not produced" >&2
+        find "$bsq_dir" -name '*.node' -print >&2 || true
+        exit 1
+      fi
+    fi
+
+    for ws in \
+      packages/release \
+      packages/contracts \
+      packages/registry-protocol \
+      packages/agui-adapter \
+      packages/plugin-runtime \
+      packages/sidecar-proto \
+      packages/launcher-proto \
+      packages/sidecar \
+      packages/platform \
+      packages/diagnostics \
+      packages/components \
+      packages/host \
+      packages/download
+    do
+      if [ -f "$ws/package.json" ]; then
+        echo "Building $ws"
+        pnpm -C "$ws" run --if-present build
+      fi
+    done
+
+    echo "Building @open-design/daemon"
+    pnpm -C apps/daemon run build
+
+    echo "Building @open-design/web (static export)"
+    pnpm --filter @open-design/web run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/open-design $out/bin
+    cp -r . $out/lib/open-design/
+
+    for ws in \
+      packages/release \
+      packages/contracts \
+      packages/registry-protocol \
+      packages/agui-adapter \
+      packages/plugin-runtime \
+      packages/sidecar-proto \
+      packages/launcher-proto \
+      packages/sidecar \
+      packages/platform \
+      packages/diagnostics \
+      packages/components \
+      packages/host \
+      packages/download \
+      apps/daemon \
+      apps/web
+    do
+      if [ -d "$out/lib/open-design/$ws" ]; then
+        if [ "$ws" = "apps/web" ]; then
+          find "$out/lib/open-design/$ws" -mindepth 1 -maxdepth 1 \
+            ! -name out \
+            ! -name dist \
+            ! -name node_modules \
+            ! -name package.json \
+            ! -name next.config.ts \
+            -exec rm -rf {} +
+        elif [ "$ws" = "apps/daemon" ]; then
+          find "$out/lib/open-design/$ws" -mindepth 1 -maxdepth 1 \
+            ! -name dist \
+            ! -name bin \
+            ! -name node_modules \
+            ! -name package.json \
+            -exec rm -rf {} +
+        else
+          find "$out/lib/open-design/$ws" -mindepth 1 -maxdepth 1 \
+            ! -name dist \
+            ! -name node_modules \
+            ! -name package.json \
+            -exec rm -rf {} +
+        fi
+      fi
+    done
+
+    rm -f \
+      $out/lib/open-design/node_modules/@open-design/components \
+      $out/lib/open-design/node_modules/@open-design/tools-dev \
+      $out/lib/open-design/node_modules/@open-design/tools-pack \
+      $out/lib/open-design/node_modules/@open-design/tools-release \
+      $out/lib/open-design/node_modules/@open-design/tools-serve \
+      $out/lib/open-design/node_modules/.bin/tools-dev \
+      $out/lib/open-design/node_modules/.bin/tools-pack \
+      $out/lib/open-design/node_modules/.bin/tools-release \
+      $out/lib/open-design/node_modules/.bin/tools-serve \
+      2>/dev/null || true
+    rm -rf $out/lib/open-design/e2e 2>/dev/null || true
+    rm -rf $out/lib/open-design/tools 2>/dev/null || true
+    rm -rf $out/lib/open-design/shells 2>/dev/null || true
+
+    chmod +x $out/lib/open-design/apps/daemon/dist/cli.js
+    makeWrapper ${lib.getExe nodejs_24} $out/bin/od \
+      --add-flags $out/lib/open-design/apps/daemon/dist/cli.js \
+      --set NODE_ENV production \
+      --run 'if [ -z "$OD_DATA_DIR" ]; then export OD_DATA_DIR="$HOME/.od"; fi'
+    ln -s $out/bin/od $out/bin/open-design
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Local-first design product — daemon (`od` CLI) + Next.js frontend for agent-native design artifacts";
+    longDescription = ''
+      OpenDesign is an open-source Claude Design alternative: a local-first
+      app that detects installed coding-agent CLIs (Claude Code, Codex,
+      Cursor, etc.), runs functional skills and design-system contracts,
+      and streams artifacts (prototypes, decks, dashboards, images,
+      HyperFrames video) into a sandboxed preview. The `od` CLI starts
+      the local Express + SQLite daemon that powers the web UI and MCP
+      server. This package builds both the daemon and the static web
+      export (apps/web/out) so `od` can serve the UI without an external
+      reverse proxy.
+    '';
+    homepage = "https://github.com/nexu-io/open-design";
+    downloadPage = "https://github.com/nexu-io/open-design/releases";
+    changelog = "https://github.com/nexu-io/open-design/blob/main/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ReStranger ];
+    platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "od";
+  };
+})

--- a/pkgs/by-name/op/open-design/package.nix
+++ b/pkgs/by-name/op/open-design/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchPnpmDeps,
-  nodejs_24,
+  nodejs_22,
   pnpm_10,
   pnpmConfigHook,
   makeWrapper,
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    nodejs_24
+    nodejs_22
     pnpm_10
     pnpmConfigHook
     makeWrapper
@@ -90,9 +90,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    export npm_config_nodedir=${nodejs_24}
+    export npm_config_nodedir=${nodejs_22}
     export npm_config_build_from_source=true
-    export PATH="${nodejs_24}/lib/node_modules/npm/bin/node-gyp-bin:$PATH"
+    export PATH="${nodejs_22}/lib/node_modules/npm/bin/node-gyp-bin:$PATH"
 
     bsq_dir=$(find node_modules/.pnpm -mindepth 2 -maxdepth 4 \
       -type d -path '*/better-sqlite3@*/node_modules/better-sqlite3' \
@@ -201,7 +201,7 @@ stdenv.mkDerivation (finalAttrs: {
     rm -rf $out/lib/open-design/shells 2>/dev/null || true
 
     chmod +x $out/lib/open-design/apps/daemon/dist/cli.js
-    makeWrapper ${lib.getExe nodejs_24} $out/bin/od \
+    makeWrapper ${lib.getExe nodejs_22} $out/bin/od \
       --add-flags $out/lib/open-design/apps/daemon/dist/cli.js \
       --set NODE_ENV production \
       --run 'if [ -z "$OD_DATA_DIR" ]; then export OD_DATA_DIR="$HOME/.od"; fi'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description
Init `open-design` at `0.21.1` — https://github.com/nexu-io/open-design

OpenDesign is an open-source Claude Design alternative: local-first app that detects installed coding-agent CLIs (Claude Code, Codex, Cursor, etc.), runs functional skills + `DESIGN.md` design-system contracts and streams artifacts (prototypes, decks, dashboards, images, HyperFrames video) into a sandboxed preview. The `od` CLI starts the local Express+SQLite daemon that powers the web UI and MCP server (`od mcp`).

This adds `pkgs/by-name/op/open-design/package.nix`:
- `nodejs_24`, `pnpm_10` (10.34.x satisfies `packageManager pnpm@10.33.2`, `engines.pnpm >=10.33.2 <11`), `fetchPnpmDeps` `fetcherVersion=4`, `pnpmWorkspaces` with `./` prefix
- Native rebuild of `better-sqlite3@12.10.0` via `node-gyp` for Node 24 / ABI 137 (upstream has no prebuilds for Node 24) — `pnpm install --ignore-scripts` + `node-gyp rebuild --release --build-from-source` against `nodejs_24` headers
- Builds all workspace deps (`packages/*` via `tsc`), then `apps/daemon` and `apps/web` (`next build` → `apps/web/out`)
- Wrapper `makeWrapper nodejs_24 $out/bin/od --add-flags .../dist/cli.js --set NODE_ENV production --run 'if [ -z "$OD_DATA_DIR" ]; then export OD_DATA_DIR="$HOME/.od"; fi'` — fixes `ENOENT mkdir /nix/store/.../.od` (store is read-only, daemon previously defaulted to `<projectRoot>/.od`)
- Exposes `open-design` symlink, `meta.mainProgram = "od"`

Upstream tag `open-design-v0.21.1` (commit `fbd4d48ebe21b20f4a2faaad0ad5e53aaeb1dc4b`), `src hash sha256-0aG4hyv+HnTQBcs3SxAgPJerDv6KJNQaZm3W8xd4lx8=`, `pnpmDeps hash sha256-yymPSQqi4Atq8CyOy2w5upo+kihyUVwfFkXnj/q7rSo=`.

Changelog: https://github.com/nexu-io/open-design/blob/main/CHANGELOG.md
Homepage: https://github.com/nexu-io/open-design

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `nix build .#open-design` → `result/bin/od --help` OK
  - `OD_DATA_DIR=$(mktemp -d) od --port 17456 --no-open` + `curl /api/health` OK, `curl /api/plugins` → 460 bundled, `curl /api/projects` OK, `od plugin list --daemon-url ... --json` OK, `od automation list --json` OK
  - Verified `$HOME/.od` default (no `/nix/store/.../.od` ENOENT)
  - `ls result/lib/open-design/apps/web/out/index.html` and `result/lib/open-design/apps/daemon/dist/cli.js` present
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
