### PR TITLE
foot: 1.27.0 -> 1.28.0

### DIFF
--- a/pkgs/by-name/fo/foot/package.nix
+++ b/pkgs/by-name/fo/foot/package.nix
@@ -27,7 +27,7 @@
 }:
 
 let
-  version = "1.27.0";
+  version = "1.28.0";
 
   # build stimuli file for PGO build and the script to generate it
   # independently of the foot's build, so we can cache the result
@@ -40,7 +40,7 @@ let
 
     src = fetchurl {
       url = "https://codeberg.org/dnkl/foot/raw/tag/${version}/scripts/generate-alt-random-writes.py";
-      hash = "sha256-d7oE3hSStET9Bz8PcmRHSZ+ga+7lrL3/oJdx7phNei8=";
+      hash = "sha256-RUCG4EK9+aXe+EKvFYv6/JzQBglGZHyaEpr63v8akW4=";
     };
 
     dontUnpack = true;
@@ -103,7 +103,7 @@ stdenv.mkDerivation {
     owner = "dnkl";
     repo = "foot";
     tag = version;
-    hash = "sha256-jbE44SpMqDhOOT2o4Wh7UCdXn6bBqxOMskCHHTzEKmU=";
+    hash = "sha256-CZlbQut5jM8/dWuLlJPDaLBykV7K5l/caB3DLQ94mG8=";
   };
 
   separateDebugInfo = true;


### PR DESCRIPTION
Changelog: https://codeberg.org/dnkl/foot/releases/tag/1.28.0
Diff: https://codeberg.org/dnkl/foot/compare/1.27.0...1.28.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
