### PR TITLE
linux: Fix booting under qemu's IBM pSeries emulation

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1213,6 +1213,9 @@ let
         SCSI_LOWLEVEL_PCMCIA = yes;
         SCSI_SAS_ATA = yes; # added to enable detection of hard drive
 
+        # Required for booting our ISO in qemu's IBM pSeries machine emulation mode via '-cdrom'.
+        SCSI_IBMVSCSI = lib.mkIf (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian) yes;
+
         SPI = yes; # needed for many devices
         SPI_MASTER = yes;
 


### PR DESCRIPTION
`qemu-system-ppc64 -machine pseries,x-vof=off` configures qemu to emulate an IBM pSeries machine with Slimline Open Firmware. By default, drives in that mode will be attached via IBM's Virtual SCSI interface, which requires the `ibmvscsi` kernel module to be usable.

To make `ibmvscsi` available during stage 1 of booting, build it into the kernel. The same was done with IDE support, for booting on Power Macintosh G5s with an IDE-attached optical drive.

---

Context in the Exotic Nix Targets room on Matrix: https://matrix.to/#/!pbdtvoHxUGLhcEvnlu:nixos.org/$vGXnasze4hX3jaN4WiNsE9jku8azwZuf1TuLlgHy_5o?via=nixos.org&via=matrix.org&via=nixos.dev

<img width="732" height="804" alt="image" src="https://github.com/user-attachments/assets/86d81982-588d-4cc2-8b65-4eb3d0f5af46" />

Alternatively, ensuring that `ibmvscsi` is in the initrd on big-endian 64-bit POWER would also make this work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no-op)
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.  
      See screenshot :)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
