### PR TITLE
vice-clipper: init at 2.10.0

### DIFF
--- a/pkgs/by-name/vi/vice-clipper/find-systemd-service-in-xdg-data-dirs.patch
+++ b/pkgs/by-name/vi/vice-clipper/find-systemd-service-in-xdg-data-dirs.patch
@@ -1,0 +1,19 @@
+diff --git a/vice/main.py b/vice/main.py
+index e5c37cb..0067652 100644
+--- a/vice/main.py
++++ b/vice/main.py
+@@ -1549,8 +1549,14 @@ def _installed_service_file() -> Optional[Path]:
+     that put the unit in /usr/lib reported "(not installed)" while the service
+     was sitting there enabled (#139).
+     """
++    data_dirs = tuple(
++        Path(path) / "systemd" / "user" / "vice.service"
++        for path in os.environ.get("XDG_DATA_DIRS", "").split(":")
++        if path
++    )
+     candidates = (
+         actual_home_dir() / ".config" / "systemd" / "user" / "vice.service",
++        *data_dirs,
+         Path("/etc/systemd/user/vice.service"),
+         Path("/usr/lib/systemd/user/vice.service"),
+         Path("/usr/local/lib/systemd/user/vice.service"),

--- a/pkgs/by-name/vi/vice-clipper/package.nix
+++ b/pkgs/by-name/vi/vice-clipper/package.nix
@@ -1,0 +1,166 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  wrapGAppsHook3,
+  gobject-introspection,
+  gtk3,
+  glib,
+  webkitgtk_4_1,
+  gst_all_1,
+  ffmpeg,
+  gpu-screen-recorder,
+  wf-recorder,
+  pulseaudio,
+  alsa-utils,
+  wl-clipboard,
+  xclip,
+  xsel,
+  xdg-utils,
+  xdotool,
+  xprop,
+  xrandr,
+  xdpyinfo,
+  wmctrl,
+  cloudflared,
+  systemd,
+  desktop-file-utils,
+  udevCheckHook,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "vice";
+  version = "2.10.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "eklonofficial";
+    repo = "Vice";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7+ahNY4ckW0WBqE2Kg1uxmRpY+hCc/5E5+rbMq3fbwE=";
+  };
+
+  patches = [
+    # Look for vice.service on XDG_DATA_DIRS as upstream only looks in /usr/lib and would report it missing
+    ./find-systemd-service-in-xdg-data-dirs.patch
+    # Unpack each alias tuple and check each name separately because some evdev key names are a tuple of
+    # aliases instead of a string but vice can only process strings so it crashes
+    ./support-evdev-key-aliases.patch
+  ];
+
+  build-system = [ python3Packages.setuptools ];
+
+  postPatch = ''
+    # Restrict raw access to keyboards as Vice only needs hotkeys and upstream grants it to every input device
+    substituteInPlace packaging/vice.rules \
+      --replace-fail \
+        'KERNEL=="event*", SUBSYSTEM=="input", TAG+="uaccess"' \
+        'KERNEL=="event*", SUBSYSTEM=="input", ENV{ID_INPUT_KEYBOARD}=="1", TAG+="uaccess"'
+  '';
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    webkitgtk_4_1
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-libav
+  ];
+
+  dependencies = with python3Packages; [
+    aiohttp
+    click
+    evdev
+    psutil
+    pygobject3
+    pywebview
+    tomli-w
+  ];
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ffmpeg
+          gpu-screen-recorder
+          wf-recorder
+          pulseaudio
+          alsa-utils
+          wl-clipboard
+          xclip
+          xsel
+          xdg-utils
+          xdotool
+          xprop
+          xrandr
+          xdpyinfo
+          wmctrl
+          cloudflared
+          systemd
+        ]
+      }
+    )
+  '';
+
+  postInstall = ''
+    install -Dm644 vice.desktop $out/share/applications/vice.desktop
+    install -Dm644 assets/vice.svg $out/share/icons/hicolor/scalable/apps/vice.svg
+    install -Dm644 packaging/vice.rules $out/lib/udev/rules.d/70-vice-input.rules
+    install -Dm644 packaging/vice.service $out/lib/systemd/user/vice.service
+    substituteInPlace $out/lib/systemd/user/vice.service \
+      --replace-fail /usr/bin/vice $out/bin/vice
+  '';
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    udevCheckHook
+    desktop-file-utils
+    ffmpeg
+  ];
+
+  doCheck = true;
+  doInstallCheck = true;
+
+  preCheck = ''
+    rm -rf build
+  '';
+
+  postInstallCheck = ''
+    desktop-file-validate $out/share/applications/vice.desktop
+  '';
+
+  pythonImportsCheck = [
+    "vice.main"
+    "vice.app"
+    "vice.editor"
+    "vice.hotkey"
+    "vice.playlists"
+    "vice.recorder"
+    "vice.runtime"
+    "vice.share"
+    "vice.updates"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linux game clip recorder, like Medal.tv, for Wayland and X11";
+    homepage = "https://github.com/eklonofficial/Vice";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ aaravrav ];
+    mainProgram = "vice";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/vi/vice-clipper/support-evdev-key-aliases.patch
+++ b/pkgs/by-name/vi/vice-clipper/support-evdev-key-aliases.patch
@@ -1,0 +1,16 @@
+diff --git a/vice/hotkey.py b/vice/hotkey.py
+index 769a020..cf7b65b 100644
+--- a/vice/hotkey.py
++++ b/vice/hotkey.py
+@@ -304,4 +304,9 @@ def can_access_hotkeys() -> bool:
+-
++
+ def list_available_keys() -> list[str]:
+     """Return all KEY_* names evdev knows about (for documentation/config help)."""
+-    return sorted(k for k in ecodes.bytype[ecodes.EV_KEY].values() if k.startswith("KEY_"))
++    return sorted(
++        name
++        for value in ecodes.bytype[ecodes.EV_KEY].values()
++        for name in (value if isinstance(value, tuple) else (value,))
++        if isinstance(name, str) and name.startswith("KEY_")
++    )


### PR DESCRIPTION
Adds [Vice](https://github.com/eklonofficial/Vice), a Medal.tv-style game clipper for Linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test