### PR TITLE
glean: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24871,6 +24871,12 @@
     githubId = 129837916;
     name = "Rohith S";
   };
+  rokuroo171 = {
+    email = "mrakkakhairilazwar@gmail.com";
+    github = "rokuroo171";
+    githubId = 238833795;
+    name = "Rakka";
+  };
   rolfschr = {
     email = "rolf.schr@posteo.de";
     github = "rolfschr";

--- a/pkgs/by-name/gl/glean/package.nix
+++ b/pkgs/by-name/gl/glean/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  npmHooks,
+  nodejs,
+  fetchNpmDeps,
+  pkg-config,
+  gtk3,
+  webkitgtk_4_1,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "glean";
+  version = "1.5.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rokuroo171";
+    repo = "glean";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-frdwT4wodBHOAChOxXhzLwDNOON03YtWBy19wWtZZTQ=";
+  };
+
+  vendorHash = "sha256-0wokAwAd41GL/KK339fnmjQa8/mEeySg8J2Pcn+lmP8=";
+
+  npmDeps = fetchNpmDeps {
+    name = "glean-frontend-deps";
+    src = "${finalAttrs.src}/frontend";
+    hash = "sha256-MOEW3oPuZuQq/xR6fnNs0/yKtbFsH6d56aY8OGJ0ZuE=";
+  };
+
+  npmRoot = "frontend";
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    webkitgtk_4_1
+  ];
+
+  preBuild = ''
+    pushd frontend
+    npm run build
+    popd
+  '';
+
+  meta = {
+    description = "Note-taking app with a constellation-based night-sky UI";
+    homepage = "https://github.com/rokuroo171/glean";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "glean";
+    maintainers = with lib.maintainers; [ rokuroo171 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Adds Glean, a note-taking app built with Go (Wails) and a Vite frontend.
Homepage: https://github.com/rokuroo171/glean

## Things done
- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.