### PR TITLE
python3Packages.crewai-{core,cli}: 1.15.17 -> 1.15.18

### DIFF
--- a/pkgs/development/python-modules/crewai-cli/default.nix
+++ b/pkgs/development/python-modules/crewai-cli/default.nix
@@ -41,7 +41,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "crewai-cli";
-  version = "1.15.17";
+  version = "1.15.18";
   pyproject = true;
   __structuredAttrs = true;
 

--- a/pkgs/development/python-modules/crewai-core/default.nix
+++ b/pkgs/development/python-modules/crewai-core/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "crewai-core";
-  version = "1.15.17";
+  version = "1.15.18";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -34,7 +34,7 @@ buildPythonPackage (finalAttrs: {
     owner = "crewAIInc";
     repo = "crewAI";
     tag = finalAttrs.version;
-    hash = "sha256-CkOX1Qq8ZDjUadKmEUt6gQsG//Z1GHw9moKzPRLAr/A=";
+    hash = "sha256-A1nhvn4jdfjTiLfYldXsIUV7lGGqa1FDiSh0KfB5Ssk=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/lib/crewai-core";

--- a/pkgs/development/python-modules/crewai/default.nix
+++ b/pkgs/development/python-modules/crewai/default.nix
@@ -59,7 +59,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "crewai";
-  version = "1.15.17";
+  version = "1.15.18";
   pyproject = true;
   __structuredAttrs = true;
 


### PR DESCRIPTION
Diff : https://github.com/crewAIInc/crewAI/compare/1.15.17...1.15.18
Changelog : https://github.com/crewAIInc/crewAI/releases/tag/1.15.18

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
