### PR TITLE
wayshadow: init at 1.0.0

### DIFF
--- a/pkgs/by-name/wa/wayshadow/package.nix
+++ b/pkgs/by-name/wa/wayshadow/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  cairo,
+  fetchFromGitHub,
+  glib,
+  gtk3,
+  libappindicator,
+  libinput,
+  libxkbcommon,
+  nix-update-script,
+  pango,
+  pkg-config,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wayshadow";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "justanoobcoder";
+    repo = "wayshadow";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YNJWirakjJnqp119NQunRuXeQd7JYDghyi8NavtfQGI=";
+  };
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    cairo
+    glib
+    gtk3
+    libappindicator
+    libinput
+    libxkbcommon
+    pango
+    wayland
+    wayland-protocols
+  ];
+
+  makeFlags = [
+    "WAYLAND_PROTOCOLS_DIR=${wayland-protocols}/share/wayland-protocols"
+    "GIT_COMMIT=nix-build"
+  ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    make test
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 755 wayshadow        $out/bin/wayshadow
+    install -D -m 644 man/wayshadow.1  $out/share/man/man1/wayshadow.1
+    install -D -m 644 man/wayshadow.conf.5 $out/share/man/man5/wayshadow.conf.5
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Keystroke visualizer for Wayland compositors";
+    homepage = "https://github.com/justanoobcoder/wayshadow";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ justanoobcoder ];
+    platforms = lib.platforms.linux;
+    mainProgram = "wayshadow";
+  };
+})


### PR DESCRIPTION
WayShadow is a keystroke visualizer for Wayland compositors.
https://github.com/justanoobcoder/wayshadow

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
