### PR TITLE
netdata: fix SNMP build using public GOPROXY

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -215,39 +215,40 @@ stdenv.mkDerivation (
       ''}
     '';
 
-    preConfigure = ''
-      ${lib.optionalString (withNetflow || withOtel || withSystemdJournal) ''
-        export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
-      ''}
+    preConfigure =
+      let
+        LOCAL_GOPROXY = lib.concatStringsSep "," (
+          [ "file://${finalAttrs.passthru.netdata-go-modules}" ]
+          ++ lib.optional withNdMcp "file://${finalAttrs.passthru.nd-mcp}"
+        );
+      in
+      ''
+        ${lib.optionalString (withNetflow || withOtel || withSystemdJournal) ''
+          export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
+        ''}
 
-      export GOCACHE=$TMPDIR/go-cache
-      export GOPATH=$TMPDIR/go
-      export GOSUMDB=off
+        export GOCACHE=$TMPDIR/go-cache
+        export GOPATH=$TMPDIR/go
+        export GOSUMDB=off
 
-      substituteInPlace packaging/cmake/Modules/NetdataGoTools.cmake \
-        --replace-fail \
-          'GOPROXY=https://proxy.golang.org' \
-          'GOPROXY=${
-            lib.concatStringsSep "," (
-              [ "file://${finalAttrs.passthru.netdata-go-modules}" ]
-              ++ lib.optional withNdMcp "file://${finalAttrs.passthru.nd-mcp}"
-            )
-          }'
+        substituteInPlace packaging/cmake/Modules/NetdataGoTools.cmake \
+          --replace-fail 'GOPROXY=https://proxy.golang.org' 'GOPROXY=${LOCAL_GOPROXY}'
 
-      # Prevent the path to be caught into the Nix store path.
-      substituteInPlace CMakeLists.txt \
-        --replace-fail 'set(CACHE_DIR "''${NETDATA_RUNTIME_PREFIX}/var/cache/netdata")' 'set(CACHE_DIR "/var/cache/netdata")' \
-        --replace-fail 'set(CONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/etc/netdata")' 'set(CONFIG_DIR "/etc/netdata")' \
-        --replace-fail 'set(LIBCONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/lib/netdata/conf.d")' 'set(LIBCONFIG_DIR "${placeholder "out"}/share/netdata/conf.d")' \
-        --replace-fail 'set(LOG_DIR "''${NETDATA_RUNTIME_PREFIX}/var/log/netdata")' 'set(LOG_DIR "/var/log/netdata")' \
-        --replace-fail 'set(PLUGINS_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata/plugins.d")' 'set(PLUGINS_DIR "${placeholder "out"}/libexec/netdata/plugins.d")' \
-        --replace-fail 'set(STOCK_DATA_DIR "''${NETDATA_RUNTIME_PREFIX}/''${STOCK_DATA_DEST}")' 'set(STOCK_DATA_DIR "${placeholder "out"}/share/netdata")' \
-        --replace-fail 'set(VARLIB_DIR "''${NETDATA_RUNTIME_PREFIX}/var/lib/netdata")' 'set(VARLIB_DIR "/var/lib/netdata")' \
-        --replace-fail 'set(pkglibexecdir_POST "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata")' 'set(pkglibexecdir_POST "${placeholder "out"}/libexec/netdata")' \
-        --replace-fail 'set(localstatedir_POST "''${NETDATA_RUNTIME_PREFIX}/var")' 'set(localstatedir_POST "/var")' \
-        --replace-fail 'set(BINDIR usr/sbin)' 'set(BINDIR "bin")' \
-        --replace-fail 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "usr/share/netdata")' 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "${placeholder "out"}/share/netdata")'
-    '';
+        # Prevent the path to be caught into the Nix store path.
+        substituteInPlace CMakeLists.txt \
+          --replace-fail 'GOPROXY=https://proxy.golang.org' 'GOPROXY=${LOCAL_GOPROXY}' \
+          --replace-fail 'set(CACHE_DIR "''${NETDATA_RUNTIME_PREFIX}/var/cache/netdata")' 'set(CACHE_DIR "/var/cache/netdata")' \
+          --replace-fail 'set(CONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/etc/netdata")' 'set(CONFIG_DIR "/etc/netdata")' \
+          --replace-fail 'set(LIBCONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/lib/netdata/conf.d")' 'set(LIBCONFIG_DIR "${placeholder "out"}/share/netdata/conf.d")' \
+          --replace-fail 'set(LOG_DIR "''${NETDATA_RUNTIME_PREFIX}/var/log/netdata")' 'set(LOG_DIR "/var/log/netdata")' \
+          --replace-fail 'set(PLUGINS_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata/plugins.d")' 'set(PLUGINS_DIR "${placeholder "out"}/libexec/netdata/plugins.d")' \
+          --replace-fail 'set(STOCK_DATA_DIR "''${NETDATA_RUNTIME_PREFIX}/''${STOCK_DATA_DEST}")' 'set(STOCK_DATA_DIR "${placeholder "out"}/share/netdata")' \
+          --replace-fail 'set(VARLIB_DIR "''${NETDATA_RUNTIME_PREFIX}/var/lib/netdata")' 'set(VARLIB_DIR "/var/lib/netdata")' \
+          --replace-fail 'set(pkglibexecdir_POST "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata")' 'set(pkglibexecdir_POST "${placeholder "out"}/libexec/netdata")' \
+          --replace-fail 'set(localstatedir_POST "''${NETDATA_RUNTIME_PREFIX}/var")' 'set(localstatedir_POST "/var")' \
+          --replace-fail 'set(BINDIR usr/sbin)' 'set(BINDIR "bin")' \
+          --replace-fail 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "usr/share/netdata")' 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "${placeholder "out"}/share/netdata")'
+      '';
 
     cmakeFlags = [
       "-DWEB_DIR=share/netdata/web"


### PR DESCRIPTION
I am encountering build failures due to illegal network access whenever I build `netdata` in CI or on a remote builder. There is an additional step executed that I don't see in the successful local build logs. I cannot explain why the same derivation hash is successfully built locally (and for the nixpkgs cache) without any mention of the "Compressing SNMP trap profile pack" step in the log. 

Noticed this when building `withIpmi = false` override for a machine where IPMI isn't available and the plugin leaves ugly log messages, but it happens for the default settings as well.

```
[112/867] Compressing SNMP trap profile pack
FAILED: [code=1] snmp-trap-profile-pack/.compressed-stamp /build/source/build/snmp-trap-profile-pack/.compressed-stamp 
cd /build/source/src/go && /nix/store/908kvhj55s5z7laavf4pddxrxl62rrgl-cmake-4.3.4/bin/cmake -P /build/source/build/snmp-trap-profile-pack-clean.cmake && /nix/store/908kvhj55s5z7laavf4pddxrxl62rrgl-cmake-4.3.4/bin/cmake -E make_directory /build/source/build/snmp-trap-profile-pack/default && /nix/store/908kvhj55s5z7laavf4pddxrxl62rrgl-cmake-4.3.4/bin/cmake -E copy_directory /build/source/src/go/plugin/go.d/config/go.d/snmp.trap-profiles/default /build/source/build/snmp-trap-profile-pack/default && /nix/store/908kvhj55s5z7laavf4pddxrxl62rrgl-cmake-4.3.4/bin/cmake -E copy_if_different /build/source/src/go/plugin/go.d/config/go.d/snmp.trap-profiles/catalogue.json /build/source/build/snmp-trap-profile-pack/catalogue.json && /nix/store/908kvhj55s5z7laavf4pddxrxl62rrgl-cmake-4.3.4/bin/cmake -E env GOROOT=/nix/store/i77g9dmcd399rmxk8688qfr4g2wzgk37-go-1.26.7/share/go CGO_ENABLED=0 GOPROXY=https://proxy.golang.org,direct /nix/store/i77g9dmcd399rmxk8688qfr4g2wzgk37-go-1.26.7/bin/go run -buildvcs=false -ldflags "-w -s -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.Version=v2.11.0 -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.NetdataBinDir=/nix/store/7bw843y5g1sywnihmmc6dsbsgm6r4qv4-netdata-2.11.0/bin -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.PluginsDir=/nix/store/7bw843y5g1sywnihmmc6dsbsgm6r4qv4-netdata-2.11.0/libexec/netdata/plugins.d -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.UserConfigDir=/etc/netdata -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.StockConfigDir=/nix/store/7bw843y5g1sywnihmmc6dsbsgm6r4qv4-netdata-2.11.0/share/netdata/conf.d -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.CacheDir=/var/cache/netdata -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.VarLibDir=/var/lib/netdata -X github.com/netdata/netdata/go/plugins/pkg/buildinfo.LogDir=/var/log/netdata" ./cmd/snmptrapprofilegen compress-zstd --rm /build/source/build/snmp-trap-profile-pack/default /build/source/build/snmp-trap-profile-pack/catalogue.json && /nix/store/908kvhj55s5z7laavf4pddxrxl62rrgl-cmake-4.3.4/bin/cmake -E touch /build/source/build/snmp-trap-profile-pack/.compressed-stamp
go: downloading github.com/golangsnmp/gomib v0.12.0
go: downloading github.com/klauspost/compress v1.19.2
go: downloading golang.org/x/text v0.40.0
cmd/snmptrapprofilegen/main.go:34:2: github.com/klauspost/compress@v1.19.2: Get "https://proxy.golang.org/github.com/klauspost/compress/@v/v1.19.2.mod": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:58103->[::1]:53: read: connection refused
/build/go/pkg/mod/github.com/santhosh-tekuri/jsonschema/v6@v6.0.3/kind/kind.go:8:2: golang.org/x/text@v0.40.0: Get "https://proxy.golang.org/golang.org/x/text/@v/v0.40.0.mod": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:53850->[::1]:53: read: connection refused
/build/go/pkg/mod/github.com/santhosh-tekuri/jsonschema/v6@v6.0.3/output.go:9:2: golang.org/x/text@v0.40.0: Get "https://proxy.golang.org/golang.org/x/text/@v/v0.40.0.mod": dial tcp: lookup proxy.golang.org on [::1]:53: read udp [::1]:53850->[::1]:53: read: connection refused
```

There are additional occurrences of explicit `GOPROXY=` settings in the build scripts of `v2.11.0`:
```
❯ git grep GOPROXY=
CMakeLists.txt:                        GOPROXY=https://proxy.golang.org,direct
CMakeLists.txt:                GOPROXY=https://proxy.golang.org,direct
packaging/cmake/Modules/NetdataGoTools.cmake:        COMMAND "${CMAKE_COMMAND}" -E env GOROOT=${GO_ROOT} CGO_ENABLED=0 GOPROXY=https://proxy.golang.org,direct "${GO_EXECUTABLE}" build -buildvcs=false -ldflags "${GO_LDFLAGS}" -o "${CMAKE_BINARY_DIR}/${output}" "./${build_dir}"
packaging/cmake/Modules/NetdataIBMPlugin.cmake:      GOPROXY=https://proxy.golang.org,direct
```

The current `preConfigure` phase only fixes `NetdataGoTools.cmake`. The failing step is from `CMakeLists.txt` directly. I opted to only fix `CMakeLists.txt` and leave the `NetdataIBMPlugin.cmake` (for DB2) as is. This isn't available to be built in the nixpkgs derivation as far as I can tell. This makes the remote build succeed for me (including the previously failing step).

```
[127/869] Compressing SNMP trap profile pack
go: downloading github.com/golangsnmp/gomib v0.12.0
go: downloading golang.org/x/text v0.40.0
go: downloading github.com/klauspost/compress v1.19.2
// continues with other jobs, no failures produced
```

The whole phase was reformatted by `nixfmt` due to the `let ... in`. Only the `LOCAL_GOPROXY` lines changed.

Side note: SNMP trap profiles were introduced recently in [this 2.7M line PR](https://github.com/netdata/netdata/pull/22652) (mostly YAML and agent definitions, though).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
