### PR TITLE
nixos/opentelemetry-collector: validate configs built from settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -129,6 +129,21 @@
   guide](https://artalk.js.org/en/guide/releases/v2.10.0.html) when invoking
   `artalk` directly. The `services.artalk` module is unaffected.
 
+- `services.opentelemetry-collector.validateConfigFile` now defaults to `true`
+  when the configuration comes from `services.opentelemetry-collector.settings`,
+  so that configuration is validated at build time. It previously defaulted to
+  `isStorePath configFile`, which is `false` whenever `settings` is used, so
+  the validation never applied to that case.
+
+  Configurations that reference confmap providers such as `${file:/path}` or
+  `${env:VAR}` for secrets will now fail to build, because `otelcol validate`
+  resolves those references and the files are not available in the build
+  sandbox. Set
+  `services.opentelemetry-collector.validateConfigOverrides` to override the
+  affected properties for validation only, for example
+  `[ "extensions::bearertokenauth::token=stub" ]`, or set
+  `services.opentelemetry-collector.validateConfigFile = false` to opt out.
+
 - `boot.vesa` has been removed. It was deprecated in 2020 because Xorg now works better with kernel modesetting. If you still need the legacy VESA 800x600 fallback, set `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
 
 - `authentik` has been updated to 2026.5.3, which changes the default listen address from `0.0.0.0` to `[::]`.

--- a/nixos/modules/services/monitoring/opentelemetry-collector.nix
+++ b/nixos/modules/services/monitoring/opentelemetry-collector.nix
@@ -83,7 +83,7 @@ in
   };
 
   options.system.build.opentelemetryCollectorConfig = mkOption {
-    type = types.package;
+    type = types.path;
     readOnly = true;
     internal = true;
     description = ''

--- a/nixos/modules/services/monitoring/opentelemetry-collector.nix
+++ b/nixos/modules/services/monitoring/opentelemetry-collector.nix
@@ -15,6 +15,7 @@ let
     getExe
     isStorePath
     literalMD
+    escapeShellArgs
     ;
 
   cfg = config.services.opentelemetry-collector;
@@ -30,7 +31,8 @@ let
     if cfg.validateConfigFile then
       pkgs.runCommandLocal "config.yaml" { inherit generatedConf; } ''
         cp $generatedConf $out
-        ${getExe opentelemetry-collector} validate --config=file:$out
+        ${getExe opentelemetry-collector} validate --config=file:$out \
+          ${escapeShellArgs (map (o: "--set=${o}") cfg.validateConfigOverrides)}
       ''
     else
       generatedConf;
@@ -60,12 +62,39 @@ in
     };
 
     validateConfigFile = lib.mkEnableOption "Validate configuration file" // {
-      defaultText = literalMD "`true` if `configFile` is a store path";
-      default = isStorePath cfg.configFile;
+      defaultText = literalMD "`true` unless `configFile` is a path outside the store";
+      default = cfg.configFile == null || isStorePath cfg.configFile;
+    };
+
+    validateConfigOverrides = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "extensions::bearertokenauth::token=stub" ];
+      description = ''
+        Property overrides passed to `otelcol validate` as `--set` arguments,
+        used only for validation and not for the configuration that is
+        deployed. Use this configuration option if you are relying on confmap
+        providers like `''${file:/path}` and `''${env:VAR}` in your setup.
+
+        Note: `::` separates path elements, because component names may
+        themselves contain `.` and `/`.
+      '';
     };
   };
 
+  options.system.build.opentelemetryCollectorConfig = mkOption {
+    type = types.package;
+    readOnly = true;
+    internal = true;
+    description = ''
+      The configuration file the service is started with, after validation.
+      Exposed primarily so that tests can assert on it.
+    '';
+  };
+
   config = mkIf cfg.enable {
+    system.build.opentelemetryCollectorConfig = conf;
+
     assertions = [
       {
         assertion = ((cfg.settings == { }) != (cfg.configFile == null));

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1342,6 +1342,9 @@ in
     (handleTestOn [ "x86_64-linux" ] ./openstack-image.nix { }).userdata or { };
   opentabletdriver = runTest ./opentabletdriver.nix;
   opentelemetry-collector = runTest ./opentelemetry-collector.nix;
+  opentelemetry-collector-validate = pkgs.callPackage ./opentelemetry-collector-validate.nix {
+    inherit evalSystem;
+  };
   openvscode-server = runTest ./openvscode-server.nix;
   openvswitch = runTest ./openvswitch.nix;
   optee = runTestOn [ "aarch64-linux" ] ./optee.nix;

--- a/nixos/tests/opentelemetry-collector-validate.nix
+++ b/nixos/tests/opentelemetry-collector-validate.nix
@@ -1,0 +1,110 @@
+# Build-time test for the configuration validation of the
+# services.opentelemetry-collector module. It needs no VM: everything under
+# test happens while the configuration is evaluated and built.
+{
+  lib,
+  runCommand,
+  testers,
+  writeText,
+  evalSystem,
+}:
+let
+  evalService =
+    module:
+    (evalSystem {
+      services.opentelemetry-collector = {
+        enable = true;
+      }
+      // module;
+    }).config;
+
+  optionsOf = config: config.services.opentelemetry-collector;
+  execStartOf = config: config.systemd.services.opentelemetry-collector.serviceConfig.ExecStart;
+  confOf = config: config.system.build.opentelemetryCollectorConfig;
+
+  minimalSettings = {
+    receivers.otlp.protocols.http = { };
+    exporters.debug = { };
+    service.pipelines.logs = {
+      receivers = [ "otlp" ];
+      exporters = [ "debug" ];
+    };
+  };
+
+  secretRef = "\${file:/var/lib/secrets/otel-token}";
+
+  # A configuration that reads a secret through a confmap provider. Validation
+  # fails on it unless the property is overridden, because the file does not
+  # exist in the build sandbox.
+  secretSettings = {
+    receivers.otlp.protocols.http = { };
+    exporters.otlphttp = {
+      endpoint = "http://localhost:4318";
+      headers.authorization = "Bearer ${secretRef}";
+    };
+    service.pipelines.logs = {
+      receivers = [ "otlp" ];
+      exporters = [ "otlphttp" ];
+    };
+  };
+
+  # A pipeline that references an exporter nobody configured.
+  invalidSettings = {
+    receivers.otlp.protocols.http = { };
+    exporters.debug = { };
+    service.pipelines.logs = {
+      receivers = [ "otlp" ];
+      exporters = [ "nonexistent" ];
+    };
+  };
+
+  fromSettings = evalService { settings = minimalSettings; };
+  fromStoreConfigFile = evalService {
+    configFile = writeText "config.yaml" (builtins.toJSON minimalSettings);
+  };
+  fromExternalConfigFile = evalService {
+    configFile = "/etc/opentelemetry-collector/config.yaml";
+  };
+  withOverrides = evalService {
+    settings = secretSettings;
+    validateConfigOverrides = [ "exporters::otlphttp::headers::authorization=stub" ];
+  };
+  withoutOverrides = evalService { settings = secretSettings; };
+  invalid = evalService { settings = invalidSettings; };
+in
+# A configuration built from `settings` is always a store path, so it is always
+# validated. This is the regression that motivated the option: the default used
+# to be `isStorePath cfg.configFile`, which is false when `configFile` is null.
+assert (optionsOf fromSettings).validateConfigFile;
+assert (optionsOf fromStoreConfigFile).validateConfigFile;
+# A configFile outside the store does not exist at build time, so validation
+# must stay off and the service must point at the path verbatim.
+assert !(optionsOf fromExternalConfigFile).validateConfigFile;
+assert lib.hasSuffix "--config=file:/etc/opentelemetry-collector/config.yaml" (
+  execStartOf fromExternalConfigFile
+);
+
+runCommand "opentelemetry-collector-validate-test"
+  {
+    # Building `validated` runs `otelcol validate`, which only passes because
+    # the `--set` override replaces the file provider reference.
+    validated = confOf withOverrides;
+    invalidFailure = testers.testBuildFailure (confOf invalid);
+    unresolvableFailure = testers.testBuildFailure (confOf withoutOverrides);
+  }
+  ''
+    # The override applies to validation only: the deployed configuration keeps
+    # the provider reference.
+    grep -F ${lib.escapeShellArg secretRef} $validated
+    ! grep -F stub $validated
+
+    # Validation rejects a config whose pipeline references an undefined
+    # component.
+    grep -F nonexistent $invalidFailure/testBuildFailure.log
+
+    # Without an override, validation resolves the file provider and fails,
+    # because the secret does not exist in the sandbox.
+    grep -F /var/lib/secrets/otel-token $unresolvableFailure/testBuildFailure.log
+
+    touch $out
+  ''


### PR DESCRIPTION
In the `opentelemetry-collector` package, `validateConfigFile` defaulted to `isStorePath cfg.configFile`, which is false whenever the configuration comes from `settings`, because `configFile` is then null. So the validation added in #392701 never applied to the idiomatic way of configuring the service.

A configuration generated from `settings` is always a store path and is therefore always available at build time. Only a `configFile` pointing outside the store is not, which is what the original guard was protecting against.

Flipping the default, by itself, would break configurations that inject secrets through confmap providers: `otelcol validate` would resolve `${file:...}` and `${env:...}` references, and those are not readable in a build sandbox, failing with an error like:

```
  Error: failed to get config: cannot resolve the configuration: unable to
  read the file file:/var/lib/secrets/dash0-token: open
  /var/lib/secrets/dash0-token: no such file or directory
```

This commit introduces the `validateConfigOverrides` option, that passes `--set` arguments to `validate` only. `--set` takes precedence before resolution, so the affected property can be replaced with a literal for validation while the deployed configuration keeps the provider reference.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
