### PR TITLE
cudaPackages.cudnn-frontend: 1.27.0 -> 1.28.0

### DIFF
--- a/pkgs/by-name/dl/dlpack/package.nix
+++ b/pkgs/by-name/dl/dlpack/package.nix
@@ -19,6 +19,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-kIHBgTYaHEmweRBFtRl1pXhOyQ5TEwU8dLUssTMEnpc=";
   };
 
+  postPatch =
+    # Fix outdated version in CMakeLists.txt. It makes dlpackConfigVersion.cmake advertise 0.6 and
+    # any call to `find_package(dlpack <1.x>)` fails.
+    ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail \
+          'project(dlpack VERSION 0.6 LANGUAGES C CXX)' \
+          'project(dlpack VERSION ${finalAttrs.version} LANGUAGES C CXX)'
+    '';
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/development/cuda-modules/packages/cudnn-frontend/package.nix
+++ b/pkgs/development/cuda-modules/packages/cudnn-frontend/package.nix
@@ -35,13 +35,13 @@ backendStdenv.mkDerivation (finalAttrs: {
   name = "${cudaNamePrefix}-${finalAttrs.pname}-${finalAttrs.version}";
 
   pname = "cudnn-frontend";
-  version = "1.27.0";
+  version = "1.28.0";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cudnn-frontend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4KDxORr6vJRgJKYrooIILaWMWkGF6ZDuti1QtrzYTfA=";
+    hash = "sha256-oMsXgbLHhCnU+Q7bItzAPAN0U8LL4ZZCuXJwFKbJpEg=";
   };
 
   # nlohmann_json should be the only vendored dependency.


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/NVIDIA/cudnn-frontend/compare/v1.27.0...v1.28.0
Changelog: https://github.com/NVIDIA/cudnn-frontend/releases/tag/v1.28.0

cc @ConnorBaker @SomeoneSerge @YorikSar @samuela @ethancedwards8 @prusnak

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test