### PR TITLE
git-mob: init at 1.9.3

### DIFF
--- a/pkgs/by-name/gi/git-mob/package.nix
+++ b/pkgs/by-name/gi/git-mob/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  git,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-mob";
+  version = "1.9.3";
+
+  src = fetchFromGitHub {
+    owner = "mubashwer";
+    repo = "git-mob";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0NSGObflI1iiRp/lVkD8RhUKS+He1ERAZUHxcU0EI8M=";
+  };
+
+  cargoHash = "sha256-0+JASgFPO7gbIeJmPskPSirMec89qSoa0461SuIxwNA=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [ git ];
+
+  checkFlags = [
+    "--skip=helpers::tests::test_execute_failure"
+    "--skip=helpers::tests::test_execute_success"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/git-mob \
+      --prefix PATH : "${lib.makeBinPath [ git ]}"
+  '';
+
+  meta = {
+    description = "CLI tool to help you automatically add Co-authored-by trailers to git commits during pair/mob programming";
+    homepage = "https://github.com/mubashwer/git-mob";
+    changelog = "https://github.com/mubashwer/git-mob/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.matthiasbeyer ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
