### PR TITLE
cargo-llvm-cov: llvmPackages_19 -> llvmPackages_22

### DIFF
--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -18,7 +18,7 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
-  llvmPackages_19,
+  llvmPackages_22,
   gitMinimal,
   writableTmpDirAsHomeHook,
 }:
@@ -30,7 +30,7 @@ let
   owner = "taiki-e";
   homepage = "https://github.com/${owner}/${pname}";
 
-  inherit (llvmPackages_19) llvm;
+  inherit (llvmPackages_22) llvm;
 in
 
 rustPlatform.buildRustPackage (finalAttrs: {


### PR DESCRIPTION
llvm 19 is fairly old. according to the support matrix at https://github.com/taiki-e/cargo-llvm-cov/blob/v0.9.0/README.md#get-coverage-of-cc-code-linked-to-rust-librarybinary, rust versions 1.82-1.98 (we're currently on rust 1.97 in nixpkgs) support llvm 19-22, so let's move up to the upper end of that range to keep things using up-to-date llvms.

we do wonder if it'd be likely to consistently work if this just pinned `rustPlatform.rust.rustc.llvm`, since we at least know our rustc is compatible with that llvm. however, we personally don't have the historical context to evaluate whether that's likely to break.

tested by running `cargo llvm-cov` on `cargo-llvm-cov` itself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
