### PR TITLE
python3Packages.pyqt{3d,chart,datavisualization}: drop libsForQt5.callPackage

### DIFF
--- a/pkgs/development/python-modules/pyqt3d/default.nix
+++ b/pkgs/development/python-modules/pyqt3d/default.nix
@@ -5,7 +5,7 @@
   pyqt5,
   pyqt-builder,
   python,
-  qt3d,
+  qt5,
   setuptools,
   sip,
 }:
@@ -46,12 +46,12 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     sip
-    qt3d
+    qt5.qt3d
     setuptools
     pyqt-builder
   ];
 
-  buildInputs = [ qt3d ];
+  buildInputs = [ qt5.qt3d ];
 
   propagatedBuildInputs = [ pyqt5 ];
 

--- a/pkgs/development/python-modules/pyqtchart/default.nix
+++ b/pkgs/development/python-modules/pyqtchart/default.nix
@@ -5,7 +5,7 @@
   pyqt5,
   pyqt-builder,
   python,
-  qtcharts,
+  qt5,
   setuptools,
   sip,
 }:
@@ -46,12 +46,12 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     sip
-    qtcharts
+    qt5.qtcharts
     setuptools
     pyqt-builder
   ];
 
-  buildInputs = [ qtcharts ];
+  buildInputs = [ qt5.qtcharts ];
 
   propagatedBuildInputs = [ pyqt5 ];
 

--- a/pkgs/development/python-modules/pyqtdatavisualization/default.nix
+++ b/pkgs/development/python-modules/pyqtdatavisualization/default.nix
@@ -5,7 +5,7 @@
   pyqt5,
   pyqt-builder,
   python,
-  qtdatavis3d,
+  qt5,
   setuptools,
   sip,
 }:
@@ -46,12 +46,12 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     sip
-    qtdatavis3d
+    qt5.qtdatavis3d
     setuptools
     pyqt-builder
   ];
 
-  buildInputs = [ qtdatavis3d ];
+  buildInputs = [ qt5.qtdatavis3d ];
 
   propagatedBuildInputs = [ pyqt5 ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15845,18 +15845,7 @@ self: super: with self; {
 
   pyqtdarktheme = callPackage ../development/python-modules/pyqtdarktheme { };
 
-  pyqtdatavisualization =
-    pkgs.libsForQt5.callPackage ../development/python-modules/pyqtdatavisualization
-      {
-        inherit (self)
-          buildPythonPackage
-          pyqt5
-          pyqt-builder
-          python
-          setuptools
-          sip
-          ;
-      };
+  pyqtdatavisualization = callPackage ../development/python-modules/pyqtdatavisualization { };
 
   pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15813,16 +15813,7 @@ self: super: with self; {
 
   pyqt-builder = callPackage ../development/python-modules/pyqt-builder { };
 
-  pyqt3d = pkgs.libsForQt5.callPackage ../development/python-modules/pyqt3d {
-    inherit (self)
-      buildPythonPackage
-      pyqt5
-      pyqt-builder
-      python
-      setuptools
-      sip
-      ;
-  };
+  pyqt3d = callPackage ../development/python-modules/pyqt3d { };
 
   pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix { inherit (pkgs) mesa; };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15841,16 +15841,7 @@ self: super: with self; {
     inherit (pkgs) mesa;
   };
 
-  pyqtchart = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtchart {
-    inherit (self)
-      buildPythonPackage
-      pyqt5
-      pyqt-builder
-      python
-      setuptools
-      sip
-      ;
-  };
+  pyqtchart = callPackage ../development/python-modules/pyqtchart { };
 
   pyqtdarktheme = callPackage ../development/python-modules/pyqtdarktheme { };
 


### PR DESCRIPTION
Using `libsForQt5.callPackage` are unnecessarily complicated here, since we can simply use `qt5.qt3d` instead of `qt3d` using the normal Python `callPackage`. Dropping `libsForQt5.callPackage` also aligns with the spirit of https://github.com/NixOS/nixpkgs/issues/180841#issuecomment-2218221636 to deprecate redundant Qt functions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
