### PR TITLE
conftest: 0.63.0 -> 0.69.0

### DIFF
--- a/pkgs/by-name/co/conftest/package.nix
+++ b/pkgs/by-name/co/conftest/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "conftest";
-  version = "0.63.0";
+  version = "0.69.0";
 
   __darwinAllowLocalNetworking = true; # required for tests
 
@@ -19,14 +19,14 @@ buildGoModule (finalAttrs: {
     owner = "open-policy-agent";
     repo = "conftest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gmfzMup4fdsbdyUufxjcJRPF2faj3RUlvIn2ciyalaQ=";
+    hash = "sha256-kF4kako/88FxV10RZ9zNM7eq/Qlz41tEtnUnTB12KtM=";
   };
-  vendorHash = "sha256-pBUWM6st5FhhOki3n9NIN4/U8JB7Kq3Aph3AtQs+Ogg=";
+  vendorHash = "sha256-vcIY3AZkl/U0l2eyWHZGHrjQyW5TWt9oPDb4BXcNUtY=";
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/open-policy-agent/conftest/internal/commands.version=${finalAttrs.version}"
+    "-X github.com/open-policy-agent/conftest/internal/version.Version=${finalAttrs.version}"
   ];
 
   nativeBuildInputs = [
@@ -56,6 +56,11 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
+
+  versionCheckKeepEnvironment = [ "XDG_DATA_HOME" ];
+  preVersionCheck = ''
+    export XDG_DATA_HOME="$(mktemp -d)"
+  '';
 
   meta = {
     description = "Write tests against structured configuration data";


### PR DESCRIPTION
Bump `conftest` from 0.63.0 to 0.69.0

Updated `ldflags` -X to point where `Version` variable is at Added env `XDG_DATA_HOME` for `versionCheckHook` as upstream's dependency `tzrikka/xdg` uses it

Without the `XDG_DATA_HOME` env variable the `versionCheckPhase` will panic with the following message: 
```
Executing versionCheckPhase                                    
Did not find version 0.69.0 in the output of the command /nix/store/v2v5awzsbn4dywv3kan76iiz1964d2jr-conftest-0.69.0/bin/conftest --version                                                  
panic: path in XDG_DATA_HOME is relative: ".local/share"
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
