### PR TITLE
{tor,mullvad}-browser: 15.0.20 -> 15.0.21

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -97,7 +97,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.20";
+  version = "15.0.21";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-EyVih1kklIg7b3fdh6tqtEE3Xh/UPpPMZgfdxtY6c5s=";
+      hash = "sha256-LHv/hY/abmy7/8nsNkKiwJh+SvRLzEO97fNNvPuYXQo=";
     };
   };
 

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -102,7 +102,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.20";
+  version = "15.0.21";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -112,7 +112,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-1DAmM9YFnS2tlOLIg7MRQdx7Paor+lqrsP0p3aGNIuk=";
+      hash = "sha256-kd1QoBi3Y5bDvrbc3yY/dFnaqsL7JelZ6AdFsVv8NZ8=";
     };
 
     i686-linux = fetchurl {
@@ -122,7 +122,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-iqvfcBsVFN25JtAKDyL94hoL/K3rM0M7pbK7gbir5ZA=";
+      hash = "sha256-LWoAry/tJFvIlE0sDsUesHY+ziYnjqz4K8YEHIjrE0Y=";
     };
   };
 


### PR DESCRIPTION
tb changelog: https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/tbb-15.0.21-build1/projects/browser/Bundle-Data/Docs-TBB/ChangeLog.txt
mb changelog: https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/mb-15.0.21-build1/projects/browser/Bundle-Data/Docs-MB/ChangeLog.txt
firefox esr: https://www.firefox.com/en-US/firefox/140.15.0/releasenotes/
firefox security advisories: https://www.mozilla.org/en-US/security/advisories/mfsa2026-84/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
