### PR TITLE
sing-box-for-desktop: init at 1.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27063,6 +27063,11 @@
     github = "snapdgn";
     githubId = 85608760;
   };
+  snemeow = {
+    github = "SugarNekoE";
+    githubId = 25338540;
+    name = "Asai Neko";
+  };
   snglth = {
     email = "illia@ishestakov.com";
     github = "snglth";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,10 @@
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).
 
+- [sing-box for desktop](https://github.com/SagerNet/sing-box-for-desktop), a
+  graphical client for the sing-box universal proxy platform, is available
+  through [programs.sing-box-for-desktop](#opt-programs.sing-box-for-desktop.enable).
+
 - [btrfs-heatmap](https://github.com/knorrie/btrfs-heatmap), setcap wrapper for `btrfs-heatmap` package, a visualizer of how a btrfs filesystem is using the underlying disk space of the block devices. Available as [programs.btrfs-heatmap](#opt-programs.btrfs-heatmap.enable)
 
 - [compsize](https://github.com/kilobyte/compsize), setcap wrapper for `compsize` package, a cli utility to to inspect compression type/ratio on BTRFS filesystems. Available as [programs.compsize](#opt-programs.compsize.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -325,6 +325,7 @@
   ./programs/sedutil.nix
   ./programs/shadow.nix
   ./programs/sharing.nix
+  ./programs/sing-box-for-desktop.nix
   ./programs/singularity.nix
   ./programs/skim.nix
   ./programs/slock.nix

--- a/nixos/modules/programs/sing-box-for-desktop.nix
+++ b/nixos/modules/programs/sing-box-for-desktop.nix
@@ -1,0 +1,347 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.sing-box-for-desktop;
+
+  nullableBool = lib.types.nullOr lib.types.bool;
+  nullableString = lib.types.nullOr lib.types.str;
+  nullablePositiveInt = lib.types.nullOr lib.types.ints.positive;
+
+  profileType = lib.types.submodule {
+    options = {
+      name = lib.mkOption {
+        type = lib.types.strMatching ".+";
+        description = "Profile display name and stable declarative identifier.";
+      };
+
+      configurationPath = lib.mkOption {
+        type = lib.types.strMatching "/.+";
+        description = ''
+          Absolute runtime path to a sing-box JSON configuration. Only the path
+          is stored in the Nix store; the desktop process reads the file when it
+          starts. Use a plain string such as /run/secrets/sing-box.json rather
+          than a Nix path literal, which would copy the file into the Nix store.
+        '';
+      };
+    };
+  };
+
+  configuredProfiles = if cfg.profiles == null then [ ] else cfg.profiles;
+  profileNames = map (profile: profile.name) configuredProfiles;
+  profileId = name: builtins.hashString "sha256" name;
+
+  managedPreferences = lib.filterAttrs (_: value: value != null) {
+    tray_enabled = cfg.settings.tray.enable;
+    tray_in_background = cfg.settings.tray.keepInBackground;
+    language = if cfg.settings.language == "auto" then null else cfg.settings.language;
+    theme = cfg.settings.appearance;
+    accent = if cfg.settings.theme == "default" then null else cfg.settings.theme;
+    disable-deprecated-warnings = cfg.settings.core.disableDeprecatedWarnings;
+  };
+
+  managedPreferenceRemovals =
+    lib.optionals (cfg.settings.language == "auto") [ "language" ]
+    ++ lib.optionals (cfg.settings.theme == "default") [ "accent" ];
+
+  managedTerminalConfiguration = lib.filterAttrs (_: value: value != null) {
+    symbolBarAlwaysShow = cfg.settings.terminal.alwaysShowSymbolBar;
+    lightThemeName = cfg.settings.terminal.lightTheme;
+    darkThemeName = cfg.settings.terminal.darkTheme;
+    lightThemeCustom =
+      if cfg.settings.terminal.lightCustomTheme == null then
+        null
+      else
+        builtins.toJSON cfg.settings.terminal.lightCustomTheme;
+    darkThemeCustom =
+      if cfg.settings.terminal.darkCustomTheme == null then
+        null
+      else
+        builtins.toJSON cfg.settings.terminal.darkCustomTheme;
+    fontFamily = cfg.settings.terminal.fontFamily;
+    fontSize = cfg.settings.terminal.fontSize;
+  };
+
+  managedConfiguration = {
+    version = 1;
+    preferences = managedPreferences;
+    removePreferences = managedPreferenceRemovals;
+    terminal = managedTerminalConfiguration;
+  }
+  // lib.optionalAttrs (cfg.settings.startAtLogin != null) {
+    openAtLogin = cfg.settings.startAtLogin;
+  }
+  // lib.optionalAttrs (cfg.profiles != null) {
+    profiles = map (profile: {
+      id = profileId profile.name;
+      inherit (profile) name configurationPath;
+    }) configuredProfiles;
+  }
+  // lib.optionalAttrs (cfg.defaultProfile != null) {
+    selectedProfileId = profileId cfg.defaultProfile;
+  };
+
+  managedConfigurationFile = pkgs.writeText "sing-box-managed-configuration.json" (
+    builtins.toJSON managedConfiguration
+  );
+  managedOpenAtLogin =
+    if cfg.settings.startAtLogin == null then
+      ""
+    else if cfg.settings.startAtLogin then
+      "true"
+    else
+      "false";
+
+  configuredPackage = pkgs.symlinkJoin {
+    name = "sing-box-for-desktop-configured";
+    paths = [ cfg.package ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram "$out/bin/sing-box" \
+        --set SING_BOX_LAUNCHER "$out/bin/sing-box" \
+        --set SING_BOX_MANAGED_OPEN_AT_LOGIN "${managedOpenAtLogin}" \
+        --set SING_BOX_MANAGED_CONFIGURATION "${managedConfigurationFile}"
+    '';
+    inherit (cfg.package) meta;
+  };
+
+  daemon = "${cfg.package}/share/sing-box-for-desktop/resources/daemon/sing-box-daemon";
+  runtimeDirectory = "sing-box-daemon";
+  workingDirectory = "/var/lib/sing-box-daemon";
+  socketPath = "/run/${runtimeDirectory}/sing-box.socket";
+in
+{
+  meta.maintainers = with lib.maintainers; [ snemeow ];
+
+  options.programs.sing-box-for-desktop = {
+    enable = lib.mkEnableOption "the sing-box Linux desktop client and its system daemon";
+
+    package = lib.mkPackageOption pkgs "sing-box-for-desktop" { };
+
+    settings = {
+      startAtLogin = lib.mkOption {
+        type = nullableBool;
+        default = null;
+        description = ''
+          Whether to start sing-box-for-desktop when a graphical session
+          starts. Null leaves the application's per-user setting unmanaged.
+        '';
+      };
+
+      tray = {
+        enable = lib.mkOption {
+          type = nullableBool;
+          default = null;
+          description = "Whether to enable the desktop tray icon. Null leaves it unmanaged.";
+        };
+
+        keepInBackground = lib.mkOption {
+          type = nullableBool;
+          default = null;
+          description = ''
+            Whether closing the final window keeps the tray process running.
+            Null leaves the application setting unmanaged.
+          '';
+        };
+      };
+
+      language = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "auto"
+            "en"
+            "zh-Hans"
+            "zh-Hant"
+            "fa"
+            "ru"
+          ]
+        );
+        default = null;
+        description = "Desktop language. Null leaves it unmanaged; auto follows the session locale.";
+      };
+
+      appearance = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "auto"
+            "light"
+            "dark"
+          ]
+        );
+        default = null;
+        description = "Light/dark appearance. Null leaves it unmanaged.";
+      };
+
+      theme = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.strMatching "(default|blue|purple|pink|red|orange|yellow|green|graphite|#[0-9a-f]{6})"
+        );
+        default = null;
+        description = "Accent theme preset or lowercase #rrggbb color. Null leaves it unmanaged.";
+      };
+
+      terminal = {
+        lightTheme = lib.mkOption {
+          type = nullableString;
+          default = null;
+          description = "Light terminal theme name; an empty string selects the custom theme.";
+        };
+
+        darkTheme = lib.mkOption {
+          type = nullableString;
+          default = null;
+          description = "Dark terminal theme name; an empty string selects the custom theme.";
+        };
+
+        lightCustomTheme = lib.mkOption {
+          type = lib.types.nullOr lib.types.attrs;
+          default = null;
+          description = "Custom light xterm.js theme encoded as JSON. Null leaves it unmanaged.";
+        };
+
+        darkCustomTheme = lib.mkOption {
+          type = lib.types.nullOr lib.types.attrs;
+          default = null;
+          description = "Custom dark xterm.js theme encoded as JSON. Null leaves it unmanaged.";
+        };
+
+        fontFamily = lib.mkOption {
+          type = nullableString;
+          default = null;
+          description = "Terminal font family. Null leaves it unmanaged.";
+        };
+
+        fontSize = lib.mkOption {
+          type = nullablePositiveInt;
+          default = null;
+          description = "Terminal font size in pixels. Null leaves it unmanaged.";
+        };
+
+        alwaysShowSymbolBar = lib.mkOption {
+          type = nullableBool;
+          default = null;
+          description = "Whether to always show the terminal symbol bar. Null leaves it unmanaged.";
+        };
+      };
+
+      core = {
+        insecureMode = lib.mkOption {
+          type = nullableBool;
+          default = null;
+          description = ''
+            Whether the privileged daemon permits configurations to use
+            privileges unrelated to networking. Null preserves the runtime
+            setting; a boolean reapplies the value whenever the service starts.
+          '';
+        };
+
+        disableDeprecatedWarnings = lib.mkOption {
+          type = nullableBool;
+          default = null;
+          description = "Whether to suppress deprecated-feature warnings. Null leaves it unmanaged.";
+        };
+      };
+    };
+
+    profiles = lib.mkOption {
+      type = lib.types.nullOr (lib.types.listOf profileType);
+      default = null;
+      description = ''
+        Ordered declarative profile list. Null preserves all user-managed
+        profiles; a list replaces them on every application launch. Each
+        profile configuration is read from its runtime configurationPath.
+      '';
+    };
+
+    defaultProfile = lib.mkOption {
+      type = nullableString;
+      default = null;
+      description = ''
+        Name of the declarative profile selected on every application launch.
+        Requires programs.sing-box-for-desktop.profiles to be set.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.length profileNames == lib.length (lib.unique profileNames);
+        message = "sing-box-for-desktop declarative profile names must be unique";
+      }
+      {
+        assertion = cfg.defaultProfile == null || cfg.profiles != null;
+        message = "sing-box-for-desktop.defaultProfile requires declarative profiles";
+      }
+      {
+        assertion = cfg.defaultProfile == null || lib.elem cfg.defaultProfile profileNames;
+        message = "sing-box-for-desktop.defaultProfile must name a declarative profile";
+      }
+    ];
+
+    environment.systemPackages = [ configuredPackage ];
+
+    environment.etc."polkit-1/actions/io.nekohasekai.sfl.policy".source =
+      "${cfg.package}/share/polkit-1/actions/io.nekohasekai.sfl.policy";
+
+    environment.etc."xdg/autostart/sing-box.desktop" = lib.mkIf (cfg.settings.startAtLogin == true) {
+      text = ''
+        [Desktop Entry]
+        Type=Application
+        Version=1.0
+        Name=sing-box
+        Exec=${configuredPackage}/bin/sing-box --start-at-login
+        Icon=sing-box
+        Terminal=false
+        StartupNotify=false
+        X-GNOME-Autostart-enabled=true
+      '';
+    };
+
+    security.polkit = {
+      enable = true;
+      enablePkexecWrapper = lib.mkDefault true;
+    };
+
+    systemd.services.sing-box-daemon = {
+      description = "sing-box desktop service";
+      documentation = [ "https://github.com/SagerNet/sing-box-for-desktop" ];
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+        "dbus.service"
+        "polkit.service"
+      ];
+      path = [
+        pkgs.systemd
+        pkgs.xdg-utils
+      ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${daemon} run --working-directory ${workingDirectory} --socket ${socketPath}";
+        RuntimeDirectory = runtimeDirectory;
+        RuntimeDirectoryMode = "0755";
+        StateDirectory = "sing-box-daemon";
+        StateDirectoryMode = "0700";
+        UMask = "0077";
+        Restart = "always";
+        RestartSec = 5;
+        LimitNOFILE = 1048576;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+      }
+      // lib.optionalAttrs (cfg.settings.core.insecureMode != null) {
+        ExecStartPre = "${daemon} service --working-directory ${workingDirectory} set-insecure-mode ${
+          if cfg.settings.core.insecureMode then "true" else "false"
+        }";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1624,6 +1624,7 @@ in
   simple-container = runTest ./simple-container.nix;
   simple-vm = runTest ./simple-vm.nix;
   sing-box = runTest ./sing-box.nix;
+  sing-box-for-desktop = runTest ./sing-box-for-desktop.nix;
   sks = runTest ./sks.nix;
   slimserver = runTest ./slimserver.nix;
   slipshow = runTest ./slipshow.nix;

--- a/nixos/tests/sing-box-for-desktop.nix
+++ b/nixos/tests/sing-box-for-desktop.nix
@@ -1,0 +1,60 @@
+{ lib, ... }:
+
+{
+  name = "sing-box-for-desktop";
+
+  meta.maintainers = with lib.maintainers; [ snemeow ];
+
+  nodes.machine = {
+    programs.sing-box-for-desktop = {
+      enable = true;
+
+      settings = {
+        startAtLogin = true;
+        tray = {
+          enable = false;
+          keepInBackground = false;
+        };
+        language = "zh-Hans";
+        appearance = "dark";
+        theme = "#112233";
+        terminal = {
+          lightTheme = "";
+          darkTheme = "Afterglow";
+          lightCustomTheme = {
+            background = "#ffffff";
+            foreground = "#111111";
+          };
+          darkCustomTheme = {
+            background = "#111111";
+            foreground = "#eeeeee";
+          };
+          fontFamily = "Iosevka";
+          fontSize = 15;
+          alwaysShowSymbolBar = true;
+        };
+        core.disableDeprecatedWarnings = true;
+      };
+
+      profiles = [
+        {
+          name = "Default";
+          configurationPath = "/run/secrets/sing-box.json";
+        }
+      ];
+      defaultProfile = "Default";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("sing-box-daemon.service")
+    machine.succeed("test -S /run/sing-box-daemon/sing-box.socket")
+    machine.succeed("test -e /etc/polkit-1/actions/io.nekohasekai.sfl.policy")
+    machine.succeed("grep -F -- '--start-at-login' /etc/xdg/autostart/sing-box.desktop")
+
+    wrapper = machine.succeed("readlink -f $(command -v sing-box)").strip()
+    machine.succeed(f"grep -F SING_BOX_MANAGED_CONFIGURATION {wrapper}")
+    machine.succeed(f"grep -F \"SING_BOX_MANAGED_OPEN_AT_LOGIN='true'\" {wrapper}")
+  '';
+}

--- a/pkgs/by-name/si/sing-box-for-desktop/cronet-go.patch
+++ b/pkgs/by-name/si/sing-box-for-desktop/cronet-go.patch
@@ -1,0 +1,27 @@
+--- a/internal/cronet/loader_unix.go
++++ b/internal/cronet/loader_unix.go
+@@ -68,10 +68,11 @@
+ 	}
+ 
+ 	var searchPaths []string
+-	executablePath, err := os.Executable()
+-	if err == nil {
+-		searchPaths = append(searchPaths, filepath.Dir(executablePath))
+-	}
++	// executablePath, err := os.Executable()
++	// if err == nil {
++	// 	searchPaths = append(searchPaths, filepath.Dir(executablePath))
++	// }
++	searchPaths = append(searchPaths, "@out@/lib")
+ 
+ 	if ldPath := os.Getenv("LD_LIBRARY_PATH"); ldPath != "" {
+ 		paths := filepath.SplitList(ldPath)
+@@ -85,7 +86,7 @@
+ 		}
+ 	}
+ 
+-	searchPaths = append(searchPaths, "/usr/local/lib", "/usr/lib")
++	// searchPaths = append(searchPaths, "/usr/local/lib", "/usr/lib")
+ 
+ 	for _, searchPath := range searchPaths {
+ 		fullPath := filepath.Join(searchPath, libName)

--- a/pkgs/by-name/si/sing-box-for-desktop/managedConfiguration.ts
+++ b/pkgs/by-name/si/sing-box-for-desktop/managedConfiguration.ts
@@ -1,0 +1,234 @@
+import { app } from "electron";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+import {
+  preferenceSnapshot,
+  removePreference,
+  setPreference,
+  settingsDatabase,
+} from "./database";
+import { setOpenAtLogin } from "./loginItem";
+
+interface ManagedProfile {
+  id: string;
+  name: string;
+  configurationPath: string;
+}
+
+interface ManagedConfiguration {
+  version: 1;
+  openAtLogin?: boolean;
+  preferences: Record<string, unknown>;
+  removePreferences: string[];
+  terminal: Record<string, unknown>;
+  profiles?: ManagedProfile[];
+  selectedProfileId?: string;
+}
+
+const MANAGED_CONFIGURATION_ENVIRONMENT = "SING_BOX_MANAGED_CONFIGURATION";
+const PROFILE_ID_PATTERN = /^[0-9a-f]{64}$/;
+const TERMINAL_DEFAULTS = {
+  symbolBarAlwaysShow: false,
+  lightThemeName: "Alabaster",
+  darkThemeName: "Afterglow",
+  lightThemeCustom: "",
+  darkThemeCustom: "",
+  fontFamily: "",
+  fontSize: 13,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseManagedProfile(value: unknown): ManagedProfile {
+  if (!isRecord(value)) {
+    throw new Error("managed profile must be an object");
+  }
+  if (typeof value.id !== "string" || !PROFILE_ID_PATTERN.test(value.id)) {
+    throw new Error("managed profile has an invalid identifier");
+  }
+  if (typeof value.name !== "string" || value.name === "") {
+    throw new Error("managed profile has an invalid name");
+  }
+  if (typeof value.configurationPath !== "string" || !isAbsolute(value.configurationPath)) {
+    throw new Error(`managed profile ${value.name} has an invalid configuration path`);
+  }
+  return {
+    id: value.id,
+    name: value.name,
+    configurationPath: value.configurationPath,
+  };
+}
+
+function loadManagedConfiguration(): ManagedConfiguration | null {
+  const path = process.env[MANAGED_CONFIGURATION_ENVIRONMENT];
+  if (!path) {
+    return null;
+  }
+  const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+  if (!isRecord(value) || value.version !== 1) {
+    throw new Error("unsupported managed configuration");
+  }
+  if (!isRecord(value.preferences) || !isRecord(value.terminal)) {
+    throw new Error("managed preferences must be objects");
+  }
+  const removePreferences = value.removePreferences ?? [];
+  if (
+    !Array.isArray(removePreferences) ||
+    !removePreferences.every(
+      (name) => typeof name === "string" && name !== "" && name.length <= 128,
+    ) ||
+    new Set(removePreferences).size !== removePreferences.length
+  ) {
+    throw new Error("managed preference removals must be unique preference names");
+  }
+  if (value.openAtLogin !== undefined && typeof value.openAtLogin !== "boolean") {
+    throw new Error("managed start-at-login setting must be boolean");
+  }
+  let profiles: ManagedProfile[] | undefined;
+  if (value.profiles !== undefined) {
+    if (!Array.isArray(value.profiles)) {
+      throw new Error("managed profiles must be an array");
+    }
+    profiles = value.profiles.map(parseManagedProfile);
+    if (new Set(profiles.map((profile) => profile.id)).size !== profiles.length) {
+      throw new Error("managed profile identifiers must be unique");
+    }
+  }
+  if (
+    value.selectedProfileId !== undefined &&
+    (typeof value.selectedProfileId !== "string" ||
+      !PROFILE_ID_PATTERN.test(value.selectedProfileId))
+  ) {
+    throw new Error("managed default profile has an invalid identifier");
+  }
+  if (
+    value.selectedProfileId !== undefined &&
+    !profiles?.some((profile) => profile.id === value.selectedProfileId)
+  ) {
+    throw new Error("managed default profile is not present in the profile list");
+  }
+  return {
+    version: 1,
+    openAtLogin: value.openAtLogin,
+    preferences: value.preferences,
+    removePreferences,
+    terminal: value.terminal,
+    profiles,
+    selectedProfileId: value.selectedProfileId,
+  };
+}
+
+function applyManagedPreferences(configuration: ManagedConfiguration): void {
+  for (const name of configuration.removePreferences) {
+    removePreference(name);
+  }
+  for (const [name, value] of Object.entries(configuration.preferences)) {
+    setPreference(name, value);
+  }
+  if (Object.keys(configuration.terminal).length > 0) {
+    const stored = preferenceSnapshot(["terminal-config"])["terminal-config"];
+    setPreference("terminal-config", {
+      ...TERMINAL_DEFAULTS,
+      ...(isRecord(stored) ? stored : {}),
+      ...configuration.terminal,
+    });
+  }
+  if (configuration.openAtLogin !== undefined) {
+    setOpenAtLogin(configuration.openAtLogin);
+  }
+}
+
+function profilesDirectory(): string {
+  return join(app.getPath("userData"), "profiles");
+}
+
+function writeProfile(profile: ManagedProfile): void {
+  const directory = profilesDirectory();
+  mkdirSync(directory, { recursive: true });
+  const path = join(directory, `${profile.id}.json`);
+  const temporaryPath = `${path}.${crypto.randomUUID()}.tmp`;
+  const configuration: unknown = JSON.parse(readFileSync(profile.configurationPath, "utf8"));
+  if (!isRecord(configuration)) {
+    throw new Error(`managed profile ${profile.name} configuration must be a JSON object`);
+  }
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(configuration, null, 2)}\n`, {
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, path);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
+function removeUnmanagedProfileFiles(profileIds: Set<string>): void {
+  const directory = profilesDirectory();
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+    const id = entry.name.slice(0, -".json".length);
+    if (!profileIds.has(id)) {
+      rmSync(join(directory, entry.name), { force: true });
+    }
+  }
+}
+
+function applyManagedProfiles(configuration: ManagedConfiguration): void {
+  if (configuration.profiles === undefined) {
+    return;
+  }
+  const profiles = configuration.profiles;
+  const profileIds = new Set(profiles.map((profile) => profile.id));
+  mkdirSync(profilesDirectory(), { recursive: true });
+  const storedSelectedProfile = preferenceSnapshot(["selected_profile_id"])[
+    "selected_profile_id"
+  ];
+  const selectedProfileId =
+    configuration.selectedProfileId ??
+    (typeof storedSelectedProfile === "string" && profileIds.has(storedSelectedProfile)
+      ? storedSelectedProfile
+      : (profiles[0]?.id ?? null));
+
+  for (const profile of profiles) {
+    writeProfile(profile);
+  }
+
+  const store = settingsDatabase();
+  store.transaction(() => {
+    store.prepare("DELETE FROM profiles").run();
+    const insert = store.prepare(
+      `INSERT INTO profiles (id, name, type, remote_url, auto_update,
+       auto_update_interval_minutes, last_updated, item_order)
+       VALUES (?, ?, 'local', NULL, 0, 60, NULL, ?)`,
+    );
+    for (const [index, profile] of profiles.entries()) {
+      insert.run(profile.id, profile.name, index);
+    }
+    if (selectedProfileId === null) {
+      removePreference("selected_profile_id");
+    } else {
+      setPreference("selected_profile_id", selectedProfileId);
+    }
+  })();
+  removeUnmanagedProfileFiles(profileIds);
+}
+
+export function applyManagedConfiguration(): void {
+  const configuration = loadManagedConfiguration();
+  if (configuration === null) {
+    return;
+  }
+  applyManagedPreferences(configuration);
+  applyManagedProfiles(configuration);
+}

--- a/pkgs/by-name/si/sing-box-for-desktop/nix-login-item-launcher.patch
+++ b/pkgs/by-name/si/sing-box-for-desktop/nix-login-item-launcher.patch
@@ -1,0 +1,39 @@
+diff --git a/src/main/loginItem.ts b/src/main/loginItem.ts
+--- a/src/main/loginItem.ts
++++ b/src/main/loginItem.ts
+@@ -16,6 +16,13 @@ function linuxLoginItemPath(): string {
+   return join(configHome, "autostart", LINUX_LOGIN_ITEM_NAME);
+ }
+ 
++function linuxLoginItemExecutable(): string {
++  const nixLauncher = process.env.SING_BOX_LAUNCHER;
++  return nixLauncher && isAbsolute(nixLauncher)
++    ? nixLauncher
++    : app.getPath("exe");
++}
++
+ function linuxLoginItemEnabled(): boolean {
+   const loginItemPath = linuxLoginItemPath();
+   if (!existsSync(loginItemPath)) {
+@@ -48,7 +55,7 @@ function setLinuxOpenAtLogin(value: boolean) {
+       "Type=Application",
+       "Version=1.0",
+       "Name=sing-box",
+-      `Exec=${escapeDesktopExecArgument(app.getPath("exe"))} ${LOGIN_ITEM_ARGUMENT}`,
++      `Exec=${escapeDesktopExecArgument(linuxLoginItemExecutable())} ${LOGIN_ITEM_ARGUMENT}`,
+       "Icon=sing-box",
+       "Terminal=false",
+       "StartupNotify=false",
+@@ -85,6 +92,12 @@ export function setOpenAtLogin(value: boolean) {
+ }
+ 
+ export function migrateLoginItem() {
++  if (process.platform === "linux") {
++    if (linuxLoginItemEnabled()) {
++      setLinuxOpenAtLogin(true);
++    }
++    return;
++  }
+   if (process.platform !== "win32") {
+     return;
+   }

--- a/pkgs/by-name/si/sing-box-for-desktop/nix-managed-configuration.patch
+++ b/pkgs/by-name/si/sing-box-for-desktop/nix-managed-configuration.patch
@@ -1,0 +1,72 @@
+diff --git a/src/main/index.ts b/src/main/index.ts
+--- a/src/main/index.ts
++++ b/src/main/index.ts
+@@ -30,6 +30,7 @@ import { settingsDatabase } from "./database";
+ import { developmentRendererURL, developmentSwitchValue } from "./development";
+ import { applyDisplayScaleFactor } from "./displayScale";
+ import { hasLoginItemArgument, migrateLoginItem, wasOpenedAtLogin } from "./loginItem";
++import { applyManagedConfiguration } from "./managedConfiguration";
+ import { registerNotifications } from "./notifications";
+ import { registerPreferences } from "./preferences";
+ import { registerOpenConnectBrowser } from "./openConnectBrowser";
+@@ -459,6 +460,7 @@ if (!singleInstanceLock) {
+       callback(permission === "clipboard-sanitized-write");
+     });
+     settingsDatabase();
++    applyManagedConfiguration();
+     archiveNativeCrashDumps();
+     terminalWindows = registerTerminalWindows(maybeQuitAfterWindowClosed);
+     profileEditorWindows = registerProfileEditorWindows(maybeQuitAfterWindowClosed);
+diff --git a/src/main/loginItem.ts b/src/main/loginItem.ts
+--- a/src/main/loginItem.ts
++++ b/src/main/loginItem.ts
+@@ -6,6 +6,7 @@
+ export const LOGIN_ITEM_ARGUMENT = "--start-at-login";
+ 
+ const LINUX_LOGIN_ITEM_NAME = "sing-box.desktop";
++const MANAGED_OPEN_AT_LOGIN_ENVIRONMENT = "SING_BOX_MANAGED_OPEN_AT_LOGIN";
+ 
+ function linuxLoginItemPath(): string {
+   const environmentConfigHome = process.env.XDG_CONFIG_HOME;
+@@ -23,6 +24,17 @@
+     : app.getPath("exe");
+ }
+ 
++function managedOpenAtLogin(): boolean | null {
++  const value = process.env[MANAGED_OPEN_AT_LOGIN_ENVIRONMENT];
++  if (value === "true") {
++    return true;
++  }
++  if (value === "false") {
++    return false;
++  }
++  return null;
++}
++
+ function linuxLoginItemEnabled(): boolean {
+   const loginItemPath = linuxLoginItemPath();
+   if (!existsSync(loginItemPath)) {
+@@ -74,6 +86,10 @@
+ }
+ 
+ export function openAtLogin(): boolean {
++  const managed = managedOpenAtLogin();
++  if (managed !== null) {
++    return managed;
++  }
+   if (process.platform === "linux") {
+     return linuxLoginItemEnabled();
+   }
+@@ -81,6 +97,12 @@
+ }
+ 
+ export function setOpenAtLogin(value: boolean) {
++  if (managedOpenAtLogin() !== null) {
++    if (process.platform === "linux") {
++      rmSync(linuxLoginItemPath(), { force: true });
++    }
++    return;
++  }
+   if (process.platform === "linux") {
+     setLinuxOpenAtLogin(value);
+     return;

--- a/pkgs/by-name/si/sing-box-for-desktop/nix-resources-path.patch
+++ b/pkgs/by-name/si/sing-box-for-desktop/nix-resources-path.patch
@@ -1,0 +1,37 @@
+diff --git a/src/main/repair.ts b/src/main/repair.ts
+index c6b924a..9d4fa6f 100644
+--- a/src/main/repair.ts
++++ b/src/main/repair.ts
+@@ -1,6 +1,6 @@
+ import { app, ipcMain } from "electron";
+ import { execFile } from "node:child_process";
+-import { join } from "node:path";
++import { dirname, join } from "node:path";
+ 
+ import { SETUP_CALL } from "../shared/ipc";
+ import type { ProfilesResult } from "../shared/ipc";
+@@ -15,7 +15,7 @@ export function daemonBinaryPath(): string {
+   const binaryName =
+     process.platform === "win32" ? "sing-box-daemon.exe" : "sing-box-daemon";
+   if (app.isPackaged) {
+-    return join(process.resourcesPath, "daemon", binaryName);
++    return join(dirname(app.getAppPath()), "daemon", binaryName);
+   }
+   return join(app.getAppPath(), "bin", binaryName);
+ }
+diff --git a/src/main/resources.ts b/src/main/resources.ts
+index 9c2198f..d18a5e4 100644
+--- a/src/main/resources.ts
++++ b/src/main/resources.ts
+@@ -1,9 +1,9 @@
+ import { app } from "electron";
+-import { join } from "node:path";
++import { dirname, join } from "node:path";
+ 
+ export function resourcePath(...segments: string[]): string {
+   if (app.isPackaged) {
+-    return join(process.resourcesPath, ...segments);
++    return join(dirname(app.getAppPath()), ...segments);
+   }
+   return join(app.getAppPath(), "resources", ...segments);
+ }

--- a/pkgs/by-name/si/sing-box-for-desktop/nix-runtime-directory.patch
+++ b/pkgs/by-name/si/sing-box-for-desktop/nix-runtime-directory.patch
@@ -1,0 +1,27 @@
+diff --git a/build/sing-box-daemon.service b/build/sing-box-daemon.service
+--- a/build/sing-box-daemon.service
++++ b/build/sing-box-daemon.service
+@@ -7,8 +7,10 @@ Type=simple
+ Type=simple
+ StateDirectory=sing-box-daemon
+ StateDirectoryMode=0700
++RuntimeDirectory=sing-box-daemon
++RuntimeDirectoryMode=0755
+ UMask=0077
+-ExecStart=/opt/sing-box/resources/daemon/sing-box-daemon run --working-directory /var/lib/sing-box-daemon --socket /run/sing-box.socket
++ExecStart=/opt/sing-box/resources/daemon/sing-box-daemon run --working-directory /var/lib/sing-box-daemon --socket /run/sing-box-daemon/sing-box.socket
+ Restart=always
+ RestartSec=5
+ 
+diff --git a/src/main/daemon.ts b/src/main/daemon.ts
+--- a/src/main/daemon.ts
++++ b/src/main/daemon.ts
+@@ -19,7 +19,7 @@ if (process.platform === "win32" && app.isPackaged) {
+     process.platform === "win32"
+       ? "\\\\.\\pipe\\ProtectedPrefix\\Administrators\\sing-box"
+       : process.platform === "linux"
+-        ? "/run/sing-box.socket"
++        ? "/run/sing-box-daemon/sing-box.socket"
+         : null;
+   const socketPath = developmentSwitchValue("daemon-socket") || defaultSocketPath;
+   if (!socketPath) {

--- a/pkgs/by-name/si/sing-box-for-desktop/package-darwin.nix
+++ b/pkgs/by-name/si/sing-box-for-desktop/package-darwin.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  xar,
+  pbzx,
+  cpio,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "sing-box-for-apple";
+  version = "1.14.0";
+
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/SagerNet/sing-box/releases/download/v${finalAttrs.version}/SFM-${finalAttrs.version}-Apple.pkg";
+    hash = "sha256-aP3lMwbzKqzS1NDvDy6grib4JgHGLDiatT3BVPtUqUw=";
+  };
+
+  dontUnpack = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    xar
+    pbzx
+    cpio
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir extracted
+    cd extracted
+    xar -xf "$src"
+
+    mkdir -p \
+      "$out/Applications" \
+      "$out/bin" \
+      "$out/share/licenses/sing-box-for-apple" \
+      "$out/share/sing-box-for-apple"
+
+    cd "$out/Applications"
+    pbzx -n "$NIX_BUILD_TOP/extracted/component-arm64.pkg/Payload" \
+      | cpio -idm --no-absolute-filenames
+
+    ln -s "$out/Applications/SFM.app/Contents/MacOS/SFM" \
+      "$out/bin/sing-box"
+    ln -s "$src" "$out/share/sing-box-for-apple/SFM.pkg"
+    install -Dm644 "$NIX_BUILD_TOP/extracted/Resources/LICENSE" \
+      "$out/share/licenses/sing-box-for-apple/LICENSE"
+
+    runHook postInstall
+  '';
+
+  # Rewriting Mach-O files would invalidate upstream's signatures. The app,
+  # system extension, and privileged helper must remain byte-for-byte intact.
+  dontFixup = true;
+
+  passthru = {
+    installer = finalAttrs.src;
+    sourceRevision = "59540eb0e1812bb76a481a9dc3dec6a788f4196f";
+  };
+
+  meta = {
+    description = "macOS client for the sing-box universal proxy platform";
+    homepage = "https://github.com/SagerNet/sing-box-for-apple";
+    license = lib.licenses.gpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ snemeow ];
+    mainProgram = "sing-box";
+    platforms = [ "aarch64-darwin" ];
+  };
+})

--- a/pkgs/by-name/si/sing-box-for-desktop/package-linux.nix
+++ b/pkgs/by-name/si/sing-box-for-desktop/package-linux.nix
@@ -11,6 +11,7 @@
   makeWrapper,
   nodejs_26,
   nodejs-slim_26,
+  nixosTests,
   pnpm_11,
   pnpmConfigHook,
 }:
@@ -215,6 +216,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit daemon dashboardPnpmDeps;
+    tests = {
+      inherit (nixosTests) sing-box-for-desktop;
+    };
     sourceRevision = finalAttrs.src.rev;
     dashboardRevision = "564dd76b2382af2fb72aee9fcc95af75db693d1a";
   };

--- a/pkgs/by-name/si/sing-box-for-desktop/package-linux.nix
+++ b/pkgs/by-name/si/sing-box-for-desktop/package-linux.nix
@@ -1,0 +1,237 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  copyDesktopItems,
+  electron_43-bin,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  fetchurl,
+  makeDesktopItem,
+  makeWrapper,
+  nodejs_26,
+  nodejs-slim_26,
+  pnpm_11,
+  pnpmConfigHook,
+}:
+
+let
+  electronVersion = "43.4.0";
+  electronPlatform =
+    {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+    }
+    .${stdenv.hostPlatform.system};
+  electronHash =
+    {
+      x86_64-linux = "sha256-fF95GLyudKBagUVDlA6yhGnAVe2qPPz0HQ/xeHsxTFI=";
+      aarch64-linux = "sha256-FwIdSHOYVxBqJt2Vv3Sflbia6SSVXDx+f/Wj8GJRrBQ=";
+    }
+    .${stdenv.hostPlatform.system};
+  electron = electron_43-bin.overrideAttrs (
+    finalElectronAttrs: previousElectronAttrs: {
+      version = electronVersion;
+      src = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${electronVersion}/electron-v${electronVersion}-${electronPlatform}.zip";
+        hash = electronHash;
+      };
+      passthru = previousElectronAttrs.passthru // {
+        dist = "${finalElectronAttrs.finalPackage}/libexec/electron";
+      };
+    }
+  );
+  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_26; };
+  daemon = callPackage ./sing-box-daemon.nix { };
+  version = "1.14.0";
+
+  # Upstream does not tag desktop releases; this revision matches sing-box 1.14.0.
+  # nixpkgs-update: no auto update
+  source = fetchFromGitHub {
+    owner = "SagerNet";
+    repo = "sing-box-for-desktop";
+    rev = "92b69e160d30249e8fc21a1106df6af538f0fb92";
+    fetchSubmodules = true;
+    hash = "sha256-f3oQG9laLWCiKYR+1yBeWwZMvsyQdh3WtEs/sSO0zGM=";
+  };
+  dashboardPnpmDeps = fetchPnpmDeps {
+    pname = "sing-box-for-desktop-dashboard";
+    inherit version pnpm;
+    src = source;
+    sourceRoot = "source/dashboard";
+    fetcherVersion = 4;
+    hash = "sha256-MCld/J2LBtAz2bS00ICjCQN/QPXlLDKwzEGtFwlEl8c=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sing-box-for-desktop";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = source;
+
+  patches = [
+    ./nix-login-item-launcher.patch
+    ./nix-managed-configuration.patch
+    ./nix-resources-path.patch
+    ./nix-runtime-directory.patch
+    ./use-nix-pnpm.patch
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-MJdf1+aTWCmS0l9XO7pAne3ErXhxGmT5xoriSLIUXEk=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    nodejs_26
+    pnpm
+    pnpmConfigHook
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+    SOURCE_DATE_EPOCH = "1788137407";
+  };
+
+  # The dependency FOD enforces upstream's release-age and trust policies while
+  # it has registry access. The actual build then trusts that verified lockfile
+  # so pnpm does not try to re-fetch registry metadata in the offline sandbox.
+  postPatch = ''
+    cp ${./managedConfiguration.ts} src/main/managedConfiguration.ts
+
+    substituteInPlace pnpm-workspace.yaml dashboard/pnpm-workspace.yaml \
+      --replace-fail \
+        'trustPolicyIgnoreAfter: 259200' \
+        $'trustPolicyIgnoreAfter: 259200\ntrustLockfile: true'
+  '';
+
+  postConfigure = ''
+    rootPnpmDeps="$pnpmDeps"
+    pnpmDeps=${dashboardPnpmDeps}
+    pnpmRoot=dashboard
+    pnpmConfigHook
+    unset pnpmRoot
+    pnpmDeps="$rootPnpmDeps"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm -C dashboard generate
+
+    applicationRoot="$PWD"
+    pushd ${daemon.src}
+    PATH="$applicationRoot/node_modules/.bin:$PATH" \
+      "$applicationRoot/node_modules/.bin/buf" generate \
+      --template "$applicationRoot/buf.gen.yaml" \
+      --output "$applicationRoot" \
+      . \
+      --path experimental/boxdd/desktop_service.proto \
+      --path daemon/started_service.proto \
+      --path daemon/managed_service.proto
+    popd
+
+    pnpm exec electron-vite build
+
+    install -Dm755 ${lib.getExe daemon} bin/sing-box-daemon
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    pnpm exec electron-builder \
+      --dir \
+      --config electron-builder.yml \
+      --config.electronDist=electron-dist \
+      --config.electronVersion=${electron.version} \
+      --config.extraMetadata.version=${finalAttrs.version} \
+      --config.npmRebuild=false \
+      --publish never
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p \
+      "$out/bin" \
+      "$out/lib/systemd/system" \
+      "$out/share/sing-box-for-desktop"
+    cp -r release/linux*-unpacked/resources "$out/share/sing-box-for-desktop/"
+
+    makeWrapper ${lib.getExe electron} "$out/bin/sing-box" \
+      --inherit-argv0 \
+      --set ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default SING_BOX_LAUNCHER "$out/bin/sing-box" \
+      --add-flags "$out/share/sing-box-for-desktop/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+
+    install -Dm644 resources/icons/512x512.png \
+      "$out/share/icons/hicolor/512x512/apps/sing-box.png"
+    install -Dm644 resources/icons/1024x1024.png \
+      "$out/share/icons/hicolor/1024x1024/apps/sing-box.png"
+    install -Dm644 build/io.nekohasekai.sfl.policy \
+      "$out/share/polkit-1/actions/io.nekohasekai.sfl.policy"
+    install -Dm644 build/io.nekohasekai.sfl.metainfo.xml \
+      "$out/share/metainfo/io.nekohasekai.sfl.metainfo.xml"
+    install -Dm644 LICENSE \
+      "$out/share/licenses/sing-box-for-desktop/LICENSE"
+
+    substitute build/sing-box-daemon.service \
+      "$out/lib/systemd/system/sing-box-daemon.service" \
+      --replace-fail "/opt/sing-box/resources/daemon/sing-box-daemon" \
+        "$out/share/sing-box-for-desktop/resources/daemon/sing-box-daemon"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "sing-box";
+      desktopName = "sing-box";
+      genericName = "SingBox Desktop Client";
+      comment = "Linux client for the sing-box universal proxy platform";
+      exec = "sing-box %U";
+      icon = "sing-box";
+      startupWMClass = "sing-box";
+      categories = [ "Network" ];
+      mimeTypes = [
+        "application/x-sing-box-profile"
+        "x-scheme-handler/sing-box"
+      ];
+    })
+  ];
+
+  passthru = {
+    inherit daemon dashboardPnpmDeps;
+    sourceRevision = finalAttrs.src.rev;
+    dashboardRevision = "564dd76b2382af2fb72aee9fcc95af75db693d1a";
+  };
+
+  meta = {
+    description = "Linux desktop client for the sing-box universal proxy platform";
+    homepage = "https://github.com/SagerNet/sing-box-for-desktop";
+    license = lib.licenses.gpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode # Electron
+    ];
+    maintainers = with lib.maintainers; [ snemeow ];
+    mainProgram = "sing-box";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})

--- a/pkgs/by-name/si/sing-box-for-desktop/package.nix
+++ b/pkgs/by-name/si/sing-box-for-desktop/package.nix
@@ -1,0 +1,6 @@
+{
+  callPackage,
+  stdenv,
+}:
+
+callPackage (if stdenv.hostPlatform.isDarwin then ./package-darwin.nix else ./package-linux.nix) { }

--- a/pkgs/by-name/si/sing-box-for-desktop/sing-box-daemon.nix
+++ b/pkgs/by-name/si/sing-box-for-desktop/sing-box-daemon.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  buildGo126Module,
+  buildPackages,
+  cronet-go,
+  fetchFromGitHub,
+  systemd,
+}:
+
+buildGo126Module (finalAttrs: {
+  pname = "sing-box-daemon";
+  version = "1.14.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "SagerNet";
+    repo = "sing-box";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1v9bgM2H439ZoSkomv5dmT5SNrkuyOJ1iFFPlYPsW/k=";
+  };
+
+  vendorHash = "sha256-Bl73SkmnOyh5kULctDaxcOzXsYXRY2DOt80ME2+lBJo=";
+
+  tags = [
+    "with_gvisor"
+    "with_quic"
+    "with_dhcp"
+    "with_wireguard"
+    "with_utls"
+    "with_acme"
+    "with_clash_api"
+    "with_tailscale"
+    "with_ccm"
+    "with_ocm"
+    "with_cloudflared"
+    "with_naive_outbound"
+    "with_usbip"
+    "with_openvpn"
+    "with_openconnect"
+    "badlinkname"
+    "tfogo_checklinkname0"
+  ];
+
+  subPackages = [ "experimental/boxdd" ];
+
+  env = {
+    CGO_ENABLED = 1;
+    CGO_LDFLAGS = "-fuse-ld=lld";
+  };
+
+  nativeBuildInputs = [ buildPackages.rustc.llvmPackages.bintools ];
+  buildInputs = [ cronet-go ];
+
+  ldflags = [
+    "-X=github.com/sagernet/sing-box/constant.Version=${finalAttrs.version}"
+    "-X=runtime.godebugDefault=multipathtcp=0,tlssha1=1,tlsunsafeekm=1"
+    "-checklinkname=0"
+    "-s"
+    "-w"
+  ];
+
+  postPatch = ''
+    substituteInPlace experimental/boxdd/cmd_service_linux.go \
+      --replace-fail 'exec.Command("systemctl",' 'exec.Command("${systemd}/bin/systemctl",'
+  '';
+
+  postConfigure = ''
+    pushd vendor/github.com/sagernet/cronet-go
+    chmod -R u+w .
+    cp -r ${cronet-go}/. .
+    patch -p1 < ${./cronet-go.patch}
+    substituteInPlace internal/cronet/loader_unix.go --subst-var out
+    popd
+  '';
+
+  postInstall = ''
+    mv "$out/bin/boxdd" "$out/bin/sing-box-daemon"
+    install -Dm644 LICENSE "$out/share/licenses/sing-box-daemon/LICENSE"
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Privileged sing-box daemon for the desktop client";
+    homepage = "https://github.com/SagerNet/sing-box";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ snemeow ];
+    mainProgram = "sing-box-daemon";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})

--- a/pkgs/by-name/si/sing-box-for-desktop/use-nix-pnpm.patch
+++ b/pkgs/by-name/si/sing-box-for-desktop/use-nix-pnpm.patch
@@ -1,0 +1,24 @@
+diff --git a/dashboard/package.json b/dashboard/package.json
+index df5d21c..53df0ac 100644
+--- a/dashboard/package.json
++++ b/dashboard/package.json
+@@ -3,7 +3,6 @@
+   "private": true,
+   "version": "0.1.0",
+   "type": "module",
+-  "packageManager": "pnpm@11.13.0",
+   "exports": {
+     ".": "./src/App.tsx",
+     "./tray": "./src/TrayMenu.tsx",
+diff --git a/package.json b/package.json
+index 4a97225..2ec1c95 100644
+--- a/package.json
++++ b/package.json
+@@ -17,7 +17,6 @@
+     "url": "git+https://github.com/SagerNet/sing-box-for-desktop.git"
+   },
+   "type": "module",
+-  "packageManager": "pnpm@11.13.0",
+   "engines": {
+     "node": "26.7.0"
+   },


### PR DESCRIPTION
Add sing-box-for-desktop, graphical client for sing-box proxy app, provides both linux and macos platform with NixOS module for declarative configs.

### Reference
- sfd-nix https://github.com/SugarNekoE/sfd-nix
- sing-box https://github.com/SagerNet/sing-box
- sing-box-for-desktop https://github.com/SagerNet/sing-box-for-desktop
- sing-box-for-apple https://github.com/SagerNet/sing-box-for-apple

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
