### PR TITLE
[Backport release-26.05] python3Packages.exiv2: 0.18.1 -> 0.19.2

### DIFF
--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -12,14 +12,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "exiv2";
-  version = "0.19.0";
+  version = "0.19.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jim-easterbrook";
     repo = "python-exiv2";
     tag = finalAttrs.version;
-    hash = "sha256-BIRIq5k4H+n+8d8B4lpr5VpfXA2JkcI54ZPPWDYtajQ=";
+    hash = "sha256-o7COS308ALPYgcQtKGrgwx+4KLGlsZ29J1LSrAldTw4=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -12,14 +12,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "exiv2";
-  version = "0.18.1";
+  version = "0.19.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jim-easterbrook";
     repo = "python-exiv2";
     tag = finalAttrs.version;
-    hash = "sha256-3r0qGsCkfe2sQuXiCipXzW0vF2JRg77L1IcOiLTPslM=";
+    hash = "sha256-BIRIq5k4H+n+8d8B4lpr5VpfXA2JkcI54ZPPWDYtajQ=";
   };
 
   build-system = [


### PR DESCRIPTION
This fixes build after exiv2 update: https://hydra.nixos.org/build/344226401/step/1/log/tail


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
