### PR TITLE
gtasks-md: init at 0.0.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14402,6 +14402,12 @@
     githubId = 2469618;
     name = "Junji Hashimoto";
   };
+  jupblb = {
+    email = "nixpkgs@kielbowi.cz";
+    github = "jupblb";
+    githubId = 3370617;
+    name = "Michal Kielbowicz";
+  };
   jurraca = {
     email = "julienu@pm.me";
     github = "jurraca";

--- a/pkgs/by-name/gt/gtasks-md/package.nix
+++ b/pkgs/by-name/gt/gtasks-md/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "gtasks-md";
+  version = "0.0.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "gtasks-md";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nocNA+dF4dSn70OfoBjP+utwfBiNfnSrMARaqCl2fuw=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    google-api-python-client
+    google-auth-httplib2
+    google-auth-oauthlib
+    markdown-it-py
+    mdformat
+    xdg
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    unittestCheckHook
+  ];
+
+  pythonImportsCheck = [ "gtasks_md" ];
+
+  meta = {
+    description = "Manage Google Tasks using a Markdown document";
+    homepage = "https://github.com/google/gtasks-md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jupblb ];
+    mainProgram = "gtasks-md";
+  };
+})


### PR DESCRIPTION
This PR adds [gtasks-md](https://github.com/google/gtasks-md), a CLI tool for managing Google Tasks declaratively through a Markdown document. It supports editing tasks in `$EDITOR`, reconciling a local Markdown file with Google Tasks, viewing tasks, and rolling back changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test