### PR TITLE
nixos/systemd-boot: retain the current counted entry

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -15,7 +15,7 @@ import warnings
 import json
 from typing import NamedTuple, Any, Protocol, Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 # These values will be replaced with actual values during the package build
 EFI_SYS_MOUNT_POINT = Path("@efiSysMountPoint@")
@@ -39,6 +39,9 @@ CHECK_MOUNTPOINTS = "@checkMountpoints@"
 STORE_DIR = "@storeDir@"
 BOOT_COUNTING_TRIES = "@bootCountingTries@"
 BOOT_COUNTING = "@bootCounting@" == "True"
+LOADER_BOOT_COUNT_PATH = Path(
+    "/sys/firmware/efi/efivars/LoaderBootCountPath-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+)
 
 
 @dataclass(frozen=True)
@@ -620,8 +623,90 @@ def remove_extra_files() -> None:
     extra_files_dir.mkdir(parents=True, exist_ok=True)
 
 
+def booted_entry_gc_roots() -> set[Path]:
+    try:
+        variable = LOADER_BOOT_COUNT_PATH.read_bytes()
+    except FileNotFoundError:
+        return set()
+    except OSError as error:
+        print(
+            f"warning: failed to read {LOADER_BOOT_COUNT_PATH}: {error}",
+            file=sys.stderr,
+        )
+        return set()
+
+    try:
+        # efivarfs prefixes variable data with a native-endian uint32 containing
+        # its attributes. LoaderBootCountPath itself is a UTF-16LE EFI path.
+        boot_count_path = variable[4:].decode("utf-16-le").rstrip("\0")
+    except UnicodeDecodeError as error:
+        print(
+            f"warning: failed to decode {LOADER_BOOT_COUNT_PATH}: {error}",
+            file=sys.stderr,
+        )
+        return set()
+
+    match = re.fullmatch(
+        r"\\loader\\entries\\nixos-(?P<hash>[0-9a-f]{64})"
+        r"\+(?P<left>[0-9]+)(?:-(?P<done>[0-9]+))?\.conf",
+        boot_count_path,
+    )
+    if match is None:
+        return set()
+
+    contents_hash = match.group("hash")
+    prefix = f"nixos-{contents_hash}"
+    done = match.group("done")
+    failed_counter = "+0" + (f"-{done}" if done is not None else "")
+    entry_names = {
+        PurePosixPath(boot_count_path.replace("\\", "/")).name,
+        f"{prefix}.conf",
+        f"{prefix}{failed_counter}.conf",
+    }
+
+    keep: set[Path] = set()
+    entries_dir = BOOT_MOUNT_POINT / "loader/entries"
+    for entry_name in entry_names:
+        entry_path = entries_dir / entry_name
+        try:
+            contents = entry_path.read_bytes()
+        except FileNotFoundError:
+            continue
+        except OSError as error:
+            print(f"warning: failed to read {entry_path}: {error}", file=sys.stderr)
+            continue
+
+        # NixOS entry names are content-addressed. Do not trust an EFI variable
+        # to retain files unless the entry content matches the name it selected.
+        if hashlib.sha256(contents).hexdigest() != contents_hash:
+            continue
+
+        try:
+            lines = contents.decode("utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+
+        keep.add(entry_path)
+        for line in lines:
+            field, separator, value = line.partition(" ")
+            if separator == "" or field not in {"linux", "initrd", "devicetree"}:
+                continue
+
+            referenced_path = PurePosixPath(value)
+            relative_parts = referenced_path.parts[1:]
+            if (
+                referenced_path.is_absolute()
+                and ".." not in referenced_path.parts
+                and relative_parts[: len(NIXOS_DIR.parts)] == NIXOS_DIR.parts
+            ):
+                keep.add(BOOT_MOUNT_POINT.joinpath(*relative_parts))
+
+    return keep
+
+
 def garbage_collect(gc_roots: BootFileList) -> None:
     keep = {BOOT_MOUNT_POINT / gc_root.path for gc_root in gc_roots}
+    keep.update(booted_entry_gc_roots())
 
     def delete_path(e: os.DirEntry) -> None:
         if e.is_file(follow_symlinks=True) and Path(e.path) not in keep:

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -187,6 +187,9 @@ let
       withBootCounting ? false,
       ...
     }:
+    let
+      bootCountingTries = 3;
+    in
     runTest (
       { lib, ... }:
       {
@@ -195,14 +198,40 @@ let
         meta.maintainers = with lib.maintainers; [ julienmalka ];
 
         nodes = {
-          inherit common;
+          common =
+            { pkgs, ... }:
+            {
+              imports = [ common ];
+              boot.initrd.extraFiles."/etc/generation-marker".source =
+                pkgs.writeText "generation-marker" "generation 1";
+              boot.loader.systemd-boot.bootCounting = {
+                enable = withBootCounting;
+                tries = bootCountingTries;
+              };
+            };
           machine =
             { nodes, ... }:
             {
               imports = [ common ];
 
-              boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
+              boot.loader.systemd-boot.bootCounting = {
+                enable = withBootCounting;
+                tries = bootCountingTries;
+              };
               boot.loader.systemd-boot.memtest86.enable = true;
+
+              # Keep the current entry counted until the test explicitly
+              # allows systemd-bless-boot to mark it successful.
+              systemd.services.hold-boot-complete = lib.mkIf withBootCounting {
+                requiredBy = [ "boot-complete.target" ];
+                before = [ "boot-complete.target" ];
+                serviceConfig.Type = "oneshot";
+                script = ''
+                  while [[ ! -e /run/allow-boot-complete ]]; do
+                    sleep 0.1
+                  done
+                '';
+              };
 
               # These are configs for different nodes, but we'll use them here in `machine`
               system.extraDependencies = [
@@ -223,18 +252,128 @@ let
             machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${baseSystem}")
             machine.succeed("nix-env -p /nix/var/nix/profiles/system --delete-generations 1")
 
-            conf_file = check_generation(1)[0]
-            new_conf_file = conf_file.replace(".conf", "+1-3.conf")
-
-            # At this point generation 1 has already been marked as good so we reintroduce counters artificially
             ${lib.optionalString withBootCounting ''
-              machine.succeed(f"mv {conf_file} {new_conf_file}")
+              import base64
+              import re
+              import shlex
+
+              boot_count_variable = (
+                  "/sys/firmware/efi/efivars/"
+                  "LoaderBootCountPath-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+              )
+              def read_boot_count_path() -> str:
+                  return base64.b64decode(
+                      machine.succeed(f"base64 -w0 {boot_count_variable}")
+                  )[4:].decode("utf-16-le").rstrip("\0")
+
+              def entry_boot_files(conf_file: str) -> set[str]:
+                  contents = machine.succeed(
+                      f"cat -- {shlex.quote(conf_file)}"
+                  )
+                  boot_files = set()
+                  for line in contents.splitlines():
+                      field, separator, value = line.partition(" ")
+                      if separator and field in {"linux", "initrd", "devicetree"}:
+                          boot_files.add(f"/boot/{value.lstrip('/')}")
+                  assert boot_files, contents
+                  return boot_files
+
+              boot_count_path = read_boot_count_path()
+              match = re.fullmatch(
+                  r"\\loader\\entries\\(?P<prefix>nixos-[0-9a-f]{64})"
+                  r"\+(?P<left>[0-9]+)(?:-(?P<done>[0-9]+))?\.conf",
+                  boot_count_path,
+              )
+              assert match is not None, boot_count_path
+              entry_prefix = match.group("prefix")
+              done = match.group("done")
+              done_suffix = f"-{done}" if done is not None else ""
+              counted_conf = "/boot" + boot_count_path.replace("\\", "/")
+              successful_conf = f"/boot/loader/entries/{entry_prefix}.conf"
+              failed_conf = (
+                  f"/boot/loader/entries/{entry_prefix}+0{done_suffix}.conf"
+              )
+              stale_conf = f"/boot/loader/entries/{entry_prefix}+1-999.conf"
+
+              machine.succeed(f"test -e {shlex.quote(counted_conf)}")
+              referenced_boot_files = entry_boot_files(counted_conf)
+
+              # Only the current, successful, and failed forms of the booted
+              # entry are valid GC roots. Another counted form remains stale.
+              machine.succeed(
+                  f"cp -- {shlex.quote(counted_conf)} {shlex.quote(failed_conf)}"
+              )
+              machine.succeed(
+                  f"cp -- {shlex.quote(counted_conf)} {shlex.quote(stale_conf)}"
+              )
+              machine.succeed(
+                  f"cp -- {shlex.quote(counted_conf)} {shlex.quote(successful_conf)}"
+              )
+              machine.succeed(
+                  f"echo '# hash mismatch' >> {shlex.quote(successful_conf)}"
+              )
+              machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
+              machine.succeed(f"test -e {shlex.quote(counted_conf)}")
+              machine.succeed(f"test -e {shlex.quote(failed_conf)}")
+              machine.fail(f"test -e {shlex.quote(stale_conf)}")
+              machine.fail(f"test -e {shlex.quote(successful_conf)}")
+              generation_2_conf = check_generation(
+                  2, tries_left=${toString bootCountingTries}
+              )[0]
+              generation_1_only_files = referenced_boot_files.difference(
+                  entry_boot_files(generation_2_conf)
+              )
+              assert generation_1_only_files, referenced_boot_files
+              for boot_file in sorted(generation_1_only_files):
+                  machine.succeed(f"test -e {shlex.quote(boot_file)}")
+
+              # Blessing still succeeds after the booted generation falls
+              # outside the configured generation limit.
+              machine.succeed("touch /run/allow-boot-complete")
+              machine.wait_for_unit("systemd-bless-boot.service")
+              machine.fail(f"test -e {shlex.quote(counted_conf)}")
+              machine.succeed(f"test -e {shlex.quote(successful_conf)}")
+
+              # The successful form and its boot files remain protected on a
+              # later online update during the same firmware boot.
+              machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
+              machine.succeed(f"test -e {shlex.quote(successful_conf)}")
+              for boot_file in sorted(generation_1_only_files):
+                  machine.succeed(f"test -e {shlex.quote(boot_file)}")
+
+              generation_2_prefix = generation_2_conf.rsplit("/", 1)[1].removesuffix(
+                  "+${toString bootCountingTries}.conf"
+              )
+
+              machine.shutdown()
+              machine.start()
+              machine.wait_for_unit("multi-user.target")
+
+              new_boot_count_path = read_boot_count_path()
+              assert new_boot_count_path != boot_count_path
+              assert new_boot_count_path.startswith(
+                  f"\\loader\\entries\\{generation_2_prefix}+"
+              )
+
+              # The EFI variable now identifies generation 2, so the old
+              # entry can be garbage-collected by the next boot loader update.
+              machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
+              machine.fail(
+                  "grep --files-with-matches 'version Generation 1 NixOS' /boot/loader/entries/nixos-*.conf"
+              )
+              for boot_file in sorted(generation_1_only_files):
+                  machine.fail(f"test -e {shlex.quote(boot_file)}")
+              machine.succeed("touch /run/allow-boot-complete")
+              machine.wait_for_unit("systemd-bless-boot.service")
+              check_generation(2)
             ''}
-            machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
-            machine.fail(
-              "grep --files-with-matches 'version Generation 1 NixOS' /boot/loader/entries/nixos-*.conf"
-            )
-            check_generation(2)
+            ${lib.optionalString (!withBootCounting) ''
+              machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
+              machine.fail(
+                  "grep --files-with-matches 'version Generation 1 NixOS' /boot/loader/entries/nixos-*.conf"
+              )
+              check_generation(2)
+            ''}
           '';
       }
     );


### PR DESCRIPTION
`systemd-boot` records the decremented boot-counted entry in the volatile
`LoaderBootCountPath` EFI variable. That variable remains authoritative for the
current firmware boot even after `systemd-bless-boot` renames the entry to its
counterless, successful form.

The NixOS systemd-boot builder previously garbage-collected entries solely from
the retained NixOS generations. An online bootloader update could therefore
delete the current boot's entry and kernel/initrd after that generation left the
profile. A delayed or manually restarted `systemd-bless-boot` then failed because
none of the entry names it recognizes remained.

This change retains the current entry's counted, successful, and failed filename
forms, together with the boot files referenced by the entry, while
`LoaderBootCountPath` identifies it. The EFI path must match the exact
content-addressed NixOS entry format, the entry's content hash is verified, and
referenced files are restricted to the configured NixOS boot directory. A real
firmware boot replaces the volatile pointer, allowing the previous entry to be
collected normally.

The regression test delays automatic blessing and runs garbage collection while
the booted entry is still counted. It verifies that the current counted, failed,
and later successful forms retain generation-specific boot files; stale counted
and hash-mismatched forms are removed; blessing still succeeds; and the old entry
and payload become collectible after the next firmware boot changes the EFI
pointer.

This is related to the stale `LoaderBootCountPath` failure discussed in
systemd/systemd#40386 and the soft-reboot fix in systemd/systemd#40399, but fixes
the NixOS-specific online garbage-collection path.

Tested with:

```console
nix build .#nixosTests.systemd-boot.garbageCollectEntryWithBootCounting --no-link -L
nix build .#nixosTests.systemd-boot.garbage-collect-entry --no-link -L
mypy --no-implicit-optional --disallow-untyped-calls --disallow-untyped-defs nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
nixfmt --check nixos/tests/systemd-boot.nix
```

AI disclosure: I used OpenAI Codex (GPT-5) for upstream research,
implementation, tests, and review. I manually reviewed the final diff and test
coverage and take responsibility for this contribution.

cc @julienmalka @edolstra

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
