### PR TITLE
python3Packages.scikit-survival: 0.27.0 -> 0.28.0

### DIFF
--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -22,19 +22,42 @@
   scipy,
 
   # tests
+  polars,
   pytestCheckHook,
 }:
 
+let
+  # very long tests, skipped in the main build and exercised by passthru.tests
+  slowTests = [
+    "test_coxph"
+    "test_datasets"
+    "test_ensemble_selection"
+    "test_minlip"
+    "test_pandas_inputs"
+    "test_survival_svm"
+    "test_tree"
+  ];
+  flakyTests =
+    lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      # Flaky numerical assertion (AssertionError)
+      "test_baseline_predict"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+      # floating point mismatch on aarch64
+      # 27079905.88052468 too far from 27079905.880496684
+      "test_coxnet"
+    ];
+in
 buildPythonPackage (finalAttrs: {
   pname = "scikit-survival";
-  version = "0.27.0";
+  version = "0.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sebp";
     repo = "scikit-survival";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BP4kfYt4W9QCklkJ5DDE6Zquca2LhRZGFsKmD9qb7vk=";
+    hash = "sha256-vqBKw/CvYg4VLsdxm9CjeN2sfT5keeg1oWTGaFM1MZg=";
   };
 
   postPatch = ''
@@ -75,25 +98,26 @@ buildPythonPackage (finalAttrs: {
     rm -rf sksurv
   '';
 
-  disabledTests = [
-    # very long tests, unnecessary for a leaf package
-    "test_coxph"
-    "test_datasets"
-    "test_ensemble_selection"
-    "test_minlip"
-    "test_pandas_inputs"
-    "test_survival_svm"
-    "test_tree"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-    # Flaky numerical assertion (AssertionError)
-    "test_baseline_predict"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    # floating point mismatch on aarch64
-    # 27079905.88052468 to far from 27079905.880496684
-    "test_coxnet"
+  # These tests require polars, which is heavy; exercised via passthru
+  disabledTestPaths = [
+    "tests/test_dataframe.py"
+    "tests/test_io.py"
+    "tests/test_polars_clinical_kernel.py"
+    "tests/test_polars_column.py"
+    "tests/test_polars_datasets.py"
+    "tests/test_polars_estimators.py"
+    "tests/test_polars_preprocessing.py"
+    "tests/test_polars_util.py"
   ];
+
+  disabledTests = slowTests ++ flakyTests;
+
+  passthru.tests.full = finalAttrs.finalPackage.overridePythonAttrs (old: {
+    pname = old.pname + "-full-tests";
+    nativeCheckInputs = old.nativeCheckInputs ++ [ polars ];
+    disabledTests = flakyTests;
+    disabledTestPaths = [ ];
+  });
 
   meta = {
     description = "Survival analysis built on top of scikit-learn";


### PR DESCRIPTION
Version bump to fix broken build on `master`. Since the new tests added a `polars` dependency, which is heavy, I moved them and the previously disabled long-running tests to `passthru.tests.full` so that they can still be exercised by the review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
