### PR TITLE
shellnoob: fix invalid unstable version scheme (and use hash instead of sha256)

### DIFF
--- a/pkgs/by-name/sh/shellnoob/package.nix
+++ b/pkgs/by-name/sh/shellnoob/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
     owner = "reyammer";
     repo = "shellnoob";
     rev = "72cf49804d8ea3de1faa7fae5794449301987bff";
-    sha256 = "xF9OTFFe8godW4+z9MFaFEkjE9FB42bKWwdl9xRcmEo=";
+    hash = "sha256-xF9OTFFe8godW4+z9MFaFEkjE9FB42bKWwdl9xRcmEo=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/sh/shellnoob/package.nix
+++ b/pkgs/by-name/sh/shellnoob/package.nix
@@ -7,7 +7,7 @@
 
 stdenvNoCC.mkDerivation {
   pname = "shellnoob";
-  version = "unstable-2022-03-16";
+  version = "2.1-unstable-2022-03-16";
 
   src = fetchFromGitHub {
     owner = "reyammer";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixing invalid unstable version schemes as part of https://github.com/NixOS/nixpkgs/issues/541820.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
