### PR TITLE
treewide: Mark packages with EOL Electrons as insecure

### DIFF
--- a/pkgs/by-name/be/beekeeper-studio/package.nix
+++ b/pkgs/by-name/be/beekeeper-studio/package.nix
@@ -159,5 +159,8 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-linux"
       "aarch64-darwin"
     ];
+    knownVulnerabilities = [
+      "Uses Electron 39.8.1, which was EOL on March 13 2026, with several known CVEs"
+    ];
   };
 })

--- a/pkgs/by-name/cy/cypress/package.nix
+++ b/pkgs/by-name/cy/cypress/package.nix
@@ -127,5 +127,8 @@ stdenv.mkDerivation rec {
       Crafter
       jonhermansen
     ];
+    knownVulnerabilities = [
+      "Uses Electron 37.6.0, EOL on October 4, 2025, Several CVEs known."
+    ];
   };
 }

--- a/pkgs/by-name/ha/hakuneko/package.nix
+++ b/pkgs/by-name/ha/hakuneko/package.nix
@@ -101,5 +101,8 @@ stdenv.mkDerivation (finalAttrs: {
       "i686-linux"
     ];
     mainProgram = "hakuneko";
+    knownVulnerabilities = [
+      "Uses Electron 6.1.7, which was EOL on February 25, 2020, with many known CVEs"
+    ];
   };
 })

--- a/pkgs/by-name/in/inav-configurator/package.nix
+++ b/pkgs/by-name/in/inav-configurator/package.nix
@@ -79,5 +79,8 @@ stdenv.mkDerivation rec {
       wucke13
     ];
     platforms = lib.platforms.linux;
+    knownVulnerabilities = [
+      "Uses Electron 38.7.2, EOL on 28-Jan-2026, with several known CVEs."
+    ];
   };
 }

--- a/pkgs/by-name/ke/keeweb/package.nix
+++ b/pkgs/by-name/ke/keeweb/package.nix
@@ -76,6 +76,9 @@ let
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sikmir ];
     platforms = builtins.attrNames srcs;
+    knownVulnerabilities = [
+      "Uses Electron 12, EOL on November 16 2012. Has many known CVEs"
+    ];
   };
 in
 if stdenv.hostPlatform.isDarwin then

--- a/pkgs/by-name/ke/keybase-gui/package.nix
+++ b/pkgs/by-name/ke/keybase-gui/package.nix
@@ -163,5 +163,8 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.bsd3;
+    knownVulnerabilities = [
+      "Uses Electron 28, EOL on 05 Dec 2023. Has many known CVEs"
+    ];
   };
 })

--- a/pkgs/by-name/pe/pencil/package.nix
+++ b/pkgs/by-name/pe/pencil/package.nix
@@ -146,5 +146,8 @@ stdenv.mkDerivation (finalAttrs: {
       mrVanDalo
     ];
     platforms = lib.platforms.linux;
+    knownVulnerabilities = [
+      "Uses Electron 6, EOL in May 2020 with many CVEs"
+    ];
   };
 })

--- a/pkgs/by-name/po/popcorntime/package.nix
+++ b/pkgs/by-name/po/popcorntime/package.nix
@@ -102,5 +102,8 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ onny ];
     mainProgram = "popcorntime";
+    knownVulnerabilities = [
+      "Uses vendored Electron 6, EOL on May 18, 2020 with many CVEs"
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
see #559231

These all have outdated Electron version vendored into their outputs. These are all EOL, and all have known CVEs.

This is exactly what is done with packages that use Nixpkgs-built Electron, though in this case we are being lenient as 
these are quite old and would generally be dropped instead. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
