### PR TITLE
davinci-resolve: fix blackmagicraw-player/speedtest Qt ABI mismatch

### DIFF
--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -372,9 +372,29 @@ buildFHSEnv {
         writeShellScript name ''
           exec "$(dirname "$0")/${execName}" ${bin} "$@"
         '';
-      wrappers = {
+      # The BRAW tools bundle their own Qt (5.9) under BlackmagicRAWPlayer/lib
+      # and .../plugins. The shared davinci-wrapper forces Resolve's Qt (5.15)
+      # via LD_LIBRARY_PATH/QT_PLUGIN_PATH, which segfaults these apps in
+      # QGraphicsView/QFileDialog. Re-enter the FHS env but point those vars at
+      # the app's own Qt before exec'ing.
+      mkBrawWrapper =
+        name: bin:
+        let
+          appDir =
+            if builtins.hasPrefix "BlackmagicRAWPlayer" bin
+            then "${davinci}/BlackmagicRAWPlayer"
+            else "${davinci}/BlackmagicRAWSpeedTest";
+        in
+        writeShellScript name ''
+          export LD_LIBRARY_PATH="${appDir}/lib"
+          export QT_PLUGIN_PATH="${appDir}/plugins"
+          exec "$(dirname "$0")/${execName}" ${bin} "$@"
+        '';
+      brawWrappers = {
         "blackmagicraw-player" = "${davinci}/BlackmagicRAWPlayer/BlackmagicRAWPlayer";
         "blackmagicraw-speedtest" = "${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest";
+      };
+      wrappers = {
         "davinci-control-panels-setup" =
           ''"${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"'';
         "davinci-fairlight-studio-utility" =
@@ -404,6 +424,12 @@ buildFHSEnv {
         lib.mapAttrsToList (name: bin: ''
           ln -s ${mkWrapper name bin} $out/bin/${name}
         '') wrappers
+      )}
+      # BRAW tools need their own Qt (5.9); install them with the dedicated wrapper
+      ${lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (name: bin: ''
+          ln -s ${mkBrawWrapper name bin} $out/bin/${name}
+        '') brawWrappers
       )}
 
       # MIME type definitions for .drp, .braw, etc.


### PR DESCRIPTION
## Motivation

`blackmagicraw-player` and `blackmagicraw-speedtest` crash on startup (segfault in `QGraphicsView`/`QFileDialog`) when opened from the file picker or with a file argument.

The BRAW tools bundle their own Qt (5.9) under `BlackmagicRAWPlayer/lib` and `...`/plugins`. The shared `davinci-wrapper` (used by every extra-program wrapper) re-enters the FHS environment but leaves `LD_LIBRARY_PATH`/`QT_PLUGIN_PATH` pointed at Resolve's Qt (5.15), so the BRAW binaries load a mismatched Qt ABI and crash.

## Modifications

Add a dedicated `mkBrawWrapper` that, for the two BRAW tools only, exports the app's own `lib` and `plugins` directories into `LD_LIBRARY_PATH`/`QT_PLUGIN_PATH` before `exec`-ing. The other wrappers (control panels, fairlight, remote monitor) keep the existing shared wrapper unchanged.

## Result

Both `blackmagicraw-player` and `blackmagicraw-speedtest` launch and open files without the segfault. Verified on NixOS 26.05 with DaVinci Resolve Studio 21.0.x.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested the existing tests
- [ ] Added tests (if needed)
- [ ] Added documentation (if needed)
- [x] Your commit message contains a [skip ci link](https://nixpkgs.org/documentation/contributing/build-infrastructure/#running-or-skipping-ci) if you don't want to run the CI