### PR TITLE
ungoogled-chromium: 152.0.7977.64-1 -> 152.0.7977.75-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -853,7 +853,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "152.0.7977.64",
+    "version": "152.0.7977.75",
     "deps": {
       "depot_tools": {
         "rev": "38c391feba5fb96812f9028da12413ffc39df394",
@@ -865,16 +865,16 @@
         "hash": "sha256-ovLx6KaORdXqnWgbsGEty10k2CHuCmTk3yEqy5//ovk="
       },
       "ungoogled-patches": {
-        "rev": "152.0.7977.64-1",
-        "hash": "sha256-9esE3TgtKiwwFL5pu87aEQznelMVtNXBslggYAJTEbc="
+        "rev": "152.0.7977.75-1",
+        "hash": "sha256-HXWnJfk0SxC8sRcgtFdGBOOeiV7kEQD2YXQFBwMsU1s="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "506c834ecceaa943c5f41e6cfe7f68acb5c45346",
-        "hash": "sha256-KEr9nzF55+c8Rvvay3SZjcWMDWVGTyv1f5Pjv3ckl3E=",
+        "rev": "4999cc1efed37c4d91dc4ce6ec4b0a50e2a9a8cb",
+        "hash": "sha256-RXykREnCulCwk8zkk8OAd62TM4qel6j4uhyaaYzgolY=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -989,8 +989,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "571752c9cb3ed36a3194854374984427794c4dda",
-        "hash": "sha256-YMgRmVMXo1Ra5M034zij/ik/1aHpb3veK4VWsKHIwhI="
+        "rev": "ab8827bc57b176eeaa89f71324130c02d4d41145",
+        "hash": "sha256-Xd1FsdIBO6hzNECnNnXR0306woHl5/L+5WZ/pxTlYfA="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1124,8 +1124,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "941348cf79c423892e1c7c219091a7103d18a68b",
-        "hash": "sha256-/b+NCAr1jRJd/Uq4Cf5aO/yTdNP00ImIWuSJ4aP+TEw="
+        "rev": "04db1f5240b636511ec4e9058a78f8274a7f65ee",
+        "hash": "sha256-vZxKC/QD2dHNnVm9OZI1Bo0Jdnn+AJhFpXYSXXF7JsA="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1694,8 +1694,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "6aacaf6256a069ee455142333b7d38cad1c8d6e0",
-        "hash": "sha256-1NX4HP/BIJ6bWxoF42K89X8ADHuHjA5akkOL/WkIeME="
+        "rev": "3de6ffffbfdcf265e9f11a5c9d1cfb4d486d7550",
+        "hash": "sha256-ZHEmeSe8r226gjazm91GYqlfbM9a5yi8KnFv4iAWFKE="
       },
       "src/agents/shared": {
         "url": "https://chromium.googlesource.com/chromium/agents.git",


### PR DESCRIPTION
Same underlying changes as #559083

https://chromereleases.googleblog.com/2026/09/stable-channel-update-for-desktop.html

This update includes 26 security fixes.

CVEs:
CVE-2026-84353 CVE-2026-84352 CVE-2026-84354 CVE-2026-84359
CVE-2026-84357 CVE-2026-84324 CVE-2026-84349 CVE-2026-84326
CVE-2026-84333 CVE-2026-84351 CVE-2026-84325 CVE-2026-84328
CVE-2026-84347 CVE-2026-84323 CVE-2026-84355 CVE-2026-84358
CVE-2026-84332 CVE-2026-84330 CVE-2026-84334 CVE-2026-84348
CVE-2026-84335 CVE-2026-84327 CVE-2026-84329 CVE-2026-84356
CVE-2026-84350 CVE-2026-84331

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
