### PR TITLE
degit: 2.8.4 -> 3.9.0

### DIFF
--- a/pkgs/by-name/de/degit/package.nix
+++ b/pkgs/by-name/de/degit/package.nix
@@ -129,7 +129,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Make copies of git repositories";
     homepage = "https://github.com/Rich-Harris/degit";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kidonng ];
+    maintainers = with lib.maintainers; [
+      eljamm
+      kidonng
+    ];
     mainProgram = "degit";
   };
 })

--- a/pkgs/by-name/de/degit/package.nix
+++ b/pkgs/by-name/de/degit/package.nix
@@ -1,28 +1,135 @@
 {
   lib,
-  buildNpmPackage,
+  stdenv,
   fetchFromGitHub,
+  bun,
+  makeWrapper,
+  nodejs,
+  writableTmpDirAsHomeHook,
 }:
 
-buildNpmPackage rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "degit";
-  version = "2.8.4";
+  version = "3.9.0";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "Rich-Harris";
     repo = "degit";
-    rev = "v${version}";
-    hash = "sha256-Vw/gtmKywi5faSCs7Wek80nmnqcPHXlQarD5qMwlsQE=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-IbFBAWD7Ci10BkZx5PcPOmg4Ur7Mm4YaRnqKvWILDlY=";
   };
 
-  npmDepsHash = "sha256-42cM31C2c1Gr7HWOowMUTEUEyL0mGnyl5fyQECcz1Sw=";
+  nativeBuildInputs = [
+    bun
+    makeWrapper
+    nodejs
+    writableTmpDirAsHomeHook
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${finalAttrs.passthru.node_modules}/. .
+    patchShebangs node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    bun run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/degit}
+    cp -r assets degit dist node_modules package.json LICENSE.md $out/lib/degit/
+
+    # NOTE:
+    # We're silencing warnings because of DEP0169 in `degit`, which is present
+    # both in the main project and its dependencies, namely `isomorphic-git`,
+    # which in turn depends on `simple-get`, which uses the deprecated API.
+    #
+    # For now, let's just silence the warning so it doesn't annoy users.
+    #
+    # Also see:
+    # - https://nodejs.org/api/deprecations.html#dep0169-insecure-urlparse
+    # - https://nodejs.org/api/url.html#the-whatwg-url-api
+    makeWrapper ${nodejs}/bin/node $out/bin/degit \
+      --add-flags "--no-deprecation" \
+      --add-flags "$out/lib/degit/degit"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    # Adapted from: pkgs/by-name/an/anytype/package.nix
+    node_modules = stdenv.mkDerivation {
+      pname = "${finalAttrs.pname}-node_modules";
+      inherit (finalAttrs) version src;
+
+      __structuredAttrs = true;
+      strictDeps = true;
+
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+        "GIT_PROXY_COMMAND"
+        "SOCKS_SERVER"
+      ];
+
+      nativeBuildInputs = [
+        bun
+        writableTmpDirAsHomeHook
+      ];
+
+      dontConfigure = true;
+
+      buildPhase = ''
+        runHook preBuild
+
+        export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+        # https://bun.com/docs/pm/cli/install#configuring-with-environment-variables
+
+        # Bun always tries to use the fastest available installation method for the target platform. On macOS, that’s clonefile and on Linux, that’s hardlink.
+        bun install \
+          --backend=copyfile \
+          --cpu="*" \
+          --frozen-lockfile \
+          --ignore-scripts \
+          --no-progress \
+          --os="*"
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        find . -type d -name node_modules -exec cp -R --parents {} $out \;
+
+        runHook postInstall
+      '';
+
+      dontFixup = true;
+
+      outputHash = "sha256-jUFea7eSY0AYtwPGUUXxoZQb6zZpmiaowqeVibck884=";
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+    };
+  };
 
   meta = {
-    changelog = "https://github.com/Rich-Harris/degit/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/Rich-Harris/degit/blob/${finalAttrs.src.rev}/docs/CHANGELOG.md";
     description = "Make copies of git repositories";
     homepage = "https://github.com/Rich-Harris/degit";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kidonng ];
     mainProgram = "degit";
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/Rich-Harris/degit/blob/v3.9.0/docs/CHANGELOG.md
Closes: https://github.com/NixOS/nixpkgs/issues/530325

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
