### PR TITLE
typescript: 5.9.3 -> 7.0.2

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -224,6 +224,8 @@
 
 - `fittrackee` 1.0.0 now requires postgres with postgis. The [upgrade guide](https://docs.fittrackee.org/en/upgrading-to-1.0.0.html) has steps to prepare for this upgrade.
 
+- `typescript` 7.0.2 now uses the Golang implementation. The [announcement document](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) has information on what was changed.
+
 ### Deprecations {#sec-nixpkgs-release-26.11-lib-deprecations}
 
 - Setting `config.allowBrokenPredicate` is deprecated in favor of

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -46,7 +46,7 @@
   stylish-haskell,
   tabnine,
   tmux,
-  typescript,
+  typescript_5,
   typescript-language-server,
   vim,
   which,
@@ -4691,7 +4691,7 @@ assertNoAdditions {
     postPatch = ''
       substituteInPlace lua/tsc/utils.lua --replace-fail \
       'bin_name = bin_name or "tsc"' \
-      'bin_name = bin_name or "${typescript}/bin/tsc"'
+      'bin_name = bin_name or "${typescript_5}/bin/tsc"'
     '';
 
     # Unit test

--- a/pkgs/by-name/ad/adw-bluetooth/package.nix
+++ b/pkgs/by-name/ad/adw-bluetooth/package.nix
@@ -7,7 +7,7 @@
   ninja,
   pkg-config,
   blueprint-compiler,
-  typescript,
+  typescript_5,
   desktop-file-utils,
   wrapGAppsHook4,
   gjs,
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     blueprint-compiler
-    typescript
+    typescript_5
     desktop-file-utils
     wrapGAppsHook4
   ];

--- a/pkgs/by-name/ag/ags_1/package.nix
+++ b/pkgs/by-name/ag/ags_1/package.nix
@@ -14,7 +14,7 @@
   libsoup_3,
   networkmanager,
   upower,
-  typescript,
+  typescript_5,
   wrapGAppsHook3,
   linux-pam,
   nix-update-script,
@@ -42,7 +42,7 @@ buildNpmPackage (finalAttrs: {
     pkg-config
     gjs
     gobject-introspection
-    typescript
+    typescript_5
     wrapGAppsHook3
   ];
 

--- a/pkgs/by-name/an/angular-language-server/package.nix
+++ b/pkgs/by-name/an/angular-language-server/package.nix
@@ -11,7 +11,7 @@
   common-updater-scripts,
   jq,
   unzip,
-  typescript,
+  typescript_5,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "angular-language-server";
@@ -44,7 +44,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     patchShebangs $out/lib/bin/ngserver $out/lib/index.js $out/lib/node_modules
     makeWrapper $out/lib/bin/ngserver $out/bin/ngserver \
       --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
-      --add-flags "--tsProbeLocations ${typescript}/lib/node_modules/typescript --ngProbeLocations $out/lib/node_modules"
+      --add-flags "--tsProbeLocations ${typescript_5}/lib/node_modules/typescript --ngProbeLocations $out/lib/node_modules"
   '';
 
   passthru = {

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -17,7 +17,7 @@
   perl,
   rustPlatform,
   go,
-  typescript,
+  typescript_5,
   makeSetupHook,
   writeShellScript,
 }:
@@ -102,7 +102,7 @@ let
     nativeBuildInputs = [
       nodejs
       openapi-generator-cli
-      typescript
+      typescript_5
     ];
 
     buildPhase = ''

--- a/pkgs/by-name/au/autobrr/package.nix
+++ b/pkgs/by-name/au/autobrr/package.nix
@@ -10,7 +10,7 @@
   pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
-  typescript,
+  typescript_5,
   versionCheckHook,
 }:
 
@@ -32,7 +32,7 @@ let
       nodejs
       pnpmConfigHook
       pnpm_11
-      typescript
+      typescript_5
     ];
 
     sourceRoot = "${src.name}/web";

--- a/pkgs/by-name/co/convertx/package.nix
+++ b/pkgs/by-name/co/convertx/package.nix
@@ -6,7 +6,7 @@
   # Build deps
   bun,
   tailwindcss_4,
-  typescript,
+  typescript_5,
   makeBinaryWrapper,
 
   # Runtime deps
@@ -81,7 +81,7 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [
     makeBinaryWrapper
     tailwindcss_4
-    typescript
+    typescript_5
   ];
 
   dontConfigure = true;

--- a/pkgs/by-name/de/decibels/package.nix
+++ b/pkgs/by-name/de/decibels/package.nix
@@ -11,7 +11,7 @@
   meson,
   ninja,
   pkg-config,
-  typescript,
+  typescript_5,
   wrapGAppsHook4,
   gnome,
 }:
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    typescript
+    typescript_5
     wrapGAppsHook4
   ];
 

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -8,7 +8,7 @@
   electron_42,
   element-web,
   callPackage,
-  typescript,
+  typescript_5,
   tsx,
   sqlcipher,
   # command line arguments which are always set
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
     nodejs
     makeWrapper
-    typescript
+    typescript_5
     pnpm
     pnpmConfigHook
     tsx

--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -17,7 +17,7 @@
   nodejs,
   pkg-config,
   python3,
-  typescript,
+  typescript_5,
   zip,
 
   gnome-keyring,
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     # desktop-notifications build doesn't pick up tsc from node_modules for some reason
-    typescript
+    typescript_5
     zip
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;

--- a/pkgs/by-name/gn/gnome-weather/package.nix
+++ b/pkgs/by-name/gn/gnome-weather/package.nix
@@ -17,7 +17,7 @@
   geoclue2,
   python3,
   gsettings-desktop-schemas,
-  typescript,
+  typescript_5,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     gobject-introspection
     gjs
-    typescript
+    typescript_5
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ig/ignition/package.nix
+++ b/pkgs/by-name/ig/ignition/package.nix
@@ -10,7 +10,7 @@
   meson,
   ninja,
   pkg-config,
-  typescript,
+  typescript_5,
   wrapGAppsHook4,
 
   gjs,
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    typescript
+    typescript_5
     wrapGAppsHook4
   ];
 

--- a/pkgs/by-name/im/imgbrd-grabber/package.nix
+++ b/pkgs/by-name/im/imgbrd-grabber/package.nix
@@ -9,7 +9,7 @@
   libpulseaudio,
   openssl,
   rsync,
-  typescript,
+  typescript_5,
   qt6,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ [
       openssl
       libpulseaudio
-      typescript
+      typescript_5
       nodejs
     ];
 

--- a/pkgs/by-name/ir/ironcalc/frontend.nix
+++ b/pkgs/by-name/ir/ironcalc/frontend.nix
@@ -10,7 +10,7 @@
   wasm-bindgen-cli_0_2_108,
   wasm-pack,
   nodejs,
-  typescript,
+  typescript_5,
   lld,
   writableTmpDirAsHomeHook,
 
@@ -38,7 +38,7 @@ let
       wasm-bindgen-cli_0_2_108
       wasm-pack
       nodejs
-      typescript
+      typescript_5
       lld
       writableTmpDirAsHomeHook
     ];

--- a/pkgs/by-name/mc/mcp-server-filesystem/package.nix
+++ b/pkgs/by-name/mc/mcp-server-filesystem/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildNpmPackage,
-  typescript,
+  typescript_5,
   fetchFromGitHub,
 }:
 
@@ -17,7 +17,7 @@ buildNpmPackage (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    typescript
+    typescript_5
   ];
 
   dontNpmPrune = true;

--- a/pkgs/by-name/mc/mcp-server-memory/package.nix
+++ b/pkgs/by-name/mc/mcp-server-memory/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildNpmPackage,
-  typescript,
+  typescript_5,
   fetchFromGitHub,
 }:
 
@@ -17,7 +17,7 @@ buildNpmPackage (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    typescript
+    typescript_5
   ];
 
   dontNpmPrune = true;

--- a/pkgs/by-name/mc/mcp-server-sequential-thinking/package.nix
+++ b/pkgs/by-name/mc/mcp-server-sequential-thinking/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildNpmPackage,
-  typescript,
+  typescript_5,
   fetchFromGitHub,
 }:
 
@@ -17,7 +17,7 @@ buildNpmPackage (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    typescript
+    typescript_5
   ];
 
   dontNpmPrune = true;

--- a/pkgs/by-name/me/mediaharbor/package.nix
+++ b/pkgs/by-name/me/mediaharbor/package.nix
@@ -20,7 +20,7 @@
   pango,
   pkg-config,
   rustPlatform,
-  typescript,
+  typescript_5,
   webkitgtk_4_1,
   wrapGAppsHook4,
   zlib,
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     nodejs
     npmHooks.npmConfigHook
     pkg-config
-    typescript
+    typescript_5
     wrapGAppsHook4
   ];
 

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -7,7 +7,7 @@
   fetchFromGitHub,
   fetchYarnDeps,
   nodejs,
-  typescript,
+  typescript_5,
   makeWrapper,
   makeDesktopItem,
   copyDesktopItems,
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     nodejs
     yarn
-    typescript
+    typescript_5
     fixup-yarn-lock
     makeWrapper
   ]

--- a/pkgs/by-name/op/opcua-commander/package.nix
+++ b/pkgs/by-name/op/opcua-commander/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildNpmPackage,
   fetchFromGitHub,
-  typescript,
+  typescript_5,
   esbuild,
   makeWrapper,
   nodejs,
@@ -22,7 +22,7 @@ buildNpmPackage rec {
   npmDepsHash = "sha256-HB4boWgZWoG+ib+cCoQbUmrrV5rECR3dMwj2lCyJjT0=";
   nativeBuildInputs = [
     esbuild
-    typescript
+    typescript_5
     makeWrapper
   ];
 

--- a/pkgs/by-name/qu/qui/package.nix
+++ b/pkgs/by-name/qu/qui/package.nix
@@ -9,7 +9,7 @@
   pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
-  typescript,
+  typescript_5,
   versionCheckHook,
 }:
 buildGo126Module (finalAttrs: {
@@ -30,7 +30,7 @@ buildGo126Module (finalAttrs: {
       nodejs
       pnpmConfigHook
       pnpm_11
-      typescript
+      typescript_5
     ];
 
     sourceRoot = "${finalAttrs.src.name}/web";

--- a/pkgs/by-name/sp/spectral-language-server/package.nix
+++ b/pkgs/by-name/sp/spectral-language-server/package.nix
@@ -5,7 +5,7 @@
   fetchYarnDeps,
   yarnConfigHook,
   fetchFromGitHub,
-  typescript,
+  typescript_5,
   jq,
   fetchpatch,
 }:
@@ -29,7 +29,7 @@ let
     };
 
     nativeBuildInputs = [
-      typescript
+      typescript_5
       jq
       yarnConfigHook
     ];

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -21,7 +21,7 @@
   rustc,
   rustPlatform,
   stdenv,
-  typescript,
+  typescript_5,
   webkitgtk_4_1,
   writableTmpDirAsHomeHook,
 }:
@@ -115,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     rustc
     rustPlatform.cargoSetupHook
-    typescript
+    typescript_5
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ty/typescript-language-server/package.nix
+++ b/pkgs/by-name/ty/typescript-language-server/package.nix
@@ -10,7 +10,7 @@
   replaceVars,
   yarn,
   testers,
-  typescript,
+  typescript_5,
   nix-update-script,
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (replaceVars ./default-fallbackTsserverPath.diff {
-      typescript = "${typescript}/lib/node_modules/typescript/lib/tsserver.js";
+      typescript = "${typescript_5}/lib/node_modules/typescript/lib/tsserver.js";
     })
   ];
 

--- a/pkgs/by-name/ty/typescript_7/package.nix
+++ b/pkgs/by-name/ty/typescript_7/package.nix
@@ -15,7 +15,7 @@ let
   buildGoModule = buildGo126Module;
 in
 buildGoModule (finalAttrs: {
-  pname = "typescript-go";
+  pname = "typescript";
   version = "7.0.2";
 
   __structuredAttrs = true;
@@ -71,20 +71,20 @@ buildGoModule (finalAttrs: {
       (nix-update-script {
         extraArgs = [
           "--use-github-releases"
-          "--version-regex=^v([\\d.]+)$"
+          "--version-regex=^v(7\\.[\\d.]+)$"
           "--src-only"
         ];
       })
 
       (lib.getExe (writeShellApplication {
-        name = "typescript-go-go-version-updater";
+        name = "typescript-go-version-updater";
         runtimeInputs = [
           nix
           gnugrep
           gnused
         ];
         text = ''
-          new_src="$(nix-build --attr 'pkgs.typescript-go.src' --no-out-link)"
+          new_src="$(nix-build --attr 'pkgs.typescript_7.src' --no-out-link)"
           new_go_major_minor="$(grep --only-matching --perl-regexp '^go \K([0-9]+\.[0-9]+)' "$new_src/tsc/go.mod")"
           sed -i -E "s/buildGo[0-9]+Module/buildGo''${new_go_major_minor//./}Module/g" '${toString ./package.nix}'
         '';
@@ -98,9 +98,9 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    description = "Go implementation of TypeScript";
-    homepage = "https://github.com/microsoft/typescript";
-    changelog = "https://github.com/microsoft/typescript/releases/tag/v${finalAttrs.version}";
+    description = "Superset of JavaScript that compiles to clean JavaScript output";
+    homepage = "https://www.typescriptlang.org/";
+    changelog = "https://github.com/microsoft/TypeScript/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       kachick

--- a/pkgs/by-name/vs/vscode-css-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-css-languageserver/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   nodejs,
-  typescript,
+  typescript_5,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -26,7 +26,7 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    typescript
+    typescript_5
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/vs/vscode-html-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-html-languageserver/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   nodejs,
-  typescript,
+  typescript_5,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -26,11 +26,11 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    typescript
+    typescript_5
   ];
 
   preBuild = ''
-    ln -s ${typescript}/lib/node_modules/typescript node_modules/typescript
+    ln -s ${typescript_5}/lib/node_modules/typescript node_modules/typescript
   '';
 
   buildPhase = ''
@@ -46,7 +46,7 @@ buildNpmPackage (finalAttrs: {
   dontNpmBuild = true;
 
   postInstall = ''
-    ln -s ${typescript}/lib/node_modules/typescript \
+    ln -s ${typescript_5}/lib/node_modules/typescript \
       $out/lib/node_modules/vscode-html-languageserver/node_modules/typescript
 
     makeBinaryWrapper ${lib.getExe nodejs} $out/bin/vscode-html-languageserver \

--- a/pkgs/by-name/vs/vscode-json-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-json-languageserver/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   nodejs,
-  typescript,
+  typescript_5,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -26,7 +26,7 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    typescript
+    typescript_5
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/we/weylus/package.nix
+++ b/pkgs/by-name/we/weylus/package.nix
@@ -28,7 +28,7 @@
   git,
   autoconf,
   libtool,
-  typescript,
+  typescript_5,
   wayland,
   libxkbcommon,
 }:
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     cmake
     git
-    typescript
+    typescript_5
     makeWrapper
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/by-name/yc/ycmd/package.nix
+++ b/pkgs/by-name/yc/ycmd/package.nix
@@ -12,7 +12,7 @@
   withRustAnalyzer ? true,
   rust-analyzer,
   withTypescript ? true,
-  typescript,
+  typescript_5,
   abseil-cpp,
   boost,
   llvmPackages,
@@ -110,7 +110,7 @@ stdenv.mkDerivation {
   ''
   + lib.optionalString withTypescript ''
     TARGET=$out/lib/ycmd/third_party/tsserver
-    ln -sf ${typescript} $TARGET
+    ln -sf ${typescript_5} $TARGET
   '';
 
   # fixup the argv[0] and replace __file__ with the corresponding path so

--- a/pkgs/desktops/gnome/extensions/pop-shell/default.nix
+++ b/pkgs/desktops/gnome/extensions/pop-shell/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   glib,
   gjs,
-  typescript,
+  typescript_5,
   unstableGitUpdater,
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     glib
     gjs
-    typescript
+    typescript_5
   ];
 
   buildInputs = [ gjs ];

--- a/pkgs/kde/third-party/karousel/default.nix
+++ b/pkgs/kde/third-party/karousel/default.nix
@@ -5,7 +5,7 @@
   kpackage,
   kwin,
   nodejs,
-  typescript,
+  typescript_5,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     kpackage
     nodejs
-    typescript
+    typescript_5
   ];
   buildInputs = [ kwin ];
   dontWrapQtApps = true;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2548,6 +2548,7 @@ mapAliases {
   trust-dns = throw "'trust-dns' has been renamed to/replaced by 'hickory-dns'"; # Converted to throw 2025-10-27
   tvbrowser-bin = throw "'tvbrowser-bin' has been renamed to/replaced by 'tvbrowser'"; # Converted to throw 2025-10-27
   twitterBootstrap = warnAlias "'twitterBootstrap' has been renamed to 'twitter-bootstrap'"; # Added 2026-02-12
+  typescript-go = lib.warnOnInstantiate "'typescript-go' has been renamed to 'typescript'" typescript; # Added 2026-09-02
   typodermic-free-fonts = throw "'typodermic-free-fonts' has been removed as it is unmaintained in nixpkgs, and the src is prone to breakage."; # Added 2026-05-07
   typodermic-public-domain = throw "'typodermic-public-domain' has been removed as it is unmaintained in nixpkgs, and the src is prone to breakage."; # Added 2026-05-07
   typst-fmt = throw "'typst-fmt' has been renamed to/replaced by 'typstfmt'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9289,7 +9289,7 @@ with pkgs;
     callPackage ../applications/networking/instant-messengers/linphone { }
   );
 
-  typescript = typescript_5;
+  typescript = typescript_7;
 
   buildTypstPackage = callPackage ../build-support/build-typst-package.nix { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Typescript moved their main repository over to typescript go and closed the typescript-go repository (https://github.com/microsoft/typescript-go). Figured I'd make the changes. 