### PR TITLE
matrix-alertmanager: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/by-name/ma/matrix-alertmanager/package.nix
+++ b/pkgs/by-name/ma/matrix-alertmanager/package.nix
@@ -3,17 +3,18 @@
   buildNpmPackage,
   fetchFromGitHub,
   jq,
+  nix-update-script,
 }:
 
 buildNpmPackage rec {
   pname = "matrix-alertmanager";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "jaywink";
     repo = "matrix-alertmanager";
     rev = "v${version}";
-    hash = "sha256-t5e9UfRtt1OzxEXuMkPLW352BbAVSLEt26fo5YppQQc=";
+    hash = "sha256-kdz5KyT0ZIbiq6MMVAQBPjz2QP1kcNWtEv10/RzH/14=";
   };
 
   postPatch = ''
@@ -21,9 +22,11 @@ buildNpmPackage rec {
     mv package.json.tmp package.json
   '';
 
-  npmDepsHash = "sha256-4UYX9ndqecr06/gZeouzrDss6568jBXY1ypcVX7DEVk=";
+  npmDepsHash = "sha256-r1OvxCk6dgVAb3NKxveTr/1PTRFYQVDhQmBHbikzALE=";
 
   dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/jaywink/matrix-alertmanager/blob/${src.rev}/CHANGELOG.md";


### PR DESCRIPTION
Diff: https://github.com/jaywink/matrix-alertmanager/compare/v0.9.0...v0.10.0
Changelog: https://github.com/jaywink/matrix-alertmanager/blob/v0.10.0/CHANGELOG.md#0100---2026-08-16

Also enables nix-update-script for bumps by @r-ryantm.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
