### PR TITLE
haskell.packages.ghc914.Cabal_3_14_2_0: jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -96,6 +96,25 @@ with haskellLib;
   primitive = doJailbreak (dontCheck super.primitive); # base <4.22 and a lot of dependencies on packages not yet working.
   splitmix = doJailbreak super.splitmix; # base <4.22
 
+  Cabal_3_14_2_0 =
+    overrideCabal
+      (drv: {
+        # avoid the GHC profiling compiler panic: GHC.StgToCmm.Env: variable not found
+        enableLibraryProfiling = false;
+        # https://github.com/haskell/cabal/pull/10814
+        # https://github.com/haskell/cabal/pull/11127
+        postPatch = (drv.postPatch or "") + ''
+          substituteInPlace Cabal.cabal \
+            --replace-fail "containers >= 0.5.8.0  && < 0.8" "containers >= 0.5.8.0  && < 0.9" \
+            --replace-fail "time       >= 1.4.0.1  && < 1.15" "time       >= 1.4.0.1  && < 1.16"
+        '';
+      })
+      (
+        super.Cabal_3_14_2_0.override {
+          # containers <0.8 and time <1.15
+          Cabal-syntax = doJailbreak super.Cabal-syntax_3_14_2_0;
+        }
+      );
   # https://github.com/phadej/boring/issues/48
   boring = doJailbreak super.boring;
   # https://github.com/haskellari/indexed-traversable/issues/49


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Needs three fixes:
1. GHC 9.14.1 panics when compiling Cabal with library profiling enabled. I found https://gitlab.haskell.org/ghc/ghc/-/work_items/26045, which seems related.
2. Cabal has outdated `containers` and `time` bounds.
3. Cabal-syntax needs a jailbreak for the same outdated bounds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
