### PR TITLE
python3Packages.osc: 1.27.2 -> 1.27.3

### DIFF
--- a/pkgs/development/python-modules/osc/default.nix
+++ b/pkgs/development/python-modules/osc/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   lib,
   rpm,
+  setuptools,
   urllib3,
   keyring,
   ruamel-yaml,
@@ -13,22 +14,24 @@
 
 buildPythonPackage rec {
   pname = "osc";
-  version = "1.27.2";
-  format = "setuptools";
+  version = "1.27.3";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openSUSE";
     repo = "osc";
-    rev = version;
-    hash = "sha256-PwOJpjlIqOtLw79DK0KWb8ktAQ9vQVnSdf657jPVfLQ=";
+    tag = version;
+    hash = "sha256-We8SuDa2phvvu9IcsBWu/YBHPvlPy0Yka716KKcFwJ8=";
   };
 
-  buildInputs = [ bashInteractive ]; # needed for bash-completion helper
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ bashInteractive ]; # needed for bash-completion helper
   nativeCheckInputs = [
     rpm
     diffstat
   ];
-  propagatedBuildInputs = [
+  dependencies = [
     urllib3
     cryptography
     keyring
@@ -47,7 +50,7 @@ buildPythonPackage rec {
     EOF
   '';
 
-  preCheck = "HOME=$TOP/tmp";
+  preCheck = "HOME=$TMPDIR";
 
   meta = {
     homepage = "https://github.com/openSUSE/osc";
@@ -57,6 +60,6 @@ buildPythonPackage rec {
       peti
       saschagrunert
     ];
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
- Update 1.27.2 -> 1.27.3
- Switch from `format = "setuptools"` to `pyproject = true`
- Replace `propagatedBuildInputs` with `dependencies`
- Replace `buildInputs` with `nativeBuildInputs` and add `build-system`
- Use `tag` instead of `rev` in `fetchFromGitHub`
- Fix `preCheck`: replace broken `$TOP` with `$TMPDIR`
- Fix license: `gpl2` -> `gpl2Plus` (upstream is GPL-2.0-or-later)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test