### PR TITLE
nixos/tests/gitea-actions-runner: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -701,6 +701,7 @@ in
     inherit pkgs runTest;
     inherit (pkgs) lib;
   };
+  gitea-actions-runner = runTest ./gitea-actions-runner.nix;
   github-runner = runTest ./github-runner.nix;
   gitlab = import ./gitlab {
     inherit runTest;

--- a/nixos/tests/gitea-actions-runner.nix
+++ b/nixos/tests/gitea-actions-runner.nix
@@ -1,0 +1,136 @@
+{ pkgs, ... }:
+{
+  name = "gitea-actions-runner";
+  meta = {
+    maintainers = pkgs.gitea-actions-runner.meta.maintainers;
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.gitea = {
+        enable = true;
+        database.type = "sqlite3";
+        settings = {
+          actions.ENABLED = true;
+          service.DISABLE_REGISTRATION = true;
+        };
+      };
+
+      services.gitea-actions-runner.instances = {
+        host = {
+          enable = true;
+          name = "ci-host";
+          url = "http://localhost:3000";
+          labels = [ "native:host" ];
+          tokenFile = "/var/lib/gitea/runner_token";
+          settings.metrics = {
+            enabled = true;
+            addr = "127.0.0.1:9101";
+          };
+        };
+
+        podman = {
+          enable = true;
+          name = "ci-podman";
+          url = "http://localhost:3000";
+          labels = [ "container:docker://test-image:latest" ];
+          tokenFile = "/var/lib/gitea/runner_token";
+          settings.metrics = {
+            enabled = true;
+            addr = "127.0.0.1:9102";
+          };
+        };
+      };
+
+      virtualisation.podman.enable = true;
+
+      environment.systemPackages = [
+        pkgs.gitea
+        pkgs.gitMinimal
+        pkgs.tea
+      ];
+    };
+
+  testScript =
+    let
+      containerImage = pkgs.dockerTools.buildLayeredImage {
+        name = "test-image";
+        tag = "latest";
+        contents = [
+          pkgs.busybox
+          pkgs.bashInteractive
+        ];
+      };
+
+      ciWorkflow = pkgs.writeText "gitea-actions-runner-test-workflow.yaml" ''
+        name: test
+        on: [push]
+        jobs:
+          host:
+            runs-on: native
+            steps:
+              - run: echo hello from the host runner
+          container:
+            runs-on: container
+            steps:
+              - run: echo hello from the podman runner
+      '';
+    in
+    ''
+      import json
+      from typing import Any
+
+
+      def gitea_admin(args: str) -> str:
+          return machine.succeed(f"su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea {args}'")
+
+
+      def tea_json(args: str) -> Any:
+          output = machine.succeed(f"tea {args} --login test -o json").strip()
+          if not output.startswith(("[", "{")):
+              return []
+          return json.loads(output)
+
+
+      start_all()
+
+      machine.wait_for_unit("gitea.service")
+      machine.wait_for_open_port(3000)
+      machine.succeed("curl --fail http://localhost:3000/")
+
+      gitea_admin("admin user create --username test --password hunter2 --email test@localhost")
+      machine.succeed(
+          "tea login add --url http://localhost:3000 --user test --password hunter2 -n test"
+      )
+
+      with subtest("Loading the test container image into podman"):
+          machine.wait_for_unit("podman.socket")
+          machine.succeed("podman load -i ${containerImage}")
+
+      with subtest("Registering the runners"):
+          token = gitea_admin("actions generate-runner-token").strip()
+          machine.succeed(f"echo TOKEN={token} > /var/lib/gitea/runner_token")
+
+          machine.wait_for_unit("gitea-runner-host.service")
+          machine.wait_until_succeeds("curl --fail http://localhost:9101/readyz")
+          machine.wait_until_succeeds("journalctl -u gitea-runner-host.service --grep 'Runner registered successfully'")
+
+          machine.wait_for_unit("gitea-runner-podman.service")
+          machine.wait_until_succeeds("curl --fail http://localhost:9102/readyz")
+          machine.wait_until_succeeds("journalctl -u gitea-runner-podman.service --grep 'Runner registered successfully'")
+
+      with subtest("Creating a repository with a workflow using both runners"):
+          tea_json("repos create --name repo --init")
+          machine.succeed(
+              "tea api -X POST /repos/test/repo/contents/.gitea%2Fworkflows%2Ftest.yaml "
+              + "--login test "
+              + "-f branch=main "
+              + '-f content="$(base64 -w0 ${ciWorkflow})" '
+              + '-f message="Add CI workflow"'
+          )
+
+      with subtest("Waiting for both jobs to be picked up and run"):
+          retry(lambda _: len(tea_json("actions runs list --repo test/repo --status success")) == 1)
+    '';
+}

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -53,17 +53,6 @@ let
                 };
               };
 
-              gitea-actions-runner.instances."test" = {
-                enable = true;
-                name = "ci";
-                url = "http://localhost:3000";
-                labels = [
-                  # don't require docker/podman
-                  "native:host"
-                ];
-                tokenFile = "/var/lib/gitea/runner_token";
-              };
-
               openssh.enable = true;
             };
             environment.systemPackages = [
@@ -160,13 +149,6 @@ let
                              + '-H "Authorization: Bearer fakesecret" '
                              + 'http://localhost:3000/metrics '
                              + '| grep gitea_accesses')
-
-          with subtest("Testing runner registration"):
-              server.succeed(
-                  "su -l gitea -c 'GITEA_WORK_DIR=/var/lib/gitea gitea actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/gitea/runner_token"
-              )
-              server.wait_for_unit("gitea-runner-test.service")
-              server.succeed("journalctl -o cat -u gitea-runner-test.service | grep -q 'Runner registered successfully'")
         '';
     });
 in

--- a/pkgs/by-name/gi/gitea-actions-runner/package.nix
+++ b/pkgs/by-name/gi/gitea-actions-runner/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   testers,
   gitea-actions-runner,
+  nixosTests,
   nix-update-script,
 }:
 
@@ -35,9 +36,12 @@ buildGoModule (finalAttrs: {
   '';
 
   passthru = {
-    tests.version = testers.testVersion {
-      package = gitea-actions-runner;
-      version = "v${finalAttrs.version}";
+    tests = {
+      version = testers.testVersion {
+        package = gitea-actions-runner;
+        version = "v${finalAttrs.version}";
+      };
+      nixos = nixosTests.gitea-actions-runner;
     };
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/gi/gitea/package.nix
+++ b/pkgs/by-name/gi/gitea/package.nix
@@ -130,7 +130,9 @@ buildGoModule (finalAttrs: {
       lib.warn "gitea.passthru.data-compressed is deprecated. Use \"compressDrvWeb gitea.data\"."
         (compressDrvWeb gitea.data { });
 
-    tests = nixosTests.gitea;
+    tests = {
+      inherit (nixosTests) gitea gitea-actions-runner;
+    };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a separate test for the actions runner, which is a bit more thorough than the subtest from the gitea nixos test. The test spins up a gitea instance + 2 runners, one native and one podman based. Then it schedules a simple workflow with an echo-job on both, and verifies that both jobs complete successfully.

I removed the existing subtest from gitea, it's probably not needed anymore.

Also registered the test to both the gitea package and the actions runner package, since updating either could break the test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
