### PR TITLE
h5v: init at 0.15.0

### DIFF
--- a/pkgs/by-name/h5/h5v/package.nix
+++ b/pkgs/by-name/h5/h5v/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  fontconfig,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "h5v";
+  version = "0.15.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "DanielHauge";
+    repo = "h5v";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xDhZG07y/InXazGmQ/FpbQJZxozOWM0DeHg4VvVM+hc=";
+  };
+
+  cargoHash = "sha256-bmQhF5pfwkIvKxmXNmIqEMP9F0DMpvtf95aIe6U3BK8=";
+
+  postPatch = ''
+    substituteInPlace Cargo.toml macros/Cargo.toml \
+      --replace-fail 'version = "0.1.0"' 'version = "${finalAttrs.version}"'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+  ];
+
+  checkFlags = [
+    # sandbox-incompatible tests
+    "--skip=importing::tests::resolves_csv_input_into_generated_hdf5_columns"
+    "--skip=importing::tests::resolves_parquet_input_into_generated_hdf5_columns"
+    "--skip=importing::tests::resolves_xlsx_input_into_sheet_groups"
+    # fails in macOS CI sandbox due to lack of system fonts for chart rendering
+    "--skip=ui::preview::chart::tests::preview_log_x_ignores_raw_index_zero"
+
+    # test expects hardcoded "0.1.0" version which we correctly patched
+    "--skip=configure::loading::tests::lua_ls_config_references_support_library"
+
+    # force single-threaded tests to prevent HDF5 C-library segfaults
+    "--test-threads=1"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "h5v";
+    description = "HDF5 Terminal Viewer";
+    longDescription = ''
+      A terminal-first HDF5 explorer for charts, matrices,
+      images, compound schemas, and scripted workflows.
+    '';
+    homepage = "https://github.com/DanielHauge/h5v";
+    downloadPage = "https://github.com/DanielHauge/h5v/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/DanielHauge/h5v/commits/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    identifiers = {
+      cpeParts = lib.meta.cpeFullVersionWithVendor "DanielHauge" finalAttrs.version;
+      purlParts = {
+        type = "github";
+        namespace = "DanielHauge";
+        name = "h5v";
+        version = finalAttrs.version;
+      };
+    };
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ KristijanZic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added h5v at 0.15.0 from https://github.com/DanielHauge/h5v

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
