### PR TITLE
python3Packages.advanced-alchemy: init at 1.11.0

### DIFF
--- a/pkgs/development/python-modules/advanced-alchemy/default.nix
+++ b/pkgs/development/python-modules/advanced-alchemy/default.nix
@@ -1,0 +1,162 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  hatchling,
+  alembic,
+  eval-type-backport,
+  exceptiongroup,
+  greenlet,
+  rich-click,
+  sqlalchemy,
+  typing-extensions,
+  argon2-cffi,
+  cryptography,
+  dogpile-cache,
+  fastnanoid,
+  fsspec,
+  obstore,
+  passlib,
+  pwdlib,
+  pyotp,
+  uuid-utils,
+  aiosqlite,
+  asgi-lifespan,
+  attrs,
+  cattrs,
+  dishka,
+  fastapi,
+  flask,
+  flask-sqlalchemy,
+  litestar,
+  msgspec,
+  numpy,
+  pgvector,
+  pydantic,
+  pydantic-extra-types,
+  pytest-asyncio,
+  pytest-lazy-fixtures,
+  pytest-mock,
+  pytest-xdist,
+  pytestCheckHook,
+  sanic,
+  sanic-ext,
+  sanic-testing,
+  sqlmodel,
+  starlette,
+  sybil,
+  typer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "advanced-alchemy";
+  version = "1.11.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "litestar-org";
+    repo = "advanced-alchemy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mAwtgqtmCewTWK8XbGMzMqaC1s8tnTi7fSc2BTTGfdU=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    alembic
+    greenlet
+    sqlalchemy
+    typing-extensions
+    rich-click
+  ]
+  ++ lib.optionals (pythonOlder "3.10") [ eval-type-backport ]
+  ++ lib.optionals (pythonOlder "3.11") [ exceptiongroup ];
+
+  optional-dependencies = {
+    argon2 = [ argon2-cffi ];
+    cryptography = [ cryptography ];
+    dogpile = [ dogpile-cache ];
+    fsspec = [ fsspec ];
+    nanoid = [ fastnanoid ];
+    obstore = [ obstore ];
+    passlib = [ passlib ] ++ passlib.optional-dependencies.argon2;
+    pwdlib = [
+      pwdlib
+      argon2-cffi
+    ];
+    pyotp = [ pyotp ];
+    uuid = [ uuid-utils ];
+  };
+
+  nativeCheckInputs = [
+    aiosqlite
+    argon2-cffi
+    asgi-lifespan
+    attrs
+    cattrs
+    cryptography
+    dishka
+    dogpile-cache
+    fastapi
+    flask
+    flask-sqlalchemy
+    fsspec
+    litestar
+    msgspec
+    numpy
+    passlib
+    pgvector
+    pwdlib
+    pydantic
+    pydantic-extra-types
+    pyotp
+    pytest-asyncio
+    pytest-lazy-fixtures
+    pytest-mock
+    pytest-xdist
+    pytestCheckHook
+    sanic
+    sanic-ext
+    sanic-testing
+    sqlmodel
+    starlette
+    sybil
+    typer
+    uuid-utils
+  ];
+
+  postPatch = ''
+    # fsspec expects memory without a URI scheme
+    substituteInPlace tests/fixtures/uuid/models.py tests/fixtures/bigint/models.py \
+      --replace-fail 'register_backend("memory://", "memory")' 'register_backend("memory", "memory")'
+  '';
+
+  pythonImportsCheck = [ "advanced_alchemy" ];
+
+  enabledTestPaths = [ "tests/unit" ];
+
+  # Stop pytest from loading tests/conftest.py which needs Docker databases we do not have
+  pytestFlags = [ "--confcutdir=tests/unit" ];
+
+  disabledTests = [
+    # Has a 1-2 second time limit that is often exceeded
+    "test_model_from_dict_performance"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "Ready-to-go SQLAlchemy concoctions";
+    homepage = "https://advanced-alchemy.litestar.dev/latest/";
+    changelog = "https://github.com/litestar-org/advanced-alchemy/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "alchemy";
+    maintainers = with lib.maintainers; [ aaravrav ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/python-modules/cross-web/default.nix
+++ b/pkgs/development/python-modules/cross-web/default.nix
@@ -71,8 +71,10 @@ buildPythonPackage (finalAttrs: {
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pytestFlags = [
-    # Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
+    # httpx with starlette.testclient is deprecated
     "-Wignore::starlette.exceptions.StarletteDeprecationWarning"
+    # Litestar deprecated this path parameter style
+    "-Wignore::litestar.exceptions.base_exceptions.LitestarDeprecationWarning"
   ];
 
   pythonImportsCheck = [ "cross_web" ];

--- a/pkgs/development/python-modules/litestar/default.nix
+++ b/pkgs/development/python-modules/litestar/default.nix
@@ -29,6 +29,7 @@
   piccolo,
   prometheus-client,
   opentelemetry-instrumentation-asgi,
+  opentelemetry-sdk,
   pydantic-extra-types,
   pydantic,
   email-validator,
@@ -60,14 +61,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "litestar";
-  version = "2.21.1";
+  version = "2.24.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "litestar-org";
     repo = "litestar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dH51GecYwVTnOO+F1FJnFR2VO3IvLbpKWbxK7jssak8=";
+    hash = "sha256-Smv3uzNOBQvOIESa0LCgcodzf9RhEWux2VtgCCVO5Hk=";
   };
 
   build-system = [ hatchling ];
@@ -105,7 +106,10 @@ buildPythonPackage (finalAttrs: {
     ];
     mako = [ mako ];
     minijinja = [ minijinja ];
-    opentelemetry = [ opentelemetry-instrumentation-asgi ];
+    opentelemetry = [
+      opentelemetry-instrumentation-asgi
+      opentelemetry-sdk
+    ];
     piccolo = [ piccolo ];
     picologging = lib.optionals (pythonOlder "3.13") [ picologging ];
     prometheus = [ prometheus-client ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -118,6 +118,8 @@ self: super: with self; {
 
   adsbcot = callPackage ../development/python-modules/adsbcot { };
 
+  advanced-alchemy = callPackage ../development/python-modules/advanced-alchemy { };
+
   advantage-air = callPackage ../development/python-modules/advantage-air { };
 
   aeidon = callPackage ../development/python-modules/aeidon { };


### PR DESCRIPTION
Adds [Advanced Alchemy](https://github.com/litestar-org/advanced-alchemy), a carefully crafted, thoroughly tested, optimized companion library for SQLAlchemy.

- Bumps `python3Packages.litestar` to 2.24.0 as advanced-alchemy requires `litestar >= 2.23`
- Updates `python3Packages.cross-web` so its tests ignore the new Litestar deprecation warning


Depends on #558771 (`dishka`) and #558778 (`fastnanoid`)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Micross/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test