### PR TITLE
trilium-desktop: declare as unfree because of CKEditor premium features

### DIFF
--- a/pkgs/by-name/tr/trilium-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-desktop/package.nix
@@ -43,7 +43,10 @@ let
   meta = {
     description = "Hierarchical note taking application with focus on building large personal knowledge bases";
     homepage = "https://triliumnotes.org/";
-    license = lib.licenses.agpl3Plus;
+    license = with lib.licenses; [
+      agpl3Plus # trilium code
+      unfree # ckeditor5-premium-features dependency, which is part of the prebuilt binary
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [
       eliandoran

--- a/pkgs/by-name/tr/trilium-server/package.nix
+++ b/pkgs/by-name/tr/trilium-server/package.nix
@@ -56,7 +56,10 @@ stdenv.mkDerivation {
   meta = {
     description = "Hierarchical note taking application with focus on building large personal knowledge bases";
     homepage = "https://github.com/TriliumNext/Notes";
-    license = lib.licenses.agpl3Plus;
+    license = with lib.licenses; [
+      agpl3Plus # trilium code
+      unfree # ckeditor5-premium-features dependency, which is part of the prebuilt binary
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
> [!NOTE]
> This PR deliberately diverges from the requirement that a backport requires a former accepted PR on the master. The PR on master was made obselete by #554847. See [the master PR](https://github.com/NixOS/nixpkgs/pull/553729#issuecomment-5387270366) & [this issue](https://github.com/NixOS/nixpkgs/issues/553730#issuecomment-5407147036) for more details.

Fixes #553730
Would be made obsolete by a backport of the newest Trilium version onto 26.05.

ping maintainers @FliegendeWurst @eliandoran 

## Original PR description

Since commit TriliumNext/Trilium@3b579a3, the prebuilt binary release of Trilium includes the proprietary dependency `ckeditor5-premium-features`. This makes the release as downloaded from GitHub proprietary & possibly even illegal to distribute because of the combination of built AGPL source code with a non-AGPL-compatible dependency.

Therefore this PR declares the trilium-* packages as (also) unfree to avoid future versions of the trilium-* derivation to be cached by Hydra & to inform users about this change.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs. (**see NOTE at top**)
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
