### PR TITLE
citrix-workspace: explain in requireFile message why the mainline tarball fails

### DIFF
--- a/pkgs/by-name/ci/citrix-workspace/package.nix
+++ b/pkgs/by-name/ci/citrix-workspace/package.nix
@@ -119,9 +119,15 @@ stdenv.mkDerivation (finalAttrs: {
 
     message = ''
       In order to use Citrix Workspace, you need to comply with the Citrix EULA and download
-      the 64-bit binaries, .tar.gz from:
+      the x86_64 tarball (.tar.gz) of the "GCC 11" technical preview from:
 
       https://www.citrix.com/downloads/workspace-app/betas-and-tech-previews/workspace-app-tp-gcc11-for-linux.html
+
+      Note: the tarball offered on the regular "Workspace app for Linux" download page is
+      NOT compatible with this package. That mainline build is linked against libsoup 2 and
+      bundles a legacy WebKitGTK 4.0 stack which crashes on Nixpkgs (selfservice fails with
+      "The authentication service could not be contacted"). nixpkgs packages the GCC 11
+      technical-preview line (libsoup 3 / WebKitGTK 4.1) exclusively.
 
       (if you do not find version ${finalAttrs.version} there, try at
       https://www.citrix.com/downloads/workspace-app/)


### PR DESCRIPTION
### Description of changes

`citrix-workspace` tracks Citrix's GCC 11 technical preview (libsoup 3 / WebKitGTK 4.1). However, Citrix's main download page currently only links the GCC 8 mainline tarball (e.g. `linuxx64-gcc-8-26.04.10.1.tar.gz`), and old mainline releases have been removed from their site.

Right now, the `requireFile` error just points users to the general download portal, leading them to grab the incompatible GCC 8 tarball. When users force this tarball through the expression (or update the hash locally), it fails at runtime in a confusing way: the GCC 8 build expects libsoup 2 and a legacy WebKitGTK 4.0 stack, leading to heap corruption (`free(): invalid next size (fast)`) and authentication errors ("The authentication service could not be contacted"). The GCC 11 tech preview doesn't have this issue since it uses libsoup 3 and pairs properly with nixpkgs' `webkitgtk_4_1`.

This PR updates the `requireFile` error message to:

* Explicitly ask for the GCC 11 technical preview x86_64 tarball.
* Warn that the standard GCC 8 tarball from the primary download page will fail at runtime.

No packaging logic or hashes changed; message updates only.

### Testing

* Verified evaluation (`nix eval .#citrix-workspace.version`).
* Verified locally on NixOS: forcing the GCC 8 tarball reproduces the heap corruption and auth failure, while using the expected GCC 11 preview tarball works fine and allows login.

### Things done

* [x] Made sure the package evaluates (`nix eval ...#citrix-workspace.version`)
* [ ] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)
* [x] Commits follow [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) conventions