### PR TITLE
abseil-cpp: 20260107.1 -> 20260817.0

### DIFF
--- a/pkgs/by-name/ab/abseil-cpp/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp/package.nix
@@ -6,7 +6,7 @@
 # required LTS branch, leaving `abseil-cpp` as an alias.
 
 {
-  abseil-cpp_202601,
+  abseil-cpp_202608,
   cxxStandard ? null,
 }:
-abseil-cpp_202601.override { inherit cxxStandard; }
+abseil-cpp_202608.override { inherit cxxStandard; }


### PR DESCRIPTION
## Things done

Diff: https://github.com/abseil/abseil-cpp/compare/20260107.1...20260817.0

Changelogs:
- https://github.com/abseil/abseil-cpp/releases/tag/20260526.0
- https://github.com/abseil/abseil-cpp/releases/tag/20260817.0

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
