### PR TITLE
vimPlugins.notmuch-nvim: init at 0.4.0

### DIFF
--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -12380,6 +12380,20 @@ final: prev: {
     meta.hydraPlatforms = [ ];
   };
 
+  notmuch-nvim = buildVimPlugin {
+    pname = "notmuch.nvim";
+    version = "0.4.0";
+    src = fetchFromGitHub {
+      owner = "yousefakbar";
+      repo = "notmuch.nvim";
+      tag = "v0.4.0";
+      hash = "sha256-A+vlH8fUNd3/lTH++sp90YXRqe3/uTxOTNw43CJQQyc=";
+    };
+    meta.homepage = "https://github.com/yousefakbar/notmuch.nvim/";
+    meta.license = unfree;
+    meta.hydraPlatforms = [ ];
+  };
+
   nterm-nvim = buildVimPlugin {
     pname = "nterm.nvim";
     version = "0-unstable-2022-05-10";

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -14,6 +14,8 @@
   yarnConfigHook,
   python3,
   # Misc dependencies
+  notmuch,
+  file,
   charm-freeze,
   code-minimap,
   dailies,
@@ -3160,6 +3162,32 @@ assertNoAdditions {
       license = lib.licenses.mit;
     };
   });
+
+  notmuch-nvim = super.notmuch-nvim.overrideAttrs {
+    checkInputs = [
+      notmuch
+    ];
+
+    # NOTE: for best user experience, consider installing optional handlers to display attachements within neovim. For instance: [ w3m catimg mupdf-headless pandoc zip ]
+    # See https://github.com/yousefakbar/notmuch.nvim/blob/v0.4.0/lua/notmuch/handlers.lua for supported handlers.
+    runtimeDeps = [
+      file
+      notmuch
+    ];
+
+    postPatch =
+      let
+        ext = stdenv.hostPlatform.extensions.sharedLibrary;
+        notmuchLib = "${lib.getLib notmuch}/lib/libnotmuch${ext}";
+      in
+      # bash
+      ''
+        substituteInPlace lua/notmuch/cnotmuch.lua \
+          --replace-fail 'ffi.load("notmuch")' 'ffi.load("${notmuchLib}")'
+      '';
+
+    meta.license = lib.licenses.mit;
+  };
 
   NrrwRgn = super.NrrwRgn.overrideAttrs (old: {
     meta = old.meta // {

--- a/pkgs/applications/editors/vim/plugins/vim-plugin-names
+++ b/pkgs/applications/editors/vim/plugins/vim-plugin-names
@@ -882,6 +882,7 @@ https://github.com/nordtheme/vim/,,nord-vim
 https://github.com/shaunsingh/nord.nvim/,,
 https://github.com/alexvzyl/nordic.nvim/,,
 https://github.com/vigoux/notifier.nvim/,,
+https://github.com/yousefakbar/notmuch.nvim/,,
 https://github.com/jlesquembre/nterm.nvim/,,
 https://github.com/nacro90/numb.nvim/,,
 https://github.com/nvchad/nvchad/,,


### PR DESCRIPTION
Adds notmuch-nvim plugin for reading and managing emails within neovim.

This plugin builds lua bindings to libnotmuch c API, and uses them to interact with notmuch email indexing to read/parse emails. I'm not sure if nativeBuildInputs is the right choice for neomuch dependency here, but it works for both running lua checks and at runtime within neovim.

It supports a bunch of applications for displaying attachements/html messages without leaving neovim. They are technically optional, but QoL suffers greatly when they are not present, so I added sane defaults as `runtimeDeps`.
Not sure whether I should make them optional here, or overrideable by the user (one might want to use its prefered app here). As-is, the plugin supports a fixed set of apps for each mime type (e.g w3c and lynx for html, etc).

Also note that there is an existing `notmuch-vim` plugin that is meant for vim, and uses ruby bindings instead of lua. This plugin's relies on `notmuch` derivation providing a `vim` output containing the plugin and ruby gems (defined [here](https://github.com/NixOS/nixpkgs/blob/1983fdc2f30e3ed2a57ee8c61e6315485a31bce6/pkgs/applications/networking/mailreaders/notmuch/default.nix#L129), used [here](https://github.com/NixOS/nixpkgs/blob/e03c6762cddd1561812f2b544428617fb9ebc70e/pkgs/applications/editors/vim/plugins/non-generated/notmuch-vim/default.nix#L7)). This did not seem necessary for integrating with `notmuch-nvim`, so I went the simpler way with automatic generation and overrides here.

This is my first time attempting to package a neovim plugin. Let me know if this is the right approach.

Best regards,
Arnaud

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
