### PR TITLE
splayer-next: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/sp/splayer-next/package.nix
+++ b/pkgs/by-name/sp/splayer-next/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -15,6 +15,8 @@
   openssl,
   ffmpeg-headless,
   alsa-lib,
+  libpulseaudio,
+  pipewire,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
@@ -23,18 +25,25 @@
 }:
 let
   electron = electron_43;
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
   shareDir = "$out/share/SPlayer-Next";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "splayer-next";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "SPlayer-Dev";
     repo = "SPlayer-Next";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D2Ja/ZF5hKRVy/O33mCsl0iulYUqP/qRiQLjX0tl0dM=";
+    hash = "sha256-ypdEoVtK7ZkrlUycfXgyE4Ki+WPHuzARj15WtbjlNCo=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      git log -1 --format=%cI > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -46,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-zCWX8N4VGZQirHjbseExOVdk4cjFUxJnjYwHFYbKWjM=";
+    hash = "sha256-Ll+nfLfKQapsBc/vGabmd4xuSvYg/XnyLBg9w9hYlhY=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
@@ -55,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       version
       src
       ;
-    hash = "sha256-iZtUPQ3yUomUNf6j+gV0HxcwsvjBPOVqwzwUvsP0CCY=";
+    hash = "sha256-36PeEuqq/ZNUG+gmPiQbIUt8cpTGF7+9lhCX6YftMr4=";
   };
 
   nativeBuildInputs = [
@@ -77,6 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     ffmpeg-headless
     alsa-lib
+    libpulseaudio
+    pipewire
   ];
 
   env = {
@@ -93,8 +104,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     # Workaround for https://github.com/electron/electron/issues/31121
-    substituteInPlace electron/main/utils/nativeLoader.ts \
+    substituteInPlace electron/main/utils/nativeLoader.ts electron/main/services/recognition/fingerprint.ts \
       --replace-fail 'process.resourcesPath' "'${shareDir}/resources'"
+
+    substituteInPlace electron.vite.config.ts \
+      --replace-fail 'import { execSync } from "child_process";' 'import { readFileSync } from "fs";' \
+      --replace-fail 'execSync("git rev-parse HEAD").toString()' 'readFileSync("COMMIT", "utf8")' \
+      --replace-fail 'execSync("git log -1 --format=%cI").toString()' 'readFileSync("SOURCE_DATE_EPOCH", "utf8")'
 
     sed -i '/^[[:space:]]*\.atleast_version/d' "$cargoDepsCopy"/{.,*}/ffmpeg_audio_sys-*/build.rs
   '';
@@ -183,6 +199,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/SPlayer-Dev/SPlayer-Next";
     changelog = "https://github.com/SPlayer-Dev/SPlayer-Next/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # resources/afp/afp.wasm.mjs
+    ];
     maintainers = with lib.maintainers; [ ccicnce113424 ];
     mainProgram = "SPlayer-Next";
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/SPlayer-Dev/SPlayer-Next/releases/tag/v1.1.0
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
