### PR TITLE
nixos/kavita: improve credential management

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -73,6 +73,15 @@
 - `services.mysql` now sets `root@localhost` authentication to `auth_socket` when used with `mysql` or `percona-server`.
   Existing deployments will also be adjusted if possible. See the [security advisory GHSA-6qxx-6rg8-c4p8](https://github.com/NixOS/nixpkgs/security/advisories/GHSA-6qxx-6rg8-c4p8) for more information.
 
+- Usability of `services.kavita` has been improved:
+  - Managing secrets or credentials within `services.kavita` has been improved to allow users to load more than 1 secret into the service with
+    `services.kavita.credentials`.
+  - `services.kavita.tokenKeyFile` has been renamed to `services.kavita.settings.TokenKey` and accepts a string. The value of
+    `services.kavita.settings.TokenKey` should be updated with placeholder text, such as `@token_key@`; and re-defined in `services.kavita.credentials`.
+    Refer to module documentation for more information.
+  - `services.kavita` now properly links default e-mail templates from upstream via `services.kavita.useDefaultEmailTemplates`. If you already
+    have custom e-mail templates in `${services.kavita.settings.dataDir}/EmailTemplates`, then you should set this to `false`.
+
 - `sqlitestudio` has been renamed to `letos` to reflect upstream changes. See [Letos: Name rebranding](https://github.com/pawelsalawa/letos/issues/5441) for more information.
 
 - `zerofs` has been updated from `1.x` to `2.x` which is a breaking change. Volumes created by earlier releases are refused at open with a clear error. There is no migration tool; older volumes remain readable and writable by the release that created them.

--- a/nixos/modules/services/web-apps/kavita.nix
+++ b/nixos/modules/services/web-apps/kavita.nix
@@ -125,7 +125,7 @@ in
       type = lib.types.bool;
       default = true;
       description = ''
-        Whether or not to copy default e-mail templates [1] from upstream to `${cfg.dataDir}/EmailTemplates`
+        Whether or not to copy default e-mail templates [1] from upstream to `''${cfg.dataDir}/EmailTemplates`
 
         [1] https://github.com/Kareadita/Kavita/tree/develop/Kavita.Server/EmailTemplates
       '';

--- a/nixos/modules/services/web-apps/kavita.nix
+++ b/nixos/modules/services/web-apps/kavita.nix
@@ -8,9 +8,7 @@
 let
   cfg = config.services.kavita;
   settingsFormat = pkgs.formats.json { };
-  appsettings = settingsFormat.generate "appsettings.json" (
-    { TokenKey = "@TOKEN@"; } // cfg.settings
-  );
+  appsettings = settingsFormat.generate "appsettings.json" cfg.settings;
 in
 {
   imports = [
@@ -26,6 +24,10 @@ in
       )
     )
     (lib.mkRenamedOptionModule [ "services" "kavita" "port" ] [ "services" "kavita" "settings" "Port" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "kavita" "tokenKeyFile" ]
+      [ "services" "kavita" "settings" "TokenKey" ]
+    )
   ];
 
   options.services.kavita = {
@@ -45,18 +47,20 @@ in
       description = "The directory where Kavita stores its state.";
     };
 
-    tokenKeyFile = lib.mkOption {
-      type = lib.types.path;
-      description = ''
-        A file containing the TokenKey, a secret with at 512+ bits.
-        It can be generated with `head -c 64 /dev/urandom | base64 --wrap=0`.
-      '';
-    };
-
     settings = lib.mkOption {
       default = { };
       description = ''
         Kavita configuration options, as configured in {file}`appsettings.json`.
+
+        Any configuration option that contains sensitive data should use a placeholder
+        value (ie, `oidc_client_secret`) enclosed with an `@` character:
+
+        `services.kavita.settings.OpenIdConnectSettings.Secret = "@oidc_client_secret@";`
+
+        Then, use the placeholder as unique key and hydrate the secret using your
+        preferred secrets management (ie, `sops-nix`):
+
+        `services.kavita.credentials."oidc_client_secret" = config.sops.secrets."client_secret".path;`
       '';
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
@@ -75,8 +79,46 @@ in
               IP Addresses to bind to. The default is to bind to all IPv4 and IPv6 addresses.
             '';
           };
+
+          TokenKey = lib.mkOption {
+            default = "@token_key@";
+            type = lib.types.str;
+            description = ''
+              A secret with at least 512 bits. It may be generated with `head -c 64 /dev/urandom | base64 --wrap=0`.
+
+              Suggest using a placeholder value (eg, `token_key`) enclosed by `@` character (eg, `@tokey_key@`) to avoid writing
+              sensitive data to world readable nix store. Placeholder value will be defined as key in `services.kavita.credentials`
+              and the associated path containing the secret will be replaced at service startup.
+            '';
+          };
         };
       };
+      example = {
+        IpAddresses = "::2,127.0.0.2";
+        Port = 5001;
+        TokenKey = "@token_key@";
+        OpenIdConnectSettings = {
+          Enabled = true;
+          Authority = "https://idp.example.com";
+          ClientId = "kavita";
+          Secret = "@oidc_client_secret@";
+        };
+      };
+    };
+
+    credentials = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        token_key = "/run/secrets/kavita/token_key";
+        oidc_client_secret = "/run/secrets/kavita/client_secret";
+      };
+      description = ''
+        Secrets that will be passed to systemd service and subsequently all placeholders in {file}`appsettings.json` will be replaced
+        prior to service startup.
+
+        It is not necessary to enclose the keys/placeholder values with `@` characters here.
+      '';
     };
 
     useDefaultEmailTemplates = lib.mkOption {
@@ -85,7 +127,7 @@ in
       description = ''
         Whether or not to copy default e-mail templates [1] from upstream to `${cfg.dataDir}/EmailTemplates`
 
-        [1]: https://github.com/Kareadita/Kavita/tree/develop/Kavita.Server/EmailTemplates
+        [1] https://github.com/Kareadita/Kavita/tree/develop/Kavita.Server/EmailTemplates
       '';
     };
   };
@@ -97,13 +139,16 @@ in
       after = [ "network.target" ];
       preStart = ''
         install -m600 ${appsettings} ${lib.escapeShellArg cfg.dataDir}/config/appsettings.json
-        ${pkgs.replace-secret}/bin/replace-secret '@TOKEN@' \
-          ''${CREDENTIALS_DIRECTORY}/token \
-          '${cfg.dataDir}/config/appsettings.json'
-      '';
+      ''
+      + lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (key: val: ''
+          ${lib.getExe pkgs.replace-secret} '@${key}@' \
+            ''${CREDENTIALS_DIRECTORY}/${key} \
+            ${cfg.dataDir}/config/appsettings.json'') cfg.credentials
+      );
       serviceConfig = {
         WorkingDirectory = cfg.dataDir;
-        LoadCredential = [ "token:${cfg.tokenKeyFile}" ];
+        LoadCredential = lib.mapAttrsToList (key: value: "${key}:${value}") cfg.credentials;
         ExecStart = lib.getExe cfg.package;
         Restart = "always";
         User = cfg.user;
@@ -115,7 +160,7 @@ in
       "d '${cfg.dataDir}/config' 0750 ${cfg.user} ${cfg.user} - -"
     ]
     ++ lib.optionals cfg.useDefaultEmailTemplates [
-      "L+ '${cfg.dataDir}/EmailTemplates' - - - - ${cfg.package}/lib/kavita/backend/EmailTemplates/"
+      "L+ '${cfg.dataDir}/EmailTemplates' - - - - ${cfg.package}/lib/kavita/backend/EmailTemplates"
     ];
 
     users = {

--- a/nixos/modules/services/web-apps/kavita.nix
+++ b/nixos/modules/services/web-apps/kavita.nix
@@ -174,5 +174,8 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ misterio77 ];
+  meta.maintainers = with lib.maintainers; [
+    misterio77
+    debtquity
+  ];
 }

--- a/nixos/modules/services/web-apps/kavita.nix
+++ b/nixos/modules/services/web-apps/kavita.nix
@@ -78,6 +78,16 @@ in
         };
       };
     };
+
+    useDefaultEmailTemplates = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether or not to copy default e-mail templates [1] from upstream to `${cfg.dataDir}/EmailTemplates`
+
+        [1]: https://github.com/Kareadita/Kavita/tree/develop/Kavita.Server/EmailTemplates
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -103,6 +113,9 @@ in
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}'        0750 ${cfg.user} ${cfg.user} - -"
       "d '${cfg.dataDir}/config' 0750 ${cfg.user} ${cfg.user} - -"
+    ]
+    ++ lib.optionals cfg.useDefaultEmailTemplates [
+      "L+ '${cfg.dataDir}/EmailTemplates' - - - - ${cfg.package}/lib/kavita/backend/EmailTemplates/"
     ];
 
     users = {

--- a/nixos/tests/kavita.nix
+++ b/nixos/tests/kavita.nix
@@ -11,7 +11,7 @@
       {
         services.kavita = {
           enable = true;
-          tokenKeyFile = builtins.toFile "kavita.key" "d26ba694b455271a8872415830fb7b5c58f8da98f9ef7f58b2ca4c34bd406512";
+          settings.TokenKey = "d26ba694b455271a8872415830fb7b5c58f8da98f9ef7f58b2ca4c34bd406512";
         };
       };
   };

--- a/nixos/tests/kavita.nix
+++ b/nixos/tests/kavita.nix
@@ -2,7 +2,10 @@
 {
   name = "kavita";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ misterio77 ];
+    maintainers = [
+      misterio77
+      debtquity
+    ];
   };
 
   nodes = {


### PR DESCRIPTION
* add ability to hide/obfuscate more than 1 secret from world readable nix store
* move/rename `services.kavita.tokenKeyFile` to `services.kavita.settings.TokenKey`
* update nixosTests.kavita to align with changes
* add new option -- `services.kavita.useDefaultEmailTemplates` -- which will symlink `cfg.dataDir` with upstream e-mail templates. Previously, this was not performed and if you have e-mail configured then it would not send e-mails

Resolves: #558959 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
