### PR TITLE
inkycap: init at v26.9.6

### DIFF
--- a/pkgs/by-name/in/inkycap/package.nix
+++ b/pkgs/by-name/in/inkycap/package.nix
@@ -1,0 +1,135 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromForgejo,
+  buildNpmPackage,
+  cargo-tauri,
+  glib-networking,
+  gst_all_1,
+  libayatana-appindicator,
+  libsecret,
+  nodejs,
+  perl,
+  pkg-config,
+  tinymist,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+}:
+
+let
+  version = "26.9.6";
+  src = fetchFromForgejo {
+    domain = "codefloe.com";
+    owner = "InkyCap";
+    repo = "app";
+    tag = "v${version}";
+    hash = "sha256-X4KjRHUDYx0C61gBa5vr9i1u0DOZok1AUTwe6srVhy4=";
+  };
+  changelog = "https://codefloe.com/InkyCap/app/releases/tag/v${version}";
+  homepage = "http://inkycap.org/";
+  license = lib.licenses.liliq-p-11;
+  maintainers = with lib.maintainers; [ luker ];
+
+  # from TINYMIST_VERSION in scripts/download-tinymist.sh.
+  # developer says it should work with newer version, but no guarantees.
+  requiredTinymistVersion = "0.15.2";
+
+  frontend = buildNpmPackage (finalAttrs: {
+    pname = "inkycap-frontend";
+    inherit version src;
+
+    npmDepsHash = "sha256-vXf4W3U5EIzqHRdUkIy1z+0+umMbR1AflQ31pJCo37M=";
+
+    # The npm hook installs with `npm ci --ignore-scripts`, so the
+    # postinstall script (patch-package) never runs. Apply the patches
+    # from patches/ explicitly, before the bundle.
+    preBuild = ''
+      ./node_modules/.bin/patch-package
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r dist $out
+      runHook postInstall
+    '';
+
+    meta = {
+      inherit
+        changelog
+        homepage
+        license
+        maintainers
+        ;
+      description = "Frontend assets for InkyCap";
+    };
+  });
+in
+assert (builtins.compareVersions requiredTinymistVersion tinymist.version) <= 0;
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "inkycap";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  cargoRoot = "src-tauri";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src cargoRoot;
+    hash = "sha256-NHlLURI2O2W28gAWGZd6Hx7lWOXn8LNeoiubReRA5Bo=";
+  };
+  buildAndTestSubdir = "src-tauri";
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    pkg-config
+    perl
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib-networking
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-libav
+    libayatana-appindicator
+    libsecret
+    webkitgtk_4_1
+  ];
+
+  postPatch = ''
+    # Tauri expects sidecars as binaries/<name>-<triple>.
+    # make sure nixpkgs version and package version are synchronized
+    install -Dm755 ${tinymist}/bin/tinymist \
+      "src-tauri/binaries/inkycap-tinymist-${stdenv.hostPlatform.rust.rustcTargetSpec}"
+
+    cp -r ${frontend} dist
+
+    # The frontend is already built; drop beforeBuildCommand so the
+    # tauri CLI does not re-run `npm run build`
+    substituteInPlace src-tauri/tauri.conf.json \
+      --replace-fail '"beforeBuildCommand": "npm run build"' "" \
+      --replace-fail '"beforeDevCommand": "npm run dev",' '"beforeDevCommand": "npm run dev"'
+  '';
+
+  doCheck = false;
+
+  meta = {
+    inherit
+      changelog
+      homepage
+      license
+      maintainers
+      ;
+    description = "Personal knowledge management (PKM) tool that uses Typst markup";
+    longDescription = ''
+      InkyCap is a personal knowledge management tool that helps you explore
+      ideas and write. Tailored for academic workflows, research, writing,
+      task and date awareness; InkyCap provides flexible ways to organize
+      your information.
+    '';
+    platforms = lib.platforms.linux;
+    mainProgram = "inkycap";
+  };
+})


### PR DESCRIPTION
New package inkycap:

A personal knowledge management tool that uses **Typst** markup.
http://inkycap.org/

They seem to have 1-2 releases a month.

I'm not that used to creating nix packages, so feel free to ask changes.

## Things done

* initially vibecoded (qwen3.8-27B)
* manual cleanup, fixed building, deps
* tested locally

Things that could be better:
* windows should be supported, I don't have anything to test it
* tauri seems comfigured to produce `dmg`, but those are not provided by the project, so I don't know if darwin is supported.
* locks a particular version of `tinymist`. would another version of tinymist work? probably, but the application seems to require a specific version. luckily it's the one currently on unstable. [codeberg issue with this question](https://codeberg.org/InkyCap/app/issues/26)


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
