### PR TITLE
sigsum: unpin buildGo125Module

### DIFF
--- a/pkgs/by-name/si/sigsum/package.nix
+++ b/pkgs/by-name/si/sigsum/package.nix
@@ -1,12 +1,13 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitLab,
+  fetchpatch2,
   versionCheckHook,
   nix-update-script,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "sigsum";
   version = "0.14.1";
 
@@ -18,6 +19,22 @@ buildGo125Module (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-ZiU5eEI2pKknpjc3HU9EqQu6u1ZD/N7sOD0DyTma0/g=";
   };
+
+  # FIXME: remove in next release
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/sigsum/sigsum-go/commit/f96375480607612154814e0442b3428696cf35f5.patch?full_index=1";
+      hash = "sha256-MR151ZVfrYniyDGzVonLNKcBAHEflAgjULBfp+vhFvg=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/sigsum/sigsum-go/commit/bbf212c19dfc9af66f102f3932381e9476428966.patch?full_index=1";
+      hash = "sha256-fPMIdcH22hVMKiARPQSJ3W/1q74LuALbaf9B5TtzD/o=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/sigsum/sigsum-go/commit/5e7b309d82a34d60872441573eb843c343bc43ba.patch?full_index=1";
+      hash = "sha256-yvKkeJxaGi353X+zlrbpLiYj/q34cuGcuVWn1ghab1s=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace internal/version/version.go \


### PR DESCRIPTION
A few upstream patches are need for sigsum to build with Go 1.26. Since git.glasklar.is is currently unavailable, these patches are fetched from the GitHub mirror.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
