### PR TITLE
quake3e: add desktop icon

### DIFF
--- a/pkgs/by-name/qu/quake3e/package.nix
+++ b/pkgs/by-name/qu/quake3e/package.nix
@@ -68,11 +68,16 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  postInstall = ''
+    install -Dm644 code/unix/quake3.svg $out/share/icons/hicolor/scalable/apps/quake3e.svg
+  '';
+
   desktopItems = [
     (makeDesktopItem {
       name = "Quake3e";
       exec = "quake3e";
       desktopName = "Quake3e";
+      icon = "quake3e";
       categories = [ "Game" ];
     })
   ];


### PR DESCRIPTION
`quake3e`'s generated `Quake3e.desktop` has no `Icon=` key, so the launcher entry shows a blank/generic icon.

The Quake III logo already ships in the source tree at `code/unix/quake3.svg` (alongside `quake3.png` and `quake3_flat.icns`) but is never installed. This installs the SVG into the hicolor icon theme and references it from the desktop item — the same approach already used for `ioquake3` (which installs `misc/quake3.svg` as `ioquake3.svg`). The icon is named `quake3e.svg` / `Icon=quake3e` to avoid colliding with `ioquake3` in a shared profile.

Verification:

```
$ nix-build -A quake3e
$ cat result/share/applications/Quake3e.desktop
[Desktop Entry]
Categories=Game
Exec=quake3e
Icon=quake3e
Name=Quake3e
Type=Application
Version=1.5
$ ls result/share/icons/hicolor/scalable/apps/
quake3e.svg
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

The commit and this PR summary were produced with Claude Code (claude-sonnet-5) and reviewed before submission; see the `Assisted-by:` trailer on the commit.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
