### PR TITLE
buildMozillaMach, firefox: apply RFC169 terminology

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -146,6 +146,16 @@
 
 - `pnpm_10` was upgraded to version 10.34.1+, which introduced stricter integrity checks. If you encounter `ERR_PNPM_MISSING_TARBALL_INTEGRITY`, you can fall back to the older `pnpm_10_34_0`.
 
+- `buildMozillaMach` is now using `enable<feature>` and `with<dependency>`
+  terminology from RFC 169 and the `wrapFirefox` and `wrapThunderbird` functions
+  check for these new attribute names on the passed package.
+  The `privacySupport` function argument has been replaced by multiple
+  granular options corresponding to individual features: `enableDataReporting`,
+  `enableLocation`, `enableWebRTC`.
+  The `requireSigning` and `allowAddonSideload` function arguments moved from
+  the outer to the inner function and were renamed to `enableAddonSigning` and
+  `enableAddonSideload`, respectively.
+
 - `fetchPnpmDeps`' `fetcherVersion = 1` and `fetcherVersion = 2` have been
   removed, as announced in the 26.05 release. Packages still using them now
   throw an evaluation error and must migrate to `fetcherVersion = 3` (or later)

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -130,8 +130,8 @@ stdenv.mkDerivation {
   passthru = {
     inherit applicationName binaryName;
     libName = "firefox-bin-${version}";
-    ffmpegSupport = true;
-    gssSupport = true;
+    withFFmpeg = true;
+    withGSSAPI = true;
     gtk3 = gtk3;
 
     # update with:

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
@@ -7,12 +7,11 @@
   buildMozillaMach,
 }:
 
-buildMozillaMach rec {
+(buildMozillaMach rec {
   pname = "firefox-devedition";
   binaryName = "firefox-devedition";
   version = "155.0b5";
   applicationName = "Firefox Developer Edition";
-  requireSigning = false;
   branding = "browser/branding/aurora";
   src = fetchurl {
     url = "mirror://mozilla/devedition/releases/${version}/source/firefox-${version}.source.tar.xz";
@@ -52,4 +51,7 @@ buildMozillaMach rec {
     versionSuffix = "b[0-9]*";
     baseUrl = "https://archive.mozilla.org/pub/devedition/releases/";
   };
-}
+}).override
+  {
+    enableAddonSigning = false;
+  }

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -69,7 +69,7 @@ let
       wmClass ? applicationName,
       nativeMessagingHosts ? [ ],
       pkcs11Modules ? [ ],
-      useGlvnd ? (!isDarwin),
+      withGlvnd ? (!isDarwin),
       cfg ? config.${applicationName} or { },
 
       ## Following options are needed for extra prefs & policies
@@ -88,20 +88,20 @@ let
     }:
 
     let
-      ffmpegSupport = browser.ffmpegSupport or false;
+      withFFmpeg = browser.withFFmpeg or false;
       # Firefox dlopens libavcodec by hardcoded soname, so each ffmpeg major needs
       # explicit browser support; keep versioned pins here (never the ffmpeg alias)
       # and add a tier when a release gains the next ABI.
       # libavcodec 62: 146 (bug 1962139), uplifted to ESR 140.10.2 (bug 2036244).
       # libavcodec 63: 154 (bug 2057577), uplifted to ESR 153.1 (bug 2057577).
       ffmpegPackage = if lib.versionAtLeast browser.version "153.1" then ffmpeg_9 else ffmpeg_8;
-      gssSupport = browser.gssSupport or false;
-      alsaSupport = browser.alsaSupport or false;
-      pipewireSupport = browser.pipewireSupport or false;
-      sndioSupport = browser.sndioSupport or false;
-      jackSupport = browser.jackSupport or false;
+      withGSSAPI = browser.withGSSAPI or false;
+      withALSA = browser.withALSA or false;
+      withPipewire = browser.withPipewire or false;
+      withSndio = browser.withSndio or false;
+      withJACK = browser.withJACK or false;
       # PCSC-Lite daemon (services.pcscd) also must be enabled for firefox to access smartcards
-      smartcardSupport = cfg.smartcardSupport or false;
+      withPCSC = cfg.smartcardSupport or false;
 
       allNativeMessagingHosts = map lib.getBin (lib.unique nativeMessagingHosts);
 
@@ -119,10 +119,10 @@ let
           ]
           ++ lib.optional (cfg.speechSynthesisSupport or true) speechd-minimal
         )
-        ++ lib.optional pipewireSupport pipewire
-        ++ lib.optional ffmpegSupport ffmpegPackage
-        ++ lib.optional gssSupport libkrb5
-        ++ lib.optional useGlvnd libglvnd
+        ++ lib.optional withPipewire pipewire
+        ++ lib.optional withFFmpeg ffmpegPackage
+        ++ lib.optional withGSSAPI libkrb5
+        ++ lib.optional withGlvnd libglvnd
         ++ lib.optionals (cfg.enableQuakeLive or false) [
           stdenv.cc
           libx11
@@ -134,10 +134,10 @@ let
           zlib
         ]
         ++ lib.optional (config.pulseaudio or (!isDarwin)) libpulseaudio
-        ++ lib.optional alsaSupport alsa-lib
-        ++ lib.optional sndioSupport sndio
-        ++ lib.optional jackSupport libjack2
-        ++ lib.optional smartcardSupport opensc
+        ++ lib.optional withALSA alsa-lib
+        ++ lib.optional withSndio sndio
+        ++ lib.optional withJACK libjack2
+        ++ lib.optional withPCSC opensc
         ++ pkcs11Modules
         ++ lib.optionals (!isDarwin) gtk_modules;
       gtk_modules = lib.optionals (!isDarwin) [ libcanberra-gtk3 ];
@@ -161,7 +161,7 @@ let
       extensions =
         if nameArray != (lib.unique nameArray) then
           throw "Firefox addon name needs to be unique"
-        else if browser.requireSigning || !browser.allowAddonSideload then
+        else if browser.enableAddonSigning || !browser.enableAddonSideload then
           throw "Nix addons are only supported with signature enforcement disabled and addon sideloading enabled (eg. LibreWolf)"
         else
           map (
@@ -195,7 +195,7 @@ let
               Install = lib.foldr (e: ret: ret ++ [ "${e.outPath}/${e.extid}.xpi" ]) [ ] extensions;
             };
           }
-          // lib.optionalAttrs smartcardSupport {
+          // lib.optionalAttrs withPCSC {
             SecurityDevices = {
               "OpenSC PKCS#11 Module" = "opensc-pkcs11.so";
             };

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -106,7 +106,7 @@ let
       gtk3
       ;
     binaryName = "thunderbird";
-    gssSupport = true;
+    withGSSAPI = true;
   };
 
 in

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -69,14 +69,14 @@ let
     }).override
       (
         {
-          geolocationSupport = false;
-          webrtcSupport = false;
+          enableLocation = false;
+          enableWebRTC = false;
 
-          pgoSupport = false; # console.warn: feeds: "downloadFeed: network connection unavailable"
+          enablePGO = false; # console.warn: feeds: "downloadFeed: network connection unavailable"
         }
         // lib.optionalAttrs (lib.versionAtLeast version "149") {
           # https://bugzilla.mozilla.org/show_bug.cgi?id=2025767
-          crashreporterSupport = false;
+          enableCrashReporter = false;
         }
       );
 

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -8,8 +8,6 @@
   application ? "browser",
   applicationName ? "Firefox",
   branding ? null,
-  requireSigning ? true,
-  allowAddonSideload ? false,
   src,
   unpackPhase ? null,
   extraPatches ? [ ],
@@ -24,12 +22,8 @@
 }:
 
 let
-  # Rename the variables to prevent infinite recursion
-  requireSigningDefault = requireSigning;
-  allowAddonSideloadDefault = allowAddonSideload;
-
   # Specifying --(dis|en)able-elf-hack on a platform for which it's not implemented will give `--disable-elf-hack is not available in this configuration`
-  # This is declared here because it's used in the default value of elfhackSupport
+  # This is declared here because it's used in the default value of enableElfhack
   isElfhackPlatform =
     stdenv:
     stdenv.hostPlatform.isElf
@@ -50,11 +44,13 @@ in
 
   # build time
   autoconf,
+  buildPackages,
   cargo,
   dump_syms,
   makeBinaryWrapper,
   mimalloc,
   nodejs,
+  overrideCC,
   perl,
   pkg-config,
   pkgsCross, # wasm32 rlbox
@@ -115,80 +111,73 @@ in
   cups,
   rsync, # used when preparing .app directory
 
-  # optionals
-
-  ## addon signing/sideloading
-  requireSigning ? requireSigningDefault,
-  allowAddonSideload ? allowAddonSideloadDefault,
-
-  ## debugging
-
-  debugBuild ? false,
-
-  # On 32bit platforms, we disable adding "-g" for easier linking.
-  enableDebugSymbols ? !stdenv.hostPlatform.is32bit,
-
-  ## optional libraries
-
-  alsaSupport ? stdenv.hostPlatform.isLinux,
+  # optional dependencies
+  withALSA ? stdenv.hostPlatform.isLinux,
   alsa-lib,
-  ffmpegSupport ? true,
-  gssSupport ? true,
+  withFFmpeg ? true,
+  withGSSAPI ? true,
   libkrb5,
-  jackSupport ? stdenv.hostPlatform.isLinux,
+  withJACK ? stdenv.hostPlatform.isLinux,
   libjack2,
-  jemallocSupport ? !stdenv.hostPlatform.isMusl,
+  withJemalloc ? !stdenv.hostPlatform.isMusl,
   jemalloc,
-  ltoSupport ? (
+  withPipewire ? withWayland && enableWebRTC,
+  withPulseaudio ? stdenv.hostPlatform.isLinux,
+  libpulseaudio,
+  withSndio ? stdenv.hostPlatform.isLinux,
+  sndio,
+  withWayland ? !stdenv.hostPlatform.isDarwin,
+  libxkbcommon,
+  libdrm,
+
+  # Build configuration
+
+  ## Addon signing/sideloading
+  enableAddonSigning ? true,
+  enableAddonSideload ? false,
+
+  ## Optimizations
+  enableElfhack ?
+    isElfhackPlatform stdenv && !(stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isAarch64),
+  enableLTO ? (
     (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin)
     && stdenv.hostPlatform.is64bit
     && !stdenv.hostPlatform.isRiscV
   ),
-  overrideCC,
-  buildPackages,
-  # PGO merges profile data with a 32-bit llvm-profdata, which runs out of
-  # address space on the huge libxul profile, so disable it on 32-bit.
-  pgoSupport ? (
+  enablePGO ? (
     stdenv.hostPlatform.isLinux
     && stdenv.hostPlatform == stdenv.buildPlatform
+    # PGO merges profile data with a 32-bit llvm-profdata, which runs out of
+    # address space on the huge libxul profile, so disable it on 32-bit.
     && stdenv.hostPlatform.is64bit
   ),
   xvfb-run,
-  elfhackSupport ?
-    isElfhackPlatform stdenv && !(stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isAarch64),
-  pipewireSupport ? waylandSupport && webrtcSupport,
-  pulseaudioSupport ? stdenv.hostPlatform.isLinux,
-  libpulseaudio,
-  sndioSupport ? stdenv.hostPlatform.isLinux,
-  sndio,
-  waylandSupport ? !stdenv.hostPlatform.isDarwin,
-  libxkbcommon,
-  libdrm,
 
-  ## privacy-related options
+  ## Debugging
+  enableDebug ? false,
 
-  privacySupport ? false,
+  ## On 32bit platforms, we disable adding "-g" for easier linking.
+  enableDebugSymbols ? !stdenv.hostPlatform.is32bit,
 
-  # WARNING: NEVER set any of the options below to `true` by default.
-  # Set to `!privacySupport` or `false`.
+  ## Privacy knobs
+  enableDataReporting ? true,
+  enableLocation ? true,
+  enableWebRTC ? true,
+  enableNeckoWiFi ? enableLocation,
 
-  crashreporterSupport ?
-    !privacySupport
+  ## Crash reporting
+  ## https://crash-stats.mozilla.org/search/?distribution_id=%3Dnixos
+  enableCrashReporter ?
+    enableDataReporting
     && !stdenv.hostPlatform.isLoongArch64
     && !stdenv.hostPlatform.isRiscV
     && !stdenv.hostPlatform.isMusl,
   curl,
-  geolocationSupport ? !privacySupport,
-  webrtcSupport ? !privacySupport,
 
-  # digital rights management
-
-  # This flag controls whether Firefox will show the nagbar, that allows
-  # users at runtime the choice to enable Widevine CDM support when a site
-  # requests it.
-  # Controlling the nagbar and widevine CDM at runtime is possible by setting
-  # `browser.eme.ui.enabled` and `media.gmp-widevinecdm.enabled` accordingly
-  drmSupport ? true,
+  ## DRM / Encrypted Media Extensions
+  # Build time toggle to control whether the DRM nagbar will appear
+  # (browser.eme.ui.enabled), when sites require it to playback media.
+  enableEMENagbar ? true,
 
   # As stated by Sylvestre Ledru (@sylvestre) on Nov 22, 2017 at
   # https://github.com/NixOS/nixpkgs/issues/31843#issuecomment-346372756 we
@@ -213,10 +202,10 @@ in
 
 assert stdenv.cc.libc or null != null;
 assert
-  pipewireSupport
-  -> !waylandSupport || !webrtcSupport
-  -> throw "${pname}: pipewireSupport requires both wayland and webrtc support.";
-assert elfhackSupport -> isElfhackPlatform stdenv;
+  withPipewire
+  -> !withWayland || !enableWebRTC
+  -> throw "${pname}: Pipewire support depends on Wayland and WebRTC support.";
+assert enableElfhack -> isElfhackPlatform stdenv;
 
 let
   inherit (lib) enableFeature;
@@ -238,7 +227,7 @@ let
   # LTO requires LLVM bintools including ld.lld and llvm-ar.
   buildStdenv = overrideCC llvmPackages.stdenv (
     llvmPackages.stdenv.cc.override {
-      bintools = if ltoSupport then buildPackages.rustc.llvmPackages.bintools else stdenv.cc.bintools;
+      bintools = if enableLTO then buildPackages.rustc.llvmPackages.bintools else stdenv.cc.bintools;
     }
   );
 
@@ -273,7 +262,7 @@ let
     );
 
   defaultPrefs =
-    if geolocationSupport then
+    if enableLocation then
       {
         "geo.provider.network.url" = {
           value = "https://api.beacondb.net/v1/geolocate";
@@ -284,7 +273,7 @@ let
       {
         "geo.provider.use_geoclue" = {
           value = false;
-          reason = "Geolocation support has been disabled through the `geolocationSupport` package attribute.";
+          reason = "Geolocation support has been disabled through the `enableLocation` package attribute.";
         };
       };
 
@@ -301,7 +290,7 @@ let
     if stdenv.hostPlatform.isDarwin then
       "cairo-cocoa"
     else
-      "cairo-gtk3${lib.optionalString waylandSupport "-wayland"}";
+      "cairo-gtk3${lib.optionalString withWayland "-wayland"}";
 
 in
 
@@ -324,10 +313,10 @@ buildStdenv.mkDerivation {
   outputs = [
     "out"
   ]
-  ++ lib.optionals crashreporterSupport [ "symbols" ];
+  ++ lib.optionals enableCrashReporter [ "symbols" ];
 
   # Add another configure-build-profiling run before the final configure phase if we build with pgo
-  preConfigurePhases = lib.optionals pgoSupport [
+  preConfigurePhases = lib.optionals enablePGO [
     "configurePhase"
     "buildPhase"
     "profilingPhase"
@@ -393,11 +382,11 @@ buildStdenv.mkDerivation {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ rsync ]
   ++ lib.optionals stdenv.hostPlatform.isx86 [ nasm ]
-  ++ lib.optionals crashreporterSupport [
+  ++ lib.optionals enableCrashReporter [
     dump_syms
     patchelf
   ]
-  ++ lib.optionals pgoSupport [ xvfb-run ]
+  ++ lib.optionals enablePGO [ xvfb-run ]
   ++ extraNativeBuildInputs;
 
   setOutputFlags = false; # `./mach configure` doesn't understand `--*dir=` flags.
@@ -430,7 +419,7 @@ buildStdenv.mkDerivation {
     export WASM_CC=${pkgsCross.wasm32-wasip1.stdenv.cc}/bin/${pkgsCross.wasm32-wasip1.stdenv.cc.targetPrefix}cc
     export WASM_CXX=${pkgsCross.wasm32-wasip1.stdenv.cc}/bin/${pkgsCross.wasm32-wasip1.stdenv.cc.targetPrefix}c++
   ''
-  + lib.optionalString pgoSupport ''
+  + lib.optionalString enablePGO ''
     if [ -e "$TMPDIR/merged.profdata" ]; then
       echo "Configuring with profiling data"
       for i in "''${!configureFlagsArray[@]}"; do
@@ -464,7 +453,7 @@ buildStdenv.mkDerivation {
   + lib.optionalString (enableOfficialBranding && !stdenv.hostPlatform.is32bit) ''
     export MOZILLA_OFFICIAL=1
   ''
-  + lib.optionalString (!requireSigning) ''
+  + lib.optionalString (!enableAddonSigning) ''
     export MOZ_REQUIRE_SIGNING=
   ''
   + lib.optionalString stdenv.hostPlatform.isMusl ''
@@ -491,13 +480,13 @@ buildStdenv.mkDerivation {
     "--target=${buildStdenv.hostPlatform.config}"
   ]
   # LTO is done using clang and lld.
-  ++ lib.optionals ltoSupport [
+  ++ lib.optionals enableLTO [
     "--enable-lto=cross,full" # Cross-Language LTO
     "--enable-linker=lld"
   ]
-  ++ lib.optional (isElfhackPlatform stdenv) (enableFeature elfhackSupport "elf-hack")
-  ++ lib.optional (!drmSupport) "--disable-eme"
-  ++ lib.optional allowAddonSideload "--allow-addon-sideload"
+  ++ lib.optional (isElfhackPlatform stdenv) (enableFeature enableElfhack "elf-hack")
+  ++ lib.optional (!enableEMENagbar) "--disable-eme"
+  ++ lib.optional enableAddonSideload "--allow-addon-sideload"
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     # MacOS builds use bundled versions of libraries: https://bugzilla.mozilla.org/show_bug.cgi?id=1776255
     "--enable-system-pixman"
@@ -514,27 +503,28 @@ buildStdenv.mkDerivation {
     "--with-system-zlib"
 
     # These options are not available on MacOS, even --disable-*
-    (enableFeature alsaSupport "alsa")
-    (enableFeature jackSupport "jack")
-    (enableFeature pulseaudioSupport "pulseaudio")
-    (enableFeature sndioSupport "sndio")
+    (enableFeature withALSA "alsa")
+    (enableFeature withJACK "jack")
+    (enableFeature withPulseaudio "pulseaudio")
+    (enableFeature withSndio "sndio")
   ]
   ++ lib.optionals (!buildStdenv.hostPlatform.isDarwin && lib.versionAtLeast version "141") [
     "--with-onnx-runtime=${lib.getLib onnxruntime}/lib"
   ]
   ++ [
-    (enableFeature crashreporterSupport "crashreporter")
-    (enableFeature ffmpegSupport "ffmpeg")
-    (enableFeature geolocationSupport "necko-wifi")
-    (enableFeature gssSupport "negotiateauth")
-    (enableFeature jemallocSupport "jemalloc")
-    (enableFeature webrtcSupport "webrtc")
+    (enableFeature withFFmpeg "ffmpeg")
+    (enableFeature withGSSAPI "negotiateauth")
+    (enableFeature withJemalloc "jemalloc")
 
-    (enableFeature debugBuild "debug")
-    (if debugBuild then "--enable-profiling" else "--enable-optimize")
+    (enableFeature enableCrashReporter "crashreporter")
+    (enableFeature enableNeckoWiFi "necko-wifi")
+    (enableFeature enableWebRTC "webrtc")
+
+    (enableFeature enableDebug "debug")
+    (if enableDebug then "--enable-profiling" else "--enable-optimize")
     # --enable-release adds -ffunction-sections & LTO that require a big amount
     # of RAM, and the 32-bit memory space cannot handle that linking
-    (enableFeature (!debugBuild && !stdenv.hostPlatform.is32bit) "release")
+    (enableFeature (!enableDebug && !stdenv.hostPlatform.is32bit) "release")
     (enableFeature enableDebugSymbols "debug-symbols")
   ]
   ++ lib.optionals enableDebugSymbols [
@@ -597,20 +587,20 @@ buildStdenv.mkDerivation {
       zlib
       (if (lib.versionAtLeast version "144") then nss_latest else nss_esr)
     ]
-    ++ lib.optional alsaSupport alsa-lib
-    ++ lib.optional jackSupport libjack2
-    ++ lib.optional pulseaudioSupport libpulseaudio # only headers are needed
-    ++ lib.optional sndioSupport sndio
-    ++ lib.optionals waylandSupport [
+    ++ lib.optional withALSA alsa-lib
+    ++ lib.optional withJACK libjack2
+    ++ lib.optional withPulseaudio libpulseaudio # only headers are needed
+    ++ lib.optional withSndio sndio
+    ++ lib.optionals withWayland [
       libxkbcommon
       libdrm
     ]
   ))
-  ++ lib.optional gssSupport libkrb5
-  ++ lib.optional jemallocSupport jemalloc
+  ++ lib.optional withGSSAPI libkrb5
+  ++ lib.optional withJemalloc jemalloc
   ++ extraBuildInputs;
 
-  profilingPhase = lib.optionalString pgoSupport ''
+  profilingPhase = lib.optionalString enablePGO ''
     # Avoid compressing the instrumented build with high levels of compression
     export MOZ_PKG_FORMAT=TAR
 
@@ -663,7 +653,7 @@ buildStdenv.mkDerivation {
   # Generate build symbols once after the final build
   # https://firefox-source-docs.mozilla.org/crash-reporting/uploading_symbol.html
   preInstall =
-    lib.optionalString crashreporterSupport ''
+    lib.optionalString enableCrashReporter ''
       ./mach buildsymbols
       mkdir -p $symbols/
       cp objdir/dist/*.crashreporter-symbols.zip $symbols/
@@ -697,7 +687,7 @@ buildStdenv.mkDerivation {
       cd ..
     '';
 
-  postFixup = lib.optionalString (crashreporterSupport && buildStdenv.hostPlatform.isLinux) ''
+  postFixup = lib.optionalString (enableCrashReporter && buildStdenv.hostPlatform.isLinux) ''
     patchelf --add-rpath "${lib.makeLibraryPath [ curl ]}" $out/lib/${binaryName}/crashreporter
   '';
 
@@ -715,21 +705,25 @@ buildStdenv.mkDerivation {
     '';
 
   passthru = {
-    inherit applicationName;
-    inherit application extraPatches;
-    inherit updateScript;
-    inherit alsaSupport;
-    inherit binaryName;
-    inherit requireSigning allowAddonSideload;
-    inherit jackSupport;
-    inherit pipewireSupport;
-    inherit sndioSupport;
-    inherit nspr;
-    inherit ffmpegSupport;
-    inherit gssSupport;
-    inherit tests;
-    inherit gtk3;
-    inherit wasiSysRoot;
+    inherit
+      application
+      applicationName
+      binaryName
+      enableAddonSideload
+      enableAddonSigning
+      extraPatches
+      gtk3
+      nspr
+      tests
+      updateScript
+      wasiSysRoot
+      withALSA
+      withFFmpeg
+      withGSSAPI
+      withJACK
+      withPipewire
+      withSndio
+      ;
     version = packageVersion;
   }
   // extraPassthru;

--- a/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
@@ -99,12 +99,12 @@ rustPlatform.buildRustPackage rec {
     # wrapped similarly to `firefoxRuntime`, and these passthru variables are
     # read when `wrapFirefox` wraps this derivation too.
     inherit (firefoxRuntime)
-      ffmpegSupport
-      gssSupport
-      alsaSupport
-      pipewireSupport
-      sndioSupport
-      jackSupport
+      withALSA
+      withFFmpeg
+      withGSSAPI
+      withJACK
+      withPipewire
+      withSndio
       ;
   };
 

--- a/pkgs/by-name/fl/floorp-bin-unwrapped/package.nix
+++ b/pkgs/by-name/fl/floorp-bin-unwrapped/package.nix
@@ -113,8 +113,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit binaryName;
     applicationName = "Floorp";
     libName = "floorp-bin-${finalAttrs.version}";
-    ffmpegSupport = true;
-    gssSupport = true;
+    withFFmpeg = true;
+    withGSSAPI = true;
     gtk3 = gtk3;
     updateScript = ./update.sh;
   };

--- a/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
@@ -96,8 +96,8 @@ stdenv.mkDerivation {
     inherit binaryName;
     applicationName = "LibreWolf";
     libName = "librewolf-bin-${version}";
-    ffmpegSupport = true;
-    gssSupport = true;
+    withFFmpeg = true;
+    withGSSAPI = true;
     gtk3 = gtk3;
     updateScript = ./update.sh;
   };

--- a/pkgs/by-name/li/librewolf-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/package.nix
@@ -15,8 +15,6 @@ in
   binaryName = "librewolf";
   version = librewolf-src.packageVersion;
   src = librewolf-src.firefox;
-  requireSigning = false;
-  allowAddonSideload = true;
   branding = "browser/branding/librewolf";
   inherit (librewolf-src)
     extraConfigureFlags
@@ -52,7 +50,10 @@ in
   };
 }).override
   {
-    crashreporterSupport = false;
+    enableAddonSigning = false;
+    enableAddonSideload = true;
+
+    enableCrashReporter = false;
     # This will set `MOZILLA_OFFICIAL=1`, which is set by the mozconfig upstream, but has to
     # be set manually in our case.
     # This will not override the branding as `branding` is already set to the official


### PR DESCRIPTION
Respin of #385672

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
