### PR TITLE
kmscon: 10.0.2 -> 10.0.3

### DIFF
--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -33,13 +33,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kmscon";
-  version = "10.0.2";
+  version = "10.0.3";
 
   src = fetchFromGitHub {
     owner = "kmscon";
     repo = "kmscon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xUqPVI6pX0Chltq4Yt/J2HMv+zQ+IKI6kAbZrkd0wY4=";
+    hash = "sha256-qSxEdgHT8jVLWhx23w+VrT0IvJa8RjbzhCs6rvFBkTM=";
   };
 
   strictDeps = true;
@@ -78,15 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     ncurses
     zlib
-  ];
-
-  # remove in next release
-  patches = [
-    (fetchpatch2 {
-      name = "fix-use-after-free-in-seat-remove-video.patch";
-      url = "https://github.com/kmscon/kmscon/commit/eb353401f56c21cc602a738c3edaece30e5639d6.patch?full_index=1";
-      hash = "sha256-NbuRfwBHK7AMlBOrzZYp4bbpOeTTEwh+uYtWBzQo2fs=";
-    })
   ];
 
   outputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a bug fix version.
https://github.com/kmscon/kmscon/releases/tag/v10.0.3
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
