### PR TITLE
python3Packages.dishka: init at 1.10.1

### DIFF
--- a/pkgs/development/python-modules/dishka/default.nix
+++ b/pkgs/development/python-modules/dishka/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  setuptools-scm,
+  exceptiongroup,
+  pytest-asyncio,
+  pytest-cov,
+  pytest-repeat,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dishka";
+  version = "1.10.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "reagento";
+    repo = "dishka";
+    tag = finalAttrs.version;
+    hash = "sha256-HW0n4XgiCNzWaiql6ZKJ5ido/7wGWTYwpd38+EjYXsA=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools==80.9.0"' '"setuptools"' \
+      --replace-fail '"setuptools-scm[simple]==9.2.0"' '"setuptools-scm[simple]"'
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = lib.optionals (pythonOlder "3.11") [ exceptiongroup ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov
+    pytest-repeat
+    pytestCheckHook
+  ];
+
+  # Other tests/integrations/* need extra frameworks like fastapi and celery
+  enabledTestPaths = [
+    "tests/integrations/base"
+    "tests/unit"
+  ];
+
+  pythonImportsCheck = [ "dishka" ];
+
+  meta = {
+    description = "Cute DI framework with scopes and agreeable API";
+    homepage = "https://dishka.readthedocs.io/en/stable/";
+    changelog = "https://github.com/reagento/dishka/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ aaravrav ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4412,6 +4412,8 @@ self: super: with self; {
 
   discum = callPackage ../development/python-modules/discum { };
 
+  dishka = callPackage ../development/python-modules/dishka { };
+
   diskcache = callPackage ../development/python-modules/diskcache { };
 
   diskcache-stubs = callPackage ../development/python-modules/diskcache-stubs { };


### PR DESCRIPTION
Adds [dishka](https://github.com/reagento/dishka)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test