### PR TITLE
[26.05] discord: backport various changes

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -64,10 +64,12 @@ let
 
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
-    modules_dir="$HOME/Library/Application Support/${configDirName}/${version}/modules"
+    user_data_dir="''${DISCORD_USER_DATA_DIR-$HOME/Library/Application Support}"
+    modules_dir="$user_data_dir''${user_data_dir:+/}${configDirName}/${version}/modules"
     mkdir -p "$modules_dir"
     for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-      ln -sfn "$store_modules/$m" "$modules_dir/$m"
+      rm -rf "$modules_dir/$m"
+      ln -s "$store_modules/$m" "$modules_dir/$m"
     done
     echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
       > "$modules_dir/installed.json"

--- a/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
+++ b/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
@@ -17,10 +17,13 @@ import os
 import sys
 from pathlib import Path
 
-config_home = {
-    "darwin": os.path.join(os.path.expanduser("~"), "Library", "Application Support"),
-    "linux": os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
-}.get(sys.platform, None)
+config_home = os.environ.get("DISCORD_USER_DATA_DIR")
+if config_home is None:
+    config_home = {
+        "darwin": os.path.join(os.path.expanduser("~"), "Library", "Application Support"),
+        "linux": os.environ.get("XDG_CONFIG_HOME")
+        or os.path.join(os.path.expanduser("~"), ".config"),
+    }.get(sys.platform, None)
 
 if config_home is None:
     print("[Nix] Unsupported operating system.")
@@ -28,8 +31,8 @@ if config_home is None:
 
 config_dir_name = "@configDirName@".replace(" ", "") if sys.platform == "darwin" else "@configDirName@"
 
-settings_path = Path(f"{config_home}/{config_dir_name}/settings.json")
-settings_path_temp = Path(f"{config_home}/{config_dir_name}/settings.json.tmp")
+settings_path = Path(config_home) / config_dir_name / "settings.json"
+settings_path_temp = settings_path.with_suffix(".json.tmp")
 
 if os.path.exists(settings_path):
     with settings_path.open(encoding="utf-8") as settings_file:

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -152,7 +152,8 @@ let
   # where Discord's JS moduleUpdater expects them.
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
-    modules_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/${lib.toLower binaryName}/${version}/modules"
+    user_data_dir="''${DISCORD_USER_DATA_DIR-''${XDG_CONFIG_HOME:-$HOME/.config}}"
+    modules_dir="$user_data_dir''${user_data_dir:+/}${lib.toLower binaryName}/${version}/modules"
     rm -rf "$modules_dir"
     mkdir -p "$modules_dir"
     for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -305,7 +305,8 @@ stdenv.mkDerivation (finalAttrs: {
     exec = binaryName;
     icon = pname;
     inherit desktopName;
-    genericName = meta.description;
+    comment = meta.description;
+    genericName = "Instant Messenger";
     categories = [
       "Network"
       "InstantMessaging"

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,627 +1,622 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-S1GwB+65+Y3uEr6h54IB8d2CWwCcMevfXZGTyspMZ2w=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/full.distro"
+      "hash": "sha256-9YJW4dp8VUDItpIQ/D/24aoTv9BBzewHskbO423DI4I=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-If+B4uqvOvS7NTnnstequpolrxIcM9MZhAsDCkFMhgM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_cloudsync/1/full.distro",
+        "hash": "sha256-q9PUaa4kUTuNzoICdKa+CLY1A0E2X6+GJWeN9wZzx4E=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-N7To9vgdOc20omNyOEWnOexsE83nO5imp9/coliuJZY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_desktop_core/1/full.distro",
+        "hash": "sha256-PfyNWcY8pXFV0imNwMMDX9cy8nJbib/4CxoLxcrnKHo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-BQ3bPkjNGS8v171JMayHdRyqbB2PX0Xxdrukz3MpJJU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_dispatch/1/full.distro",
+        "hash": "sha256-dIX2q5JyyeIfZw8hu8H7mu+GfSnDym09ePIVRN89YbM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-E/rjqsFNFLWLZxHqAzVHvRmoI1pSWt7my4C+2mNUuJE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_erlpack/1/full.distro",
+        "hash": "sha256-kInDtc5xfygCjVXcMgXhuJjA8etUBAH8YBAp9Ap2JnY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-oUlod+YECmdqy4c+sWPZt1yYvGZwYimoIVRPA5v6r+8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_game_utils/1/full.distro",
+        "hash": "sha256-0jbPTDyXQoXffwH+1+J1s6zbgvUljVL+mPWGtGVuTBk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-xDEDlwIInDVSRISoWb07KQvVOqdNxzjWM/s5R/1Ra44=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_krisp/1/full.distro",
+        "hash": "sha256-2TInlgg96P6elUWnLyd9hOU8i/gdKqXpze1K7ioPA2Y=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-Gh0JBMfaX63sUIGQ+OKqrSzDuADhjKJB3ger9ONkz9k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_modules/1/full.distro",
+        "hash": "sha256-XC+1tSCpM9ZuJMQloVcuslH7grRog6ojrkOSpgDcQuA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-texX0BTDW0Pef2gMmkOFjxikKIBYIKSTT+Rsk8Zdn5A=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_rpc/1/full.distro",
+        "hash": "sha256-HiOy+5mxBRMa+McDqIACF2e5ImYd8Ovqr4d9XTAeUR8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-NrhpLEVLW3SqoGGiFcNbcM4sQQzW+6mkUaI50Ry66dY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_spellcheck/1/full.distro",
+        "hash": "sha256-ORY9xLnjdcCrZaHQMnyzJdJmQUYy+3bk+xsQSYyrGYE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-uXPBkrdnXQnYs3+oTn2gds+au+ZDMYNvOBXTjjhcFsQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_utils/1/full.distro",
+        "hash": "sha256-SOt8SpaC+tfE0fhXjqdWQ2y6UcPV/ynuGki8UizwK1w=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-UeXNXR+BHljnW5Xb/E9CrJhBv5hchPS6R1P0dvKoZGQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_voice/1/full.distro",
+        "hash": "sha256-sDutxfcbq5aGI5G63Ta4jbj5ny5yNYBUJx8pklnvkYw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-llG+0+Z0boy5ZhtPGiCDUr4sVa4mdR6FjT71ZSX5ez4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_zstd/1/full.distro",
+        "hash": "sha256-bwOySuEuD59oKIy/clAiqc3Kt4jclQej7kU/vB7gGDc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1177"
+    "version": "1.0.1317"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-Je/HUlN3aWGXRKj7yFv4S5YtlrCyEZNJ+GPJlG3GA/U=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/full.distro"
+      "hash": "sha256-1HZQdXs1DlEjwK1L4m1c/LxWhDC0MvDg61usSVpOebI=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-tZVDeeocUb4lcx8fBGLvzW7cdws4vB0Tsu6LzwS7Jyc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_cloudsync/1/full.distro",
+        "hash": "sha256-hdBSBtBAlA+U62YMM5H0kOeGiGklXrvRJQ3mGAc4+UA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-qVhVFbRuUYMWoONhmc1aQFRYtCOBh59xiMUIBsIInng=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_desktop_core/1/full.distro",
+        "hash": "sha256-ZPLsRV8WY2pwuzwx8UOVrYowMxgPLx4twwA1efgvz8c=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-hGGTK6xHBTyMHXTs4uRcms9hA8zpv2h13xuZW/K6FHk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_dispatch/1/full.distro",
+        "hash": "sha256-Bu/0l7/tHr4MN9oHuRPPJ68v4Q12FxCscDbQUdshmJ8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-2i4dMQQQV0EO2rafVG7no1bMVOb++qkwga5I4hNiJ1c=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_erlpack/1/full.distro",
+        "hash": "sha256-OcwmhtXtvzBDTXmZqJzv4Borscxk56nqQMzMI4zhYIk=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-l5STKk1FYHIWLpq/dVwsY5Q8ce89EiSYZyKE5drzpTQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_game_utils/1/full.distro",
+        "hash": "sha256-FYbvqD1hqDARMz9WBPoDpfP9k66hzT0Yk1O5wEdTi1A=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-93GXORqBh2IDZz7gwC1lLP/dHwfXK1wqfOdDl7nmy6w=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_krisp/1/full.distro",
+        "hash": "sha256-4ENv3/G1h2dhzWvQwbxRHLVn4U8GqXkVqI+Vs5S39Jc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-sMsii7pOnusjkmj9gzhRbyLGzAusYhizzZ0Unry+oYQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_modules/1/full.distro",
+        "hash": "sha256-r2j3yDQzsQMVn7mjICuPiMVgznAVwgvCip8P75piUb4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-M6FtXDTGWsqafyQPsVIPJ3F0zUiJZxejuAGJg5MxF+E=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_rpc/1/full.distro",
+        "hash": "sha256-cgGk6IvD2cLTugbKtS+23WxLckGPiFIwHa9X6hiwmEU=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-pkJLh3aZ99E5wuBF08uEU4fP9QqDn9Xrwtbk4i0Q/Rw=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_spellcheck/1/full.distro",
+        "hash": "sha256-7WL+UYrZaw1uDZXRqsGgjaPdcLOKb85SkDAF4xeyQkQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-f01INbXJ1l/L5VuskTnz32YF9NH2R9/Apla2iYoEF5M=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_utils/1/full.distro",
+        "hash": "sha256-Djt6iqhFbNBRUecbaHOKkNYTprwA4DOei30l6B4f1Vs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-YDij0YVearAetTN/1j14eBle+7LKcYGdE1TDIbWH27Y=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_voice/1/full.distro",
+        "hash": "sha256-R0X6K5EsSr2/whZZda2NDY2+gX9jpEfOddJWIz3xW0c=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-PC5yxqN/ky/ThGRMCCKBSZBqVUJjAV+sl41LlPCvHc0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_zstd/1/full.distro",
+        "hash": "sha256-MKXHjhRm/Nxxt8eAIx2axXUzAqm9hgPadFNe60HE9HE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.992"
+    "version": "1.0.997"
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-hZi+7k6+KoroSosJ5jOmhfKCrXqK5mzMlChvd+O57lE=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/full.distro"
+      "hash": "sha256-S1Nyb7mkVX7BZ1QuCFy9mMENY5PYOD5ZoPYExiExWMo=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-g63Wz47H63bOiyLJ2V4/4z6ZpCVZFWkdJUEaYtTzv5U=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_cloudsync/1/full.distro",
+        "hash": "sha256-J+c8FEtoACGGCD38fA+IWJw9cKLEuz8xwAASOa/4AMs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-78r6lth+V0OPEEJQ53FZhDGAS8RJ2/gGXqROi508Rzk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_desktop_core/1/full.distro",
+        "hash": "sha256-7nguOkkH1uLyVX6F70wLAZZzo0IMetyc5MS+GxqWdfI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Q+1rU46jP3/GuJ3yjvVk4xC0xHuY866JCPVsiqE2/Dk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_dispatch/1/full.distro",
+        "hash": "sha256-rWvu1QPaBLRWPs/VTFzGWVigKDapRs/Tx2i60ieYb3Q=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-Zxv+pZIiX/dgWLtQu+ouJIiaDECBGgcbxzVst/x5QtI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_erlpack/1/full.distro",
+        "hash": "sha256-Eih3jAe4+q6xzKPHZtdg1nB/ugeHdqR26pvIaSYL0xM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-HxQldTPK3dGuJyRKw6q23iyR4rO9UkASHa/F7zzHbX0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_game_utils/1/full.distro",
+        "hash": "sha256-Je5KFZ5pAU3SOPAbQJHpD2eE/Qzj7g+a7SXlvwfvQSI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-ptVbz0AcEttoldc7WV/nD1lYptJTnIy8p6QUD5pbkYg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_krisp/1/full.distro",
+        "hash": "sha256-DVESIQCdKIBlrpFw7PtO154JFgyhWQkUlxDiIooUY4E=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-ex9Jud2OTjcWZbcx+D39uyIrh6K5OJANCMc+zfx0Sv8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_modules/1/full.distro",
+        "hash": "sha256-sGv+1aWjwFXC0FN/ZvyWloqRZ1+x0EhdR76UcZqSosI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-TZqW1pxrqVIszGLBcoKErZUoNGNeepRHNqaOXoG9rHs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_rpc/1/full.distro",
+        "hash": "sha256-0TJv3qj7j6wWyQE7ux8Bx3tJ87P4fj6W6ike+1cT09w=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-a20ZUdyDnnG31DnJP1+ADZxQbk3B1YKPrNPcb13S//4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_spellcheck/1/full.distro",
+        "hash": "sha256-JcNMteYTvz7jf0IXCQPi2e8yifIcSgiYviQ1UlPmin8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-W7m6Ql9L5GwRQnx9TUjbRZ8c0HGFfFriMoF6HC/RfZg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_utils/1/full.distro",
+        "hash": "sha256-+WMYNrb0H0rR6decBoUloWDUvkq4TeRYsyRbMbKdh38=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-S9z/eS5P4sn5yuPdHP9HrmreEIU5vE44Np6QtHVdZm0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_voice/1/full.distro",
+        "hash": "sha256-AFQ49Kk3WPB0sz/ZwhNXhZleU5CFTwQvXaSrnx1NzSo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-rhoLsPy3zW5+bQuGYGxMtgDHaICrSKapTQD4Zcw3GHo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_zstd/1/full.distro",
+        "hash": "sha256-mBnF4mFTBQjKAAGoQyoJds9wjVfJXnuwFflIc8f8eiI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.193"
+    "version": "1.0.196"
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-XqiD6DtJgFPmh4cSBgbvz52uBnJ7FUZ+VMcB9KxBzeE=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/full.distro"
+      "hash": "sha256-EHDShPB/ytnwKaVtMSZ8Z475TFxDVX5eZlH9+8a5yEQ=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-NHT/o5cb0VQZQ4CaItCHTOkfXEjYqPlIA3gSSLvCgJk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_cloudsync/1/full.distro",
+        "hash": "sha256-0kZ5XGJl4k0zQDJd3dW9bhzYn7n0R/3zZ++6Ls81UWA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-THCGUwshMlNWCHgTf0d/W2SlBDEUcZ5dg255O4DwQHQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_desktop_core/1/full.distro",
+        "hash": "sha256-cjWUlqhyk4/YQ0ST35ujWQ4FgzWV2ufynvUgJFXD7OM=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-C1742juma1bCGVWMCT903BFHNedc6V+iws8kKTQBE4M=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_dispatch/1/full.distro",
+        "hash": "sha256-YeInPLTYIm2Yts2w+YQm3LKyU8YDVoPVqa3mu8BAGnE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-IrLq1n96rm1YE1UA/P2b9VHzX09Wa4DT9yj5wHhytno=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_erlpack/1/full.distro",
+        "hash": "sha256-7bCspbkjmFJ4hznqjoIyEFSpFk+sIc6Tzc6nrWSQOfw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-Y3shNsfjcBvSvUt+D56qIMaa73lpF/+c/jURWd9hV/g=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_game_utils/1/full.distro",
+        "hash": "sha256-4QZ6F90heQGk3uER85X/JXAKKIirwWFT9zG5tkW7qEY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-b+n1X67Iscs1Cjq7KbpXBqqIC35tWqaQh/hPEbq0vuc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_krisp/1/full.distro",
+        "hash": "sha256-bkhdL8hiREog48HmxZVdhHNbI/ruErb7Liu0NbuI0eQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-U3f+1y1WlGZuP5OlJ4AeakhNYXlx5xbKqHjiCFfGg0E=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_modules/1/full.distro",
+        "hash": "sha256-JQaSnEx7vDbrlwYatKApt2N1C6WzUZhOO+ScjsdtSAI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-rtBhw5MHG/MCAVG2YvzKOEVmN8f02DPI5LBKg8Qj9ZA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_rpc/1/full.distro",
+        "hash": "sha256-MVq1mbdRkXrz7Zwi1tPgdnlCpnkq9NF5R7F26Wr4NHg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-BFTkMV1n9ann2c+GMiuIHZexGO8C/yOi8sbBWrqErKE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_spellcheck/1/full.distro",
+        "hash": "sha256-mWb79Esw9/ddMVNMUrmRX45N+EMW8Kz+ugbGkQelDlA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-isXprPxivFIdD1Cvb7tbhdWSNPbU3Rrv2muYg6tXW0M=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_utils/1/full.distro",
+        "hash": "sha256-TtDw051M2y29TvLdXbcq8Wy75KsvYy+Bt9dDHkY7ExM=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-v60GjLJ3LuAppMRSjZQNWSLEamswDcTm/AjtwG04fgM=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_voice/1/full.distro",
+        "hash": "sha256-8x/uLNdrpIsPM9L3uPdGu3r3o1M0O12918dTKdfPh5s=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-Db8KbISU5W8G0qfqGaumrOZU75B6IWBzf3JFIyUzadU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_zstd/1/full.distro",
+        "hash": "sha256-5iGxBV1thj4WM/eRcv9ous31/tRgr4OVc3xgbneC4Nw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.141"
+    "version": "1.0.143"
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-cKGa089UswaZzoAHzkStkROitXDNUMmGENQzUkrmTlY=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/full.distro"
+      "hash": "sha256-BQuscZlHaaozENpmeQiHAEi8H6ReyUT7L3nmzXB95gU=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-9QGggOph9Xs4Q/LjnZ3KFwhXxgNRyli9fNoFz6H3jqM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_cloudsync/1/full.distro",
+        "hash": "sha256-o6UxvrqBRzEr7V588VnoYzkJ2InPX/rgn46c6hDVPGI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-UNTm7ItVQkEIEb6htmc13DxEJdqli0uL69OR9ADVAEk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_desktop_core/1/full.distro",
+        "hash": "sha256-tRF0Y7LvzvARLjmRdnFQgjQBICknzPyxb/4YAyxJXyo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-TihLreO5lbuQGAxljjAaPZVr+KGmmveqTd6tUYvKV1I=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_dispatch/1/full.distro",
+        "hash": "sha256-SQK+Z6gtAu35Idx854zxQrwAV5FvYUYECkp3a6saG1Y=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-oaUEWbrxizY/kP1IPHhumErlTKQVQMRyt5P/7dJU9DI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_erlpack/1/full.distro",
+        "hash": "sha256-ifjvoD8qhtciEcMc+bSC/y77bCwKqmwqUWTTwPNJF8k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-KCA77WXi9MFBfH04DLpiJCcUnX6V03UbiN2ZhvR951k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_game_utils/1/full.distro",
+        "hash": "sha256-h8fnthereq6ocgaxRQCXrCAod1VzWu9FSkCZOAQudeU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-LDzacYKK1/6blKRI+9fLMz83GT7QpAkw7R9pFzpO2Rg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_intents/1/full.distro",
+        "hash": "sha256-ZDOy4W3jm3kRwV8IynOR4AUKoKq86Jf5GZUnUHz7ohk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-Xmcukut0dljr87fHH3hLuuum1aKaEbyz6/Doy+5aOOc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_krisp/1/full.distro",
+        "hash": "sha256-/v2bmmi6+jmIhtwaJFY8ZxUH9u/glnlxGtTvmre2mS0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-EAPj4leGDWMV/80fZUJjgsJDea5e+GAEhl8fyU7i/7o=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_modules/1/full.distro",
+        "hash": "sha256-4NR0Y87njkeavPvBNRHREqT2DNeRZyw9ic2hMFfyuRg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-N5ZsYM7Y/XcMG6nOc3xVd4zg16MlozmZXK1xO3ARW/8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_notifications/1/full.distro",
+        "hash": "sha256-0znPK/iGXuNJRNzyA7atiSDs6jSQi2Yak+PS3cmgM/U=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-NvwdAvR6fZd/Hlcw3Kb5sINche3ZdiTwQO0P0nY3jVQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_rpc/1/full.distro",
+        "hash": "sha256-TUICpdWb+aHJbD1OwDbSkrWmkkgI4tEyaApwax9ZlJg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-4V0Ij/kniCO46cmy8pYOc7Hu2VFRuSYx1EmTV+wZDsQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_spellcheck/1/full.distro",
+        "hash": "sha256-Q8QJAVjPgEzFh9kR+9g9LeY73QDXSqLZBXIrn4O+aPk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-zPVB5RaxPLSyakY8ZqyyVNWuZEJog78KOROHbupxTSs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_utils/8/full.distro",
-        "version": 8
+        "hash": "sha256-3t5uyx7jPOnMWtt4a70HOQs01U8mqUVyc5k2SJ1ZANA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_utils/5/full.distro",
+        "version": 5
       },
       "discord_voice": {
-        "hash": "sha256-1CSPUCxqeLQxSHZWlSeAYIj9XqCXWD2gxcR4F9kd+54=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_voice/6/full.distro",
-        "version": 6
+        "hash": "sha256-S5YJPauGurgYnjE568uZ0SGgNTIHkttcQr3D0W5RJxc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_voice/3/full.distro",
+        "version": 3
       },
       "discord_webauthn": {
-        "hash": "sha256-ZMo19cg7Q0uXdDATAHkYWzDrU44jXicHeqpsIiA0iEs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_webauthn/1/full.distro",
+        "hash": "sha256-GClieyAeMa6N0ulE5IdsOfnTEPm0X5Xms5KG2U7nZP8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-NyK4eH6joep5BzM91AZLRU3jXC2sXdSp3/s4w/Xqkn0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_zstd/1/full.distro",
+        "hash": "sha256-Xj4P5YsJKQcyfVxhGFOTpmcxycExj8qxAhP7ptB3D4M=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1132"
+    "version": "0.0.1165"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-9rlxgLp8PxtuFSjK+nDshIiDigjsBjox2bUI7cp1XXs=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/full.distro"
+      "hash": "sha256-NDTB54CLKI6Ib9bZecjLxulbMHE1+5baW8MZkFR+fR4=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-6DAvT/Rocsu6tYMMt4VJMmfhYxLw1Hl0EgJK6hmw6j0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_cloudsync/1/full.distro",
+        "hash": "sha256-JMuSMLvHf0yGAShv0UqKxgf0vbe+RU8pDVG0QdRpCd0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-xA53RC1WAcsmyKl5c2f2CGhFzficibB/h7psEsr3IRs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_desktop_core/1/full.distro",
+        "hash": "sha256-l0n/Q/0DTAaqVery5ZezKK/TWcNW5FvroytdzInBpqY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-ebWRxbIIsrf72bj1NoxamL2cxZNrmvkRxfB/jXS6HmI=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_dispatch/1/full.distro",
+        "hash": "sha256-Jp1Q+8GtvH5uM06NDRFhRjQXwFjNnlXpX0K4ziYdsKQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-GLaAXTePgAWeRwVskt+tBtrVTn3miadBWImPMibG/+Y=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_erlpack/1/full.distro",
+        "hash": "sha256-0SR35QaALv/01OxXK1hV6V6hY8INOgOm0CRgEQrk9+U=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-A2+GyRC/RXTMnDagsT6zP1S5T+PCyMK55eiEF2JMV84=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_game_utils/1/full.distro",
+        "hash": "sha256-nwiDtajSk3TzzCubr6Xqqf4mKQaNk0T9HfLhtHq78Ws=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-sjylilIyOziJgH4gl+1Y6oIB1drMF7EWrt2mVMliCoU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_intents/1/full.distro",
+        "hash": "sha256-NoqCBRCFQ9TwvrLLYLRtdsr1nnEJTDS0q6rsWhnOL/s=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-w4ZRMT30/KzMrXv0wxUd0U9yv95jOVhSG/6zzbrBaG8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_ml": {
-        "hash": "sha256-TVyM430eeKoq9RNXoLmd1xe2t3xqgxmbQd5G5+chcnI=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_ml/1/full.distro",
+        "hash": "sha256-ARHk9F3I+B6G3wFxWhWeIekAfARjyw0WJr/muxkNEQM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-TKsAh8tNHzQELizvKfMcfLvm0h4F69iON2VBIWq3qxY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_modules/1/full.distro",
+        "hash": "sha256-8dWTYBh8nzJOFGCTWyLLZhMOF9Q/fc5YoHAL8S5h0tU=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-O1+hqRWztrhlYvyHv/oYTO82Ru5VRwPxo7FyAQSbgkI=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_notifications/1/full.distro",
+        "hash": "sha256-QuzxdrGVmdXS9N/25iXGYqoJVXxOmw4ku2Avg8XNR2g=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-zcx4PDynhCApRWJyI1KA8t4IS0flDxtc9NGiT3mqaKY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_rpc/1/full.distro",
+        "hash": "sha256-zA8o1tDIKL2gmXOPF6VKgT3g0uclgXL58pmW1Vc88Og=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-A0gObDSLQWb3Fp+f/xQC8ij2mGBdzeHMuC+A5+XpZdo=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_spellcheck/1/full.distro",
+        "hash": "sha256-/ys5eUpR2YqphdAQkw7cuuGgAnn7k2ChBNeV/RQTFbQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-SvipA8cXIeeFkBC9RdcNHielVmpwlilGB0mmHFXNUx0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_utils/1/full.distro",
+        "hash": "sha256-mDpF72Uu7/SGyqN6XKlNzo0vgCsPatAq7iX3bK5vSeY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-BQhaZXj8jVuNtVvGN5nmSfkv2OpETTu+VRt/AZzkSms=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_voice/1/full.distro",
+        "hash": "sha256-P0+ef7UvYffv1Zar0dy5AnbINAEWAgcyMdIdZdNJrbk=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-XRs6HhQ5XOhQZ2CjhzNW8jMFORby80eWUU5FHBN0Ui8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_webauthn/1/full.distro",
+        "hash": "sha256-i+NSW+yDWZZhK2Yan2JP2zC6N4OBvF4YBjwajwEUfBw=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-9cRSkG1gVP6+casDOnJ1gSknXh1kumIeUQd+EcLtNZM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_zstd/1/full.distro",
+        "hash": "sha256-mzf/Nu6tHl4g+pHWY3sZHDAQrR9IraIZtASQAsIJ9/c=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.993"
+    "version": "1.0.999"
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-yxbYcpaoUkUlHIC2wf3yVYlxM1KBcCA6vnXqeUctRhQ=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/full.distro"
+      "hash": "sha256-gjtVP0dhhU0d/B1ix61JfyMtqoGAGP1aUxS3Vqx7x5k=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-RDTWKgPcehCjcR1J+jmj+ICZz65ozCMS1zPxroTcxE0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_cloudsync/1/full.distro",
+        "hash": "sha256-BfU2fW6ok1OkCVtA2Y1LYIeJMelFFsRv/MzZZtZqoZ8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-w3yILQKWaqX6rXFmDhpakUlw5xFW6LI7Z3CL1lPddsI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_desktop_core/1/full.distro",
+        "hash": "sha256-rI9DtxV6/SvHx29slu9y/tFfsHJ5Xryw5I4iUDZkJ6s=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-RnOLwaCiWS04PFD/d3XLL6erxtDYYrNJ0D6YCcE0uMk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_dispatch/1/full.distro",
+        "hash": "sha256-+UTH+tfh7rxyrgiVXrxBXBnNsneaOmbxE4pC41xLsdU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-IgeoTXiFWw4BcljPwl7fqAL+Av6bRLFT80tfG5v2Muw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_erlpack/1/full.distro",
+        "hash": "sha256-Zbwj8Ajq6Sw+ABzRPDaCAXxRfBoDTd9iLKwawHIeCnM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-dOSI1OTNkfxfWisrl9DTA8WRU/PjS05c0ZDzNBbBpRg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_game_utils/1/full.distro",
+        "hash": "sha256-e7/nOrzcQO7rn2no3zScTklYDcp5+BsCuSex93pWaLo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-EFeUxVEPex20Mrfd04dHYCpfKZM4zIZqOEyREixPcqI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_intents/1/full.distro",
+        "hash": "sha256-MJWw3vfD8mNea/of5KBl2+L/KZkaVI7ong4f2mo7hdM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-XkzYfeQ32JpdzmIOnYBi9bsSSJFCzbSDFNHAPFcAwGc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_krisp/1/full.distro",
+        "hash": "sha256-EM2P2MCBGaEVfu7drkiz5aA7nLeoA4O9l1x6XwNUSzQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-v7Hdk7WO2wCRbJD6SOHfUKAFX8ZVYfe5qhNHnTZvsZk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_modules/1/full.distro",
+        "hash": "sha256-PLlZFGnwf7Yk5ve2tHLWseIv6ycPzbA5MGE7uOhhqWc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-T+4YM57ZbYZSSCPsAgfqcdVl3Ifuf5q/j3p9YUGHfwM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_notifications/1/full.distro",
+        "hash": "sha256-QhjNyzXzhpIfHaZBHsL7CHh7WVgfHlGyPFagjIMM9rs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-hPPQ5+jHeJSMG3SythZrndhU2F5sl6am3K1lVtDrE40=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_rpc/1/full.distro",
+        "hash": "sha256-tnLRRUm2Q4zRwdxtfW06Ugad6uczwVYyN10bMis4IyE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-yIHkUjjWaPTwvlVaKlucpZUimVWbGd3dDOKOoWcJJAc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_spellcheck/1/full.distro",
+        "hash": "sha256-FQE/W9tKg32IQ1MAiJ/5LoWRvSrt22m2s8+tF4Ye4EI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-DgAQns2Ky1nBABIhTuSfjvLLOry0/sDx6TRUfVqy8PA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_utils/1/full.distro",
+        "hash": "sha256-ECv8ciVQjoxycMF4Gnq37vRmIfoKA8mOM+dmSglfKn4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-esidGrZQjLpOix2HWYYEPwCoU/QcU6AGM7XZPMvSzsA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_voice/1/full.distro",
+        "hash": "sha256-IS42+iy6WVyNwb4LBDVKMs2AOcOqzn4GYzts7qYU6XA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-Iwl0cgBmJdAFUSyq+l6wuIAS633yxwBl0lxUktmKa5Y=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_webauthn/1/full.distro",
+        "hash": "sha256-Q9tSvZxrlKObIA7WgQdNpEkeSSwFG6Fp2zWb1LObdn0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-GTWMUSTNYa4ZdmSBy0a3+PejYRITwTLrj5MOZsCVW4U=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_zstd/1/full.distro",
+        "hash": "sha256-eQzO+gJC68UI4mf1Pl/reiL4D1QLKHcEVRJ7uyPgajo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.237"
+    "version": "0.0.240"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-y8Dr+me5JFnw5/kMcnce1YCjiAN1mqOw77NHykAYQKY=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/full.distro"
+      "hash": "sha256-s8nqZR2Lir7V0uVMA5vOLr2hz1g9Jh3orTHkLEpW7rM=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-+MaEpY7bCNqJNOk2VcHDBM1ZEEctvkjDJIoO0dCTa/0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_cloudsync/1/full.distro",
+        "hash": "sha256-XHm1w6ruwHeYa3QGzcZyD8j/2zBV2D2nu9ojio/hjoI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-n0i+FEtNF6ZOrZNBzSex5pMUtnR9j6kllCsVk7yYN70=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_desktop_core/1/full.distro",
+        "hash": "sha256-Dm0rh22QooDw76IIR1TaJEC+UMtROJONIn6cTVf0L78=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Qo1cGTH5wQe4Cpzfld5Z/D/C+BKzjAw/d2nk/EUgj3c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_dispatch/1/full.distro",
+        "hash": "sha256-BeZdWCWaKu8sHRlpd3arZEcZSzkoGdYHSub84EOAcvc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-jC+2AXMlD0d2+Bcme1lHsAXYn1Dj+vvxjvWK41SvODg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_erlpack/1/full.distro",
+        "hash": "sha256-3GjnZf8WMh5XKLrkFi8o1Cf8j6niiRjMGjEgKQSXE5U=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-HoEsai4W/z6W3sLCGoP6v1BWmuZQvmzOXLLCIUkXNqk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_game_utils/1/full.distro",
+        "hash": "sha256-Gx3AFmew9NtY6jPCjyZAugIBA3R59q1BJpW7JcmcJvg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-Tk3D3Ail8Bu9+mYbASLJDsSAltD/f/g7q1/vUlIIutc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_intents/1/full.distro",
+        "hash": "sha256-nNU4xwPopCOcuqnxwfCq1O+j06YJLbouj5V9pk2Wi8U=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-6Vt93M5bwstZEn7mb33w2IlgpvstGa6kGTV+Tza92B4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_krisp/1/full.distro",
+        "hash": "sha256-BQ5+Gcp9UdKy/rSSYes8nQPu3HL4XbsQTSTcOB6WDMk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-Hl+q4s2zYWa57RwpyZ4p9oEfkUl1ekq6xrKitS4BPN0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_modules/1/full.distro",
+        "hash": "sha256-ZMpIo3KFDhRhzvYisgh9rPZz8BiZT2RhvkiRhBHKOTk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-rnHE+V90VsR9DWDZ9jN2+pRrQu96clqNq9sFoMpiNZg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_notifications/1/full.distro",
+        "hash": "sha256-2gWZFlKvGvD6hESlbwP1SCENIQ6s5V7hTt3HobhRofE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-azkCFwPM51sqHjbgsRCOyoPlBMwf+wVt2qrlTl1v+1c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_rpc/1/full.distro",
+        "hash": "sha256-pDQ7FUB3xmPBa9lshlctUB/NmhpeuXOeuo0LJ8yruE4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-x7qjYGYC4LDbk3wDxDOjqo/cBoyRJQlzsXpoyJyzFnU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_spellcheck/1/full.distro",
+        "hash": "sha256-u+bno6GbefJDhJFMA05cFUIBGMrF9R8+W8piO6G9q1s=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-sdvSFA7GZS6dUXiemSJpsn92UhaRlNCH9N8UkgQRV/Y=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_utils/1/full.distro",
+        "hash": "sha256-lISFU3glD1xjUOA6tOtQl6hk99vTGZIPnuaMUv/V+4k=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-2/oH5L7MIIsKLavU4J0O8/hqzFx9BpY9LSuSJKaSwDo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_voice/1/full.distro",
+        "hash": "sha256-Do5yMMz6xoXWExRYwcNw3NHmFIIV3NqQBIU4BJh0FVc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-z0sbteCmrXjvWathL+c1oXL63UV9fhGYtTEOXnBqa4o=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_webauthn/1/full.distro",
+        "hash": "sha256-TRQGedxqhCu9Ge0CcsT+M2Y4ZEdhPdGk5V8IAL3jQOQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-mCzmStANoOc4b/UPZmkndzhnxZ1H6Q+rnNsroObPnCg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_zstd/1/full.distro",
+        "hash": "sha256-INQGfOUMoGQ7Udb95t3AXYbJxihoaChVs1suvs9WLIY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.393"
+    "version": "0.0.395"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,622 +1,622 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-9YJW4dp8VUDItpIQ/D/24aoTv9BBzewHskbO423DI4I=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/full.distro"
+      "hash": "sha256-ni3qAnuZkAGpIed7HwBxWheutuq31L0fA/j33Htoe1M=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-q9PUaa4kUTuNzoICdKa+CLY1A0E2X6+GJWeN9wZzx4E=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_cloudsync/1/full.distro",
+        "hash": "sha256-eRrm0Wt1amf95Kl//x3r24vllKrYPIxd25jfNpENz3U=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-PfyNWcY8pXFV0imNwMMDX9cy8nJbib/4CxoLxcrnKHo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_desktop_core/1/full.distro",
+        "hash": "sha256-uFcI9sPYwav/+tgj7YvJy9oaxPOrtfmrAm4g/YM1zoI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-dIX2q5JyyeIfZw8hu8H7mu+GfSnDym09ePIVRN89YbM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_dispatch/1/full.distro",
+        "hash": "sha256-TrQYkG0tslUVVeu7KNBgeMZp5MZG0b7pzn/ZiWdrl1o=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-kInDtc5xfygCjVXcMgXhuJjA8etUBAH8YBAp9Ap2JnY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_erlpack/1/full.distro",
+        "hash": "sha256-7hpiYvaq91vIEft7k5x1uGOzEvQoZiyzq+QsO1+Zaao=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-0jbPTDyXQoXffwH+1+J1s6zbgvUljVL+mPWGtGVuTBk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_game_utils/1/full.distro",
+        "hash": "sha256-2nOjP4q+vhUbslPx/SEw3ALeEmkbuAkO9WZLJsvtALc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-2TInlgg96P6elUWnLyd9hOU8i/gdKqXpze1K7ioPA2Y=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_krisp/1/full.distro",
+        "hash": "sha256-SdrQxeuUr27dr7BeQXB36LBZ0e83vGPb3ByO1de95wE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-XC+1tSCpM9ZuJMQloVcuslH7grRog6ojrkOSpgDcQuA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_modules/1/full.distro",
+        "hash": "sha256-qXkXb4e44ob0zrpItysGhlYhczSCQ0zfWFopQulcsmg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-HiOy+5mxBRMa+McDqIACF2e5ImYd8Ovqr4d9XTAeUR8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_rpc/1/full.distro",
+        "hash": "sha256-vX7rk31R/QVpa33eSsqAEAUeIBkCy8vx76MB5W3TkGQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-ORY9xLnjdcCrZaHQMnyzJdJmQUYy+3bk+xsQSYyrGYE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_spellcheck/1/full.distro",
+        "hash": "sha256-399bwv2grdhPXjh4raNGXMLg8LZmiOC92pJB1XZ86Kk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-SOt8SpaC+tfE0fhXjqdWQ2y6UcPV/ynuGki8UizwK1w=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_utils/1/full.distro",
+        "hash": "sha256-Xz0DNvZc+HwGsovz9bWQXhx0UolJhRTbmJfj6WGmQ9E=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-sDutxfcbq5aGI5G63Ta4jbj5ny5yNYBUJx8pklnvkYw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_voice/1/full.distro",
+        "hash": "sha256-pSxb6hIWfX/3c9U8gZ9IVZ5r2ck9QONkkK3BIy584eY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-bwOySuEuD59oKIy/clAiqc3Kt4jclQej7kU/vB7gGDc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1317/discord_zstd/1/full.distro",
+        "hash": "sha256-naSJ+jJqIS3cRs3im3Z1d+wptYvSfloSvtkWjd8hx3A=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1317"
+    "version": "1.0.1361"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-1HZQdXs1DlEjwK1L4m1c/LxWhDC0MvDg61usSVpOebI=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/full.distro"
+      "hash": "sha256-nuuKzByzGh8I2VoVUSAOiiwULYpXWKBBScyBvr31Wlk=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-hdBSBtBAlA+U62YMM5H0kOeGiGklXrvRJQ3mGAc4+UA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_cloudsync/1/full.distro",
+        "hash": "sha256-kYe2Ytbr2NhSA+K7ZtbTuSYHXb7rYt1KC0coKkEs5l0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-ZPLsRV8WY2pwuzwx8UOVrYowMxgPLx4twwA1efgvz8c=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_desktop_core/1/full.distro",
+        "hash": "sha256-9vJj0Kj5PDWuGAjv/uF4kBB2oxQux7R56QrfVnw5Oi0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Bu/0l7/tHr4MN9oHuRPPJ68v4Q12FxCscDbQUdshmJ8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_dispatch/1/full.distro",
+        "hash": "sha256-0RyujN2tWt4NteAq8nqL4rh1ym/uVlUOW44sveWnoyo=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-OcwmhtXtvzBDTXmZqJzv4Borscxk56nqQMzMI4zhYIk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_erlpack/1/full.distro",
+        "hash": "sha256-ks/bDNwSRghbyXY3/YgU+KP6qXCf+BMwc1KwT9d+Ma4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-FYbvqD1hqDARMz9WBPoDpfP9k66hzT0Yk1O5wEdTi1A=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_game_utils/1/full.distro",
+        "hash": "sha256-TdnRNffj+m9Wi+p2wOQ8S1mOim83bCUqETjL58y487I=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-4ENv3/G1h2dhzWvQwbxRHLVn4U8GqXkVqI+Vs5S39Jc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_krisp/1/full.distro",
+        "hash": "sha256-skPhdRKA0Go6dY3lyUjzmHZ8Fs2ES2UTyXOcLaM68ao=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-r2j3yDQzsQMVn7mjICuPiMVgznAVwgvCip8P75piUb4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_modules/1/full.distro",
+        "hash": "sha256-rEneOm4sS1WqBR9vQsF4Cwsmzq7UX/1uly0OMRQ+dBg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-cgGk6IvD2cLTugbKtS+23WxLckGPiFIwHa9X6hiwmEU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_rpc/1/full.distro",
+        "hash": "sha256-k3H+U1kSWjHecyekhHs3E/op919y1eBHW990xagqaQE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-7WL+UYrZaw1uDZXRqsGgjaPdcLOKb85SkDAF4xeyQkQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_spellcheck/1/full.distro",
+        "hash": "sha256-KOLicqkKK/0A+X+qfqQxjqjhkdn5iUdb/itqQ8yuW8k=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-Djt6iqhFbNBRUecbaHOKkNYTprwA4DOei30l6B4f1Vs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_utils/1/full.distro",
+        "hash": "sha256-C655mfym1fdVRMZN+RN+vOZDNWBOj+o0D+BLwCBpFhc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-R0X6K5EsSr2/whZZda2NDY2+gX9jpEfOddJWIz3xW0c=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_voice/1/full.distro",
+        "hash": "sha256-KiNXS5WzULeVY1TFzKPfSUFKtAe8cClyuXmBz/oO164=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-MKXHjhRm/Nxxt8eAIx2axXUzAqm9hgPadFNe60HE9HE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.997/discord_zstd/1/full.distro",
+        "hash": "sha256-TjE3qZmPtANGvKNo+CMA8ISml+wXZHXzsp0puuDk4RE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.997"
+    "version": "1.0.1000"
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-S1Nyb7mkVX7BZ1QuCFy9mMENY5PYOD5ZoPYExiExWMo=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/full.distro"
+      "hash": "sha256-o3DyP4F11335gkhQxylAoUfF43w217o+pR4oQ584jKo=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-J+c8FEtoACGGCD38fA+IWJw9cKLEuz8xwAASOa/4AMs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_cloudsync/1/full.distro",
+        "hash": "sha256-XfAxWs7mTPKBsIti+mXJyJSDlrr4TKOEakhIzqU+kvE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-7nguOkkH1uLyVX6F70wLAZZzo0IMetyc5MS+GxqWdfI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_desktop_core/1/full.distro",
+        "hash": "sha256-mLwc2i1OlAl0HpNq2AumyNGyS9msSxat5VJFiEx+ujU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-rWvu1QPaBLRWPs/VTFzGWVigKDapRs/Tx2i60ieYb3Q=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_dispatch/1/full.distro",
+        "hash": "sha256-snXP8JiX/xSkknUl/Bxn78/F+GRQcTTQ2hcMkdyaY3g=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-Eih3jAe4+q6xzKPHZtdg1nB/ugeHdqR26pvIaSYL0xM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_erlpack/1/full.distro",
+        "hash": "sha256-Ft1QEulHnhA95Oeyb5GUszgJ9kK+9NPO0g+HaUxrlLo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-Je5KFZ5pAU3SOPAbQJHpD2eE/Qzj7g+a7SXlvwfvQSI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_game_utils/1/full.distro",
+        "hash": "sha256-6+0U4X6565a+KVZ+ddJZhb7/SAuyqcPTEMnAJv+QLHU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-DVESIQCdKIBlrpFw7PtO154JFgyhWQkUlxDiIooUY4E=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_krisp/1/full.distro",
+        "hash": "sha256-oJI84UY7a2jIK81l3OMxuuSI2mDN2/yNGYvNIHORkuE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-sGv+1aWjwFXC0FN/ZvyWloqRZ1+x0EhdR76UcZqSosI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_modules/1/full.distro",
+        "hash": "sha256-0u32Hvz7thSLeSAvbpmHCbkoCyJR/ayTM2s5sd4RPeA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-0TJv3qj7j6wWyQE7ux8Bx3tJ87P4fj6W6ike+1cT09w=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_rpc/1/full.distro",
+        "hash": "sha256-CoPZR7yuDgra0ScN2MPuMdbQ7Cmz8WkLkPzFFeCkJKA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-JcNMteYTvz7jf0IXCQPi2e8yifIcSgiYviQ1UlPmin8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_spellcheck/1/full.distro",
+        "hash": "sha256-AEQv9lXxcSqnZVLXjW1H4thqs9MUXVkk37nnANqJfQg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-+WMYNrb0H0rR6decBoUloWDUvkq4TeRYsyRbMbKdh38=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_utils/1/full.distro",
+        "hash": "sha256-LTv5H+gSY3ALbxWGdgmETk4a10I6Rnjsx/HKmkVn10k=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-AFQ49Kk3WPB0sz/ZwhNXhZleU5CFTwQvXaSrnx1NzSo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_voice/1/full.distro",
+        "hash": "sha256-52AparLkD9nYwcmQDdZJ83v08zwC5KeDq3YzcVPrTuU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-mBnF4mFTBQjKAAGoQyoJds9wjVfJXnuwFflIc8f8eiI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.196/discord_zstd/1/full.distro",
+        "hash": "sha256-3CKZhGPKs5KWXeNDJcIQgMlLcQtoJSnG5WAXsgJqb+k=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.196"
+    "version": "1.0.197"
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-EHDShPB/ytnwKaVtMSZ8Z475TFxDVX5eZlH9+8a5yEQ=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/full.distro"
+      "hash": "sha256-fgtszwNLSypVpcijOLc1QPgsRWkq743qpsZjv+iBtBQ=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-0kZ5XGJl4k0zQDJd3dW9bhzYn7n0R/3zZ++6Ls81UWA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_cloudsync/1/full.distro",
+        "hash": "sha256-waCBE5ch939dUHBvn/MXXqZMfUsilU0ibdxV5WoPY7o=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-cjWUlqhyk4/YQ0ST35ujWQ4FgzWV2ufynvUgJFXD7OM=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_desktop_core/1/full.distro",
+        "hash": "sha256-QLgMl9F/fGsGUBJztzRFcp446KEbCQa046fRaLFn+tI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-YeInPLTYIm2Yts2w+YQm3LKyU8YDVoPVqa3mu8BAGnE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_dispatch/1/full.distro",
+        "hash": "sha256-njLo5N5FC9YSvjQ9rQVN+9qrOWXKvzaaHg7HNwPKi+k=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-7bCspbkjmFJ4hznqjoIyEFSpFk+sIc6Tzc6nrWSQOfw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_erlpack/1/full.distro",
+        "hash": "sha256-aBQFOhy1vTByxQg9DqdEZyaH/oOlyWf50aMLFSifbvo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-4QZ6F90heQGk3uER85X/JXAKKIirwWFT9zG5tkW7qEY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_game_utils/1/full.distro",
+        "hash": "sha256-uVkKc8hK8zwK1LRs5GqdOPlpG++s+qaZyMcHFV2gnXY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-bkhdL8hiREog48HmxZVdhHNbI/ruErb7Liu0NbuI0eQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_krisp/1/full.distro",
+        "hash": "sha256-mgXOsvsFFxeW50Hk9/64DDf2I2OoaYY4SRs4N5azC40=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-JQaSnEx7vDbrlwYatKApt2N1C6WzUZhOO+ScjsdtSAI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_modules/1/full.distro",
+        "hash": "sha256-L2Ab18BnUJedBVpcoAt9XJ787ahQhipUIlLMtfMuqkg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-MVq1mbdRkXrz7Zwi1tPgdnlCpnkq9NF5R7F26Wr4NHg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_rpc/1/full.distro",
+        "hash": "sha256-CQgtSoNNXqGsB93fzevcNm8mvlEdzGcJaaNKGLSNN08=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-mWb79Esw9/ddMVNMUrmRX45N+EMW8Kz+ugbGkQelDlA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_spellcheck/1/full.distro",
+        "hash": "sha256-1Jzi0SXWC1v6b4caHncezrQlcV8zawESLG4hNYjY4to=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-TtDw051M2y29TvLdXbcq8Wy75KsvYy+Bt9dDHkY7ExM=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_utils/1/full.distro",
+        "hash": "sha256-xUZ4IeTKOxLlrYOem65p79ZOGpn9PAf1ao3G8rSoAe0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-8x/uLNdrpIsPM9L3uPdGu3r3o1M0O12918dTKdfPh5s=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_voice/1/full.distro",
+        "hash": "sha256-s5GQ+z8hv1wFbXp2wtbLcXBhLRqnZTZ0U1f+vySnw7c=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-5iGxBV1thj4WM/eRcv9ous31/tRgr4OVc3xgbneC4Nw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.143/discord_zstd/1/full.distro",
+        "hash": "sha256-T4RWIOHUEa+MgKMwEuChMPTRVsA+fsUxbPiNTOz09eo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.143"
+    "version": "1.0.144"
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-BQuscZlHaaozENpmeQiHAEi8H6ReyUT7L3nmzXB95gU=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/full.distro"
+      "hash": "sha256-NM8ysudNqHPyrNmvXO7ofFboF7NB35Nov7U+ZQ6UTX4=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-o6UxvrqBRzEr7V588VnoYzkJ2InPX/rgn46c6hDVPGI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_cloudsync/1/full.distro",
+        "hash": "sha256-DmI/ueI9ipGrP15u6QW3FCaPaNqnpGaZX/NjMmMIPPY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-tRF0Y7LvzvARLjmRdnFQgjQBICknzPyxb/4YAyxJXyo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_desktop_core/1/full.distro",
+        "hash": "sha256-TgMaRoog6g6Iq2T7ZNGjsYknXB3KCkC5aWOPfyOYjfU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-SQK+Z6gtAu35Idx854zxQrwAV5FvYUYECkp3a6saG1Y=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_dispatch/1/full.distro",
+        "hash": "sha256-ttvbzwaEJqo2PIDJe+9Uo5F8cdw0P6vVbEniL2Xnl7U=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-ifjvoD8qhtciEcMc+bSC/y77bCwKqmwqUWTTwPNJF8k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_erlpack/1/full.distro",
+        "hash": "sha256-zFhQejW9guxkweMF4mNO7SibOpsqJA5aCxhBhLFuCkI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-h8fnthereq6ocgaxRQCXrCAod1VzWu9FSkCZOAQudeU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_game_utils/1/full.distro",
+        "hash": "sha256-oS+b4kNxlTsfoGq3C7YiEQ+wG5ObP68tGA3nQkcOQis=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-ZDOy4W3jm3kRwV8IynOR4AUKoKq86Jf5GZUnUHz7ohk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_intents/1/full.distro",
+        "hash": "sha256-gFB6rMFv1pRl3ErMjcPSLHroNqKGr2cJGtHuBXvrAng=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-/v2bmmi6+jmIhtwaJFY8ZxUH9u/glnlxGtTvmre2mS0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_krisp/1/full.distro",
+        "hash": "sha256-aSPV75YMuLiBrsQWhevHy5Uhx6AEOkw7VpPDT9yHnLk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-4NR0Y87njkeavPvBNRHREqT2DNeRZyw9ic2hMFfyuRg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_modules/1/full.distro",
+        "hash": "sha256-ZEGaNJd39XuvaCUieCTcpTrh4k/vyuRHu3y1jlyM+TM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-0znPK/iGXuNJRNzyA7atiSDs6jSQi2Yak+PS3cmgM/U=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_notifications/1/full.distro",
+        "hash": "sha256-mqebBEAhJz5ZVFfZg5mn5gg7+SkbA7Pwy/zvj1qWOKs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-TUICpdWb+aHJbD1OwDbSkrWmkkgI4tEyaApwax9ZlJg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_rpc/1/full.distro",
+        "hash": "sha256-6fAlGCxAVFM4ji4ltda9g/cgK7l/aoZGLTMXm2iw/GM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-Q8QJAVjPgEzFh9kR+9g9LeY73QDXSqLZBXIrn4O+aPk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_spellcheck/1/full.distro",
+        "hash": "sha256-joJDIn45czpwIubDORmqA8lmuMGqDaHyurRA35TVT9I=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-3t5uyx7jPOnMWtt4a70HOQs01U8mqUVyc5k2SJ1ZANA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_utils/5/full.distro",
-        "version": 5
+        "hash": "sha256-gCT6sf5cdU7mvcaQlD5cp83D/7jeB5+87qj+0VM/YTE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_utils/1/full.distro",
+        "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-S5YJPauGurgYnjE568uZ0SGgNTIHkttcQr3D0W5RJxc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_voice/3/full.distro",
+        "hash": "sha256-UmSb70MsfOKJOWqokkOyRYPn/GDgClPcj3D2fMcK/fA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_voice/3/full.distro",
         "version": 3
       },
       "discord_webauthn": {
-        "hash": "sha256-GClieyAeMa6N0ulE5IdsOfnTEPm0X5Xms5KG2U7nZP8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_webauthn/1/full.distro",
+        "hash": "sha256-An7ZWBn9u09NhNLOtmwmtjvDFea/1rla9zxpKlq+m24=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-Xj4P5YsJKQcyfVxhGFOTpmcxycExj8qxAhP7ptB3D4M=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1165/discord_zstd/1/full.distro",
+        "hash": "sha256-NJuBHVhohDypwdfZajdPUs1Gz+py6aUxHI/XrdlRTs8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1165"
+    "version": "0.0.1176"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-NDTB54CLKI6Ib9bZecjLxulbMHE1+5baW8MZkFR+fR4=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/full.distro"
+      "hash": "sha256-BzMlo7SCoBk33n9IpdGHUHvKgIFc10zsWHd1i+/DKEw=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-JMuSMLvHf0yGAShv0UqKxgf0vbe+RU8pDVG0QdRpCd0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_cloudsync/1/full.distro",
+        "hash": "sha256-X7FtyDk0TqrzNlViZprjPvjMVus6Hmk97UW8R3fZiIg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-l0n/Q/0DTAaqVery5ZezKK/TWcNW5FvroytdzInBpqY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_desktop_core/1/full.distro",
+        "hash": "sha256-wKiWAT91u/JoJyPJmxcLWtfu2cQX8pWrV30ykU3m+C4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Jp1Q+8GtvH5uM06NDRFhRjQXwFjNnlXpX0K4ziYdsKQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_dispatch/1/full.distro",
+        "hash": "sha256-zIUiL1lmdgP2MS4rf/coEBOGHMXLdNn3P2TE/H195Sg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-0SR35QaALv/01OxXK1hV6V6hY8INOgOm0CRgEQrk9+U=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_erlpack/1/full.distro",
+        "hash": "sha256-hanEeOs3ViiDbRCc1ykpK12ZqvclKsOZzmROtOX0Fas=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-nwiDtajSk3TzzCubr6Xqqf4mKQaNk0T9HfLhtHq78Ws=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_game_utils/1/full.distro",
+        "hash": "sha256-9oPfmprVb7/XpMrJY1GI7W4NIBDWWFxRvRdSQWMZbHM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-NoqCBRCFQ9TwvrLLYLRtdsr1nnEJTDS0q6rsWhnOL/s=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_intents/1/full.distro",
+        "hash": "sha256-cPJDxZEIxliBN3vRVngVaKAXFZxKX5fIEqTc+ftgb6E=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-ARHk9F3I+B6G3wFxWhWeIekAfARjyw0WJr/muxkNEQM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_krisp/1/full.distro",
+        "hash": "sha256-6goOzUIqmbR4Vq9hQKDtMSm4RFtHKe/jl1nZkIc3w4Q=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-8dWTYBh8nzJOFGCTWyLLZhMOF9Q/fc5YoHAL8S5h0tU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_modules/1/full.distro",
+        "hash": "sha256-Fl1AC68OgtJowO2HrDGH2FmVW37g7dsMPT+sITJlwd8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-QuzxdrGVmdXS9N/25iXGYqoJVXxOmw4ku2Avg8XNR2g=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_notifications/1/full.distro",
+        "hash": "sha256-7/XpDcGt/sr5FiQJg+WL8Haq6I2kUrAm/IsLM+Eyr04=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-zA8o1tDIKL2gmXOPF6VKgT3g0uclgXL58pmW1Vc88Og=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_rpc/1/full.distro",
+        "hash": "sha256-FSv/9IZ2fpv2o8sQh2xKUD0By2cKrx0COQM54WJE+n4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-/ys5eUpR2YqphdAQkw7cuuGgAnn7k2ChBNeV/RQTFbQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_spellcheck/1/full.distro",
+        "hash": "sha256-S/YCcm66IX+lK2uXgWEcAwYH1Jc74nbjJIuaQUn3fRs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-mDpF72Uu7/SGyqN6XKlNzo0vgCsPatAq7iX3bK5vSeY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_utils/1/full.distro",
+        "hash": "sha256-3SIxjSMZneurupQswe9kSMqU0q+upssWResqxt7FKYo=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-P0+ef7UvYffv1Zar0dy5AnbINAEWAgcyMdIdZdNJrbk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_voice/1/full.distro",
+        "hash": "sha256-s6eUlfKEXpVjTSZULUieB7ooqSwRl7PlfPGOSDlEj/M=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-i+NSW+yDWZZhK2Yan2JP2zC6N4OBvF4YBjwajwEUfBw=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_webauthn/1/full.distro",
+        "hash": "sha256-6S73R9eRsl6Lr5qpMsikUjJDbdtpD/iK0UxF/jHGNvA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-mzf/Nu6tHl4g+pHWY3sZHDAQrR9IraIZtASQAsIJ9/c=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.999/discord_zstd/1/full.distro",
+        "hash": "sha256-rJI4bRdFFICw/IEhXqbYMHRtor38jsQUJIT5pWJ3KJA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.999"
+    "version": "1.0.1001"
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-gjtVP0dhhU0d/B1ix61JfyMtqoGAGP1aUxS3Vqx7x5k=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/full.distro"
+      "hash": "sha256-ov4G2IhHCiT0f0xHMP14FVtjTgj0w2Z9QHhafASxzl0=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-BfU2fW6ok1OkCVtA2Y1LYIeJMelFFsRv/MzZZtZqoZ8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_cloudsync/1/full.distro",
+        "hash": "sha256-ux9xyW1nk7is1mWHGnEYoSKpcQIodLT3vrE9XZ+TwXM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-rI9DtxV6/SvHx29slu9y/tFfsHJ5Xryw5I4iUDZkJ6s=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_desktop_core/1/full.distro",
+        "hash": "sha256-Mcfi2LRrGGcT16ujKcScAcJibmQFr81ZaRwCXn4ED4Y=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-+UTH+tfh7rxyrgiVXrxBXBnNsneaOmbxE4pC41xLsdU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_dispatch/1/full.distro",
+        "hash": "sha256-hpBNT4OvkGCKsY/ZYkXkedtXHN1j11VEnuvyPIXZNPc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-Zbwj8Ajq6Sw+ABzRPDaCAXxRfBoDTd9iLKwawHIeCnM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_erlpack/1/full.distro",
+        "hash": "sha256-S2v53ysW2HBQupTRDrhfTca+M8B8pI1H7fcfUC/xgLI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-e7/nOrzcQO7rn2no3zScTklYDcp5+BsCuSex93pWaLo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_game_utils/1/full.distro",
+        "hash": "sha256-MIT8bD3qMmaJ5Oow7DhvP60fTOHPxiOqPjU6WEI7gwY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-MJWw3vfD8mNea/of5KBl2+L/KZkaVI7ong4f2mo7hdM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_intents/1/full.distro",
+        "hash": "sha256-BFfWqSs/Bo6cRpvqcvBPnM2w96Z7ryKB6ReUMwhx57c=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-EM2P2MCBGaEVfu7drkiz5aA7nLeoA4O9l1x6XwNUSzQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_krisp/1/full.distro",
+        "hash": "sha256-4Pf2e5+mi6zqwbziREyNVd31M1na4OAaL2g/+6bDhyk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-PLlZFGnwf7Yk5ve2tHLWseIv6ycPzbA5MGE7uOhhqWc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_modules/1/full.distro",
+        "hash": "sha256-8sr7EnrI5lxpRliROu7lSbAQsSLt6Fusgx4sARVHaDw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-QhjNyzXzhpIfHaZBHsL7CHh7WVgfHlGyPFagjIMM9rs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_notifications/1/full.distro",
+        "hash": "sha256-Hvmts1uF2nYu2VzkNb34ZT2ZYE7w5e9CdiZq8C420aI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-tnLRRUm2Q4zRwdxtfW06Ugad6uczwVYyN10bMis4IyE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_rpc/1/full.distro",
+        "hash": "sha256-exZK9KCHCKWc1TUewlqqMr9pYngA+V1XmY2+KpvbScQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-FQE/W9tKg32IQ1MAiJ/5LoWRvSrt22m2s8+tF4Ye4EI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_spellcheck/1/full.distro",
+        "hash": "sha256-7jkHZDdMh8Gb0t0w4/JET7M4S6YLr1T947YsGLQAw/A=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-ECv8ciVQjoxycMF4Gnq37vRmIfoKA8mOM+dmSglfKn4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_utils/1/full.distro",
+        "hash": "sha256-ZYZnxE6/pZ4EFJR7U27aAcs/tdgMItgHEMtuaJOkVm4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-IS42+iy6WVyNwb4LBDVKMs2AOcOqzn4GYzts7qYU6XA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_voice/1/full.distro",
+        "hash": "sha256-YqR41JkdIdm7iF4RzJYuyCHKnomQzB62WVTK78aGSDw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-Q9tSvZxrlKObIA7WgQdNpEkeSSwFG6Fp2zWb1LObdn0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_webauthn/1/full.distro",
+        "hash": "sha256-baHBDixswYR0dxa7pW5/AAreI7BI1DdRNXYybIX6SZw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-eQzO+gJC68UI4mf1Pl/reiL4D1QLKHcEVRJ7uyPgajo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.240/discord_zstd/1/full.distro",
+        "hash": "sha256-U6KhPVxxPbUuKWEbdp+GXIRTvMy+KLJR4l7eB+YiOnA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.240"
+    "version": "0.0.241"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-s8nqZR2Lir7V0uVMA5vOLr2hz1g9Jh3orTHkLEpW7rM=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/full.distro"
+      "hash": "sha256-o2yw5BwDSyks6oEU4YVRecHW4Oq1b4ZV54SlutrfkJw=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-XHm1w6ruwHeYa3QGzcZyD8j/2zBV2D2nu9ojio/hjoI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_cloudsync/1/full.distro",
+        "hash": "sha256-ctUNZY0WToBsI8pd1ioxjvppqO/cehwSSif7nN5xX9E=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-Dm0rh22QooDw76IIR1TaJEC+UMtROJONIn6cTVf0L78=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_desktop_core/1/full.distro",
+        "hash": "sha256-2WA2b37oEUifbZPNpexgCFiKZ65lruLir6CAn8MF1Pc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-BeZdWCWaKu8sHRlpd3arZEcZSzkoGdYHSub84EOAcvc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_dispatch/1/full.distro",
+        "hash": "sha256-8QMSQJNKRJxr+XFLt4cP6qxKQ6eWVX3EMnHGPdjcjwU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-3GjnZf8WMh5XKLrkFi8o1Cf8j6niiRjMGjEgKQSXE5U=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_erlpack/1/full.distro",
+        "hash": "sha256-dC8x9QqG9DPgK6EjSImmoPo+REg9qu5/vzX4x/7+wLE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-Gx3AFmew9NtY6jPCjyZAugIBA3R59q1BJpW7JcmcJvg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_game_utils/1/full.distro",
+        "hash": "sha256-aiVp8rbE3oVdb1+EDlld8vVOPQwzjkhwj69cpXS1bcQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-nNU4xwPopCOcuqnxwfCq1O+j06YJLbouj5V9pk2Wi8U=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_intents/1/full.distro",
+        "hash": "sha256-wVV4Xrmzu6MPOnie5A4+CsbQM4UUEwWWxONAqK8G738=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-BQ5+Gcp9UdKy/rSSYes8nQPu3HL4XbsQTSTcOB6WDMk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_krisp/1/full.distro",
+        "hash": "sha256-qYCTYUVixnxIC8eIqJQlHKzqFcMPyrCHp96+hU1nSsI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-ZMpIo3KFDhRhzvYisgh9rPZz8BiZT2RhvkiRhBHKOTk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_modules/1/full.distro",
+        "hash": "sha256-jV9JMH9O5QGp8yCt39cHfWYV2SXwN+pvMioYlrBrn3Y=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-2gWZFlKvGvD6hESlbwP1SCENIQ6s5V7hTt3HobhRofE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_notifications/1/full.distro",
+        "hash": "sha256-hSYjrrx5Cb0r26j1IhzT7uccxU5536vnFT1Q/J0Tpqw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-pDQ7FUB3xmPBa9lshlctUB/NmhpeuXOeuo0LJ8yruE4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_rpc/1/full.distro",
+        "hash": "sha256-MaEFCjyWL4Mhf31Xq7QAiF0MxrABPrr2+pFKHwlMI8I=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-u+bno6GbefJDhJFMA05cFUIBGMrF9R8+W8piO6G9q1s=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_spellcheck/1/full.distro",
+        "hash": "sha256-6sVVutWpWaNifNqNFARq3SZDxUalfbuWuP/YzzkJ3E8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-lISFU3glD1xjUOA6tOtQl6hk99vTGZIPnuaMUv/V+4k=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_utils/1/full.distro",
+        "hash": "sha256-MSd3l18SUCkdYm6ozaQs6YsG4KcWsj0wecyudV+dl3U=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-Do5yMMz6xoXWExRYwcNw3NHmFIIV3NqQBIU4BJh0FVc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_voice/1/full.distro",
+        "hash": "sha256-r5e2bps5kwWMfKf/QboLQeuqZyxaooR8Im6cgh3QGgs=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-TRQGedxqhCu9Ge0CcsT+M2Y4ZEdhPdGk5V8IAL3jQOQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_webauthn/1/full.distro",
+        "hash": "sha256-Wk1lsZnZXMKWQ03hmh5B4eDKGGzvNtkfqB+tKOX0DhU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-INQGfOUMoGQ7Udb95t3AXYbJxihoaChVs1suvs9WLIY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.395/discord_zstd/1/full.distro",
+        "hash": "sha256-RoGe77NOFERwFURtBIDaFKZ2g8Alqe3Tcx844uqLRcY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.395"
+    "version": "0.0.396"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,642 +1,627 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-BpUwh7PnnpGXJPQLBDojvT8LHjiwPsGVQ1LS+Vn3cmA=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/full.distro"
+      "hash": "sha256-S1GwB+65+Y3uEr6h54IB8d2CWwCcMevfXZGTyspMZ2w=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-hm9vhRw5BdVGqGt5h3PN37FbtbZkWo0Gqw8RppKteA0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_cloudsync/1/full.distro",
+        "hash": "sha256-If+B4uqvOvS7NTnnstequpolrxIcM9MZhAsDCkFMhgM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-itTYR2CfdGb95+svtBW1ujf6zIR4gdvN4aYg9u/sVRs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_desktop_core/1/full.distro",
+        "hash": "sha256-N7To9vgdOc20omNyOEWnOexsE83nO5imp9/coliuJZY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-5gRMY1aLh+/vEQoy4Tr65Rjwt6VGkZrg6lWjBjfa+y0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_dispatch/1/full.distro",
+        "hash": "sha256-BQ3bPkjNGS8v171JMayHdRyqbB2PX0Xxdrukz3MpJJU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-whx4RIJ6w42GLyAbaWVsD9RicdZo2d1EM+o878zQMTE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_erlpack/1/full.distro",
+        "hash": "sha256-E/rjqsFNFLWLZxHqAzVHvRmoI1pSWt7my4C+2mNUuJE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-iymnSrKb8CJJW+boiVgAyoSUoTmbKCGhSdcCeTQw/ws=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_game_utils/1/full.distro",
+        "hash": "sha256-oUlod+YECmdqy4c+sWPZt1yYvGZwYimoIVRPA5v6r+8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-0/QocEt8DcGUPp1zxMIdCD09ITaAusW654b4sutytb8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_krisp/1/full.distro",
+        "hash": "sha256-xDEDlwIInDVSRISoWb07KQvVOqdNxzjWM/s5R/1Ra44=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-0luEEeOxf5zScbGyuh4OdkphF9BZPHjl5086hY+gkOA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_modules/1/full.distro",
+        "hash": "sha256-Gh0JBMfaX63sUIGQ+OKqrSzDuADhjKJB3ger9ONkz9k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-1JN31j2i3bNyqlNSPPh+hpJhmEOa7UWsuHDQ3LGRJ3g=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_rpc/1/full.distro",
+        "hash": "sha256-texX0BTDW0Pef2gMmkOFjxikKIBYIKSTT+Rsk8Zdn5A=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-MGBSbP7zDmf5pHLLk5kpvUtpWXYFf+pFqTpv2ZIEjJk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_spellcheck/1/full.distro",
+        "hash": "sha256-NrhpLEVLW3SqoGGiFcNbcM4sQQzW+6mkUaI50Ry66dY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-AkV235CX/Ghq6RvaKuyMVIQfO6BN92FZmcAO2WwpwOA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_utils/1/full.distro",
+        "hash": "sha256-uXPBkrdnXQnYs3+oTn2gds+au+ZDMYNvOBXTjjhcFsQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-R9Wgz38tNz6DkW9oISTGeRj5wcSr9AA/CMjo6BxQCjg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_voice/1/full.distro",
+        "hash": "sha256-UeXNXR+BHljnW5Xb/E9CrJhBv5hchPS6R1P0dvKoZGQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-lpKGkBM9HVEiJyGl0Zu1Hy6fjgCWCaL/tQXKM3LPZgI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1095/discord_zstd/1/full.distro",
+        "hash": "sha256-llG+0+Z0boy5ZhtPGiCDUr4sVa4mdR6FjT71ZSX5ez4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1177/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1095"
+    "version": "1.0.1177"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-e5ozU27/X5GvEV56JUOcIvZgC1UCfuSnO+wGYWgkHF4=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/full.distro"
+      "hash": "sha256-Je/HUlN3aWGXRKj7yFv4S5YtlrCyEZNJ+GPJlG3GA/U=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-0Olth2MN1X6DChyWypXlWwvBlZ1e/gUHYE+Yxbc4upI=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_cloudsync/1/full.distro",
+        "hash": "sha256-tZVDeeocUb4lcx8fBGLvzW7cdws4vB0Tsu6LzwS7Jyc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-qykX7f8IMoIPCjZznTuHQa2LGNcHkNoQ1B3pjG0cMKc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_desktop_core/1/full.distro",
+        "hash": "sha256-qVhVFbRuUYMWoONhmc1aQFRYtCOBh59xiMUIBsIInng=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-04l5nXKjRyVwAVLh4E7q0J/2ahk+Yp/xWwaR/JOqrAk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_dispatch/1/full.distro",
+        "hash": "sha256-hGGTK6xHBTyMHXTs4uRcms9hA8zpv2h13xuZW/K6FHk=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-UQcqJTQJ9ANxrqWrF0C1VZjhGhYoOJAm394j9ljYpj4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_erlpack/1/full.distro",
+        "hash": "sha256-2i4dMQQQV0EO2rafVG7no1bMVOb++qkwga5I4hNiJ1c=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-DUZbbCeuoeZEA795Nshjsks/wHvwZrKZToSPd02dW8g=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_game_utils/1/full.distro",
+        "hash": "sha256-l5STKk1FYHIWLpq/dVwsY5Q8ce89EiSYZyKE5drzpTQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-cCrlYVWvypmHWVJ6x9gtcIf3HgREGtXFt0GfWbBxTxI=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_krisp/1/full.distro",
+        "hash": "sha256-93GXORqBh2IDZz7gwC1lLP/dHwfXK1wqfOdDl7nmy6w=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-lq10/naN078vjiHHNCy2Oknb7AAespmiFrE7CtG9AoA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_modules/1/full.distro",
+        "hash": "sha256-sMsii7pOnusjkmj9gzhRbyLGzAusYhizzZ0Unry+oYQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-yZMDNieVQnllGX7CpOkqPwEODXHQUcZl82kt5p9pz7g=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_rpc/1/full.distro",
+        "hash": "sha256-M6FtXDTGWsqafyQPsVIPJ3F0zUiJZxejuAGJg5MxF+E=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-41mKwi6++A4KPZps/CIBMOHMv6ZW8inIRU+QuAPvCk0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_spellcheck/1/full.distro",
+        "hash": "sha256-pkJLh3aZ99E5wuBF08uEU4fP9QqDn9Xrwtbk4i0Q/Rw=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-XOV02hRl9EMSNlpeLnGLX10m80NFIQCtZ87JeFkGebU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_utils/1/full.distro",
+        "hash": "sha256-f01INbXJ1l/L5VuskTnz32YF9NH2R9/Apla2iYoEF5M=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-K8eFHLgqf+C3IfjnAs4sb1dVNpdc6GkXuf5QGK9FUaM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_voice/1/full.distro",
+        "hash": "sha256-YDij0YVearAetTN/1j14eBle+7LKcYGdE1TDIbWH27Y=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-zVynSyfpaNz3zl4x7537Jdw17h/RQ8Tt9JLK0FG7w/o=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.981/discord_zstd/1/full.distro",
+        "hash": "sha256-PC5yxqN/ky/ThGRMCCKBSZBqVUJjAV+sl41LlPCvHc0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.992/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.981"
+    "version": "1.0.992"
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-krt+uEhFPkFicyxY2FvW/cTENpqm7tdr1AZ067GII6k=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/full.distro"
+      "hash": "sha256-hZi+7k6+KoroSosJ5jOmhfKCrXqK5mzMlChvd+O57lE=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-zw+5u4g9+X3Ij9UXTKYpnp7Bb7diV8d5OxJUIpbwFOM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_cloudsync/1/full.distro",
+        "hash": "sha256-g63Wz47H63bOiyLJ2V4/4z6ZpCVZFWkdJUEaYtTzv5U=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-DkDdCkF8m4xUfIHU68fR7Mto7XNSRme/hfPq/6/Oi78=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_desktop_core/1/full.distro",
+        "hash": "sha256-78r6lth+V0OPEEJQ53FZhDGAS8RJ2/gGXqROi508Rzk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Puk419IfCpZ3AQXoR69B8J0Na4Qt7Ms/8o5OOeoVGsM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_dispatch/1/full.distro",
+        "hash": "sha256-Q+1rU46jP3/GuJ3yjvVk4xC0xHuY866JCPVsiqE2/Dk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-OS37PDrUaeQnQnk3j7MPsaRwRpfyI3BRUERBJlBUjGg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_erlpack/1/full.distro",
+        "hash": "sha256-Zxv+pZIiX/dgWLtQu+ouJIiaDECBGgcbxzVst/x5QtI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-JvvrO6WEr1GZcXXVv6Upx5g/uE/ASF7u+qPimncOFkc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_game_utils/1/full.distro",
+        "hash": "sha256-HxQldTPK3dGuJyRKw6q23iyR4rO9UkASHa/F7zzHbX0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-iU6TSZ7mk2spu8ywMPneFZ9H899a/QE2NzVbDbxtZIk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_krisp/1/full.distro",
+        "hash": "sha256-ptVbz0AcEttoldc7WV/nD1lYptJTnIy8p6QUD5pbkYg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-cS263pydXez5YOQNzLGbfOIgah4av4pBFM5NRw/HOqM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_modules/1/full.distro",
+        "hash": "sha256-ex9Jud2OTjcWZbcx+D39uyIrh6K5OJANCMc+zfx0Sv8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-nu+MCe79gz2QVlI+zZ47JkA53nXgu2YLec01T3Iphpg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_rpc/1/full.distro",
+        "hash": "sha256-TZqW1pxrqVIszGLBcoKErZUoNGNeepRHNqaOXoG9rHs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-0wcn+6hm0SDN7mke9d5nM2t15WSH6LhHZxFZCJ2CD10=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_spellcheck/1/full.distro",
+        "hash": "sha256-a20ZUdyDnnG31DnJP1+ADZxQbk3B1YKPrNPcb13S//4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-4lr1sET7fwSBGIV5qDvFITLUzuN0D0Pr5vC2Q6s1dz0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_utils/1/full.distro",
+        "hash": "sha256-W7m6Ql9L5GwRQnx9TUjbRZ8c0HGFfFriMoF6HC/RfZg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-2wZ8fTOHq/PZ/cdnMn1ZklI7OzZeaNdXoKUWlGn7TFY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_voice/1/full.distro",
+        "hash": "sha256-S9z/eS5P4sn5yuPdHP9HrmreEIU5vE44Np6QtHVdZm0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-9uBA0j+SmpZs4peIhAWfzcVHl4ZSA68F708duyDgc5M=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.191/discord_zstd/1/full.distro",
+        "hash": "sha256-rhoLsPy3zW5+bQuGYGxMtgDHaICrSKapTQD4Zcw3GHo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.193/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.191"
+    "version": "1.0.193"
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-mQhXEJdSk7Cw7h3kZST/OEAM16mAU0vu77wCyUI3JYE=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/full.distro"
+      "hash": "sha256-XqiD6DtJgFPmh4cSBgbvz52uBnJ7FUZ+VMcB9KxBzeE=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-ASodX6XZIn0jHWWEMiuzTR/bjstTyqQ1KYobAMUtBE4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_cloudsync/1/full.distro",
+        "hash": "sha256-NHT/o5cb0VQZQ4CaItCHTOkfXEjYqPlIA3gSSLvCgJk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-AQjcF9cX3g5VthbXh/ZpPQXoBRcwNUlDB4RQFJBLCBM=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_desktop_core/1/full.distro",
+        "hash": "sha256-THCGUwshMlNWCHgTf0d/W2SlBDEUcZ5dg255O4DwQHQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-BNsOlr8qy7vb5pzJeWsOpqoc05q07qTZYOzlVn1ea94=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_dispatch/1/full.distro",
+        "hash": "sha256-C1742juma1bCGVWMCT903BFHNedc6V+iws8kKTQBE4M=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-LKyA5MWvY8f55GJ5XsxGxrd197vQlIClX6FkpHTnCXo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_erlpack/1/full.distro",
+        "hash": "sha256-IrLq1n96rm1YE1UA/P2b9VHzX09Wa4DT9yj5wHhytno=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-yzBN13Z55DUPFtfxRYXlEB2S7EOpSGuVwqCGJ4pq2/Y=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_game_utils/1/full.distro",
+        "hash": "sha256-Y3shNsfjcBvSvUt+D56qIMaa73lpF/+c/jURWd9hV/g=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-E/+0xN+ZwWLvfdH2+UxfyjdUrEHDKSGR1snmurgViQs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_krisp/1/full.distro",
+        "hash": "sha256-b+n1X67Iscs1Cjq7KbpXBqqIC35tWqaQh/hPEbq0vuc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-Gu1ArzHiHPem/PyBXJ2uu9BrooGUtSBnHuVO4u56wG4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_modules/1/full.distro",
+        "hash": "sha256-U3f+1y1WlGZuP5OlJ4AeakhNYXlx5xbKqHjiCFfGg0E=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-rjuT57qohzTqrB1hSznnr0zcxIyNuEGT9OWO1y78qxY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_rpc/1/full.distro",
+        "hash": "sha256-rtBhw5MHG/MCAVG2YvzKOEVmN8f02DPI5LBKg8Qj9ZA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-LXe6sNbCBrU2u066UOFxjVhg6++7IU0jvKwdUBu7xGc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_spellcheck/1/full.distro",
+        "hash": "sha256-BFTkMV1n9ann2c+GMiuIHZexGO8C/yOi8sbBWrqErKE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-EOQe69wzNfvYlN6sCa/eUEI4TBqofeyAyYayH/z7eNk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_utils/1/full.distro",
+        "hash": "sha256-isXprPxivFIdD1Cvb7tbhdWSNPbU3Rrv2muYg6tXW0M=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-Kin0igXzEF1qgG09nLK5pD89tuEfPfoFnVcrQKGmWXQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_voice/1/full.distro",
+        "hash": "sha256-v60GjLJ3LuAppMRSjZQNWSLEamswDcTm/AjtwG04fgM=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-OUGtH9vqI4mNmcSnwJO0tXBvOApUEp5HcHR5iiQqg3c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.138/discord_zstd/1/full.distro",
+        "hash": "sha256-Db8KbISU5W8G0qfqGaumrOZU75B6IWBzf3JFIyUzadU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.141/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.138"
+    "version": "1.0.141"
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-lGBj8eDOFubn2+wirPUfWC+ue8YCaxO5h1IOWwKnLjE=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/full.distro"
+      "hash": "sha256-cKGa089UswaZzoAHzkStkROitXDNUMmGENQzUkrmTlY=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-LpUlFrARzyYbFo1JG1XRVHCpQvxui58Wtzkgs/MDAGg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_cloudsync/1/full.distro",
+        "hash": "sha256-9QGggOph9Xs4Q/LjnZ3KFwhXxgNRyli9fNoFz6H3jqM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-kPI1Y8ZRoj2CcmQPdB731uRc2KNcQl1rBncmO+arbrQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_desktop_core/1/full.distro",
+        "hash": "sha256-UNTm7ItVQkEIEb6htmc13DxEJdqli0uL69OR9ADVAEk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-lEvBXl8nHA1uIMCVhfarxPzVlEKEFKpYlTFSTo9zfbU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_dispatch/1/full.distro",
+        "hash": "sha256-TihLreO5lbuQGAxljjAaPZVr+KGmmveqTd6tUYvKV1I=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-zY36prf4F8fBn2uCMh2YoasUtTde1BsgAuD7uiXmF78=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_erlpack/1/full.distro",
+        "hash": "sha256-oaUEWbrxizY/kP1IPHhumErlTKQVQMRyt5P/7dJU9DI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-7XoHixFlryr23hPsVG0BHASNh8uAlnE7QphGsNQ4Fw0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_game_utils/1/full.distro",
+        "hash": "sha256-KCA77WXi9MFBfH04DLpiJCcUnX6V03UbiN2ZhvR951k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-JsEpw6IXUDqWDPNRrplHOnaixqAlmcSRSwgqOhiXtKM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_intents/1/full.distro",
+        "hash": "sha256-LDzacYKK1/6blKRI+9fLMz83GT7QpAkw7R9pFzpO2Rg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-XOyylN8yS0Ib1PewycB2XPsNOsmtlr7QKGguWV64Uuw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_ml": {
-        "hash": "sha256-BPz6tWjvGdtgTQn/o+qPNBJjy07VPHHuVH9qTxRI5HY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_ml/1/full.distro",
+        "hash": "sha256-Xmcukut0dljr87fHH3hLuuum1aKaEbyz6/Doy+5aOOc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-eq79n19N5Ns68hAUEuNPVVUQ6nh05U+O2H7kBHQLYEs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_modules/1/full.distro",
+        "hash": "sha256-EAPj4leGDWMV/80fZUJjgsJDea5e+GAEhl8fyU7i/7o=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-rpW8FnlgWEf7s11ny2m5uZqDhXrOTYzZKZcpXQ8cKKk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_notifications/1/full.distro",
+        "hash": "sha256-N5ZsYM7Y/XcMG6nOc3xVd4zg16MlozmZXK1xO3ARW/8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-Y2m9lQ1E/TU6n4Pfjf1Xo7+TLebc8579NHckS+Rqv9k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_rpc/1/full.distro",
+        "hash": "sha256-NvwdAvR6fZd/Hlcw3Kb5sINche3ZdiTwQO0P0nY3jVQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-+zldyihvpFRILqEaAq+cexVCsAX24ujJlgEgLObg1aQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_spellcheck/1/full.distro",
+        "hash": "sha256-4V0Ij/kniCO46cmy8pYOc7Hu2VFRuSYx1EmTV+wZDsQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-bOI8bhbjdB+NufNoJkZqoaN02ABe1I8plxZ5uelvlVU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_utils/4/full.distro",
-        "version": 4
+        "hash": "sha256-zPVB5RaxPLSyakY8ZqyyVNWuZEJog78KOROHbupxTSs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_utils/8/full.distro",
+        "version": 8
       },
       "discord_voice": {
-        "hash": "sha256-Rdd6mzTPtqUXkGiWjl0hEeD7V2KX+GHlaxMCtKuCfwg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_voice/1/full.distro",
-        "version": 1
+        "hash": "sha256-1CSPUCxqeLQxSHZWlSeAYIj9XqCXWD2gxcR4F9kd+54=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_voice/6/full.distro",
+        "version": 6
       },
       "discord_webauthn": {
-        "hash": "sha256-9qe2t9cVI4d03rypha32CDaQIi4YJAiMAG0gMKQYyBY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_webauthn/1/full.distro",
+        "hash": "sha256-ZMo19cg7Q0uXdDATAHkYWzDrU44jXicHeqpsIiA0iEs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-YNnFKy3UMBszW7HF7jmr1KOGyy38ABoIw5Ut0hErrqc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1114/discord_zstd/1/full.distro",
+        "hash": "sha256-NyK4eH6joep5BzM91AZLRU3jXC2sXdSp3/s4w/Xqkn0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1132/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1114"
+    "version": "0.0.1132"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-KuvWcUPFXfj4QW3K8IGS8E0BiffEEMknncjxbMCkvTI=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/full.distro"
+      "hash": "sha256-9rlxgLp8PxtuFSjK+nDshIiDigjsBjox2bUI7cp1XXs=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-vX0ZzFkcIJGlZ6CVixrc1U1LGDAszZhexXSWFtbSVpk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_cloudsync/1/full.distro",
+        "hash": "sha256-6DAvT/Rocsu6tYMMt4VJMmfhYxLw1Hl0EgJK6hmw6j0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-m/+55zUpSXI/nwZKMaIknAzDsYlnCIcxyGoSeLafDEM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_desktop_core/1/full.distro",
+        "hash": "sha256-xA53RC1WAcsmyKl5c2f2CGhFzficibB/h7psEsr3IRs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-vvofUseRpHi4wMMbOaM2mI8eYYrwlI1F6dfKyZX8jvU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_dispatch/1/full.distro",
+        "hash": "sha256-ebWRxbIIsrf72bj1NoxamL2cxZNrmvkRxfB/jXS6HmI=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-D9/lpVfwXKj26dMrreSLBPaND/4iCMmC9/u3+T1NVPE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_erlpack/1/full.distro",
+        "hash": "sha256-GLaAXTePgAWeRwVskt+tBtrVTn3miadBWImPMibG/+Y=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-vsAIH6YnxbXAiDqDeeLSuinZLmLn+3D6mbdRJb5L99Y=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_game_utils/1/full.distro",
+        "hash": "sha256-A2+GyRC/RXTMnDagsT6zP1S5T+PCyMK55eiEF2JMV84=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-1JO4nwtiduv+JZqoPparHV1dgjPVKhYeWzDzuUzWTTs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_intents/1/full.distro",
+        "hash": "sha256-sjylilIyOziJgH4gl+1Y6oIB1drMF7EWrt2mVMliCoU=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-1oO+B/78bZhlQfRl1V1PHH9zMWJb+2mi2DlVK3NCmVk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_krisp/1/full.distro",
+        "hash": "sha256-w4ZRMT30/KzMrXv0wxUd0U9yv95jOVhSG/6zzbrBaG8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_ml": {
-        "hash": "sha256-RunRar9d7lbF9PkOmQwokmjgfFblc0u4pu2gQGtrc/E=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_ml/1/full.distro",
+        "hash": "sha256-TVyM430eeKoq9RNXoLmd1xe2t3xqgxmbQd5G5+chcnI=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_ml/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-vkz0ZWMFFatdrMgEWM16AMuWSaFSI+HFFzq3oP+3dJ4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_modules/1/full.distro",
+        "hash": "sha256-TKsAh8tNHzQELizvKfMcfLvm0h4F69iON2VBIWq3qxY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-/h00K6D/bZBwea852GO+4+1w4oLDFQP7OlrTsupBcwc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_notifications/1/full.distro",
+        "hash": "sha256-O1+hqRWztrhlYvyHv/oYTO82Ru5VRwPxo7FyAQSbgkI=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-3f7O1xyYd4XdOe4+RU1o6TCcwYA8VK4oC6/zlQHIWBE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_rpc/1/full.distro",
+        "hash": "sha256-zcx4PDynhCApRWJyI1KA8t4IS0flDxtc9NGiT3mqaKY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-j+rwWr+pq+Cg3NaaF8EoO31lUDt7Za6h/M033CJjaxQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_spellcheck/1/full.distro",
+        "hash": "sha256-A0gObDSLQWb3Fp+f/xQC8ij2mGBdzeHMuC+A5+XpZdo=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-nXryRxbYrJ1cO+wXGfu52oWPIxj5Efs6J4EQqeronrI=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_utils/1/full.distro",
+        "hash": "sha256-SvipA8cXIeeFkBC9RdcNHielVmpwlilGB0mmHFXNUx0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-sEtDXKyrA5Y2yuHzHX06LJUx4zibt2tlZtXmVohyL6c=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_voice/1/full.distro",
+        "hash": "sha256-BQhaZXj8jVuNtVvGN5nmSfkv2OpETTu+VRt/AZzkSms=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-kFfptFhrbFkluiBmupcXasbSlq9ygbWkH9S4wTbG0rs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_webauthn/1/full.distro",
+        "hash": "sha256-XRs6HhQ5XOhQZ2CjhzNW8jMFORby80eWUU5FHBN0Ui8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-2TuxeigNLFPe70njbSaBSmzHsTjb369o7mSxC9XpKVk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.987/discord_zstd/1/full.distro",
+        "hash": "sha256-9cRSkG1gVP6+casDOnJ1gSknXh1kumIeUQd+EcLtNZM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.993/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.987"
+    "version": "1.0.993"
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-NRQtYNYZZch4SioDIPnfAl1S7Fa5CciLkLP6JZc5oBw=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/full.distro"
+      "hash": "sha256-yxbYcpaoUkUlHIC2wf3yVYlxM1KBcCA6vnXqeUctRhQ=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-zpkiCGvarZCCHf1DBrlpvv6NMQCFKwdJc/RzWJRzHaA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_cloudsync/1/full.distro",
+        "hash": "sha256-RDTWKgPcehCjcR1J+jmj+ICZz65ozCMS1zPxroTcxE0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-JfizDxN8/9p4NZI3qNrkH+trMM9IiSR133wvMShnybM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_desktop_core/1/full.distro",
+        "hash": "sha256-w3yILQKWaqX6rXFmDhpakUlw5xFW6LI7Z3CL1lPddsI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-fD+Qdv/Ata12kU98dS96gi6UKTmIIJz/+VAjLT+kBHE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_dispatch/1/full.distro",
+        "hash": "sha256-RnOLwaCiWS04PFD/d3XLL6erxtDYYrNJ0D6YCcE0uMk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-2pNq6peNi++0vNypv86Wi4BWKE1ifqfdkP08/xvyoSo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_erlpack/1/full.distro",
+        "hash": "sha256-IgeoTXiFWw4BcljPwl7fqAL+Av6bRLFT80tfG5v2Muw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-Mqxch0LYlqW/a4eEO5BKG/BD6uaUf0YAni3QTOjBirQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_game_utils/1/full.distro",
+        "hash": "sha256-dOSI1OTNkfxfWisrl9DTA8WRU/PjS05c0ZDzNBbBpRg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-yRlfU3h6nBzPzMYmrt0cftgRQ3MMQ5cGXPGr2+X0Qs8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_intents/1/full.distro",
+        "hash": "sha256-EFeUxVEPex20Mrfd04dHYCpfKZM4zIZqOEyREixPcqI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-kPVDiRkJumiCDcmfhG6PG12iz1SBJeKyc02OwYnde6Q=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_ml": {
-        "hash": "sha256-Bn2mDI6ExXAZcKnO08a2SdBOHq0Cso0f9pRgBmgIyRM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_ml/1/full.distro",
+        "hash": "sha256-XkzYfeQ32JpdzmIOnYBi9bsSSJFCzbSDFNHAPFcAwGc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-hLkuAkHf6IXkhjQChH5nnJXXcUpiL2PRv5JQl3/BC8k=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_modules/1/full.distro",
+        "hash": "sha256-v7Hdk7WO2wCRbJD6SOHfUKAFX8ZVYfe5qhNHnTZvsZk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-ADdxLcx9hO2sfZq/BUjI2jE63iBuNzj9KIy8fTs/0pA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_notifications/1/full.distro",
+        "hash": "sha256-T+4YM57ZbYZSSCPsAgfqcdVl3Ifuf5q/j3p9YUGHfwM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-AP2yW5O7KXTQsXTKrtSeVaXpRGhEd6skqwZJ/y/hazk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_rpc/1/full.distro",
+        "hash": "sha256-hPPQ5+jHeJSMG3SythZrndhU2F5sl6am3K1lVtDrE40=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-pUJ/QamKoZOcXurPWi7eJj/TtLyUsGRYmHaaRHSPw7s=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_spellcheck/1/full.distro",
+        "hash": "sha256-yIHkUjjWaPTwvlVaKlucpZUimVWbGd3dDOKOoWcJJAc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-Hie0b0Y7uM9ySb4toiQZIYZ24tkjvsOXlgYNFkPNXjM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_utils/1/full.distro",
+        "hash": "sha256-DgAQns2Ky1nBABIhTuSfjvLLOry0/sDx6TRUfVqy8PA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-LbYu8SKK4DW4P8BgakKGVl/ox0qeMavJrGhkmNB+dMs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_voice/1/full.distro",
+        "hash": "sha256-esidGrZQjLpOix2HWYYEPwCoU/QcU6AGM7XZPMvSzsA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-DckpFbwQpb1ql5BRer3i/zbT9rOXVIJnYTwM8izyuYk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_webauthn/1/full.distro",
+        "hash": "sha256-Iwl0cgBmJdAFUSyq+l6wuIAS633yxwBl0lxUktmKa5Y=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-B48b/B4ARDVcK1g3m1Cbn+kwil5OuEW+Xe5XBBTknTs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.234/discord_zstd/1/full.distro",
+        "hash": "sha256-GTWMUSTNYa4ZdmSBy0a3+PejYRITwTLrj5MOZsCVW4U=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.237/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.234"
+    "version": "0.0.237"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-f5nHsPoB80ByFEZbFiyjEI4oQex8d1D0aQbonujbjZ8=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/full.distro"
+      "hash": "sha256-y8Dr+me5JFnw5/kMcnce1YCjiAN1mqOw77NHykAYQKY=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-sUi5kXAkhtCC48rePaBSndN0gromC6VESA9ffwiCEpw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_cloudsync/1/full.distro",
+        "hash": "sha256-+MaEpY7bCNqJNOk2VcHDBM1ZEEctvkjDJIoO0dCTa/0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-D/EXZZj/VJJQBcIFCL5n656YJfkFmkZB7+zDBYPPmb4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_desktop_core/1/full.distro",
+        "hash": "sha256-n0i+FEtNF6ZOrZNBzSex5pMUtnR9j6kllCsVk7yYN70=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Q6yD87WbJlJT+I+WRBxIJYN2f8wodtOBTPn/epOPc9w=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_dispatch/1/full.distro",
+        "hash": "sha256-Qo1cGTH5wQe4Cpzfld5Z/D/C+BKzjAw/d2nk/EUgj3c=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-lP4fzciImPpeR9KMpXded/Vc8+nrz/g2hXiJZEcrH2A=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_erlpack/1/full.distro",
+        "hash": "sha256-jC+2AXMlD0d2+Bcme1lHsAXYn1Dj+vvxjvWK41SvODg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-0XH839e+Qv1f00o6BKVkwtT7qbAU+SXeW7zSLWh65sw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_game_utils/1/full.distro",
+        "hash": "sha256-HoEsai4W/z6W3sLCGoP6v1BWmuZQvmzOXLLCIUkXNqk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-eoH+4jmLEIt/liwiy6J0NISAWRDbG0boF4Ry2kDCU/8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_intents/1/full.distro",
+        "hash": "sha256-Tk3D3Ail8Bu9+mYbASLJDsSAltD/f/g7q1/vUlIIutc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-/cAJqx8LfdAkWVrk4zMDhOSNRkn/hvkHukcq6IsMTac=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_ml": {
-        "hash": "sha256-P3p0tBdUPPFEMrkmqQNGP5i/qlNjBazOJSedZ7bAFWI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_ml/1/full.distro",
+        "hash": "sha256-6Vt93M5bwstZEn7mb33w2IlgpvstGa6kGTV+Tza92B4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-soo7hXzLa/HjGg9xUr4k23BlbfzTE1IIIQLZAMdS8p8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_modules/1/full.distro",
+        "hash": "sha256-Hl+q4s2zYWa57RwpyZ4p9oEfkUl1ekq6xrKitS4BPN0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-5sHbOpY+x0+tp92yhbqt/n9EVzfuM9aY959nErp8K6w=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_notifications/1/full.distro",
+        "hash": "sha256-rnHE+V90VsR9DWDZ9jN2+pRrQu96clqNq9sFoMpiNZg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-LWbgkvHR8uG/gqnxj6xjrG1xvB6YTKkSUv+OdcZQO5k=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_rpc/1/full.distro",
+        "hash": "sha256-azkCFwPM51sqHjbgsRCOyoPlBMwf+wVt2qrlTl1v+1c=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-9eimbVeV160GsTvAPKphd3gIiY9Ia8UEqnVlCVYth0o=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_spellcheck/1/full.distro",
+        "hash": "sha256-x7qjYGYC4LDbk3wDxDOjqo/cBoyRJQlzsXpoyJyzFnU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-FZMfdq/xAx+dEveQdqYbzaCXIyPeLZ2AlzpMQxH5mvA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_utils/1/full.distro",
+        "hash": "sha256-sdvSFA7GZS6dUXiemSJpsn92UhaRlNCH9N8UkgQRV/Y=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-pmAZZskHQ3ZcZ5zOklRsn9kdqbuFwjlucRnKyRMKl5w=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_voice/1/full.distro",
+        "hash": "sha256-2/oH5L7MIIsKLavU4J0O8/hqzFx9BpY9LSuSJKaSwDo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-+AHgJr8pfGKJCZLDAv6BRBcoPcov9qTqPWl6Le+Iu/M=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_webauthn/1/full.distro",
+        "hash": "sha256-z0sbteCmrXjvWathL+c1oXL63UV9fhGYtTEOXnBqa4o=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-oYlu63s/hIELL+eH4nFlZ0Kk+bb0HhlGKOgdjkWRsZQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.390/discord_zstd/1/full.distro",
+        "hash": "sha256-mCzmStANoOc4b/UPZmkndzhnxZ1H6Q+rnNsroObPnCg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.393/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.390"
+    "version": "0.0.393"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,662 +1,692 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-duXSPkT9dsNdDLpalcSu0ZES7F0STDmtKVPKg7jlRZY=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/full.distro"
+      "hash": "sha256-4j3ii6uD9f0tV71mU8XFFxWch7LiWCwclnkHa5NGj+4=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-0NBDfbjZwIHm7+xTZ3+xEGBCzZ2uC57SjHrUVgExmvo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_arborium/1/full.distro",
+        "hash": "sha256-I6JRlVELq5Mldcaz+lKMt0izsNSfWdw/e5JPqBGLOzE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-1tJKJGB/UBGBcNKFmqW5HTatDblma7bFvydqmzUz7vU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_cloudsync/1/full.distro",
+        "hash": "sha256-ZulqlXaIFr+Ds20ON02HZLn45JFqq9POuYoFV1t0eZI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-IUSuxVDVXgOFYngO7T+TDtrgWP10FdbKAPq+05XnhWM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_desktop_core/1/full.distro",
+        "hash": "sha256-H7mcz7tm2FQXrmbfLz9n1bxbuAMNAnGK9iWEbMoVoew=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-ey1uOhCKm3zhEs6kkbO+Uic3WBBBFwx/GOQxj1VjDKI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_dispatch/1/full.distro",
+        "hash": "sha256-XTmNR20AqtrpWiwOy0vMrUy0K2bDG7P27a80hbvWS58=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-FPPVL2uH4uRDtck+/Bp3vWU7QBUflgXwVtYijLh29i8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_erlpack/1/full.distro",
+        "hash": "sha256-zH6H8EchYRXbK7HgG6F09Oiieep6JyTw1+r2nRmtQ6Q=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-IpBC1k3MSW8S73zkM5Gh/gfiIqAPLjGeGAUPdDapgfo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_game_utils/1/full.distro",
+        "hash": "sha256-3H3KVkC/t6UdxTQEUtKg9rfk1xKaWf0MDerUm5yO3/Y=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-dGxEdFhAwyaLRkq6VdrvIE+ldykwMTpbDfiTCk4U/kE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_krisp/1/full.distro",
+        "hash": "sha256-w8XATCZyCv1FeoRBweo7+wL9NAX2jD8JNKiF1ED7T1w=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-ub9rhTxTqfFX+12TI9aYpkguEIJgSdsaJRCoLRge9E8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_modules/1/full.distro",
+        "hash": "sha256-Qd4gefF0GDNmZpwtIuuOdGRxRn7b+l88N7lbsRebe9U=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-DC+D+NDHWbbedeJKXvduCgmrwJzcW3oVMp3f5PVk2XY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_rpc/1/full.distro",
+        "hash": "sha256-XxkRTULSxx7o8PNwCtz4FeZ9vowa8EHr7DNryvG/vMk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-g966Xj0y4AI2LDfaGkWi0XRyibxSCIgxMYDVIaXZYT0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_spellcheck/1/full.distro",
+        "hash": "sha256-mFEZg/Z33mdj4dIwJNfj7pCj/xcLoCTch/t2pssl45c=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-O5XrO1uL6zNHbIh6XUXQP3e/ZcAd46Z4s26+ihzWfBU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-AyfvPHKrhWjO/x3czzDfVugvBFrRJzckKIqe7WAlhvU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_utils/1/full.distro",
+        "hash": "sha256-aN53SHC3x1YKzd3pmmQX7lWu6iVRC7kN9BxViPSSNV8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-oOUkEZPfndE4Hr1CYOTOtrkdoQMWz5gmxanRQ8XRaRU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_voice/1/full.distro",
+        "hash": "sha256-pbzNmysNg7tWzbpQSqGr8OBWdaGSR8/pi5A15y2oZno=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-TvUI5v6SuZR3Zl5/nHhCS0HyqOKYC9YDXf2xqyVGx2g=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_zstd/1/full.distro",
+        "hash": "sha256-E+ai701mLhnEdSAO+9dR0KEWZuVEJvCzmrRjPB0ST0I=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1708"
+    "version": "1.0.1766"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-tmjpT2oZ+1BefLhh4Bxipi0xLTO3JjOzzGLdVcmyuvE=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/full.distro"
+      "hash": "sha256-OMis04U+LPw0z2Gu6TwYDCexuuF9Pxvom96ph9VO5zo=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-yEK2W6Fp0pcF6FSCZYgopcKMTC7ofswVq1G3SK/TOWY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_arborium/1/full.distro",
+        "hash": "sha256-1rB32mdmYQ6JlvLg0fytohjtT0LT3oiuN+BPUeI8X5k=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-hNSSWkwjEaqaKYqFBBh3v8PBEHB0YEa2bZJd6Lt0xbc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_cloudsync/1/full.distro",
+        "hash": "sha256-2Fzh0M2rz1l+aQBnekeRJgzd4ywhW7usVF+PiVl5zUA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-TYzmzahlesOKI6sUNGNq2fr6++sJpRycLWZRUAhtfhc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_desktop_core/1/full.distro",
+        "hash": "sha256-quUJBTBM51VWZUpmOgHdr0Y0NFI6OjFttyxMxYK7ogE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-xZ2d7lTbZunbHcQJKPm9Z0NQE7Oq3qH4uR2zq71IdOs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_dispatch/1/full.distro",
+        "hash": "sha256-E6XXMqoVY6UMvMcFoHiYlDi5awZCvJgn7OnbKGBpxBI=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-LC1cBf23zXmSfpW6I7UxuLi30y6m0l+2NwqJsSCt4Cw=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_erlpack/1/full.distro",
+        "hash": "sha256-3gx7VPXOT9tw/PNv9V2upLMwz7vPL1/67vd2h3YqQ8g=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-zrxP8s1Npfs6GSHW5q8MuWkhFeINzXwi9A+S93o9vD8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_game_utils/1/full.distro",
+        "hash": "sha256-HPxVMWsyglbfKNwS12DdkJWrRyaBb4p4sidRMzOs26o=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-ulpY2VnZwBFbEBcwXXO8cNhGgWEqkoBVEbMn/ictKQg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_krisp/1/full.distro",
+        "hash": "sha256-ln2ku9QMGja9+luuTwYA/i9DCr6nOZVpNcMNzj69xho=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-BCrN7APbCd0bw55cL51umhfpYBUpkEIBxHF8IZaEpRM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_modules/1/full.distro",
+        "hash": "sha256-WFaN7WYtWqjox837JD0CsBBKFv5X1kdcnlX6Rv3sneU=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-RsWNLlNSyuIhnFqpSG374vlmLqfFEZRAL8XcmiI3JPE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_rpc/1/full.distro",
+        "hash": "sha256-V6R0p5A/MUAoisqLkhVTyWTa7HWEfW5BFsQlKAlNhtI=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-KyeC+llmxpjjbjJGf7F4RYXnIQxnhDnvgixHeubM27Y=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_spellcheck/1/full.distro",
+        "hash": "sha256-0I0ac66B4HtTCKSir+aHfRxmoyeohUR5y7SJcMI1tX0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-G4D7ks+CEk9k5h22GlipptKEH3K8sI5n582UguhTjbE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-iKsHKmIlzSTbmsbtNTUwhClJLNf/dF55A/S0ZHuwLUg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_utils/1/full.distro",
+        "hash": "sha256-zOfj+AKqj96fSRYnJ2jtdX9jvAYsKqEWQVs4vE2/kMs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-tWiXPoJUXHGmZE7d+oS5hD5LfuqK6NQOKVPILFmvGLY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_voice/1/full.distro",
+        "hash": "sha256-7LzgcNLH1GyRY5wLULdId5BfFVFt+IPPHQ+esk/2n2I=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-s4fndo1YnagUsY1Nb9CLb/goaxID8+cPJKOzf0NAXh0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_zstd/1/full.distro",
+        "hash": "sha256-m6CwaCJQcpnR8ssPh0G3WiO9Q1mQXZW7asd1YVKs00c=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1010/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1009"
+    "version": "1.0.1010"
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-YuPWTFqMbxM0BtvYLqb46nXIBXxJhcZ6hvz3U+Mi6pA=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/full.distro"
+      "hash": "sha256-9eq0gqGesGYXCLsztSt9mf0laH/OuLhjCuOKRL8Xnp4=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-+0VfAA/9BP4DTHXDJ7pcem2yHuwSVd4tH8hsGCre46Q=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_arborium/1/full.distro",
+        "hash": "sha256-w4mPCev2fCDBLeozW24Aps/m+5kWAyVtYD55868lQzA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-9WlMhXNpu+JizKkF2z3suff7wMumhbAFAHTk1/+ba08=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_cloudsync/1/full.distro",
+        "hash": "sha256-BXIIi69tGkND16aykVut6cE8B/WiVe6/9mpPBBxVZ1s=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-zA1qsFzuANQnAF1wXhym9eZwD2sxbanHDUZXF51Eij0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_desktop_core/1/full.distro",
+        "hash": "sha256-gB3j55jhG/qh13itZ79Oiio2Ys7i61k5d4NIj9+a4d8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-r8o/AU5zxMiGx7kXcnbafj6GTPa5Kr2n3xee4ryFSdE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_dispatch/1/full.distro",
+        "hash": "sha256-OcokUI/f0Ra6JBC7xJ3+Icv0yyZlD7g1As7c718f3AY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-ZbaazM4RIwxrzzZJyDZx+Iw7rJ2oEW9e2XbXNDA/R7g=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_erlpack/1/full.distro",
+        "hash": "sha256-z9pwZyP59qIDZeojVaNgJohsu4SNstQliXvuIJjTWU0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-xUOwGyzobWjXbFJkgL9uqBIuaIjnPeEiJFRwnyNWBRg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_game_utils/1/full.distro",
+        "hash": "sha256-pBvHJOJ8LqV1yDY/AKhxl9+5CBuGDdZxNECQ+mzPPcA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-lpRh/qiO03VdgZPifdzsFVoGrHRC02fzu1xDXTlmYgc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_krisp/1/full.distro",
+        "hash": "sha256-302w/9D93ESPY3ij6vbOeig32nikoWDD8t8YoCPGWEc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-cRE2T8itmMSt4pyhVLF5BdNvab+7zrQzFbmVItAday4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_modules/1/full.distro",
+        "hash": "sha256-zDsZa17X3GIIGeNG6JBuTTyXqtqD2NiZRrmcL67oSj4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-tM1m9Z++9ocv86Vq51Mk3fV6gw7gXVro0s+KRYHiNv4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_rpc/1/full.distro",
+        "hash": "sha256-ndZwouBJpQHNDIWfuC/xvM2+fIIwrUutLAQwj+fNyXY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-AQNCD5PR+64533K6qFZL5ElJQ3DNNA9sTt5vT/ycNys=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_spellcheck/1/full.distro",
+        "hash": "sha256-se40Ubw07Fwg7VBIkvgfIzBIbpdWyOEAHHk+SrAk9Dk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-kbJsxsqrjoVajWCUDAywNQlEVHQ6Iyl6FjltvGenAPg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-PIzILnXT9d3mmIWHye/qriZE6D50b6/ti74Lxj1Ffzs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_utils/1/full.distro",
+        "hash": "sha256-l32yxA7h01KsBvc5wambNoyxiACacprLdJXnM5c0bxU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-Kz0npGXNghQEWNESWQVVeLomcBGz9/VOFgDbX0hPAZI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_voice/1/full.distro",
+        "hash": "sha256-vuX/J5+Br2lC+rsEnAWlrYivkAF7HKb3FG+xBO3HxOI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-B+kNjxDLa2fU0X4uEZYP0FG6erqkAC4Fdx6Bp4cHsOg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_zstd/1/full.distro",
+        "hash": "sha256-ZZ1cKzbxPKyu7Ku+T6iQ9Qrs9tFA++Yebpu02v9IkMg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.209"
+    "version": "1.0.211"
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-Jbe1c2lQC2ZboXx0lTR5MIuE70YXNstEDRSOa1AaGJo=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/full.distro"
+      "hash": "sha256-8gWwie6ns9oLR+YcN5Yo0Ml9cozrM6Ybg7IXg3hEir0=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-s4CrlXD5GOzFa5QuvIVbpIVXzTnQo7tToA84Jn2ROdY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_arborium/1/full.distro",
+        "hash": "sha256-W0u/dID213JCOtMxvINaGPRXRMfOkbqWxw2LYJM03N4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-2lfPTEVyLYo5HgC+sSJoXU43KaLUjMy4YvQI6TfURRw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_cloudsync/1/full.distro",
+        "hash": "sha256-kCFreXY3IBuMZ7FtqVSv4IAMzQYBNV4qplQZx9PlQlU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-HFAorKlSZ/Dru4CslYdy0pf/sFYwG4Ir8y4gtozmKW0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_desktop_core/1/full.distro",
+        "hash": "sha256-s7WzMCq0J6XacDErIvMfmIlt9McK00dNshz+w7VJ0wo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-ZZTfsK9fSK1DGuKVTSt09G9JacaJjJ/VY8kUCP9Iq/8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_dispatch/1/full.distro",
+        "hash": "sha256-PHjwOQ71MsbPTDSGGljPd9m4D471ImQp3a8obW7lod8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-VZcVF6+4Rz3f4kf/fO+UddoHyF5pUisBc19sj55Zz6g=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_erlpack/1/full.distro",
+        "hash": "sha256-vtd9yB9mK6twH74dgC7NuT2rVCr5ucjSv+11yCOF0Gs=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-kZa3R0JcdhjKTRSOAUwutLRgxf1paeB7wAaZ9Qr7hwk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_game_utils/1/full.distro",
+        "hash": "sha256-H3FM1Ml97v9MkGVCgYUW+mz2JOd9CZP/Dgzvu2rGOuE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-kpceuaumwlLM4ge3X/cFgpad2Jz780Z0zaLeZxAikX4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_krisp/1/full.distro",
+        "hash": "sha256-lCOK9yjqa1yLcSOdhILgW/kr1ZJjqxAdbo93/FnyNnk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-uAU0xzJcXNHbOmb7MRP6Y0uxbpY+o9feJqeIMd6+Xy8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_modules/1/full.distro",
+        "hash": "sha256-OC2VIUOXaiGcoqV8NOzW55z3DpRpdqfTBdni3wNyvlA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-y9qMa45isIIuMamURN8GnJR9IwJcQBVdjZ9y/APyVjw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_rpc/1/full.distro",
+        "hash": "sha256-GS/nOO/ec43OgYN744Gao4IHYWBPpznA1stk/BmPEqQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-rEDql1sShCczi93qFJQRC2SM67JUysjZ99WT3GSGOW8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_spellcheck/1/full.distro",
+        "hash": "sha256-oBGlUOrQ2/cW5EbTcTe31wvfm5V14gyBoStucMXDJqU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-8XatkwwkD3Sv49D8jWbBfzXB+ZTdFl/pxis0g34IeqQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_utils/1/full.distro",
+        "hash": "sha256-BOb01yg0+O3/k5CX0TKVaz8598HqcQp09R4vA60e87s=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-ahEm4vS8E2iviZg2OkC8wddnPtNdKWLLURHxVnvjA8Y=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_voice/1/full.distro",
+        "hash": "sha256-ib2a5g6Pr6YR+RUWYm4u929yTgWUMtMaETwMNaEal7M=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-twZ9vlBJMrqxGI6+jJ9LSrDyVA8R4d4jHMaSVBq+Dnw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_zstd/1/full.distro",
+        "hash": "sha256-QNYSCSoJJVKeV3w+AS6AbaVcTnIs6gMX1nek0tn/eoA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.154"
+    "version": "1.0.155"
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-0eSfGBiXwqkMU61ssjsXhvkFBumAkjdITlWL6tTi92g=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/full.distro"
+      "hash": "sha256-g2G2hLwYUiQBDHUiWKGH7BK153qnRZvySwzktOio8SI=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-Zn7+k0v5nHnih2cdLK/wJPWepojTzOU0wxtmXrDonGE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_arborium/1/full.distro",
+        "hash": "sha256-KNEcVAc7z4n9yPSi3LT+sZe3iq4J7QtH66OAJ473nqM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-6CpegWEs1dQpbfgPl6O0PIeKBVJXK6yMixMGWQF5yC8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_cloudsync/1/full.distro",
+        "hash": "sha256-0iKZk1fyyN5te8AUaC3H1gsOr/BGxhMwionpCgkna4A=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-JVBcxhVmu6FpHMlph/exCphc05vxQd61vFJHGYzge2o=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_desktop_core/1/full.distro",
+        "hash": "sha256-K4O77jQCWBh2nYjFhwlJCHzxmmuadouv3pqLN0q8c9s=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-t7jWDXKar67dGJ9jK2pgfqMoK/Jle+FVSZun6HGo5KE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_dispatch/1/full.distro",
+        "hash": "sha256-6T4HWFZpkGQcpwfVWMaw4sTpibG4wo1HLk8ZcmtBfvM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-BCoB0Rc/n+5h2oSkwggNHKK4OsDqs4bRv6PdaGdsmso=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_erlpack/1/full.distro",
+        "hash": "sha256-MNX10Hk1nzEq000t15Msg8hzmGCkby7z/I6b9LuR5Sk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-MGeX2vzmnr0NH5ydrWbBHALw6AEJAhIDlkj2lqtQj9k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_game_utils/1/full.distro",
+        "hash": "sha256-6znm3uE1Fl7ItuT/1OVRxP21kSYaDXkTIl1SNadWSSQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-hRonAfO181VG7D47a6s7sado/4UliuBmGoSTRFrQKHE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_intents/1/full.distro",
+        "hash": "sha256-titG9Z0eXKm2QnWm1xdPljUF7s3VBwM3kZN0Mwc730E=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-V0GXYcWxqnLf7W6BUWpXXRPbAn1V6QLjz6zHqUZSacM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_krisp/1/full.distro",
+        "hash": "sha256-9v2+nnjkQeI7RLt2+Q05zfGaKvchoCxRFciJFT5VrDc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-vNzSz1CBayfESmuJV4CVN+CTv0cWwHMhWeUa3w0xuYg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_modules/1/full.distro",
+        "hash": "sha256-LAc5uFvYdg5ruzmd2Msh3c7eegChFoIBXj8X7JYJVqs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-8eMZfw7I5cJ6r+ZqZQ/mwdXAXwEp/7o3JcJJIITPZas=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_notifications/1/full.distro",
+        "hash": "sha256-mxQb3Em0wDma8EXTN4cULjvW31JwVxDzQ3ne9FcKbC4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-A12BPHYO8QWfFhV+WIeok6VG1cc8JrYj6GM61VPVGpg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_rpc/1/full.distro",
+        "hash": "sha256-DXSY6qhtxW0S3rE9w5/KO85bsU7JP2ldx5tOoTwoptM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-1bOOriRzzHZjSL1ztV14c6KFSai5qDqyAD13agO0lq4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_spellcheck/1/full.distro",
+        "hash": "sha256-X5BitbmM9HnEex2DsRN3t56tLBRtkyeeY7rZ9QgoNdU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-SHpivOq+XZeEiU9EAfD2YMeIo10DvWDmzU0C0cm3wuQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-Pv5XFbdWFbU6eWXDW+zupqksD7avzqpLx1x9xXJ8QuM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_utils/2/full.distro",
-        "version": 2
+        "hash": "sha256-MVLPSCP3AxDs3DNFuwyYjlZHyA4cVErANFCMTzorGWk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_utils/3/full.distro",
+        "version": 3
       },
       "discord_voice": {
-        "hash": "sha256-0928JNCYg9G3I7eNENoxuTFacVINxw9XOi7uUsiGrMA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_voice/2/full.distro",
+        "hash": "sha256-mfoo7ZBsU/fRkHGxKk0j/i0qj2PnBnzdTSt8pI0t53s=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_voice/2/full.distro",
         "version": 2
       },
       "discord_webauthn": {
-        "hash": "sha256-lD6wGZtGq7lcr9TRonRXlcRI7qTozRFHiH14X/gUMq4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_webauthn/1/full.distro",
+        "hash": "sha256-kCeElNUwLB1yFrHTqP6W+S6/F5npRiYo5uH6M31uNxo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-/6Qw8tqF80RfPW9dvD0vuE2anPiyNo0yy3j9r9nkwAM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_zstd/1/full.distro",
+        "hash": "sha256-15edfIf+s9zPaYWYw7SPsUGXXFJK9LMGK6LzaDvSiyE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1277"
+    "version": "0.0.1294"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-h+90ma3vDxyFepJafVMPt+xnnwhlHp8xyWiEy4e8BtE=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/full.distro"
+      "hash": "sha256-aiZb5Qo4KODTb/U5u7Inm9hvRQX42TPbFdzMTpYgrts=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-0CSXXOysVTXkOIX+PGiLxhO5TF52RbnAeAdaUt8gIsA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_arborium/1/full.distro",
+        "hash": "sha256-Q4SjFrNy3nuZ1/4rLWPCUlldACMplBtSkwWIAbrjSPQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-OTFs1oZxifyZQCSawl15uwmUGEtdMmfn3IirfqNM7Dg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_cloudsync/1/full.distro",
+        "hash": "sha256-QKDTHJnZKBCVuVfHqzDDMJbdvDPcik3qCclLIXue524=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-ZdfclWKmnf4LDp3bZuHa8yOLoH/nQJg1HXY97yz2+Zs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_desktop_core/1/full.distro",
+        "hash": "sha256-xBRP8cj1jD1UADCV6eip2sFRXB2d6btRgx+iBd3PH0I=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-TdKvrQD5QEdU91Iuk6Bj0zahMHzebLp/+9iJ6YVcQos=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_dispatch/1/full.distro",
+        "hash": "sha256-+OKDT1aqFUGSD5JiIO0e9Yz7z6aQ/qIk9hjIU56HUAY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-8mo1PxrdfoACT0ue1Vnn+9V66iYWYo0sAKpbPV/Z9AA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_erlpack/1/full.distro",
+        "hash": "sha256-e+cefd+dWKo7z3x45ArWup69kWzwyKuthn987i2qQBQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-q6iYGIUMgn6ONBiP+uYB+NOoqtAIWf8kAJGHBOSPHCY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_game_utils/1/full.distro",
+        "hash": "sha256-k2ImnT4SJXOFiZS8RUMuzC2dWTJ3IaCShnPOelhd9W8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-cSWAEnxpiN2L3OqYo+WXW/CGgUs+fK0c5WqgwC+/PV0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_intents/1/full.distro",
+        "hash": "sha256-70AtvOqme2dhCSuW0jgg4R2buFyP4OHMLYlcYLC02MI=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-S7oaSuskr7Tlb//L6+oU9UTEnvME63h/UQ6WClPjr4U=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_krisp/1/full.distro",
+        "hash": "sha256-ro9SXvsx+R7fgGy28MjDpDJQmjfQGOL+o33jTdCVFmI=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-WvuQBFrzhJXvUWpeD44VTEWT9fx9SJShfBSvkI1G32M=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_modules/1/full.distro",
+        "hash": "sha256-aShM2lm6JXeuBJhcXyTdsipV0PrigHB39LD+VF+SIoQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-56laGA0e4UDYLDvympNDYhzYN/xpdXxZwOI7tQ5wQFM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_notifications/1/full.distro",
+        "hash": "sha256-NxtjCFJfFwEWLalUHItrxwjn4d+k7tD/ctXeId6Vyj8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-Hxkf9GgMO3oHZXAgrzVp14xunA+QPcq+esKiVaAhvJU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_rpc/1/full.distro",
+        "hash": "sha256-u7LOBuuF+4Yhybq7MQb8SVfGWSOL4Q6ma21JveVjs5I=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-VFwm5bLjYbbc7g4VDKHuO51/Hu9JQbvEGnm4SBAnf3U=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_spellcheck/1/full.distro",
+        "hash": "sha256-LfK6f9zdALcZ1T40eKVmTtKE7aHVJf+/SyU7taPd0XQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-VwNyg0v4Kmf8zYBKlvhqO2SY2yjX6+o8tXRvXqdpzhg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-7MIIqJEPA3Fw13kQS1mCoQNeKoOa9X8RlpwIjf1ug38=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_utils/1/full.distro",
+        "hash": "sha256-z5gHPTNh+ih42eDYTtZDau1NEYGC4tx5+vZGB2O83sQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-X7Ao2wuOSbYEjbVqLxHzWDq19QpVuKseo1lAUCSn4YQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_voice/1/full.distro",
+        "hash": "sha256-UPkxSLW1k2DZLl+WB6kIrXSqcyJ9Uk5GFVGnT5NPg2o=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-UoXmSxoU0lrk8KYHTlOY2pGYdNEp/E5dxINq/b3J5HQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_webauthn/1/full.distro",
+        "hash": "sha256-mb7XSK6X7uX4ss1hOLaVtItIwWXEBHEqpRK43XSV5xg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-cUu9IJje2A7eqGAOTYdCADN81zE2hZSH3hnWUsUynEA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_zstd/1/full.distro",
+        "hash": "sha256-esWD4Zaumd5Pcs5FueiJMAeifQbLm4oby4mR4xZqG+o=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1021/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1017"
+    "version": "1.0.1021"
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-w9wB8KPh6CthR9Yw2H+gFNg6fmv5PmLgEhtboWvhxZU=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/full.distro"
+      "hash": "sha256-mTArbvIvLjOSGpb35GO17K8lnCqAHd6fDdxpzwFKmg4=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-Jx1TGmpFWtE/679SdXmNiB+X/DOkoEz52LAESihTqzQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_arborium/1/full.distro",
+        "hash": "sha256-eySEVa1AmxNMG8P1cqxLFftrQjyzWrN8QInF8rUh53Q=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-dXNUW+/Y2GAChywnGvWY8B8f1kKLz3MDgvE5eEz7/rw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_cloudsync/1/full.distro",
+        "hash": "sha256-7/60p+KD/WIxA0ErfHUrSPXGxVTmyNiC9Kcu6WUAPsQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-F1VFToFXQ9NIUpO+kd6d01GYr2npT0m0Vm1S6kMWu1g=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_desktop_core/1/full.distro",
+        "hash": "sha256-xtxh0mvHKtAtohJptt/89DhEVpC1UbWloVnhvK3kmO4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-oYcIU26YlSLc18DdPvGEcMHJ9bnoumPLqjO2WZQwffA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_dispatch/1/full.distro",
+        "hash": "sha256-wi67HEYdj+bL+Zs+PrNkaMSfzjyGR0eMi0smyyvJoig=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-vd83Ll52GppTUerq9UN0lWg7uUkYiQdKNRyxwyMhmBk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_erlpack/1/full.distro",
+        "hash": "sha256-rhf2TnRJaz3uqFq2tu8JCIbUFdBHJFQWupn2BvreeiM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-X1wyM8qaJT5hidS65P+ndCUBlGFqDnqIc88g+es+Mos=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_game_utils/1/full.distro",
+        "hash": "sha256-3GlzC6GHnC+hb6YMWNcA9ly7g8vKMuMf48Xv04tpMMw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-oohGlWZ+6CMQ20hQuU5cfqs+0vZR6d1txcUxPOzK3Lo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_intents/1/full.distro",
+        "hash": "sha256-6cDb4uNVlpVTiqww03+74raqkOAbWgI0jS5xG0lgO0g=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-jw91Bv0gyok8a8NvJ1hBjhDEfgOnokIzoUZ2ZZWpWoI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_krisp/1/full.distro",
+        "hash": "sha256-jx0nK45QkHhkl9DMB81qwJw6GceFu8KPBcQVMvJKRXI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-0ikZoFZOkyYm+vRmBY4JII2f9uVpW5XK2fpDFTIXqkQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_modules/1/full.distro",
+        "hash": "sha256-kELcckM97k084WfqVyFaJb9Nmdp1UOsXvL8vfeyzDck=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-bR/hgTn+1YL6uQ9F+ApVbVm5KcF6gq3rY0XeGkUTLPc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_notifications/1/full.distro",
+        "hash": "sha256-lVlDGN+qYKOPKUgHZ20b5b36T0GNj2KyHzRQZclJ6w8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-38pYMWnIgynjCw1vWGq0N8zREa9EAyAwgCGCn9VpWf4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_rpc/1/full.distro",
+        "hash": "sha256-gwqGxzJPCBIoYTftUIUiTi7D1qtsdxDJgCIqM8MRifo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-FNrmbCafS3ULo2nYK2Rr4F7Zp10Yj17v1QoLB0timFU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_spellcheck/1/full.distro",
+        "hash": "sha256-SeglC/2Wp8DdSt7EAdxdEB4kfx7pAZdelv7OQYb0fz4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-PDaNTbEZxg4W8HteDJ1QSgUcpizvnRRLGkYp3YNiSkY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-guG7HpsqRInvA88VVq1k2FM92bQBksIGhyKoy6ayZLs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_utils/1/full.distro",
+        "hash": "sha256-zGNUOs+uWSAgAht56Oe6y5xgEhtaSKOLwVmNC0L6t6Y=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-tWMz0z32xTDh19o1/Ftq8r3u0P4UUuDqylvGO3T39NM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_voice/1/full.distro",
+        "hash": "sha256-pF3ki+YCVyrD/dL9aPCgylc7gs21MppkZOHROEiDm+w=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-VpoB4yt3BjaaCEzKT3saETLw55kVLFLwHsW0Wfato54=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_webauthn/1/full.distro",
+        "hash": "sha256-z+rVhzu+CL8nu9FfyQESkDbJBWVGHz03j/EGBc1f1vI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-fpCJlVh4JQoCWQDhc9gClDJ026xEJ5kkml8W0YvCgPM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_zstd/1/full.distro",
+        "hash": "sha256-5cNp0u8jlQYI9LBIbi3pmL7jm43tgD3EVq3bamPZSxE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.254"
+    "version": "0.0.256"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-4eUfTXY1D61HnGIJqYI1VC8qT1Ipxg1oiFKVyV+Qtpc=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/full.distro"
+      "hash": "sha256-KfWALYNAd/FX+LQRMIyCt69MY6J5jRS7gFg4jCl4fSY=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-EP2Wkh1PLyW7LAUJisYLRsQldoH2up4mRmoa4Vk0R+0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_arborium/1/full.distro",
+        "hash": "sha256-53S9PggFNCKdfQ0sYl6Mn5R5Kngg2/T6eElq9C+DN08=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-HmYxI3KpcOGOMaE/ECfaaOdI1kg+PrT2jHF4PGW7ZFk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_cloudsync/1/full.distro",
+        "hash": "sha256-/ySgAAJ0n2TWB/wbvB7OihFxRrC7NyTjQ1H4TqvWZ84=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-bxyIWGQkibkqc53asTFGdQiBH3OsH6QADp0JsVPmTAw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_desktop_core/1/full.distro",
+        "hash": "sha256-szNLjknsUqkkxLPpyJjEfxT46AUjM4g+DTMoPgrxBm0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-8IYg26rQe8vZmsHbLZXIcCHmq/0geIZ0GGh0ZWJIYu8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_dispatch/1/full.distro",
+        "hash": "sha256-UoWIZ1Uc0Q6YXSTzulJSWNjgdRyTiX54R05UTh8fTiE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-8bFghQQNHPuKC/ei3DvCFsZQ25D5BI54lqN1wYWPs0s=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_erlpack/1/full.distro",
+        "hash": "sha256-xlWB+o/sjHFLZVMFke9RCQt65lBVn/pUT8jNUUkfSyI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-9AWMVZ8gV8v3N1d0XHGL9XJJvYsb23ovzuGiOpMoixc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_game_utils/1/full.distro",
+        "hash": "sha256-Hqs0td1l6gWvdNcn0WA/DfADlZq+OT0+HlgUXiyvwEk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-64mNiwVeJBAAfPWz7n7nxsPbLD4RBtd2aJPOeNM9Kgo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_intents/1/full.distro",
+        "hash": "sha256-jKNBNIlXutv2ex6MuO8kmwkx7kcQ2uaIt0f/ogw4Vws=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-0ZUnE7LVixEi9YocAaHJZZLB3+1dsFkwYTkPnTjVtjE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_krisp/1/full.distro",
+        "hash": "sha256-7OizZzIYAlP4CmZ1kcpFc52ijT6abHYJ4KvQAhaG/J0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-Eaa41WNjsVDH7E7eP0xje9+FDsObprylN+jaXH23xeI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_modules/1/full.distro",
+        "hash": "sha256-l3obGjd4nK7DQtwoml6PvzmQnYaRu36xAEUjd0TKmIs=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-OTzoqfivxP6sRiiH8FXW+tbwnIQv3yfQAsfr7w2g7Ps=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_notifications/1/full.distro",
+        "hash": "sha256-8XfxczmmMq5w4HRLQnCjxjFV0fQgDwaEkcezXGd7gNU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-6Ik/T50MityBsfWdwEeZzW6diVPNdjJsvf2OjnyAuQA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_rpc/1/full.distro",
+        "hash": "sha256-1n+gO1c4SZrV2jOD2SVMCQYnHU8e5ErrB0eJEv8hvus=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-Ywd8DbFjOkaM+/VgyllYepZhaYYmIr1x0HVK1xA+B8A=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_spellcheck/1/full.distro",
+        "hash": "sha256-QPZOJTNAU5rShPeV4SU2P9eBmDEbLZHEwThyXdRPsLg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-+bvRepVC0gDfNIRTFzn6KOJLEyuIRi7zR+ILbUD/BHY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_utils/1/full.distro",
+        "hash": "sha256-PMv/psANJnI+yhGwsibWDdLGdlUQC8/Rh0h5nmNQfJY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-3oZ7b7aMLjovdBptrCzcCO113s+FKWheE5oqUzpuxHw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_voice/1/full.distro",
+        "hash": "sha256-GtnSgoFM1aGBLLLwaB/81iRhuQvuuNuvNehO3k/UP7c=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-U2PWtTh9MAsWmZPW0tX74AYgx5HI7Mb3LjcikJugnO4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_webauthn/1/full.distro",
+        "hash": "sha256-r0WinKYXuJtY0YWn2GHoFrUID1mwBGRMVVJOMLFGSOs=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-GkYJn+VWfPrEKXFqWNldTAqZdAXENsSrondtxGx/few=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_zstd/1/full.distro",
+        "hash": "sha256-pBA8Iyv1S7wePlvdNI4lj4MfY2Z8MPtiVaf6EBi8rY0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.408"
+    "version": "0.0.409"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,622 +1,622 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-ni3qAnuZkAGpIed7HwBxWheutuq31L0fA/j33Htoe1M=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/full.distro"
+      "hash": "sha256-YXwWHjQnqHIVHte3ZYJwONFukCd2KmseEmzKAZltw28=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-eRrm0Wt1amf95Kl//x3r24vllKrYPIxd25jfNpENz3U=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_cloudsync/1/full.distro",
+        "hash": "sha256-mJ8h1KC6JbqLhYFZ98Ko/0rHajxyFfeOVp0poazdHKk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-uFcI9sPYwav/+tgj7YvJy9oaxPOrtfmrAm4g/YM1zoI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_desktop_core/1/full.distro",
+        "hash": "sha256-nILxbgnowDmGgvl6evlBC11BNRhv5G88ni4uvgo+VhI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-TrQYkG0tslUVVeu7KNBgeMZp5MZG0b7pzn/ZiWdrl1o=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_dispatch/1/full.distro",
+        "hash": "sha256-HndezvELozyQ77lEkkTNn7Gl7V6czWOZq8EyfJBVdVg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-7hpiYvaq91vIEft7k5x1uGOzEvQoZiyzq+QsO1+Zaao=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_erlpack/1/full.distro",
+        "hash": "sha256-vM6OYH5yGTRigIyg36Y1KKg0WtNq9Hd5hmdX9r72eyQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-2nOjP4q+vhUbslPx/SEw3ALeEmkbuAkO9WZLJsvtALc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_game_utils/1/full.distro",
+        "hash": "sha256-5b1mNvLLrYCtcNHn0vWAlfEns4DVJVsdLlu/fhGbfQ0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-SdrQxeuUr27dr7BeQXB36LBZ0e83vGPb3ByO1de95wE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_krisp/1/full.distro",
+        "hash": "sha256-W1tDAyW0lD9dG7G9Mm3Az5FUsR07oGXgR0yeKbVzXjc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-qXkXb4e44ob0zrpItysGhlYhczSCQ0zfWFopQulcsmg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_modules/1/full.distro",
+        "hash": "sha256-TlBDD+sSlOIYpnYZ35vE1WyJl/1qHOFzhcfLLWWb0eM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-vX7rk31R/QVpa33eSsqAEAUeIBkCy8vx76MB5W3TkGQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_rpc/1/full.distro",
+        "hash": "sha256-8sRdHH/lcfjKMvspohhV+4qz0LYIQIox87bKA/Vwe80=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-399bwv2grdhPXjh4raNGXMLg8LZmiOC92pJB1XZ86Kk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_spellcheck/1/full.distro",
+        "hash": "sha256-3ap4R+mraQPUySPP0Uxc5cvNv6X5646GWFP9tYMxa2I=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-Xz0DNvZc+HwGsovz9bWQXhx0UolJhRTbmJfj6WGmQ9E=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_utils/1/full.distro",
+        "hash": "sha256-hhZQW48n2k4RiMwMrpKV2RVPw3OI+M4nYN1Q4rpnTgY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-pSxb6hIWfX/3c9U8gZ9IVZ5r2ck9QONkkK3BIy584eY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_voice/1/full.distro",
+        "hash": "sha256-MFDCDC3gBjRpXdre24TLCLre78ETA8klca1Op8heTRw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-naSJ+jJqIS3cRs3im3Z1d+wptYvSfloSvtkWjd8hx3A=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1361/discord_zstd/1/full.distro",
+        "hash": "sha256-9nSczIYl6rR/Z4jxqA1/2/z79uHdqyNTSgoCJbNWDlM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1361"
+    "version": "1.0.1398"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-nuuKzByzGh8I2VoVUSAOiiwULYpXWKBBScyBvr31Wlk=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/full.distro"
+      "hash": "sha256-1gqCetK6SEW9h68uvvbdQdG3/aeSEBAcSFWeR5HWAzE=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-kYe2Ytbr2NhSA+K7ZtbTuSYHXb7rYt1KC0coKkEs5l0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_cloudsync/1/full.distro",
+        "hash": "sha256-++Fr9fxL8TycHVPJGHgNwLQbGj/plLbCVV0WjBFKfWs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-9vJj0Kj5PDWuGAjv/uF4kBB2oxQux7R56QrfVnw5Oi0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_desktop_core/1/full.distro",
+        "hash": "sha256-tUeNfyHYRlSVlo9z7no7DvqpYME/sq9OSuat61IhArs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-0RyujN2tWt4NteAq8nqL4rh1ym/uVlUOW44sveWnoyo=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_dispatch/1/full.distro",
+        "hash": "sha256-cX0KaUlY4gRy3seF9O4PHWr5gBrEWfMLJEIaxzzhYJQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-ks/bDNwSRghbyXY3/YgU+KP6qXCf+BMwc1KwT9d+Ma4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_erlpack/1/full.distro",
+        "hash": "sha256-+AEkr5uLoxH3puHYXHTT5GmmC8foCUTSrpFhMuThNLo=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-TdnRNffj+m9Wi+p2wOQ8S1mOim83bCUqETjL58y487I=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_game_utils/1/full.distro",
+        "hash": "sha256-teskTOsRJweCYeTvxS8PR5CEX4EaGm8tU/oseL4ad1s=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-skPhdRKA0Go6dY3lyUjzmHZ8Fs2ES2UTyXOcLaM68ao=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_krisp/1/full.distro",
+        "hash": "sha256-k6oid+zDm+yfUTtSZY1Irm808zUa/5s+J4OQHPEI+1M=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-rEneOm4sS1WqBR9vQsF4Cwsmzq7UX/1uly0OMRQ+dBg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_modules/1/full.distro",
+        "hash": "sha256-8iM6E+UQMOIXfFjqIvJb+VdfT5wF49gvKU4tX6lc3/Q=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-k3H+U1kSWjHecyekhHs3E/op919y1eBHW990xagqaQE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_rpc/1/full.distro",
+        "hash": "sha256-wxiU4kGdLfpBA5MqLvGnzvlCutaSErRl82SEaL+Xn/I=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-KOLicqkKK/0A+X+qfqQxjqjhkdn5iUdb/itqQ8yuW8k=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_spellcheck/1/full.distro",
+        "hash": "sha256-9r7wsEAg0LNbL1FbVJl/3pJ65h4nuSSnpUUy2iC7gMg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-C655mfym1fdVRMZN+RN+vOZDNWBOj+o0D+BLwCBpFhc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_utils/1/full.distro",
+        "hash": "sha256-AcPgnX4VhD+n9cTGru0qsOC838TCmjrtjtTNI86/Nts=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-KiNXS5WzULeVY1TFzKPfSUFKtAe8cClyuXmBz/oO164=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_voice/1/full.distro",
+        "hash": "sha256-UIruTOyO62eFeB7qfabr5rEhwzwd7jNUCqKtQnVfB7E=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-TjE3qZmPtANGvKNo+CMA8ISml+wXZHXzsp0puuDk4RE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1000/discord_zstd/1/full.distro",
-        "version": 1
-      }
-    },
-    "version": "1.0.1000"
-  },
-  "linux-ptb": {
-    "distro": {
-      "hash": "sha256-o3DyP4F11335gkhQxylAoUfF43w217o+pR4oQ584jKo=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/full.distro"
-    },
-    "kind": "distro",
-    "modules": {
-      "discord_cloudsync": {
-        "hash": "sha256-XfAxWs7mTPKBsIti+mXJyJSDlrr4TKOEakhIzqU+kvE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_cloudsync/1/full.distro",
-        "version": 1
-      },
-      "discord_desktop_core": {
-        "hash": "sha256-mLwc2i1OlAl0HpNq2AumyNGyS9msSxat5VJFiEx+ujU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_desktop_core/1/full.distro",
-        "version": 1
-      },
-      "discord_dispatch": {
-        "hash": "sha256-snXP8JiX/xSkknUl/Bxn78/F+GRQcTTQ2hcMkdyaY3g=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_dispatch/1/full.distro",
-        "version": 1
-      },
-      "discord_erlpack": {
-        "hash": "sha256-Ft1QEulHnhA95Oeyb5GUszgJ9kK+9NPO0g+HaUxrlLo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_erlpack/1/full.distro",
-        "version": 1
-      },
-      "discord_game_utils": {
-        "hash": "sha256-6+0U4X6565a+KVZ+ddJZhb7/SAuyqcPTEMnAJv+QLHU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_game_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_krisp": {
-        "hash": "sha256-oJI84UY7a2jIK81l3OMxuuSI2mDN2/yNGYvNIHORkuE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_modules": {
-        "hash": "sha256-0u32Hvz7thSLeSAvbpmHCbkoCyJR/ayTM2s5sd4RPeA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_modules/1/full.distro",
-        "version": 1
-      },
-      "discord_rpc": {
-        "hash": "sha256-CoPZR7yuDgra0ScN2MPuMdbQ7Cmz8WkLkPzFFeCkJKA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_rpc/1/full.distro",
-        "version": 1
-      },
-      "discord_spellcheck": {
-        "hash": "sha256-AEQv9lXxcSqnZVLXjW1H4thqs9MUXVkk37nnANqJfQg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_spellcheck/1/full.distro",
-        "version": 1
-      },
-      "discord_utils": {
-        "hash": "sha256-LTv5H+gSY3ALbxWGdgmETk4a10I6Rnjsx/HKmkVn10k=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_voice": {
-        "hash": "sha256-52AparLkD9nYwcmQDdZJ83v08zwC5KeDq3YzcVPrTuU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_voice/1/full.distro",
-        "version": 1
-      },
-      "discord_zstd": {
-        "hash": "sha256-3CKZhGPKs5KWXeNDJcIQgMlLcQtoJSnG5WAXsgJqb+k=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.197/discord_zstd/1/full.distro",
-        "version": 1
-      }
-    },
-    "version": "1.0.197"
-  },
-  "linux-stable": {
-    "distro": {
-      "hash": "sha256-fgtszwNLSypVpcijOLc1QPgsRWkq743qpsZjv+iBtBQ=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/full.distro"
-    },
-    "kind": "distro",
-    "modules": {
-      "discord_cloudsync": {
-        "hash": "sha256-waCBE5ch939dUHBvn/MXXqZMfUsilU0ibdxV5WoPY7o=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_cloudsync/1/full.distro",
-        "version": 1
-      },
-      "discord_desktop_core": {
-        "hash": "sha256-QLgMl9F/fGsGUBJztzRFcp446KEbCQa046fRaLFn+tI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_desktop_core/1/full.distro",
-        "version": 1
-      },
-      "discord_dispatch": {
-        "hash": "sha256-njLo5N5FC9YSvjQ9rQVN+9qrOWXKvzaaHg7HNwPKi+k=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_dispatch/1/full.distro",
-        "version": 1
-      },
-      "discord_erlpack": {
-        "hash": "sha256-aBQFOhy1vTByxQg9DqdEZyaH/oOlyWf50aMLFSifbvo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_erlpack/1/full.distro",
-        "version": 1
-      },
-      "discord_game_utils": {
-        "hash": "sha256-uVkKc8hK8zwK1LRs5GqdOPlpG++s+qaZyMcHFV2gnXY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_game_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_krisp": {
-        "hash": "sha256-mgXOsvsFFxeW50Hk9/64DDf2I2OoaYY4SRs4N5azC40=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_modules": {
-        "hash": "sha256-L2Ab18BnUJedBVpcoAt9XJ787ahQhipUIlLMtfMuqkg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_modules/1/full.distro",
-        "version": 1
-      },
-      "discord_rpc": {
-        "hash": "sha256-CQgtSoNNXqGsB93fzevcNm8mvlEdzGcJaaNKGLSNN08=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_rpc/1/full.distro",
-        "version": 1
-      },
-      "discord_spellcheck": {
-        "hash": "sha256-1Jzi0SXWC1v6b4caHncezrQlcV8zawESLG4hNYjY4to=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_spellcheck/1/full.distro",
-        "version": 1
-      },
-      "discord_utils": {
-        "hash": "sha256-xUZ4IeTKOxLlrYOem65p79ZOGpn9PAf1ao3G8rSoAe0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_voice": {
-        "hash": "sha256-s5GQ+z8hv1wFbXp2wtbLcXBhLRqnZTZ0U1f+vySnw7c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_voice/1/full.distro",
-        "version": 1
-      },
-      "discord_zstd": {
-        "hash": "sha256-T4RWIOHUEa+MgKMwEuChMPTRVsA+fsUxbPiNTOz09eo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.144/discord_zstd/1/full.distro",
-        "version": 1
-      }
-    },
-    "version": "1.0.144"
-  },
-  "osx-canary": {
-    "distro": {
-      "hash": "sha256-NM8ysudNqHPyrNmvXO7ofFboF7NB35Nov7U+ZQ6UTX4=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/full.distro"
-    },
-    "kind": "distro",
-    "modules": {
-      "discord_cloudsync": {
-        "hash": "sha256-DmI/ueI9ipGrP15u6QW3FCaPaNqnpGaZX/NjMmMIPPY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_cloudsync/1/full.distro",
-        "version": 1
-      },
-      "discord_desktop_core": {
-        "hash": "sha256-TgMaRoog6g6Iq2T7ZNGjsYknXB3KCkC5aWOPfyOYjfU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_desktop_core/1/full.distro",
-        "version": 1
-      },
-      "discord_dispatch": {
-        "hash": "sha256-ttvbzwaEJqo2PIDJe+9Uo5F8cdw0P6vVbEniL2Xnl7U=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_dispatch/1/full.distro",
-        "version": 1
-      },
-      "discord_erlpack": {
-        "hash": "sha256-zFhQejW9guxkweMF4mNO7SibOpsqJA5aCxhBhLFuCkI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_erlpack/1/full.distro",
-        "version": 1
-      },
-      "discord_game_utils": {
-        "hash": "sha256-oS+b4kNxlTsfoGq3C7YiEQ+wG5ObP68tGA3nQkcOQis=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_game_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_intents": {
-        "hash": "sha256-gFB6rMFv1pRl3ErMjcPSLHroNqKGr2cJGtHuBXvrAng=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_intents/1/full.distro",
-        "version": 1
-      },
-      "discord_krisp": {
-        "hash": "sha256-aSPV75YMuLiBrsQWhevHy5Uhx6AEOkw7VpPDT9yHnLk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_modules": {
-        "hash": "sha256-ZEGaNJd39XuvaCUieCTcpTrh4k/vyuRHu3y1jlyM+TM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_modules/1/full.distro",
-        "version": 1
-      },
-      "discord_notifications": {
-        "hash": "sha256-mqebBEAhJz5ZVFfZg5mn5gg7+SkbA7Pwy/zvj1qWOKs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_notifications/1/full.distro",
-        "version": 1
-      },
-      "discord_rpc": {
-        "hash": "sha256-6fAlGCxAVFM4ji4ltda9g/cgK7l/aoZGLTMXm2iw/GM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_rpc/1/full.distro",
-        "version": 1
-      },
-      "discord_spellcheck": {
-        "hash": "sha256-joJDIn45czpwIubDORmqA8lmuMGqDaHyurRA35TVT9I=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_spellcheck/1/full.distro",
-        "version": 1
-      },
-      "discord_utils": {
-        "hash": "sha256-gCT6sf5cdU7mvcaQlD5cp83D/7jeB5+87qj+0VM/YTE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_voice": {
-        "hash": "sha256-UmSb70MsfOKJOWqokkOyRYPn/GDgClPcj3D2fMcK/fA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_voice/3/full.distro",
-        "version": 3
-      },
-      "discord_webauthn": {
-        "hash": "sha256-An7ZWBn9u09NhNLOtmwmtjvDFea/1rla9zxpKlq+m24=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_webauthn/1/full.distro",
-        "version": 1
-      },
-      "discord_zstd": {
-        "hash": "sha256-NJuBHVhohDypwdfZajdPUs1Gz+py6aUxHI/XrdlRTs8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1176/discord_zstd/1/full.distro",
-        "version": 1
-      }
-    },
-    "version": "0.0.1176"
-  },
-  "osx-development": {
-    "distro": {
-      "hash": "sha256-BzMlo7SCoBk33n9IpdGHUHvKgIFc10zsWHd1i+/DKEw=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/full.distro"
-    },
-    "kind": "distro",
-    "modules": {
-      "discord_cloudsync": {
-        "hash": "sha256-X7FtyDk0TqrzNlViZprjPvjMVus6Hmk97UW8R3fZiIg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_cloudsync/1/full.distro",
-        "version": 1
-      },
-      "discord_desktop_core": {
-        "hash": "sha256-wKiWAT91u/JoJyPJmxcLWtfu2cQX8pWrV30ykU3m+C4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_desktop_core/1/full.distro",
-        "version": 1
-      },
-      "discord_dispatch": {
-        "hash": "sha256-zIUiL1lmdgP2MS4rf/coEBOGHMXLdNn3P2TE/H195Sg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_dispatch/1/full.distro",
-        "version": 1
-      },
-      "discord_erlpack": {
-        "hash": "sha256-hanEeOs3ViiDbRCc1ykpK12ZqvclKsOZzmROtOX0Fas=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_erlpack/1/full.distro",
-        "version": 1
-      },
-      "discord_game_utils": {
-        "hash": "sha256-9oPfmprVb7/XpMrJY1GI7W4NIBDWWFxRvRdSQWMZbHM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_game_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_intents": {
-        "hash": "sha256-cPJDxZEIxliBN3vRVngVaKAXFZxKX5fIEqTc+ftgb6E=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_intents/1/full.distro",
-        "version": 1
-      },
-      "discord_krisp": {
-        "hash": "sha256-6goOzUIqmbR4Vq9hQKDtMSm4RFtHKe/jl1nZkIc3w4Q=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_modules": {
-        "hash": "sha256-Fl1AC68OgtJowO2HrDGH2FmVW37g7dsMPT+sITJlwd8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_modules/1/full.distro",
-        "version": 1
-      },
-      "discord_notifications": {
-        "hash": "sha256-7/XpDcGt/sr5FiQJg+WL8Haq6I2kUrAm/IsLM+Eyr04=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_notifications/1/full.distro",
-        "version": 1
-      },
-      "discord_rpc": {
-        "hash": "sha256-FSv/9IZ2fpv2o8sQh2xKUD0By2cKrx0COQM54WJE+n4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_rpc/1/full.distro",
-        "version": 1
-      },
-      "discord_spellcheck": {
-        "hash": "sha256-S/YCcm66IX+lK2uXgWEcAwYH1Jc74nbjJIuaQUn3fRs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_spellcheck/1/full.distro",
-        "version": 1
-      },
-      "discord_utils": {
-        "hash": "sha256-3SIxjSMZneurupQswe9kSMqU0q+upssWResqxt7FKYo=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_voice": {
-        "hash": "sha256-s6eUlfKEXpVjTSZULUieB7ooqSwRl7PlfPGOSDlEj/M=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_voice/1/full.distro",
-        "version": 1
-      },
-      "discord_webauthn": {
-        "hash": "sha256-6S73R9eRsl6Lr5qpMsikUjJDbdtpD/iK0UxF/jHGNvA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_webauthn/1/full.distro",
-        "version": 1
-      },
-      "discord_zstd": {
-        "hash": "sha256-rJI4bRdFFICw/IEhXqbYMHRtor38jsQUJIT5pWJ3KJA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1001/discord_zstd/1/full.distro",
+        "hash": "sha256-ex0pjGnH8RgssZ64kfX+AA7f4THmPNUFb/pMiOZruX4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_zstd/1/full.distro",
         "version": 1
       }
     },
     "version": "1.0.1001"
   },
-  "osx-ptb": {
+  "linux-ptb": {
     "distro": {
-      "hash": "sha256-ov4G2IhHCiT0f0xHMP14FVtjTgj0w2Z9QHhafASxzl0=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/full.distro"
+      "hash": "sha256-l8zQPa9N2lzJ4Rpsuhr8EsyXkwWXVTU0L7fm1+RzOJs=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-ux9xyW1nk7is1mWHGnEYoSKpcQIodLT3vrE9XZ+TwXM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_cloudsync/1/full.distro",
+        "hash": "sha256-qrdzHzhRaPSOdbAf2O2XqOUOMouh7HCMcTF5PFwBqBE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-Mcfi2LRrGGcT16ujKcScAcJibmQFr81ZaRwCXn4ED4Y=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_desktop_core/1/full.distro",
+        "hash": "sha256-pA3U5WSNeH07RYpeer062khjGk9B1fLwlmGFRiH0XSY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-hpBNT4OvkGCKsY/ZYkXkedtXHN1j11VEnuvyPIXZNPc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_dispatch/1/full.distro",
+        "hash": "sha256-n0QRUZgqF7t0mTaNn44bUw4wo5YJwBt/nrfawpDRjGs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-S2v53ysW2HBQupTRDrhfTca+M8B8pI1H7fcfUC/xgLI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_erlpack/1/full.distro",
+        "hash": "sha256-OeYaeB6Uwtie9Gh7wEIXbWrzI3PRzForP0mBLAMdrSI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-MIT8bD3qMmaJ5Oow7DhvP60fTOHPxiOqPjU6WEI7gwY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_game_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_intents": {
-        "hash": "sha256-BFfWqSs/Bo6cRpvqcvBPnM2w96Z7ryKB6ReUMwhx57c=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_intents/1/full.distro",
+        "hash": "sha256-qG+kR+IxMa9+12anqeuLaAQJdtgsXhItWUVIYvlNHmY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-4Pf2e5+mi6zqwbziREyNVd31M1na4OAaL2g/+6bDhyk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_krisp/1/full.distro",
+        "hash": "sha256-UrTU83pYGII+URgwqgBCAWBUV7U2dH2Cyhc3O6IZkEM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-8sr7EnrI5lxpRliROu7lSbAQsSLt6Fusgx4sARVHaDw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_modules/1/full.distro",
-        "version": 1
-      },
-      "discord_notifications": {
-        "hash": "sha256-Hvmts1uF2nYu2VzkNb34ZT2ZYE7w5e9CdiZq8C420aI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_notifications/1/full.distro",
+        "hash": "sha256-KO+26TE5VHUnrdEwXYfYwKrwVZePmmlBH/tGL77gyq8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-exZK9KCHCKWc1TUewlqqMr9pYngA+V1XmY2+KpvbScQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_rpc/1/full.distro",
+        "hash": "sha256-iphB/rQ7Wx39EqpViid9MgOG50gH5BxsPARPDkJXhkM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-7jkHZDdMh8Gb0t0w4/JET7M4S6YLr1T947YsGLQAw/A=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_spellcheck/1/full.distro",
+        "hash": "sha256-OzYl5D/3F4T8TOdAtv8EcL+B2Jb9avlG8iSD18WsDss=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-ZYZnxE6/pZ4EFJR7U27aAcs/tdgMItgHEMtuaJOkVm4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_utils/1/full.distro",
+        "hash": "sha256-lfkvyLXha83pV/H9NCf0+8ky+PK6AuNmW9zKj8lCmeE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-YqR41JkdIdm7iF4RzJYuyCHKnomQzB62WVTK78aGSDw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_voice/1/full.distro",
-        "version": 1
-      },
-      "discord_webauthn": {
-        "hash": "sha256-baHBDixswYR0dxa7pW5/AAreI7BI1DdRNXYybIX6SZw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_webauthn/1/full.distro",
+        "hash": "sha256-BH+AGzAKJulallcT1pP06xC1Ib8t0Rq85rMWJujWQDA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-U6KhPVxxPbUuKWEbdp+GXIRTvMy+KLJR4l7eB+YiOnA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.241/discord_zstd/1/full.distro",
+        "hash": "sha256-HleJ0AvFtKKxBqWn3UAVRHBFMQi2fdHoYCPimCDmVJc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.241"
+    "version": "1.0.198"
+  },
+  "linux-stable": {
+    "distro": {
+      "hash": "sha256-DOc00KaMDkG0ggfeB3XaoFNDLB5DNFCsy0LpNcRTSNo=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/full.distro"
+    },
+    "kind": "distro",
+    "modules": {
+      "discord_cloudsync": {
+        "hash": "sha256-zrREHNdv2oD9IiYroQwmwGCXoGopJ9FOPtfzJZEtJQ8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_cloudsync/1/full.distro",
+        "version": 1
+      },
+      "discord_desktop_core": {
+        "hash": "sha256-jz/qQx+B1HraLPc+cuWeLMI/yJEx/OGPWdSBctqmjE4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_desktop_core/1/full.distro",
+        "version": 1
+      },
+      "discord_dispatch": {
+        "hash": "sha256-jjSf/9zBWqZ90HskSd2x0Kxi7dy2Yd2wdpO7q/ksSVE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_dispatch/1/full.distro",
+        "version": 1
+      },
+      "discord_erlpack": {
+        "hash": "sha256-gStY1JHxI7NVZ+ZrRIFepDtGmfScaQYv/UF+aumnkxM=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_erlpack/1/full.distro",
+        "version": 1
+      },
+      "discord_game_utils": {
+        "hash": "sha256-7UMUAB48PFnGPrzQE5bbdT5dNk08+5I/TIIFj4Sog3U=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_game_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_krisp": {
+        "hash": "sha256-DsnIrErojTUd7jN5YNoE2opqFC34ykKP+WkcU0TksFw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_krisp/1/full.distro",
+        "version": 1
+      },
+      "discord_modules": {
+        "hash": "sha256-3awhenotD42Frkp6RZx6QwzCyOmpXIznasG2ihGjiDs=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_modules/1/full.distro",
+        "version": 1
+      },
+      "discord_rpc": {
+        "hash": "sha256-OT/o8zvHG2QaLvme3F9QhB9qrfadX5iUAYKIPdkAjgE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_rpc/1/full.distro",
+        "version": 1
+      },
+      "discord_spellcheck": {
+        "hash": "sha256-GWRqjMnJBeZi5aR61s9BieoEoc6IYxRRxgRw+q0xdh4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_utils": {
+        "hash": "sha256-AJftqpwcrGzu203HgucYHDYGkIWEFhU0eKYHSgF29zc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_voice": {
+        "hash": "sha256-ViHQZnR6mxYKH51n63TJjniaJC63dxpNI/m60uV88dc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_voice/1/full.distro",
+        "version": 1
+      },
+      "discord_zstd": {
+        "hash": "sha256-HpB27U60HXn9rNu6Mi8JLzWZ0DGIUKZJh1r91myTBg4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_zstd/1/full.distro",
+        "version": 1
+      }
+    },
+    "version": "1.0.146"
+  },
+  "osx-canary": {
+    "distro": {
+      "hash": "sha256-MABVLE+3vnmBCmhHVpJqIKpxDBzj7N5ulcNBqWDUp94=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/full.distro"
+    },
+    "kind": "distro",
+    "modules": {
+      "discord_cloudsync": {
+        "hash": "sha256-fLocipTy9vP6rf4XjaFuZDUQnWoaakmcbjLYOnh5OFg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_cloudsync/1/full.distro",
+        "version": 1
+      },
+      "discord_desktop_core": {
+        "hash": "sha256-1IJai0qH3RVA5jkzqf1KkCZlz+1D/KNBRGf8HlUGZWY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_desktop_core/1/full.distro",
+        "version": 1
+      },
+      "discord_dispatch": {
+        "hash": "sha256-L95JqWyryZYAKuOWUZ+gexgTlziWfl41hopVBVCqjLs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_dispatch/1/full.distro",
+        "version": 1
+      },
+      "discord_erlpack": {
+        "hash": "sha256-xb3fxy6MqhnqN1i5HTJi3L6GPYxAPvfkahtMV0WlT7U=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_erlpack/1/full.distro",
+        "version": 1
+      },
+      "discord_game_utils": {
+        "hash": "sha256-HsqjBvYiBkJ/xjmEhX+TR7UkokxnLe3LEPOEBB2RHd4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_game_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_intents": {
+        "hash": "sha256-gEozULgI4A+iNcIabHmB1iWH+LNQKQnSTId+/r2X4go=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_intents/1/full.distro",
+        "version": 1
+      },
+      "discord_krisp": {
+        "hash": "sha256-6W7CuREYkbZIRAaFHxkTNPLl6ScHDej2NWnmcTEcgpY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_krisp/1/full.distro",
+        "version": 1
+      },
+      "discord_modules": {
+        "hash": "sha256-kpLahPp2iWcFBHJgblEg9g/lk19e6os/Kz//Yl5oge4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_modules/1/full.distro",
+        "version": 1
+      },
+      "discord_notifications": {
+        "hash": "sha256-RvSKe1XNvXqoE/MPl8/9bOhA+tW71cnc7EYd/L39dKE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_notifications/1/full.distro",
+        "version": 1
+      },
+      "discord_rpc": {
+        "hash": "sha256-dGLMa/SYxy4RPrqfj6oVF2i6xrFZbgkv08kaaVl7uXo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_rpc/1/full.distro",
+        "version": 1
+      },
+      "discord_spellcheck": {
+        "hash": "sha256-LqyZA0KhqLrbw8Scw1Ctt8VPcE5sbOnTEQp29FMqiXg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_utils": {
+        "hash": "sha256-Mab3V31DCfao0Hpe7p0aBOpWAiYFNay2FcBIO3ENL28=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_utils/3/full.distro",
+        "version": 3
+      },
+      "discord_voice": {
+        "hash": "sha256-s6xAtPnD24uGEuvfHgtySWHIgSbtMhihfxdmWWSgED4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_voice/1/full.distro",
+        "version": 1
+      },
+      "discord_webauthn": {
+        "hash": "sha256-e0K4owkgsogjveuWlvXSpvmT0Roic0Udz1aN5lAm4ME=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_webauthn/1/full.distro",
+        "version": 1
+      },
+      "discord_zstd": {
+        "hash": "sha256-DfwIq15/ymRoPTHWBPmMtOZnfplpeOflFTUixq33bf0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_zstd/1/full.distro",
+        "version": 1
+      }
+    },
+    "version": "0.0.1187"
+  },
+  "osx-development": {
+    "distro": {
+      "hash": "sha256-Oh7Z3Vgz6X94gouVGH6ZK1cyY8xJB5sRD4SGV0bLJGU=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/full.distro"
+    },
+    "kind": "distro",
+    "modules": {
+      "discord_cloudsync": {
+        "hash": "sha256-f7oEWFia4x12EzKdsedVXF/SRRqdcrD+I8jqs9zrKkA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_cloudsync/1/full.distro",
+        "version": 1
+      },
+      "discord_desktop_core": {
+        "hash": "sha256-v3rQ9qIb/n4YCKzmajU0IDHz3hV/y+k+KytmQ/YXmLk=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_desktop_core/1/full.distro",
+        "version": 1
+      },
+      "discord_dispatch": {
+        "hash": "sha256-SHfcGs/NBldbjbmL0BJZd/WTYom6AcVG7I5m7ymNPZc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_dispatch/1/full.distro",
+        "version": 1
+      },
+      "discord_erlpack": {
+        "hash": "sha256-Y7BqeSkpZcyOpkI0GJyw6WZUBJRYoVL+bupbf1SojPc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_erlpack/1/full.distro",
+        "version": 1
+      },
+      "discord_game_utils": {
+        "hash": "sha256-4ZMhl4mCSkHHjyqz1t4x2uGmLa1X317GzFHrWAxqfuY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_game_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_intents": {
+        "hash": "sha256-rhubNaouXncxstHF6AMbp8rF6GWVZwP9466jPYSFRK0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_intents/1/full.distro",
+        "version": 1
+      },
+      "discord_krisp": {
+        "hash": "sha256-AJy1HPU6gCkvymmF0VJtioJ4b0iWl68LK6oD3ZqPmlM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_krisp/1/full.distro",
+        "version": 1
+      },
+      "discord_modules": {
+        "hash": "sha256-1b1JyS8rk0roXq2Pj38asbtqV0Tv54QN51ayHfMfQFg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_modules/1/full.distro",
+        "version": 1
+      },
+      "discord_notifications": {
+        "hash": "sha256-K+qPQAS+a+Aw62XTQRT+QKCXhMCcTyXidXgfVlQW7gM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_notifications/1/full.distro",
+        "version": 1
+      },
+      "discord_rpc": {
+        "hash": "sha256-1pmg/bEY+88kB2YC5wLpaGGqKiT/B3XYbadUVsBmna0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_rpc/1/full.distro",
+        "version": 1
+      },
+      "discord_spellcheck": {
+        "hash": "sha256-xIB3D9YXDlsquJZYEkSu2tMtC/J+NGe/seHN1UwVGGM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_utils": {
+        "hash": "sha256-6C0B2Vylwjhx4H1W2LkgUgrzwyNDDwFhM6nOOUn5tGY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_voice": {
+        "hash": "sha256-Bifs4a+ezNg+wLIyI4y1F8aXMNifq4XcPlnh/GxP73I=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_voice/1/full.distro",
+        "version": 1
+      },
+      "discord_webauthn": {
+        "hash": "sha256-pcowWk2E/oeisZPUvzpgUChv0SotEjdlwvo4DSDmiA8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_webauthn/1/full.distro",
+        "version": 1
+      },
+      "discord_zstd": {
+        "hash": "sha256-RO25Js1nsUR0Mjakjebvk+xA0qSq8csgyu7Goqm7Dm0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_zstd/1/full.distro",
+        "version": 1
+      }
+    },
+    "version": "1.0.1002"
+  },
+  "osx-ptb": {
+    "distro": {
+      "hash": "sha256-8rGN6l46T86ITq5sietYgvzBXmXoT6nwzjMnuuQSjZA=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/full.distro"
+    },
+    "kind": "distro",
+    "modules": {
+      "discord_cloudsync": {
+        "hash": "sha256-HBRk6tuF/ZVUwdbTc12WAB0yoO/LvpgeKDcbicTBdZA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_cloudsync/1/full.distro",
+        "version": 1
+      },
+      "discord_desktop_core": {
+        "hash": "sha256-g93AhKKuH7AzT9Y8ffrHG9hRebkWKYYOjjcs++yUdEE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_desktop_core/1/full.distro",
+        "version": 1
+      },
+      "discord_dispatch": {
+        "hash": "sha256-e7mbVl2k7M36/sZx71kYvrLDMy42yNrsRqqjZMiWCuA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_dispatch/1/full.distro",
+        "version": 1
+      },
+      "discord_erlpack": {
+        "hash": "sha256-efKY4APaWuWfExbIc4FDml2uiDyjHtUJienynt971gM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_erlpack/1/full.distro",
+        "version": 1
+      },
+      "discord_game_utils": {
+        "hash": "sha256-DpoEfSuoD9p4cdAFCA/qZ3hLcczSo6MBkfo4fxb+A4E=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_game_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_intents": {
+        "hash": "sha256-jTXiR+et6y6AgNBVNrgeapxeuzR0/DWp8su8GhsQSAQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_intents/1/full.distro",
+        "version": 1
+      },
+      "discord_krisp": {
+        "hash": "sha256-tYwNFZW/BUJtKxRZnaJSRR4XFeDi+IW7o3+PjQkBlSo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_krisp/1/full.distro",
+        "version": 1
+      },
+      "discord_modules": {
+        "hash": "sha256-9kKjZzWePOU35wDHiBsl0zII9o5RH4eyOyCPFZR0XZo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_modules/1/full.distro",
+        "version": 1
+      },
+      "discord_notifications": {
+        "hash": "sha256-+3dkquHgrax8lj7n08Xx9HF6OQ01WIL5d+aCY26nhLU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_notifications/1/full.distro",
+        "version": 1
+      },
+      "discord_rpc": {
+        "hash": "sha256-rWC5DloPUbkvDIEBPKg4EKDY5FSacBshxo+vJvuJ5AE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_rpc/1/full.distro",
+        "version": 1
+      },
+      "discord_spellcheck": {
+        "hash": "sha256-M9TflkDKRWbTPi+cgW3PrEYCB7zp3Woc9yB/pNH8p6E=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_utils": {
+        "hash": "sha256-3zpREVrc0xRUPAKNg01O40Koq8lUTrMLVq+y/Prjph4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_voice": {
+        "hash": "sha256-J0LWWnNHquFmL9A21aTWNtoSQFokRRaWCn9j7vbTrc8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_voice/1/full.distro",
+        "version": 1
+      },
+      "discord_webauthn": {
+        "hash": "sha256-awMRcEndx6Z7gakNs+xjU0B1xTkpzKLy6mh0FzV9FaM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_webauthn/1/full.distro",
+        "version": 1
+      },
+      "discord_zstd": {
+        "hash": "sha256-pKQb8nsBQYttsfxVSr8x9OcIyMcvqZOqRfoRL+VkGbg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_zstd/1/full.distro",
+        "version": 1
+      }
+    },
+    "version": "0.0.243"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-o2yw5BwDSyks6oEU4YVRecHW4Oq1b4ZV54SlutrfkJw=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/full.distro"
+      "hash": "sha256-uIFpupv+dYzsrm7u4oRD16xgcJGdB0F66Y8PloIuhNs=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-ctUNZY0WToBsI8pd1ioxjvppqO/cehwSSif7nN5xX9E=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_cloudsync/1/full.distro",
+        "hash": "sha256-XmekQCmlwasCDjk8PKqYb1NlsCRYncYA8NEHZ64nIBI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-2WA2b37oEUifbZPNpexgCFiKZ65lruLir6CAn8MF1Pc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_desktop_core/1/full.distro",
+        "hash": "sha256-vRkYtbDncwynzAHMPbrcgbue8eNwD192ZTWpKlhMts0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-8QMSQJNKRJxr+XFLt4cP6qxKQ6eWVX3EMnHGPdjcjwU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_dispatch/1/full.distro",
+        "hash": "sha256-33M/ThvatgTHmPY6CIVG1kTrzNqaiz5kEyKS7o20m2Q=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-dC8x9QqG9DPgK6EjSImmoPo+REg9qu5/vzX4x/7+wLE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_erlpack/1/full.distro",
+        "hash": "sha256-yWIUP5aJ4X+Cb0RkS4yTg8DMywdoXW3hSQa7FGmbLXg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-aiVp8rbE3oVdb1+EDlld8vVOPQwzjkhwj69cpXS1bcQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_game_utils/1/full.distro",
+        "hash": "sha256-vnXPaWtiSg0rbX7MGo//+jI+jVGEZvsSBo+TzFAwW2U=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-wVV4Xrmzu6MPOnie5A4+CsbQM4UUEwWWxONAqK8G738=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_intents/1/full.distro",
+        "hash": "sha256-LMzWKuGH6nFaFgPuzL6NZd4HIxO+0VFqbagoNb1lV8M=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-qYCTYUVixnxIC8eIqJQlHKzqFcMPyrCHp96+hU1nSsI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_krisp/1/full.distro",
+        "hash": "sha256-p+3SKNKUsrGlLA5GkkYr2TD7k7ldVIxH90u6TxW5OtI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-jV9JMH9O5QGp8yCt39cHfWYV2SXwN+pvMioYlrBrn3Y=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_modules/1/full.distro",
+        "hash": "sha256-iamZlUKVHMlm3ZCX6kVx7EfEP1Xsox5a1DL+TzyPZ4U=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-hSYjrrx5Cb0r26j1IhzT7uccxU5536vnFT1Q/J0Tpqw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_notifications/1/full.distro",
+        "hash": "sha256-UUdOFaSrcWdvslEAUtkaio9GjsdIKvJ3it871ZcdX9c=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-MaEFCjyWL4Mhf31Xq7QAiF0MxrABPrr2+pFKHwlMI8I=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_rpc/1/full.distro",
+        "hash": "sha256-i9X90vIFc2Sf/NEHcc9EOqd9vHRl0liOOeJiu8VsjDs=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-6sVVutWpWaNifNqNFARq3SZDxUalfbuWuP/YzzkJ3E8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_spellcheck/1/full.distro",
+        "hash": "sha256-mWYbD4w/Hg53Ncl+b4dDAqw/iXvIlFa2OQZanhAdN4Q=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-MSd3l18SUCkdYm6ozaQs6YsG4KcWsj0wecyudV+dl3U=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_utils/1/full.distro",
+        "hash": "sha256-S7N+84gmA8jTN4FOVhFt1jRtku+hvACJ+SH75gvZXcA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-r5e2bps5kwWMfKf/QboLQeuqZyxaooR8Im6cgh3QGgs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_voice/1/full.distro",
+        "hash": "sha256-2AenCW7EKw1R+znM1wGaiw8UHDZSKCqwmzNeFhqIyx8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-Wk1lsZnZXMKWQ03hmh5B4eDKGGzvNtkfqB+tKOX0DhU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_webauthn/1/full.distro",
+        "hash": "sha256-fR6ArgR+/oo1QpkJQ1GralesT1o7W9hvuRxN5NjXGGI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-RoGe77NOFERwFURtBIDaFKZ2g8Alqe3Tcx844uqLRcY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.396/discord_zstd/1/full.distro",
+        "hash": "sha256-JUbwxsOw5XAE+EWj1F67kCXLHmltLCwsz9kC4E7/O5Q=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.396"
+    "version": "0.0.398"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,83 +1,78 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-4j3ii6uD9f0tV71mU8XFFxWch7LiWCwclnkHa5NGj+4=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/full.distro"
+      "hash": "sha256-UHlT587DCEDz7YSxN57S3mZ+4R2bi8/Aqvf62QuibEY=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/full.distro"
     },
     "kind": "distro",
     "modules": {
-      "discord_arborium": {
-        "hash": "sha256-I6JRlVELq5Mldcaz+lKMt0izsNSfWdw/e5JPqBGLOzE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_arborium/1/full.distro",
-        "version": 1
-      },
       "discord_cloudsync": {
-        "hash": "sha256-ZulqlXaIFr+Ds20ON02HZLn45JFqq9POuYoFV1t0eZI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_cloudsync/1/full.distro",
+        "hash": "sha256-/gA7pLPkyWAMQc2gNgq9L14W9hu3Bi5rPtCyWZGghqQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-H7mcz7tm2FQXrmbfLz9n1bxbuAMNAnGK9iWEbMoVoew=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_desktop_core/1/full.distro",
+        "hash": "sha256-/iCoCP3vNeAVXRK3smZdf8XrQNYanejlcjZ9fcddbHg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-XTmNR20AqtrpWiwOy0vMrUy0K2bDG7P27a80hbvWS58=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_dispatch/1/full.distro",
+        "hash": "sha256-KjrgWGgTHuNOqm2NnOiDATyAgngaGSktATe5OnV3Cjg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-zH6H8EchYRXbK7HgG6F09Oiieep6JyTw1+r2nRmtQ6Q=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_erlpack/1/full.distro",
+        "hash": "sha256-eLse+k1w07/mGh0h3beXGZtsCz7NuP6qSQH6hJcNspM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-3H3KVkC/t6UdxTQEUtKg9rfk1xKaWf0MDerUm5yO3/Y=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_game_utils/1/full.distro",
+        "hash": "sha256-JPacuW/LhaFGftu3tR3C4AKU+6nnJuc4N99CnvJskf8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-w8XATCZyCv1FeoRBweo7+wL9NAX2jD8JNKiF1ED7T1w=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_krisp/1/full.distro",
+        "hash": "sha256-xYryuPZXFp9nvDQ4l8qFANh16CcO+ZNCEUc0/UXrBzE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-Qd4gefF0GDNmZpwtIuuOdGRxRn7b+l88N7lbsRebe9U=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_modules/1/full.distro",
+        "hash": "sha256-KCAWR5Eoib/RkO3MVn8oHh6WBTfTMA2fMLMjMCrRiZs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-XxkRTULSxx7o8PNwCtz4FeZ9vowa8EHr7DNryvG/vMk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_rpc/1/full.distro",
+        "hash": "sha256-uYcDMwefWLdUzCjpN6b0h5pN95UKZs6gwgwA3uiPmb4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-mFEZg/Z33mdj4dIwJNfj7pCj/xcLoCTch/t2pssl45c=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_spellcheck/1/full.distro",
+        "hash": "sha256-xSOog8VBcJBhbfzWXUlMMHWYfQ+Mkx0O5/IGu72zTvY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-O5XrO1uL6zNHbIh6XUXQP3e/ZcAd46Z4s26+ihzWfBU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_sysimg/1/full.distro",
+        "hash": "sha256-UTNNk4RY6fk9GnTxNyhBI3XLmA38oSsdKVpLl3VqtjU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-aN53SHC3x1YKzd3pmmQX7lWu6iVRC7kN9BxViPSSNV8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_utils/1/full.distro",
+        "hash": "sha256-CbAcjtjZdENZcjcrEOLP/SOdi9Yay4/J4re0UguvO40=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-pbzNmysNg7tWzbpQSqGr8OBWdaGSR8/pi5A15y2oZno=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_voice/1/full.distro",
+        "hash": "sha256-Ev6sh9hjfjdZ+5ZmXKW4QXFdGwQAozXP4/F6P6BYISI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-E+ai701mLhnEdSAO+9dR0KEWZuVEJvCzmrRjPB0ST0I=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1766/discord_zstd/1/full.distro",
+        "hash": "sha256-1Sfz6Wymr9T3mIwdRb4e6KYNl/iI2eDoiK+DDsGUty8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1766"
+    "version": "1.0.1794"
   },
   "linux-development": {
     "distro": {
@@ -161,253 +156,253 @@
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-9eq0gqGesGYXCLsztSt9mf0laH/OuLhjCuOKRL8Xnp4=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/full.distro"
+      "hash": "sha256-4LjSOiwKk82VvmxYEKGJnp0yz5pNbdJ3mDOgnK3+GCs=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-w4mPCev2fCDBLeozW24Aps/m+5kWAyVtYD55868lQzA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_arborium/1/full.distro",
+        "hash": "sha256-1Oh0s1LoS/IqGUfP5ZLYdVGPXZVzK/hRNRa6qelYqFc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-BXIIi69tGkND16aykVut6cE8B/WiVe6/9mpPBBxVZ1s=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_cloudsync/1/full.distro",
+        "hash": "sha256-Tv21h/Zx3cCz3JiCuM/NN8VwZti+KGTqscmDZRsGC2Y=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-gB3j55jhG/qh13itZ79Oiio2Ys7i61k5d4NIj9+a4d8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_desktop_core/1/full.distro",
+        "hash": "sha256-bfZVCO3uEWlHJa5IhENPpArW1j75wICaRe7BS2FyDN0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-OcokUI/f0Ra6JBC7xJ3+Icv0yyZlD7g1As7c718f3AY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_dispatch/1/full.distro",
+        "hash": "sha256-C/o9W9HQM27j7Yd9EL/gPqZ4Qwh1PnWeh1hfdwWwnQE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-z9pwZyP59qIDZeojVaNgJohsu4SNstQliXvuIJjTWU0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_erlpack/1/full.distro",
+        "hash": "sha256-tGXulf3fiJh/rYWAVkc3X0BEfYmJ7B+bpco1jdGshiM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-pBvHJOJ8LqV1yDY/AKhxl9+5CBuGDdZxNECQ+mzPPcA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_game_utils/1/full.distro",
+        "hash": "sha256-HteWjRWb7cGjTVx4KR9s6usA742cp09NbTeHF91tCys=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-302w/9D93ESPY3ij6vbOeig32nikoWDD8t8YoCPGWEc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_krisp/1/full.distro",
+        "hash": "sha256-ntr0p+Mjam+JDwFWTgrFhbmesXPg0CzkajBM/D4pZPw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-zDsZa17X3GIIGeNG6JBuTTyXqtqD2NiZRrmcL67oSj4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_modules/1/full.distro",
+        "hash": "sha256-YC00gpi63MLWWQG52neNOcrE0CLmLPo1f2qtqOQyCNI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-ndZwouBJpQHNDIWfuC/xvM2+fIIwrUutLAQwj+fNyXY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_rpc/1/full.distro",
+        "hash": "sha256-+e6mv8np0+rcHbql4cBW2gymQPAceLC+1EX/fHOWf0k=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-se40Ubw07Fwg7VBIkvgfIzBIbpdWyOEAHHk+SrAk9Dk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_spellcheck/1/full.distro",
+        "hash": "sha256-KxWS1m9gD5+hZHqbLmjZV8nmvRJflVITugyvj14aZjM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-kbJsxsqrjoVajWCUDAywNQlEVHQ6Iyl6FjltvGenAPg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_sysimg/1/full.distro",
+        "hash": "sha256-g8mckNZNTCZDD8m1WnWx3vtsqZ1B/Ou0qGMf5F0bgX8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-l32yxA7h01KsBvc5wambNoyxiACacprLdJXnM5c0bxU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_utils/1/full.distro",
+        "hash": "sha256-/OKjhFGVQ/U3O/YvNkc+xrPNJGBAkmctgUjLiK2cOcY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-vuX/J5+Br2lC+rsEnAWlrYivkAF7HKb3FG+xBO3HxOI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_voice/1/full.distro",
+        "hash": "sha256-EgEXB1pXz5RTXtUPNwkDfuSP001luOYqFIH/TiIWGB4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-ZZ1cKzbxPKyu7Ku+T6iQ9Qrs9tFA++Yebpu02v9IkMg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.211/discord_zstd/1/full.distro",
+        "hash": "sha256-ivgN/iLzXIXdV0KTzZMakkgWj7mDvlAZ06RjLWvB1qQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.211"
+    "version": "1.0.212"
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-8gWwie6ns9oLR+YcN5Yo0Ml9cozrM6Ybg7IXg3hEir0=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/full.distro"
+      "hash": "sha256-vvQ7e7rsk85mPCbNeb00d3OCUWUzUkFNYVctPYvBGRE=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-W0u/dID213JCOtMxvINaGPRXRMfOkbqWxw2LYJM03N4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_arborium/1/full.distro",
+        "hash": "sha256-JUA2EDfYcRaVnU4zzhOKZ8Q0X8YafPhKJcUd0J+MztU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-kCFreXY3IBuMZ7FtqVSv4IAMzQYBNV4qplQZx9PlQlU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_cloudsync/1/full.distro",
+        "hash": "sha256-J+lGNUKZJ+DtbQ8pXLUuw07T6MH7fyzblKr6fQ9bb2s=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-s7WzMCq0J6XacDErIvMfmIlt9McK00dNshz+w7VJ0wo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_desktop_core/1/full.distro",
+        "hash": "sha256-21p4kuV4dJUvxNVWgYsVIxkyYohak7NxgscIYdlD0a0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-PHjwOQ71MsbPTDSGGljPd9m4D471ImQp3a8obW7lod8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_dispatch/1/full.distro",
+        "hash": "sha256-P5FQFCzWsgrDNu7OoyI1mjStfBP5nM6C45fu42MoYv4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-vtd9yB9mK6twH74dgC7NuT2rVCr5ucjSv+11yCOF0Gs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_erlpack/1/full.distro",
+        "hash": "sha256-nfgYCt0rHjlZUedu40sRThxp1TEdfB+9TXz31RFZ60k=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-H3FM1Ml97v9MkGVCgYUW+mz2JOd9CZP/Dgzvu2rGOuE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_game_utils/1/full.distro",
+        "hash": "sha256-gAB1QY8QjHl6xogqQr1uxgYuuywQV+VcqMB5cAC0vNc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-lCOK9yjqa1yLcSOdhILgW/kr1ZJjqxAdbo93/FnyNnk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_krisp/1/full.distro",
+        "hash": "sha256-bmMDt2FshcCZA3eDZ+uVmxzCqgkTI81Zc6Wrrw3ZK/0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-OC2VIUOXaiGcoqV8NOzW55z3DpRpdqfTBdni3wNyvlA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_modules/1/full.distro",
+        "hash": "sha256-YVhJEFMOo8AmGFpET5sdTdLiRLO407t5Z6KCixKEjGk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-GS/nOO/ec43OgYN744Gao4IHYWBPpznA1stk/BmPEqQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_rpc/1/full.distro",
+        "hash": "sha256-Av9sjzLybZV9OD5WEteV0sHRDzNp8LiBUOb1V63oZv8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-oBGlUOrQ2/cW5EbTcTe31wvfm5V14gyBoStucMXDJqU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_spellcheck/1/full.distro",
-        "version": 1
-      },
-      "discord_utils": {
-        "hash": "sha256-BOb01yg0+O3/k5CX0TKVaz8598HqcQp09R4vA60e87s=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_voice": {
-        "hash": "sha256-ib2a5g6Pr6YR+RUWYm4u929yTgWUMtMaETwMNaEal7M=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_voice/1/full.distro",
-        "version": 1
-      },
-      "discord_zstd": {
-        "hash": "sha256-QNYSCSoJJVKeV3w+AS6AbaVcTnIs6gMX1nek0tn/eoA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.155/discord_zstd/1/full.distro",
-        "version": 1
-      }
-    },
-    "version": "1.0.155"
-  },
-  "osx-canary": {
-    "distro": {
-      "hash": "sha256-g2G2hLwYUiQBDHUiWKGH7BK153qnRZvySwzktOio8SI=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/full.distro"
-    },
-    "kind": "distro",
-    "modules": {
-      "discord_arborium": {
-        "hash": "sha256-KNEcVAc7z4n9yPSi3LT+sZe3iq4J7QtH66OAJ473nqM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_arborium/1/full.distro",
-        "version": 1
-      },
-      "discord_cloudsync": {
-        "hash": "sha256-0iKZk1fyyN5te8AUaC3H1gsOr/BGxhMwionpCgkna4A=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_cloudsync/1/full.distro",
-        "version": 1
-      },
-      "discord_desktop_core": {
-        "hash": "sha256-K4O77jQCWBh2nYjFhwlJCHzxmmuadouv3pqLN0q8c9s=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_desktop_core/1/full.distro",
-        "version": 1
-      },
-      "discord_dispatch": {
-        "hash": "sha256-6T4HWFZpkGQcpwfVWMaw4sTpibG4wo1HLk8ZcmtBfvM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_dispatch/1/full.distro",
-        "version": 1
-      },
-      "discord_erlpack": {
-        "hash": "sha256-MNX10Hk1nzEq000t15Msg8hzmGCkby7z/I6b9LuR5Sk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_erlpack/1/full.distro",
-        "version": 1
-      },
-      "discord_game_utils": {
-        "hash": "sha256-6znm3uE1Fl7ItuT/1OVRxP21kSYaDXkTIl1SNadWSSQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_game_utils/1/full.distro",
-        "version": 1
-      },
-      "discord_intents": {
-        "hash": "sha256-titG9Z0eXKm2QnWm1xdPljUF7s3VBwM3kZN0Mwc730E=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_intents/1/full.distro",
-        "version": 1
-      },
-      "discord_krisp": {
-        "hash": "sha256-9v2+nnjkQeI7RLt2+Q05zfGaKvchoCxRFciJFT5VrDc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_krisp/1/full.distro",
-        "version": 1
-      },
-      "discord_modules": {
-        "hash": "sha256-LAc5uFvYdg5ruzmd2Msh3c7eegChFoIBXj8X7JYJVqs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_modules/1/full.distro",
-        "version": 1
-      },
-      "discord_notifications": {
-        "hash": "sha256-mxQb3Em0wDma8EXTN4cULjvW31JwVxDzQ3ne9FcKbC4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_notifications/1/full.distro",
-        "version": 1
-      },
-      "discord_rpc": {
-        "hash": "sha256-DXSY6qhtxW0S3rE9w5/KO85bsU7JP2ldx5tOoTwoptM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_rpc/1/full.distro",
-        "version": 1
-      },
-      "discord_spellcheck": {
-        "hash": "sha256-X5BitbmM9HnEex2DsRN3t56tLBRtkyeeY7rZ9QgoNdU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_spellcheck/1/full.distro",
+        "hash": "sha256-O0p451X8HYslCd9QWJ/SbjQ+tIs3otCfxzBPmZjM6LI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-SHpivOq+XZeEiU9EAfD2YMeIo10DvWDmzU0C0cm3wuQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_sysimg/1/full.distro",
+        "hash": "sha256-9HxsiEhAPIpTRPoYYvsyakWJT6GaT+3/L1dvtxNZNhA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-MVLPSCP3AxDs3DNFuwyYjlZHyA4cVErANFCMTzorGWk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_utils/3/full.distro",
-        "version": 3
+        "hash": "sha256-qsB1dfte6qoD+nT0rZ+mJnn6L0p6OSeGVMWQobc9WM4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_utils/1/full.distro",
+        "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-mfoo7ZBsU/fRkHGxKk0j/i0qj2PnBnzdTSt8pI0t53s=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_voice/2/full.distro",
-        "version": 2
-      },
-      "discord_webauthn": {
-        "hash": "sha256-kCeElNUwLB1yFrHTqP6W+S6/F5npRiYo5uH6M31uNxo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_webauthn/1/full.distro",
+        "hash": "sha256-icxv/ISGtR5d7ZdQaFzrspulK8KRYZfMzxzatX7/xhI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-15edfIf+s9zPaYWYw7SPsUGXXFJK9LMGK6LzaDvSiyE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1294/discord_zstd/1/full.distro",
+        "hash": "sha256-tndzE1U8DA+K4XGbX9jII7zrSiybG1qAqSzCwypSYYo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.156/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1294"
+    "version": "1.0.156"
+  },
+  "osx-canary": {
+    "distro": {
+      "hash": "sha256-SjRGJwvd+IOkCqrG6akvvlFFpDV4gQozf4mPinKrZQE=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/full.distro"
+    },
+    "kind": "distro",
+    "modules": {
+      "discord_cloudsync": {
+        "hash": "sha256-uynrrQxSvQjnGsS2V+CpiRfBCpNzAVgo94nySxMWrGw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_cloudsync/1/full.distro",
+        "version": 1
+      },
+      "discord_desktop_core": {
+        "hash": "sha256-7tAXBdi+OXZaXl8+camk2IHEwzqrUpHjcc8QYI3oals=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_desktop_core/1/full.distro",
+        "version": 1
+      },
+      "discord_dispatch": {
+        "hash": "sha256-Kd3fZYacc9H2MfOfHIgdDu56HCeRYF60dG6234Uin2c=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_dispatch/1/full.distro",
+        "version": 1
+      },
+      "discord_erlpack": {
+        "hash": "sha256-/JAAcJ/bDJaUllVn+0aAErWysh//dSPrT64uGe5THVU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_erlpack/1/full.distro",
+        "version": 1
+      },
+      "discord_game_utils": {
+        "hash": "sha256-4x+ZNH831aCeuNVK2RLiAfaYolFcPSXFcnk/Y/19/Nc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_game_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_intents": {
+        "hash": "sha256-1RzkNxAlvdLr7vpW2sIj+dE/6gkauXbgmyU6ZfROxvk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_intents/1/full.distro",
+        "version": 1
+      },
+      "discord_krisp": {
+        "hash": "sha256-WY5x578AvlwSUC/tV0j+SZItOCiHqzNZDfV4TfK52XM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_krisp/1/full.distro",
+        "version": 1
+      },
+      "discord_modules": {
+        "hash": "sha256-tOTaUzDS5EEJpxCT+2eMaELyqrpBpyg4VVAR2qoKpqs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_modules/1/full.distro",
+        "version": 1
+      },
+      "discord_notifications": {
+        "hash": "sha256-wgywWGbwb4ZOxAbvP1zwGmXYY7YcWVZZ/3oHPTi6+ns=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_notifications/1/full.distro",
+        "version": 1
+      },
+      "discord_rpc": {
+        "hash": "sha256-76+PQX58ftimpJWWaasvVUz5csbR+mKL0DTcUYAYuHs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_rpc/1/full.distro",
+        "version": 1
+      },
+      "discord_spellcheck": {
+        "hash": "sha256-An1SBmKEPI8pRip6g/YZW6dGsLpx0TIvS+QCkI1YnWs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-9MJv02Fk+ega0kbbLL7/s420Mx149sJFWvkkU66yJuY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_sysimg/1/full.distro",
+        "version": 1
+      },
+      "discord_utils": {
+        "hash": "sha256-ptioApBU8h3ryIan7db5A77Tf87MTqRRNSVZhiUeUcA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_utils/1/full.distro",
+        "version": 1
+      },
+      "discord_voice": {
+        "hash": "sha256-pVs09tpg7jTKfm54N1uaRf731Du9vpB7q8UFUHorpWU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_voice/1/full.distro",
+        "version": 1
+      },
+      "discord_webauthn": {
+        "hash": "sha256-op6K8vlmdjXxsZ2+23CSuZGmdvS7tb7gCq5eRrD1r6g=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_webauthn/1/full.distro",
+        "version": 1
+      },
+      "discord_zstd": {
+        "hash": "sha256-bibBKtu5xxBdtk5lfJAMtrjVMz/YMjzFTjHu2xoTNSc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_zstd/1/full.distro",
+        "version": 1
+      }
+    },
+    "version": "0.0.1306"
   },
   "osx-development": {
     "distro": {
@@ -506,187 +501,192 @@
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-mTArbvIvLjOSGpb35GO17K8lnCqAHd6fDdxpzwFKmg4=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/full.distro"
+      "hash": "sha256-0itWlg4uO9n251oeACGHfgId6sV9WwWXib+xTpLlKdg=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-eySEVa1AmxNMG8P1cqxLFftrQjyzWrN8QInF8rUh53Q=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_arborium/1/full.distro",
+        "hash": "sha256-nxM1iYpiUhF5out+DCCJGaiPr/WuQDYXxHHnOVG542U=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-7/60p+KD/WIxA0ErfHUrSPXGxVTmyNiC9Kcu6WUAPsQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_cloudsync/1/full.distro",
+        "hash": "sha256-+XUuoUmKHd0paaXCm64M/6GbI6oox3auQrHo2QB7IqY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-xtxh0mvHKtAtohJptt/89DhEVpC1UbWloVnhvK3kmO4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_desktop_core/1/full.distro",
+        "hash": "sha256-+n+arWUqZyDX9pTRYd90uuo//JXqMo6L3mIymSkrUTY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-wi67HEYdj+bL+Zs+PrNkaMSfzjyGR0eMi0smyyvJoig=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_dispatch/1/full.distro",
+        "hash": "sha256-7nuF4fhgJx0B7s73dnGddPr1gLpnaVksRYpKQmqf5Qk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-rhf2TnRJaz3uqFq2tu8JCIbUFdBHJFQWupn2BvreeiM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_erlpack/1/full.distro",
+        "hash": "sha256-YP5XoJ4gdPJwRVP9Poj0G+Rv+ZrWE1O8TQ211LfD6tI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-3GlzC6GHnC+hb6YMWNcA9ly7g8vKMuMf48Xv04tpMMw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_game_utils/1/full.distro",
+        "hash": "sha256-QOggWiTw6TK9mj7mnn5EvoI6Ai/QuF6R6c16vJQQwMA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-6cDb4uNVlpVTiqww03+74raqkOAbWgI0jS5xG0lgO0g=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_intents/1/full.distro",
+        "hash": "sha256-n+LHKnwc/eDih0rCT11BCMNMG0Nb9LluIxkZ/qdLxYs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-jx0nK45QkHhkl9DMB81qwJw6GceFu8KPBcQVMvJKRXI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_krisp/1/full.distro",
+        "hash": "sha256-hnPCYcyTRyXrq/HaQn7HoFlKF13VSvSwTRn3lrzYAxw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-kELcckM97k084WfqVyFaJb9Nmdp1UOsXvL8vfeyzDck=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_modules/1/full.distro",
+        "hash": "sha256-l5X0AeddEKdXzc8z3SkiIEeu0aF9pz7SlRN2+jgvJsQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-lVlDGN+qYKOPKUgHZ20b5b36T0GNj2KyHzRQZclJ6w8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_notifications/1/full.distro",
+        "hash": "sha256-1Hl6kvliMkmATrqPLUazkTkVhjXxuYufjV/wbg8WMsM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-gwqGxzJPCBIoYTftUIUiTi7D1qtsdxDJgCIqM8MRifo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_rpc/1/full.distro",
+        "hash": "sha256-pZtk1ilJRl6/UnKV70ON4X1gEewdwUHN8l0VjiGb1QU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-SeglC/2Wp8DdSt7EAdxdEB4kfx7pAZdelv7OQYb0fz4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_spellcheck/1/full.distro",
+        "hash": "sha256-wPa9fIcrPk1yln0/dbhdJzJO93Y7G9x+L61mpGmu9Uk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-PDaNTbEZxg4W8HteDJ1QSgUcpizvnRRLGkYp3YNiSkY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_sysimg/1/full.distro",
+        "hash": "sha256-at2pxdYqY4h7I0vmmpJN+nuSi3b85qZvngfYVwjD7q0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-zGNUOs+uWSAgAht56Oe6y5xgEhtaSKOLwVmNC0L6t6Y=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_utils/1/full.distro",
+        "hash": "sha256-83pMGx2wlw5gCqcZPKwqUqztF6EnJzHSNExi/LaUsn0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-pF3ki+YCVyrD/dL9aPCgylc7gs21MppkZOHROEiDm+w=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_voice/1/full.distro",
+        "hash": "sha256-bR4oAeMkBEi4miW27/I6YD7wjcQWOaLZJMsEcA5GttM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-z+rVhzu+CL8nu9FfyQESkDbJBWVGHz03j/EGBc1f1vI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_webauthn/1/full.distro",
+        "hash": "sha256-JAhcJogkRO6w5lgDau3lQs7R9yvuw2J3e5yNeZkeOCc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-5cNp0u8jlQYI9LBIbi3pmL7jm43tgD3EVq3bamPZSxE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.256/discord_zstd/1/full.distro",
+        "hash": "sha256-YuztgnEkhGX5bUhqRTt4CNj3Cr/TKWFs9GFrnLHccXs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.256"
+    "version": "0.0.257"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-KfWALYNAd/FX+LQRMIyCt69MY6J5jRS7gFg4jCl4fSY=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/full.distro"
+      "hash": "sha256-J2gIsqC0Kzn+G9FaLqkO5xCr4g5VhIyydPHRKt13eMk=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-53S9PggFNCKdfQ0sYl6Mn5R5Kngg2/T6eElq9C+DN08=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_arborium/1/full.distro",
+        "hash": "sha256-1qA8sYKihOt3wymjEVgRTPhX2jSVtthc8KX4w54t+qE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-/ySgAAJ0n2TWB/wbvB7OihFxRrC7NyTjQ1H4TqvWZ84=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_cloudsync/1/full.distro",
+        "hash": "sha256-VH8rFK6asP+2lGPiC4NbNY4t20dx7qwGmlp7Mj8iVTE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-szNLjknsUqkkxLPpyJjEfxT46AUjM4g+DTMoPgrxBm0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_desktop_core/1/full.distro",
+        "hash": "sha256-ZJKB5FeNJ7Z9+tuSxK9zcFG4826VFUMTrT6XHFi36YM=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-UoWIZ1Uc0Q6YXSTzulJSWNjgdRyTiX54R05UTh8fTiE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_dispatch/1/full.distro",
+        "hash": "sha256-D7R3j/sZpwel0WBwshGHqM/HMIWwA1vW2gxUCDpUZKU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-xlWB+o/sjHFLZVMFke9RCQt65lBVn/pUT8jNUUkfSyI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_erlpack/1/full.distro",
+        "hash": "sha256-kSKDbwiqhXVcGWtOqW184yO6uKeACyCAxgEKTOoqGOI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-Hqs0td1l6gWvdNcn0WA/DfADlZq+OT0+HlgUXiyvwEk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_game_utils/1/full.distro",
+        "hash": "sha256-jz65aXMzEct+HT1Shs1ziyaksbFIWyAY8YjWZTvt6jI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-jKNBNIlXutv2ex6MuO8kmwkx7kcQ2uaIt0f/ogw4Vws=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_intents/1/full.distro",
+        "hash": "sha256-nU9TvJqrH6+ROZsF3WD+L/ZvuIqIuGbfejQe0C0XypY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-7OizZzIYAlP4CmZ1kcpFc52ijT6abHYJ4KvQAhaG/J0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_krisp/1/full.distro",
+        "hash": "sha256-Jm1/RTUsXrvwntxWZKblkRzlwsVGVegzo9uqyjBH98Q=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-l3obGjd4nK7DQtwoml6PvzmQnYaRu36xAEUjd0TKmIs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_modules/1/full.distro",
+        "hash": "sha256-7Nsbay4MP424IAtpQCcgEmSeSxVphOFUJuY/Dytb1LY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-8XfxczmmMq5w4HRLQnCjxjFV0fQgDwaEkcezXGd7gNU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_notifications/1/full.distro",
+        "hash": "sha256-4m4DjudjLxua1KUwjKN+DouU8JYxsa7wvTvbCTEkzKU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-1n+gO1c4SZrV2jOD2SVMCQYnHU8e5ErrB0eJEv8hvus=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_rpc/1/full.distro",
+        "hash": "sha256-kv8Qh9F3PmCru7DKmvsJiq+4/LoYAOtpiE9SCpPBMbc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-QPZOJTNAU5rShPeV4SU2P9eBmDEbLZHEwThyXdRPsLg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_spellcheck/1/full.distro",
+        "hash": "sha256-dzieOT9NurZjWKaetEY5Z1DWXe/Axq7eLtPNyT3ATbk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_spellcheck/1/full.distro",
+        "version": 1
+      },
+      "discord_sysimg": {
+        "hash": "sha256-ruKew+1lZZO9FpvVkJp2U/X4/l5EaTAjuQqZZP+u2wU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-PMv/psANJnI+yhGwsibWDdLGdlUQC8/Rh0h5nmNQfJY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_utils/1/full.distro",
+        "hash": "sha256-M6Hd5ehiB7j/VLRRzP/UoO5AK7UdCO8iWdlM+5cps3E=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-GtnSgoFM1aGBLLLwaB/81iRhuQvuuNuvNehO3k/UP7c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_voice/1/full.distro",
+        "hash": "sha256-eHBSpQfP+oDcbctuDhPeNkAT75bfk+IVhe212D2jCTI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-r0WinKYXuJtY0YWn2GHoFrUID1mwBGRMVVJOMLFGSOs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_webauthn/1/full.distro",
+        "hash": "sha256-Wlqq/elXIb8m8mZF3P6xWG1mViqrUieBmd83mS9V7Rg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-pBA8Iyv1S7wePlvdNI4lj4MfY2Z8MPtiVaf6EBi8rY0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.409/discord_zstd/1/full.distro",
+        "hash": "sha256-+OkUUomOUW6uj1/6cMZmi6dmEkR4HPDkjm1dJ5gSnTY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.410/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.409"
+    "version": "0.0.410"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,78 +1,78 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-4nUnQx19P9O1lRgpeGR8EBRtllpLTDIF2Ve0yST7qQE=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/full.distro"
+      "hash": "sha256-FUuG8LKZwvszmdrKjnEKu+iQT0Ly08aLFO91FGzdGO8=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-J7av4dx1OMSeop00Eqe05BIfw3ZcCS6UUn3ZWosRMUE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_arborium/1/full.distro",
+        "hash": "sha256-D+NJvpdGsE2IiPB4vl+CDHLNmga8zrHSu1Q9skD2E80=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-z/84+k8byRDLPkuoV0LERMyyZzBDv79+H7VM9BrtpGw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_cloudsync/1/full.distro",
-        "version": 1
+        "hash": "sha256-BopR1WtIPEgfx6b5bhHSSKYtMOSIVxJr34GE6E7rATk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_cloudsync/2/full.distro",
+        "version": 2
       },
       "discord_desktop_core": {
-        "hash": "sha256-PikHYaMHkNENx0p0A/q+qLJIiEq5+pVupL/yshtsNAI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_desktop_core/1/full.distro",
-        "version": 1
+        "hash": "sha256-OWORDE77w5HBh7I5d7bnTjzdU8x7MxOCtzrWoQNX3Zs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_desktop_core/2/full.distro",
+        "version": 2
       },
       "discord_dispatch": {
-        "hash": "sha256-+4ecTzNxBToBfzj20C83muMSX72e493geKkcHsGuw5A=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_dispatch/1/full.distro",
-        "version": 1
+        "hash": "sha256-SGsUToeQaZ/bQtHy8RMIxHg0dHz8Zhvu5sVckyXUQ18=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_dispatch/2/full.distro",
+        "version": 2
       },
       "discord_erlpack": {
-        "hash": "sha256-62ldpyV9LgV1gfO9TI/2atgWokwq4DrI5u0fFTbfGi4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_erlpack/1/full.distro",
+        "hash": "sha256-P40ZPbTL4FfeoWKjjwAuh+ysQRgtYUBX/a3Oj/2BX1U=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-xDZsOkb93ugR9JfF+EptWKnVRznUfTQ54j7PHipeOoQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_game_utils/1/full.distro",
-        "version": 1
+        "hash": "sha256-sHzwAS6iQ7XiRw9RzIsOzgHyK/D0gMwmlwez29EGGMA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_game_utils/2/full.distro",
+        "version": 2
       },
       "discord_krisp": {
-        "hash": "sha256-DlfgIscLn9Ya38D9xaI3p2yNBDu45xReqdGqjXkQGdI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_krisp/1/full.distro",
-        "version": 1
+        "hash": "sha256-JY+82GDMUzdL7yQ+55F1r2+kU86wHnfW1HSRGA+gs44=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_krisp/2/full.distro",
+        "version": 2
       },
       "discord_modules": {
-        "hash": "sha256-f7ahh310bYRUlJltj9l72CtTSZB5qjj5T2toYM8P50M=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_modules/1/full.distro",
-        "version": 1
+        "hash": "sha256-NodXtAgXZZl3EOO4Rak1gCYpkxmJbJ9P4HHS3W/AW5A=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_modules/2/full.distro",
+        "version": 2
       },
       "discord_rpc": {
-        "hash": "sha256-WcvN38d9hPzlEO65q2OYKVyqc5xIYF69wxiekjWFLLQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_rpc/1/full.distro",
-        "version": 1
+        "hash": "sha256-USuVJtYZG+V3mZahEmcn0r+Pc45xCYqBk8gxKZB+4ZY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_rpc/2/full.distro",
+        "version": 2
       },
       "discord_spellcheck": {
-        "hash": "sha256-TDVRsaybdgsTogUvbGzdesQnbxTr4VqdY/+4iXrpVic=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_spellcheck/1/full.distro",
+        "hash": "sha256-BL7UkZR2O5562UUmkadrxOVifL2d/vqRqzaW9k+lUks=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-tazljX9G9wcnHNTejDKgEcr1QNksLF5nmAu/F0dafp4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_utils/1/full.distro",
-        "version": 1
+        "hash": "sha256-IS7WwTqJwx/+OYgO2ZP3TxsVTXscLQOn5bEWLOBGOzY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_utils/2/full.distro",
+        "version": 2
       },
       "discord_voice": {
-        "hash": "sha256-XPxQzRmB+G8gxNedcwBJ2zq+sn7AEjboxxwcONj0hV0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_voice/1/full.distro",
-        "version": 1
+        "hash": "sha256-g2oiDEFwq0qbbeVlMM0xHKAGFjVTwSl4reDaDQGcZUU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_voice/2/full.distro",
+        "version": 2
       },
       "discord_zstd": {
-        "hash": "sha256-DchoZ8gBq3OT/XkersDVWrrx36VjLmcgh4T7nRKXbj8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_zstd/1/full.distro",
-        "version": 1
+        "hash": "sha256-hqysSEE+kDmW2VWt6PyVUW4lUMZfu6OH2KtmchMil8E=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_zstd/2/full.distro",
+        "version": 2
       }
     },
-    "version": "1.0.1646"
+    "version": "1.0.1656"
   },
   "linux-development": {
     "distro": {
@@ -227,73 +227,73 @@
   "linux-stable": {
     "distro": {
       "hash": "sha256-AzcQ2f6fsLAOvamgJMxMVJbhVh3JSkHeeLRsCwNqsnw=",
-      "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/full.distro"
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
         "hash": "sha256-wOodeJufXbDUDSsSyrG8+OJ/OxBPFfg3r7utbI7slms=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_arborium/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
         "hash": "sha256-Z9AHOO66v3eo/l9dMNE6FPduXwk7itn/ux+IBHKyUNw=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_cloudsync/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
         "hash": "sha256-Zis/QM7anwCebhJVXeO+kYQ+82JVxE/l/9DSFvbE0M8=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_desktop_core/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
         "hash": "sha256-rpF8mVEsRC9sR+OiihCV9EhJF1c0JwuEFlKxaeREhYY=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_dispatch/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
         "hash": "sha256-MMcPGHruTeb/Fu9syNn5/XTxUR0JTNqAesGTLbAi20s=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_erlpack/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
         "hash": "sha256-UkZ7f/Ckc2oDKSI1tdZU/2YBukkVV1eugtOCQ5ShVgk=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_game_utils/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
         "hash": "sha256-rFGeGhR5d7Y7Jo1R3netJNz0aAkHd8uBfRtbcK3mZFg=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_krisp/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
         "hash": "sha256-9/KdLuTux8f5mWoQBSpqNkcU/PvodaMVmAuGRkHW72c=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_modules/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
         "hash": "sha256-8AgyHPFu3ixeCi71M1W4hjcZHvacWZK2vPNhqRMFqZs=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_rpc/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
         "hash": "sha256-lZZitgtDkVaznkda2t7/5krxfOh3hF2R6ID9oHfaNos=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_spellcheck/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
         "hash": "sha256-bi74t/4DTAL4X8LIiRvx95UlvPy1b1ORgVo49S5iGrA=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_utils/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
         "hash": "sha256-o8dEAGCZbwy7MNGX3XlEb1/2cfSwW6t9NUS5S4ePd5o=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_voice/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
         "hash": "sha256-wPVbgwlzi7qvim3+VeXvk1oXBYVniNi7tilH1R3/Xm4=",
-        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_zstd/1/full.distro",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_zstd/1/full.distro",
         "version": 1
       }
     },
@@ -317,9 +317,9 @@
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-Tcb6S/HtSvoNLfAK0GVnKBqp+2upf0UxuStxaIXVK3o=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_desktop_core/1/full.distro",
-        "version": 1
+        "hash": "sha256-bxAGSMxQr9Bp5/N8VVMIg3ro7Z/lHtlEmaIm56qgg+k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_desktop_core/2/full.distro",
+        "version": 2
       },
       "discord_dispatch": {
         "hash": "sha256-2DKqLoaZtxY5LhYOPPejnsVq43mv5spxuMXAhCiq/NM=",
@@ -367,14 +367,14 @@
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-ZDv3ejnvfCzRlhJm7CEWhm5MX+C/lA+ETKXT+97lCz4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_utils/1/full.distro",
-        "version": 1
+        "hash": "sha256-zbCFs+lEaT4s4cBw+UeOaxtWM9cIf4Sh/YnFX1DdUkA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_utils/9/full.distro",
+        "version": 9
       },
       "discord_voice": {
-        "hash": "sha256-WVv+Bdbuodno6Q3+p6JBWe0FlgtOxLYkUm8YrJI5Ows=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_voice/2/full.distro",
-        "version": 2
+        "hash": "sha256-Ud+AaFDH01n1ArYaMSyvx7JKv/CFqXahe5+49rPi3Rk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_voice/4/full.distro",
+        "version": 4
       },
       "discord_webauthn": {
         "hash": "sha256-4iSifUx00540kHxVmTRUELc7CTdeQlrzumL6PoZ5UYc=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,78 +1,78 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-FUuG8LKZwvszmdrKjnEKu+iQT0Ly08aLFO91FGzdGO8=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/full.distro"
+      "hash": "sha256-duXSPkT9dsNdDLpalcSu0ZES7F0STDmtKVPKg7jlRZY=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-D+NJvpdGsE2IiPB4vl+CDHLNmga8zrHSu1Q9skD2E80=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_arborium/1/full.distro",
+        "hash": "sha256-0NBDfbjZwIHm7+xTZ3+xEGBCzZ2uC57SjHrUVgExmvo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-BopR1WtIPEgfx6b5bhHSSKYtMOSIVxJr34GE6E7rATk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_cloudsync/2/full.distro",
-        "version": 2
+        "hash": "sha256-1tJKJGB/UBGBcNKFmqW5HTatDblma7bFvydqmzUz7vU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_cloudsync/1/full.distro",
+        "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-OWORDE77w5HBh7I5d7bnTjzdU8x7MxOCtzrWoQNX3Zs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_desktop_core/2/full.distro",
-        "version": 2
+        "hash": "sha256-IUSuxVDVXgOFYngO7T+TDtrgWP10FdbKAPq+05XnhWM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_desktop_core/1/full.distro",
+        "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-SGsUToeQaZ/bQtHy8RMIxHg0dHz8Zhvu5sVckyXUQ18=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_dispatch/2/full.distro",
-        "version": 2
+        "hash": "sha256-ey1uOhCKm3zhEs6kkbO+Uic3WBBBFwx/GOQxj1VjDKI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_dispatch/1/full.distro",
+        "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-P40ZPbTL4FfeoWKjjwAuh+ysQRgtYUBX/a3Oj/2BX1U=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_erlpack/1/full.distro",
+        "hash": "sha256-FPPVL2uH4uRDtck+/Bp3vWU7QBUflgXwVtYijLh29i8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-sHzwAS6iQ7XiRw9RzIsOzgHyK/D0gMwmlwez29EGGMA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_game_utils/2/full.distro",
-        "version": 2
+        "hash": "sha256-IpBC1k3MSW8S73zkM5Gh/gfiIqAPLjGeGAUPdDapgfo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_game_utils/1/full.distro",
+        "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-JY+82GDMUzdL7yQ+55F1r2+kU86wHnfW1HSRGA+gs44=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_krisp/2/full.distro",
-        "version": 2
+        "hash": "sha256-dGxEdFhAwyaLRkq6VdrvIE+ldykwMTpbDfiTCk4U/kE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_krisp/1/full.distro",
+        "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-NodXtAgXZZl3EOO4Rak1gCYpkxmJbJ9P4HHS3W/AW5A=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_modules/2/full.distro",
-        "version": 2
+        "hash": "sha256-ub9rhTxTqfFX+12TI9aYpkguEIJgSdsaJRCoLRge9E8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_modules/1/full.distro",
+        "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-USuVJtYZG+V3mZahEmcn0r+Pc45xCYqBk8gxKZB+4ZY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_rpc/2/full.distro",
-        "version": 2
+        "hash": "sha256-DC+D+NDHWbbedeJKXvduCgmrwJzcW3oVMp3f5PVk2XY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_rpc/1/full.distro",
+        "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-BL7UkZR2O5562UUmkadrxOVifL2d/vqRqzaW9k+lUks=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_spellcheck/1/full.distro",
+        "hash": "sha256-g966Xj0y4AI2LDfaGkWi0XRyibxSCIgxMYDVIaXZYT0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-IS7WwTqJwx/+OYgO2ZP3TxsVTXscLQOn5bEWLOBGOzY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_utils/2/full.distro",
-        "version": 2
+        "hash": "sha256-AyfvPHKrhWjO/x3czzDfVugvBFrRJzckKIqe7WAlhvU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_utils/1/full.distro",
+        "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-g2oiDEFwq0qbbeVlMM0xHKAGFjVTwSl4reDaDQGcZUU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_voice/2/full.distro",
-        "version": 2
+        "hash": "sha256-oOUkEZPfndE4Hr1CYOTOtrkdoQMWz5gmxanRQ8XRaRU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_voice/1/full.distro",
+        "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-hqysSEE+kDmW2VWt6PyVUW4lUMZfu6OH2KtmchMil8E=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1656/discord_zstd/2/full.distro",
-        "version": 2
+        "hash": "sha256-TvUI5v6SuZR3Zl5/nHhCS0HyqOKYC9YDXf2xqyVGx2g=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1708/discord_zstd/1/full.distro",
+        "version": 1
       }
     },
-    "version": "1.0.1656"
+    "version": "1.0.1708"
   },
   "linux-development": {
     "distro": {
@@ -151,243 +151,243 @@
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-Q9bks5auAvdLgra4XjdfPWuTB3vk9XLK88qDzt/n+u4=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/full.distro"
+      "hash": "sha256-YuPWTFqMbxM0BtvYLqb46nXIBXxJhcZ6hvz3U+Mi6pA=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-jMExmUWqVbOq4EYIoyTNGKS/rfkU4+O7Z+Fg134B5kA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_arborium/1/full.distro",
+        "hash": "sha256-+0VfAA/9BP4DTHXDJ7pcem2yHuwSVd4tH8hsGCre46Q=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-B01L+R+aqv1RE3fwzHpN4F66QAtW2aPtCe4kwxndSgc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_cloudsync/1/full.distro",
+        "hash": "sha256-9WlMhXNpu+JizKkF2z3suff7wMumhbAFAHTk1/+ba08=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-bQs4Mw9m6EgEvxJQhyVDDZxmEIl1+QF2fEGomFWBfks=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_desktop_core/1/full.distro",
+        "hash": "sha256-zA1qsFzuANQnAF1wXhym9eZwD2sxbanHDUZXF51Eij0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-ZVeNgOm+LJkfPWUcmuU2WpUVXv97rQhddra+4vddfbc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_dispatch/1/full.distro",
+        "hash": "sha256-r8o/AU5zxMiGx7kXcnbafj6GTPa5Kr2n3xee4ryFSdE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-dHKetV4PhR3MJg15n/C4d+g6g8q+WQozh6eg1LEb0Ps=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_erlpack/1/full.distro",
+        "hash": "sha256-ZbaazM4RIwxrzzZJyDZx+Iw7rJ2oEW9e2XbXNDA/R7g=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-z2iSEoCSAbWaU2Ne9/jZUfv9JCk1sYremsP2gruBQbc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_game_utils/1/full.distro",
+        "hash": "sha256-xUOwGyzobWjXbFJkgL9uqBIuaIjnPeEiJFRwnyNWBRg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-xQeO7W2XlWw+dc7NJY3ne9aNQL0qzZU200mSUhiTYiU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_krisp/1/full.distro",
+        "hash": "sha256-lpRh/qiO03VdgZPifdzsFVoGrHRC02fzu1xDXTlmYgc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-0FcNSnp0ycvJ8DNEFOB5p+YZmd9uZHZiRHhqJZVwtZ0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_modules/1/full.distro",
+        "hash": "sha256-cRE2T8itmMSt4pyhVLF5BdNvab+7zrQzFbmVItAday4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-gNzN1OgThJdMEZLos56V/2ZSGrLZ3jqmJw8DCnxLKwg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_rpc/1/full.distro",
+        "hash": "sha256-tM1m9Z++9ocv86Vq51Mk3fV6gw7gXVro0s+KRYHiNv4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-KkY5vaELo/9FdTJDygYM2+n2e7xxEhBdmwHf7GiD2hg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_spellcheck/1/full.distro",
+        "hash": "sha256-AQNCD5PR+64533K6qFZL5ElJQ3DNNA9sTt5vT/ycNys=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-bxWkpq0mY8a3Um2HoTDF+1xuY/0YNS/UHGc1xb6aB+E=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_utils/1/full.distro",
+        "hash": "sha256-PIzILnXT9d3mmIWHye/qriZE6D50b6/ti74Lxj1Ffzs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-0k2Y/qhKv551VDkIwenvZ1Gj01pEL/IRkF00d7t2vEc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_voice/1/full.distro",
+        "hash": "sha256-Kz0npGXNghQEWNESWQVVeLomcBGz9/VOFgDbX0hPAZI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-xSmXAHdAQpbgdOmHLorQU9ONRvKL62+s4+OaX9ZyKsk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_zstd/1/full.distro",
+        "hash": "sha256-B+kNjxDLa2fU0X4uEZYP0FG6erqkAC4Fdx6Bp4cHsOg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.209/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.207"
+    "version": "1.0.209"
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-AzcQ2f6fsLAOvamgJMxMVJbhVh3JSkHeeLRsCwNqsnw=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/full.distro"
+      "hash": "sha256-Jbe1c2lQC2ZboXx0lTR5MIuE70YXNstEDRSOa1AaGJo=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-wOodeJufXbDUDSsSyrG8+OJ/OxBPFfg3r7utbI7slms=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_arborium/1/full.distro",
+        "hash": "sha256-s4CrlXD5GOzFa5QuvIVbpIVXzTnQo7tToA84Jn2ROdY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-Z9AHOO66v3eo/l9dMNE6FPduXwk7itn/ux+IBHKyUNw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_cloudsync/1/full.distro",
+        "hash": "sha256-2lfPTEVyLYo5HgC+sSJoXU43KaLUjMy4YvQI6TfURRw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-Zis/QM7anwCebhJVXeO+kYQ+82JVxE/l/9DSFvbE0M8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_desktop_core/1/full.distro",
+        "hash": "sha256-HFAorKlSZ/Dru4CslYdy0pf/sFYwG4Ir8y4gtozmKW0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-rpF8mVEsRC9sR+OiihCV9EhJF1c0JwuEFlKxaeREhYY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_dispatch/1/full.distro",
+        "hash": "sha256-ZZTfsK9fSK1DGuKVTSt09G9JacaJjJ/VY8kUCP9Iq/8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-MMcPGHruTeb/Fu9syNn5/XTxUR0JTNqAesGTLbAi20s=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_erlpack/1/full.distro",
+        "hash": "sha256-VZcVF6+4Rz3f4kf/fO+UddoHyF5pUisBc19sj55Zz6g=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-UkZ7f/Ckc2oDKSI1tdZU/2YBukkVV1eugtOCQ5ShVgk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_game_utils/1/full.distro",
+        "hash": "sha256-kZa3R0JcdhjKTRSOAUwutLRgxf1paeB7wAaZ9Qr7hwk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-rFGeGhR5d7Y7Jo1R3netJNz0aAkHd8uBfRtbcK3mZFg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_krisp/1/full.distro",
+        "hash": "sha256-kpceuaumwlLM4ge3X/cFgpad2Jz780Z0zaLeZxAikX4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-9/KdLuTux8f5mWoQBSpqNkcU/PvodaMVmAuGRkHW72c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_modules/1/full.distro",
+        "hash": "sha256-uAU0xzJcXNHbOmb7MRP6Y0uxbpY+o9feJqeIMd6+Xy8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-8AgyHPFu3ixeCi71M1W4hjcZHvacWZK2vPNhqRMFqZs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_rpc/1/full.distro",
+        "hash": "sha256-y9qMa45isIIuMamURN8GnJR9IwJcQBVdjZ9y/APyVjw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-lZZitgtDkVaznkda2t7/5krxfOh3hF2R6ID9oHfaNos=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_spellcheck/1/full.distro",
+        "hash": "sha256-rEDql1sShCczi93qFJQRC2SM67JUysjZ99WT3GSGOW8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-bi74t/4DTAL4X8LIiRvx95UlvPy1b1ORgVo49S5iGrA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_utils/1/full.distro",
+        "hash": "sha256-8XatkwwkD3Sv49D8jWbBfzXB+ZTdFl/pxis0g34IeqQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-o8dEAGCZbwy7MNGX3XlEb1/2cfSwW6t9NUS5S4ePd5o=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_voice/1/full.distro",
+        "hash": "sha256-ahEm4vS8E2iviZg2OkC8wddnPtNdKWLLURHxVnvjA8Y=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-wPVbgwlzi7qvim3+VeXvk1oXBYVniNi7tilH1R3/Xm4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_zstd/1/full.distro",
+        "hash": "sha256-twZ9vlBJMrqxGI6+jJ9LSrDyVA8R4d4jHMaSVBq+Dnw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.154/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.153"
+    "version": "1.0.154"
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-oMoOhtB5M0BbSKhHbomjp5vCyNYCAh8UtEpINCi4wlc=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/full.distro"
+      "hash": "sha256-0eSfGBiXwqkMU61ssjsXhvkFBumAkjdITlWL6tTi92g=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-6NYHxQfprHHdZGknYMxEl0lo29pt0ryrR9sDvYHO05s=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_arborium/1/full.distro",
+        "hash": "sha256-Zn7+k0v5nHnih2cdLK/wJPWepojTzOU0wxtmXrDonGE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-+PHB1wpTO5+R3zA9dufE3xLy0syuQYSS+a0jsCNGNjs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_cloudsync/1/full.distro",
+        "hash": "sha256-6CpegWEs1dQpbfgPl6O0PIeKBVJXK6yMixMGWQF5yC8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-bxAGSMxQr9Bp5/N8VVMIg3ro7Z/lHtlEmaIm56qgg+k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_desktop_core/2/full.distro",
-        "version": 2
+        "hash": "sha256-JVBcxhVmu6FpHMlph/exCphc05vxQd61vFJHGYzge2o=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_desktop_core/1/full.distro",
+        "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-2DKqLoaZtxY5LhYOPPejnsVq43mv5spxuMXAhCiq/NM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_dispatch/1/full.distro",
+        "hash": "sha256-t7jWDXKar67dGJ9jK2pgfqMoK/Jle+FVSZun6HGo5KE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-nBObSAmMDKQKGYvgnsV8j/D1Z6z/zVHK7yIt7JnD/Zs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_erlpack/1/full.distro",
+        "hash": "sha256-BCoB0Rc/n+5h2oSkwggNHKK4OsDqs4bRv6PdaGdsmso=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-7KQ38od6K27ycVkvOnaH7SLv/Jx6hPYOE84nzFH1dXI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_game_utils/1/full.distro",
+        "hash": "sha256-MGeX2vzmnr0NH5ydrWbBHALw6AEJAhIDlkj2lqtQj9k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-APCh8BArgt5RevI2QJOVLAssgYS/cjdFpIHs8JPTTAg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_intents/1/full.distro",
+        "hash": "sha256-hRonAfO181VG7D47a6s7sado/4UliuBmGoSTRFrQKHE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-fLU6kopr2sQUkXG4A+atBY+AVxjHSxfYAR6TGBdZLvY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_krisp/1/full.distro",
+        "hash": "sha256-V0GXYcWxqnLf7W6BUWpXXRPbAn1V6QLjz6zHqUZSacM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-rC8XQ2jm17GBY9FCZXjVILpEIqW20wGs7jauzX7f87A=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_modules/1/full.distro",
+        "hash": "sha256-vNzSz1CBayfESmuJV4CVN+CTv0cWwHMhWeUa3w0xuYg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-RUDniZB+PdGPlDcVRYlsJYeHvaYokmZ2BZNRO3KOJH4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_notifications/1/full.distro",
+        "hash": "sha256-8eMZfw7I5cJ6r+ZqZQ/mwdXAXwEp/7o3JcJJIITPZas=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-ruTPBYzfG71eKxnglHyC6OkhZQryh1ftqFNMWOJ/3CU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_rpc/1/full.distro",
+        "hash": "sha256-A12BPHYO8QWfFhV+WIeok6VG1cc8JrYj6GM61VPVGpg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-DQryV7MY/Xz2XL8agjM3iJY2wY4LYsjQ5ImYfEnUvnQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_spellcheck/1/full.distro",
+        "hash": "sha256-1bOOriRzzHZjSL1ztV14c6KFSai5qDqyAD13agO0lq4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-zbCFs+lEaT4s4cBw+UeOaxtWM9cIf4Sh/YnFX1DdUkA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_utils/9/full.distro",
-        "version": 9
+        "hash": "sha256-Pv5XFbdWFbU6eWXDW+zupqksD7avzqpLx1x9xXJ8QuM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_utils/2/full.distro",
+        "version": 2
       },
       "discord_voice": {
-        "hash": "sha256-Ud+AaFDH01n1ArYaMSyvx7JKv/CFqXahe5+49rPi3Rk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_voice/4/full.distro",
-        "version": 4
+        "hash": "sha256-0928JNCYg9G3I7eNENoxuTFacVINxw9XOi7uUsiGrMA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_voice/2/full.distro",
+        "version": 2
       },
       "discord_webauthn": {
-        "hash": "sha256-4iSifUx00540kHxVmTRUELc7CTdeQlrzumL6PoZ5UYc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_webauthn/1/full.distro",
+        "hash": "sha256-lD6wGZtGq7lcr9TRonRXlcRI7qTozRFHiH14X/gUMq4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-IAfkqNAHP1nGZ1mavrRYVnkNwyfTchb70XLuFAiTB+I=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_zstd/1/full.distro",
+        "hash": "sha256-/6Qw8tqF80RfPW9dvD0vuE2anPiyNo0yy3j9r9nkwAM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1277/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1263"
+    "version": "0.0.1277"
   },
   "osx-development": {
     "distro": {
@@ -481,182 +481,182 @@
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-xqK2ccjvIq2205uSde7nZwuzjE7U3V65xbISl1O9Z+Y=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/full.distro"
+      "hash": "sha256-w9wB8KPh6CthR9Yw2H+gFNg6fmv5PmLgEhtboWvhxZU=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-392qPOUB5/+KYju+svk+Vphg+ECmDdwE82NAWD5Eubw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_arborium/1/full.distro",
+        "hash": "sha256-Jx1TGmpFWtE/679SdXmNiB+X/DOkoEz52LAESihTqzQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-dB9v3tSGOGLgQ0fF+q0m8ckZpBqsC/NXoKcgZStjmQs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_cloudsync/1/full.distro",
+        "hash": "sha256-dXNUW+/Y2GAChywnGvWY8B8f1kKLz3MDgvE5eEz7/rw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-kPusXzr83hV2JDCHY7dldgmD0rWMIjfwPTznizQb++w=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_desktop_core/1/full.distro",
+        "hash": "sha256-F1VFToFXQ9NIUpO+kd6d01GYr2npT0m0Vm1S6kMWu1g=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-LCfwTLjH+W58GZPhlIvpsafywd6hm9e4Zc/JJEE7lH4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_dispatch/1/full.distro",
+        "hash": "sha256-oYcIU26YlSLc18DdPvGEcMHJ9bnoumPLqjO2WZQwffA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-2L/D74gNqiycvKxoaCYJGeeyjf45qTeQ/eFa7N6w6vE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_erlpack/1/full.distro",
+        "hash": "sha256-vd83Ll52GppTUerq9UN0lWg7uUkYiQdKNRyxwyMhmBk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-wViTZ6iAtKtR2ny5uSj+3/vxn0z4mPhKVCDTEPQufmU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_game_utils/1/full.distro",
+        "hash": "sha256-X1wyM8qaJT5hidS65P+ndCUBlGFqDnqIc88g+es+Mos=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-m11Mg6dE5R+Om5jkk3spTK4QC9fapaklioIM4puAa0g=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_intents/1/full.distro",
+        "hash": "sha256-oohGlWZ+6CMQ20hQuU5cfqs+0vZR6d1txcUxPOzK3Lo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-xFGTfwJ/50pBAgShh2aglGb2VoROHR1aElUVFuVVkzE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_krisp/1/full.distro",
+        "hash": "sha256-jw91Bv0gyok8a8NvJ1hBjhDEfgOnokIzoUZ2ZZWpWoI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-plKi3K4GuAEgWdyzYXQMlSZbhdMcmbBFoAe1tl8jJd0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_modules/1/full.distro",
+        "hash": "sha256-0ikZoFZOkyYm+vRmBY4JII2f9uVpW5XK2fpDFTIXqkQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-tgwZxO9PvUrdIfqtweOgqx81beNIqDW6EUvrfOVByT8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_notifications/1/full.distro",
+        "hash": "sha256-bR/hgTn+1YL6uQ9F+ApVbVm5KcF6gq3rY0XeGkUTLPc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-flPvXkXnvmIGWm+fNl1vz3sqNAOVX/2Jg8p0Ux1qwFY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_rpc/1/full.distro",
+        "hash": "sha256-38pYMWnIgynjCw1vWGq0N8zREa9EAyAwgCGCn9VpWf4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-mv+fYsdqFfWaIWewqpSfgDY0g+HMGWzjT0Z1a7xz+vw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_spellcheck/1/full.distro",
+        "hash": "sha256-FNrmbCafS3ULo2nYK2Rr4F7Zp10Yj17v1QoLB0timFU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-vJ9f3liVgZEa38lBUK+uEg6H0vfDLWTsELAwUAn769c=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_utils/1/full.distro",
+        "hash": "sha256-guG7HpsqRInvA88VVq1k2FM92bQBksIGhyKoy6ayZLs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-GtyeRTOi8OQQalHYiL/ec0G3tg6hefnxJlfAokQ/A2c=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_voice/1/full.distro",
+        "hash": "sha256-tWMz0z32xTDh19o1/Ftq8r3u0P4UUuDqylvGO3T39NM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-GpyqMtJqmVRIMmPdnBWRmWXLcEjCQPu3EShRaZ5PuBI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_webauthn/1/full.distro",
+        "hash": "sha256-VpoB4yt3BjaaCEzKT3saETLw55kVLFLwHsW0Wfato54=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-L8fVldjKOA95/gd0vJRAn3p2oRHwQi7iv9DfC5RwpEM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_zstd/1/full.distro",
+        "hash": "sha256-fpCJlVh4JQoCWQDhc9gClDJ026xEJ5kkml8W0YvCgPM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.254/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.252"
+    "version": "0.0.254"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-v1xV1DYVKfwelYbYMVhL3BDKAfsXe9Npny4kqpX6qDs=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/full.distro"
+      "hash": "sha256-4eUfTXY1D61HnGIJqYI1VC8qT1Ipxg1oiFKVyV+Qtpc=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-4PVxJjyYtSGI9StNjMKeaUSbYIifEYWTz7kktr5cPOk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_arborium/1/full.distro",
+        "hash": "sha256-EP2Wkh1PLyW7LAUJisYLRsQldoH2up4mRmoa4Vk0R+0=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-ffvvOuTkACsGgnBmubB6XDibYpeihr2i/lmlOGOa7VE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_cloudsync/1/full.distro",
+        "hash": "sha256-HmYxI3KpcOGOMaE/ECfaaOdI1kg+PrT2jHF4PGW7ZFk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-y46vUEzpmwRnRCs/KGzD/pRRSLA0/5l11VKJsEoridQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_desktop_core/1/full.distro",
+        "hash": "sha256-bxyIWGQkibkqc53asTFGdQiBH3OsH6QADp0JsVPmTAw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-LEm7zYYCVLB9l5JdlsIhJ6zVR3eCiyJfhvsMKvK6yTI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_dispatch/1/full.distro",
+        "hash": "sha256-8IYg26rQe8vZmsHbLZXIcCHmq/0geIZ0GGh0ZWJIYu8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-ClyKJPwYhHXW2p2nCVsa1Kf5Faeuxur4H0CI7xpnBdA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_erlpack/1/full.distro",
+        "hash": "sha256-8bFghQQNHPuKC/ei3DvCFsZQ25D5BI54lqN1wYWPs0s=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-aUVuPOS5zxnzVXUs+pstMWt9rkJsecvrBSruTNjHKyY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_game_utils/1/full.distro",
+        "hash": "sha256-9AWMVZ8gV8v3N1d0XHGL9XJJvYsb23ovzuGiOpMoixc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-qWgjn5WOjl78GVTAO/J/RA8ljlFrmYynfpEAXqYbGAo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_intents/1/full.distro",
+        "hash": "sha256-64mNiwVeJBAAfPWz7n7nxsPbLD4RBtd2aJPOeNM9Kgo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-RtQS0+jCoeBt0V2CGRkwjuTEar9+JxOv1V864e64cHk=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_krisp/1/full.distro",
+        "hash": "sha256-0ZUnE7LVixEi9YocAaHJZZLB3+1dsFkwYTkPnTjVtjE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-De6mRVFdakXVDk5IMLTdCTXVnVkNfmvcLLPRvtj3XAY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_modules/1/full.distro",
+        "hash": "sha256-Eaa41WNjsVDH7E7eP0xje9+FDsObprylN+jaXH23xeI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-AzLpxosut9r3acJPPBVw1pumW/le24+hMVlYDSu2u48=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_notifications/1/full.distro",
+        "hash": "sha256-OTzoqfivxP6sRiiH8FXW+tbwnIQv3yfQAsfr7w2g7Ps=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-bPvnC2DfmRETFYJFDQviXdFF2YI8gWRz5FcgZr8CX8A=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_rpc/1/full.distro",
+        "hash": "sha256-6Ik/T50MityBsfWdwEeZzW6diVPNdjJsvf2OjnyAuQA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-K6JoXsJNim/VOAVjqHU5Izaj1n4HZiDKTDU8HRFDQaU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_spellcheck/1/full.distro",
+        "hash": "sha256-Ywd8DbFjOkaM+/VgyllYepZhaYYmIr1x0HVK1xA+B8A=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-GkcdoGruyIOzokHgd/jeCPkPsGtHAry1c3WrOaRuHYI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_utils/1/full.distro",
+        "hash": "sha256-+bvRepVC0gDfNIRTFzn6KOJLEyuIRi7zR+ILbUD/BHY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-9B1pjqlvOM5Pit1JImYrVOzIAURyJN4pwIS+NBLaqvI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_voice/1/full.distro",
+        "hash": "sha256-3oZ7b7aMLjovdBptrCzcCO113s+FKWheE5oqUzpuxHw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-tqxA5qhMdUjKUWSRChBUnE5ul4obLxodxZPuSUE6+Sw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_webauthn/1/full.distro",
+        "hash": "sha256-U2PWtTh9MAsWmZPW0tX74AYgx5HI7Mb3LjcikJugnO4=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-QJ46FR7YP7eAmbs844t3ueQtcKNK9PJm3jNEPKCx0Vw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_zstd/1/full.distro",
+        "hash": "sha256-GkYJn+VWfPrEKXFqWNldTAqZdAXENsSrondtxGx/few=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.408/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.407"
+    "version": "0.0.408"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,622 +1,662 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-YXwWHjQnqHIVHte3ZYJwONFukCd2KmseEmzKAZltw28=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/full.distro"
+      "hash": "sha256-BNQNOzFsyHIlLiK7A6LAu19TkcAiDDx89Fk7OsUales=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-kT/0a5v4uAmFWWulmDWeGRv6oN5lc9n/HJwWsr9l2NM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-mJ8h1KC6JbqLhYFZ98Ko/0rHajxyFfeOVp0poazdHKk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_cloudsync/1/full.distro",
+        "hash": "sha256-wyJvwriVCmae8JFWFXYJ9soCPpseUPHGYEOKHW02Nus=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-nILxbgnowDmGgvl6evlBC11BNRhv5G88ni4uvgo+VhI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_desktop_core/1/full.distro",
+        "hash": "sha256-JQUFPdtj7aBkKr5R9+z6oL7oVV0NJbVGNETp+EO6wNs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-HndezvELozyQ77lEkkTNn7Gl7V6czWOZq8EyfJBVdVg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_dispatch/1/full.distro",
+        "hash": "sha256-EKaAD3agTQJ1KaNdOf4jBvGWoJfDTWgTs+8G99nycls=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-vM6OYH5yGTRigIyg36Y1KKg0WtNq9Hd5hmdX9r72eyQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_erlpack/1/full.distro",
+        "hash": "sha256-IPdxHTzaXv/r0LwVAT3quztXaK8vOCNJh1v55xmEcEw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-5b1mNvLLrYCtcNHn0vWAlfEns4DVJVsdLlu/fhGbfQ0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_game_utils/1/full.distro",
+        "hash": "sha256-mBunzae+Z4nR1tjMTRWTSVpyOf3pMxUDlnw85upZUwU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-W1tDAyW0lD9dG7G9Mm3Az5FUsR07oGXgR0yeKbVzXjc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_krisp/1/full.distro",
+        "hash": "sha256-yTvD3BzhH78hb6D6nWLRqu+3VleABNl+BPZCwMOM/vQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-TlBDD+sSlOIYpnYZ35vE1WyJl/1qHOFzhcfLLWWb0eM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_modules/1/full.distro",
+        "hash": "sha256-Y4llPF2dyYFswmwrJXspHxp9pQxtqTW+4GZ8Op8KCHo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-8sRdHH/lcfjKMvspohhV+4qz0LYIQIox87bKA/Vwe80=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_rpc/1/full.distro",
+        "hash": "sha256-RmUSfrf8HRW5p/Pl7F4ruGLRGgS60z+aWR7JHqmSeDI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-3ap4R+mraQPUySPP0Uxc5cvNv6X5646GWFP9tYMxa2I=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_spellcheck/1/full.distro",
+        "hash": "sha256-s+kgdS4JfvZq5+HrXzoZ765+m5c6s0QjFK8ogFNw5mI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-hhZQW48n2k4RiMwMrpKV2RVPw3OI+M4nYN1Q4rpnTgY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_utils/1/full.distro",
+        "hash": "sha256-6bPR3g63x/lbrkVT7MUAxA6uvNU90poRkrzVlRNcRa4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-MFDCDC3gBjRpXdre24TLCLre78ETA8klca1Op8heTRw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_voice/1/full.distro",
+        "hash": "sha256-532zqSYG4GGIK+94HfnbvrOr2Gh4lGEAo0jOZdVpgTY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-9nSczIYl6rR/Z4jxqA1/2/z79uHdqyNTSgoCJbNWDlM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1398/discord_zstd/1/full.distro",
+        "hash": "sha256-e7R2k88OIUpdOghohak+QHEiFhzoxD3y7TCkaO8zf8c=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1398"
+    "version": "1.0.1576"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-1gqCetK6SEW9h68uvvbdQdG3/aeSEBAcSFWeR5HWAzE=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/full.distro"
+      "hash": "sha256-zfiZMsEHhOGllXh6YiWuor42QfIKjCNTho9tie1lKmQ=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-rOrOSnL08Qx3t7B1I7yf3rn35ABpNbBiIqQy/GlakW8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-++Fr9fxL8TycHVPJGHgNwLQbGj/plLbCVV0WjBFKfWs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_cloudsync/1/full.distro",
+        "hash": "sha256-x+GMHorLVMKcmoxONHqerudU+HQbkJR+3tTCdlnbJsM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-tUeNfyHYRlSVlo9z7no7DvqpYME/sq9OSuat61IhArs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_desktop_core/1/full.distro",
+        "hash": "sha256-Zw7Shd9h/JUKEhzxzydx0hF+6xrp4QZfpyfaZ2D/rzw=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-cX0KaUlY4gRy3seF9O4PHWr5gBrEWfMLJEIaxzzhYJQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_dispatch/1/full.distro",
+        "hash": "sha256-6ASiSKT/okH1XAi+Pq7K4pJA15hy1rTRLee38ZQtZHg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-+AEkr5uLoxH3puHYXHTT5GmmC8foCUTSrpFhMuThNLo=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_erlpack/1/full.distro",
+        "hash": "sha256-fQyflEjpuY4rYPWG44dDZ9RCm9WMucrNmM86sO1ooL0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-teskTOsRJweCYeTvxS8PR5CEX4EaGm8tU/oseL4ad1s=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_game_utils/1/full.distro",
+        "hash": "sha256-wQfRqLrY1AxHyas8qCtLGqjXYB41uad8landaQUpgWA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-k6oid+zDm+yfUTtSZY1Irm808zUa/5s+J4OQHPEI+1M=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_krisp/1/full.distro",
+        "hash": "sha256-bAAAyPjM/Q6cnxQij/zO5x63wlv6NDwezKpp7HOM08g=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-8iM6E+UQMOIXfFjqIvJb+VdfT5wF49gvKU4tX6lc3/Q=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_modules/1/full.distro",
+        "hash": "sha256-x5wbM3RHr0LO5bCK+e/0UCBc2DdKoWp/9CYdXQ6zdFA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-wxiU4kGdLfpBA5MqLvGnzvlCutaSErRl82SEaL+Xn/I=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_rpc/1/full.distro",
+        "hash": "sha256-+BFXqTDJKrUf2wWHc+O6croSuIQnu0LAr/mxEJnff+k=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-9r7wsEAg0LNbL1FbVJl/3pJ65h4nuSSnpUUy2iC7gMg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_spellcheck/1/full.distro",
+        "hash": "sha256-C/foWHzEyvoFVX6KLOhlN58qCljn2CnaL6iNj5g2l+E=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-AcPgnX4VhD+n9cTGru0qsOC838TCmjrtjtTNI86/Nts=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_utils/1/full.distro",
+        "hash": "sha256-N4twRDAPHb53m0XovQPrrUQu+uNMTnThxajEeAgjq9s=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-UIruTOyO62eFeB7qfabr5rEhwzwd7jNUCqKtQnVfB7E=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_voice/1/full.distro",
+        "hash": "sha256-vUkoGmVokO7PN3bm2+ZFDF0VKxPwyOySAXEgcGnCw6c=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-ex0pjGnH8RgssZ64kfX+AA7f4THmPNUFb/pMiOZruX4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1001/discord_zstd/1/full.distro",
+        "hash": "sha256-thGh50fP/fiVhCpbzDUWidrpsB5AXuXv5TSaDpPhmN8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1001"
+    "version": "1.0.1006"
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-l8zQPa9N2lzJ4Rpsuhr8EsyXkwWXVTU0L7fm1+RzOJs=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/full.distro"
+      "hash": "sha256-rvVY35FvDyW1cGCn3UoTubeMPppsvqMoqWyb6SKVzvk=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-I8ShHnk09JgaN8JbNJ4ypqIUUpjaNvcbkHwZOPEmlME=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-qrdzHzhRaPSOdbAf2O2XqOUOMouh7HCMcTF5PFwBqBE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_cloudsync/1/full.distro",
+        "hash": "sha256-2L63AQE65sDijjWMfUcg2TYNOd1RmL/UEGw4tVeMacE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-pA3U5WSNeH07RYpeer062khjGk9B1fLwlmGFRiH0XSY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_desktop_core/1/full.distro",
+        "hash": "sha256-5cZniGW1YERHZba2sWXk3KsmqqHs7/gRAcXqvIraIak=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-n0QRUZgqF7t0mTaNn44bUw4wo5YJwBt/nrfawpDRjGs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_dispatch/1/full.distro",
+        "hash": "sha256-5IuFLhPbHM4y0GeRzTQv7EeHu/3IKSWaC6OZceU4C0w=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-OeYaeB6Uwtie9Gh7wEIXbWrzI3PRzForP0mBLAMdrSI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_erlpack/1/full.distro",
+        "hash": "sha256-gg9apvFeb3yaDaGI7LxsEsVG4aJEoutbX8Mirf7iKvw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-qG+kR+IxMa9+12anqeuLaAQJdtgsXhItWUVIYvlNHmY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_game_utils/1/full.distro",
+        "hash": "sha256-WJhVpqix0UL/H6h4XKLDnTyNO8D+169HZJF7nfyQO/s=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-UrTU83pYGII+URgwqgBCAWBUV7U2dH2Cyhc3O6IZkEM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_krisp/1/full.distro",
+        "hash": "sha256-EFXpq83j/BMjUz7drDGINdCUD9AcY3xMxCVIagznUvg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-KO+26TE5VHUnrdEwXYfYwKrwVZePmmlBH/tGL77gyq8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_modules/1/full.distro",
+        "hash": "sha256-AXHAyQMcTb6uabLHV8Lk19x03ua8DhJgjFV465pVlj4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-iphB/rQ7Wx39EqpViid9MgOG50gH5BxsPARPDkJXhkM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_rpc/1/full.distro",
+        "hash": "sha256-RxEYoZ6kvdr57VlUdBp7BRDs6M4cD+6WH1Oy1gHPbi8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-OzYl5D/3F4T8TOdAtv8EcL+B2Jb9avlG8iSD18WsDss=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_spellcheck/1/full.distro",
+        "hash": "sha256-ODCIIRCNM7cPMFodKe2zSRIAlgRRcJm7fdNFFWVMliM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-lfkvyLXha83pV/H9NCf0+8ky+PK6AuNmW9zKj8lCmeE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_utils/1/full.distro",
+        "hash": "sha256-/rJuuQMnS1mOMzBOi8RASdzdeRiaGcOUdfO4PMOQ5SE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-BH+AGzAKJulallcT1pP06xC1Ib8t0Rq85rMWJujWQDA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_voice/1/full.distro",
+        "hash": "sha256-Ue1qfeS5gJ0wP50JM74+XvOG/TB+CZVvflpv3HgdqK4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-HleJ0AvFtKKxBqWn3UAVRHBFMQi2fdHoYCPimCDmVJc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.198/discord_zstd/1/full.distro",
+        "hash": "sha256-GLYnIN10RBec54Xw/B9B3Col7f0IyFZRnXcf+bt+vJg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.198"
+    "version": "1.0.206"
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-DOc00KaMDkG0ggfeB3XaoFNDLB5DNFCsy0LpNcRTSNo=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/full.distro"
+      "hash": "sha256-3P0AC0nzWyxUCZZfqeeZj8p57E8bD6dfAnC7rYCUch4=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-EctcvW6AClcKnx+WMc1Az6XBD3Gr12H20sJrwJggjkU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-zrREHNdv2oD9IiYroQwmwGCXoGopJ9FOPtfzJZEtJQ8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_cloudsync/1/full.distro",
+        "hash": "sha256-b7WtS7VLHO7wUIXRbUqD5e4Kg22bAa8z71n0akkjSs8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-jz/qQx+B1HraLPc+cuWeLMI/yJEx/OGPWdSBctqmjE4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_desktop_core/1/full.distro",
+        "hash": "sha256-IKEkagNscLksT9TMsNjZFrhcgXr0jVMXlT4g25cx8Us=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-jjSf/9zBWqZ90HskSd2x0Kxi7dy2Yd2wdpO7q/ksSVE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_dispatch/1/full.distro",
+        "hash": "sha256-A+1g70FYSe+CY9/a/S7BSIGy5OMfFbOrbnoJTPVAUyU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-gStY1JHxI7NVZ+ZrRIFepDtGmfScaQYv/UF+aumnkxM=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_erlpack/1/full.distro",
+        "hash": "sha256-Uz8QoOc8c6fMUXEHyLZ80nOKDMb26IxdHGw7Pw8ZEp8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-7UMUAB48PFnGPrzQE5bbdT5dNk08+5I/TIIFj4Sog3U=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_game_utils/1/full.distro",
+        "hash": "sha256-HdWOJQy25w1l8Rmt4EwlJh06w5LxLVpfcLHhV8FZaRI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-DsnIrErojTUd7jN5YNoE2opqFC34ykKP+WkcU0TksFw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_krisp/1/full.distro",
+        "hash": "sha256-wcLDDaaNbyjBZGiN+OwIGsKPob5nHYVY2Qy1vAY11ss=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-3awhenotD42Frkp6RZx6QwzCyOmpXIznasG2ihGjiDs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_modules/1/full.distro",
+        "hash": "sha256-Ih6vth/F4DTkNs15nhtvLmb5cUCQRRERaVUBAuqc3F8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-OT/o8zvHG2QaLvme3F9QhB9qrfadX5iUAYKIPdkAjgE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_rpc/1/full.distro",
+        "hash": "sha256-3YCXPhC1WoakCT5nYBrrilwh8Pzn34lz2mT1aRYOReQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-GWRqjMnJBeZi5aR61s9BieoEoc6IYxRRxgRw+q0xdh4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_spellcheck/1/full.distro",
+        "hash": "sha256-LHGbGj/Tg3Xqt9VSvVZ12SNE+rgEwX8EcSsMGBqdA5I=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-AJftqpwcrGzu203HgucYHDYGkIWEFhU0eKYHSgF29zc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_utils/1/full.distro",
+        "hash": "sha256-To64PXhcM77MPEgvs5iHCGi/lxnTykLUR45wZ9fYA/M=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-ViHQZnR6mxYKH51n63TJjniaJC63dxpNI/m60uV88dc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_voice/1/full.distro",
+        "hash": "sha256-i5oAPf1e/FMD0E6nIXaxXWxC/VWBBOREMQxWaMUkvxs=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-HpB27U60HXn9rNu6Mi8JLzWZ0DGIUKZJh1r91myTBg4=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.146/discord_zstd/1/full.distro",
+        "hash": "sha256-vxFw1kpEiPAyt9oFCnGKrnXo9JsqQEwlv2OnRW4mWC8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.146"
+    "version": "1.0.152"
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-MABVLE+3vnmBCmhHVpJqIKpxDBzj7N5ulcNBqWDUp94=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/full.distro"
+      "hash": "sha256-9co1+qZefrLv1K4lnU5Xwgj9/eBqNpzRmYW5vLdkPDM=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-V0cQcMLSMw45vK9GGcqaww+WDjH8HoY29GlokVcEAV0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-fLocipTy9vP6rf4XjaFuZDUQnWoaakmcbjLYOnh5OFg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_cloudsync/1/full.distro",
+        "hash": "sha256-6dI0ON8pQ+Gh+L77y9VnXThjs7PJe9nv2NTBR4Otfhk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-1IJai0qH3RVA5jkzqf1KkCZlz+1D/KNBRGf8HlUGZWY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_desktop_core/1/full.distro",
+        "hash": "sha256-1Cd/HnwlOBk31L0x3YrToabxe/Vyw0VaYPVgNuQG+/c=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-L95JqWyryZYAKuOWUZ+gexgTlziWfl41hopVBVCqjLs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_dispatch/1/full.distro",
+        "hash": "sha256-dmYG5I7a4EQD7U8Jojt2EDAUmEE7p2VOnijTO/TdF20=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-xb3fxy6MqhnqN1i5HTJi3L6GPYxAPvfkahtMV0WlT7U=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_erlpack/1/full.distro",
+        "hash": "sha256-yBKtw+j16NHpSTcYS9n4iKQgeVNIwAfSsB3C9DIbEoc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-HsqjBvYiBkJ/xjmEhX+TR7UkokxnLe3LEPOEBB2RHd4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_game_utils/1/full.distro",
+        "hash": "sha256-m4DFxqv2x36qMCTeJp5B9XyyTupwjETrhSK0sV+GLec=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-gEozULgI4A+iNcIabHmB1iWH+LNQKQnSTId+/r2X4go=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_intents/1/full.distro",
+        "hash": "sha256-8YvFEAr+OYjfLRQLRF7VVbGfKVIbW4bov1GXz9xobdU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-6W7CuREYkbZIRAaFHxkTNPLl6ScHDej2NWnmcTEcgpY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_krisp/1/full.distro",
+        "hash": "sha256-HUvA/45D51g7mu63I8FESqISOfJjkyIb3eCsllej5vY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-kpLahPp2iWcFBHJgblEg9g/lk19e6os/Kz//Yl5oge4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_modules/1/full.distro",
+        "hash": "sha256-qMuNrAFufG7ujORzTW9W9dkQRcKPUT8w9lmBv2uzZsM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-RvSKe1XNvXqoE/MPl8/9bOhA+tW71cnc7EYd/L39dKE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_notifications/1/full.distro",
+        "hash": "sha256-GCmofjj/hXrorH4zDykUHqHjDbn87AQ4Ypqhg049RkQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-dGLMa/SYxy4RPrqfj6oVF2i6xrFZbgkv08kaaVl7uXo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_rpc/1/full.distro",
+        "hash": "sha256-mGDreWl+hE759OYdih/mYhULBjZFBhgTWtGVtOEmKtA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-LqyZA0KhqLrbw8Scw1Ctt8VPcE5sbOnTEQp29FMqiXg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_spellcheck/1/full.distro",
+        "hash": "sha256-+g/URoRFl5yRgKNg76FNQVM3io4+v/HksgJfV8iE+hU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-Mab3V31DCfao0Hpe7p0aBOpWAiYFNay2FcBIO3ENL28=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_utils/3/full.distro",
-        "version": 3
+        "hash": "sha256-eMjSyTPurOk8bADY3sicvREpy9Tdo3zaCcApTV00oco=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_utils/1/full.distro",
+        "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-s6xAtPnD24uGEuvfHgtySWHIgSbtMhihfxdmWWSgED4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_voice/1/full.distro",
+        "hash": "sha256-0EIaoHdFEnjGK5GArgOiCtvwycGJ2wrhykbN/xqzunI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-e0K4owkgsogjveuWlvXSpvmT0Roic0Udz1aN5lAm4ME=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_webauthn/1/full.distro",
+        "hash": "sha256-A5eJ60MQL/lhadgHdgw9alOlkFbN6mmol+uGSbpJDLw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-DfwIq15/ymRoPTHWBPmMtOZnfplpeOflFTUixq33bf0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1187/discord_zstd/1/full.distro",
+        "hash": "sha256-0Y8yKLJ+cSm2TnDF5TiosH2pt68q7UkI5BEtmgd1M3k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1187"
+    "version": "0.0.1235"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-Oh7Z3Vgz6X94gouVGH6ZK1cyY8xJB5sRD4SGV0bLJGU=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/full.distro"
+      "hash": "sha256-AxJdjMhqczCvcyP36DZA1V77De54VLXJMDFuIx/4Kno=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-1rooxrHTw2zz8zhrOsjXOVcaPoD41XqXgeAKo6WADfU=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-f7oEWFia4x12EzKdsedVXF/SRRqdcrD+I8jqs9zrKkA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_cloudsync/1/full.distro",
+        "hash": "sha256-eoQMlpNaiOFk7hso03BUWlihSWLkT2zM+eRXPp+xrEA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-v3rQ9qIb/n4YCKzmajU0IDHz3hV/y+k+KytmQ/YXmLk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_desktop_core/1/full.distro",
+        "hash": "sha256-3jAQsVaIroFL6Wfqnlu6iwbek0k/1Z+IuAKXs0KNHho=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-SHfcGs/NBldbjbmL0BJZd/WTYom6AcVG7I5m7ymNPZc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_dispatch/1/full.distro",
+        "hash": "sha256-V6mqIyF45hWht0MFgjyVBBbmiAdvPgfHJYvl0LWmDUk=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-Y7BqeSkpZcyOpkI0GJyw6WZUBJRYoVL+bupbf1SojPc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_erlpack/1/full.distro",
+        "hash": "sha256-OJvn2Diy/fqgUve2L8lak3WsL1DUteLpWxbM8nA+8jo=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-4ZMhl4mCSkHHjyqz1t4x2uGmLa1X317GzFHrWAxqfuY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_game_utils/1/full.distro",
+        "hash": "sha256-WutxVu+zGIDFGbELFyjb5dBVrFJRJj5V8JTCmn4iMTw=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-rhubNaouXncxstHF6AMbp8rF6GWVZwP9466jPYSFRK0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_intents/1/full.distro",
+        "hash": "sha256-IIJU1Ah4b3gxo6CrFue/YOWy2BVtUvbfNO4w7ERCAQM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-AJy1HPU6gCkvymmF0VJtioJ4b0iWl68LK6oD3ZqPmlM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_krisp/1/full.distro",
+        "hash": "sha256-Ob+b2d5LFXfJZ6mFRfH5lLaVDrPwr9pnNnBHtZ/0dyQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-1b1JyS8rk0roXq2Pj38asbtqV0Tv54QN51ayHfMfQFg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_modules/1/full.distro",
+        "hash": "sha256-QB93JvGxNxfqO9vfeREsTugvYtg1frlDn5yAmwERISE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-K+qPQAS+a+Aw62XTQRT+QKCXhMCcTyXidXgfVlQW7gM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_notifications/1/full.distro",
+        "hash": "sha256-TxctbxtERNH/Yl0FzHeU24pHn7A1MfMn+4hXIbApD5o=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-1pmg/bEY+88kB2YC5wLpaGGqKiT/B3XYbadUVsBmna0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_rpc/1/full.distro",
+        "hash": "sha256-AhXfGIn8yJM88SpQWRwoI3YXm7tpPbOc6GpxHA+HTmM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-xIB3D9YXDlsquJZYEkSu2tMtC/J+NGe/seHN1UwVGGM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_spellcheck/1/full.distro",
+        "hash": "sha256-x/054CiPQDI6sUdo2igu50ewg4S5KuFLoqm1sWW1wFc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-6C0B2Vylwjhx4H1W2LkgUgrzwyNDDwFhM6nOOUn5tGY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_utils/1/full.distro",
+        "hash": "sha256-GtIoZPTK/PfZt/UeRafoHEjS4Y7XatJKyyqfO0YvD6c=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-Bifs4a+ezNg+wLIyI4y1F8aXMNifq4XcPlnh/GxP73I=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_voice/1/full.distro",
+        "hash": "sha256-TiXEGpRhqvql7UBMkhQ+3F8Ulm6mLMVSSfeRTwTxA18=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-pcowWk2E/oeisZPUvzpgUChv0SotEjdlwvo4DSDmiA8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_webauthn/1/full.distro",
+        "hash": "sha256-bR4rs6P8jigB0oVUmaYkMTTxcN8pvrS/U2xribQMob8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-RO25Js1nsUR0Mjakjebvk+xA0qSq8csgyu7Goqm7Dm0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1002/discord_zstd/1/full.distro",
+        "hash": "sha256-HDKanat3AvBc2V+sikNiFzgPzVuZax7heQaJN43VBF0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1002"
+    "version": "1.0.1012"
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-8rGN6l46T86ITq5sietYgvzBXmXoT6nwzjMnuuQSjZA=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/full.distro"
+      "hash": "sha256-5iQy5SLHeITTlY03gJUNUx1PKC1jOQbdIo2zUVyDGuA=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-PyaPQwTY/2Cpv5DtDOZJ+RFKAYAyzlT9v3AFF36BKLQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-HBRk6tuF/ZVUwdbTc12WAB0yoO/LvpgeKDcbicTBdZA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_cloudsync/1/full.distro",
+        "hash": "sha256-BbX5pZd++LNV+3JQFwH8kJ1bh9RWE2Yqq2eCN5+0/H4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-g93AhKKuH7AzT9Y8ffrHG9hRebkWKYYOjjcs++yUdEE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_desktop_core/1/full.distro",
+        "hash": "sha256-nyfIF5erFieTIiCsQL6GNYxCO7Gpz8DeelO/B2Rpw/E=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-e7mbVl2k7M36/sZx71kYvrLDMy42yNrsRqqjZMiWCuA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_dispatch/1/full.distro",
+        "hash": "sha256-4mJogxLOZnEeZ5MuI7p3tSbe7vsxb0eGmpzT6MttT2k=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-efKY4APaWuWfExbIc4FDml2uiDyjHtUJienynt971gM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_erlpack/1/full.distro",
+        "hash": "sha256-cLJk6Szerl1zTZ0v+Zf9UJP+OXO+nCEC2bdbZACvnPE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-DpoEfSuoD9p4cdAFCA/qZ3hLcczSo6MBkfo4fxb+A4E=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_game_utils/1/full.distro",
+        "hash": "sha256-oqNKT3eoLPsNJqlfm2AzEklOiGfc2JscAEsXL5Wamyk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-jTXiR+et6y6AgNBVNrgeapxeuzR0/DWp8su8GhsQSAQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_intents/1/full.distro",
+        "hash": "sha256-CVlq/aYaAkPDxZWrrxF6Bs2iIHE5Pn6inQDlgmTrJ/E=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-tYwNFZW/BUJtKxRZnaJSRR4XFeDi+IW7o3+PjQkBlSo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_krisp/1/full.distro",
+        "hash": "sha256-bVATOPBQT95sjIdjDmTV7UtzsbbUJPt7wJzuB42Pxm4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-9kKjZzWePOU35wDHiBsl0zII9o5RH4eyOyCPFZR0XZo=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_modules/1/full.distro",
+        "hash": "sha256-55kX72P0TNG2Fjd2nC8VBdkzIDiwe43k0npi14OhHvY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-+3dkquHgrax8lj7n08Xx9HF6OQ01WIL5d+aCY26nhLU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_notifications/1/full.distro",
+        "hash": "sha256-ud8Gdem7I0wWztgXLb5nAIZKbjRJFe7vC4rDuWcVtVc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-rWC5DloPUbkvDIEBPKg4EKDY5FSacBshxo+vJvuJ5AE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_rpc/1/full.distro",
+        "hash": "sha256-udobFEZilri4O5flLuYB/6xeUu3bRAmHzl1tYg6jhqc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-M9TflkDKRWbTPi+cgW3PrEYCB7zp3Woc9yB/pNH8p6E=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_spellcheck/1/full.distro",
+        "hash": "sha256-qm0rDkgQ9cCvg/iRWPGeJ88JEcboRh2hIRGZvuF4Bps=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-3zpREVrc0xRUPAKNg01O40Koq8lUTrMLVq+y/Prjph4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_utils/1/full.distro",
+        "hash": "sha256-1VbHOcY9YvN1fr/jVSLT4uzkfqCH3jFaeG7VAP9Egb4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-J0LWWnNHquFmL9A21aTWNtoSQFokRRaWCn9j7vbTrc8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_voice/1/full.distro",
+        "hash": "sha256-g6NZ8wftX0NQo1RPgVIRttkMWneYLHQoCPMXABHryaA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-awMRcEndx6Z7gakNs+xjU0B1xTkpzKLy6mh0FzV9FaM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_webauthn/1/full.distro",
+        "hash": "sha256-v3b3G5zNsrxN0YbiWj9CnpJ7pElD/yEQ0FuhLHbBTV0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-pKQb8nsBQYttsfxVSr8x9OcIyMcvqZOqRfoRL+VkGbg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.243/discord_zstd/1/full.distro",
+        "hash": "sha256-QSIsCxlGm1zoWVsgocJzRm40p6q8va98itL2r+Pteyk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.243"
+    "version": "0.0.251"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-uIFpupv+dYzsrm7u4oRD16xgcJGdB0F66Y8PloIuhNs=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/full.distro"
+      "hash": "sha256-3rm5PmBdDnyzea20P+BjEGtLRqlVEoP41Xt+K7ToZr4=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/full.distro"
     },
     "kind": "distro",
     "modules": {
+      "discord_arborium": {
+        "hash": "sha256-QqwrF2RnvD0/qIg4w8AVVCNpWHCJfORLpmORb5bS48g=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_arborium/1/full.distro",
+        "version": 1
+      },
       "discord_cloudsync": {
-        "hash": "sha256-XmekQCmlwasCDjk8PKqYb1NlsCRYncYA8NEHZ64nIBI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_cloudsync/1/full.distro",
+        "hash": "sha256-No7N8S1iybTalWHjsdu2Q3brsftAEFspW25jX1FDurA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-vRkYtbDncwynzAHMPbrcgbue8eNwD192ZTWpKlhMts0=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_desktop_core/1/full.distro",
+        "hash": "sha256-HEes8D0s/M6rawNH2roB8lqYn4ApZz3kApphY1ezuis=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-33M/ThvatgTHmPY6CIVG1kTrzNqaiz5kEyKS7o20m2Q=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_dispatch/1/full.distro",
+        "hash": "sha256-hKcC+xAJEpwS+M1Ib9Pddd8LJlTNWb/oaIs3DkUnKWY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-yWIUP5aJ4X+Cb0RkS4yTg8DMywdoXW3hSQa7FGmbLXg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_erlpack/1/full.distro",
+        "hash": "sha256-XIRdZYiKWjLJUf21KesnHJSYpdNl0QlsCDp52IMz4ro=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-vnXPaWtiSg0rbX7MGo//+jI+jVGEZvsSBo+TzFAwW2U=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_game_utils/1/full.distro",
+        "hash": "sha256-QdIJ7dXjNHsRuFvVbEODVl8NgOEY5Ip2jxMCCavNP9Y=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-LMzWKuGH6nFaFgPuzL6NZd4HIxO+0VFqbagoNb1lV8M=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_intents/1/full.distro",
+        "hash": "sha256-ZjVI/78+05sIeWkLguMPn9iQkdTynloJYgTZuFNKaio=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-p+3SKNKUsrGlLA5GkkYr2TD7k7ldVIxH90u6TxW5OtI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_krisp/1/full.distro",
+        "hash": "sha256-H9CJRAzGw+xQGpO/7kc1BY7NSy80sqOxAsoOY92QMZc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-iamZlUKVHMlm3ZCX6kVx7EfEP1Xsox5a1DL+TzyPZ4U=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_modules/1/full.distro",
+        "hash": "sha256-oqj7CWUg++zp4SZnUjztpOxSznm1dUz1YmdgljmoN1A=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-UUdOFaSrcWdvslEAUtkaio9GjsdIKvJ3it871ZcdX9c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_notifications/1/full.distro",
+        "hash": "sha256-2ecYCv2VSybC8rQQZF2ZnpNx1HFliubic87gX/tb3A8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-i9X90vIFc2Sf/NEHcc9EOqd9vHRl0liOOeJiu8VsjDs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_rpc/1/full.distro",
+        "hash": "sha256-3aaqwwkrGJ7hHBKEsnZpuZzKeGfjbiJIHbpg8W+zuiU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-mWYbD4w/Hg53Ncl+b4dDAqw/iXvIlFa2OQZanhAdN4Q=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_spellcheck/1/full.distro",
+        "hash": "sha256-kNbKVxSt2uUhGP7YnBpbdA4AhwJ6M7oWpRgtajKDvIw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-S7N+84gmA8jTN4FOVhFt1jRtku+hvACJ+SH75gvZXcA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_utils/1/full.distro",
+        "hash": "sha256-3iw1MeZQnuzXrDw6A6xGJIeYAMF6wKyOh2K9yHDuC+A=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-2AenCW7EKw1R+znM1wGaiw8UHDZSKCqwmzNeFhqIyx8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_voice/1/full.distro",
+        "hash": "sha256-0Fn4yiGAc3Yb8G2K6xADTuXabB9r+IsTgMNFTGIsnEQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-fR6ArgR+/oo1QpkJQ1GralesT1o7W9hvuRxN5NjXGGI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_webauthn/1/full.distro",
+        "hash": "sha256-kLFIqxe60DylQUjno0gaPWZzM12J4NLHerVkpeT3pek=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-JUbwxsOw5XAE+EWj1F67kCXLHmltLCwsz9kC4E7/O5Q=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.398/discord_zstd/1/full.distro",
+        "hash": "sha256-7SYKwoygMwadLfyrH5Tw9N5lt2UqauhKBbFC8loZrqg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.398"
+    "version": "0.0.405"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,78 +1,78 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-UHlT587DCEDz7YSxN57S3mZ+4R2bi8/Aqvf62QuibEY=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/full.distro"
+      "hash": "sha256-xL+ntb88+J1cTuxjsnTaWT8CFrDWYr0pSMc64YIGuZE=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-/gA7pLPkyWAMQc2gNgq9L14W9hu3Bi5rPtCyWZGghqQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_cloudsync/1/full.distro",
+        "hash": "sha256-0Aymzs0pcCNbJXkkuyo5xSkQrhbOhx5JOzG6tHcE5nY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-/iCoCP3vNeAVXRK3smZdf8XrQNYanejlcjZ9fcddbHg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_desktop_core/1/full.distro",
+        "hash": "sha256-gYEF/ZIpUmmHWfV/R/UI4ns6d92OEAmDnb+5qxZ0fvA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-KjrgWGgTHuNOqm2NnOiDATyAgngaGSktATe5OnV3Cjg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_dispatch/1/full.distro",
+        "hash": "sha256-Z6vYHG2Dmmo5GX1xmgUG8hWvNgGD5BZGDOgRYy9ndnI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-eLse+k1w07/mGh0h3beXGZtsCz7NuP6qSQH6hJcNspM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_erlpack/1/full.distro",
+        "hash": "sha256-9tnEm3suVSpo7fAmKs/U1GIMDYSmru8iIu9gC+VYwfc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-JPacuW/LhaFGftu3tR3C4AKU+6nnJuc4N99CnvJskf8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_game_utils/1/full.distro",
+        "hash": "sha256-vAyeZHHAJehnu+AZgOjF9YAP10B2ae4K3lRhw4Wt4rw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-xYryuPZXFp9nvDQ4l8qFANh16CcO+ZNCEUc0/UXrBzE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_krisp/1/full.distro",
+        "hash": "sha256-6tsDKeI91t8blQ3L2KcDsJgZVpTcmZo8SjncWJZ6tEo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-KCAWR5Eoib/RkO3MVn8oHh6WBTfTMA2fMLMjMCrRiZs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_modules/1/full.distro",
+        "hash": "sha256-9jKMVVZ5/Vpl73l5211gz3B51+v//oivW8j5JcykOjk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-uYcDMwefWLdUzCjpN6b0h5pN95UKZs6gwgwA3uiPmb4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_rpc/1/full.distro",
+        "hash": "sha256-bAmp7Db9RCsJLw4Ck9WXOTakid48xyKqiJvU8Q+E0/k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-xSOog8VBcJBhbfzWXUlMMHWYfQ+Mkx0O5/IGu72zTvY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_spellcheck/1/full.distro",
+        "hash": "sha256-nGGBkx6H1hpF1ZJCj5wUu+FqbQDO/Ty9mWOuHQH/7Ds=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-UTNNk4RY6fk9GnTxNyhBI3XLmA38oSsdKVpLl3VqtjU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_sysimg/1/full.distro",
+        "hash": "sha256-EsflP0BDA/oUtQAoCd7d4TzVcXuCRYSIkRGYlwQujcw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-CbAcjtjZdENZcjcrEOLP/SOdi9Yay4/J4re0UguvO40=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_utils/1/full.distro",
+        "hash": "sha256-egS7bHXtnR6dzrHGAhihFb1KSPb2ttt/ZDXODHkIKjw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-Ev6sh9hjfjdZ+5ZmXKW4QXFdGwQAozXP4/F6P6BYISI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_voice/1/full.distro",
+        "hash": "sha256-K5ZmvT6nUdtPifJU9W1Xp2JKBGk8KNjhaYb5n8IQ8XM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-1Sfz6Wymr9T3mIwdRb4e6KYNl/iI2eDoiK+DDsGUty8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1794/discord_zstd/1/full.distro",
+        "hash": "sha256-tt5ite79S0aAJB7xlwNQp+w0pRD7K8nI1E86Z1XsVbo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1794"
+    "version": "1.0.1836"
   },
   "linux-development": {
     "distro": {
@@ -156,83 +156,78 @@
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-4LjSOiwKk82VvmxYEKGJnp0yz5pNbdJ3mDOgnK3+GCs=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/full.distro"
+      "hash": "sha256-fxA8n+5uO+pBjjPFmgY6dbTRqZbayTYE+j4cO7qPMyM=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/full.distro"
     },
     "kind": "distro",
     "modules": {
-      "discord_arborium": {
-        "hash": "sha256-1Oh0s1LoS/IqGUfP5ZLYdVGPXZVzK/hRNRa6qelYqFc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_arborium/1/full.distro",
-        "version": 1
-      },
       "discord_cloudsync": {
-        "hash": "sha256-Tv21h/Zx3cCz3JiCuM/NN8VwZti+KGTqscmDZRsGC2Y=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_cloudsync/1/full.distro",
+        "hash": "sha256-KCKZN2egYyexRz9JRX6Fg+p9luaMlDTDCfLdli5ISpQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-bfZVCO3uEWlHJa5IhENPpArW1j75wICaRe7BS2FyDN0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_desktop_core/1/full.distro",
+        "hash": "sha256-Wfgdtnp72mdDXpM3wTc2xNWT0PIUTTMidkQfL3w6VNE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-C/o9W9HQM27j7Yd9EL/gPqZ4Qwh1PnWeh1hfdwWwnQE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_dispatch/1/full.distro",
+        "hash": "sha256-1v9+28gF7z5GIi993yWx4EkPdxVa49HRLdtVwzggsWw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-tGXulf3fiJh/rYWAVkc3X0BEfYmJ7B+bpco1jdGshiM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_erlpack/1/full.distro",
+        "hash": "sha256-w6mHJMULPoHBb0a3WxMXdyLs48dEf+idpUHIJhQ8P9c=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-HteWjRWb7cGjTVx4KR9s6usA742cp09NbTeHF91tCys=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_game_utils/1/full.distro",
+        "hash": "sha256-xmeSzIv0pWf/5vYzzIxC95Szq3LZWdqj3MPzeHwLNVs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-ntr0p+Mjam+JDwFWTgrFhbmesXPg0CzkajBM/D4pZPw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_krisp/1/full.distro",
+        "hash": "sha256-sLECcnoHWJVglSXTuG2sq0TlaShdW6aKSeAHmt/Q1LU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-YC00gpi63MLWWQG52neNOcrE0CLmLPo1f2qtqOQyCNI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_modules/1/full.distro",
+        "hash": "sha256-1gyExQP4ENt+ISWZMVCU0H+O5AJQJ+glAyxsUYrYFDQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-+e6mv8np0+rcHbql4cBW2gymQPAceLC+1EX/fHOWf0k=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_rpc/1/full.distro",
+        "hash": "sha256-5sdL4sOlqQED9sYt2hP5klY9tF63qc6WAFc7ib3LRNo=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-KxWS1m9gD5+hZHqbLmjZV8nmvRJflVITugyvj14aZjM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_spellcheck/1/full.distro",
+        "hash": "sha256-sEaqqxYpHwAZtdMWs8lSHs8facsVfTigoLPbIkmdrFU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-g8mckNZNTCZDD8m1WnWx3vtsqZ1B/Ou0qGMf5F0bgX8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_sysimg/1/full.distro",
+        "hash": "sha256-vEOU4CqjWrE6XRRJ9+vOnYLkKfBFsGtPA2ARRnpvKNk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-/OKjhFGVQ/U3O/YvNkc+xrPNJGBAkmctgUjLiK2cOcY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_utils/1/full.distro",
+        "hash": "sha256-Ro1sw3Bean1EZTxOiAQWcZIxmn8L+YAXR/uXBbPs+0s=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-EgEXB1pXz5RTXtUPNwkDfuSP001luOYqFIH/TiIWGB4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_voice/1/full.distro",
+        "hash": "sha256-k/acD3/IhutROjNsLhb7Dwziv0/2GugNRq9jse5aMrY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-ivgN/iLzXIXdV0KTzZMakkgWj7mDvlAZ06RjLWvB1qQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.212/discord_zstd/1/full.distro",
+        "hash": "sha256-L4YH4B9xcKSp8f5sscQtrWdwjpxmnhsTRPOmmBz+NJE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.213/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.212"
+    "version": "1.0.213"
   },
   "linux-stable": {
     "distro": {
@@ -316,93 +311,93 @@
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-SjRGJwvd+IOkCqrG6akvvlFFpDV4gQozf4mPinKrZQE=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/full.distro"
+      "hash": "sha256-zG2DO0aJS8+fdfPvkiVc0nAE2mLDR/nniX3fR3uhnuQ=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-uynrrQxSvQjnGsS2V+CpiRfBCpNzAVgo94nySxMWrGw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_cloudsync/1/full.distro",
+        "hash": "sha256-8hmJBUMuZPl3Dkz9m4g67atYpewI5PcjLkq788tz0gk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-7tAXBdi+OXZaXl8+camk2IHEwzqrUpHjcc8QYI3oals=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_desktop_core/1/full.distro",
+        "hash": "sha256-UB5LRQTnHhbN9KC+kD3HX7QI8m0q0SObmz4EVrY6LDU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Kd3fZYacc9H2MfOfHIgdDu56HCeRYF60dG6234Uin2c=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_dispatch/1/full.distro",
+        "hash": "sha256-gUFPHu0TZBvpIOvW4XAOl7VWr7XMOOVs51n6+KnNSDw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-/JAAcJ/bDJaUllVn+0aAErWysh//dSPrT64uGe5THVU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_erlpack/1/full.distro",
+        "hash": "sha256-HtTpSD91ImClMs8ZbuzvGcHYNFCYw2GQGoE3VbBG9vQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-4x+ZNH831aCeuNVK2RLiAfaYolFcPSXFcnk/Y/19/Nc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_game_utils/1/full.distro",
+        "hash": "sha256-LMcKWglZhlKMSTnpKUnX0XeHTqk1X/BhHm7nLR+n+4o=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-1RzkNxAlvdLr7vpW2sIj+dE/6gkauXbgmyU6ZfROxvk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_intents/1/full.distro",
+        "hash": "sha256-UPlyqwDrIMOcE0tAHvirDHDZHqG9iUXm4irp5fqZV4g=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-WY5x578AvlwSUC/tV0j+SZItOCiHqzNZDfV4TfK52XM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_krisp/1/full.distro",
+        "hash": "sha256-/ArMS/+JGi/4BidFDXkRfdtA54Ju9DxuToW0hR9T8jg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-tOTaUzDS5EEJpxCT+2eMaELyqrpBpyg4VVAR2qoKpqs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_modules/1/full.distro",
+        "hash": "sha256-hz935fQ+Hs4azbvDCeLGl45vE6f/D3Ol+Nnp/MSnn5I=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-wgywWGbwb4ZOxAbvP1zwGmXYY7YcWVZZ/3oHPTi6+ns=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_notifications/1/full.distro",
+        "hash": "sha256-cXDUUw7ABarI5ki0bUAvGWDfQ1Aq/sWZnVxDZ6Fm3Hs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-76+PQX58ftimpJWWaasvVUz5csbR+mKL0DTcUYAYuHs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_rpc/1/full.distro",
+        "hash": "sha256-YJdIxtab/VF4CfOV/vAqDDESkXFd+8ps+n+ckRrFC2U=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-An1SBmKEPI8pRip6g/YZW6dGsLpx0TIvS+QCkI1YnWs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_spellcheck/1/full.distro",
+        "hash": "sha256-Tr1ss8BDNnY1qrQyWdKJV+VblrQaL4jxzTl82MP/GaY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-9MJv02Fk+ega0kbbLL7/s420Mx149sJFWvkkU66yJuY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_sysimg/1/full.distro",
+        "hash": "sha256-w4IO5X5Cpw2BrU5FGy1HS8xt9Ch2JG+4//bOjOqz94k=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-ptioApBU8h3ryIan7db5A77Tf87MTqRRNSVZhiUeUcA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_utils/1/full.distro",
-        "version": 1
+        "hash": "sha256-3/6v6CNXFHfwGr63ytXz2P1qzWGPB9rm48JEz9tPiRc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_utils/6/full.distro",
+        "version": 6
       },
       "discord_voice": {
-        "hash": "sha256-pVs09tpg7jTKfm54N1uaRf731Du9vpB7q8UFUHorpWU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_voice/1/full.distro",
-        "version": 1
+        "hash": "sha256-a27b533QSmdo7RiRes2gjSfcJRs/mDE/6TVC97nN/1s=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_voice/5/full.distro",
+        "version": 5
       },
       "discord_webauthn": {
-        "hash": "sha256-op6K8vlmdjXxsZ2+23CSuZGmdvS7tb7gCq5eRrD1r6g=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_webauthn/1/full.distro",
+        "hash": "sha256-vVhZm/hL9NpoCzplatI274NzjFwQxpUhHLx7ff1adh4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-bibBKtu5xxBdtk5lfJAMtrjVMz/YMjzFTjHu2xoTNSc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1306/discord_zstd/1/full.distro",
+        "hash": "sha256-kcWqLjg4kpp35RFykVXdwiJ+Uj8ts9ZXWUpWkRgmjXE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1306"
+    "version": "0.0.1311"
   },
   "osx-development": {
     "distro": {
@@ -501,98 +496,93 @@
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-0itWlg4uO9n251oeACGHfgId6sV9WwWXib+xTpLlKdg=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/full.distro"
+      "hash": "sha256-xSJnHM75GzxhNkdTEzEnR+jh4PP3zgIANIA7ndwqUiM=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/full.distro"
     },
     "kind": "distro",
     "modules": {
-      "discord_arborium": {
-        "hash": "sha256-nxM1iYpiUhF5out+DCCJGaiPr/WuQDYXxHHnOVG542U=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_arborium/1/full.distro",
-        "version": 1
-      },
       "discord_cloudsync": {
-        "hash": "sha256-+XUuoUmKHd0paaXCm64M/6GbI6oox3auQrHo2QB7IqY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_cloudsync/1/full.distro",
+        "hash": "sha256-Buv0wcl/2EAWvSCJzFlc0bKEEOOSIbnqXjMwY+cwI5M=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-+n+arWUqZyDX9pTRYd90uuo//JXqMo6L3mIymSkrUTY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_desktop_core/1/full.distro",
+        "hash": "sha256-rQyt0hoUxW+xMz73asGnFeMxkZufNDbmLDdgJUc9fEE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-7nuF4fhgJx0B7s73dnGddPr1gLpnaVksRYpKQmqf5Qk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_dispatch/1/full.distro",
+        "hash": "sha256-veiXEnZbvuiiHI7MqidLzQQABtWTxSco70LIVUOsK0A=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-YP5XoJ4gdPJwRVP9Poj0G+Rv+ZrWE1O8TQ211LfD6tI=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_erlpack/1/full.distro",
+        "hash": "sha256-y8mR/ItEI/35NUtOlQk/uFFfpC0XvrikPztniBCZ0mw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-QOggWiTw6TK9mj7mnn5EvoI6Ai/QuF6R6c16vJQQwMA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_game_utils/1/full.distro",
+        "hash": "sha256-a/Rd2yrYnSyRH46q7K4TjdyOxhjTV5wxmyr+e28aHME=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-n+LHKnwc/eDih0rCT11BCMNMG0Nb9LluIxkZ/qdLxYs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_intents/1/full.distro",
+        "hash": "sha256-vH5bLwFYVw1jmJUQAVSIAfkZLxMciXAgruMSz5FfskI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-hnPCYcyTRyXrq/HaQn7HoFlKF13VSvSwTRn3lrzYAxw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_krisp/1/full.distro",
+        "hash": "sha256-P4MaFl0tLzBNkzIy5cmXCtH8bhYpbnH8Xw8Uc7+OHzA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-l5X0AeddEKdXzc8z3SkiIEeu0aF9pz7SlRN2+jgvJsQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_modules/1/full.distro",
+        "hash": "sha256-6Df+jLQk9C/Rt1OsnNT60T1xqGVruSJpVO2eLsEx/jI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-1Hl6kvliMkmATrqPLUazkTkVhjXxuYufjV/wbg8WMsM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_notifications/1/full.distro",
+        "hash": "sha256-UdTzaszapaIt7wpssfCtmrdxkkEqvC/R6qHF/fTJDEQ=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-pZtk1ilJRl6/UnKV70ON4X1gEewdwUHN8l0VjiGb1QU=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_rpc/1/full.distro",
+        "hash": "sha256-Si0wowMId+zY1gYxhImkomdmv9fPF8m3IcGST+b7ZN0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-wPa9fIcrPk1yln0/dbhdJzJO93Y7G9x+L61mpGmu9Uk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_spellcheck/1/full.distro",
+        "hash": "sha256-F32hBklAZJxNEdstJopKPYLbY1B9MMjeAL9bFC2aDds=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-at2pxdYqY4h7I0vmmpJN+nuSi3b85qZvngfYVwjD7q0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_sysimg/1/full.distro",
+        "hash": "sha256-DZJrWk+vxq/f9Cv7f+54hjLfHR4Kw6/XY6qGuH9tNR0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-83pMGx2wlw5gCqcZPKwqUqztF6EnJzHSNExi/LaUsn0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_utils/1/full.distro",
+        "hash": "sha256-QwyNqhjJbxCnCRETabeQvJ3kPBlYBnCIotcm2c1Ju1M=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-bR4oAeMkBEi4miW27/I6YD7wjcQWOaLZJMsEcA5GttM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_voice/1/full.distro",
+        "hash": "sha256-/X03uFHTlI/YqCHhFm5BVft7son2SS0O00jy3ykMdLE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-JAhcJogkRO6w5lgDau3lQs7R9yvuw2J3e5yNeZkeOCc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_webauthn/1/full.distro",
+        "hash": "sha256-Dp94O8MbmaDs6oHbDI2TyYgtICP9kzudQAoi6otJI0w=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-YuztgnEkhGX5bUhqRTt4CNj3Cr/TKWFs9GFrnLHccXs=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.257/discord_zstd/1/full.distro",
+        "hash": "sha256-wyqD4miVuMQlvQLZzNr+uDbv/qMsC9JdgtdTIyUOuKw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.259/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.257"
+    "version": "0.0.259"
   },
   "osx-stable": {
     "distro": {

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,78 +1,78 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-xL+ntb88+J1cTuxjsnTaWT8CFrDWYr0pSMc64YIGuZE=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/full.distro"
+      "hash": "sha256-uQxJyinR8mB56H3KGSwWaXpZyIoxFgzohUh9K9IZwY8=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_cloudsync": {
-        "hash": "sha256-0Aymzs0pcCNbJXkkuyo5xSkQrhbOhx5JOzG6tHcE5nY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_cloudsync/1/full.distro",
+        "hash": "sha256-ykYw8jQfU1BJXsKbrprCQt5g6cNT0RXcUyVNPmSNjpo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-gYEF/ZIpUmmHWfV/R/UI4ns6d92OEAmDnb+5qxZ0fvA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_desktop_core/1/full.distro",
+        "hash": "sha256-BtxzmKUVQBJto711gws1ARGN821TFRWaC1np+fh3/FU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-Z6vYHG2Dmmo5GX1xmgUG8hWvNgGD5BZGDOgRYy9ndnI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_dispatch/1/full.distro",
+        "hash": "sha256-B98prLZThAcAgKUOJnua/iItc0i4DhoBH2/+jzojj6g=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-9tnEm3suVSpo7fAmKs/U1GIMDYSmru8iIu9gC+VYwfc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_erlpack/1/full.distro",
+        "hash": "sha256-+BZSW5BTiBDTVhxe6/f9cLkNlp+lCtooNvhAfdhNzxU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-vAyeZHHAJehnu+AZgOjF9YAP10B2ae4K3lRhw4Wt4rw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_game_utils/1/full.distro",
+        "hash": "sha256-S4P4KzT83TWK/jhH35AcG+zGthrV4Mlf0cfeIgfcJgY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-6tsDKeI91t8blQ3L2KcDsJgZVpTcmZo8SjncWJZ6tEo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_krisp/1/full.distro",
+        "hash": "sha256-g79im20tF1XQniy8aOhnqL6EWLNpSoUKc+6z2bDOpG8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-9jKMVVZ5/Vpl73l5211gz3B51+v//oivW8j5JcykOjk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_modules/1/full.distro",
+        "hash": "sha256-teJ5+Yg1pfF8gtAOBcIRVY45Cl3U+jMF7/PrfBm6OzY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-bAmp7Db9RCsJLw4Ck9WXOTakid48xyKqiJvU8Q+E0/k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_rpc/1/full.distro",
+        "hash": "sha256-BiUEtZYaKUYgtgDtxeezIz73o9iuRZHQzd9bJGNzAUw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-nGGBkx6H1hpF1ZJCj5wUu+FqbQDO/Ty9mWOuHQH/7Ds=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_spellcheck/1/full.distro",
+        "hash": "sha256-ZpaCPCHOVttMumVWON0HKVf+1TIK7UIyfmts1loBvEQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_sysimg": {
-        "hash": "sha256-EsflP0BDA/oUtQAoCd7d4TzVcXuCRYSIkRGYlwQujcw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_sysimg/1/full.distro",
+        "hash": "sha256-1g1nY1AnoHnxjbTdeGEa1kE7DciXXDn4qjSuPdj81UY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_sysimg/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-egS7bHXtnR6dzrHGAhihFb1KSPb2ttt/ZDXODHkIKjw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_utils/1/full.distro",
+        "hash": "sha256-INtmrjzvkJ6UQM0FnOHZUc+ETABG7zRHzXvbJza06sE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-K5ZmvT6nUdtPifJU9W1Xp2JKBGk8KNjhaYb5n8IQ8XM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_voice/1/full.distro",
+        "hash": "sha256-7WwuJ2yEIVOtIsR5nlK8rElr2fOgY4Ixo+mzkGBbJps=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-tt5ite79S0aAJB7xlwNQp+w0pRD7K8nI1E86Z1XsVbo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1836/discord_zstd/1/full.distro",
+        "hash": "sha256-YuoqodJ8vjlwyTzUptSlwdnfuL9biV+pCn4taWnSD+4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1837/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1836"
+    "version": "1.0.1837"
   },
   "linux-development": {
     "distro": {
@@ -377,9 +377,9 @@
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-3/6v6CNXFHfwGr63ytXz2P1qzWGPB9rm48JEz9tPiRc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_utils/6/full.distro",
-        "version": 6
+        "hash": "sha256-DGFzmkvpdEjRsKo2UNJvl1Tm8HP8j2ruGS4fYiWb8z4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1311/discord_utils/7/full.distro",
+        "version": 7
       },
       "discord_voice": {
         "hash": "sha256-a27b533QSmdo7RiRes2gjSfcJRs/mDE/6TVC97nN/1s=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,78 +1,78 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-BNQNOzFsyHIlLiK7A6LAu19TkcAiDDx89Fk7OsUales=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/full.distro"
+      "hash": "sha256-fKTr5/vkjP7sCc1yrS0kOVmi2OrqIVb2JL2RPUsqQnw=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-kT/0a5v4uAmFWWulmDWeGRv6oN5lc9n/HJwWsr9l2NM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_arborium/1/full.distro",
+        "hash": "sha256-8phc8K4TUv4mt2ntoYlaBRg4RtFuVcrfirY64Qp+ZBk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-wyJvwriVCmae8JFWFXYJ9soCPpseUPHGYEOKHW02Nus=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_cloudsync/1/full.distro",
+        "hash": "sha256-jFtuRcUn+fKYUN2wkiptosbKl/7e1CVmeVUtHyJ8MY8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-JQUFPdtj7aBkKr5R9+z6oL7oVV0NJbVGNETp+EO6wNs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_desktop_core/1/full.distro",
+        "hash": "sha256-2dUsisCRQjwtD/d1q0PiN3XK8cDNnzvxznOTJNcTGKY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-EKaAD3agTQJ1KaNdOf4jBvGWoJfDTWgTs+8G99nycls=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_dispatch/1/full.distro",
+        "hash": "sha256-JceufgMU2nH2aogafb5Is7gLd0h9ni78kTbuYOlJaHQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-IPdxHTzaXv/r0LwVAT3quztXaK8vOCNJh1v55xmEcEw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_erlpack/1/full.distro",
+        "hash": "sha256-3mLWumzibVOYtYS1rbn4erJeulxy5ZtfCRLQaAqeAps=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-mBunzae+Z4nR1tjMTRWTSVpyOf3pMxUDlnw85upZUwU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_game_utils/1/full.distro",
+        "hash": "sha256-g4pNJtLQXSnKeFZsZFERZo/3miCWAQVVQlP7rpb7t3s=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-yTvD3BzhH78hb6D6nWLRqu+3VleABNl+BPZCwMOM/vQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_krisp/1/full.distro",
+        "hash": "sha256-NLgteYsBOypnUODnWpXqc/qR4XDKDo82MCzohhcggxA=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-Y4llPF2dyYFswmwrJXspHxp9pQxtqTW+4GZ8Op8KCHo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_modules/1/full.distro",
+        "hash": "sha256-BQrgr95SnpYlD1d35UbNo1OAOB5sbfyHK+AUVSgOplg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-RmUSfrf8HRW5p/Pl7F4ruGLRGgS60z+aWR7JHqmSeDI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_rpc/1/full.distro",
+        "hash": "sha256-bEPGrW2uzYm3hgTRuEsGZvdo3mnT2Qg2rp8sHV1aRNc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-s+kgdS4JfvZq5+HrXzoZ765+m5c6s0QjFK8ogFNw5mI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_spellcheck/1/full.distro",
+        "hash": "sha256-L3XrGaU5dHyNTjRvzFsLpgnARNZyxPrtJnHgnwtphR0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-6bPR3g63x/lbrkVT7MUAxA6uvNU90poRkrzVlRNcRa4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_utils/1/full.distro",
+        "hash": "sha256-DxcXM3/jx6yu6KQTTSxvkNs0EI/9Dn7iebvjAo66r5M=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-532zqSYG4GGIK+94HfnbvrOr2Gh4lGEAo0jOZdVpgTY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_voice/1/full.distro",
+        "hash": "sha256-z7WvZ6A33ohjpxfw4v+gK36juG1aDppAvV0piBSWheE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-e7R2k88OIUpdOghohak+QHEiFhzoxD3y7TCkaO8zf8c=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1576/discord_zstd/1/full.distro",
+        "hash": "sha256-KFVV6YOezaxUMXpIfefTVndwgrPNlFwuIV2XPu5PDL0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1576"
+    "version": "1.0.1627"
   },
   "linux-development": {
     "distro": {
@@ -151,78 +151,78 @@
   },
   "linux-ptb": {
     "distro": {
-      "hash": "sha256-rvVY35FvDyW1cGCn3UoTubeMPppsvqMoqWyb6SKVzvk=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/full.distro"
+      "hash": "sha256-Q9bks5auAvdLgra4XjdfPWuTB3vk9XLK88qDzt/n+u4=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-I8ShHnk09JgaN8JbNJ4ypqIUUpjaNvcbkHwZOPEmlME=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_arborium/1/full.distro",
+        "hash": "sha256-jMExmUWqVbOq4EYIoyTNGKS/rfkU4+O7Z+Fg134B5kA=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-2L63AQE65sDijjWMfUcg2TYNOd1RmL/UEGw4tVeMacE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_cloudsync/1/full.distro",
+        "hash": "sha256-B01L+R+aqv1RE3fwzHpN4F66QAtW2aPtCe4kwxndSgc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-5cZniGW1YERHZba2sWXk3KsmqqHs7/gRAcXqvIraIak=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_desktop_core/1/full.distro",
+        "hash": "sha256-bQs4Mw9m6EgEvxJQhyVDDZxmEIl1+QF2fEGomFWBfks=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-5IuFLhPbHM4y0GeRzTQv7EeHu/3IKSWaC6OZceU4C0w=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_dispatch/1/full.distro",
+        "hash": "sha256-ZVeNgOm+LJkfPWUcmuU2WpUVXv97rQhddra+4vddfbc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-gg9apvFeb3yaDaGI7LxsEsVG4aJEoutbX8Mirf7iKvw=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_erlpack/1/full.distro",
+        "hash": "sha256-dHKetV4PhR3MJg15n/C4d+g6g8q+WQozh6eg1LEb0Ps=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-WJhVpqix0UL/H6h4XKLDnTyNO8D+169HZJF7nfyQO/s=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_game_utils/1/full.distro",
+        "hash": "sha256-z2iSEoCSAbWaU2Ne9/jZUfv9JCk1sYremsP2gruBQbc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-EFXpq83j/BMjUz7drDGINdCUD9AcY3xMxCVIagznUvg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_krisp/1/full.distro",
+        "hash": "sha256-xQeO7W2XlWw+dc7NJY3ne9aNQL0qzZU200mSUhiTYiU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-AXHAyQMcTb6uabLHV8Lk19x03ua8DhJgjFV465pVlj4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_modules/1/full.distro",
+        "hash": "sha256-0FcNSnp0ycvJ8DNEFOB5p+YZmd9uZHZiRHhqJZVwtZ0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-RxEYoZ6kvdr57VlUdBp7BRDs6M4cD+6WH1Oy1gHPbi8=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_rpc/1/full.distro",
+        "hash": "sha256-gNzN1OgThJdMEZLos56V/2ZSGrLZ3jqmJw8DCnxLKwg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-ODCIIRCNM7cPMFodKe2zSRIAlgRRcJm7fdNFFWVMliM=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_spellcheck/1/full.distro",
+        "hash": "sha256-KkY5vaELo/9FdTJDygYM2+n2e7xxEhBdmwHf7GiD2hg=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-/rJuuQMnS1mOMzBOi8RASdzdeRiaGcOUdfO4PMOQ5SE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_utils/1/full.distro",
+        "hash": "sha256-bxWkpq0mY8a3Um2HoTDF+1xuY/0YNS/UHGc1xb6aB+E=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-Ue1qfeS5gJ0wP50JM74+XvOG/TB+CZVvflpv3HgdqK4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_voice/1/full.distro",
+        "hash": "sha256-0k2Y/qhKv551VDkIwenvZ1Gj01pEL/IRkF00d7t2vEc=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-GLYnIN10RBec54Xw/B9B3Col7f0IyFZRnXcf+bt+vJg=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.206/discord_zstd/1/full.distro",
+        "hash": "sha256-xSmXAHdAQpbgdOmHLorQU9ONRvKL62+s4+OaX9ZyKsk=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/linux/x64/1.0.207/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.206"
+    "version": "1.0.207"
   },
   "linux-stable": {
     "distro": {
@@ -242,9 +242,9 @@
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-IKEkagNscLksT9TMsNjZFrhcgXr0jVMXlT4g25cx8Us=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_desktop_core/1/full.distro",
-        "version": 1
+        "hash": "sha256-YNJiO7xyeAMEYioARzVTTYcnBQtqqeQLi/y6eOpZ7oc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_desktop_core/2/full.distro",
+        "version": 2
       },
       "discord_dispatch": {
         "hash": "sha256-A+1g70FYSe+CY9/a/S7BSIGy5OMfFbOrbnoJTPVAUyU=",
@@ -301,362 +301,362 @@
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-9co1+qZefrLv1K4lnU5Xwgj9/eBqNpzRmYW5vLdkPDM=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/full.distro"
+      "hash": "sha256-UP/fCbqWT/dvpcWNYR/5n/XuqmVpAhCxjYaHWvk2Cjg=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-V0cQcMLSMw45vK9GGcqaww+WDjH8HoY29GlokVcEAV0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_arborium/1/full.distro",
+        "hash": "sha256-3VO8JC7ebIzMziyhH6brav7p8TtPbl4sq61pPbJOMzc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-6dI0ON8pQ+Gh+L77y9VnXThjs7PJe9nv2NTBR4Otfhk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_cloudsync/1/full.distro",
+        "hash": "sha256-kLSGxgA7S3v+xeZBtGgN0khkxdh9hcbrsGlyVBjw1cE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-1Cd/HnwlOBk31L0x3YrToabxe/Vyw0VaYPVgNuQG+/c=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_desktop_core/1/full.distro",
+        "hash": "sha256-Nhi6krB47b1VDk0CgAnwA+PvstX6gLcLbZImqf0c9HU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-dmYG5I7a4EQD7U8Jojt2EDAUmEE7p2VOnijTO/TdF20=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_dispatch/1/full.distro",
+        "hash": "sha256-cH4vazbRvhzI9YqlTgCDRAxIkw4qVX4cOV5dtlxMeuY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-yBKtw+j16NHpSTcYS9n4iKQgeVNIwAfSsB3C9DIbEoc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_erlpack/1/full.distro",
+        "hash": "sha256-x2DM3JHnpQ2+Wt4rceU5Z0mtxzUuXH/oE4z1ca3QAGY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-m4DFxqv2x36qMCTeJp5B9XyyTupwjETrhSK0sV+GLec=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_game_utils/1/full.distro",
+        "hash": "sha256-kih79540futkJFSWoTejizyJxB/Mf3K3nxATdXm2x6s=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-8YvFEAr+OYjfLRQLRF7VVbGfKVIbW4bov1GXz9xobdU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_intents/1/full.distro",
+        "hash": "sha256-vr7+4hRAyxys6CT5o/x0fIwdjETu09d/RCtSVlz2mEU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-HUvA/45D51g7mu63I8FESqISOfJjkyIb3eCsllej5vY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_krisp/1/full.distro",
+        "hash": "sha256-Dspe24q4z9/bBSoc6N7Z5w8GPFNIkkjYMAroRupehqI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-qMuNrAFufG7ujORzTW9W9dkQRcKPUT8w9lmBv2uzZsM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_modules/1/full.distro",
+        "hash": "sha256-eYq4mX8RREjp/xR14Rv8U+bJaabaE9rq+vDRQvzQqH0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-GCmofjj/hXrorH4zDykUHqHjDbn87AQ4Ypqhg049RkQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_notifications/1/full.distro",
+        "hash": "sha256-J9EfoyGE2Ft1SSWrOGVfyJ/Ib/bc1uiyt9cD69tXUQM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-mGDreWl+hE759OYdih/mYhULBjZFBhgTWtGVtOEmKtA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_rpc/1/full.distro",
+        "hash": "sha256-gk89NCtK0LLqRANigvkdjEHTjpRvnKm6fc0+pt54IEo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-+g/URoRFl5yRgKNg76FNQVM3io4+v/HksgJfV8iE+hU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_spellcheck/1/full.distro",
+        "hash": "sha256-hDDSdkjDgz08vZ6BN1jZVh31bJsRGHsenYCWXyd3WK8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-eMjSyTPurOk8bADY3sicvREpy9Tdo3zaCcApTV00oco=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_utils/1/full.distro",
+        "hash": "sha256-vTPvAY0RQP3vJTp8QhyYY03ZVEgumIhSIP4ngTPlvKs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-0EIaoHdFEnjGK5GArgOiCtvwycGJ2wrhykbN/xqzunI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_voice/1/full.distro",
+        "hash": "sha256-Xc7M38bbRC1ZlxMk0XkCdW0edyWVcfzOrsd7YLb39MY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-A5eJ60MQL/lhadgHdgw9alOlkFbN6mmol+uGSbpJDLw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_webauthn/1/full.distro",
+        "hash": "sha256-XQhYnvKtsmiDKxT7V3yUOx360kUXYLfdEBgMAz02xN4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-0Y8yKLJ+cSm2TnDF5TiosH2pt68q7UkI5BEtmgd1M3k=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1235/discord_zstd/1/full.distro",
+        "hash": "sha256-MgkmX1D2KMeCHz1owh0b2ZUWPfWrEmlbiqYr9a1VDp0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1235"
+    "version": "0.0.1256"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-AxJdjMhqczCvcyP36DZA1V77De54VLXJMDFuIx/4Kno=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/full.distro"
+      "hash": "sha256-ZijJyatJvrcSWu5Iq4tYIv+i1D7Hgqz3kH+o4BYbhUo=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-1rooxrHTw2zz8zhrOsjXOVcaPoD41XqXgeAKo6WADfU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_arborium/1/full.distro",
+        "hash": "sha256-XtUrMBmI+g9fbzsDsSSfwFL1piRxWIONHaPiZTQmpmo=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-eoQMlpNaiOFk7hso03BUWlihSWLkT2zM+eRXPp+xrEA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_cloudsync/1/full.distro",
+        "hash": "sha256-3L48hdOQ+Lq5rnNBzBy/HGqmmx4Wyt50YdJGxfx3h7s=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-3jAQsVaIroFL6Wfqnlu6iwbek0k/1Z+IuAKXs0KNHho=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_desktop_core/1/full.distro",
+        "hash": "sha256-aMMoX5ODlBb1bAAp+3A9OLLxIo1kmTsPF+47zs//Gu4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-V6mqIyF45hWht0MFgjyVBBbmiAdvPgfHJYvl0LWmDUk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_dispatch/1/full.distro",
+        "hash": "sha256-gJ/KtS9qjy+FmVHxpNR6XkmcwA2nOjmBWHU3sUCehLw=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-OJvn2Diy/fqgUve2L8lak3WsL1DUteLpWxbM8nA+8jo=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_erlpack/1/full.distro",
+        "hash": "sha256-+0ExSIVvMQWGboVYYng0Ncr+MjrmOF/7xZ7a1KvIsZg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-WutxVu+zGIDFGbELFyjb5dBVrFJRJj5V8JTCmn4iMTw=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_game_utils/1/full.distro",
+        "hash": "sha256-RcVLZYzA+jS7n8xXS+f+pkQ+f2w3hi0qIZh2zPUQCuc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-IIJU1Ah4b3gxo6CrFue/YOWy2BVtUvbfNO4w7ERCAQM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_intents/1/full.distro",
+        "hash": "sha256-1MUzJopQ/BED9UMur65DJWFCkgrw3Xlu4Y3ItBX/TW0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-Ob+b2d5LFXfJZ6mFRfH5lLaVDrPwr9pnNnBHtZ/0dyQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_krisp/1/full.distro",
+        "hash": "sha256-utIdxi9tyR7cvYDBACWunNABKk0vtr/cjI5jIYvquLc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-QB93JvGxNxfqO9vfeREsTugvYtg1frlDn5yAmwERISE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_modules/1/full.distro",
+        "hash": "sha256-EMQ9e+gFZIOnG1SS9Q+h0lB1yo+ByULyT/H5twNOU/w=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-TxctbxtERNH/Yl0FzHeU24pHn7A1MfMn+4hXIbApD5o=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_notifications/1/full.distro",
+        "hash": "sha256-ai+CIMOiPFswrVSB3J46VXgDpuRHPQqFDAYL4RnrWzo=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-AhXfGIn8yJM88SpQWRwoI3YXm7tpPbOc6GpxHA+HTmM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_rpc/1/full.distro",
+        "hash": "sha256-rVokXOQnMUb75i3nenmHHdbM1UuXjFe+F3J8DU/2/dg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-x/054CiPQDI6sUdo2igu50ewg4S5KuFLoqm1sWW1wFc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_spellcheck/1/full.distro",
+        "hash": "sha256-TYUVId8Y4kcNLIde54M8N4zFntdY9QhRKXZQ3JcxfMY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-GtIoZPTK/PfZt/UeRafoHEjS4Y7XatJKyyqfO0YvD6c=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_utils/1/full.distro",
+        "hash": "sha256-mQ786DyCLgT8yNR/roX3mSrfa0k+Oze7/zNsp2CZCIU=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-TiXEGpRhqvql7UBMkhQ+3F8Ulm6mLMVSSfeRTwTxA18=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_voice/1/full.distro",
+        "hash": "sha256-6DxoYnWBGUUSX4Qrfa8WaSjo8UNHm2/W6I3dC7P7XjY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-bR4rs6P8jigB0oVUmaYkMTTxcN8pvrS/U2xribQMob8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_webauthn/1/full.distro",
+        "hash": "sha256-U79yaA+TZfTXtjBfYe++OpDJbdB83J58FXLnPA3ACU0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-HDKanat3AvBc2V+sikNiFzgPzVuZax7heQaJN43VBF0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1012/discord_zstd/1/full.distro",
+        "hash": "sha256-KHKEBdo5E6p8CzIGBDBYXbT1eDIkjWy1IyZKRlLA9lk=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1012"
+    "version": "1.0.1013"
   },
   "osx-ptb": {
     "distro": {
-      "hash": "sha256-5iQy5SLHeITTlY03gJUNUx1PKC1jOQbdIo2zUVyDGuA=",
-      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/full.distro"
+      "hash": "sha256-xqK2ccjvIq2205uSde7nZwuzjE7U3V65xbISl1O9Z+Y=",
+      "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-PyaPQwTY/2Cpv5DtDOZJ+RFKAYAyzlT9v3AFF36BKLQ=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_arborium/1/full.distro",
+        "hash": "sha256-392qPOUB5/+KYju+svk+Vphg+ECmDdwE82NAWD5Eubw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-BbX5pZd++LNV+3JQFwH8kJ1bh9RWE2Yqq2eCN5+0/H4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_cloudsync/1/full.distro",
+        "hash": "sha256-dB9v3tSGOGLgQ0fF+q0m8ckZpBqsC/NXoKcgZStjmQs=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-nyfIF5erFieTIiCsQL6GNYxCO7Gpz8DeelO/B2Rpw/E=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_desktop_core/1/full.distro",
+        "hash": "sha256-kPusXzr83hV2JDCHY7dldgmD0rWMIjfwPTznizQb++w=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-4mJogxLOZnEeZ5MuI7p3tSbe7vsxb0eGmpzT6MttT2k=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_dispatch/1/full.distro",
+        "hash": "sha256-LCfwTLjH+W58GZPhlIvpsafywd6hm9e4Zc/JJEE7lH4=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-cLJk6Szerl1zTZ0v+Zf9UJP+OXO+nCEC2bdbZACvnPE=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_erlpack/1/full.distro",
+        "hash": "sha256-2L/D74gNqiycvKxoaCYJGeeyjf45qTeQ/eFa7N6w6vE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-oqNKT3eoLPsNJqlfm2AzEklOiGfc2JscAEsXL5Wamyk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_game_utils/1/full.distro",
+        "hash": "sha256-wViTZ6iAtKtR2ny5uSj+3/vxn0z4mPhKVCDTEPQufmU=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-CVlq/aYaAkPDxZWrrxF6Bs2iIHE5Pn6inQDlgmTrJ/E=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_intents/1/full.distro",
+        "hash": "sha256-m11Mg6dE5R+Om5jkk3spTK4QC9fapaklioIM4puAa0g=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-bVATOPBQT95sjIdjDmTV7UtzsbbUJPt7wJzuB42Pxm4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_krisp/1/full.distro",
+        "hash": "sha256-xFGTfwJ/50pBAgShh2aglGb2VoROHR1aElUVFuVVkzE=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-55kX72P0TNG2Fjd2nC8VBdkzIDiwe43k0npi14OhHvY=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_modules/1/full.distro",
+        "hash": "sha256-plKi3K4GuAEgWdyzYXQMlSZbhdMcmbBFoAe1tl8jJd0=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-ud8Gdem7I0wWztgXLb5nAIZKbjRJFe7vC4rDuWcVtVc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_notifications/1/full.distro",
+        "hash": "sha256-tgwZxO9PvUrdIfqtweOgqx81beNIqDW6EUvrfOVByT8=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-udobFEZilri4O5flLuYB/6xeUu3bRAmHzl1tYg6jhqc=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_rpc/1/full.distro",
+        "hash": "sha256-flPvXkXnvmIGWm+fNl1vz3sqNAOVX/2Jg8p0Ux1qwFY=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-qm0rDkgQ9cCvg/iRWPGeJ88JEcboRh2hIRGZvuF4Bps=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_spellcheck/1/full.distro",
+        "hash": "sha256-mv+fYsdqFfWaIWewqpSfgDY0g+HMGWzjT0Z1a7xz+vw=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-1VbHOcY9YvN1fr/jVSLT4uzkfqCH3jFaeG7VAP9Egb4=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_utils/1/full.distro",
+        "hash": "sha256-vJ9f3liVgZEa38lBUK+uEg6H0vfDLWTsELAwUAn769c=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-g6NZ8wftX0NQo1RPgVIRttkMWneYLHQoCPMXABHryaA=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_voice/1/full.distro",
+        "hash": "sha256-GtyeRTOi8OQQalHYiL/ec0G3tg6hefnxJlfAokQ/A2c=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-v3b3G5zNsrxN0YbiWj9CnpJ7pElD/yEQ0FuhLHbBTV0=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_webauthn/1/full.distro",
+        "hash": "sha256-GpyqMtJqmVRIMmPdnBWRmWXLcEjCQPu3EShRaZ5PuBI=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-QSIsCxlGm1zoWVsgocJzRm40p6q8va98itL2r+Pteyk=",
-        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.251/discord_zstd/1/full.distro",
+        "hash": "sha256-L8fVldjKOA95/gd0vJRAn3p2oRHwQi7iv9DfC5RwpEM=",
+        "url": "https://ptb.dl2.discordapp.net/distro/app/ptb/osx/universal/0.0.252/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.251"
+    "version": "0.0.252"
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-3rm5PmBdDnyzea20P+BjEGtLRqlVEoP41Xt+K7ToZr4=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/full.distro"
+      "hash": "sha256-Xs01Ui0u96n2Fpc/T5qObZWjqmbNuU4WTa9Z8OOtNk0=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-QqwrF2RnvD0/qIg4w8AVVCNpWHCJfORLpmORb5bS48g=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_arborium/1/full.distro",
+        "hash": "sha256-15EkIwQbVXPCnv65FpUc05Y+W/LfiIcFD8BJ0DehqEg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-No7N8S1iybTalWHjsdu2Q3brsftAEFspW25jX1FDurA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_cloudsync/1/full.distro",
+        "hash": "sha256-z8yUwMAWanKhcs1dEIB2Xn05KPjPqDInE56pbbHis+c=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-HEes8D0s/M6rawNH2roB8lqYn4ApZz3kApphY1ezuis=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_desktop_core/1/full.distro",
-        "version": 1
+        "hash": "sha256-jtzoHhXgMlPRkyd6FO52IyMyTjVzonJslADK1G4toiU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_desktop_core/2/full.distro",
+        "version": 2
       },
       "discord_dispatch": {
-        "hash": "sha256-hKcC+xAJEpwS+M1Ib9Pddd8LJlTNWb/oaIs3DkUnKWY=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_dispatch/1/full.distro",
+        "hash": "sha256-FteG3F0mMpOiLburBCySJ/DacqT01T2jfx4m5UW1UF8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-XIRdZYiKWjLJUf21KesnHJSYpdNl0QlsCDp52IMz4ro=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_erlpack/1/full.distro",
+        "hash": "sha256-p83ovML/oSDeEsdjuP9RH27ehXzbLLjVwAS1a58ItZ8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-QdIJ7dXjNHsRuFvVbEODVl8NgOEY5Ip2jxMCCavNP9Y=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_game_utils/1/full.distro",
+        "hash": "sha256-o+zjv5zskYrhoFtHq2UnvKkPkg66JSCnhV1h210Bt+w=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-ZjVI/78+05sIeWkLguMPn9iQkdTynloJYgTZuFNKaio=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_intents/1/full.distro",
+        "hash": "sha256-6aIKC5/mFx1Xy2hvckMGEZOJaZjbosbiccPVfvncZUg=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-H9CJRAzGw+xQGpO/7kc1BY7NSy80sqOxAsoOY92QMZc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_krisp/1/full.distro",
+        "hash": "sha256-AnVRy1f8PyTnHZ0xYtickRJFWcbvpQl5PKoCg3WlUxU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-oqj7CWUg++zp4SZnUjztpOxSznm1dUz1YmdgljmoN1A=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_modules/1/full.distro",
+        "hash": "sha256-VKN53f0QD8mavsVN1iJASDyBEbQWbrKzGMKCtZzoCFA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-2ecYCv2VSybC8rQQZF2ZnpNx1HFliubic87gX/tb3A8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_notifications/1/full.distro",
+        "hash": "sha256-kwzPD9lHU+IIoq44dF8rKs3fRqh5UI0N4uz2LC8UrGQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-3aaqwwkrGJ7hHBKEsnZpuZzKeGfjbiJIHbpg8W+zuiU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_rpc/1/full.distro",
+        "hash": "sha256-YgeTVunMN9Rk5uodwkJclD43ApqzO/6dGad02XZtsgo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-kNbKVxSt2uUhGP7YnBpbdA4AhwJ6M7oWpRgtajKDvIw=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_spellcheck/1/full.distro",
+        "hash": "sha256-Wk9cUfZspD2PtcbyO7pmT/351SvNa7z+5bwP5kKlEuA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-3iw1MeZQnuzXrDw6A6xGJIeYAMF6wKyOh2K9yHDuC+A=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_utils/1/full.distro",
+        "hash": "sha256-G0WtNX4hbO4iB9Xz8rY43ZEmeSUFU0m3XlLrlOhAzZE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-0Fn4yiGAc3Yb8G2K6xADTuXabB9r+IsTgMNFTGIsnEQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_voice/1/full.distro",
+        "hash": "sha256-EzRy0SjuEzkMvFlH7w6GyVDEh22hSeikw7hD5s7lsw8=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-kLFIqxe60DylQUjno0gaPWZzM12J4NLHerVkpeT3pek=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_webauthn/1/full.distro",
+        "hash": "sha256-fivCWaJhxbouKbhWPRgrXqv/7FKL+RpS8Qn9lIHngnc=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-7SYKwoygMwadLfyrH5Tw9N5lt2UqauhKBbFC8loZrqg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.405/discord_zstd/1/full.distro",
+        "hash": "sha256-IEHHrGPCcxWjKTPY7hYEQzk6Zh5UsC6rTCANgF77mjI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.405"
+    "version": "0.0.406"
   }
 }

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,153 +1,153 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-fKTr5/vkjP7sCc1yrS0kOVmi2OrqIVb2JL2RPUsqQnw=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/full.distro"
+      "hash": "sha256-wVyW1GrvmMEM/btexjTf2uFkTt7GNG+dkI3C+dWnrJQ=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-8phc8K4TUv4mt2ntoYlaBRg4RtFuVcrfirY64Qp+ZBk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_arborium/1/full.distro",
+        "hash": "sha256-F5zZEtp67OAUM4gLtV0Uhsy4Gj1eqX7vBjIlOn/GzNI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-jFtuRcUn+fKYUN2wkiptosbKl/7e1CVmeVUtHyJ8MY8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_cloudsync/1/full.distro",
+        "hash": "sha256-Tic8LFWOoX4AyiGmMwYwCr6T807aXLYbamW72/bZwN4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-2dUsisCRQjwtD/d1q0PiN3XK8cDNnzvxznOTJNcTGKY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_desktop_core/1/full.distro",
+        "hash": "sha256-zSF6kyKXzCERAEx8LslGt/YYPtWXNgr2Kdpj0Yx05F0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-JceufgMU2nH2aogafb5Is7gLd0h9ni78kTbuYOlJaHQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_dispatch/1/full.distro",
+        "hash": "sha256-8jJd14m9a3eias4cMCT1wRnu1aT8dzXUXCv5dAMLxN8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-3mLWumzibVOYtYS1rbn4erJeulxy5ZtfCRLQaAqeAps=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_erlpack/1/full.distro",
+        "hash": "sha256-uhrQCnQC4Dm/XkoYRqVzjUvweYabsJxQrA2LtUxQ7Ac=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-g4pNJtLQXSnKeFZsZFERZo/3miCWAQVVQlP7rpb7t3s=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_game_utils/1/full.distro",
+        "hash": "sha256-32OQHDin9330UsgJ6JYWkT2dv+ToyWzbBpxMKnjxEQY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-NLgteYsBOypnUODnWpXqc/qR4XDKDo82MCzohhcggxA=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_krisp/1/full.distro",
+        "hash": "sha256-2SfBfbzwcl2yhKikIiaw95qqixa/hm8apwhVnks/3cM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-BQrgr95SnpYlD1d35UbNo1OAOB5sbfyHK+AUVSgOplg=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_modules/1/full.distro",
+        "hash": "sha256-PmTRUml1bZY45GNEfZqMWDl3eNHdGrkM2f/kASSoFEQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-bEPGrW2uzYm3hgTRuEsGZvdo3mnT2Qg2rp8sHV1aRNc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_rpc/1/full.distro",
+        "hash": "sha256-n4WUN1e2mYwyd4TEa5AEOFv9OhXlimkTCNe6cWucH3s=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-L3XrGaU5dHyNTjRvzFsLpgnARNZyxPrtJnHgnwtphR0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_spellcheck/1/full.distro",
+        "hash": "sha256-koi/kVLiq9lSGlhiCXl2Cbw0O812+PPkgC2aBH0kKwU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-DxcXM3/jx6yu6KQTTSxvkNs0EI/9Dn7iebvjAo66r5M=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_utils/1/full.distro",
+        "hash": "sha256-c9HSxlOz9RMvwSie5nEjHsI51cLyC+mInQrSwFbuHAo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-z7WvZ6A33ohjpxfw4v+gK36juG1aDppAvV0piBSWheE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_voice/1/full.distro",
+        "hash": "sha256-KBesDj1E++Ty2JO3CXKr81RR4DOfL+26sYi1F6oZJfo=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-KFVV6YOezaxUMXpIfefTVndwgrPNlFwuIV2XPu5PDL0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1627/discord_zstd/1/full.distro",
+        "hash": "sha256-Q5KpWnY3TaE9R9qXw/1E1m5wu1UXegFlfWY7rh2iQ3g=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1627"
+    "version": "1.0.1635"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-zfiZMsEHhOGllXh6YiWuor42QfIKjCNTho9tie1lKmQ=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/full.distro"
+      "hash": "sha256-yrpyHVaPpM5uPbB+iCApdeQmkyyGaqN1LrT6ZYHbhbY=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-rOrOSnL08Qx3t7B1I7yf3rn35ABpNbBiIqQy/GlakW8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_arborium/1/full.distro",
+        "hash": "sha256-ONuhQI6g6BmU+TpWAPlijXyqn3nIvaPkT0sydfxvZao=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-x+GMHorLVMKcmoxONHqerudU+HQbkJR+3tTCdlnbJsM=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_cloudsync/1/full.distro",
+        "hash": "sha256-KOOtLoQpgQN+ZB6jJ/dHVX6GsdY+Rwbs6Lg7XAaIMs8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-Zw7Shd9h/JUKEhzxzydx0hF+6xrp4QZfpyfaZ2D/rzw=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_desktop_core/1/full.distro",
+        "hash": "sha256-OFRRyIG92N+w0uH5i4oKrQjfaSMFLn1+XdCQlx2MLhQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-6ASiSKT/okH1XAi+Pq7K4pJA15hy1rTRLee38ZQtZHg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_dispatch/1/full.distro",
+        "hash": "sha256-LPnrtss4ahqkSsJLbi7oNv4w6fGtRYEbwwJAkM6lXDs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-fQyflEjpuY4rYPWG44dDZ9RCm9WMucrNmM86sO1ooL0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_erlpack/1/full.distro",
+        "hash": "sha256-W8qd42fl2vbwC0QR4QrJjPC+mgT/a7aZ0C9IRNOOlI8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-wQfRqLrY1AxHyas8qCtLGqjXYB41uad8landaQUpgWA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_game_utils/1/full.distro",
+        "hash": "sha256-IMqtXTj2vZKhRpS/WstkhLDjltFFXlGEOqbaz6ex+5I=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-bAAAyPjM/Q6cnxQij/zO5x63wlv6NDwezKpp7HOM08g=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_krisp/1/full.distro",
+        "hash": "sha256-AoKbpqRFOZDNDOFSJegmvRbTKnQeLWmLYXA5XNZz3qE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-x5wbM3RHr0LO5bCK+e/0UCBc2DdKoWp/9CYdXQ6zdFA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_modules/1/full.distro",
+        "hash": "sha256-itja8snUwlNzic87xWv9LM3ppB63QlzZalOyCdNELsE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-+BFXqTDJKrUf2wWHc+O6croSuIQnu0LAr/mxEJnff+k=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_rpc/1/full.distro",
+        "hash": "sha256-Lj+Cwc8M1nyIlMwQryv8tmw9Doyq/tYBqG9KFCW1Zh4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-C/foWHzEyvoFVX6KLOhlN58qCljn2CnaL6iNj5g2l+E=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_spellcheck/1/full.distro",
+        "hash": "sha256-QU4mP0bNQHh/+Y18vI8jsTDSmTlRGbnDjU41gjSfYTg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-N4twRDAPHb53m0XovQPrrUQu+uNMTnThxajEeAgjq9s=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_utils/1/full.distro",
+        "hash": "sha256-Eua48+eBqqsFXJZnfM6mup3PstbdOt/1IxL/THhM+l0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-vUkoGmVokO7PN3bm2+ZFDF0VKxPwyOySAXEgcGnCw6c=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_voice/1/full.distro",
+        "hash": "sha256-QNYGjzAsete+b2i4izZxGGiqBj70IX33SLdFYNQHR1g=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-thGh50fP/fiVhCpbzDUWidrpsB5AXuXv5TSaDpPhmN8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1006/discord_zstd/1/full.distro",
+        "hash": "sha256-3z2OmC0r9JpkzcDOPWwNlK+qrgyaQjKn7rkB+Jb/XGY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1006"
+    "version": "1.0.1008"
   },
   "linux-ptb": {
     "distro": {
@@ -301,183 +301,183 @@
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-UP/fCbqWT/dvpcWNYR/5n/XuqmVpAhCxjYaHWvk2Cjg=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/full.distro"
+      "hash": "sha256-6zmHOjqyBufB6xXawxcSJKoQm1pWdYkIp5ISAeHjfe0=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-3VO8JC7ebIzMziyhH6brav7p8TtPbl4sq61pPbJOMzc=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_arborium/1/full.distro",
+        "hash": "sha256-jy9RTaxyDXIpZbdC+5bx9uju0PeDxQaNTKgxFzVIZpM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-kLSGxgA7S3v+xeZBtGgN0khkxdh9hcbrsGlyVBjw1cE=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_cloudsync/1/full.distro",
+        "hash": "sha256-TV5AuV66V9CI7K9leE3sO569mGYLXnloaUz621Wg1Ow=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-Nhi6krB47b1VDk0CgAnwA+PvstX6gLcLbZImqf0c9HU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_desktop_core/1/full.distro",
+        "hash": "sha256-DNiXFsfr0KZbeoZbMNdZr8rEu1kqosTVlMBw8N7UvzI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-cH4vazbRvhzI9YqlTgCDRAxIkw4qVX4cOV5dtlxMeuY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_dispatch/1/full.distro",
+        "hash": "sha256-908gzkHlwxHhoipBf2KveaKEQQTg+KMCID0smEM4SWw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-x2DM3JHnpQ2+Wt4rceU5Z0mtxzUuXH/oE4z1ca3QAGY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_erlpack/1/full.distro",
+        "hash": "sha256-k29XwPhAnWFK9Y2KkXHI5LoRZuUAmF464OMQvSD8kzw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-kih79540futkJFSWoTejizyJxB/Mf3K3nxATdXm2x6s=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_game_utils/1/full.distro",
+        "hash": "sha256-vsPbERMnUxRFaQi/4K6ncqpvUshKN1q8boE2RUne0j0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-vr7+4hRAyxys6CT5o/x0fIwdjETu09d/RCtSVlz2mEU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_intents/1/full.distro",
+        "hash": "sha256-QG63psMwtqLpVxUhL5Qw89kyyAafzRIFC2u8pMmzyS0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-Dspe24q4z9/bBSoc6N7Z5w8GPFNIkkjYMAroRupehqI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_krisp/1/full.distro",
+        "hash": "sha256-t6GDZyGfX5YLvSBaNRFzaMOsdYHEX3XoX2yXQr1STKs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-eYq4mX8RREjp/xR14Rv8U+bJaabaE9rq+vDRQvzQqH0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_modules/1/full.distro",
+        "hash": "sha256-lvD9cYkx4qV2dPC880HEYmyE3cR3kQOCnLzHFin+nec=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-J9EfoyGE2Ft1SSWrOGVfyJ/Ib/bc1uiyt9cD69tXUQM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_notifications/1/full.distro",
+        "hash": "sha256-zCpbLLX6VSkTbltrJTViCRmnR3dBxeU8rcPhOCxl2LQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-gk89NCtK0LLqRANigvkdjEHTjpRvnKm6fc0+pt54IEo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_rpc/1/full.distro",
+        "hash": "sha256-urpWdkMSqKioIOxpdjNT3JJZcikDvs0dSsVUkUG4PY0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-hDDSdkjDgz08vZ6BN1jZVh31bJsRGHsenYCWXyd3WK8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_spellcheck/1/full.distro",
+        "hash": "sha256-/50/mm6byljJ8MC6SalU+lRggcF1CKy9cwclpbMsrAk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-vTPvAY0RQP3vJTp8QhyYY03ZVEgumIhSIP4ngTPlvKs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_utils/1/full.distro",
-        "version": 1
+        "hash": "sha256-zXams2ljKyMGgco9hvSQHC3HD42TQCVKfMyG/PF9ubw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_utils/5/full.distro",
+        "version": 5
       },
       "discord_voice": {
-        "hash": "sha256-Xc7M38bbRC1ZlxMk0XkCdW0edyWVcfzOrsd7YLb39MY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_voice/1/full.distro",
-        "version": 1
+        "hash": "sha256-waDSMuxHPQLNzTdIzoELL0erZjFJej4KWOIYzSDVNvU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_voice/2/full.distro",
+        "version": 2
       },
       "discord_webauthn": {
-        "hash": "sha256-XQhYnvKtsmiDKxT7V3yUOx360kUXYLfdEBgMAz02xN4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_webauthn/1/full.distro",
+        "hash": "sha256-YhBNYnuXHlr17VqnOpMlH0p4TyDMZmr63Y0v/1efwJk=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-MgkmX1D2KMeCHz1owh0b2ZUWPfWrEmlbiqYr9a1VDp0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1256/discord_zstd/1/full.distro",
+        "hash": "sha256-xN5RNiSGDbpt7qrJkhhf4cn3XA/Z2P/Ro1xdkBulzB4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1256"
+    "version": "0.0.1259"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-ZijJyatJvrcSWu5Iq4tYIv+i1D7Hgqz3kH+o4BYbhUo=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/full.distro"
+      "hash": "sha256-5kbK9PeDcx16e8R1cdvy5UTPfurhJw9G6M4N09XDczU=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-XtUrMBmI+g9fbzsDsSSfwFL1piRxWIONHaPiZTQmpmo=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_arborium/1/full.distro",
+        "hash": "sha256-SePXBJQn09OPdGk8C1kkNSWz35GXi18PJn6Uj9xzR0w=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-3L48hdOQ+Lq5rnNBzBy/HGqmmx4Wyt50YdJGxfx3h7s=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_cloudsync/1/full.distro",
+        "hash": "sha256-oTarTEo+9DXqiA4vFObY7Db/TXvOGQs0iVi1LLNmalQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-aMMoX5ODlBb1bAAp+3A9OLLxIo1kmTsPF+47zs//Gu4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_desktop_core/1/full.distro",
+        "hash": "sha256-EsGnAbLFwGZxvVu2vQdOLqwHDFRt2tItlsaSdQ835NA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-gJ/KtS9qjy+FmVHxpNR6XkmcwA2nOjmBWHU3sUCehLw=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_dispatch/1/full.distro",
+        "hash": "sha256-X9Fln640uCRnnpg09U5o32uDiCDwoizjck7VNcwY1W0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-+0ExSIVvMQWGboVYYng0Ncr+MjrmOF/7xZ7a1KvIsZg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_erlpack/1/full.distro",
+        "hash": "sha256-v1uDvFN/lwwgDsIpVfQyNiuaSBsgsCrkQhT1uwSzBXY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-RcVLZYzA+jS7n8xXS+f+pkQ+f2w3hi0qIZh2zPUQCuc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_game_utils/1/full.distro",
+        "hash": "sha256-hLFkB034tOioo8QqSESbExeKvYQWO4lFK83gyNqfODk=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-1MUzJopQ/BED9UMur65DJWFCkgrw3Xlu4Y3ItBX/TW0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_intents/1/full.distro",
+        "hash": "sha256-l8XAfLol1w9UdPz0sYbZF5DBjEAalM7+pugIwZdIiKE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-utIdxi9tyR7cvYDBACWunNABKk0vtr/cjI5jIYvquLc=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_krisp/1/full.distro",
+        "hash": "sha256-EUKEYMfWE7BF2ttIvhyJFnJQ2dhXqXphTT1QQjQz/iQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-EMQ9e+gFZIOnG1SS9Q+h0lB1yo+ByULyT/H5twNOU/w=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_modules/1/full.distro",
+        "hash": "sha256-YdUOQ+JcpHDBc7HQsm8iQ60a8Afa4M000AcerwhHqT0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-ai+CIMOiPFswrVSB3J46VXgDpuRHPQqFDAYL4RnrWzo=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_notifications/1/full.distro",
+        "hash": "sha256-ku7VBMlahg0WHlv6FoLgyqPMKJwcJU5HzaigW+8qL0g=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-rVokXOQnMUb75i3nenmHHdbM1UuXjFe+F3J8DU/2/dg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_rpc/1/full.distro",
+        "hash": "sha256-YiZ/PJyP0qHpRxHjguS3XWtwYlnl9Wf19IoToEIyFOA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-TYUVId8Y4kcNLIde54M8N4zFntdY9QhRKXZQ3JcxfMY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_spellcheck/1/full.distro",
+        "hash": "sha256-6adzIekyegQdXwBkd8jgmhJIl8RwmQs4kxQe1iuTbJ4=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-mQ786DyCLgT8yNR/roX3mSrfa0k+Oze7/zNsp2CZCIU=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_utils/1/full.distro",
+        "hash": "sha256-y/sDjwW2VHJmLfhFORQwzR/fyV65RmyDI1AsWGJdX8w=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-6DxoYnWBGUUSX4Qrfa8WaSjo8UNHm2/W6I3dC7P7XjY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_voice/1/full.distro",
+        "hash": "sha256-prXIjXQAR5IvOMf+eezdBltr9rKN+EOKjEM6sEpNgO0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-U79yaA+TZfTXtjBfYe++OpDJbdB83J58FXLnPA3ACU0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_webauthn/1/full.distro",
+        "hash": "sha256-5ngUr7GKUW372bvByaP0Dy3EEsSHJS2DPwcITOIFjfA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-KHKEBdo5E6p8CzIGBDBYXbT1eDIkjWy1IyZKRlLA9lk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1013/discord_zstd/1/full.distro",
+        "hash": "sha256-V6lNy0S9ECxQBSVa8Ly1gqdV5pBXpwvqKlnStxp57cE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1013"
+    "version": "1.0.1015"
   },
   "osx-ptb": {
     "distro": {

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,153 +1,153 @@
 {
   "linux-canary": {
     "distro": {
-      "hash": "sha256-wVyW1GrvmMEM/btexjTf2uFkTt7GNG+dkI3C+dWnrJQ=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/full.distro"
+      "hash": "sha256-4nUnQx19P9O1lRgpeGR8EBRtllpLTDIF2Ve0yST7qQE=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-F5zZEtp67OAUM4gLtV0Uhsy4Gj1eqX7vBjIlOn/GzNI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_arborium/1/full.distro",
+        "hash": "sha256-J7av4dx1OMSeop00Eqe05BIfw3ZcCS6UUn3ZWosRMUE=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-Tic8LFWOoX4AyiGmMwYwCr6T807aXLYbamW72/bZwN4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_cloudsync/1/full.distro",
+        "hash": "sha256-z/84+k8byRDLPkuoV0LERMyyZzBDv79+H7VM9BrtpGw=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-zSF6kyKXzCERAEx8LslGt/YYPtWXNgr2Kdpj0Yx05F0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_desktop_core/1/full.distro",
+        "hash": "sha256-PikHYaMHkNENx0p0A/q+qLJIiEq5+pVupL/yshtsNAI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-8jJd14m9a3eias4cMCT1wRnu1aT8dzXUXCv5dAMLxN8=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_dispatch/1/full.distro",
+        "hash": "sha256-+4ecTzNxBToBfzj20C83muMSX72e493geKkcHsGuw5A=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-uhrQCnQC4Dm/XkoYRqVzjUvweYabsJxQrA2LtUxQ7Ac=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_erlpack/1/full.distro",
+        "hash": "sha256-62ldpyV9LgV1gfO9TI/2atgWokwq4DrI5u0fFTbfGi4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-32OQHDin9330UsgJ6JYWkT2dv+ToyWzbBpxMKnjxEQY=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_game_utils/1/full.distro",
+        "hash": "sha256-xDZsOkb93ugR9JfF+EptWKnVRznUfTQ54j7PHipeOoQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-2SfBfbzwcl2yhKikIiaw95qqixa/hm8apwhVnks/3cM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_krisp/1/full.distro",
+        "hash": "sha256-DlfgIscLn9Ya38D9xaI3p2yNBDu45xReqdGqjXkQGdI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-PmTRUml1bZY45GNEfZqMWDl3eNHdGrkM2f/kASSoFEQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_modules/1/full.distro",
+        "hash": "sha256-f7ahh310bYRUlJltj9l72CtTSZB5qjj5T2toYM8P50M=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-n4WUN1e2mYwyd4TEa5AEOFv9OhXlimkTCNe6cWucH3s=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_rpc/1/full.distro",
+        "hash": "sha256-WcvN38d9hPzlEO65q2OYKVyqc5xIYF69wxiekjWFLLQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-koi/kVLiq9lSGlhiCXl2Cbw0O812+PPkgC2aBH0kKwU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_spellcheck/1/full.distro",
+        "hash": "sha256-TDVRsaybdgsTogUvbGzdesQnbxTr4VqdY/+4iXrpVic=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-c9HSxlOz9RMvwSie5nEjHsI51cLyC+mInQrSwFbuHAo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_utils/1/full.distro",
+        "hash": "sha256-tazljX9G9wcnHNTejDKgEcr1QNksLF5nmAu/F0dafp4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-KBesDj1E++Ty2JO3CXKr81RR4DOfL+26sYi1F6oZJfo=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_voice/1/full.distro",
+        "hash": "sha256-XPxQzRmB+G8gxNedcwBJ2zq+sn7AEjboxxwcONj0hV0=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-Q5KpWnY3TaE9R9qXw/1E1m5wu1UXegFlfWY7rh2iQ3g=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1635/discord_zstd/1/full.distro",
+        "hash": "sha256-DchoZ8gBq3OT/XkersDVWrrx36VjLmcgh4T7nRKXbj8=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/linux/x64/1.0.1646/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1635"
+    "version": "1.0.1646"
   },
   "linux-development": {
     "distro": {
-      "hash": "sha256-yrpyHVaPpM5uPbB+iCApdeQmkyyGaqN1LrT6ZYHbhbY=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/full.distro"
+      "hash": "sha256-tmjpT2oZ+1BefLhh4Bxipi0xLTO3JjOzzGLdVcmyuvE=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-ONuhQI6g6BmU+TpWAPlijXyqn3nIvaPkT0sydfxvZao=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_arborium/1/full.distro",
+        "hash": "sha256-yEK2W6Fp0pcF6FSCZYgopcKMTC7ofswVq1G3SK/TOWY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-KOOtLoQpgQN+ZB6jJ/dHVX6GsdY+Rwbs6Lg7XAaIMs8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_cloudsync/1/full.distro",
+        "hash": "sha256-hNSSWkwjEaqaKYqFBBh3v8PBEHB0YEa2bZJd6Lt0xbc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-OFRRyIG92N+w0uH5i4oKrQjfaSMFLn1+XdCQlx2MLhQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_desktop_core/1/full.distro",
+        "hash": "sha256-TYzmzahlesOKI6sUNGNq2fr6++sJpRycLWZRUAhtfhc=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-LPnrtss4ahqkSsJLbi7oNv4w6fGtRYEbwwJAkM6lXDs=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_dispatch/1/full.distro",
+        "hash": "sha256-xZ2d7lTbZunbHcQJKPm9Z0NQE7Oq3qH4uR2zq71IdOs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-W8qd42fl2vbwC0QR4QrJjPC+mgT/a7aZ0C9IRNOOlI8=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_erlpack/1/full.distro",
+        "hash": "sha256-LC1cBf23zXmSfpW6I7UxuLi30y6m0l+2NwqJsSCt4Cw=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-IMqtXTj2vZKhRpS/WstkhLDjltFFXlGEOqbaz6ex+5I=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_game_utils/1/full.distro",
+        "hash": "sha256-zrxP8s1Npfs6GSHW5q8MuWkhFeINzXwi9A+S93o9vD8=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-AoKbpqRFOZDNDOFSJegmvRbTKnQeLWmLYXA5XNZz3qE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_krisp/1/full.distro",
+        "hash": "sha256-ulpY2VnZwBFbEBcwXXO8cNhGgWEqkoBVEbMn/ictKQg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-itja8snUwlNzic87xWv9LM3ppB63QlzZalOyCdNELsE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_modules/1/full.distro",
+        "hash": "sha256-BCrN7APbCd0bw55cL51umhfpYBUpkEIBxHF8IZaEpRM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-Lj+Cwc8M1nyIlMwQryv8tmw9Doyq/tYBqG9KFCW1Zh4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_rpc/1/full.distro",
+        "hash": "sha256-RsWNLlNSyuIhnFqpSG374vlmLqfFEZRAL8XcmiI3JPE=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-QU4mP0bNQHh/+Y18vI8jsTDSmTlRGbnDjU41gjSfYTg=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_spellcheck/1/full.distro",
+        "hash": "sha256-KyeC+llmxpjjbjJGf7F4RYXnIQxnhDnvgixHeubM27Y=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-Eua48+eBqqsFXJZnfM6mup3PstbdOt/1IxL/THhM+l0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_utils/1/full.distro",
+        "hash": "sha256-iKsHKmIlzSTbmsbtNTUwhClJLNf/dF55A/S0ZHuwLUg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-QNYGjzAsete+b2i4izZxGGiqBj70IX33SLdFYNQHR1g=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_voice/1/full.distro",
+        "hash": "sha256-tWiXPoJUXHGmZE7d+oS5hD5LfuqK6NQOKVPILFmvGLY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-3z2OmC0r9JpkzcDOPWwNlK+qrgyaQjKn7rkB+Jb/XGY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1008/discord_zstd/1/full.distro",
+        "hash": "sha256-s4fndo1YnagUsY1Nb9CLb/goaxID8+cPJKOzf0NAXh0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/linux/x64/1.0.1009/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1008"
+    "version": "1.0.1009"
   },
   "linux-ptb": {
     "distro": {
@@ -226,258 +226,258 @@
   },
   "linux-stable": {
     "distro": {
-      "hash": "sha256-3P0AC0nzWyxUCZZfqeeZj8p57E8bD6dfAnC7rYCUch4=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/full.distro"
+      "hash": "sha256-AzcQ2f6fsLAOvamgJMxMVJbhVh3JSkHeeLRsCwNqsnw=",
+      "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-EctcvW6AClcKnx+WMc1Az6XBD3Gr12H20sJrwJggjkU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_arborium/1/full.distro",
+        "hash": "sha256-wOodeJufXbDUDSsSyrG8+OJ/OxBPFfg3r7utbI7slms=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-b7WtS7VLHO7wUIXRbUqD5e4Kg22bAa8z71n0akkjSs8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_cloudsync/1/full.distro",
+        "hash": "sha256-Z9AHOO66v3eo/l9dMNE6FPduXwk7itn/ux+IBHKyUNw=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-YNJiO7xyeAMEYioARzVTTYcnBQtqqeQLi/y6eOpZ7oc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_desktop_core/2/full.distro",
-        "version": 2
+        "hash": "sha256-Zis/QM7anwCebhJVXeO+kYQ+82JVxE/l/9DSFvbE0M8=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_desktop_core/1/full.distro",
+        "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-A+1g70FYSe+CY9/a/S7BSIGy5OMfFbOrbnoJTPVAUyU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_dispatch/1/full.distro",
+        "hash": "sha256-rpF8mVEsRC9sR+OiihCV9EhJF1c0JwuEFlKxaeREhYY=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-Uz8QoOc8c6fMUXEHyLZ80nOKDMb26IxdHGw7Pw8ZEp8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_erlpack/1/full.distro",
+        "hash": "sha256-MMcPGHruTeb/Fu9syNn5/XTxUR0JTNqAesGTLbAi20s=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-HdWOJQy25w1l8Rmt4EwlJh06w5LxLVpfcLHhV8FZaRI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_game_utils/1/full.distro",
+        "hash": "sha256-UkZ7f/Ckc2oDKSI1tdZU/2YBukkVV1eugtOCQ5ShVgk=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-wcLDDaaNbyjBZGiN+OwIGsKPob5nHYVY2Qy1vAY11ss=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_krisp/1/full.distro",
+        "hash": "sha256-rFGeGhR5d7Y7Jo1R3netJNz0aAkHd8uBfRtbcK3mZFg=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-Ih6vth/F4DTkNs15nhtvLmb5cUCQRRERaVUBAuqc3F8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_modules/1/full.distro",
+        "hash": "sha256-9/KdLuTux8f5mWoQBSpqNkcU/PvodaMVmAuGRkHW72c=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-3YCXPhC1WoakCT5nYBrrilwh8Pzn34lz2mT1aRYOReQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_rpc/1/full.distro",
+        "hash": "sha256-8AgyHPFu3ixeCi71M1W4hjcZHvacWZK2vPNhqRMFqZs=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-LHGbGj/Tg3Xqt9VSvVZ12SNE+rgEwX8EcSsMGBqdA5I=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_spellcheck/1/full.distro",
+        "hash": "sha256-lZZitgtDkVaznkda2t7/5krxfOh3hF2R6ID9oHfaNos=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-To64PXhcM77MPEgvs5iHCGi/lxnTykLUR45wZ9fYA/M=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_utils/1/full.distro",
+        "hash": "sha256-bi74t/4DTAL4X8LIiRvx95UlvPy1b1ORgVo49S5iGrA=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-i5oAPf1e/FMD0E6nIXaxXWxC/VWBBOREMQxWaMUkvxs=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_voice/1/full.distro",
+        "hash": "sha256-o8dEAGCZbwy7MNGX3XlEb1/2cfSwW6t9NUS5S4ePd5o=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-vxFw1kpEiPAyt9oFCnGKrnXo9JsqQEwlv2OnRW4mWC8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/linux/x64/1.0.152/discord_zstd/1/full.distro",
+        "hash": "sha256-wPVbgwlzi7qvim3+VeXvk1oXBYVniNi7tilH1R3/Xm4=",
+        "url": "https://dl.discordapp.net/distro/app/stable/linux/x64/1.0.153/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.152"
+    "version": "1.0.153"
   },
   "osx-canary": {
     "distro": {
-      "hash": "sha256-6zmHOjqyBufB6xXawxcSJKoQm1pWdYkIp5ISAeHjfe0=",
-      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/full.distro"
+      "hash": "sha256-oMoOhtB5M0BbSKhHbomjp5vCyNYCAh8UtEpINCi4wlc=",
+      "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-jy9RTaxyDXIpZbdC+5bx9uju0PeDxQaNTKgxFzVIZpM=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_arborium/1/full.distro",
+        "hash": "sha256-6NYHxQfprHHdZGknYMxEl0lo29pt0ryrR9sDvYHO05s=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-TV5AuV66V9CI7K9leE3sO569mGYLXnloaUz621Wg1Ow=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_cloudsync/1/full.distro",
+        "hash": "sha256-+PHB1wpTO5+R3zA9dufE3xLy0syuQYSS+a0jsCNGNjs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-DNiXFsfr0KZbeoZbMNdZr8rEu1kqosTVlMBw8N7UvzI=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_desktop_core/1/full.distro",
+        "hash": "sha256-Tcb6S/HtSvoNLfAK0GVnKBqp+2upf0UxuStxaIXVK3o=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-908gzkHlwxHhoipBf2KveaKEQQTg+KMCID0smEM4SWw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_dispatch/1/full.distro",
+        "hash": "sha256-2DKqLoaZtxY5LhYOPPejnsVq43mv5spxuMXAhCiq/NM=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-k29XwPhAnWFK9Y2KkXHI5LoRZuUAmF464OMQvSD8kzw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_erlpack/1/full.distro",
+        "hash": "sha256-nBObSAmMDKQKGYvgnsV8j/D1Z6z/zVHK7yIt7JnD/Zs=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-vsPbERMnUxRFaQi/4K6ncqpvUshKN1q8boE2RUne0j0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_game_utils/1/full.distro",
+        "hash": "sha256-7KQ38od6K27ycVkvOnaH7SLv/Jx6hPYOE84nzFH1dXI=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-QG63psMwtqLpVxUhL5Qw89kyyAafzRIFC2u8pMmzyS0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_intents/1/full.distro",
+        "hash": "sha256-APCh8BArgt5RevI2QJOVLAssgYS/cjdFpIHs8JPTTAg=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-t6GDZyGfX5YLvSBaNRFzaMOsdYHEX3XoX2yXQr1STKs=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_krisp/1/full.distro",
+        "hash": "sha256-fLU6kopr2sQUkXG4A+atBY+AVxjHSxfYAR6TGBdZLvY=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-lvD9cYkx4qV2dPC880HEYmyE3cR3kQOCnLzHFin+nec=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_modules/1/full.distro",
+        "hash": "sha256-rC8XQ2jm17GBY9FCZXjVILpEIqW20wGs7jauzX7f87A=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-zCpbLLX6VSkTbltrJTViCRmnR3dBxeU8rcPhOCxl2LQ=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_notifications/1/full.distro",
+        "hash": "sha256-RUDniZB+PdGPlDcVRYlsJYeHvaYokmZ2BZNRO3KOJH4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-urpWdkMSqKioIOxpdjNT3JJZcikDvs0dSsVUkUG4PY0=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_rpc/1/full.distro",
+        "hash": "sha256-ruTPBYzfG71eKxnglHyC6OkhZQryh1ftqFNMWOJ/3CU=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-/50/mm6byljJ8MC6SalU+lRggcF1CKy9cwclpbMsrAk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_spellcheck/1/full.distro",
+        "hash": "sha256-DQryV7MY/Xz2XL8agjM3iJY2wY4LYsjQ5ImYfEnUvnQ=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-zXams2ljKyMGgco9hvSQHC3HD42TQCVKfMyG/PF9ubw=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_utils/5/full.distro",
-        "version": 5
+        "hash": "sha256-ZDv3ejnvfCzRlhJm7CEWhm5MX+C/lA+ETKXT+97lCz4=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_utils/1/full.distro",
+        "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-waDSMuxHPQLNzTdIzoELL0erZjFJej4KWOIYzSDVNvU=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_voice/2/full.distro",
+        "hash": "sha256-WVv+Bdbuodno6Q3+p6JBWe0FlgtOxLYkUm8YrJI5Ows=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_voice/2/full.distro",
         "version": 2
       },
       "discord_webauthn": {
-        "hash": "sha256-YhBNYnuXHlr17VqnOpMlH0p4TyDMZmr63Y0v/1efwJk=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_webauthn/1/full.distro",
+        "hash": "sha256-4iSifUx00540kHxVmTRUELc7CTdeQlrzumL6PoZ5UYc=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-xN5RNiSGDbpt7qrJkhhf4cn3XA/Z2P/Ro1xdkBulzB4=",
-        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1259/discord_zstd/1/full.distro",
+        "hash": "sha256-IAfkqNAHP1nGZ1mavrRYVnkNwyfTchb70XLuFAiTB+I=",
+        "url": "https://canary.dl2.discordapp.net/distro/app/canary/osx/universal/0.0.1263/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.1259"
+    "version": "0.0.1263"
   },
   "osx-development": {
     "distro": {
-      "hash": "sha256-5kbK9PeDcx16e8R1cdvy5UTPfurhJw9G6M4N09XDczU=",
-      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/full.distro"
+      "hash": "sha256-h+90ma3vDxyFepJafVMPt+xnnwhlHp8xyWiEy4e8BtE=",
+      "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-SePXBJQn09OPdGk8C1kkNSWz35GXi18PJn6Uj9xzR0w=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_arborium/1/full.distro",
+        "hash": "sha256-0CSXXOysVTXkOIX+PGiLxhO5TF52RbnAeAdaUt8gIsA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-oTarTEo+9DXqiA4vFObY7Db/TXvOGQs0iVi1LLNmalQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_cloudsync/1/full.distro",
+        "hash": "sha256-OTFs1oZxifyZQCSawl15uwmUGEtdMmfn3IirfqNM7Dg=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-EsGnAbLFwGZxvVu2vQdOLqwHDFRt2tItlsaSdQ835NA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_desktop_core/1/full.distro",
+        "hash": "sha256-ZdfclWKmnf4LDp3bZuHa8yOLoH/nQJg1HXY97yz2+Zs=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_desktop_core/1/full.distro",
         "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-X9Fln640uCRnnpg09U5o32uDiCDwoizjck7VNcwY1W0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_dispatch/1/full.distro",
+        "hash": "sha256-TdKvrQD5QEdU91Iuk6Bj0zahMHzebLp/+9iJ6YVcQos=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-v1uDvFN/lwwgDsIpVfQyNiuaSBsgsCrkQhT1uwSzBXY=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_erlpack/1/full.distro",
+        "hash": "sha256-8mo1PxrdfoACT0ue1Vnn+9V66iYWYo0sAKpbPV/Z9AA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-hLFkB034tOioo8QqSESbExeKvYQWO4lFK83gyNqfODk=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_game_utils/1/full.distro",
+        "hash": "sha256-q6iYGIUMgn6ONBiP+uYB+NOoqtAIWf8kAJGHBOSPHCY=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-l8XAfLol1w9UdPz0sYbZF5DBjEAalM7+pugIwZdIiKE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_intents/1/full.distro",
+        "hash": "sha256-cSWAEnxpiN2L3OqYo+WXW/CGgUs+fK0c5WqgwC+/PV0=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-EUKEYMfWE7BF2ttIvhyJFnJQ2dhXqXphTT1QQjQz/iQ=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_krisp/1/full.distro",
+        "hash": "sha256-S7oaSuskr7Tlb//L6+oU9UTEnvME63h/UQ6WClPjr4U=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-YdUOQ+JcpHDBc7HQsm8iQ60a8Afa4M000AcerwhHqT0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_modules/1/full.distro",
+        "hash": "sha256-WvuQBFrzhJXvUWpeD44VTEWT9fx9SJShfBSvkI1G32M=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-ku7VBMlahg0WHlv6FoLgyqPMKJwcJU5HzaigW+8qL0g=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_notifications/1/full.distro",
+        "hash": "sha256-56laGA0e4UDYLDvympNDYhzYN/xpdXxZwOI7tQ5wQFM=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-YiZ/PJyP0qHpRxHjguS3XWtwYlnl9Wf19IoToEIyFOA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_rpc/1/full.distro",
+        "hash": "sha256-Hxkf9GgMO3oHZXAgrzVp14xunA+QPcq+esKiVaAhvJU=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-6adzIekyegQdXwBkd8jgmhJIl8RwmQs4kxQe1iuTbJ4=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_spellcheck/1/full.distro",
+        "hash": "sha256-VFwm5bLjYbbc7g4VDKHuO51/Hu9JQbvEGnm4SBAnf3U=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-y/sDjwW2VHJmLfhFORQwzR/fyV65RmyDI1AsWGJdX8w=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_utils/1/full.distro",
+        "hash": "sha256-7MIIqJEPA3Fw13kQS1mCoQNeKoOa9X8RlpwIjf1ug38=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-prXIjXQAR5IvOMf+eezdBltr9rKN+EOKjEM6sEpNgO0=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_voice/1/full.distro",
+        "hash": "sha256-X7Ao2wuOSbYEjbVqLxHzWDq19QpVuKseo1lAUCSn4YQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-5ngUr7GKUW372bvByaP0Dy3EEsSHJS2DPwcITOIFjfA=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_webauthn/1/full.distro",
+        "hash": "sha256-UoXmSxoU0lrk8KYHTlOY2pGYdNEp/E5dxINq/b3J5HQ=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-V6lNy0S9ECxQBSVa8Ly1gqdV5pBXpwvqKlnStxp57cE=",
-        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1015/discord_zstd/1/full.distro",
+        "hash": "sha256-cUu9IJje2A7eqGAOTYdCADN81zE2hZSH3hnWUsUynEA=",
+        "url": "https://development.dl2.discordapp.net/distro/app/development/osx/universal/1.0.1017/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "1.0.1015"
+    "version": "1.0.1017"
   },
   "osx-ptb": {
     "distro": {
@@ -571,92 +571,92 @@
   },
   "osx-stable": {
     "distro": {
-      "hash": "sha256-Xs01Ui0u96n2Fpc/T5qObZWjqmbNuU4WTa9Z8OOtNk0=",
-      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/full.distro"
+      "hash": "sha256-v1xV1DYVKfwelYbYMVhL3BDKAfsXe9Npny4kqpX6qDs=",
+      "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/full.distro"
     },
     "kind": "distro",
     "modules": {
       "discord_arborium": {
-        "hash": "sha256-15EkIwQbVXPCnv65FpUc05Y+W/LfiIcFD8BJ0DehqEg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_arborium/1/full.distro",
+        "hash": "sha256-4PVxJjyYtSGI9StNjMKeaUSbYIifEYWTz7kktr5cPOk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_arborium/1/full.distro",
         "version": 1
       },
       "discord_cloudsync": {
-        "hash": "sha256-z8yUwMAWanKhcs1dEIB2Xn05KPjPqDInE56pbbHis+c=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_cloudsync/1/full.distro",
+        "hash": "sha256-ffvvOuTkACsGgnBmubB6XDibYpeihr2i/lmlOGOa7VE=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_cloudsync/1/full.distro",
         "version": 1
       },
       "discord_desktop_core": {
-        "hash": "sha256-jtzoHhXgMlPRkyd6FO52IyMyTjVzonJslADK1G4toiU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_desktop_core/2/full.distro",
-        "version": 2
+        "hash": "sha256-y46vUEzpmwRnRCs/KGzD/pRRSLA0/5l11VKJsEoridQ=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_desktop_core/1/full.distro",
+        "version": 1
       },
       "discord_dispatch": {
-        "hash": "sha256-FteG3F0mMpOiLburBCySJ/DacqT01T2jfx4m5UW1UF8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_dispatch/1/full.distro",
+        "hash": "sha256-LEm7zYYCVLB9l5JdlsIhJ6zVR3eCiyJfhvsMKvK6yTI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_dispatch/1/full.distro",
         "version": 1
       },
       "discord_erlpack": {
-        "hash": "sha256-p83ovML/oSDeEsdjuP9RH27ehXzbLLjVwAS1a58ItZ8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_erlpack/1/full.distro",
+        "hash": "sha256-ClyKJPwYhHXW2p2nCVsa1Kf5Faeuxur4H0CI7xpnBdA=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_erlpack/1/full.distro",
         "version": 1
       },
       "discord_game_utils": {
-        "hash": "sha256-o+zjv5zskYrhoFtHq2UnvKkPkg66JSCnhV1h210Bt+w=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_game_utils/1/full.distro",
+        "hash": "sha256-aUVuPOS5zxnzVXUs+pstMWt9rkJsecvrBSruTNjHKyY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_game_utils/1/full.distro",
         "version": 1
       },
       "discord_intents": {
-        "hash": "sha256-6aIKC5/mFx1Xy2hvckMGEZOJaZjbosbiccPVfvncZUg=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_intents/1/full.distro",
+        "hash": "sha256-qWgjn5WOjl78GVTAO/J/RA8ljlFrmYynfpEAXqYbGAo=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_intents/1/full.distro",
         "version": 1
       },
       "discord_krisp": {
-        "hash": "sha256-AnVRy1f8PyTnHZ0xYtickRJFWcbvpQl5PKoCg3WlUxU=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_krisp/1/full.distro",
+        "hash": "sha256-RtQS0+jCoeBt0V2CGRkwjuTEar9+JxOv1V864e64cHk=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_krisp/1/full.distro",
         "version": 1
       },
       "discord_modules": {
-        "hash": "sha256-VKN53f0QD8mavsVN1iJASDyBEbQWbrKzGMKCtZzoCFA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_modules/1/full.distro",
+        "hash": "sha256-De6mRVFdakXVDk5IMLTdCTXVnVkNfmvcLLPRvtj3XAY=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_modules/1/full.distro",
         "version": 1
       },
       "discord_notifications": {
-        "hash": "sha256-kwzPD9lHU+IIoq44dF8rKs3fRqh5UI0N4uz2LC8UrGQ=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_notifications/1/full.distro",
+        "hash": "sha256-AzLpxosut9r3acJPPBVw1pumW/le24+hMVlYDSu2u48=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_notifications/1/full.distro",
         "version": 1
       },
       "discord_rpc": {
-        "hash": "sha256-YgeTVunMN9Rk5uodwkJclD43ApqzO/6dGad02XZtsgo=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_rpc/1/full.distro",
+        "hash": "sha256-bPvnC2DfmRETFYJFDQviXdFF2YI8gWRz5FcgZr8CX8A=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_rpc/1/full.distro",
         "version": 1
       },
       "discord_spellcheck": {
-        "hash": "sha256-Wk9cUfZspD2PtcbyO7pmT/351SvNa7z+5bwP5kKlEuA=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_spellcheck/1/full.distro",
+        "hash": "sha256-K6JoXsJNim/VOAVjqHU5Izaj1n4HZiDKTDU8HRFDQaU=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_spellcheck/1/full.distro",
         "version": 1
       },
       "discord_utils": {
-        "hash": "sha256-G0WtNX4hbO4iB9Xz8rY43ZEmeSUFU0m3XlLrlOhAzZE=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_utils/1/full.distro",
+        "hash": "sha256-GkcdoGruyIOzokHgd/jeCPkPsGtHAry1c3WrOaRuHYI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_utils/1/full.distro",
         "version": 1
       },
       "discord_voice": {
-        "hash": "sha256-EzRy0SjuEzkMvFlH7w6GyVDEh22hSeikw7hD5s7lsw8=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_voice/1/full.distro",
+        "hash": "sha256-9B1pjqlvOM5Pit1JImYrVOzIAURyJN4pwIS+NBLaqvI=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_voice/1/full.distro",
         "version": 1
       },
       "discord_webauthn": {
-        "hash": "sha256-fivCWaJhxbouKbhWPRgrXqv/7FKL+RpS8Qn9lIHngnc=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_webauthn/1/full.distro",
+        "hash": "sha256-tqxA5qhMdUjKUWSRChBUnE5ul4obLxodxZPuSUE6+Sw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_webauthn/1/full.distro",
         "version": 1
       },
       "discord_zstd": {
-        "hash": "sha256-IEHHrGPCcxWjKTPY7hYEQzk6Zh5UsC6rTCANgF77mjI=",
-        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.406/discord_zstd/1/full.distro",
+        "hash": "sha256-QJ46FR7YP7eAmbs844t3ueQtcKNK9PJm3jNEPKCx0Vw=",
+        "url": "https://stable.dl2.discordapp.net/distro/app/stable/osx/universal/0.0.407/discord_zstd/1/full.distro",
         "version": 1
       }
     },
-    "version": "0.0.406"
+    "version": "0.0.407"
   }
 }


### PR DESCRIPTION
I have compared the history of both branches. Some minor changes were already backported individually. I have skipped the following backports:

- d4dfed7be328ce1fb8894bba42b82028c3142ef9 drops x86_64-darwin, still supported on 26.05
- c7404c9232864bbdd6d4843f494f64bf8126c567 treewide-ish change
- 3ab69ab334af0d41158c79aa068f22b51dfedc72 FHSEnv seems like a breaking change
- 1313b4a16fe102bbbbee93e42c20dc8c8ecc0824 fix for FHSEnv
- 49145654ab02b01068f5b162aa4ace86e08ee6b3 another fix for FHSEnv
- fb2e88a8654c557610c3302c6da8076d70e3d066 conflicts due to FHSEnv changes. Not useful anyway

Final list of backports:

- 4c292ca105ef5cd71baa25442cb55cedf1970831
- 4f71495cda64a70e8110aa65e960b8c801eb4ce0
- f9353dfb9fa3ab72a192ef0996b5c74481c3605d
- 6620a6f892ce7124db36db579f4c1754e66dd296
- c62a8ae7df9a2ad7866f5e4b3172f1bd29946bfe
- 232594377388c8653560d53a61583c8f3ef7bd76
- ca5951dfa6746b75d508da490f516e4e57b27f9f
- acd42e97ecdf3dd848b1fab9aa2ac0e8887d0a31
- 6df59e4f296f179bff54143d17f38a8b8bc8c108
- edea913b8a59d9f3b329ffc555f1aea25b902486
- 348c5a807d5ebab8584162e0ac1a88112cb75f3a
- 33ab1ada2af94cbf3d7c80f07978db1f15911369
- 14b4e9abf85117eae055a691220f24490c32e567
- ca75742496ade81a53998c2b46fde31d460b7dd2
- 233963a0d00927bb41fdd9cc1cc1b48874061cc8
- 1b6fef720d3b61a9bcffaeb536017e17d318f35e


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
