### PR TITLE
linkwarden: shrink runtime dependencies size

### DIFF
--- a/pkgs/by-name/li/linkwarden/package.nix
+++ b/pkgs/by-name/li/linkwarden/package.nix
@@ -154,6 +154,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     # Shrink closure a bit
+    # Remove postinstall for web, fails to clean out dev deps without this.
+    substituteInPlace apps/web/package.json \
+      --replace-fail 'playwright install --with-deps chromium' ""
+    yarn workspaces focus --production linkwarden @linkwarden/web @linkwarden/worker
     shopt -s extglob
     rm -rf node_modules/bcrypt node_modules/@next/swc-* node_modules/lightningcss* node_modules/react-native* node_modules/@react-native* \
       node_modules/expo* node_modules/@expo node_modules/.bin/!(next|tsx) node_modules/zeego/node_modules/.bin node_modules/@react-navigation/native* \
@@ -168,7 +172,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -r packages $out/share/linkwarden/
     cp -r node_modules $out/share/linkwarden/
     cp -r node_modules/.bin $out/share/linkwarden/node_modules/
-    rm -r $out/share/linkwarden/node_modules/@linkwarden/{mobile,react-native-render-html}
 
     echo "#!${lib.getExe bash} -e
     export DATABASE_URL=\''${DATABASE_URL-"postgresql://\$DATABASE_USER:\$POSTGRES_PASSWORD@\$DATABASE_HOST:\$DATABASE_PORT/\$DATABASE_NAME"}


### PR DESCRIPTION
output size goes from 1.3GB to 955MB with no downsides. Would like to remove other dependencies since this still feels very large(1.7GB total closure size including this package), but whatever. Pretty quick and easy size savings.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
