### PR TITLE
claude-code: 2.1.257 -> 2.1.258

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-o0O82OWidTBn67wJceUIMofi6/xdg7e+WNsCoEz+fY8=";
+          hash = "sha256-eIJB3cp3HeD5DGcr/mp4kjkY/gMFp9oam8cGKeKSOMc=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-oJ+CFTVqIGgLhFl286ghOUSgSYAlLsDKhyfn9hoO550=";
+          hash = "sha256-SG5Mj3qd0VUOErXUtHiAHaPCWmDoCCNSnNoQBa4cBCw=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-hhF4qJDmuTyWeb3suop7p8sRUU6pGIM2qwHB/O/OFyM=";
+          hash = "sha256-gOOI6PqNdET7phteeqZ9ejcXTpstipMSGVTGxyf+od0=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.257";
+      version = "2.1.258";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.zst.json
+++ b/pkgs/by-name/cl/claude-code/manifest.zst.json
@@ -1,61 +1,60 @@
 {
-  "version": "2.1.257",
+  "version": "2.1.258",
   "manifestSignatureEnforcement": "flag",
-  "commit": "2c673eef7f8749077ab2f06e2f2a4139db3ba640",
-  "buildDate": "2026-09-01T05:40:10Z",
+  "commit": "b3cd543a1f6fcdf4d8fabc0f5e5538d2ee7f38e1",
+  "buildDate": "2026-09-01T22:04:05Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude.zst",
-      "checksum": "cdae82ddc99d35681add074a9bffcc42d05d6a9a03493fa369abd43adbf35e34",
-      "size": 65806396,
+      "checksum": "ee83f6743e0e5f60ec1456ea813851c625051241f7bc55d607faafe44cf4bc82",
+      "size": 65811873,
       "bundle": {
-        "checksum": "2d97e870980bcdb05b12430dec1bd67a5ccfd275c02bd5323547c0d7ec6845bf",
-        "size": 65811453
+        "checksum": "412f0b36da7cff5b20e7d856c939b449449583ee0971e9217c54972d1dfb4df3",
+        "size": 65814874
       }
     },
     "darwin-x64": {
       "binary": "claude.zst",
-      "checksum": "20a4b40ce2a8bf6b9e6def4bf3c43b3c50a146dfdff85bc1458d2875124497c3",
-      "size": 69875512,
+      "checksum": "160aa9a06afcb80c293ecd4e42ea62adb67e471bed6b9a813504f26b96978034",
+      "size": 69876596,
       "bundle": {
-        "checksum": "1c5296418fc62476469629724a1a35a1e12cb1a4bfd1f55f13c8256a7fbd3d3a",
-        "size": 69876719
+        "checksum": "575203804ea01ddd3c12226c7c9cdcd068f1d039c732e22916297d438944510c",
+        "size": 69878203
       }
     },
     "linux-arm64": {
       "binary": "claude.zst",
-      "checksum": "06742f7f94a17386acb2769f84524a3d34c5cc12cf12553b37f526ccee4fcf3e",
-      "size": 75033302
+      "checksum": "31768a9f65e58e48a3cacf7fce069bb6d7bd707cdb49874af2cb19b9d05af671",
+      "size": 75035372
     },
     "linux-x64": {
       "binary": "claude.zst",
-      "checksum": "f1b05baa487f7e102d8e31b6b0c04ecfdf767c5511377003bf4c0f98fc4dbdd5",
-      "size": 75667664
+      "checksum": "88207a58aee5a82e47db834ce81111200ad8fae9ea9abe2ff1ff9773d6a2100a",
+      "size": 75670149
     },
     "linux-arm64-musl": {
       "binary": "claude.zst",
-      "checksum": "867ddb99ec4bcd5a76bcb91e2b86e87f7f911bea6b14ca0c82f72a91bc56b983",
-      "size": 73516368
+      "checksum": "6658622d769ad18dfbc1e70ea0056e34e88e258b15769e9c63c6c444cb83625a",
+      "size": 73516216
     },
     "linux-x64-musl": {
       "binary": "claude.zst",
-      "checksum": "9696e6b79d67f9fc9d7c440ff0f054204f5c7ecf3c7b96e8ab8bbcbadabae34d",
-      "size": 74185146
+      "checksum": "d357e596364fb922923e5db2b3877d3d7ba4a1b9d2f44f44879efa103bf459a0",
+      "size": 74188445
     },
     "win32-x64": {
       "binary": "claude.exe.zst",
-      "checksum": "7f39419bdb85dfc07bcd22c601efee1fc3841e5b3c3d9b35898914227b319072",
-      "size": 78070415
+      "checksum": "94c7203fbeaa42f67dba3e7aabc544b1356dcec76bf830693948e99f4e4f21bc",
+      "size": 78074015
     },
     "win32-arm64": {
       "binary": "claude.exe.zst",
-      "checksum": "a2be876461a2e320067fb014ed870089363a70d17e2e6508ca972e6377ebbb95",
-      "size": 74811809
+      "checksum": "28eb7de6beb1adc3bc628426eada6aabd9592d42b66174cc419f64cb208f0127",
+      "size": 74810598
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.216",
       "0.3.217",
       "0.3.218",
       "0.3.219",


### PR DESCRIPTION
Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard maintainers/scripts/update.nix script.

Updates `claude-code` and the matching `vscode-extensions.anthropic.claude-code` from 2.1.257 to 2.1.258.

Changelog: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
