### PR TITLE
hyper-headset: init at 1.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15356,6 +15356,12 @@
     githubId = 1903418;
     name = "Kovacsics Robert";
   };
+  koyfm = {
+    email = "itzik@koyfman.net";
+    github = "koyfm";
+    githubId = 74200683;
+    name = "Itzik Koyfman";
+  };
   kozm9000 = {
     email = "ubermailbox@protonmail.ch";
     github = "kozm9000";

--- a/pkgs/by-name/hy/hyper-headset/package.nix
+++ b/pkgs/by-name/hy/hyper-headset/package.nix
@@ -1,0 +1,83 @@
+{
+  dbus,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  udev,
+  udevCheckHook,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hyper-headset";
+  version = "1.10.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "LennardKittner";
+    repo = "HyperHeadset";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NAuPEaB3DRafrg9yDkrcXEm8Ipa49yKB9uPnrlewiOQ=";
+  };
+
+  cargoHash = "sha256-SsQkhM5ydzSAojnBEpESnNgjVUSJYZXadLObd8wLc6g=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    dbus
+    udev
+  ];
+
+  buildFeatures = [ "eq-editor" ];
+
+  cargoBuildFlags = [
+    "--bin"
+    "hyper_headset"
+    "--bin"
+    "hyper_headset_cli"
+  ];
+
+  postPatch = ''
+    # Upstream grants a blanket MODE="0666" on the USB and hidraw nodes. Delegate
+    # to logind instead, so that only the locally logged in user is given access.
+    # The tag is consumed by systemd's 73-seat-late.rules, hence the rules are
+    # installed below under a name that sorts before it.
+    substituteInPlace 99-HyperHeadset.rules \
+      --replace-fail 'MODE="0666"' 'TAG+="uaccess"'
+  '';
+
+  postInstall = ''
+    install -Dm644 99-HyperHeadset.rules $out/lib/udev/rules.d/60-hyper-headset.rules
+    install -Dm644 hyper-headset.desktop -t $out/share/applications
+
+    for bin in hyper_headset hyper_headset_cli; do
+      wrapProgram $out/bin/$bin --set-default HYPERHEADSET_NO_AUTO_UDEV 1
+    done
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    udevCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI and tray application for monitoring and managing HyperX headsets";
+    homepage = "https://github.com/LennardKittner/HyperHeadset";
+    changelog = "https://github.com/LennardKittner/HyperHeadset/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ koyfm ];
+    mainProgram = "hyper_headset";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[HyperHeadset](https://github.com/LennardKittner/HyperHeadset) is a CLI and tray application for monitoring and managing HyperX headsets.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

The app uses mode 0666 for udev rules however the derivation rewrites the rules to use uaccess tag so that only the logged in user gets access via systemd-logind.
The rules file prefix is changed to 60- because the uaccess tag is used by systemd's 73-seat-late.rules.
[HYPERHEADSET_NO_AUTO_UDEV=1](https://github.com/LennardKittner/HyperHeadset/pull/61) is set to disable the app from trying to write the udev rules on its own (thanks @ch4og).
I verified the x86_64-linux build works on my HyperX Cloud III S Wireless (03f0:06be).