### PR TITLE
curl: add echSupport flag

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -56,8 +56,10 @@
   zlib,
   zstdSupport ? false,
   zstd,
+  echSupport ? false,
 
   # for passthru.tests
+  curl,
   coeurl,
   curlpp,
   haskellPackages,
@@ -83,6 +85,10 @@ assert
       rustlsSupport
     ]) > 1
   );
+
+# Encrypted Client Hello (ECH) support requires at least OpenSSL 4.0 or rustls.
+assert
+  echSupport -> (opensslSupport && lib.versionAtLeast openssl.version "4.0.0") || rustlsSupport;
 
 let
   isCross = !lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform;
@@ -209,6 +215,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature ldapSupport "ldap")
     (lib.enableFeature ldapSupport "ldaps")
     (lib.enableFeature websocketSupport "websockets")
+    (lib.enableFeature echSupport "ech")
     # --with-ca-fallback is only supported for openssl https://github.com/curl/curl/blame/curl-8_16_0/acinclude.m4#L1258
     (lib.withFeature opensslSupport "ca-fallback")
     (lib.withFeature http3Support "nghttp3")
@@ -217,6 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeature rustlsSupport "rustls")
     (lib.withFeature zstdSupport "zstd")
     (lib.withFeature pslSupport "libpsl")
+
     (lib.withFeatureAs brotliSupport "brotli" (lib.getDev brotli))
     (lib.withFeatureAs gnutlsSupport "gnutls" (lib.getDev gnutls))
     (lib.withFeatureAs idnSupport "libidn2" (lib.getDev libidn2))
@@ -307,6 +315,11 @@ stdenv.mkDerivation (finalAttrs: {
         withCheck = finalAttrs.finalPackage.overrideAttrs (_: {
           doCheck = true;
         });
+        ech = curl.override {
+          echSupport = true;
+          opensslSupport = false;
+          rustlsSupport = true;
+        };
         fetchpatch = tests.fetchpatch.simple.override {
           fetchpatch = (fetchpatch.override { fetchurl = useThisCurl fetchurl; }) // {
             version = 1;


### PR DESCRIPTION
Add a `echSupport` to allow building curl with support for Encrypted Client Hello (ECH).

Disabled by default for now, because
- Upstream still marks the feature as experimental
- it requires OpenSSL 4.0 or newer (or alternatively rustls), while we still build curl with an earlier OpenSSL version at the moment and obviously we shouldn't override the OpenSSL version just for this one feature

Use 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
