### PR TITLE
python3Packages.nccl4py: 0.4.1 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/nccl4py/default.nix
+++ b/pkgs/development/python-modules/nccl4py/default.nix
@@ -105,6 +105,7 @@ buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } (finalAttrs
     # `cudaPackages.nccl` is BSD3 but the bindings are licensed under
     # Apache License 2.0
     license = lib.licenses.bsd3;
+    teams = [ lib.teams.cuda ];
     maintainers = with lib.maintainers; [
       GaetanLepage
       thefossguy

--- a/pkgs/development/python-modules/nccl4py/default.nix
+++ b/pkgs/development/python-modules/nccl4py/default.nix
@@ -1,9 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
   cudaPackages,
-  addDriverRunpath,
+  fetchFromGitHub,
 
   # build-system
   cython,
@@ -11,22 +10,21 @@
 
   # dependencies
   cuda-core,
+  cuda-pathfinder,
   numpy,
   nvidia-cutlass-dsl,
   packaging,
-  pythonOlder,
-  typing-extensions,
 
   # passthru
   runCommand,
   python,
 }:
 
-buildPythonPackage (finalAttrs: {
+buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } (finalAttrs: {
   pname = "nccl4py";
   # `nccl4py` is versioned independently of `nccl` and should be the same as the contents of
-  # `${cudaPackages.nccl.src}/bindings/nccl4py/nccl/_version.py`
-  version = "0.4.1";
+  # `${cudaPackages.nccl.src}/bindings/nccl4py/nccl/core/_version.py`
+  version = "0.5.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -34,33 +32,19 @@ buildPythonPackage (finalAttrs: {
     owner = "NVIDIA";
     repo = "nccl";
     tag = "nccl4py-v${finalAttrs.version}";
-    hash = "sha256-p9z4NlccBdI0auMRzTJtK8VbAOSunLdwKKU0Wn5c6c0=";
+    hash = "sha256-f9hOqRJSC/tuRUAN6qKRaItHR62dG7mu1rtw9nJQhic=";
   };
   sourceRoot = "${finalAttrs.src.name}/bindings/nccl4py";
 
-  postPatch =
-    let
-      # taken from `cuda-bindings`'s `postPatch`
-      libCudaPath =
-        # Use cuda_compat to provide libcuda.so on pre-Thor Jetsons
-        if (cudaPackages.cuda_compat.meta.available or false) then
-          cudaPackages.cuda_compat
-
-        # Else, use the host CUDA driver library
-        else
-          addDriverRunpath.driverLink;
-    in
-    ''
-      substituteInPlace nccl/bindings/_internal/nccl_linux.pyx \
-        --replace-fail \
-          "handle = dlopen('libcuda.so.1'" \
-          "handle = dlopen('${libCudaPath}/lib/libcuda.so.1'"
-
-      substituteInPlace nccl/bindings/_internal/nccl_linux.pyx \
-        --replace-fail \
-          'cdef uintptr_t handle = load_nvidia_dynamic_lib("nccl")._handle_uint' \
-          'cdef uintptr_t handle = <uintptr_t>dlopen("${lib.getLib cudaPackages.nccl}/lib/libnccl.so.2", RTLD_NOW | RTLD_GLOBAL)'
-    '';
+  postPatch = ''
+    substituteInPlace nccl/bindings/_internal/nccl_linux.pyx \
+      --replace-fail \
+        'from cuda.pathfinder import load_nvidia_dynamic_lib' \
+        'from posix.dlfcn cimport dlopen, RTLD_GLOBAL, RTLD_NOW' \
+      --replace-fail \
+        'cdef uintptr_t handle = load_nvidia_dynamic_lib("nccl")._handle_uint' \
+        'cdef uintptr_t handle = <uintptr_t>dlopen("${lib.getLib cudaPackages.nccl}/lib/libnccl.so.2", RTLD_NOW | RTLD_GLOBAL)'
+  '';
 
   build-system = [
     cython
@@ -70,9 +54,9 @@ buildPythonPackage (finalAttrs: {
   env = {
     # `${sourceRoot}/setup.py` insists on reading only from $CUDA_HOME/include
     CUDA_HOME = (lib.getInclude cudaPackages.cuda_cudart).outPath;
-    # Since `cudaPackages.nccl` is used as a byte string, it gets
-    # compressed and no dependency is created. Disable string
-    # compression for Nix to correctly detect the dependency.
+    # Since `cudaPackages.nccl` is used as a byte string, it gets compressed and no dependency is
+    # created.
+    # Disable string compression for Nix to correctly detect the dependency.
     NIX_CFLAGS_COMPILE = "-DCYTHON_COMPRESS_STRINGS=0";
   };
 
@@ -86,12 +70,10 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     cuda-core
+    cuda-pathfinder
     numpy
     nvidia-cutlass-dsl
     packaging
-  ]
-  ++ lib.optionals (pythonOlder "3.13") [
-    typing-extensions
   ];
 
   pythonImportsCheck = [
@@ -100,6 +82,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   passthru.tests = {
+    # Ensure that `libnccl` is found outside of the build sandbox.
     import-clean-env =
       runCommand "import-clean-env-nccl4py"
         {
@@ -107,7 +90,7 @@ buildPythonPackage (finalAttrs: {
         }
         ''
           LD_LIBRARY_PATH="${lib.getLib cudaPackages.cuda_cudart}/lib/stubs" \
-              python -c 'import nccl.bindings.nccl'
+              python -c 'from nccl.bindings import nccl; print(nccl.get_version())'
           touch $out
         '';
   };


### PR DESCRIPTION
## Things done

Diff: https://github.com/NVIDIA/nccl/compare/nccl4py-v0.4.1...nccl4py-v0.5.0
Changelog: https://github.com/NVIDIA/nccl/releases/tag/nccl4py-v0.5.0

cc @thefossguy
cc @NixOS/cuda-maintainers 

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test