### PR TITLE
kotonoha: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -215,6 +215,12 @@
     github = "21eleven";
     githubId = 8813855;
   };
+  _27Aaron = {
+    name = "Aaron";
+    email = "niceboy@duck.com";
+    github = "27Aaron";
+    githubId = 85681241;
+  };
   _2gn = {
     name = "Hiram Tanner";
     github = "2gn";

--- a/pkgs/by-name/ko/kotonoha/package.nix
+++ b/pkgs/by-name/ko/kotonoha/package.nix
@@ -69,10 +69,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
       "$out/share/man/man1/kotonoha.1"
   '';
 
-  # Python's wrapper is a shell script, so wrapQtAppsHook does not detect it.
+  # Pass Qt's wrapper arguments to Python's generated launcher directly.
+  # This avoids wrapping the same script a second time.
   dontWrapQtApps = true;
-  postFixup = ''
-    wrapQtApp "$out/bin/kotonoha"
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
   pythonImportsCheck = [

--- a/pkgs/by-name/ko/kotonoha/package.nix
+++ b/pkgs/by-name/ko/kotonoha/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  cmake,
+  desktop-file-utils,
+  fetchFromGitHub,
+  kdePackages,
+  ninja,
+  pkg-config,
+  python3Packages,
+  qt6,
+  wayland,
+  wayland-scanner,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "kotonoha";
+  version = "0.2.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "locez";
+    repo = "kotonoha";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vym24/K7K4vVFzGnNTCasLkZirsqLRuMNe+vtlDglPQ=";
+  };
+
+  build-system = [ python3Packages.scikit-build-core ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    kdePackages.layer-shell-qt
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qtwayland
+    wayland
+  ];
+
+  dependencies = with python3Packages; [
+    aiohttp
+    dbus-fast
+    mutagen
+    pyqt6
+    qasync
+  ];
+
+  # scikit-build-core owns the CMake configure/build lifecycle for the wheel.
+  dontUseCmakeConfigure = true;
+  cmakeFlags = [
+    (lib.cmakeFeature "KOTONOHA_INSTALL_DIR" "kotonoha")
+    (lib.cmakeBool "KOTONOHA_INSTALL_LICENSE" false)
+  ];
+
+  postInstall = ''
+    install -Dm644 packaging/kotonoha.desktop \
+      "$out/share/applications/kotonoha.desktop"
+    install -Dm644 src/kotonoha/assets/icon.png \
+      "$out/share/icons/hicolor/1024x1024/apps/kotonoha.png"
+    install -Dm644 packaging/dev.locez.kotonoha.metainfo.xml \
+      "$out/share/metainfo/dev.locez.kotonoha.metainfo.xml"
+    install -Dm644 packaging/kotonoha.1 \
+      "$out/share/man/man1/kotonoha.1"
+  '';
+
+  # Python's wrapper is a shell script, so wrapQtAppsHook does not detect it.
+  dontWrapQtApps = true;
+  postFixup = ''
+    wrapQtApp "$out/bin/kotonoha"
+  '';
+
+  pythonImportsCheck = [
+    "kotonoha"
+    "kotonoha.platform.native"
+    "PyQt6.QtCore"
+    "PyQt6.QtSvg"
+  ];
+
+  nativeCheckInputs = [ desktop-file-utils ];
+  doCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    test -x "$out/bin/kotonoha"
+    test -f "$out/${python3Packages.python.sitePackages}/kotonoha/libkoto-layer.so"
+    desktop-file-validate "$out/share/applications/kotonoha.desktop"
+    "$out/bin/kotonoha" --help > /dev/null
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Linux desktop lyrics overlay for MPRIS players";
+    homepage = "https://github.com/locez/kotonoha";
+    changelog = "https://github.com/locez/kotonoha/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      lgpl21Plus
+      mit
+    ];
+    maintainers = with lib.maintainers; [ _27Aaron ];
+    mainProgram = "kotonoha";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds Kotonoha 0.2.1, a synchronized lyrics overlay for MPRIS-compatible media players on Linux.

Upstream: https://github.com/locez/kotonoha

Version 0.2.1 includes an upstream fix that keeps the overlay click-through state synchronized with the persisted configuration and tray lock action.

The package builds the Wayland Layer Shell bridge from source and installs the desktop entry, icon, AppStream metadata, and man page.

Testing:
- Built and used successfully on x86_64-linux physical hardware.
- Built and used successfully on an aarch64-linux virtual machine.
- Verified the v0.2.1 source hash and Linux package evaluation.
- Verified Python imports, native bridge installation, desktop entry validation, and `kotonoha --help`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## Automation disclosure

This contribution was assisted by OpenAI Codex (GPT-5) for packaging implementation and review. I manually reviewed the changes and verified the package on x86_64-linux physical hardware and an aarch64-linux virtual machine.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
