### PR TITLE
trilium-server: fix aarch64-linux build

### DIFF
--- a/pkgs/by-name/tr/trilium-server/package.nix
+++ b/pkgs/by-name/tr/trilium-server/package.nix
@@ -46,7 +46,8 @@ stdenv.mkDerivation {
 
     cp -r ./* "$out/share/trilium-server/"
 
-    rm $out/share/trilium-server/node_modules/better-sqlite3/prebuilds/linuxmusl-x64.node
+    # Unused musl prebuilds confuse autoPatchelfHook (glibc-only).
+    rm -f "$out/share/trilium-server/node_modules/better-sqlite3/prebuilds"/linuxmusl-*.node
 
     makeWrapper "$out/share/trilium-server/node/bin/node" "$out/bin/trilium-server" \
       --chdir "$out/share/trilium-server" \


### PR DESCRIPTION
The 0.105.0 bump removes `better-sqlite3`'s unused musl prebuild so autoPatchelfHook does not try to patch it. That `rm` was hardcoded to `linuxmusl-x64.node`. The arm64 tarball ships `linuxmusl-arm64.node` instead, so installPhase failed on aarch64-linux.

This removes any `linuxmusl-*.node` prebuild.

https://hydra.nixos.org/build/343428234
Resolves #559163

Built on x86_64-linux. I did not build aarch64-linux here (no binfmt). I listed both release tarballs and ran the same `rm` against the extracted arm64 tree.

Assisted-by: Grok Build (xAI Grok 4.6)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
