### PR TITLE
folia: init at 26.1.2-8

### DIFF
--- a/pkgs/by-name/fo/folia/package.nix
+++ b/pkgs/by-name/fo/folia/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  jdk25_headless,
+  udev,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "folia";
+  version = "26.1.2-8";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://fill-data.papermc.io/v1/objects/607afd1c3320008e1ffd2eaee6780ace4419d5f8c527b75e79f259be79ebf57b/folia-26.1.2-8.jar";
+    hash = "sha256-YHr9HDMgAI4f/S6u5ngKzkQZ1fjFJ7deefJZvnnr9Xs=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/share/folia/folia.jar
+
+    makeWrapper ${lib.getExe jdk25_headless} "$out/bin/minecraft-server" \
+      --append-flags "-jar $out/share/folia/folia.jar nogui" \
+      ${lib.optionalString stdenvNoCC.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}"}
+
+    runHook postInstall
+  '';
+
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  passthru = {
+    updateScript = ./update.py;
+  };
+
+  meta = {
+    description = "Fork of Paper which adds regionised multithreading to the dedicated server";
+    homepage = "https://papermc.io/software/folia";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ aaravrav ];
+    mainProgram = "minecraft-server";
+  };
+})

--- a/pkgs/by-name/fo/folia/update.py
+++ b/pkgs/by-name/fo/folia/update.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 -p "python3.withPackages (ps: [ ps.requests ])"
+
+import base64
+import os
+import re
+import sys
+
+import requests
+
+API = "https://fill.papermc.io/v3/projects/folia"
+TIMEOUT = 30
+
+PINNED_JAVA = 25
+
+
+def get_json(url: str):
+    resp = requests.get(url, timeout=TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def minecraft_version_key(version: str) -> list[int]:
+    return [int(part) for part in version.split(".")]
+
+
+def minecraft_versions() -> list[str]:
+    groups = get_json(API)["versions"]
+    versions = [
+        v
+        for ids in groups.values()
+        for v in ids
+        if re.fullmatch(r"\d+(\.\d+)*", v)
+    ]
+    return sorted(versions, key=minecraft_version_key, reverse=True)
+
+
+def latest_stable_build():
+    for mc_version in minecraft_versions():
+        resp = get_json(f"{API}/versions/{mc_version}")
+        java_min = (
+            resp.get("version", {})
+            .get("java", {})
+            .get("version", {})
+            .get("minimum")
+        )
+        for build in sorted(resp["builds"], reverse=True):
+            detail = get_json(f"{API}/versions/{mc_version}/builds/{build}")
+            if detail["channel"] == "STABLE":
+                download = detail["downloads"]["server:default"]
+                return (
+                    mc_version,
+                    build,
+                    download["url"],
+                    download["checksums"]["sha256"],
+                    java_min,
+                )
+    raise RuntimeError("no stable Folia build found")
+
+
+def to_sri(sha256_hex: str) -> str:
+    return "sha256-" + base64.b64encode(bytes.fromhex(sha256_hex)).decode()
+
+
+def main() -> None:
+    mc_version, build, url, sha256_hex, java_min = latest_stable_build()
+    version = f"{mc_version}-{build}"
+    sri = to_sri(sha256_hex)
+
+    if java_min is not None and java_min != PINNED_JAVA:
+        print(
+            f"ERROR: Folia {version} requires Java {java_min}, but package.nix "
+            f"pins jdk{PINNED_JAVA}_headless. Update the jdk input in package.nix "
+            f"and PINNED_JAVA in this script to match, then re-run.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    package_nix = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "package.nix"
+    )
+    with open(package_nix) as f:
+        content = f.read()
+
+    content = re.sub(r'version = "[^"]*";', f'version = "{version}";', content, count=1)
+    content = re.sub(r'url = "[^"]*";', f'url = "{url}";', content, count=1)
+    content = re.sub(r'hash = "[^"]*";', f'hash = "{sri}";', content, count=1)
+
+    with open(package_nix, "w") as f:
+        f.write(content)
+
+    print(f"folia: updated to {version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds [Folia](https://papermc.io/software/folia), PaperMC’s regionised multithreading Minecraft server.

Same packaging approach as `papermc`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test