### PR TITLE
home-assistant-custom-components.calendar_export: 0.1.0-unstable-2025-12-13 -> 0.2.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/calendar_export/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/calendar_export/package.nix
@@ -5,16 +5,16 @@
   icalendar,
 }:
 
-buildHomeAssistantComponent {
+buildHomeAssistantComponent (finalAttrs: {
   owner = "JosephAbbey";
   domain = "calendar_export";
-  version = "0.1.0-unstable-2025-12-13";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "JosephAbbey";
     repo = "ha_calendar_export";
-    rev = "abe73d46a42aaec11aca19fed7913ceb525ca784";
-    hash = "sha256-x1UXjpFXKU06FDPLbpPx39nwr1o3ZuluWuSNKomS8SU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7cz9G6/oVRTMA4UhEftC1NEvHhEjHwv1drIu6lkmCOs=";
   };
 
   dependencies = [ icalendar ];
@@ -22,9 +22,10 @@ buildHomeAssistantComponent {
   ignoreVersionRequirement = [ "icalendar" ];
 
   meta = {
+    changelog = "https://github.com/josephabbey/ha_calendar_export/releases/tag/${finalAttrs.src.tag}";
     description = "Export calendar events in the iCalendar format";
     homepage = "https://github.com/JosephAbbey/ha_calendar_export";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/josephabbey/ha_calendar_export/releases/tag/v0.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
