### PR TITLE
ioskeley-mono: v2.0.0 -> v2.1.0

### DIFF
--- a/pkgs/data/fonts/ioskeley-mono/default.nix
+++ b/pkgs/data/fonts/ioskeley-mono/default.nix
@@ -3,18 +3,19 @@
   stdenvNoCC,
   fetchzip,
   installFonts,
+
+  width ? "Normal",
+  hinted ? true,
 }:
 
 let
-  version = "v2.0.0";
+  version = "v2.1.0";
 
   mkFont =
     {
-      width,
       variant ? "",
       hash,
       isNF ? false,
-      hinted ? true,
     }:
     let
       fileName = "IoskeleyMono${if variant != "" then "-${variant}" else ""}${
@@ -24,12 +25,10 @@ let
 
       pname =
         let
-          wPart = "-${lib.toLower width}";
           vPart = if variant != "" then "-${variant}" else "";
           nfPart = if isNF then "-NF" else "";
-          hPart = if !hinted && !isNF then "-unhinted" else "";
         in
-        "ioskeley-mono${wPart}${vPart}${nfPart}${hPart}";
+        "ioskeley-mono${vPart}${nfPart}";
     in
     stdenvNoCC.mkDerivation {
       inherit pname version;
@@ -54,89 +53,42 @@ let
         maintainers = with lib.maintainers; [ nuexq ];
       };
     };
-
-  allWidths = [
-    "Normal"
-    "SemiCondensed"
-    "Condensed"
-  ];
-
-  mkWidths =
-    {
-      suffix ? "",
-      withHinting ? false,
-      ...
-    }@args:
-    let
-      mkWidthSet =
-        hinted:
-        map (w: {
-          name = "${lib.strings.toLower (builtins.substring 0 1 w)}${builtins.substring 1 (-1) w}${
-            if suffix != "" then "-${suffix}" else ""
-          }${if !hinted then "-unhinted" else ""}";
-
-          value = mkFont (
-            {
-              width = w;
-              inherit hinted;
-            }
-            // (removeAttrs args [
-              "suffix"
-              "withHinting"
-            ])
-          );
-        }) allWidths;
-    in
-    lib.listToAttrs (
-      if withHinting then
-        lib.concatMap (h: mkWidthSet h) [
-          true
-          false
-        ]
-      else
-        mkWidthSet true
-    );
 in
+{
+  # Standard
+  standard = mkFont {
+    hash = "sha256-1WGAPwbfSG3fpssUTnHCTVI8eKNHSHWHdfdq4JUQ9ls=";
+  };
 
-# Standard
-mkWidths {
-  hash = "sha256-EJDlA18XZPq7vhtpw/74n5s1NmTy0/DLu2oYB7OuvbA=";
-  withHinting = true;
-}
+  # Term
+  term = mkFont {
+    variant = "Term";
+    hash = "sha256-Ei6cRAMC9C62X8coHsTMvfPZfloiUp+A4HeT89df3pk=";
+  };
 
-# Term
-// mkWidths {
-  suffix = "term";
-  variant = "Term";
-  hash = "sha256-E7I7gmu9EOaCKn4JOFkCjHP/I/1wadRkZoCxVfm+b1k=";
-  withHinting = true;
-}
+  # Term Nerd Font
+  term-nf = mkFont {
+    variant = "Term";
+    isNF = true;
+    hash = "sha256-joAhNADErBErDqTrNelJ0ulGZCN/OUZ1SMYyU++7l6U=";
+  };
 
-// mkWidths {
-  suffix = "term-NF";
-  variant = "Term";
-  isNF = true;
-  hash = "sha256-GiMI2YTl20K+zUObcFNzgP1ivm7pH2zHWFG15gFgasg=";
-}
+  # NL
+  nl = mkFont {
+    variant = "NL";
+    hash = "sha256-3zqO7W23Zcdz7L8cO0A8oAH0PQqYUNwKiKnAmN/Ja8s=";
+  };
 
-# NL
-// mkWidths {
-  suffix = "NL";
-  variant = "NL";
-  hash = "sha256-dNOpQJ1VOrjcKS/UtPXKUP9W0gaxFMvH4aa+xK2hg2w=";
-  withHinting = true;
-}
+  # NL Nerd Font
+  nl-nf = mkFont {
+    variant = "NL";
+    isNF = true;
+    hash = "sha256-3eTVqMlLx/AF3aoTbQ68Qzhr5nQzWIKt4HWZZsH2yE0=";
+  };
 
-// mkWidths {
-  suffix = "NL-NF";
-  variant = "NL";
-  isNF = true;
-  hash = "sha256-N7mtM/aQwps77u907z8Rop3RftRGR4K8zDXFX8xWq5w=";
-}
-
-# Nerd Font Standard
-// mkWidths {
-  suffix = "NF";
-  isNF = true;
-  hash = "sha256-Nt8EaVhKvlb9BMKQe4l5iNGcPLzKba6KScIWZbcL8gA=";
+  # Nerd Font Standard
+  nf = mkFont {
+    isNF = true;
+    hash = "sha256-b0mqhLeDT+uYPYiOKB+cxc5M1TtFkICKAmlcmW3IjDg=";
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/ahatem/IoskeleyMono/compare/v2.0.0...v2.1.0
Changelog: https://github.com/ahatem/IoskeleyMono/releases/tag/v2.1.0

Also changed how the package works: instead of generating a separate package for each width and hinting combination, width and hinting are now configurable through `override`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
