### PR TITLE
chickenPackages_4.chicken: mark for removal

### DIFF
--- a/pkgs/development/compilers/chicken/4/chicken.nix
+++ b/pkgs/development/compilers/chicken/4/chicken.nix
@@ -98,6 +98,12 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://www.call-cc.org/";
     license = lib.licenses.bsd3;
+    problems.removal = {
+      message = "CHICKEN 4 is an outdated release which upstream no longer supports; use chickenPackages_5 or chickenPackages_6 instead. This set will be removed once ugarit, its only remaining user in Nixpkgs, has been ported to a supported release.";
+      urls = [
+        "https://wiki.call-cc.org/man/4/The%20User's%20Manual#outdated-chicken-release"
+      ];
+    };
     maintainers = with lib.maintainers; [ corngood ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin; # Maybe other Unix
     description = "Portable compiler for the Scheme programming language";


### PR DESCRIPTION
Marks `chickenPackages_4` for removal with `meta.problems.removal`, so that anyone still using CHICKEN 4 gets told it is going before it goes.

CHICKEN 4 is [listed as an outdated release](https://wiki.call-cc.org/man/4/The%20User's%20Manual#outdated-chicken-release) in upstream's own manual and has had no release since 2019. CHICKEN 5 has been in Nixpkgs for years, and CHICKEN 6 is being added in #552047. The CHICKEN 4 expression is also the odd one out in that directory: it predates `deps.toml` and `update.sh`, curates its egg set by hand with `egg2nix`, and patches and regenerates the compiler's own sources, which is why the shared expressions in that pull request cover only 5 and 6.

`ugarit` is the only package in Nixpkgs still using it. Its author has said he intends to port it to CHICKEN 6, so this pull request only *announces* the removal rather than doing it; the set can be dropped once that port has landed.

This came out of review on #552047, where @DerGuteMoritz suggested it.

## Effect

`removal` problems are handled as a warning by default, so nothing is blocked: the CHICKEN 4 set and `ugarit` both still evaluate and build, and users see

```
evaluation warning: Package 'chicken-4.13.0' in pkgs/development/compilers/chicken/4/chicken.nix:109 has the following problem: removal: CHICKEN 4 is an outdated release which upstream no longer supports; use chickenPackages_5 or chickenPackages_6 instead. This set will be removed once ugarit, its only remaining user in Nixpkgs, has been ported to a supported release. …
```

The change is `meta` only. I checked that it rebuilds nothing by comparing derivation paths before and after: `chickenPackages_4.chicken` and `ugarit` are unchanged at `gdg60wcrmdf94d053iadcl6x48mdfvl0` and `cp9ipnmjimzchwvp1jwhw25wzwjiqqzm` respectively.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

`nixpkgs-review` is unticked because there is nothing for it to build: no derivation changes. The release note boxes are unticked deliberately too — nothing is removed or broken yet, and `meta.problems.removal` is itself the announcement mechanism. A release note belongs on the pull request that actually drops the set.

## Automation disclosure

This contribution was produced with Claude Code (primary model: `claude-opus-5[1m]`), which wrote the change, the commit message and this summary; the commit carries an `Assisted-by:` trailer, per the [automation/AI policy]. I am accountable for it and have reviewed it before submission. The claims above about evaluation behaviour and the absence of rebuilds were checked against this tree rather than assumed.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test