### PR TITLE
nsd: 4.15.0 -> 4.15.2

### DIFF
--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -33,22 +33,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nsd";
-  version = "4.15.0";
+  version = "4.15.1";
 
   src = fetchurl {
     url = "https://www.nlnetlabs.nl/downloads/nsd/nsd-${finalAttrs.version}.tar.gz";
-    hash = "sha256-hPG+4ukqna20HZXsxkET5NPe+GIk3ndM2SADrdjE9XA=";
+    hash = "sha256-zkHhMxfTXXpbPzRgVIdCk5GkHsp3sgBu3RHpRTQyxgk=";
   };
-
-  patches = [
-    # https://github.com/NLnetLabs/nsd/pull/495 -- Without this patch, the build
-    # breaks with { openssl = libressl; bind8Stats = true; }. The patch will be
-    # included in 4.15.1, so we can drop it here on the next update.
-    (fetchurl {
-      url = "https://github.com/NLnetLabs/nsd/commit/15cf8736e3bfa0fd8f426b13637c44e638fa0d40.patch";
-      hash = "sha256-JVazJ83U80ASZypjic0epE92PZd3F1yi8UU6EapdW5U=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -33,11 +33,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nsd";
-  version = "4.15.1";
+  version = "4.15.2";
 
   src = fetchurl {
     url = "https://www.nlnetlabs.nl/downloads/nsd/nsd-${finalAttrs.version}.tar.gz";
-    hash = "sha256-zkHhMxfTXXpbPzRgVIdCk5GkHsp3sgBu3RHpRTQyxgk=";
+    hash = "sha256-u01XdTwswqZByS2rECEBbSX7S5cpIL9PC7uMQMGpzOI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This pull request supersedes #557026, which updated NSD from 4.15.0 to 4.15.1, but which did not get merged before the release of 4.15.2.

4.15.1 included fixes for CVE-2026-18664, CVE-2026-18916, CVE-2026-19401, and CVE-2026-19538.
4.15.2 does not include new security fixes on top of that.

[Full upstream changelog](https://github.com/NLnetLabs/nsd/releases/tag/NSD_4_15_2_REL)

Testing: This new package is currently running on the nameservers for my personal domains.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. (No AI used)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
