### PR TITLE
glean: fix package metadata and maintainer entry

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24871,6 +24871,12 @@
     githubId = 129837916;
     name = "Rohith S";
   };
+  rokuroo171 = {
+    email = "mrakkakhairilazwar@gmail.com";
+    github = "rokuroo171";
+    githubId = 238833795;
+    name = "Rakka";
+  };
   rolfschr = {
     email = "rolf.schr@posteo.de";
     github = "rolfschr";

--- a/pkgs/by-name/gl/glean/package.nix
+++ b/pkgs/by-name/gl/glean/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  npmHooks,
+  nodejs,
+  fetchNpmDeps,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "glean";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "rokuroo171";
+    repo = "glean";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-frdwT4wodBHOAChOxXhzLwDNOON03YtWBy19wWtZZTQ=";
+  };
+
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-0wokAwAd41GL/KK339fnmjQa8/mEeySg8J2Pcn+lmP8=";
+
+  npmDeps = fetchNpmDeps {
+    name = "glean-frontend-deps";
+    src = "${finalAttrs.src}/frontend";
+    hash = "sha256-MOEW3oPuZuQq/xR6fnNs0/yKtbFsH6d56aY8OGJ0ZuE=";
+  };
+
+  npmRoot = "frontend";
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+  ];
+
+  preBuild = ''
+    cd frontend
+    npm run build
+    cd ..
+  '';
+
+  meta = {
+    description = "Open-source note-taking app with lots of customization";
+    homepage = "https://github.com/rokuroo171/glean";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "glean";
+    maintainers = with lib.maintainers; [ rokuroo171 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
**glean: init at 1.5.0**

Adds [glean](https://github.com/rokuroo171/glean), an open-source note-taking app built with Go (Wails) and a Vite/JS frontend.

Built from source using `buildGoModule` with `npmHooks` for the frontend assets.

- [x] Built on platform(s): x86_64-linux
- [x] Tested execution of all binary files