### PR TITLE
rustup: 1.29.0 -> 1.29.1

### DIFF
--- a/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
@@ -1,8 +1,8 @@
 diff --git a/src/dist/component/package.rs b/src/dist/component/package.rs
-index dc545d4b62..4dd8ade86e 100644
+index 28e22f8635..568097ccf0 100644
 --- a/src/dist/component/package.rs
 +++ b/src/dist/component/package.rs
-@@ -130,6 +130,7 @@
+@@ -132,6 +132,7 @@
                      } else {
                          builder.move_file(path.clone(), &src_path)?
                      }
@@ -10,7 +10,7 @@ index dc545d4b62..4dd8ade86e 100644
                  }
                  ComponentPartKind::Dir => {
                      if self.copy {
-@@ -152,6 +153,176 @@
+@@ -154,6 +155,176 @@
      }
  }
  

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -25,16 +25,16 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustup";
-  version = "1.29.0";
+  version = "1.29.1";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rustup";
     tag = finalAttrs.version;
-    hash = "sha256-jbB0nmXtc95Ac+YfmyELh6n5OTRMmeDPT4OFIlJNrZc=";
+    hash = "sha256-zL/N2Bx3HIEzrRQQVdTQ7VnSoNNbqe8FE26GcjwHSjM=";
   };
 
-  cargoHash = "sha256-m/KoXNJh00zYKZo7MIJsBvo4zldfKdofrUh8AItJqXI=";
+  cargoHash = "sha256-soSeDzZzIPxR9cham+0VQfI21LgLX5o/9r00xK7fNHY=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
@@ -91,6 +91,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # reaches out to the network to test TLS roots, which can't be done in the
     # build sandbox
     "--skip=suite::static_roots::store_static_roots"
+    # tries to hide the cc from rustup by setting PATH to an empty directory,
+    # but this doesn't work due to how nixpkgs wraps binaries
+    "--skip=suite::cli_inst_interactive::install_warns_if_default_linker_missing"
   ];
 
   postInstall = ''


### PR DESCRIPTION
blog: https://blog.rust-lang.org/2026/09/01/Rustup-1.29.1/
changelog: https://github.com/rust-lang/rustup/blob/1.29.1/CHANGELOG.md

tested installing, updating, and uninstalling toolchains and then using the resulting components.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
