### PR TITLE
nixos/flarum: make database submodule to support partial overrides

### DIFF
--- a/nixos/modules/services/web-apps/flarum.nix
+++ b/nixos/modules/services/web-apps/flarum.nix
@@ -13,7 +13,8 @@ let
   # Only placeholders reach the world-readable Nix store; the install
   # script substitutes the real secrets at runtime.
   dbConfig =
-    cfg.database
+    # `engine` is MySQL-only; omit for other drivers
+    (if cfg.database.driver == "mysql" then cfg.database else removeAttrs cfg.database [ "engine" ])
     // optionalAttrs (cfg.databasePasswordFile != null) {
       password = "@databasePassword@";
     };
@@ -138,36 +139,84 @@ in
     };
 
     database = mkOption {
-      type =
-        with types;
-        attrsOf (oneOf [
-          str
-          bool
-          int
-        ]);
+      type = types.submodule {
+        freeformType =
+          with types;
+          attrsOf (oneOf [
+            str
+            bool
+            int
+          ]);
+        options = {
+          driver = mkOption {
+            type = types.str;
+            default = "mysql";
+            description = "Database driver; i.e. MySQL, MariaDB...";
+          };
+          host = mkOption {
+            type = types.str;
+            default = "localhost";
+            description = "Database server hostname.";
+          };
+          port = mkOption {
+            type = types.port;
+            default = 3306;
+            description = "Database connection port; defaults to 3306 with MySQL.";
+          };
+          database = mkOption {
+            type = types.str;
+            default = "flarum";
+            description = "Database name.";
+          };
+          username = mkOption {
+            type = types.str;
+            default = "flarum";
+            description = "Username for database server access.";
+          };
+          password = mkOption {
+            type = types.str;
+            default = "";
+            description = "Password for database server access.";
+          };
+          charset = mkOption {
+            type = types.str;
+            default = "utf8mb4";
+            description = "Character encoding for the database.";
+          };
+          collation = mkOption {
+            type = types.str;
+            default = "utf8mb4_unicode_ci";
+            description = "Character collation for database sorting and comparison.";
+          };
+          prefix = mkOption {
+            type = types.str;
+            default = "";
+            description = "Table prefix; useful for sharing a database with other services.";
+          };
+          strict = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable strict SQL mode.";
+          };
+          engine = mkOption {
+            type = types.str;
+            default = "InnoDB";
+            description = "Storage engine for new tables; MySQL-only.";
+          };
+          prefix_indexes = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Apply table prefix to database index names.";
+          };
+        };
+      };
+      default = { };
       description = ''
         MySQL database parameters.
 
         WARNING: A `password` set here is stored world-readable in the
         Nix store. Use {option}`databasePasswordFile` instead.
       '';
-      default = {
-        # the database driver; i.e. MySQL; MariaDB...
-        driver = "mysql";
-        # the host of the connection; localhost in most cases unless using an external service
-        host = "localhost";
-        # the name of the database in the instance
-        database = "flarum";
-        # database username
-        username = "flarum";
-        # database password
-        password = "";
-        # the prefix for the tables; useful if you are sharing the same database with another service
-        prefix = "";
-        # the port of the connection; defaults to 3306 with MySQL
-        port = 3306;
-        strict = false;
-      };
     };
 
     databasePasswordFile = mkOption {
@@ -291,8 +340,13 @@ in
       before = [ "phpfpm-flarum.service" ];
       requires = [ "mysql.service" ];
       after = [ "mysql.service" ];
+      restartTriggers = [
+        cfg.package
+        configPhpFile
+      ];
       serviceConfig = {
         Type = "oneshot";
+        RemainAfterExit = true;
         User = cfg.user;
         Group = cfg.group;
         # The secret-filled install config is staged in /tmp


### PR DESCRIPTION
Make database a declarative submodule with explicit options so partial overrides preserve other settings, and add engine attribute handling with service restart triggers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
