### PR TITLE
uefitoolPackages: use top-level callPackage

### DIFF
--- a/pkgs/tools/system/uefitool/old-engine.nix
+++ b/pkgs/tools/system/uefitool/old-engine.nix
@@ -1,14 +1,13 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
-  qtbase,
-  qmake,
+  qt5,
   cmake,
   zip,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "uefitool";
   version = "0.28.0";
 
@@ -19,11 +18,12 @@ mkDerivation rec {
     tag = version;
   };
 
-  buildInputs = [ qtbase ];
+  buildInputs = [ qt5.qtbase ];
   nativeBuildInputs = [
-    qmake
+    qt5.qmake
     cmake
     zip
+    qt5.wrapQtAppsHook
   ];
 
   dontConfigure = true;

--- a/pkgs/tools/system/uefitool/variants.nix
+++ b/pkgs/tools/system/uefitool/variants.nix
@@ -1,5 +1,5 @@
-{ libsForQt5, qt6Packages }:
+{ callPackage }:
 {
-  new-engine = qt6Packages.callPackage ./new-engine.nix { };
-  old-engine = libsForQt5.callPackage ./old-engine.nix { };
+  new-engine = callPackage ./new-engine.nix { };
+  old-engine = callPackage ./old-engine.nix { };
 }


### PR DESCRIPTION
See #180841 for the intuition of removing Qt `derivation`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
