### PR TITLE
haskell: enable shared libraries for GHC's wasm interpreter

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -64,8 +64,11 @@
   enableProfiledLibs ? !stdenv.hostPlatform.isRiscV64,
 
   # Whether to build dynamic libs for the standard library (on the target
-  # platform). Static libs are always built.
-  enableShared ? with stdenv.targetPlatform; !isWindows && !useiOSPrebuilt && !isStatic && !isGhcjs,
+  # platform). Static libs are always built. GHC's wasm target interpreter
+  # uses shared libraries.
+  enableShared ?
+    with stdenv.targetPlatform;
+    !isWindows && !useiOSPrebuilt && (!isStatic || isWasm) && !isGhcjs,
 
   # Whether to build terminfo.
   enableTerminfo ?

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -124,10 +124,10 @@ in
   enableLibraryProfiling ? !stdenv.hostPlatform.isGhcjs,
   enableExecutableProfiling ? false,
   profilingDetail ? "exported-functions",
-  # TODO enable shared libs for cross-compiling
+  # TODO enable shared libs for non-wasm cross-compiling
   enableSharedExecutables ? false,
   enableSharedLibraries ?
-    !stdenv.hostPlatform.isStatic
+    (!stdenv.hostPlatform.isStatic || stdenv.hostPlatform.isWasm)
     && (ghc.enableShared or false)
     && !stdenv.hostPlatform.useAndroidPrebuilt, # TODO: figure out why /build leaks into RPATH
   enableDeadCodeElimination ? (!stdenv.hostPlatform.isDarwin), # TODO: use -dead_strip for darwin
@@ -1105,6 +1105,11 @@ lib.fix (
       // optionalAttrs (args ? changelog) { inherit changelog; }
       // optionalAttrs (args ? mainProgram) { inherit mainProgram; };
 
+    }
+    # The static stdenv adapter appends --enable-static and --disable-shared
+    # to configureFlags, overriding shared libraries requested above.
+    // optionalAttrs (stdenv.hostPlatform.isStatic && enableSharedLibraries) {
+      dontAddStaticConfigureFlags = true;
     }
     // optionalAttrs (args ? sourceRoot) { inherit sourceRoot; }
     // optionalAttrs (args ? setSourceRoot) { inherit setSourceRoot; }


### PR DESCRIPTION
GHC's wasm target interpreter needs shared Haskell libraries when a Template Haskell splice imports code from another package. Without them, a cross-package splice fails during interactive linking:

```
       > During interactive linking, GHCi couldn't find the following symbol:
       >   closure:makeValue
```

- `generic-builder.nix` enables shared libraries for wasm.
- `generic-builder.nix` prevents the static stdenv adapter from adding `--enable-static` and `--disable-shared` when shared libraries are enabled.
- `common-hadrian.nix` configures GHC when targeting wasm to provide the shared libraries used by its interpreter.

### Alternative considered
An alternative would be setting `hasSharedLibraries = true` for WASI, but that also affects unrelated WASI C and C++ packages. Testing that showed `libcxx` and `hello` failed to build. Scoping the change to Haskell infrastructure avoids those unrelated changes.

### How to test and verify the change

[The test case](https://github.com/ilkecan/ghc-wasm-nix/tree/6fb23cc11d4199808aff7845a1dfa125b3d944a9/checks/shared-libraries) uses two packages, a dependency package exporting `makeValue` and a package whose Template Haskell splice imports it:

```haskell
import Repro.Dependency (makeValue)

value :: String
value = $(makeValue)
```

Create the `nixpkgs-review` checkout:

```sh
nixpkgs-review pr 558928
```

From the resulting review shell, run:

```sh
repro_flake="github:ilkecan/ghc-wasm-nix/6fb23cc11d4199808aff7845a1dfa125b3d944a9"
review_nixpkgs="git+file://$PWD/nixpkgs"
# before
nix build "$repro_flake#shared-libraries-repro" --override-input nixpkgs "$review_nixpkgs?rev=483daeee8c253622f6db7684620f83ceac268e89" --no-link -L
# after
nix build "$repro_flake#shared-libraries-repro" --override-input nixpkgs "$review_nixpkgs" --no-link -L
```

The before command fails during the Template Haskell splice because the dependency shared object is unavailable. The after command succeeds.

The repro uses an externally supplied wasm GHC bindist. A source-built wasm GHC build was attempted[^1] but is currently blocked before reaching Hadrian because the `libffi` and `gmp-static` dependencies fail to build for the WASI target.

[^1]: using `nix build -f . pkgsCross.wasi32.buildPackages.haskell.compiler.ghc9141 -L --print-out-paths`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
