### PR TITLE
desync: 1.1.0 -> 1.1.3

### DIFF
--- a/pkgs/by-name/de/desync/package.nix
+++ b/pkgs/by-name/de/desync/package.nix
@@ -8,16 +8,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "desync";
-  version = "1.1.0";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "folbricht";
     repo = "desync";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ViwNE+8fmYbAMPFd8yiWXDLbaenkgri9PBe92M0Se5U=";
+    hash = "sha256-xiiN+0veHRxVNsIpob7W/iRH+dABYIiWfw22DH1bTEs=";
   };
 
-  vendorHash = "sha256-dAFci7GXe1fPPABIG1dngEyGqC5TKa90fyQPYSbJJrk=";
+  vendorHash = "sha256-FRXwQUOD1UiGSlGkBLXT0RGG382RJdEGUJxaQiyzR9A=";
+
+  ldflags = [ "-X main.version=${finalAttrs.src.tag}" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -26,25 +28,7 @@ buildGoModule (finalAttrs: {
 
   checkFlags =
     let
-      skippedTests = [
-        "TestExtract" # block cloning fails on ZFS
-        "TestExtractCommand/extract_while_regenerating_the_corrupted_seed" # block cloning fails on ZFS
-        "TestExtractCommand/extract_with_seed_directory" # block cloning fails on ZFS
-        "TestExtractCommand/extract_with_single_seed" # block cloning fails on ZFS
-        "TestExtractCommand/extract_with_single_seed,_explicit_data_directory_and_unexpected_seed_options" # block cloning fails on ZFS
-        "TestExtractCommand/extract_with_single_seed_and_explicit_data_directory" # block cloning fails on ZFS
-        "TestExtractWithNonStaticSeeds" # block cloning fails on ZFS
-        "TestLocalFSDirSetgidWhilePopulated" # cannot setgid in /tmp
-        "TestMountIndex" # FUSE does not work in sandbox
-        "TestSeed/extract_repetitive_file" # block cloning fails on ZFS
-        "TestTar" # xattr.list: operation not supported
-        "TestUnTarDirMTime" # xattr.list: operation not supported
-        "TestUnTarIntoReadOnlyDir" # xattr.list: operation not supported
-        "TestUnTarNoSamePermissionsOverReadOnlyTree" # xattr.list: operation not supported
-        "TestUnTarReadOnlyDir" # xattr.list: operation not supported
-        "TestUnTarReadOnlyDirNoSamePermissions" # xattr.list: operation not supported
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      skippedTests = lib.optionals stdenv.hostPlatform.isDarwin [
         "TestS3StoreGetChunk/fail" # sendfile is not permitted in Darwin sandbox
         "TestS3StoreGetChunk/recover" # sendfile is not permitted in Darwin sandbox
       ];


### PR DESCRIPTION
- https://github.com/folbricht/desync/releases/tag/v1.1.1
- https://github.com/folbricht/desync/releases/tag/v1.1.2
- https://github.com/folbricht/desync/releases/tag/v1.1.3
- Supported the `version` command added in v1.1.1 by adding corresponding `ldflags`
- Disabled tests were fixed in the following PRs, so reenable them (AI was used to test that these tests now pass in a VM with Hydra-like configuration):
  - https://github.com/folbricht/desync/pull/356
  - https://github.com/folbricht/desync/pull/403 fixed xattr ENOTSUP processing
  - https://github.com/folbricht/desync/pull/415
  - https://github.com/folbricht/desync/pull/416

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test