### PR TITLE
python3Packages.qtile: run checks in passthru

### DIFF
--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -65,6 +65,7 @@
   xvfb,
 
   # passthru.tests
+  qtile,
   nixosTests,
 }:
 
@@ -152,6 +153,8 @@ buildPythonPackage (finalAttrs: {
     librsvg
   ];
 
+  doCheck = false; # The test suite is slow and tends to flaky in hydra jobs
+
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
@@ -202,7 +205,12 @@ buildPythonPackage (finalAttrs: {
   ];
 
   passthru = {
-    tests.qtile = nixosTests.qtile;
+    tests = {
+      nixosTestSession = nixosTests.qtile;
+      withCheck = qtile.overridePythonAttrs (_: {
+        doCheck = true;
+      });
+    };
     providedSessions = [ "qtile" ];
   };
 


### PR DESCRIPTION
- close https://github.com/NixOS/nixpkgs/issues/559128

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
