### PR TITLE
blueprint-compiler: 0.20.4 -> 0.22.2

### DIFF
--- a/pkgs/by-name/bl/blueprint-compiler/package.nix
+++ b/pkgs/by-name/bl/blueprint-compiler/package.nix
@@ -16,18 +16,25 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "blueprint-compiler";
-  version = "0.20.4";
+  version = "0.22.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "blueprint-compiler";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-dA+FQTRmTz6rl5ToZJ8CXY1Zd7Em7VwvF3U3Qoyvu80=";
+    hash = "sha256-DRpPUfiufwK2c2RW01IYIX6tgVyxfFl5hnv5F8+9aD4=";
   };
 
   postPatch = ''
     patchShebangs docs/collect-sections.py
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$out/${python3.sitePackages}"
+      --prefix PYTHONPATH : "${python3.pkgs.makePythonPath [ python3.pkgs.pygobject3 ]}"
+    )
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates `blueprint-compiler` 0.20.4 → 0.22.2.

Changelog: https://gitlab.gnome.org/GNOME/blueprint-compiler/-/blob/v0.22.2/NEWS.md

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
