### PR TITLE
python3Packages.nidaqmx: fix build by adding missing runtime deps (init nitypes)

### DIFF
--- a/pkgs/development/python-modules/nidaqmx/default.nix
+++ b/pkgs/development/python-modules/nidaqmx/default.nix
@@ -8,6 +8,7 @@
   fetchFromGitHub,
   grpcio,
   hightime,
+  nitypes,
   numpy,
   poetry-core,
   protobuf,
@@ -16,6 +17,7 @@
   sphinx-rtd-theme,
   sphinx,
   toml,
+  typing-extensions,
   tzlocal,
 }:
 
@@ -37,9 +39,11 @@ buildPythonPackage rec {
     click
     deprecation
     hightime
+    nitypes
     numpy
     python-decouple
     requests
+    typing-extensions
     tzlocal
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/development/python-modules/nitypes/default.nix
+++ b/pkgs/development/python-modules/nitypes/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hightime,
+  numpy,
+  poetry-core,
+  pytest-benchmark,
+  pytest-cov-stub,
+  pytest-doctestplus,
+  pytest-mock,
+  pytestCheckHook,
+  tomlkit,
+  tzlocal,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "nitypes";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ni";
+    repo = "nitypes-python";
+    tag = finalAttrs.version;
+    hash = "sha256-gUHu5Bp9qJGX3gTRVmE5J/86zpcSrlypKBkan9LZY2s=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    hightime
+    numpy
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-doctestplus
+    pytest-mock
+    pytest-benchmark
+    tomlkit
+    tzlocal
+  ];
+
+  pythonImportsCheck = [ "nitypes" ];
+
+  meta = {
+    changelog = "https://github.com/ni/nitypes-python/releases/tag/${finalAttrs.version}";
+    description = "Data types for NI Python APIs";
+    homepage = "https://github.com/ni/nitypes-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zehuajun ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12036,6 +12036,8 @@ self: super: with self; {
 
   nitrokey = callPackage ../development/python-modules/nitrokey { };
 
+  nitypes = callPackage ../development/python-modules/nitypes { };
+
   niworkflows = callPackage ../development/python-modules/niworkflows { };
 
   nix-kernel = callPackage ../development/python-modules/nix-kernel { inherit (pkgs) nix; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. **Introduce `python3Packages.nitypes` at 1.1.0** — new package, MIT,
   data types for NI Python APIs (waveforms, spectrums, complex
   integers, time conversion). Depends on `hightime`, `numpy`,
   `typing-extensions`.
2. **Add `nitypes` and `typing-extensions` to `nidaqmx`'s `dependencies`**
   so the runtime dependency check passes.

Resolves #555511 

Prepared with assistance from an AI assistant (Doubao); the author has reviewed the changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
