### PR TITLE
leaf-markdown-viewer: init at 1.28.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25893,6 +25893,12 @@
     githubId = 11320;
     name = "Sergiu Ivanov";
   };
+  SConaway = {
+    email = "steven.conaway@icloud.com";
+    github = "SConaway";
+    githubId = 20807660;
+    name = "Steven Conaway";
+  };
   scottstephens = {
     email = "stephens.js@gmail.com";
     github = "scottstephens";

--- a/pkgs/by-name/le/leaf-markdown-viewer/package.nix
+++ b/pkgs/by-name/le/leaf-markdown-viewer/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  installShellFiles,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "leaf-markdown-viewer";
+  version = "1.28.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "RivoLink";
+    repo = "leaf";
+    tag = finalAttrs.version;
+    hash = "sha256-xAO52Xhu2QOXzg/TJubTguJ7URddKnQekACnvytx5Qw=";
+  };
+
+  cargoHash = "sha256-Y+sOyHOSEjKW+NEpSjZgqJwXH3IOSFMBGM84oytRNsc=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd leaf $src/completions/leaf.{bash,fish,nu,zsh}
+  '';
+
+  meta = {
+    description = "Terminal Markdown previewer — GUI-like experience";
+    homepage = "https://github.com/RivoLink/leaf";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SConaway ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [`leaf`](https://github.com/RivoLink/leaf) which is a markdown viewer! 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- ~~NixOS Release Notes~~
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy] (none used). 

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
