### PR TITLE
ocamlPackages.odoc: split into multiple outputs

### DIFF
--- a/pkgs/build-support/ocaml/topkg.nix
+++ b/pkgs/build-support/ocaml/topkg.nix
@@ -7,7 +7,6 @@
   topkg,
   ocamlbuild,
   cmdliner,
-  odoc,
   b0,
 }:
 

--- a/pkgs/development/ocaml-modules/mlx/ocamlmerlin-mlx.nix
+++ b/pkgs/development/ocaml-modules/mlx/ocamlmerlin-mlx.nix
@@ -7,7 +7,6 @@
   cppo,
   csexp,
   menhir,
-  odoc,
 }:
 buildDunePackage {
   pname = "ocamlmerlin-mlx";
@@ -21,7 +20,6 @@ buildDunePackage {
     merlin-lib
     csexp
     menhir
-    odoc
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/ocamlformat-mlx/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat-mlx/default.nix
@@ -1,7 +1,6 @@
 {
   buildDunePackage,
   cmdliner,
-  odoc,
   ocamlformat-mlx-lib,
   re,
 }:
@@ -13,7 +12,6 @@ buildDunePackage {
   buildInputs = [
     cmdliner
     re
-    odoc
     ocamlformat-mlx-lib
   ];
 }

--- a/pkgs/development/ocaml-modules/ocamlformat-mlx/lib.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat-mlx/lib.nix
@@ -20,7 +20,6 @@
   astring,
   result,
   camlp-streams,
-  odoc,
 }:
 buildDunePackage (finalAttrs: {
   pname = "ocamlformat-mlx-lib";
@@ -51,7 +50,6 @@ buildDunePackage (finalAttrs: {
     astring
     result
     camlp-streams
-    odoc
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/odig/default.nix
+++ b/pkgs/development/ocaml-modules/odig/default.nix
@@ -3,7 +3,6 @@
   fetchurl,
   buildTopkgPackage,
   cmdliner,
-  odoc,
   b0,
 }:
 
@@ -18,7 +17,6 @@ buildTopkgPackage rec {
 
   buildInputs = [
     cmdliner
-    odoc
     b0
   ];
 

--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -1,6 +1,8 @@
 {
   lib,
+  ocaml,
   buildDunePackage,
+  removeReferencesTo,
   ocaml-crunch,
   astring,
   cmdliner,
@@ -25,6 +27,7 @@ buildDunePackage (self: {
   nativeBuildInputs = [
     cppo
     ocaml-crunch
+    removeReferencesTo
   ];
   buildInputs = [
     astring
@@ -64,6 +67,7 @@ buildDunePackage (self: {
   installPhase = ''
     runHook preInstall
     dune install --prefix=$bin --libdir=$lib/lib/ocaml/${ocaml.version}/site-lib odoc
+    remove-references-to -t ${ocaml} $bin/bin/odoc
     runHook postInstall
   '';
 

--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -55,6 +55,18 @@ buildDunePackage (self: {
     patchShebangs test
   '';
 
+  outputs = [
+    "bin"
+    "lib"
+    "out"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix=$bin --libdir=$lib/lib/ocaml/${ocaml.version}/site-lib odoc
+    runHook postInstall
+  '';
+
   meta = {
     description = "Documentation generator for OCaml";
     mainProgram = "odoc";

--- a/pkgs/development/tools/ocaml/dune-release/default.nix
+++ b/pkgs/development/tools/ocaml/dune-release/default.nix
@@ -11,7 +11,6 @@
   rresult,
   logs,
   fpath,
-  odoc,
   opam-format,
   opam-core,
   opam-state,
@@ -60,14 +59,12 @@ buildDunePackage (finalAttrs: {
     opam-core
     rresult
     logs
-    odoc
     bos
     yojson
     astring
     fpath
   ];
   nativeCheckInputs = [
-    odoc
     gitMinimal
   ];
   checkInputs = [ alcotest ] ++ runtimeInputs;

--- a/pkgs/tools/misc/wyrd/default.nix
+++ b/pkgs/tools/misc/wyrd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     ocamlPackages.findlib
     ocamlPackages.ocaml
-    ocamlPackages.odoc
+    (lib.getBin ocamlPackages.odoc)
   ];
 
   buildInputs = [


### PR DESCRIPTION
Various derivation spuriously use `odoc` as a build input. This PR fixes that.

`wyrd` only needs the `odoc` binary and I think this is a common use case, therefore the `odoc` derivation is split into multiple outputs such that the `bin` output has a small closure.

So as to reduce the closure size of said output even more, references to the OCaml compiler are removed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
