### PR TITLE
lighthouse: 8.1.0 -> 8.2.2

### DIFF
--- a/pkgs/by-name/li/lighthouse/package.nix
+++ b/pkgs/by-name/li/lighthouse/package.nix
@@ -17,7 +17,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lighthouse";
-  version = "8.1.3";
+  version = "8.2.2";
 
   # lighthouse/common/deposit_contract/build.rs, `TAG`
   depositContractSpecVersion = "0.12.1";
@@ -28,14 +28,14 @@ rustPlatform.buildRustPackage rec {
     owner = "sigp";
     repo = "lighthouse";
     tag = "v${version}";
-    hash = "sha256-TXJT9ZFgf3B5K44sWVaUpEGM+sZim2mBA5w3eAuoVds=";
+    hash = "sha256-Eb4C6uBJmrb7NOwSDp+Fxkuw7fGcPrtuU8DLGxd2cCM=";
   };
 
   patches = [
     ./use-system-sqlite.patch
   ];
 
-  cargoHash = "sha256-T40R4LfdM5V2PAgkOWayId6xUm2FlGJrefqXgPTDzvM=";
+  cargoHash = "sha256-5lSDbwL1+x91yI8YjgXrkZ2C1CwiaoJjrnGcylFbArs=";
 
   buildFeatures = [
     "gnosis"

--- a/pkgs/by-name/li/lighthouse/use-system-sqlite.patch
+++ b/pkgs/by-name/li/lighthouse/use-system-sqlite.patch
@@ -1,13 +1,13 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index aac26e060..d10c34a40 100644
+index 3400d59..62acf89 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -228,7 +228,7 @@ reqwest = { version = "0.12", default-features = false, features = [
- ] }
+@@ -204,7 +204,7 @@ regex = "1"
+ reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "stream", "rustls-tls"] }
  ring = "0.17"
  rpds = "0.11"
--rusqlite = { version = "0.28", features = ["bundled"] }
-+rusqlite = { version = "0.28" }
+-rusqlite = { version = "0.38", features = ["bundled"] }
++rusqlite = { version = "0.38" }
  rust_eth_kzg = "0.9"
  safe_arith = "0.1"
  sensitive_url = { version = "0.1", features = ["serde"] }


### PR DESCRIPTION
The autoupdate bot has been unable to update to new versions because the sqlite patch could not apply cleanly. This change updates the patch.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
