### PR TITLE
[Backport release-26.05] borgbackup: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/by-name/bo/borgbackup/package.nix
+++ b/pkgs/by-name/bo/borgbackup/package.nix
@@ -22,14 +22,14 @@ let
 in
 python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "borgbackup";
-  version = "1.4.4";
+  version = "1.4.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "borgbackup";
     repo = "borg";
     tag = finalAttrs.version;
-    hash = "sha256-pMZr9cVr84b948b5Iuevpy6AtMeYo/Ma8uFLuagAYy4=";
+    hash = "sha256-jkFF+nNZL8lEXgworFLNoEKTr2LgCat1fOFlTh7AWs4=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Manual backport of #543360 to `release-26.05`.

1.4.5 is a maintenance release in the same 1.4 series as the 1.4.4 currently on this branch. It carries a security fix for CVE-2026-62268 in `borg extract` (low severity — an attacker would need repository write access, and the key and passphrase if the repository is encrypted), which seems worth having on a stable branch on its own.

It also adds `create --quick-stats`, which records archive statistics while omitting the "All archives" and repository chunk statistics that `--stats` computes. For an automated backup that records a recovery point on every run, that repository-wide scan can be the slowest part of the job, so the option can be the difference between a create that stays inside its time budget and one that doesn't.

The follow-up fix on master (998e7b4, switching to `pytest9_0CheckHook`) is intentionally not included: it was needed because master moved to pytest 9.1, whereas `release-26.05` still ships pytest 9.0.3 — which is what this package expects — so `pytestCheckHook` remains correct here.

The package builds and its test suite passes on `x86_64-linux` against this branch.

Flagging for a maintainer's judgement on whether this clears the release-acceptable bar — happy to close it if not.
