### PR TITLE
opsdroid: 0.30.0 -> 0.31.0

### DIFF
--- a/pkgs/by-name/op/opsdroid/package.nix
+++ b/pkgs/by-name/op/opsdroid/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "opsdroid";
-  version = "0.30.0";
+  version = "0.31.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "opsdroid";
     repo = "opsdroid";
     tag = "v${version}";
-    hash = "sha256-7H44wdhJD4Z6OP1sUmSGlepuvx+LlwKLq7iR8cwqR24=";
+    hash = "sha256-47KTxq2V+2JhV8I9BgKp+S2sAmZsy+hddewjNeWGwiw=";
   };
 
   build-system = with python3Packages; [ setuptools ];
@@ -21,7 +21,6 @@ python3Packages.buildPythonPackage rec {
   dependencies = with python3Packages; [
     aiohttp
     aiohttp-middlewares
-    aioredis
     aiosqlite
     appdirs
     arrow
@@ -36,14 +35,15 @@ python3Packages.buildPythonPackage rec {
     emoji
     get-video-properties
     ibm-watson
+    imagesize
     (matrix-nio.override { withVodozemac = true; })
     mattermostdriver
     motor
     multidict
     nbconvert
     nbformat
-    opsdroid-get-image-size
     parse
+    pkg-resources-backport # for pkg_resources
     puremagic
     pycron
     python-olm


### PR DESCRIPTION
changelog: https://github.com/opsdroid/opsdroid/releases/tag/v0.31.0
diff: https://github.com/opsdroid/opsdroid/compare/v0.30.0...v0.31.0

Built without `webexteamssdk` support due to it being broken right now. Should the dependencies be separated into `optional-dependencies`? Also seems to need `pip` at runtime. I'd also be fine dropping this package.

Tracking: #293201


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
