### PR TITLE
jetbrains-mono: Use installFonts hook

### DIFF
--- a/pkgs/by-name/je/jetbrains-mono/package.nix
+++ b/pkgs/by-name/je/jetbrains-mono/package.nix
@@ -2,25 +2,26 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  python313Packages,
+  python3Packages,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "jetbrains-mono";
   version = "2.304";
 
   src = fetchFromGitHub {
     owner = "jetbrains";
     repo = "jetbrainsmono";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-SW9d5yVud2BWUJpDOlqYn1E1cqicIHdSZjbXjqOAQGw=";
   };
 
   env."PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION" = "python";
 
   nativeBuildInputs = [
-    # Currently broken on 3.14
-    python313Packages.gftools
+    python3Packages.gftools
+    installFonts
   ];
 
   buildPhase = ''
@@ -29,21 +30,20 @@ stdenvNoCC.mkDerivation rec {
     runHook postBuild
   '';
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm644 -t "$out/share/fonts/opentype/" fonts/otf/*.otf
-    install -Dm644 -t "$out/share/fonts/truetype/" fonts/ttf/*.ttf
-    install -Dm644 -t "$out/share/fonts/truetype/" fonts/variable/*.ttf
-    install -Dm644 -t "$out/share/fonts/WOFF2/" fonts/webfonts/*.woff2
-    runHook postInstall
-  '';
+  # gftools pulls in ninja which we don't need here.
+  dontUseNinjaInstall = true;
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   meta = {
     description = "Typeface made for developers";
     homepage = "https://jetbrains.com/mono/";
-    changelog = "https://github.com/JetBrains/JetBrainsMono/blob/v${version}/Changelog.md";
+    changelog = "https://github.com/JetBrains/JetBrainsMono/blob/v${finalAttrs.src.tag}/Changelog.md";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ vinnymeller ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Link: https://github.com/NixOS/nixpkgs/issues/495640

Switches Jetbrains Mono to use the installFonts hook. Also bumps the gftools dependency to python 3.14.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
