### PR TITLE
nixos/gitea-actions-runner: various fixes

### DIFF
--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -200,10 +200,10 @@ in
               "network-online.target"
             ]
             ++ optionals wantsDocker [
-              "docker.service"
+              "docker.socket"
             ]
             ++ optionals wantsPodman [
-              "podman.service"
+              "podman.socket"
             ];
             wantedBy = [
               "multi-user.target"

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -96,9 +96,13 @@ in
             type = nullOr (either str path);
             default = null;
             description = ''
-              Path to an environment file, containing the `TOKEN` environment
-              variable, that holds a token to register at the configured
+              Path to a file containing a token to register at the configured
               Gitea/Forgejo instance.
+
+              For backwards compatibility, the file may instead be a
+              systemd-style environment file containing a `TOKEN` assignment,
+              but this format is deprecated: a warning is emitted at runtime,
+              and support will be removed in the future.
             '';
           };
 
@@ -209,10 +213,7 @@ in
               "multi-user.target"
             ];
             environment =
-              optionalAttrs (instance.token != null) {
-                TOKEN = "${instance.token}";
-              }
-              // optionalAttrs wantsPodman {
+              optionalAttrs wantsPodman {
                 DOCKER_HOST = "unix:///run/podman/podman.sock";
               }
               // {
@@ -243,7 +244,18 @@ in
               ExecStartPre = [
                 (pkgs.writeShellScript "gitea-register-runner-${name}" ''
                   # force reregistration on changed token or labels
-                  export TOKEN_HASH_CURRENT="$(printf '%s' "$TOKEN" | sha256sum | cut -d' ' -f1)"
+
+                  if grep -q -m1 -E '^[[:space:]]*TOKEN=' "$CREDENTIALS_DIRECTORY/token"; then
+                    echo "gitea-actions-runner: providing 'tokenFile' as an environment file with a TOKEN= assignment is deprecated." >&2
+                    echo "please provide the raw token as the file's content instead." >&2
+
+                    sed -n -E 's/^[[:space:]]*TOKEN=//p' "$CREDENTIALS_DIRECTORY/token" | tail -n1 > "$RUNTIME_DIRECTORY/token"
+                    export TOKEN_FILE="$RUNTIME_DIRECTORY/token"
+                  else
+                    export TOKEN_FILE="$CREDENTIALS_DIRECTORY/token"
+                  fi
+
+                  export TOKEN_HASH_CURRENT="$(sha256sum "$TOKEN_FILE" | cut -d' ' -f1)"
                   export TOKEN_HASH_STORED="$(cat "$TOKEN_HASH_FILE" 2>/dev/null || echo "")"
                   export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
                   export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
@@ -255,7 +267,7 @@ in
                     # perform the registration
                     ${getExe cfg.package} register --no-interactive \
                       --instance ${escapeShellArg instance.url} \
-                      --token "$TOKEN" \
+                      --token-file "$TOKEN_FILE" \
                       --name ${escapeShellArg instance.name} \
                       --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
                       --config ${configFile}
@@ -275,9 +287,18 @@ in
                 ++ optionals wantsPodman [
                   "podman"
                 ];
-            }
-            // optionalAttrs (instance.tokenFile != null) {
-              EnvironmentFile = instance.tokenFile;
+
+              LoadCredential =
+                let
+                  tokenCredentialSource =
+                    if instance.tokenFile != null then
+                      instance.tokenFile
+                    else
+                      pkgs.writeText "gitea-runner-${name}-token" instance.token;
+                in
+                "token:${tokenCredentialSource}";
+              RuntimeDirectory = "gitea-runner/${name}";
+              RuntimeDirectoryMode = "0700";
             };
           };
       in

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -134,6 +134,14 @@ in
 
             type = types.submodule {
               freeformType = settingsFormat.type;
+
+              options.cache.external_secret_file = mkOption {
+                type = nullOr (either str path);
+                default = null;
+                description = ''
+                  Path to a file containing the shared secret for an external cache server.
+                '';
+              };
             };
 
             default = { };
@@ -194,7 +202,18 @@ in
             wantsHost = hasHostScheme instance;
             wantsDocker = wantsContainerRuntime && config.virtualisation.docker.enable;
             wantsPodman = wantsContainerRuntime && config.virtualisation.podman.enable;
-            configFile = settingsFormat.generate "config.yaml" instance.settings;
+            configFile =
+              let
+                credentialsDirectory = "/run/credentials/gitea-runner-${escapeSystemdPath name}.service";
+              in
+              settingsFormat.generate "config.yaml" (
+                if instance.settings.cache.external_secret_file != null then
+                  lib.recursiveUpdate instance.settings {
+                    cache.external_secret_file = "${credentialsDirectory}/external-secret";
+                  }
+                else
+                  instance.settings
+              );
           in
           nameValuePair "gitea-runner-${escapeSystemdPath name}" {
             inherit (instance) enable;
@@ -296,7 +315,10 @@ in
                     else
                       pkgs.writeText "gitea-runner-${name}-token" instance.token;
                 in
-                "token:${tokenCredentialSource}";
+                [ "token:${tokenCredentialSource}" ]
+                ++ optionals (instance.settings.cache.external_secret_file != null) [
+                  "external-secret:${instance.settings.cache.external_secret_file}"
+                ];
               RuntimeDirectory = "gitea-runner/${name}";
               RuntimeDirectoryMode = "0700";
             };

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -217,6 +217,9 @@ in
               }
               // {
                 HOME = "/var/lib/gitea-runner/${name}";
+                INSTANCE_DIR = "/var/lib/gitea-runner/${name}";
+                TOKEN_HASH_FILE = "/var/lib/gitea-runner/${name}/.token-hash";
+                LABELS_FILE = "/var/lib/gitea-runner/${name}/.labels";
               };
             path =
               with pkgs;
@@ -227,8 +230,11 @@ in
             serviceConfig = {
               DynamicUser = true;
               User = "gitea-runner";
-              StateDirectory = "gitea-runner";
-              WorkingDirectory = "-/var/lib/gitea-runner/${name}";
+              StateDirectory = [
+                "gitea-runner"
+                "gitea-runner/${name}"
+              ];
+              WorkingDirectory = "/var/lib/gitea-runner/${name}";
 
               # gitea-runner might fail when gitea is restarted during upgrade.
               Restart = "on-failure";
@@ -236,15 +242,9 @@ in
 
               ExecStartPre = [
                 (pkgs.writeShellScript "gitea-register-runner-${name}" ''
-                  export INSTANCE_DIR="$STATE_DIRECTORY/${name}"
-                  mkdir -vp "$INSTANCE_DIR"
-                  cd "$INSTANCE_DIR"
-
                   # force reregistration on changed token or labels
-                  export TOKEN_HASH_FILE="$INSTANCE_DIR/.token-hash"
                   export TOKEN_HASH_CURRENT="$(printf '%s' "$TOKEN" | sha256sum | cut -d' ' -f1)"
                   export TOKEN_HASH_STORED="$(cat "$TOKEN_HASH_FILE" 2>/dev/null || echo "")"
-                  export LABELS_FILE="$INSTANCE_DIR/.labels"
                   export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
                   export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
 

--- a/nixos/tests/gitea-actions-runner.nix
+++ b/nixos/tests/gitea-actions-runner.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   name = "gitea-actions-runner";
   meta = {
@@ -42,6 +42,10 @@
           };
         };
       };
+
+      # started manually once the runner token is available
+      systemd.services.gitea-runner-host.wantedBy = lib.mkForce [ ];
+      systemd.services.gitea-runner-podman.wantedBy = lib.mkForce [ ];
 
       virtualisation.podman.enable = true;
 
@@ -112,10 +116,12 @@
           token = gitea_admin("actions generate-runner-token").strip()
           machine.succeed(f"echo TOKEN={token} > /var/lib/gitea/runner_token")
 
+          machine.systemctl("start gitea-runner-host.service")
           machine.wait_for_unit("gitea-runner-host.service")
           machine.wait_until_succeeds("curl --fail http://localhost:9101/readyz")
           machine.wait_until_succeeds("journalctl -u gitea-runner-host.service --grep 'Runner registered successfully'")
 
+          machine.systemctl("start gitea-runner-podman.service")
           machine.wait_for_unit("gitea-runner-podman.service")
           machine.wait_until_succeeds("curl --fail http://localhost:9102/readyz")
           machine.wait_until_succeeds("journalctl -u gitea-runner-podman.service --grep 'Runner registered successfully'")


### PR DESCRIPTION

This PR fixes the following:

- Instead of waiting for the docker/podman service, only wait for its socket so the services can start in parallel.
- Use `--token-file` for all token passing to avoid exposure in `/proc/*/cmdline`. (`token` will ofc still leak into the nix store)
- Pass the token-file via `LoadCredentials` (succeeds #483135)
- Pass the external cache creds via `LoadCredentials`.

These changes were tested against #559009

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
