### PR TITLE
dawarich: 1.14.0 -> 1.14.4

### DIFF
--- a/nixos/tests/web-apps/dawarich.nix
+++ b/nixos/tests/web-apps/dawarich.nix
@@ -5,6 +5,8 @@
   nodes.machine =
     { lib, pkgs, ... }:
     {
+      virtualisation.memorySize = 1536;
+
       services.dawarich = {
         enable = true;
         localDomain = "localhost";

--- a/pkgs/by-name/da/dawarich/gemset.nix
+++ b/pkgs/by-name/da/dawarich/gemset.nix
@@ -688,17 +688,6 @@
     };
     version = "11.3.1";
   };
-  database_consistency = {
-    dependencies = [ "activerecord" ];
-    groups = [ "development" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "0fs7nz3ckyplaxv28nv4xhjdj6fl4ih7jkfjnzgfgphkp5fy5anf";
-      type = "gem";
-    };
-    version = "3.0.5";
-  };
   date = {
     groups = [
       "default"
@@ -1161,32 +1150,6 @@
       type = "gem";
     };
     version = "1.4.2";
-  };
-  gpx = {
-    dependencies = [
-      "csv"
-      "nokogiri"
-      "rake"
-    ];
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "06p5wkyj6lcj01szv22g1jcx8qkkpc4cypj9hdmji9n9h5ipd8bq";
-      type = "gem";
-    };
-    version = "1.2.2";
-  };
-  groupdate = {
-    dependencies = [ "activesupport" ];
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "0405sjsqz2x62g5yghswbsm570xjh1j434p5867c70d9ijhhxy8n";
-      type = "gem";
-    };
-    version = "6.8.0";
   };
   h3 = {
     dependencies = [
@@ -3179,16 +3142,6 @@
       type = "gem";
     };
     version = "3.5.2";
-  };
-  stackprof = {
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "014s1zxlxcw35shislar3y1i3mqa0c6gh3m21js14q1q5zharhjf";
-      type = "gem";
-    };
-    version = "0.2.28";
   };
   stimulus-rails = {
     dependencies = [ "railties" ];

--- a/pkgs/by-name/da/dawarich/gemset.nix
+++ b/pkgs/by-name/da/dawarich/gemset.nix
@@ -1410,10 +1410,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "115ll278g3zdvff7b05gfxqc9n74vw9xfzcc8jkv22bkphpkbng4";
+      sha256 = "1mqps8z4ly74hpksfajcfamqk1wb79biy187pn10knmi6zzb26al";
       type = "gem";
     };
-    version = "2.10.3";
+    version = "3.2.0";
   };
   kaminari = {
     dependencies = [
@@ -2617,10 +2617,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1bc3n2h2dpalms230rsh1zw0jr8nnpcm53x97b8in78y1p0f4372";
+      sha256 = "1qfjxabqpcmmnp12frydip5y4l8vdx0riy4vfnndmcjsjx6h8vb2";
       type = "gem";
     };
-    version = "0.7.0";
+    version = "0.7.2";
   };
   resolv-replace = {
     dependencies = [ "resolv" ];

--- a/pkgs/by-name/da/dawarich/sources.json
+++ b/pkgs/by-name/da/dawarich/sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.2",
-  "hash": "sha256-yS+cBRK7sqPtUODFyvKc36k4MtuHkHn3rAIhVHe9ANg=",
+  "version": "1.14.3",
+  "hash": "sha256-JbTPx4vxvpyPctADKV8eaMR439U6C/A5lFkdCS09xgU=",
   "npmHash": "sha256-WXwDi3K9s77+d/1lEOmUKeOZkcvUEsh8YnPztaqKHjk="
 }

--- a/pkgs/by-name/da/dawarich/sources.json
+++ b/pkgs/by-name/da/dawarich/sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.3",
-  "hash": "sha256-JbTPx4vxvpyPctADKV8eaMR439U6C/A5lFkdCS09xgU=",
+  "version": "1.14.4",
+  "hash": "sha256-QwDb8iAuoVG+Er9vfN8aGqcqjtWV/qGyr01PWy7HgBM=",
   "npmHash": "sha256-WXwDi3K9s77+d/1lEOmUKeOZkcvUEsh8YnPztaqKHjk="
 }

--- a/pkgs/by-name/da/dawarich/sources.json
+++ b/pkgs/by-name/da/dawarich/sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.0",
-  "hash": "sha256-ZIwhjWp+5R6EgvQ61U3nKByGPvYQVZd7izzgwwWpCOk=",
+  "version": "1.14.2",
+  "hash": "sha256-yS+cBRK7sqPtUODFyvKc36k4MtuHkHn3rAIhVHe9ANg=",
   "npmHash": "sha256-WXwDi3K9s77+d/1lEOmUKeOZkcvUEsh8YnPztaqKHjk="
 }


### PR DESCRIPTION
https://github.com/Freika/dawarich/releases/tag/1.14.1
https://github.com/Freika/dawarich/releases/tag/1.14.2
https://github.com/Freika/dawarich/releases/tag/1.14.3
https://github.com/Freika/dawarich/releases/tag/1.14.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
