### PR TITLE
plex-tui: init at 0.17.29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27096,6 +27096,11 @@
     githubId = 1437166;
     name = "Xia Bin";
   };
+  so1omon563 = {
+    github = "so1omon563";
+    githubId = 43015107;
+    name = "Jedidiah Foster";
+  };
   sochotnicky = {
     email = "stanislav+github@ochotnicky.com";
     github = "sochotnicky";

--- a/pkgs/by-name/pl/plex-tui/package.nix
+++ b/pkgs/by-name/pl/plex-tui/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  mpv,
+  python3Packages,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "plex-tui";
+  version = "0.17.29";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "so1omon563";
+    repo = "plex-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J0DqZ0SoPep2MUkm/JnKkxjdteZwZJXWnvGMYeNYh/E=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  build-system = [ python3Packages.hatchling ];
+
+  dependencies = with python3Packages; [
+    pillow
+    platformdirs
+    plexapi
+    textual
+  ];
+
+  nativeCheckInputs = [ versionCheckHook ];
+
+  pythonImportsCheck = [ "plextui" ];
+
+  postFixup = ''
+    wrapProgram $out/bin/plex-tui \
+      --prefix PATH : ${lib.makeBinPath [ mpv ]}
+  '';
+
+  meta = {
+    description = "Terminal UI for browsing and playing media from Plex";
+    homepage = "https://github.com/so1omon563/plex-tui";
+    changelog = "https://github.com/so1omon563/plex-tui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ so1omon563 ];
+    mainProgram = "plex-tui";
+  };
+})


### PR DESCRIPTION
Adds [plex-tui](https://github.com/so1omon563/plex-tui), a terminal UI for browsing Plex and launching playback through mpv.

The package uses nixpkgs' Python dependencies, wraps mpv onto the runtime path, and checks both the Python import and executable version.

AI disclosure: OpenAI Codex (GPT-5) assisted with the package expression and this pull request text. I reviewed the change, understand it, and accept responsibility for the contribution. The commit includes the required `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Validation:

- `nix-build -A plex-tui --no-out-link`
- `nixfmt --check pkgs/by-name/pl/plex-tui/package.nix maintainers/maintainer-list.nix`
- `./ci/nixpkgs-vet.sh master /src`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
