### PR TITLE
typescript-go: update repository, enable __structuredAttrs

### DIFF
--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -20,11 +20,12 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "typescript-go";
-    tag = "typescript/v${finalAttrs.version}";
-    hash = "sha256-fRejdQSwaxSS2pjHrbJO2CQgZS5lWJmBNEM/TgbJTJ8=";
-    fetchSubmodules = false;
+    repo = "typescript";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j1AY4sf/Jb6uwOah35lrYooc7BnSeaZ2NO6Fx1zMj60=";
   };
+
+  modRoot = "tsc";
 
   vendorHash = "sha256-q6dMb2ab4uZ3GTrcA7v2JzfmOM+ZzBcJN6gKOpLfM/k=";
 
@@ -53,7 +54,7 @@ buildGoModule (finalAttrs: {
       (nix-update-script {
         extraArgs = [
           "--use-github-releases"
-          "--version-regex=^typescript/v([\\d.]+)$"
+          "--version-regex=^v([\\d.]+)$"
           "--src-only"
         ];
       })
@@ -67,7 +68,7 @@ buildGoModule (finalAttrs: {
         ];
         text = ''
           new_src="$(nix-build --attr 'pkgs.typescript-go.src' --no-out-link)"
-          new_go_major_minor="$(grep --only-matching --perl-regexp '^go \K([0-9]+\.[0-9]+)' "$new_src/go.mod")"
+          new_go_major_minor="$(grep --only-matching --perl-regexp '^go \K([0-9]+\.[0-9]+)' "$new_src/tsc/go.mod")"
           sed -i -E "s/buildGo[0-9]+Module/buildGo''${new_go_major_minor//./}Module/g" '${toString ./package.nix}'
         '';
       }))
@@ -81,8 +82,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Go implementation of TypeScript";
-    homepage = "https://github.com/microsoft/typescript-go";
-    changelog = "https://github.com/microsoft/typescript-go/releases/tag/typescript/v${finalAttrs.version}";
+    homepage = "https://github.com/microsoft/typescript";
+    changelog = "https://github.com/microsoft/typescript/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       kachick

--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -18,6 +18,8 @@ buildGoModule (finalAttrs: {
   pname = "typescript-go";
   version = "7.0.2";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "typescript";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* https://web.archive.org/web/20260902083209/https://github.com/microsoft/typescript-go
* https://github.com/microsoft/typescript-go/commit/89d5d5b2849a0db0957065889ca58536fa6d2e4a

I noticed upstream moved the repository when reviewing https://github.com/NixOS/nixpkgs/pull/558890.
This PR focuses on updating the repository source.
Merging with the `typescript` package is currently being discussed and drafted in the PR.

cc: @GIP2000

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
