### PR TITLE
rlottie: 0.2-unstable-2026-08-11 -> 0.2-unstable-2026-09-01

### DIFF
--- a/pkgs/by-name/rl/rlottie/package.nix
+++ b/pkgs/by-name/rl/rlottie/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
+  unstableGitUpdater,
   meson,
   ninja,
   pkg-config,
@@ -33,6 +34,10 @@ stdenv.mkDerivation {
   env.NIX_CFLAGS_COMPILE = lib.optionalString (
     stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64
   ) "-U__ARM_NEON__";
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = {
     homepage = "https://github.com/Samsung/rlottie";

--- a/pkgs/by-name/rl/rlottie/package.nix
+++ b/pkgs/by-name/rl/rlottie/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation {
   pname = "rlottie";
-  version = "0.2-unstable-2026-08-11";
+  version = "0.2-unstable-2026-09-01";
 
   src = fetchFromGitHub {
     owner = "Samsung";
     repo = "rlottie";
-    rev = "27f2f23ece8a98f3e0a870e2c125faaac37e8904";
-    hash = "sha256-wEcdPKmS0f6C0A/Rg7vsZGoRi2Uv1EmA31BR2EmIlGg=";
+    rev = "25648aef19187b3f87f4d9420b8d761453ad4630";
+    hash = "sha256-sLjunpnQh1HCy5VLB8EpCTaGuBRPGCLhDovTzAAjAK0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This PR bumps rlottie to the latest commit, closes #558817.
It also adds an updateScript to allow for automated version bumps.

Only security fixes were made in the code, so no breaking change is expected.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
