### PR TITLE
openvswitch: enable unbound

### DIFF
--- a/pkgs/by-name/op/openvswitch/package.nix
+++ b/pkgs/by-name/op/openvswitch/package.nix
@@ -24,6 +24,7 @@
   python3,
   sphinxHook,
   tcpdump,
+  unbound,
   util-linux,
   which,
 }:
@@ -74,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     procps
     python3
+    unbound
     util-linux
     which
   ]
@@ -125,6 +127,9 @@ stdenv.mkDerivation (finalAttrs: {
   preCheck = ''
     export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
     export RECHECK=yes
+
+    # Nix sandbox has no /etc/resolv.conf
+    export OVS_RESOLV_CONF=/dev/null
 
     patchShebangs tests/
   '';


### PR DESCRIPTION
This allows to use domain names instead of IP addresses, e.g. when
configuring openflow controller for ovs-vswitchd.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
