### PR TITLE
cy: init at 1.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31109,6 +31109,12 @@
     github = "wilsonehusin";
     githubId = 14004487;
   };
+  wilsonsk0 = {
+    email = "skwilson03@proton.me";
+    github = "wilsonsk0";
+    githubId = 145277297;
+    name = "Sam Wilson";
+  };
   wineee = {
     email = "lhongxu@outlook.com";
     github = "wineee";

--- a/pkgs/by-name/cy/cy/disable-deadlock-lock-order.patch
+++ b/pkgs/by-name/cy/cy/disable-deadlock-lock-order.patch
@@ -1,0 +1,10 @@
+--- a/vendor/github.com/sasha-s/go-deadlock/deadlock.go
++++ b/vendor/github.com/sasha-s/go-deadlock/deadlock.go
+@@ -33,6 +33,7 @@ var Opts = struct {
+ 	// Will print deadlock info to log buffer.
+ 	LogBuf io.Writer
+ }{
++	DisableLockOrderDetection: true,
+ 	DeadlockTimeout: time.Second * 30,
+ 	OnPotentialDeadlock: func() {
+ 		os.Exit(2)

--- a/pkgs/by-name/cy/cy/package.nix
+++ b/pkgs/by-name/cy/cy/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  bash,
+  buildGoModule,
+  fetchFromGitHub,
+  libx11,
+  ncurses,
+  vim,
+  testers,
+  makeBinaryWrapper,
+}:
+buildGoModule (finalAttrs: {
+  pname = "cy";
+  version = "1.12.0";
+  src = fetchFromGitHub {
+    owner = "cfoust";
+    repo = "cy";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-QWPaFLzySiju17u5YEIFjAaNbDEXI+e0yZ91pdaPC+4=";
+  };
+  vendorHash = null;
+
+  subPackages = [ "cmd/cy" ];
+
+  patches = [ ./disable-deadlock-lock-order.patch ];
+
+  postPatch = ''
+    substituteInPlace \
+      pkg/cy/cy_test.go \
+      pkg/cy/testing.go \
+      --replace-fail "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    libx11
+  ];
+
+  ldflags =
+    let
+      versionPkg = "github.com/cfoust/cy/pkg/version";
+    in
+    [
+      "-X ${versionPkg}.Version=v${finalAttrs.version}"
+      "-X ${versionPkg}.GoVersion=${finalAttrs.finalPackage.go.version}"
+      "-X ${versionPkg}.GitCommit=${finalAttrs.src.rev}"
+    ];
+
+  postFixup = ''
+    wrapProgram $out/bin/cy \
+      --suffix TERMINFO_DIRS : ${ncurses}/share/terminfo \
+      --suffix LD_LIBRARY_PATH : ${libx11}/lib
+  '';
+
+  nativeCheckInputs = [
+    bash
+    vim
+  ];
+
+  preCheck = ''
+    export HOME="$TMPDIR"
+    mkdir -p "$HOME"
+
+    export TERMINFO_DIRS="${ncurses}/share/terminfo"
+    export EDITOR="${vim}/bin/vim"
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "cy --version";
+      version = "v${finalAttrs.version}";
+    };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "A time travelling terminal multiplexer";
+    homepage = "https://cfoust.github.io/cy/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.wilsonsk0 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "cy";
+  };
+})


### PR DESCRIPTION
From the [cy](https://cfoust.github.io/cy/index.html) README.
> cy is an experimental terminal multiplexer that aims to be a simple, modern, and ergonomic alternative to tmux.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
