### PR TITLE
atmos: fix Darwin build with 1Password SDK dependency

### DIFF
--- a/pkgs/by-name/at/atmos/package.nix
+++ b/pkgs/by-name/at/atmos/package.nix
@@ -16,7 +16,9 @@ buildGoModule (finalAttrs: {
     hash = "sha256-wFM7jLBEqKFCBSUIghTXbxPmlKHr/ZxAZN1izuTq7Co=";
   };
 
-  vendorHash = "sha256-Gs90dEuk2uq2MbT/05g4x73FPOmZhJjWBxLmxe37vlg=";
+  vendorHash = "sha256-LuWGOiLPLwPuRNmg6rXRnk0O37i8glgq+xf28wKSoVo=";
+
+  proxyVendor = true;
 
   env.CGO_ENABLED = 0; # Compiles a pure statically linked Go binary.
 


### PR DESCRIPTION
Fixes the `atmos` build on `aarch64-darwin`.

The generated vendor tree contains `github.com/1password/onepassword-sdk-go` under Nix's case-collision path. The Go build runs with `-mod=vendor`, so it cannot resolve the source import path. Use `proxyVendor = true` so the build resolves modules from the module cache instead.

Closes #558825

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI assistance was used to investigate the build failure and draft this PR. The patch and verification were reviewed before submission.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
