### PR TITLE
dnsperf: 2.14.0 -> 2.16.0

### DIFF
--- a/pkgs/by-name/dn/dnsperf/package.nix
+++ b/pkgs/by-name/dn/dnsperf/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   autoreconfHook,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   fetchpatch,
   ldns,
   libck,
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dnsperf";
-  version = "2.14.0";
+  version = "2.16.0";
 
-  src = fetchFromGitHub {
+  src = fetchFromCodeberg {
     owner = "DNS-OARC";
     repo = "dnsperf";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-eDDVNFMjj+0wEBe1qO6r4Bai554Sp+EmP86reJ/VXGk=";
+    hash = "sha256-4DSIdEj7fqDLaT7ZrLg/bgK/QeCE4puMdWr18h9Tr0A=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
     nghttp2
     openssl
   ];
+
+  strictDeps = true;
 
   patches = lib.optionals stdenv.hostPlatform.isMusl [
     # dnsperf doesn't have support for musl (https://github.com/DNS-OARC/dnsperf/issues/265)


### PR DESCRIPTION
Bump `dnsperf` from 2.14.0 to 2.16.0

Upstream moved to Codeberg, so using `fetchFromCodeberg` now 
Added `strictDeps`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
