### PR TITLE
vikunja: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/by-name/vi/vikunja/frontend.nix
+++ b/pkgs/by-name/vi/vikunja/frontend.nix
@@ -1,0 +1,68 @@
+{
+  src,
+  version,
+
+  lib,
+  stdenv,
+  nodejs_24,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  dart-sass,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vikunja-frontend";
+  inherit version src;
+
+  sourceRoot = "${finalAttrs.src.name}/frontend";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-aQWTzJZU6NJrZxuoCeQDJjujPq+niixmFvqtPdWS4wk=";
+  };
+
+  nativeBuildInputs = [
+    nodejs_24
+    dart-sass
+    pnpmConfigHook
+    pnpm_10
+  ];
+
+  postPatch = ''
+    substituteInPlace src/version.json \
+      --replace-fail '"dev"' '"${finalAttrs.version}"'
+  '';
+
+  postBuild = ''
+    # Force sass-embedded to use our dart-sass instead of bundled binaries.
+    substituteInPlace node_modules/sass-embedded/dist/lib/src/compiler-path.js \
+      --replace-fail 'compilerCommand = (() => {' 'compilerCommand = (() => { return ["${lib.getExe dart-sass}"];'
+    pnpm run build
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    pnpm run test:unit --run
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist/ $out
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -2,75 +2,16 @@
   lib,
   callPackage,
   fetchFromGitHub,
-  stdenv,
-  nodejs_24,
-  pnpm_10,
-  fetchPnpmDeps,
-  pnpmConfigHook,
-  buildGoModule,
+  buildGo127Module,
   mage,
-  dart-sass,
+  writableTmpDirAsHomeHook,
   writeShellScriptBin,
   nixosTests,
   nix-update-script,
 }:
 
 let
-  version = "2.5.0";
-  src = fetchFromGitHub {
-    owner = "go-vikunja";
-    repo = "vikunja";
-    rev = "v${version}";
-    hash = "sha256-qI4mkgcN9yYRmh5V+KzIHupX7uWsszV4Xb31OYvukxQ=";
-  };
-
-  frontend = stdenv.mkDerivation (finalAttrs: {
-    pname = "vikunja-frontend";
-    inherit version src;
-
-    sourceRoot = "${finalAttrs.src.name}/frontend";
-
-    pnpmDeps = fetchPnpmDeps {
-      inherit (finalAttrs)
-        pname
-        version
-        src
-        sourceRoot
-        ;
-      pnpm = pnpm_10;
-      fetcherVersion = 3;
-      hash = "sha256-xZBgE4GM59Ihl5a3qgcmkjR4Q3wYlcsiDapiNEzBQOg=";
-    };
-
-    nativeBuildInputs = [
-      nodejs_24
-      dart-sass
-      pnpmConfigHook
-      pnpm_10
-    ];
-
-    postPatch = ''
-      substituteInPlace src/version.json \
-        --replace-fail '"dev"' '"${finalAttrs.version}"'
-    '';
-
-    doCheck = true;
-
-    postBuild = ''
-      # Force sass-embedded to use our dart-sass instead of bundled binaries.
-      substituteInPlace node_modules/sass-embedded/dist/lib/src/compiler-path.js \
-        --replace-fail 'compilerCommand = (() => {' 'compilerCommand = (() => { return ["${lib.getExe dart-sass}"];'
-      pnpm run build
-    '';
-
-    checkPhase = ''
-      pnpm run test:unit --run
-    '';
-
-    installPhase = ''
-      cp -r dist/ $out
-    '';
-  });
+  buildGoModule = buildGo127Module;
 
   # Injects a `t.Skip()` into a given test since there's apparently no other way to skip tests here.
   skipTest =
@@ -85,14 +26,21 @@ let
     '';
 in
 buildGoModule (finalAttrs: {
-  inherit src version;
   pname = "vikunja";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "go-vikunja";
+    repo = "vikunja";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Xh1ozUTOVqywk0i8xQWkG/bPRgPH9EABjRW8p4do1mE=";
+  };
 
   nativeBuildInputs =
     let
       fakeGit = writeShellScriptBin "git" ''
         if [[ $@ = "describe --tags --always --abbrev=10" ]]; then
-            echo "${version}"
+            echo "${finalAttrs.version}"
         else
             >&2 echo "Unknown command: $@"
             exit 1
@@ -102,15 +50,23 @@ buildGoModule (finalAttrs: {
     [
       fakeGit
       mage
+      # mage wants to write some files to HOME
+      writableTmpDirAsHomeHook
     ];
 
-  vendorHash = "sha256-bn+bcGzeB0/KkhPNkbjK/EgKQG3iqVlJxtt6betGUNE=";
+  vendorHash = "sha256-R6M5UyF10pIdoAvjWnS6Dqe/U6LTxmS6OwRTgmxfU4g=";
 
-  inherit frontend;
-  veans = callPackage ./veans.nix { inherit (finalAttrs) src version meta; };
+  frontend = callPackage ./frontend.nix {
+    inherit (finalAttrs) src version;
+  };
+
+  veans = callPackage ./veans.nix {
+    inherit (finalAttrs) src version meta;
+    inherit buildGoModule;
+  };
 
   prePatch = ''
-    cp -r ${frontend} frontend/dist
+    cp -r ${finalAttrs.frontend} frontend/dist
   '';
 
   postConfigure = ''
@@ -125,27 +81,34 @@ buildGoModule (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    # Fixes "mkdir /homeless-shelter: permission denied" - "Error: error compiling magefiles" during build
-    export HOME=$(mktemp -d)
     mage build:build
 
     runHook postBuild
   '';
 
   checkPhase = ''
+    runHook preCheck
+
     mage test:feature
     mage test:web
+
+    runHook postCheck
   '';
 
   installPhase = ''
     runHook preInstall
+
     install -Dt $out/bin vikunja
+
     runHook postInstall
   '';
 
   passthru = {
+    # used by vikunja-desktop
+    inherit (finalAttrs) frontend;
+
     tests.vikunja = nixosTests.vikunja;
-    frontend = frontend;
+
     updateScript = nix-update-script {
       extraArgs = [
         "--subpackage"
@@ -157,7 +120,7 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/go-vikunja/vikunja/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/go-vikunja/vikunja/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Todo-app to organize your life";
     homepage = "https://vikunja.io/";
     license = lib.licenses.agpl3Plus;

--- a/pkgs/by-name/vi/vikunja/veans.nix
+++ b/pkgs/by-name/vi/vikunja/veans.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
 
   modRoot = "veans";
 
-  vendorHash = "sha256-4Ayug+r7sWL/JZI8fGCyDZ1SaTwCvSWrQpqv7uYCHhc=";
+  vendorHash = "sha256-ac2M7wNlOn6ku8sn/rZmPCSGPodw88ufR8tr1lh54II=";
 
   env.CGO_ENABLED = 0;
 


### PR DESCRIPTION
Changelog: https://github.com/go-vikunja/vikunja/blob/v2.6.0/CHANGELOG.md

Needed go 1.27.

Also split out frontend into a separate file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
