### PR TITLE
nixos/syncoid: catch up missed timer runs (Persistent=true)

### DIFF
--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -362,7 +362,6 @@ in
           {
             description = "Syncoid ZFS synchronization from ${c.source} to ${c.target}";
             after = [ "zfs.target" ];
-            startAt = cfg.interval;
             # syncoid may need zpool to get feature@extensible_dataset
             path = [ "/run/booted-system/sw/bin/" ];
             serviceConfig = {
@@ -472,6 +471,23 @@ in
           c.service
         ]
       )
+    ) cfg.commands;
+
+    systemd.timers = lib.concatMapAttrs (
+      name: c:
+      lib.optionalAttrs
+        (config.systemd.services."syncoid-${escapeUnitName name}".enable && cfg.interval != [ ])
+        {
+          "syncoid-${escapeUnitName name}" = {
+            wantedBy = [ "timers.target" ];
+            timerConfig = {
+              OnCalendar = cfg.interval;
+              # Backup timers should catch up on missed windows (e.g. the
+              # machine was powered off), like restic and btrbk do.
+              Persistent = true;
+            };
+          };
+        }
     ) cfg.commands;
   };
 


### PR DESCRIPTION
Using startAt for the syncoid timer defaults Persistent=false, The PR explicitly sets it to true so that Syncoid runs on a machine that is off once the machine is back on.

If changing the default behavior is an issue (I can't come up with any concrete reason why) then we could at least allow a way to override it as part of the configuration.

## Things done

- Explicitly created timer with Persistent=true

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests) (`nixosTests.sanoid`).
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

---

*Disclosure per the automation/AI policy: this change and PR description
were prepared with the assistance of Claude Code (claude-fable-5),
reviewed and submitted by a human.*
