### PR TITLE
terragrunt-atlantis-config: init at 1.21.1

### DIFF
--- a/pkgs/by-name/te/terragrunt-atlantis-config/package.nix
+++ b/pkgs/by-name/te/terragrunt-atlantis-config/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "terragrunt-atlantis-config";
+  version = "1.21.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "transcend-io";
+    repo = "terragrunt-atlantis-config";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lh5c5+Lj2jb9BrM3piG9ERUjluiN0f/sPYp4OyKzYBw=";
+  };
+
+  vendorHash = "sha256-brTFOsO2tgWlli1z0W0DGh7114iSlTMHlSZWoFmGdAs=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  preCheck = ''
+    mkdir -p cmd/test_artifacts
+  '';
+
+  meta = {
+    changelog = "https://github.com/transcend-io/terragrunt-atlantis-config/releases/tag/v${finalAttrs.version}";
+    description = "Generate Atlantis config for Terragrunt projects";
+    homepage = "https://github.com/transcend-io/terragrunt-atlantis-config";
+    license = lib.licenses.mit;
+    mainProgram = "terragrunt-atlantis-config";
+    maintainers = with lib.maintainers; [ benley ];
+  };
+})


### PR DESCRIPTION
terragrunt-atlantis-config is a Atlantis config generator for Terragrunt projects:

https://github.com/transcend-io/terragrunt-atlantis-config
https://transcend.io/blog/why-we-use-terragrunt

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
