### PR TITLE
rerun: 0.36.3 -> 0.37.0

### DIFF
--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -40,7 +40,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rerun";
-  version = "0.36.3";
+  version = "0.37.0";
 
   __structuredAttrs = true;
 
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "rerun-io";
     repo = "rerun";
     tag = finalAttrs.version;
-    hash = "sha256-oJduGAL+fqnQKEWIcpgH/X8F0+sW3BTF9x0nBco4Do4=";
+    hash = "sha256-KVKIUVKZlmDaD/U5u4wVg+uykhxE1olXNMl3O2pedWY=";
   };
 
   # The path in `build.rs` is wrong for some reason, so we patch it to make the passthru tests work
@@ -62,7 +62,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"rerun_sdk/rerun_cli/rerun"' '"rerun_sdk/rerun"'
   '';
 
-  cargoHash = "sha256-8rNIf6Rl7MYo+nk1qxOdmY8BmTKvjBb47Hk6xBeMIVE=";
+  cargoHash = "sha256-ivcvlypKgfYenS1Y4J39w7rtOCd0Btb8kyoflPz5vLw=";
 
   cargoBuildFlags = [
     "--package"

--- a/pkgs/development/python-modules/rerun-notebook/default.nix
+++ b/pkgs/development/python-modules/rerun-notebook/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
     inherit (finalAttrs) version;
     format = "wheel";
     python = "py2.py3";
-    hash = "sha256-QYOfTf2PCEjLA0YI6G/HDtA3UlUkhV5t7fCdw9QU584=";
+    hash = "sha256-O5e4oxNZo6fI4x+0+4vl3saLATObRDL9Zx/+JKXJGCQ=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/rerun-sdk/default.nix
+++ b/pkgs/development/python-modules/rerun-sdk/default.nix
@@ -137,6 +137,7 @@ buildPythonPackage {
     "test_asset_mode_timeline_type_timestamp_applies_to_index_chunk"
     "test_custom_entity_path_applies_to_every_chunk"
     "test_default_mode_produces_video_stream_chunks"
+    "test_optimize_only_coarsens_the_readers_gop_partition"
     "test_output_codec_same_as_source_stays_on_the_direct_path"
     "test_stream_mode_chunk_by_gop_false_emits_one_sample_per_chunk"
     "test_stream_mode_chunk_by_gop_true_packs_multiple_samples"
@@ -144,10 +145,7 @@ buildPythonPackage {
 
     # ConnectionError: Connection: connecting to server: transport error
     "test_batch_shape"
-    "test_decode_matrix"
-    "test_fixed_rate_sampling_duplicates_decode_correctly"
     "test_isolated_streams"
-    "test_off_grid_capture_rate_decodes_correctly"
     "test_roundtrip_parity"
     "test_save_screenshot"
     "test_send_dataframe_roundtrip"
@@ -163,9 +161,7 @@ buildPythonPackage {
 
     # av.InvalidDataError: the mp4 asset is a Git LFS pointer, not the real
     # video (rerun.src is fetched without fetchLFS).
-    "test_anchor_path_decodes_mid_gop_target"
     "test_collect_optimize_video_stream_summary"
-    "test_heuristic_fallback_when_is_keyframe_column_absent"
 
     # AssertionError: the Git LFS pointer mp4 asset fails to demux before the
     # expected "FFmpeg executable not found" error can be raised, so the
@@ -174,6 +170,13 @@ buildPythonPackage {
   ];
 
   disabledTestPaths = [
+    # av.InvalidDataError: every test builds its recording from the mp4 asset, which is a Git LFS
+    # pointer, not the real video (rerun.src is fetched without fetchLFS).
+    "rerun_py/tests/integration/test_dataloader_video.py"
+
+    # ConnectionError: Connection: connecting to server: transport error
+    "rerun_py/tests/integration/test_dataloader_video_codecs.py"
+
     # RuntimeError: MCAP error: Bad magic number. The .mcap test assets are
     # Git LFS pointer files, not real binaries (rerun.src is fetched without
     # fetchLFS).


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/rerun-io/rerun/compare/0.36.3...0.37.0
Changelog: https://github.com/rerun-io/rerun/blob/0.37.0/CHANGELOG.md

cc @SomeoneSerge

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test