### PR TITLE
openvswitch: 3.7.1 -> 4.0.0

### DIFF
--- a/nixos/modules/virtualisation/openvswitch.nix
+++ b/nixos/modules/virtualisation/openvswitch.nix
@@ -105,6 +105,7 @@ in
               /var/db/openvswitch/conf.db
           '';
           Restart = "always";
+          RestartMode = "direct";
           RestartSec = 3;
           PIDFile = "/run/openvswitch/ovsdb.pid";
           # Use service type 'forking' to correctly determine when ovsdb-server is ready.
@@ -131,6 +132,7 @@ in
           # Use service type 'forking' to correctly determine when vswitchd is ready.
           Type = "forking";
           Restart = "always";
+          RestartMode = "direct";
           RestartSec = 3;
         };
       };

--- a/nixos/modules/virtualisation/openvswitch.nix
+++ b/nixos/modules/virtualisation/openvswitch.nix
@@ -64,9 +64,22 @@ in
 
       boot.extraModulePackages = [ cfg.package ];
 
+      systemd.sockets.ovsdb = {
+        description = "Open_vSwitch Database Socket";
+        wantedBy = [ "sockets.target" ];
+        before = [ "ovsdb.service" ];
+        socketConfig = {
+          ListenStream = "${runDir}/db.sock";
+          Service = "ovsdb.service";
+          SocketMode = "0770";
+        };
+      };
+
       systemd.services.ovsdb = {
         description = "Open_vSwitch Database Server";
         wantedBy = [ "multi-user.target" ];
+        requires = [ "ovsdb.socket" ];
+        after = [ "ovsdb.socket" ];
         path = [ cfg.package ];
         restartTriggers = [
           db
@@ -95,7 +108,7 @@ in
         serviceConfig = {
           ExecStart = ''
             ${cfg.package}/bin/ovsdb-server \
-              --remote=punix:${runDir}/db.sock \
+              --remote=pfd:3 \
               --private-key=db:Open_vSwitch,SSL,private_key \
               --certificate=db:Open_vSwitch,SSL,certificate \
               --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert \
@@ -119,8 +132,8 @@ in
       systemd.services.ovs-vswitchd = {
         description = "Open_vSwitch Daemon";
         wantedBy = [ "multi-user.target" ];
-        bindsTo = [ "ovsdb.service" ];
-        after = [ "ovsdb.service" ];
+        requires = [ "ovsdb.socket" ];
+        after = [ "ovsdb.socket" ];
         path = [ cfg.package ];
         serviceConfig = {
           ExecStart = ''

--- a/nixos/tests/openvswitch.nix
+++ b/nixos/tests/openvswitch.nix
@@ -58,5 +58,27 @@
 
       node1.wait_until_succeeds("ping -c1 10.0.0.2", timeout=30)
       node2.wait_until_succeeds("ping -c1 10.0.0.1", timeout=30)
+
+      with subtest("Restarting ovsdb preserves OpenFlow flows"):
+          ovs_ofctl = "ovs-ofctl -O OpenFlow13"
+          marker_cookie = "0x5eed"
+
+          def check_marker_flow():
+              node1.succeed(
+                  f"{ovs_ofctl} dump-flows vs0 | grep -q 'cookie={marker_cookie}'"
+              )
+
+          node1.succeed(
+              f"{ovs_ofctl} add-flow vs0 "
+              f"'cookie={marker_cookie},priority=100,ip,nw_src=192.0.2.1,actions=drop'"
+          )
+          check_marker_flow()
+
+          node1.succeed("systemctl restart ovsdb.service")
+          node1.wait_for_unit("ovsdb.service")
+          node1.wait_for_unit("ovs-vswitchd.service")
+          node1.wait_for_unit("vs0-netdev.service")
+
+          check_marker_flow()
     '';
 }

--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = if withDPDK then "openvswitch-dpdk" else "openvswitch";
-  version = "3.7.1";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "openvswitch";
     repo = "ovs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3FQjV4BZZpn7Loiu9Xm30cCqzkU1HgJ3sAc+I6D8OvQ=";
+    hash = "sha256-+WjpNJkM3AztBY1gPO6RdujGi86GDTjskJyDK16/9Dc=";
   };
 
   outputs = [
@@ -108,13 +108,9 @@ stdenv.mkDerivation (finalAttrs: {
     installShellCompletion utilities/ovs-vsctl-bashcomp.bash
 
     mkdir -p $tools/{bin,share/openvswitch/scripts}
-    mv $out/share/openvswitch/bugtool-plugins $tools/share/openvswitch
-    mv $out/share/openvswitch/scripts/ovs-{bugtool*,check-dead-ifs,monitor-ipsec,vtep} $tools/share/openvswitch/scripts
+    mv $out/share/openvswitch/scripts/ovs-{check-dead-ifs,monitor-ipsec,vtep} $tools/share/openvswitch/scripts
     mv $out/share/openvswitch/scripts/usdt $tools/share/openvswitch/scripts
-    mv $out/bin/ovs-{bugtool,dpctl-top,l3ping,parse-backtrace,pcap,tcpdump,tcpundump,test,vlan-test} $tools/bin
-
-    wrapProgram $tools/bin/ovs-l3ping \
-      --prefix PYTHONPATH : $out/share/openvswitch/python
+    mv $out/bin/ovs-{dpctl-top,pcap,tcpdump,tcpundump} $tools/bin
 
     wrapProgram $tools/bin/ovs-tcpdump \
       --prefix PATH : ${lib.makeBinPath [ tcpdump ]} \

--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -134,7 +134,10 @@ stdenv.mkDerivation (finalAttrs: {
     pyparsing
     pytest
     setuptools
-  ]);
+    tftpy
+  ])
+  # pyftpdlib depends on pysendfile extension, which cannot be static
+  ++ lib.optionals (!stdenv.hostPlatform.isStatic) [ python3.pkgs.pyftpdlib ];
 
   passthru = {
     tests = {


### PR DESCRIPTION
- **openvswitch: 3.7.1 -> 4.0.0**
- **openvswitch: enable pytest tests**
- **nixos/openvswitch: use RestartMode=direct**
- **nixos/openvswitch: use socket activation for ovsdb**

Adopt 4.0.0. Update NixOS module to use the new socket activation for ovsdb-server, which allows vswitchd to survive ovsdb-server restart, and allows clients to wait on the db socket while ovsdb-server restarts. Also, adopt RestartMode=direct to better handling of ovs service crashes (and align with upstream units).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
