### PR TITLE
python3Packages.tcia-utils: remove sgomezsal as maintainer

### DIFF
--- a/pkgs/development/python-modules/tcia-utils/default.nix
+++ b/pkgs/development/python-modules/tcia-utils/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage (finalAttrs: {
     description = "Python utilities for interacting with The Cancer Imaging Archive (TCIA)";
     homepage = "https://github.com/kirbyju/tcia_utils";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ sgomezsal ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
## Description

Removing myself (sgomezsal) as maintainer of `tcia-utils`. I no longer
use or actively maintain this package.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].