### PR TITLE
jetbrains-jdk: 25.0.3b508.4 -> 25.0.4.1b583.48

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -28,8 +28,8 @@ let
   # cd jetbrainsruntime
   # git tag --points-at [revision]
   # Look for the line that starts with jbr-
-  javaVersion = "25.0.3";
-  build = "508.4";
+  javaVersion = "25.0.4.1";
+  build = "583.48";
 in
 callPackage ./common.nix
   {
@@ -38,8 +38,8 @@ callPackage ./common.nix
   {
     inherit javaVersion build;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    sourceDateEpoch = 1780959777;
-    srcHash = "sha256-N+7D++Cxu0RGWChEWW8gtNz7E2I8qM2AFbXv4luAXto=";
+    sourceDateEpoch = 1786554980;
+    srcHash = "sha256-kVL0saXyA+CpKG/1MDUWVQEKsJjAzSHMbQXucFWqG1c=";
     jcefPackage = jetbrains.jcef;
     extraBuildPhase = ''
       cp -r ${gtk-protocols.out} gtk-shell.xml

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -2,7 +2,6 @@
   autoPatchelfHook,
   fetchFromGitHub,
   fetchurl,
-  fetchpatch,
   stdenv,
   cmake,
   python3,
@@ -53,50 +52,41 @@ let
   inherit (arches) depsArch projectArch targetArch;
 
   # `cef_binary_${CEF_VERSION}_linux64_minimal`, where CEF_VERSION is from $src/CMakeLists.txt
-  cef-name = "cef_binary_144.0.15+g72717cf+chromium-144.0.7559.172_${platform}_minimal";
+  cef-name = "cef_binary_150.0.14+g7c1aa68+chromium-150.0.7871.129_${platform}_minimal";
 
   cef-bin = cef-binary.override {
-    version = "144.0.15";
-    gitRevision = "72717cf";
-    chromiumVersion = "144.0.7559.172";
+    version = "150.0.14";
+    gitRevision = "7c1aa68";
+    chromiumVersion = "150.0.7871.129";
     srcHashes = {
-      aarch64-linux = "sha256-2w2TDj7LGjYeUjpVvojAsHb8HlqG82AwH8Arg0NxREg=";
-      x86_64-linux = "sha256-JDlZmIEg9ajjuFOL8qAr6HDVbeu3/Cg21Z57fHryfdc=";
+      aarch64-linux = "sha256-tA4hWg9G/UDQSxXUuDO+IRjvc8Qx1cEdGOtiXg3ktk0=";
+      x86_64-linux = "sha256-QO9hPkVcrNB6p8gfQl76qLb3frg/E8wo1HDuuk5h+Y8=";
     };
   };
 
-  thrift20 = thrift.overrideAttrs (old: {
-    version = "0.20.0";
+  thrift23 = thrift.overrideAttrs (old: {
+    version = "0.23.0";
 
     src = fetchFromGitHub {
       owner = "apache";
       repo = "thrift";
-      tag = "v0.20.0";
-      hash = "sha256-cwFTcaNHq8/JJcQxWSelwAGOLvZHoMmjGV3HBumgcWo=";
+      tag = "v0.23.0";
+      hash = "sha256-7N9jLDwvw6xh8uUY13Mmw6KEaNLYVowudrYSL2yJj2Q=";
     };
 
     cmakeFlags = (old.cmakeFlags or [ ]) ++ [
       "-DCMAKE_POLICY_VERSION_MINIMUM=3.10"
-    ];
-    patches = (old.patches or [ ]) ++ [
-      # Fix build with gcc15
-      # https://github.com/apache/thrift/pull/3078
-      (fetchpatch {
-        name = "thrift-add-missing-cstdint-include-gcc15.patch";
-        url = "https://github.com/apache/thrift/commit/947ad66940cfbadd9b24ba31d892dfc1142dd330.patch";
-        hash = "sha256-pWcG6/BepUwc/K6cBs+6d74AWIhZ2/wXvCunb/KyB0s=";
-      })
     ];
   });
 
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "fa677024a129747bd8cb05447af8918c494e4af7";
+  rev = "5a9c64ca090f24d1d037de7b3edca2ee5607c995";
   # This is the commit number
-  # Currently from the branch: https://github.com/JetBrains/jcef/tree/261
+  # Currently from the branch: https://github.com/JetBrains/jcef/tree/263
   # Run `git rev-list --count HEAD`
-  version = "1207";
+  version = "1231";
 
   nativeBuildInputs = [
     cmake
@@ -119,14 +109,14 @@ stdenv.mkDerivation rec {
     libxdamage
     nss
     nspr
-    thrift20
+    thrift23
   ];
 
   src = fetchFromGitHub {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-eYn1T4cRrHeVDSye6FKBv8X3zZPDGFurk6HJG+jPypY=";
+    hash = "sha256-Q4LQnzbUiAGyWgsfCuMayj76FzC4bN0l1O90vP96IGM=";
   };
 
   # Find the hash in tools/buildtools/linux64/clang-format.sha1
@@ -159,7 +149,7 @@ stdenv.mkDerivation rec {
       -e 's|vcpkg_install_package(boost-filesystem boost-interprocess thrift)||' \
       -i CMakeLists.txt
 
-    sed -e 's|vcpkg_bring_host_thrift()|set(THRIFT_COMPILER_HOST ${lib.getExe thrift20})|' -i remote/CMakeLists.txt
+    sed -e 's|vcpkg_bring_host_thrift()|set(THRIFT_COMPILER_HOST ${lib.getExe thrift23})|' -i remote/CMakeLists.txt
 
     mkdir jcef_build
     cd jcef_build
@@ -175,12 +165,6 @@ stdenv.mkDerivation rec {
 
   postBuild = ''
     export JCEF_ROOT_DIR=$(realpath ..)
-
-    # Apply https://github.com/JetBrains/jcef/pull/42
-    substituteInPlace ../build.xml \
-      --replace-fail \
-        '<matches pattern="17*.*" string="''${java.version}"/>' \
-        '<javaversion atLeast="17"/>'
 
     ../tools/compile.sh ${platform} Release
   '';


### PR DESCRIPTION
Update jetbrains.jcef from 1207 to 1231 (CEF 144.0.15 to 150.0.14) and use upstream’s Thrift 0.23 pin.

Release notes:
https://github.com/JetBrains/JetBrainsRuntime/releases/tag/jbr-release-25.0.4.1b583.48

JCEF comparison:
https://github.com/JetBrains/jcef/compare/fa677024a129747bd8cb05447af8918c494e4af7...5a9c64ca090f24d1d037de7b3edca2ee5607c995


<img width="616" height="495" alt="image" src="https://github.com/user-attachments/assets/0c908a40-34cd-4954-83f7-50878e34a90a" />

@theCapypara @jamesward

jetbrains idea has switched to vanilla JBR. And we should switch to `jetbrains.jdk-no-jcef` to match upstream (https://github.com/NixOS/nixpkgs/blob/53c17c0c5051b6b5027a857a33e27f6fc75aa925/pkgs/applications/editors/jetbrains/default.nix#L25).  We may also rename `jdk-no-jcef` to `jdk` at some point. 

Assisted-by: Codex (GPT-5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
