### PR TITLE
python3Packages.control: fix build with matplotlib 3.11 and numpy 2.5

### DIFF
--- a/pkgs/development/python-modules/control/default.nix
+++ b/pkgs/development/python-modules/control/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   cvxopt,
   fetchFromGitHub,
+  fetchpatch,
   matplotlib,
   numpy,
   numpydoc,
@@ -24,6 +25,19 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-E9RZDUK01hzjutq83XdLr3d97NwjmQzt65hqVg2TBGE=";
   };
+
+  patches = [
+    # matplotlib >= 3.11 no longer warns when tight layout is not applied
+    (fetchpatch {
+      url = "https://github.com/python-control/python-control/commit/3b70cb41b5d41ed4aa4da9f2db2eb3d83c3ffdcd.patch";
+      hash = "sha256-zJAbgbeiYQlglG/mbtREvs7AFxwGxzlzrr0iuKPHp5I=";
+    })
+    # numpy >= 2.5 deprecates assigning to .shape
+    (fetchpatch {
+      url = "https://github.com/python-control/python-control/commit/ae4915c4ece5f417fa514dadeb0d30ab412a28aa.patch";
+      hash = "sha256-Z5U9sgtlp35bHYOYC2ag9007fGVXwzhTgBQN7yLsjCI=";
+    })
+  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
Broken on `master` because of assertions in tests. I didn't want to suppress whole tests, especially since both have already been fixed upstream.

New releases are not very frequent on this project, so I'm making the minimal patches instead of going to unstable on `master`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
