### PR TITLE
secretspec: 0.19.1 -> 0.20.0

### DIFF
--- a/pkgs/by-name/se/secretspec/package.nix
+++ b/pkgs/by-name/se/secretspec/package.nix
@@ -4,6 +4,7 @@
   fetchCrate,
   fetchurl,
   cacert,
+  gitMinimal,
   jq,
   sops,
   nix-update-script,
@@ -11,21 +12,21 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "secretspec";
-  version = "0.19.1";
+  version = "0.20.0";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-hntOPTOrCfVWE4MaNmXfPQ4WAlOG1CFG5/ykSyviJ3A=";
+    hash = "sha256-UuXCDQ/DiC1xDs63+kbJNC01ZQfsh2j5/qRP76MVle8=";
   };
 
-  cargoHash = "sha256-KRC3b6AqSYxjSInULchYNQGm9hw97lDws0+stFZasmc=";
+  cargoHash = "sha256-41UxtnzpDMYpWshpopXLIXyz6rzikJkqKbvxHVua1oo=";
 
   postPatch = ''
     mkdir -p ../tests/fixtures
     cp ${
       fetchurl {
         url = "https://raw.githubusercontent.com/cachix/secretspec/v${finalAttrs.version}/tests/fixtures/bw-shim.sh";
-        hash = "sha256-Xg1d8h2DOA6p0Hn9xP9TYzFN1863Wyk3QuQlFk+Y0ME=";
+        hash = "sha256-wHXeJk3KYu01J73BEdll9lCcjOD4+8g8rlWUw93Cyok=";
       }
     } ../tests/fixtures/bw-shim.sh
     chmod +x ../tests/fixtures/bw-shim.sh
@@ -33,12 +34,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   nativeCheckInputs = [
+    gitMinimal
     jq
     sops
   ];
 
   preCheck = ''
     export HOME="$TMPDIR"
+    export NO_COLOR=1
     export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
   '';
 


### PR DESCRIPTION
Updates SecretSpec to 0.20.0.

Release notes: https://github.com/cachix/secretspec/releases/tag/v0.20.0

Adds Git to the check environment for the new Git credential integration tests. Also disables colored test output to avoid a process-global color override race in the upstream test suite.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and core functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test