### PR TITLE
tailcat: 0.3.0 -> 0.6.0

### DIFF
--- a/pkgs/by-name/ta/tailcat/package.nix
+++ b/pkgs/by-name/ta/tailcat/package.nix
@@ -1,14 +1,14 @@
 {
   lib,
-  buildGoModule,
+  buildGo127Module,
   fetchFromGitHub,
   nix-update-script,
   versionCheckHook,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo127Module (finalAttrs: {
   pname = "tailcat";
-  version = "0.3.0";
+  version = "0.6.0";
 
   __structuredAttrs = true;
 
@@ -16,12 +16,20 @@ buildGoModule (finalAttrs: {
     owner = "tailscale";
     repo = "tailcat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EwjhZzovODhW4seO3FToPLiAV+YwVbrX/u93RfbWMZ4=";
+    hash = "sha256-TwrEezNpn9ylDl7+Vo4XS/SaVOgU6h6PO1UWSrXnBWk=";
   };
 
-  vendorHash = "sha256-3uVUHATnd2s+Axdq06/xAQ2IbzJZfP1yQ/nEopgckq0=";
+  vendorHash = "sha256-hpFVgsUKswE7g69EieoeKGPR1nVkcRmBhDKbnB2CDBg=";
 
   subPackages = [ "cmd/tailcat" ];
+
+  # Build with the same tags as the official release binaries. The
+  # comma-separated list lives in build-tags.txt in the source tree
+  # (see build-tags.md there); it omits unused tailscale.com library
+  # features to shrink the binary.
+  preBuild = ''
+    IFS=, read -ra tags < build-tags.txt
+  '';
 
   ldflags = [
     "-s"
@@ -29,6 +37,13 @@ buildGoModule (finalAttrs: {
   ];
 
   env.CGO_ENABLED = "0";
+
+  # The release tags apply only to the binary. Vendored test helpers
+  # do not compile with the omit tags, and upstream CI runs go test
+  # without them.
+  preCheck = ''
+    unset tags
+  '';
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Build with the release build tags from build-tags.txt in the source
tree, matching official binaries; they omit unused tailscale.com
library features and shrink the binary about 16%. Reading the file at
build time keeps the list in sync across future updates.

tailcat 0.6.0 (as of 0.4.0) requires Go 1.27, so switch to buildGo127Module.

Changelog: https://github.com/tailscale/tailcat/releases/tag/v0.4.0

Assisted-by: Claude Code (claude-fable-5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
