### PR TITLE
python3Packages.selfies: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5012,6 +5012,12 @@
     githubId = 1689801;
     name = "Mikhail Chekan";
   };
+  chemonke = {
+    email = "nixpkgs@chemonke.ch";
+    github = "chemonke";
+    githubId = 183837749;
+    name = "Curdin Bosshart";
+  };
   chen = {
     email = "i@cuichen.cc";
     github = "cu1ch3n";

--- a/pkgs/development/python-modules/selfies/default.nix
+++ b/pkgs/development/python-modules/selfies/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  rdkit,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "selfies";
+  version = "2.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "the-matter-lab";
+    repo = "selfies";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XYMzMhu/lzgmk2ek2Wd8T6hCPK/cfTTim+Al+nxMuaE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    rdkit
+  ];
+
+  pythonImportsCheck = [ "selfies" ];
+
+  meta = {
+    description = "Robust representation of semantically constrained graphs, in particular for molecules in chemistry";
+    homepage = "https://github.com/the-matter-lab/selfies";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ chemonke ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18681,6 +18681,8 @@ self: super: with self; {
 
   selenium-wire-roadtx = callPackage ../development/python-modules/selenium-wire-roadtx { };
 
+  selfies = callPackage ../development/python-modules/selfies { };
+
   semantic-version = callPackage ../development/python-modules/semantic-version { };
 
   semaphore-bot = callPackage ../development/python-modules/semaphore-bot { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add SELFIES. https://github.com/the-matter-lab/selfies

SELFIES is a Python library implementing the SELFIES molecular graph representation. Unlike other formats, every syntactically valid SELFIES string maps to a valid molecule, making it useful for generative ML.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
