### PR TITLE
pi-coding-agent: build with bun

### DIFF
--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -69,7 +69,14 @@ buildNpmPackage (finalAttrs: {
     npm run build --workspace=packages/coding-agent
 
     pushd packages/coding-agent
-    bun build --compile --no-compile-autoload-bunfig --target=bun-linux-x64-baseline \
+    bun build --compile --no-compile-autoload-bunfig --target=${
+      if stdenvNoCC.hostPlatform.isDarwin then
+        if stdenvNoCC.hostPlatform.isAarch64 then "bun-darwin-arm64" else "bun-darwin-x64"
+      else if stdenvNoCC.hostPlatform.isAarch64 then
+        "bun-linux-arm64"
+      else
+        "bun-linux-x64-baseline"
+    } \
       ./dist/bun/cli.js ./src/utils/image-resize-worker.ts \
       --outfile $TMPDIR/pi
     popd

--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -10,6 +10,7 @@
   fd,
   makeBinaryWrapper,
   stdenvNoCC,
+  bun,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "pi-coding-agent";
@@ -49,6 +50,7 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
+    bun
   ];
 
   # Build workspace dependencies in order, then the coding-agent.
@@ -65,6 +67,12 @@ buildNpmPackage (finalAttrs: {
     npx tsgo -p packages/protocol/tsconfig.build.json
     npx tsgo -p packages/client/tsconfig.build.json
     npm run build --workspace=packages/coding-agent
+
+    pushd packages/coding-agent
+    bun build --compile --no-compile-autoload-bunfig --target=bun-linux-x64-baseline \
+      ./dist/bun/cli.js ./src/utils/image-resize-worker.ts \
+      --outfile $TMPDIR/pi
+    popd
 
     runHook postBuild
   '';
@@ -98,6 +106,16 @@ buildNpmPackage (finalAttrs: {
 
     # Clean up now-dangling .bin symlinks
     find "$nm/.bin" -xtype l -delete
+
+    # bun binary replaces node wrapper — bun-only
+    install -Dm755 $TMPDIR/pi $out/bin/pi
+
+    # bun binary needs package.json next to PI_PACKAGE_DIR for VERSION
+    mkdir -p $out/share/pi
+    cp packages/coding-agent/package.json $out/share/pi/package.json
+    cp -r packages/coding-agent/dist/modes/interactive/theme $out/share/pi/theme 2>/dev/null || true
+    cp -r packages/coding-agent/dist/modes/interactive/assets $out/share/pi/assets 2>/dev/null || true
+    cp -r packages/coding-agent/dist/core/export-html $out/share/pi/export-html 2>/dev/null || true
   ''
   + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
     # Remove foreign Linux binaries that make audit-tmpdir try to inspect ELF
@@ -114,6 +132,7 @@ buildNpmPackage (finalAttrs: {
         fd
       ]
     } \
+      --set PI_PACKAGE_DIR $out/share/pi \
       --set-default PI_SKIP_VERSION_CHECK 1 \
       --set-default PI_TELEMETRY 0
   '';

--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -121,9 +121,9 @@ buildNpmPackage (finalAttrs: {
     # bun binary needs package.json next to PI_PACKAGE_DIR for VERSION
     mkdir -p $out/share/pi
     cp packages/coding-agent/package.json $out/share/pi/package.json
-    cp -r packages/coding-agent/dist/modes/interactive/theme $out/share/pi/theme 2>/dev/null || true
-    cp -r packages/coding-agent/dist/modes/interactive/assets $out/share/pi/assets 2>/dev/null || true
-    cp -r packages/coding-agent/dist/core/export-html $out/share/pi/export-html 2>/dev/null || true
+    cp -r packages/coding-agent/dist/modes/interactive/theme $out/share/pi/theme
+    cp -r packages/coding-agent/dist/modes/interactive/assets $out/share/pi/assets
+    cp -r packages/coding-agent/dist/core/export-html $out/share/pi/export-html
   ''
   + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
     # Remove foreign Linux binaries that make audit-tmpdir try to inspect ELF

--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -70,12 +70,13 @@ buildNpmPackage (finalAttrs: {
 
     pushd packages/coding-agent
     bun build --compile --no-compile-autoload-bunfig --target=${
-      if stdenvNoCC.hostPlatform.isDarwin then
-        if stdenvNoCC.hostPlatform.isAarch64 then "bun-darwin-arm64" else "bun-darwin-x64"
-      else if stdenvNoCC.hostPlatform.isAarch64 then
-        "bun-linux-arm64"
-      else
-        "bun-linux-x64-baseline"
+      {
+        aarch64-darwin = "bun-darwin-arm64";
+        aarch64-linux = "bun-linux-arm64";
+        x86_64-linux = "bun-linux-x64-baseline";
+      }
+      .${stdenvNoCC.hostPlatform.system}
+        or (throw "Unsupported system for pi-coding-agent bun target: ${stdenvNoCC.hostPlatform.system}")
     } \
       ./dist/bun/cli.js ./src/utils/image-resize-worker.ts \
       --outfile $TMPDIR/pi


### PR DESCRIPTION
   <!--
   Please summarise the changes you have done and explain why they are necessary here
   -->

   ### pi-coding-agent: build with bun

   Switch `pi-coding-agent` from Node wrapper to upstream's `bun` compiled binary (`build:binary`).

   **Changes:**
   - Add `bun` to `nativeBuildInputs`
   - `buildPhase`: after `npm run build --workspace=packages/coding-agent` 
```bash
bun build --compile --no-compile-autoload-bunfig --target=bun-linux-x64-baseline \
./dist/bun/cli.js ./src/utils/image-resize-worker.ts --outfile $TMPDIR/pi
 ```

   identical to upstream packages/coding-agent/package.json#build:binary (src/bun/cli.ts → dist/bun/cli.js after
 tsgo), keeps existing tsgo/npmDepsHash/modelData logic intact
 - postInstall: install -Dm755 $TMPDIR/pi $out/bin/pi (replaces Node wrapper), copy package.json +
   theme/assets/export-html to $out/share/pi for PI_PACKAGE_DIR (required for VERSION and interactive mode)
 - postFixup: wrapProgram $out/bin/pi --set PI_PACKAGE_DIR $out/share/pi (keeps ripgrep/fd in PATH,
   PI_SKIP_VERSION_CHECK/PI_TELEMETRY)
 - meta.description: ... (bun compiled)

 Why:
 Upstream ships a standalone bun --compile binary as the primary distribution. The previous Node wrapper required a
 Node runtime in closure and diverged from dist/bun/cli.ts / restore-sandbox-env / registerBunOAuthFlows path. Bun
 binary is faster cold start, single file, and matches how upstream tests/releases pi. No hash changes,
 npmDepsHash/modelData untouched.

 For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover
 breaking updates.
 - Changelog: https://github.com/earendil-works/pi/blob/v0.84.4/packages/coding-agent/CHANGELOG.md
 - No breaking config changes, drop-in replacement for bin/pi.

 Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
 - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
 - [x] Tested basic functionality of all binary files, usually in ./result/bin/ 
 ```
 pi --version via versionCheckHook
 ```
(doInstallCheck = true + writableTmpDirAsHomeHook), PI_PACKAGE_DIR set correctly.

 - Nixpkgs Release Notes
     - [ ] Package update: when the change is major or breaking.
 - NixOS Release Notes
     - [ ] Module addition: when adding a new NixOS module.
     - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
AI disclosure: PR description was partially drafted with pi-coding-agent (gpt-5.4), reviewed and edited by me before posting.
