### PR TITLE
tirith: 0.3.3 -> 0.4.1

### DIFF
--- a/pkgs/by-name/ti/tirith/package.nix
+++ b/pkgs/by-name/ti/tirith/package.nix
@@ -8,19 +8,24 @@
 }:
 rustPlatform.buildRustPackage (final: {
   pname = "tirith";
-  version = "0.3.3";
+  version = "0.4.1";
   src = fetchFromGitHub {
     owner = "sheeki03";
     repo = "tirith";
     tag = "v${final.version}";
-    hash = "sha256-kU/HeCW4QNS1Ica69YZkdSgL3gsbDOJVGTyINZOnHUQ=";
+    hash = "sha256-WyLcLKQ75UVaE6WtT0CaxfDS4qY/ShO9roMxQJPp5qE=";
   };
 
-  cargoHash = "sha256-r13gquMmfJhR5N8Vu3/R+3SWUyVWyJFE6fiJbqbE5n4=";
+  cargoHash = "sha256-MYYAltyAFFt1BSkOwWpMEKw5rzQfduzDG7JcBEzKbOg=";
 
   cargoBuildFlags = [
     "-p"
     "tirith"
+  ];
+
+  # crates/tirith/tests/* needs git, a PTY, network, or a writable home
+  cargoTestFlags = [
+    "--bins"
   ];
 
   postPatch = ''
@@ -42,6 +47,22 @@ rustPlatform.buildRustPackage (final: {
     "--skip=init_zsh_output"
     # fails with: no such file or directory
     "--skip=cli::checkpoint::tests::restore_checkpoint_nonzero_on_partial_failure"
+    "--skip=cli::checkpoint::tests::run_command_preserves_multiple_argv_boundaries"
+    # nix sandbox: /bin/sh is not root-owned, no POSIX ACLs, HOME=/homeless-shelter, no ptrace
+    "--skip=cli::capsule::"
+    "--skip=cli::capsule_child::"
+    "--skip=cli::install::tests::"
+    "--skip=cli::selfupdate::tests::extract_tirith_binary"
+    "--skip=cli::selfupdate::tests::hermes_install_proof"
+    "--skip=cli::selfupdate::tests::lost_hermes_reproof"
+    "--skip=cli::setup::fs_helpers::tests::cli_runner"
+    "--skip=cli::setup::run_impl::tests::generated_tirith_bin"
+    "--skip=cli::setup::tools::tests::"
+    "--skip=cli::task_receipt_keys::"
+    "--skip=cli::fetch::tests::human_renderer_neutralizes_untrusted_terminal_controls"
+    "--skip=cli::gateway::tests::exact_launch_"
+    # tirith-threatdb-compile: needs a git checkout
+    "--skip=git_source_revision_and_tracked_cleanliness_are_enforced"
   ];
 
   nativeBuildInputs = lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [

--- a/pkgs/by-name/ti/tirith/package.nix
+++ b/pkgs/by-name/ti/tirith/package.nix
@@ -5,6 +5,7 @@
   stdenv,
   installShellFiles,
   versionCheckHook,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (final: {
   pname = "tirith";
@@ -78,6 +79,8 @@ rustPlatform.buildRustPackage (final: {
       --zsh <("$out/bin/tirith" completions zsh) \
       --fish <("$out/bin/tirith" completions fish)
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Shell security tool that guards against homograph URL attacks, pipe-to-shell exploits, and other command-line threats before they execute";


### PR DESCRIPTION
Update to 0.4.1.

Diff: https://github.com/sheeki03/tirith/compare/v0.3.3...v0.4.1
Changelog: https://github.com/sheeki03/tirith/blob/v0.4.1/CHANGELOG.md

0.4.1 is a patch on 0.4. Bash enter mode now actually blocks; earlier releases fell back to warn-only. The crate also installs `tirith-threatdb-compile` and `tirith-package-approval-authority`.

I skipped crate tests that need a real `/bin/sh` owner, POSIX ACLs, ptrace, or a git checkout, and I do not run `crates/tirith/tests/*` (needs git/PTY/network/home). `nix-build -A tirith` on x86_64-linux ran the remaining bin tests and versionCheckHook. I ran `--version`, `--help`, `check --help`, `check --offline -- 'echo hello'`, and bash completions.

Resolves #559085

Assisted-by: Grok Build (xAI Grok 4.6)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test