### PR TITLE
python3Packages.fastnanoid: init at 0.4.3

### DIFF
--- a/pkgs/development/python-modules/fastnanoid/default.nix
+++ b/pkgs/development/python-modules/fastnanoid/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nanoid,
+  rustPlatform,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fastnanoid";
+  version = "0.4.3";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "oliverlambson";
+    repo = "fastnanoid";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RQg+Srv/wi1mfRel746UwLTAL22uAt0DJBlXlV9p8dE=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-d/BoEl9xfo4+5H+8xQxacpmadAJXlV+92yiKlgoERtk=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  nativeCheckInputs = [
+    nanoid
+    pytestCheckHook
+  ];
+
+  # Skip python/ here as it shadows installed fastnanoid
+  # pytest puts python/ on sys.path so the source tree is imported first
+  enabledTestPaths = [
+    "benchmarks"
+    "tests"
+  ];
+
+  pythonImportsCheck = [ "fastnanoid" ];
+
+  meta = {
+    description = "Tiny, secure URL-friendly, and fast unique string ID generator for Python, written in Rust";
+    homepage = "https://github.com/oliverlambson/fastnanoid";
+    changelog = "https://github.com/oliverlambson/fastnanoid/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aaravrav ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5942,6 +5942,8 @@ self: super: with self; {
 
   fastmri = callPackage ../development/python-modules/fastmri { };
 
+  fastnanoid = callPackage ../development/python-modules/fastnanoid { };
+
   fastnlo-toolkit = toPythonModule (
     pkgs.fastnlo-toolkit.override {
       withPython = true;


### PR DESCRIPTION
Adds [fastnanoid](https://github.com/oliverlambson/fastnanoid), a Rust-backed nanoid generator for Python.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test