### PR TITLE
red-table: init at 0.2.0

### DIFF
--- a/pkgs/by-name/re/red-table/package.nix
+++ b/pkgs/by-name/re/red-table/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "red-table";
+  version = "0.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "volker-schukai";
+    repo = "red-table";
+    tag = finalAttrs.version;
+    hash = "sha256-wloknsKIfYd1DVJ81SWc3y6+AB0cZgr7MtcAek2TyfY=";
+  };
+
+  cargoHash = "sha256-6ALtsU9/sRVy05GSKIp8f6rCsaaojHE6T/Hp2xuQ5ic=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "red-table";
+    description = ''
+      Fast keyboard-driven terminal image browser for browsing,
+      comparing, and selecting large image collections
+    '';
+    longDescription = ''
+      red-table is a performance-first terminal image browser for large image collections.
+      It provides a searchable, scrollable thumbnail grid controlled entirely from the keyboard,
+      including arrow keys and Vim-style h, j, k, and l navigation.
+    '';
+    homepage = "https://github.com/volker-schukai/red-table";
+    downloadPage = "https://github.com/volker-schukai/red-table/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/volker-schukai/red-table/commits/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    identifiers = {
+      cpeParts = lib.meta.cpeFullVersionWithVendor "volker-schukai" finalAttrs.version;
+      purlParts = {
+        type = "github";
+        namespace = "volker-schukai";
+        name = "red-table";
+        version = finalAttrs.version;
+      };
+    };
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added red-table at 0.2.0 from https://github.com/volker-schukai/red-table

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
