### PR TITLE
catdoc: apply debian patches

### DIFF
--- a/pkgs/by-name/ca/catdoc/package.nix
+++ b/pkgs/by-name/ca/catdoc/package.nix
@@ -11,45 +11,45 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "http://ftp.wagner.pp.ru/pub/catdoc/catdoc-${finalAttrs.version}.tar.gz";
-    sha256 = "514a84180352b6bf367c1d2499819dfa82b60d8c45777432fa643a5ed7d80796";
+    hash = "sha256-UUqEGANStr82fB0kmYGd+oK2DYxFd3Qy+mQ6XtfYB5Y=";
   };
 
   patches = [
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/01-amd64_fixes.patch";
-      sha256 = "sha256-aIbtmYm291mo4Sfm1KaucnvmUi9RgbXGexInfOQxxug=";
+      hash = "sha256-aIbtmYm291mo4Sfm1KaucnvmUi9RgbXGexInfOQxxug=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/02-Makefile_fixes.patch";
-      sha256 = "sha256-cOeuAdjD707FEdwep+slzmDcjjF1MDm59E3drv+mWd0=";
+      hash = "sha256-cOeuAdjD707FEdwep+slzmDcjjF1MDm59E3drv+mWd0=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/03-Type_fixes.patch";
-      sha256 = "sha256-tu34+p0d21w7vjH7WBusfffish3edObqPplKs90Ms9U=";
+      hash = "sha256-tu34+p0d21w7vjH7WBusfffish3edObqPplKs90Ms9U=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/04-XLS_parsing_improvements.patch";
-      sha256 = "sha256-ePkvLxUE/rA1/iMhX7k2zh91N5zgCgbHo2xlPCVVmCI=";
+      hash = "sha256-ePkvLxUE/rA1/iMhX7k2zh91N5zgCgbHo2xlPCVVmCI=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/05-CVE-2017-11110.patch";
-      sha256 = "1ljnwvssvzig94hwx8843b88p252ww2lbxh8zybcwr3kwwlcymx7";
+      hash = "sha256-p1fPKOdzZM6W/wj2RQXnooiL0BoEoc4hSS/+rfXmVtI=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/06-Fix_OLENAMELENGTH.patch";
-      sha256 = "sha256-p64iQlXlhwRjJ4XGyvju+gTSmSOOxOcv4sgzQXGDYsE=";
+      hash = "sha256-p64iQlXlhwRjJ4XGyvju+gTSmSOOxOcv4sgzQXGDYsE=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/0007-Added-guards-against-a-signed-text-length-when-parsi.patch";
-      sha256 = "sha256-7N5frjh2ggxBhNqumeLW56D/rxINqoO9PRIfqSVIhNw=";
+      hash = "sha256-7N5frjh2ggxBhNqumeLW56D/rxINqoO9PRIfqSVIhNw=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/0008-Added-a-guard-against-a-product-overflow-when-proces.patch";
-      sha256 = "sha256-Cfo7muRZfyCvZiJ4s9u7+tZKQtCLj/wSQUPz3MWUg4Y=";
+      hash = "sha256-Cfo7muRZfyCvZiJ4s9u7+tZKQtCLj/wSQUPz3MWUg4Y=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/0009-Added-guards-against-invalid-sector-sizes-when-tryin.patch";
-      sha256 = "sha256-TCU+aixaXQolZ6h0QKO0p/mWj6yTFZqfcwVDsaVGl8Q=";
+      hash = "sha256-TCU+aixaXQolZ6h0QKO0p/mWj6yTFZqfcwVDsaVGl8Q=";
     })
   ];
 

--- a/pkgs/by-name/ca/catdoc/package.nix
+++ b/pkgs/by-name/ca/catdoc/package.nix
@@ -16,8 +16,40 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-4.1/debian/patches/05-CVE-2017-11110.patch";
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/01-amd64_fixes.patch";
+      sha256 = "sha256-aIbtmYm291mo4Sfm1KaucnvmUi9RgbXGexInfOQxxug=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/02-Makefile_fixes.patch";
+      sha256 = "sha256-cOeuAdjD707FEdwep+slzmDcjjF1MDm59E3drv+mWd0=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/03-Type_fixes.patch";
+      sha256 = "sha256-tu34+p0d21w7vjH7WBusfffish3edObqPplKs90Ms9U=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/04-XLS_parsing_improvements.patch";
+      sha256 = "sha256-ePkvLxUE/rA1/iMhX7k2zh91N5zgCgbHo2xlPCVVmCI=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/05-CVE-2017-11110.patch";
       sha256 = "1ljnwvssvzig94hwx8843b88p252ww2lbxh8zybcwr3kwwlcymx7";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/06-Fix_OLENAMELENGTH.patch";
+      sha256 = "sha256-p64iQlXlhwRjJ4XGyvju+gTSmSOOxOcv4sgzQXGDYsE=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/0007-Added-guards-against-a-signed-text-length-when-parsi.patch";
+      sha256 = "sha256-7N5frjh2ggxBhNqumeLW56D/rxINqoO9PRIfqSVIhNw=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/0008-Added-a-guard-against-a-product-overflow-when-proces.patch";
+      sha256 = "sha256-Cfo7muRZfyCvZiJ4s9u7+tZKQtCLj/wSQUPz3MWUg4Y=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-6/debian/patches/0009-Added-guards-against-invalid-sector-sizes-when-tryin.patch";
+      sha256 = "sha256-TCU+aixaXQolZ6h0QKO0p/mWj6yTFZqfcwVDsaVGl8Q=";
     })
   ];
 


### PR DESCRIPTION
Apply debian patches to catdoc.

We already have one of these; this adds the rest. In particular, `06-Fix_OLENAMELENGTH.patch` allows catdoc to open doc files created by libreoffice.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
