### PR TITLE
rust-bindgen: pass target triple when cross-compiling

### DIFF
--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -132,6 +132,9 @@
     substitutions = {
       libclang = (lib.getLib clang.cc);
       inherit clang;
+      targetFlag = lib.optionalString (
+        stdenv.targetPlatform != stdenv.hostPlatform
+      ) "--target=${stdenv.targetPlatform.config}";
     };
     meta.license = lib.licenses.mit;
   } ./rust-bindgen-hook.sh;

--- a/pkgs/build-support/rust/hooks/rust-bindgen-hook.sh
+++ b/pkgs/build-support/rust/hooks/rust-bindgen-hook.sh
@@ -6,7 +6,7 @@
 
 populateBindgenEnv () {
     export LIBCLANG_PATH=@libclang@/lib
-    BINDGEN_EXTRA_CLANG_ARGS="$(< @clang@/nix-support/cc-cflags) $(< @clang@/nix-support/libc-cflags) $(< @clang@/nix-support/libcxx-cxxflags) $NIX_CFLAGS_COMPILE"
+    BINDGEN_EXTRA_CLANG_ARGS="@targetFlag@ $(< @clang@/nix-support/cc-cflags) $(< @clang@/nix-support/libc-cflags) $(< @clang@/nix-support/libcxx-cxxflags) $NIX_CFLAGS_COMPILE"
     export BINDGEN_EXTRA_CLANG_ARGS
 }
 

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -4,9 +4,15 @@
   bash,
   runCommand,
   runCommandCC,
+  stdenv,
 }:
 let
   clang = rust-bindgen-unwrapped.clang;
+  targetFlag =
+    if stdenv.targetPlatform != stdenv.hostPlatform then
+      "--target=${stdenv.targetPlatform.config}"
+    else
+      "";
   self =
     runCommand "rust-bindgen-${rust-bindgen-unwrapped.version}"
       {
@@ -49,6 +55,7 @@ let
           --replace-fail "@bash@" "${bash}" \
           --replace-fail "@cxxincludes@" "$cxxincludes" \
           --replace-fail "@cincludes@" "$cincludes" \
+          --replace-fail "@targetFlag@" "${targetFlag}" \
           --replace-fail "@unwrapped@" "${rust-bindgen-unwrapped}"
         chmod +x $out/bin/bindgen
       '';

--- a/pkgs/development/tools/rust/bindgen/wrapper.sh
+++ b/pkgs/development/tools/rust/bindgen/wrapper.sh
@@ -28,7 +28,7 @@ if [[ -n "$NIX_DEBUG" ]]; then
   set -x;
 fi;
 # shellcheck disable=SC2086
-# cxxflags and NIX_CFLAGS_COMPILE should be word-split
-exec -a "$0" @unwrapped@/bin/bindgen "$@" $sep $cxxflags @cincludes@ $NIX_CFLAGS_COMPILE
+# targetFlag, cxxflags and NIX_CFLAGS_COMPILE should be word-split
+exec -a "$0" @unwrapped@/bin/bindgen "$@" $sep @targetFlag@ $cxxflags @cincludes@ $NIX_CFLAGS_COMPILE
 # note that we add the flags after $@ which is incorrect. This is only for the sake
 # of simplicity.


### PR DESCRIPTION
Pass the target triple to libclang from `bindgenHook` and the `rust-bindgen` wrapper when cross-compiling. Without it, bindgen can parse target libc headers using the wrong architecture.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
