### PR TITLE
curl: remove rtmpSupport

### DIFF
--- a/pkgs/by-name/cu/curlFull/package.nix
+++ b/pkgs/by-name/cu/curlFull/package.nix
@@ -8,7 +8,6 @@ curl.override (
     c-aresSupport = true;
     ldapSupport = true;
     gsaslSupport = true;
-    rtmpSupport = true;
     websocketSupport = true;
   }
   // removeAttrs args [ "curl" ]

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -46,8 +46,6 @@
   openssl,
   pslSupport ? false,
   libpsl,
-  rtmpSupport ? false,
-  rtmpdump,
   scpSupport ? zlibSupport && !stdenv.hostPlatform.isSunOS && !stdenv.hostPlatform.isCygwin,
   libssh2,
   rustlsSupport ? false,
@@ -189,7 +187,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional ldapSupport openldap
     ++ lib.optional opensslSupport openssl
     ++ lib.optional pslSupport libpsl
-    ++ lib.optional rtmpSupport rtmpdump
     ++ lib.optional scpSupport libssh2
     ++ lib.optional rustlsSupport rustls-ffi
     ++ lib.optional zlibSupport zlib
@@ -213,7 +210,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeature opensslSupport "ca-fallback")
     (lib.withFeature http3Support "nghttp3")
     (lib.withFeature http3Support "ngtcp2")
-    (lib.withFeature rtmpSupport "librtmp")
     (lib.withFeature rustlsSupport "rustls")
     (lib.withFeature zstdSupport "zstd")
     (lib.withFeature pslSupport "libpsl")

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -331,6 +331,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.curl;
     maintainers = with lib.maintainers; [
       Scrumplex
+      tmarkus
     ];
     teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
RTMP support has been removed from upstream as of version 8.20: https://daniel.haxx.se/blog/2026/03/21/bye-bye-rtmp/

Also add myself as maintainer.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
