### PR TITLE
ipatool: 2.3.2 -> 2.5.0

### DIFF
--- a/pkgs/by-name/ip/ipatool/package.nix
+++ b/pkgs/by-name/ip/ipatool/package.nix
@@ -6,26 +6,30 @@
   testers,
   ipatool,
   writableTmpDirAsHomeHook,
+  installShellFiles,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "ipatool";
-  version = "2.3.2";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "majd";
     repo = "ipatool";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jIdjTDs/g41j805vkC1PqLvChtzB055JYmd4GbEHNZU=";
+    hash = "sha256-yC6MSyL3b9u/mb+YJUIZTsH2dtVgE0w2K3F2LlQE9tI=";
   };
 
-  vendorHash = "sha256-HNus5wZUmiuVVdDj4i9X9sO8iyccrq4h//s0zkQNYjY=";
+  vendorHash = "sha256-/DIJ41YXPMKZgnNraBasnJ1AIgfC5OA3fLn/vFJqs/Q=";
 
   # Fixes "import lookup disabled by -mod=vendor" for onepassword-sdk-go on macOS
   proxyVendor = true;
 
   # Fixes "unable to open output file '/homeless-shelter/.cache/clang/ModuleCache/" on macOS
-  nativeBuildInputs = [ writableTmpDirAsHomeHook ];
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    installShellFiles
+  ];
 
   ldflags = [
     "-s"
@@ -39,6 +43,13 @@ buildGoModule (finalAttrs: {
   #   go generate ./...
   # '';
   doCheck = false;
+
+  postInstall = ''
+    installShellCompletion --cmd ipatool \
+      --bash <($out/bin/ipatool completion bash) \
+      --fish <($out/bin/ipatool completion fish) \
+      --zsh <($out/bin/ipatool completion zsh)
+  '';
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Update ipatool to 2.5.0. This is a major breaking change as Apple changed their authentication methods, which are mitigated by [using SAP-signed requests](https://github.com/majd/ipatool/pull/525). Thus, it should also be backported.

No LLMs or automated tooling, as described under the [automation/AI Policy], were used to make this pull request.

Diff: [`ipatool@2.3.2...2.5.0`](https://github.com/majd/ipatool/compare/v2.3.2...v2.5.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
