### PR TITLE
nix-required-mounts: Gracefully exit when derivation is absent

### DIFF
--- a/pkgs/by-name/ni/nix-required-mounts/eval-test.nix
+++ b/pkgs/by-name/ni/nix-required-mounts/eval-test.nix
@@ -11,6 +11,7 @@ let
       presets.nvidia-gpu.enable = true;
     };
     fileSystems."/".device = "/dev/null";
+    fileSystems."/".fsType = "none";
     boot.loader.grub.enable = false;
     system.stateVersion = lib.trivial.release;
   };

--- a/pkgs/by-name/ni/nix-required-mounts/nix_required_mounts.py
+++ b/pkgs/by-name/ni/nix-required-mounts/nix_required_mounts.py
@@ -55,7 +55,7 @@ parser.add_argument("-v", "--verbose", action="count", default=0)
 
 def parse_derivation(
     derivation_path: PathString, nix_exe: PathString | None
-) -> dict:
+) -> dict | None:
     """Extract the content of a .drv file into a JSON dict"""
     if not Path(derivation_path).exists():
         logging.error(
@@ -63,6 +63,7 @@ def parse_derivation(
             " Cf. https://github.com/NixOS/nix/issues/9272"
             " Exiting the hook",
         )
+        return None
 
     proc = subprocess.run(
         [
@@ -86,7 +87,8 @@ def parse_derivation(
             f". Expected JSON, observed: {output_str}",
         )
         logging.error(textwrap.indent(output_str, prefix=" " * 4))
-        logging.info("Exiting the nix-required-binds hook")
+        logging.info("Exiting the nix-required-mounts hook")
+        return None
 
     [canon_drv_path] = parsed_drv.keys()
 
@@ -291,7 +293,10 @@ def entrypoint() -> None:
     with open(args.patterns, "r") as f:
         patterns = json.load(f)
 
-    parsed_drv: dict = parse_derivation(args.derivation_path, args.nix_exe)
+    parsed_drv: dict | None = parse_derivation(args.derivation_path, args.nix_exe)
+    if parsed_drv is None:
+        # Details are already logged in parse_derivation
+        return
     features: set[str] = get_required_system_features(parsed_drv)
     required_patterns: AllowedPatterns = patterns_for_features(
         patterns, features


### PR DESCRIPTION

When derivation is absent, current code would prevent the build and produce an unexpected error like this:

```
ERROR:root:/nix/store/qs3g6m1yyms1l9qhqwkvwh5jb7a6n9as-pre-eval.drv doesn't exist. Cf. https://github.com/NixOS/nix/issues/9272 Exiting the hook
ERROR:root:Couldn't parse the output of`nix show-derivation`. Expected JSON, observed:
ERROR:root:
Traceback (most recent call last):
File "/nix/store/kw6y875jj193lzzzisqj1vjib8jrhfa0-nix-required-mounts-0.0.1/bin/.nix-required-mounts-wrapped", line 9, in <module>
  sys.exit(entrypoint())
           ~~~~~~~~~~^^
File "/nix/store/kw6y875jj193lzzzisqj1vjib8jrhfa0-nix-required-mounts-0.0.1/lib/python3.13/site-packages/nix_required_mounts.py", line 294, in entrypoint
  parsed_drv: dict = parse_derivation(args.derivation_path, args.nix_exe)
                     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/nix/store/kw6y875jj193lzzzisqj1vjib8jrhfa0-nix-required-mounts-0.0.1/lib/python3.13/site-packages/nix_required_mounts.py", line 91, in parse_derivation
  [canon_drv_path] = parsed_drv.keys()
                     ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'parsed_drv' where it is not associated with a value
```

Fix this by actually exiting as the log suggests instead of letting Python eat its tail.
This lets us use builders with nix-required-mounts for regular remote builds without pushing derivations to them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
