### PR TITLE
ci/commits: CJS `__dirname` → ESM

### DIFF
--- a/ci/github-script/commits.js
+++ b/ci/github-script/commits.js
@@ -4,6 +4,8 @@ import { dismissReviews, postReview } from './reviews.js'
 import { classify } from './supportedBranches.js'
 import withRateLimit from './withRateLimit.js'
 
+const dirname = import.meta.dirname
+
 export default async ({ github, context, core, dry, cherryPicks }) => {
   const reviewKey = 'check-commits'
 
@@ -94,7 +96,7 @@ export default async ({ github, context, core, dry, cherryPicks }) => {
     function diff({ sha, commit, original_sha }) {
       const diff = execFileSync('git', [
         '-C',
-        __dirname,
+        dirname,
         'range-diff',
         '--no-color',
         '--ignore-all-space',
@@ -121,7 +123,7 @@ export default async ({ github, context, core, dry, cherryPicks }) => {
 
       const colored_diff = execFileSync('git', [
         '-C',
-        __dirname,
+        dirname,
         'range-diff',
         '--color',
         '--no-notes',
@@ -160,7 +162,7 @@ export default async ({ github, context, core, dry, cherryPicks }) => {
       // Fetching all commits we need for diff at once is much faster than any other method.
       execFileSync('git', [
         '-C',
-        __dirname,
+        dirname,
         'fetch',
         '--depth=2',
         'origin',


### PR DESCRIPTION
ESM modules no longer support CJS-style `__dirname` or `__filename`, instead we should use `import.meta.dirname` and `import.meta.filename` respectively.

See: https://nodejs.org/api/esm.html#no-__filename-or-__dirname

Followup to https://github.com/NixOS/nixpkgs/pull/558135#event-30313456451


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] `npm test` in `ci/github-script`
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
