### PR TITLE
y509: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14682,6 +14682,12 @@
     github = "KangaZero";
     githubId = 107836643;
   };
+  kanywst = {
+    email = "niwatakuma@icloud.com";
+    github = "kanywst";
+    githubId = 45947799;
+    name = "kt";
+  };
   kaptcha0 = {
     name = "J'C Kabunga";
     github = "kaptcha0";

--- a/pkgs/by-name/y5/y509/package.nix
+++ b/pkgs/by-name/y5/y509/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "y509";
+  version = "1.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kanywst";
+    repo = "y509";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Erk9haxNa66BAKWITJWbilaDDhCOk+Lcw7KAgXJTbS8=";
+  };
+
+  vendorHash = "sha256-TEunzNuyN6n4fWYhJsEnTgj6KK/CEQkZ78baGtLH4zA=";
+
+  subPackages = [ "cmd/y509" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-X=github.com/kanywst/y509/internal/version.Version=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    installManPage man/man1/y509.1
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd y509 \
+      --bash <($out/bin/y509 completion bash) \
+      --fish <($out/bin/y509 completion fish) \
+      --zsh <($out/bin/y509 completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI for inspecting and validating X.509 certificate chains";
+    longDescription = ''
+      y509 verifies a certificate chain against the system trust store and
+      separately reports how the chain was served: a missing intermediate, a
+      redundant root, or certificates sent out of order. Chains can be read
+      from PEM/DER files, from stdin, or from a live server, including behind
+      STARTTLS. The validate subcommand exits non-zero on anything a TLS client
+      would reject, with optional JSON output for CI.
+    '';
+    homepage = "https://github.com/kanywst/y509";
+    changelog = "https://github.com/kanywst/y509/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kanywst ];
+    mainProgram = "y509";
+  };
+})


### PR DESCRIPTION
TUI for inspecting and validating X.509 certificate chains

https://github.com/kanywst/y509

Left maintainers empty.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
