### PR TITLE
[Backport release-26.05] xeus-cpp: init at 0.10.0

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/xeus-cpp/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cpp/default.nix
@@ -1,0 +1,37 @@
+{
+  callPackage,
+}:
+
+# Jupyter console:
+# nix run --impure --expr 'with import <nixpkgs> {}; jupyter-console.withSingleKernel cpp17-kernel'
+
+# Jupyter notebook:
+# nix shell --impure --expr 'with import <nixpkgs> {}; [ (jupyter.override { definitions = { cpp17 = cpp17-kernel; }; }) ]' -c jupyter-notebook
+
+let
+  xeus-cpp = callPackage ./xeus-cpp.nix { };
+
+  mkKernelSpec = std: {
+    displayName = builtins.replaceStrings [ "c++" ] [ "C++ " ] std;
+    argv = [
+      "${xeus-cpp}/bin/xcpp"
+      "-std=${std}"
+      "-f"
+      "{connection_file}"
+    ];
+    language = "cpp";
+    logo32 = "${xeus-cpp}/share/jupyter/kernels/xcpp17/logo-32x32.png";
+    logo64 = "${xeus-cpp}/share/jupyter/kernels/xcpp17/logo-64x64.png";
+  };
+
+in
+
+{
+  cpp11-kernel = mkKernelSpec "c++11";
+  cpp14-kernel = mkKernelSpec "c++14";
+  cpp17-kernel = mkKernelSpec "c++17";
+  cpp20-kernel = mkKernelSpec "c++20";
+  cpp23-kernel = mkKernelSpec "c++23";
+
+  inherit xeus-cpp;
+}

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cpp/xeus-cpp.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cpp/xeus-cpp.nix
@@ -1,0 +1,183 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+
+  cpp-interop,
+  cling,
+
+  # Jupyter / xeus stack
+  xeus,
+  xeus-zmq,
+  nlohmann_json,
+  argparse,
+  pugixml,
+
+  # Runtime libs
+  zeromq,
+  openssl,
+  libuuid,
+  curl,
+  makeWrapper,
+
+  # tests
+  doctest,
+
+  # installCheck
+  python3,
+  jq,
+
+  # "clang-repl" | "cling"
+  backend ? "clang-repl",
+}:
+
+let
+  stdenv = clangStdenv;
+
+  useCling = backend == "cling";
+  cppInterop = cpp-interop.override { inherit backend; };
+
+  # xeus-cpp 0.10.0 needs newer xeus / xeus-zmq than nixpkgs ships by default.
+  xeus_6 = xeus.overrideAttrs (old: {
+    version = "6.0.5";
+    src = fetchFromGitHub {
+      owner = "jupyter-xeus";
+      repo = "xeus";
+      tag = "6.0.5";
+      hash = "sha256-nbjq4dzrukVsZI6X3lWpr9oCZV5IUu/vkqSNKD7o3vo=";
+    };
+    doCheck = false;
+  });
+
+  xeus_zmq_4 = (xeus-zmq.override { xeus = xeus_6; }).overrideAttrs (old: {
+    version = "4.0.0";
+    src = fetchFromGitHub {
+      owner = "jupyter-xeus";
+      repo = "xeus-zmq";
+      tag = "4.0.0";
+      hash = "sha256-Ux8klPh33XWFu9eu+GTk5ZcqIcoP/GM4/J1uaz9xRHI=";
+    };
+  });
+
+  # The interpreter behind CppInterOp must be told where the C/C++ standard
+  # library and Clang builtin headers live: there is no system compiler to detect
+  # at runtime in the Nix sandbox. We pass this set via CppInterOp's runtime
+  # override env var. For the Cling backend cling.flags already carries it; for
+  # clang-repl we reuse the hermetic resource dir and include flags CppInterOp
+  # exposes.
+  resourceDir = if useCling then "${cling.unwrapped}/lib/clang/20" else cppInterop.resourceDir;
+  interpreterArgs = lib.concatStringsSep " " (
+    if useCling then cling.flags else cppInterop.interpreterArgs
+  );
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xeus-cpp";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "compiler-research";
+    repo = "xeus-cpp";
+    tag = finalAttrs.version;
+    hash = "sha256-r6ojIcebWzpP85Djl36EMucnfQQgjGJUakSbMYW+czs=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    cppInterop
+    xeus_6
+    xeus_zmq_4
+    nlohmann_json
+    argparse
+    pugixml
+    zeromq
+    openssl
+    libuuid
+    curl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "XEUS_CPP_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    "-DXEUS_CPP_RESOURCE_DIR=${resourceDir}"
+  ];
+
+  # Make the kernel hermetic: hand the interpreter the include/resource flags it
+  # needs, since it cannot probe a system compiler in the sandbox.
+  postInstall = ''
+    wrapProgram $out/bin/xcpp \
+      --set-default CPPINTEROP_EXTRA_INTERPRETER_ARGS "${interpreterArgs}"
+
+    # xeus-cpp builds the kernelspec argv from CMAKE_INSTALL_PREFIX *and* the
+    # (absolute, under Nix) CMAKE_INSTALL_BINDIR, producing a doubled store path
+    # for xcpp. Point each kernel.json back at the wrapped binary.
+    for k in $out/share/jupyter/kernels/*/kernel.json; do
+      substituteInPlace "$k" --replace-fail "$out/$out/bin/xcpp" "$out/bin/xcpp"
+    done
+  '';
+
+  # Run the upstream doctest suite. Like the wrapped kernel, the test binary
+  # drives CppInterOp directly, so it needs the same hermetic interpreter args.
+  doCheck = true;
+  checkInputs = [ doctest ];
+  checkPhase = ''
+    runHook preCheck
+
+    export CPPINTEROP_EXTRA_INTERPRETER_ARGS="${interpreterArgs}"
+    # The test binary is linked with the install RPATH ($out/lib), which does not
+    # exist yet at check time; point it at the freshly built libxeus-cpp instead.
+    export LD_LIBRARY_PATH="$PWD''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    cmake --build . --target check-xeus-cpp
+
+    runHook postCheck
+  '';
+
+  # Smoke test: drive the installed, wrapped kernel through Papermill and check
+  # it actually compiles and runs C++.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    export HOME=$(mktemp -d)
+    mkdir -p "$HOME/kernels/xcpp"
+    cat > "$HOME/kernels/xcpp/kernel.json" <<EOF
+    {"argv":["$out/bin/xcpp","-std=c++17","-f","{connection_file}"],"language":"cpp","display_name":"C++"}
+    EOF
+    export JUPYTER_PATH="$HOME"
+
+    cat > "$HOME/test.ipynb" <<'NBEOF'
+    {"cells":[
+      {"cell_type":"code","id":"a","metadata":{},"execution_count":null,"outputs":[],"source":["#include <iostream>"]},
+      {"cell_type":"code","id":"b","metadata":{},"execution_count":null,"outputs":[],"source":["std::cout << \"Hello world.\" << std::endl;"]}
+    ],"metadata":{"kernelspec":{"name":"xcpp","display_name":"C++","language":"cpp"}},"nbformat":4,"nbformat_minor":5}
+    NBEOF
+
+    ${python3.pkgs.papermill}/bin/papermill "$HOME/test.ipynb" "$HOME/out.ipynb" --kernel xcpp
+    ${jq}/bin/jq -e '[.. | .text? // empty | tostring] | add | contains("Hello world.")' "$HOME/out.ipynb"
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit backend;
+    flags = interpreterArgs;
+  };
+
+  meta = {
+    description = "Jupyter kernel for C++ based on CppInterOp (${backend} backend)";
+    mainProgram = "xcpp";
+    homepage = "https://github.com/compiler-research/xeus-cpp";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/cp/cpp-interop/package.nix
+++ b/pkgs/by-name/cp/cpp-interop/package.nix
@@ -1,0 +1,192 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  llvmPackages_21,
+  cling,
+  gcc-unwrapped,
+  libffi,
+  libxml2,
+  ncurses,
+  zlib,
+  zstd,
+
+  # tests
+  gtest,
+
+  # Which interpreter backend to build against. CppInterOp can use either
+  # clang-repl (from upstream LLVM/Clang) or Cling. They are mutually exclusive.
+  backend ? "clang-repl", # "clang-repl" | "cling"
+}:
+
+let
+  llvmPackages = llvmPackages_21;
+  inherit (llvmPackages) stdenv;
+
+  useCling = backend == "cling";
+  llvm = llvmPackages.llvm;
+  clang = llvmPackages.clang-unwrapped;
+
+  # For the cling backend we build against the LLVM/Clang/Cling that ship inside
+  # `cling` itself (its LLVM 20 fork), so the ABI matches libcling. The CMake
+  # config packages (LLVM, Clang, Cling) all live under cling.unwrapped.
+  clingRoot = cling.unwrapped;
+
+  # The Clang resource dir and standard-library include flags the JIT interpreter
+  # needs, since there is no system compiler to probe in the Nix sandbox. Both
+  # this package's own tests and xeus-cpp (via passthru) feed these to CppInterOp
+  # through CPPINTEROP_EXTRA_INTERPRETER_ARGS. The resource dir must match the
+  # Clang that CppInterOp was built against: the cling fork for the cling backend,
+  # upstream LLVM otherwise. -nostdinc(++) makes the search hermetic: only the
+  # -isystem paths below are used, never any stray host include dirs.
+  resourceDir =
+    if useCling then
+      "${clingRoot}/lib/clang/20"
+    else
+      "${lib.getLib clang}/lib/clang/${lib.versions.major llvm.version}";
+  interpreterArgs = [
+    "-nostdinc"
+    "-nostdinc++"
+    "-resource-dir"
+    resourceDir
+    "-isystem"
+    "${resourceDir}/include"
+    "-isystem"
+    "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}"
+    "-isystem"
+    "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}/${stdenv.hostPlatform.config}"
+    "-isystem"
+    "${lib.getDev stdenv.cc.libc}/include"
+  ];
+in
+
+assert lib.assertOneOf "backend" backend [
+  "clang-repl"
+  "cling"
+];
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cpp-interop-${backend}";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "compiler-research";
+    repo = "CppInterOp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-am2WObER9dlNQU/VMTY2ScMe/w8c4N8m/DVyNwHiBnw=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+  ];
+
+  buildInputs = [
+    libffi
+    libxml2
+    ncurses
+    zlib
+    zstd
+  ]
+  ++ (
+    if useCling then
+      [ clingRoot ]
+    else
+      [
+        llvm
+        clang
+      ]
+  );
+
+  # Upstream's unittests/CMakeLists.txt only fetches GoogleTest over the network
+  # (forbidden in the sandbox) when no gtest target exists; point it at the
+  # nixpkgs gtest instead so the tests can build offline.
+  postPatch = ''
+    substituteInPlace unittests/CMakeLists.txt \
+      --replace-fail "include(GoogleTest)" "find_package(GTest REQUIRED)"
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "CPPINTEROP_USE_CLING" useCling)
+    (lib.cmakeBool "CPPINTEROP_USE_REPL" (!useCling))
+    (lib.cmakeBool "CPPINTEROP_ENABLE_TESTING" finalAttrs.finalPackage.doCheck)
+  ]
+  ++ (
+    if useCling then
+      [
+        "-DCling_DIR=${clingRoot}/lib/cmake/cling"
+        "-DLLVM_DIR=${clingRoot}/lib/cmake/llvm"
+        "-DClang_DIR=${clingRoot}/lib/cmake/clang"
+      ]
+    else
+      [
+        "-DLLVM_DIR=${llvm.dev}/lib/cmake/llvm"
+        "-DClang_DIR=${clang.dev}/lib/cmake/clang"
+      ]
+  );
+
+  # Run the upstream GoogleTest suite. Only the clang-repl backend is exercised;
+  # the Cling backend skips many of these tests upstream.
+  doCheck = !useCling;
+  checkInputs = [ gtest ];
+  checkPhase = ''
+    runHook preCheck
+
+    export CPPINTEROP_EXTRA_INTERPRETER_ARGS="${lib.concatStringsSep " " interpreterArgs}"
+    # Upstream registers the tests only in the unittests subdir; its
+    # check-cppinterop target builds them and runs ctest from the right place.
+    ninja check-cppinterop
+
+    runHook postCheck
+  '';
+
+  # Smoke test: drive the backend to JIT-compile and run a function, proving
+  # the installed library, headers and runtime linking all work together.
+  doInstallCheck = !useCling;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cat > smoke.cpp <<'EOF'
+    #include "CppInterOp/CppInterOp.h"
+    #include <cstdio>
+    int main() {
+      Cpp::CreateInterpreter();
+      if (Cpp::Declare("int square(int x) { return x * x; }") != 0) return 1;
+      bool hadError = false;
+      intptr_t result = Cpp::Evaluate("square(7)", &hadError);
+      if (hadError) return 2;
+      if (result != 49) { std::printf("expected 49, got %ld\n", (long)result); return 3; }
+      if (Cpp::GetNamed("square") == nullptr) return 4;
+      return 0;
+    }
+    EOF
+
+    $CXX -std=c++17 smoke.cpp -I$out/include -L$out/lib -lclangCppInterOp -o smoke
+    LD_LIBRARY_PATH=$out/lib ./smoke
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit backend resourceDir interpreterArgs;
+  };
+
+  meta = {
+    description = "Clang-based C++ interoperability library (${backend} backend)";
+    homepage = "https://github.com/compiler-research/CppInterOp";
+    changelog = "https://github.com/compiler-research/CppInterOp/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4632,6 +4632,7 @@ with pkgs;
     cpp2a-kernel
     xeus-cling
     ;
+  inherit (callPackage ../applications/editors/jupyter-kernels/xeus-cpp { }) xeus-cpp;
 
   dhall = haskell.lib.compose.justStaticExecutables haskellPackages.dhall;
 


### PR DESCRIPTION
Bot-based backport to `release-26.05`, triggered by a label in #537184.

**Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).**

Even as a non-committer, if you find that it is not acceptable, leave a comment.

> [!TIP]
> If you maintain all packages touched by this pull request, and they are all located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this PR using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md#nixpkgs-merge-bot).

Note: I closed #558638 and re-opened this in order to remove 9711744, which isn't appropriate to backport.