### PR TITLE
zinit: 3.15.0 -> 3.17.0

### DIFF
--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -4,17 +4,18 @@
   fetchFromGitHub,
   installShellFiles,
   nix-update-script,
+  zsh,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zinit";
-  version = "3.15.0";
+  version = "3.17.0";
 
   src = fetchFromGitHub {
     owner = "zdharma-continuum";
     repo = "zinit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lVdia0iDGy7RDT3Ho4BBslwbng/NpsJWbbVBqgNccCg=";
+    hash = "sha256-5QURQfU0J1zrnJFVlFYM3WNRbQPd5iWTX6MGxManDOs=";
   };
 
   outputs = [
@@ -34,7 +35,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     # Source files
     mkdir -p $out/share/zinit
-    install -m0444 zinit{,-side,-install,-autoload,-additional}.zsh _zinit $out/share/zinit
+    install -m0444 zinit{,-side,-install,-autoload,-additional}.zsh _zinit VERSION $out/share/zinit
     mkdir $out/share/zinit/share
     install -m0555 share/git-process-output.zsh $out/share/zinit/share
     install -m0444 share/rpm2cpio.zsh $out/share/zinit/share
@@ -49,7 +50,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     mkdir -p $doc/share/doc/zinit
     install -m0444 doc/zsdoc/*.adoc $doc/share/doc/zinit
-    install -m0444 doc/HACKING.md $doc/share/doc/zinit
+    install -m0444 CHANGELOG.md doc/HACKING.md $doc/share/doc/zinit
 
     runHook postInstall
   '';
@@ -61,6 +62,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --replace-fail "ZINIT[MAN_DIR]:=\''${ZPFX}/man" "ZINIT[MAN_DIR]:=$man/share/man"
   '';
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ zsh ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    HOME="$TMPDIR" \
+      ZINIT_DIR="$out/share/zinit" \
+      zsh -dfc '
+        source "$ZINIT_DIR/zinit.zsh"
+        (( $+functions[zinit] ))
+      '
+
+    runHook postInstallCheck
+  '';
+
   passthru = {
     updateScript = nix-update-script { };
   };
@@ -68,7 +84,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/zdharma-continuum/zinit";
     description = "Flexible zsh plugin manager";
-    changelog = "https://github.com/zdharma-continuum/zinit/blob/${finalAttrs.src.rev}/doc/CHANGELOG.md";
+    changelog = "https://github.com/zdharma-continuum/zinit/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
