### PR TITLE
espanso: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/by-name/es/espanso/package.nix
+++ b/pkgs/by-name/es/espanso/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   kdePackages,
   dbus,
+  kdotool,
   libx11,
   libxcb,
   libxi,
@@ -125,6 +126,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
                 setxkbmap
               ]
               ++ lib.optionals waylandSupport [
+                kdotool
                 wl-clipboard
               ]
               ++ lib.optionals x11Support [

--- a/pkgs/by-name/es/espanso/package.nix
+++ b/pkgs/by-name/es/espanso/package.nix
@@ -35,13 +35,13 @@ assert stdenv.hostPlatform.isDarwin -> !x11Support;
 assert stdenv.hostPlatform.isDarwin -> !waylandSupport;
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "espanso";
-  version = "2.4.0";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "espanso";
     repo = "espanso";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MCV4v0f7VXwS0ZrphURMb/sZqKR2pwPPCut6zOzWYIE=";
+    hash = "sha256-hfdR0XzZqF/l0jU5Ma4VnnHd4Rfw0d57ufxMyvsEBi4=";
   };
 
   cargoHash = "sha256-JFXCsTV9DAIP5T3QouQ2bzSlVVa+LIgQBOE68Z7UVe4=";
@@ -115,6 +115,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ''
     else
       ''
+        install -Dm644 espanso/src/res/linux/espanso.desktop $out/share/applications/espanso.desktop
+        install -Dm644 espanso/src/res/linux/espanso.png $out/share/pixmaps/espanso.png
         wrapProgram $out/bin/espanso \
           --prefix PATH : ${
             lib.makeBinPath (


### PR DESCRIPTION
changelog: https://github.com/espanso/espanso/releases/tag/v2.4.1


[Install on Wayland](https://espanso.org/docs/install/linux/#install-on-wayland) note about kdotool. [kdotool](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/kd/kdotool/package.nix) doesn't appear to bring any huge dependencies with it so it seemed fine to just always include in Wayland package builds.

> App-specific configurations might work in KDE-Wayland distros if you can install kdotool.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
