### PR TITLE
openmpi: add rocm support

### DIFF
--- a/pkgs/by-name/op/openmpi/package.nix
+++ b/pkgs/by-name/op/openmpi/package.nix
@@ -24,6 +24,9 @@
   # Enable CUDA support
   cudaSupport ? config.cudaSupport,
   cudaPackages,
+  # Enable ROCm support
+  rocmSupport ? config.rocmSupport,
+  rocmPackages,
   # Enable the Sun Grid Engine bindings
   enableSGE ? false,
   # Pass PATH/LD_LIBRARY_PATH to point to current mpirun by default
@@ -37,6 +40,8 @@
   # up to AVX is enabled by default.
   avxOptions ? { },
 }:
+
+assert cudaSupport -> !rocmSupport;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openmpi";
@@ -94,6 +99,15 @@ stdenv.mkDerivation (finalAttrs: {
     ucc
   ]
   ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
+  ++ lib.optionals rocmSupport (
+    with rocmPackages;
+    [
+      rocm-core
+      rocm-runtime
+      rocm-device-libs
+      clr
+    ]
+  )
   ++ lib.optionals (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isFreeBSD) [ rdma-core ]
   # needed for internal pmix
   ++ lib.optionals (!stdenv.hostPlatform.isLinux) [ python3 ]
@@ -129,11 +143,13 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeatureAs cudaSupport "cuda" (lib.getOutput "include" cudaPackages.cuda_cudart))
     (lib.withFeatureAs cudaSupport "cuda-libdir" "${lib.getLib cudaPackages.cuda_cudart}/lib")
     (lib.enableFeature cudaSupport "dlopen")
+    (lib.withFeatureAs rocmSupport "rocm" rocmPackages.clr)
     (lib.withFeatureAs fabricSupport "psm2" (lib.getDev libpsm2))
     (lib.withFeatureAs fabricSupport "ofi" (lib.getDev libfabric))
     # The flag --without-ofi-libdir is not supported from some reason, so we
     # don't use lib.withFeatureAs
   ]
+  ++ lib.optionals rocmSupport [ "--with-rocm-libdir=${lib.getLib rocmPackages.clr}/lib" ]
   ++ lib.optionals fabricSupport [ "--with-ofi-libdir=${lib.getLib libfabric}/lib" ];
 
   enableParallelBuilding = true;
@@ -265,7 +281,7 @@ stdenv.mkDerivation (finalAttrs: {
       avx2 = stdenv.hostPlatform.avx2Support;
       avx512 = stdenv.hostPlatform.avx512Support;
     };
-    inherit cudaSupport;
+    inherit cudaSupport rocmSupport;
     cudatoolkit = cudaPackages.cudatoolkit; # For backward compatibility only
   };
 


### PR DESCRIPTION
Adds RoCM support for OpenMPI, identical to how CUDA is supported.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
