### PR TITLE
bkt-bitbucket: init at 0.31.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2928,6 +2928,11 @@
     name = "avitex";
     keys = [ { fingerprint = "271E 136C 178E 06FA EA4E  B854 8B36 6C44 3CAB E942"; } ];
   };
+  avivsinai = {
+    github = "avivsinai";
+    githubId = 16213;
+    name = "Aviv Sinai";
+  };
   avnik = {
     email = "avn@avnik.info";
     github = "avnik";

--- a/pkgs/by-name/bk/bkt-bitbucket/package.nix
+++ b/pkgs/by-name/bk/bkt-bitbucket/package.nix
@@ -9,6 +9,8 @@ buildGoModule (finalAttrs: {
   pname = "bkt-bitbucket";
   version = "0.31.1";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "avivsinai";
     repo = "bitbucket-cli";

--- a/pkgs/by-name/bk/bkt-bitbucket/package.nix
+++ b/pkgs/by-name/bk/bkt-bitbucket/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "bkt-bitbucket";
+  version = "0.31.1";
+
+  src = fetchFromGitHub {
+    owner = "avivsinai";
+    repo = "bitbucket-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-amowjmW0exFB/YN1rYfy/KvST+TfzOAAocoRzR9oRRs=";
+  };
+
+  vendorHash = "sha256-9wjEq4a5snJJ4uD4y+O3wJ15vVNs6Mcu8JVG43n94To=";
+
+  subPackages = [ "cmd/bkt" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/avivsinai/bitbucket-cli/internal/build.versionFromLdflags=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/bkt";
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI for Bitbucket Cloud and Bitbucket Data Center, installing the `bkt` binary";
+    longDescription = ''
+      A gh-style command-line interface for Bitbucket Cloud and Bitbucket
+      Data Center: repositories, pull requests, branches, pipelines and more.
+      Unrelated to the `bkt` subprocess-caching tool and to swisscom's
+      bitbucket-cli.
+    '';
+    homepage = "https://github.com/avivsinai/bitbucket-cli";
+    changelog = "https://github.com/avivsinai/bitbucket-cli/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "bkt";
+    maintainers = with lib.maintainers; [ avivsinai ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
Adds `bkt-bitbucket`: a `gh`-style CLI for Bitbucket Cloud and Bitbucket Data Center (repositories, pull requests, branches, pipelines), installing the `bkt` binary. Homepage: https://github.com/avivsinai/bitbucket-cli

Naming: both natural attribute names are taken by unrelated projects — `bkt` (subprocess caching tool) and `bitbucket-cli` (swisscom's Bitbucket Enterprise CLI) — hence `bkt-bitbucket`. `meta.description` and `longDescription` disambiguate.

Notes for reviewers:
- I am the upstream author (self-packaging), added to `maintainer-list.nix` in the first commit.
- Source builds intentionally do not embed Bitbucket Cloud OAuth client credentials (those are only in upstream's official release binaries); Cloud login works via `bkt auth login --kind cloud --web-token` or user-supplied `BKT_OAUTH_CLIENT_ID`/`BKT_OAUTH_CLIENT_SECRET`. Data Center auth is unaffected.
- `passthru.updateScript = nix-update-script` for automated updates; `versionCheckHook` enabled via `doInstallCheck`.

Automation/AI disclosure: this PR was prepared with Claude Code (model claude-fable-5) under my direction and review; commits carry `Assisted-by:` trailers per the automation/AI policy. The package definition was built and its install check run locally before submission.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (`bkt --version` reports 0.31.1 via versionCheckHook; `bkt --help` exits 0).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
