### PR TITLE
batman-adv: 2026.2 -> 2026.3

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
       philiptaron
     ];
     platforms = with lib.platforms; linux;
+    broken = lib.versionOlder kernel.version cfg.minKernelVersion;
   };
 }

--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,14 +1,16 @@
 {
-  version = "2026.2";
+  version = "2026.3";
+
+  minKernelVersion = "5.15";
 
   # To get these, run:
   #
   # ```
-  # for tool in alfred batctl batman-adv; do nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2026.2/$tool-2026.2.tar.gz --type sha256 | xargs nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri; done
+  # for tool in alfred batctl batman-adv; do nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2026.3/$tool-2026.3.tar.gz --type sha256 | xargs nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri; done
   # ```
   sha256 = {
-    alfred = "sha256-2ZV0i+X2KkIJFSXMwQLfWsZCGG6bkBRpipVaRGm2m5Y=";
-    batctl = "sha256-wdWAr7Bm0xZcI5tnQwuUxpkyYZwGqQsSlegoy1CBsSI=";
-    batman-adv = "sha256-Thf87SyAlF4iYJvodTRIFzP/G10XBQ3k5PMjwXFBgTU=";
+    alfred = "sha256-H4FQVIGqSIjpcRazdPKVOqQsJdoQYphGciadxZG7BDE=";
+    batctl = "sha256-LIRD+uezRxpQCDf4z7vCt7urYC5DzoxhsQBWDewdnuA=";
+    batman-adv = "sha256-w1JOfY8Uh4agUmVKexCQ45R0bTpx7l1lf5ht168WF2I=";
   };
 }


### PR DESCRIPTION
## Changes

### batman-adv
- support latest kernels (5.15 - 7.3)
- coding style cleanups and refactoring
- reduce memory and runtime overhead by only handling attached interfaces
- optimize throughput meters unacked packets handling
- bugs squashed:
  - clean untagged VLAN on netdev registration failure
  - ensure minimal ethernet header on TX
  - fix VLAN priority offset
  - bla: avoid CRC corruption due to parallel claim add
  - bla: fix freeing of claims on meshif deletion
  - bla: prevent CRC corruptions after claim flush
  - dat: atomically update mac addresses
  - dat: avoid unaligned fault in IP extraction
  - dat: fix tie-break for candidate selection
  - frag: fix primary_if leak on failed linearization
  - frag: fix stale receive device on merged fragments
  - frag: free unfragmentable packet
  - mcast: avoid OOB read of num_dests header
  - mcast: fix TX priority extraction for BATADV_FORW_MCAST
  - mcast: ensure unshared skb for multicast packets
  - mcast: linearize skbuff for packet generation
  - mcast: reject unrepresentable TVLV offsets
  - tt: avoid request storms during pending request
  - tt: prevent TVLV OOB check overflow
  - tvlv: handle negative tvlv processing return codes

### batctl
- coding style cleanups and refactoring
- bugs squashed:
  - bat-hosts: compare full path for deduplication
  - bat-hosts: free bat_host when hash_add fails
  - dat_cache: fix multicast/unicast filter for MAC address
  - debug: avoid endless getopt loop for attached '-w' argument
  - debug: reject non-finite/negative interval/timeout values
  - debug: reject trailing garbage for intervals
  - debug: use strict interval/timeout parsing
  - event: don't print timestamp prefix for skipped events
  - fix parsing of parameters with arguments
  - genl_json: avoid negative chars in sanitize_string
  - genl_json: escape non-printable characters as valid JSON
  - genl_json: reject unknown options in handle_json_query
  - handle netlink callback object on error
  - icmp_helper: attach socket filter before packets can arrive
  - icmp_helper: fail send when the primary mac is unknown
  - icmp_helper: return only initialized icmp destination unreached bytes
  - icmp_helper: return proper errno on syscall failures
  - improve number parsing error handling
  - interface: report rtnl query failures
  - interface: return fail for non-existing interface
  - isolation_mark: fix error message for invalid mark/mask values
  - netlink: abort netlink_print_common when message allocation fails
  - netlink: always 0-terminate hardif name
  - netlink: check for BATADV_ATTR_MESH_ADDRESS before accessing it
  - netlink: detect receive errors in netlink_print_common
  - netlink: detect receive errors in netlink_simple_request
  - netlink: detect receive errors in query_rtnl_link
  - netlink: detect receive errors in query_rtnl_link_single
  - netlink: don't format NULL extra_info in info_callback
  - netlink: free header lines after error
  - netlink: report dump errors signalled in the NLMSG_DONE message
  - netlink: report error on query_rtnl_link send failure
  - netlink: report kernel errors when writing settings
  - netlink: report send errors in netlink_simple_request
  - originators: fix throughput lines with bat_hosts
  - ping/traceroute: don't restart RTT timer on stray replies
  - ping: count sent and not received pings
  - ping: fix rtt minimum tracking when a sample is 0.0
  - ping: keep huge '-i' intervals from turning into a flood ping
  - ping: reject invalid packet count argument
  - ping: reject invalid timeout argument
  - tcpdump: check frame length before reading the ethernet header
  - tcpdump: correct output of VLAN IDs
  - tcpdump: don't label unknown ICMPv6 types as unreachable
  - tcpdump: fix "subtybe" typo in 4ADDR output
  - tcpdump: fix coded packet mac dest mac addresses
  - tcpdump: fix endianness of fragmentation sequence number
  - tcpdump: fix reported length for ICMP6_TIME_EXCEEDED
  - tcpdump: fix source address selection for 802.11 data frames
  - tcpdump: handle TCP packet with bogus data offset
  - tcpdump: print the unreachable host for ICMP port unreachable
  - tcpdump: reject invalid packet type arguments
  - tcpdump: resolve bat-host name for ROAMv1 client
  - tcpdump: return EXIT_SUCCESS on normal termination
  - tcpdump: skip partial line for oversized ICMPv6 errors
  - tpmeter: abort result wait on receive errors
  - tpmeter: don't cancel test from the signal handler
  - tpmeter: fix Gbps output
  - tpmeter: label sub-kByte/s rate in bits per second
  - tpmeter: reject invalid test duration argument
  - traceroute: handle fast replies
  - traceroute: probe the advertised maximum number of hops
  - traceroute: return EXIT_NOSUCCESS when destination not reached
  - translate: don't overwrite the search key
  - version: avoid use of uninitialized read buffer

### alfred
- bugs squashed:
  - seed the random() generator for transaction IDs



Source: https://www.open-mesh.org/news/129

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
