### PR TITLE
linecast: 2.1.0 -> 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2600,6 +2600,11 @@
     name = "Mariia Holovata";
     keys = [ { fingerprint = "409D 201E 9450 8732 A49E  D0FC 6BDA F874 0068 08DF"; } ];
   };
+  ashuttl = {
+    github = "ashuttl";
+    githubId = 2095936;
+    name = "Andrew Shuttleworth Fowler";
+  };
   asiantuntija = {
     github = "asiantuntija";
     githubId = 8327991;

--- a/pkgs/by-name/li/linecast/package.nix
+++ b/pkgs/by-name/li/linecast/package.nix
@@ -8,7 +8,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "linecast";
-  version = "2.1.0";
+  version = "2.2.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -16,7 +16,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "ashuttl";
     repo = "linecast";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9y84PWXiwRh+yXN5rkM3K4269+qNer94oQ1SPpBbI4c=";
+    hash = "sha256-NjuA/WNUi+4NcPiFr3R0Nl163IHQwaMHfK71QTSAYsk=";
   };
 
   build-system = [
@@ -67,6 +67,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
         version = finalAttrs.version;
       };
     };
-    maintainers = with lib.maintainers; [ KristijanZic ];
+    maintainers = with lib.maintainers; [
+      KristijanZic
+      ashuttl
+    ];
   };
 })


### PR DESCRIPTION
Updates linecast to 2.2.0 ([changelog](https://github.com/ashuttl/linecast/blob/v2.2.0/CHANGELOG.md)) and adds me — the upstream author — as a co-maintainer.

cc @KristijanZic, who kindly packaged this — thank you!

Disclosure per the automation/AI policy: this change was prepared with Claude Code (Claude Fable 5); commits carry `Assisted-by:` trailers. I reviewed the diff and the build and test output before submitting.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable: (no package or NixOS tests exist)
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).