### PR TITLE
tinygo: 0.41.1 -> 0.42.0

### DIFF
--- a/pkgs/by-name/ti/tinygo/Makefiles.patch
+++ b/pkgs/by-name/ti/tinygo/Makefiles.patch
@@ -1,8 +1,8 @@
-diff --git a/GNUmakefile b/GNUmakefile
-index f078bde5..901c8e08 100644
---- a/GNUmakefile
-+++ b/GNUmakefile
-@@ -21,11 +21,6 @@ LLVM_VERSIONS = 19 18 17 16 15
+diff --git a/make/config.mk b/make/config.mk
+index 5b592d82..86481a21 100644
+--- a/make/config.mk
++++ b/make/config.mk
+@@ -20,11 +20,6 @@ LLVM_VERSIONS = 19 18 17 16 15
  errifempty = $(if $(1),$(1),$(error $(2)))
  detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
  toolSearchPathsVersion = $(1)-$(2)
@@ -14,9 +14,12 @@ index f078bde5..901c8e08 100644
  # First search for a custom built copy, then move on to explicitly version-tagged binaries, then just see if the tool is in path with its normal name.
  findLLVMTool = $(call detect,$(1),$(abspath llvm-build/bin/$(1)) $(foreach ver,$(LLVM_VERSIONS),$(call toolSearchPathsVersion,$(1),$(ver))) $(1))
  CLANG ?= $(call findLLVMTool,clang)
-@@ -942,10 +937,9 @@ endif
- wasmtest:
- 	$(GO) test ./tests/wasm
+diff --git a/make/release.mk b/make/release.mk
+index 89dc4c9e..b43bf814 100644
+--- a/make/release.mk
++++ b/make/release.mk
+@@ -1,9 +1,8 @@
+ # Build the release tarball and the Debian package.
  
 -build/release: tinygo gen-device $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binaryen)
 +build/release:
@@ -26,7 +29,7 @@ index f078bde5..901c8e08 100644
  	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
  	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
  	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/crt
-@@ -968,7 +962,6 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
+@@ -27,7 +26,6 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
  	@cp -p  build/wasm-opt$(EXE)         build/release/tinygo/bin
  endif
  	@cp -rp lib/bdwgc/*                  build/release/tinygo/lib/bdwgc
@@ -34,12 +37,12 @@ index f078bde5..901c8e08 100644
  	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
  	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
  	@cp -rp lib/macos-minimal-sdk/*      build/release/tinygo/lib/macos-minimal-sdk
-@@ -1060,8 +1053,7 @@ endif
+@@ -120,8 +118,7 @@ endif
  	@cp -rp lib/wasi-libc/libc-top-half/musl/src/unistd             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
  	@cp -rp lib/wasi-libc/libc-top-half/sources                     build/release/tinygo/lib/wasi-libc/libc-top-half
  	@cp -rp lib/wasi-cli/wit                                        build/release/tinygo/lib/wasi-cli/wit
--	@cp -rp llvm-project/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt-builtins
--	@cp -rp llvm-project/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt-builtins
+-	@cp -rp ${LLVM_PROJECTDIR}/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt-builtins
+-	@cp -rp ${LLVM_PROJECTDIR}/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt-builtins
 +	@cp -rp lib/compiler-rt-builtins     build/release/tinygo/lib/compiler-rt-builtins
  	@cp -rp src                          build/release/tinygo/src
  	@cp -rp targets                      build/release/tinygo/targets

--- a/pkgs/by-name/ti/tinygo/package.nix
+++ b/pkgs/by-name/ti/tinygo/package.nix
@@ -1,11 +1,11 @@
 {
   stdenv,
   lib,
-  buildGo126Module,
+  buildGo127Module,
   fetchFromGitHub,
   makeWrapper,
-  llvmPackages_20,
-  go_1_26,
+  llvmPackages_22,
+  go_1_27,
   xar,
   binaryen,
   avrdude,
@@ -18,10 +18,10 @@
 let
   # nixpkgs typically updates default llvm and go versions faster than tinygo releases
   # which ends up breaking this build. Use fixed versions for each release.
-  buildGoModule = buildGo126Module;
-  go = go_1_26;
+  buildGoModule = buildGo127Module;
+  go = go_1_27;
   llvmMajor = lib.versions.major llvm.version;
-  inherit (llvmPackages_20)
+  inherit (llvmPackages_22)
     llvm
     clang
     compiler-rt
@@ -38,13 +38,13 @@ in
 
 buildGoModule (finalAttrs: {
   pname = "tinygo";
-  version = "0.41.1";
+  version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8Zpvhx+xgC/Cjdm3zSpntLKOT4HsBU7lPWdLumWeFyw=";
+    hash = "sha256-9XIqkrq8lInPpQ7G2D5gxRs8Q+pf5ry6JMgvf6dXxds=";
     fetchSubmodules = true;
     # The public hydra server on `hydra.nixos.org` is configured with
     # `max_output_size` of 3GB. The purpose of this `postFetch` step
@@ -55,10 +55,10 @@ buildGoModule (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-OO8o/s71jZIypfYZCLT6jwUPyQJ89AKg3DfzTrbrD/A=";
+  vendorHash = "sha256-GkFyLorvYJ6pr1eNqV7AodilnJxitncnaaZDEav6jCo=";
 
   patches = [
-    ./0001-GNUmakefile.patch
+    ./Makefiles.patch
   ];
 
   nativeCheckInputs = [ binaryen ];
@@ -93,7 +93,7 @@ buildGoModule (finalAttrs: {
     mkdir -p lib/compiler-rt-builtins
     cp -a ${compiler-rt.src}/compiler-rt/lib/builtins/* lib/compiler-rt-builtins/
 
-    substituteInPlace GNUmakefile \
+    substituteInPlace make/release.mk \
       --replace "build/release/tinygo/bin" "$out/bin" \
       --replace "build/release/" "$out/share/"
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
