### PR TITLE
nixos/udev: generate hwdb.bin with a stable --root

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -175,21 +175,25 @@ let
         packages = lib.unique (map toString ([ udev ] ++ cfg.packages));
       }
       ''
-        mkdir -p etc/udev/hwdb.d
+        mkdir -p $out/etc/udev/hwdb.d
         for i in $packages; do
           echo "Adding hwdb files for package $i"
           for j in $i/{etc,lib}/udev/hwdb.d/*; do
             # This must be a copy, not a symlink, because --root below will chase links within the root argument.
-            cp $j etc/udev/hwdb.d/$(basename $j)
+            cp $j $out/etc/udev/hwdb.d/$(basename $j)
           done
         done
 
         echo "Generating hwdb database..."
         # hwdb --update doesn't return error code even on errors!
-        res="$(${pkgs.buildPackages.systemd}/bin/systemd-hwdb --root=$(pwd) update 2>&1)"
+        # v3 hwdb.bin stores each source filename. $out is a stable prefix;
+        # $(pwd) would embed the build directory (NixOS/nixpkgs#558933).
+        res="$(${pkgs.buildPackages.systemd}/bin/systemd-hwdb --root=$out update 2>&1)"
         echo "$res"
         [ -z "$(echo "$res" | egrep '^Error')" ]
-        mv etc/udev/hwdb.bin $out
+        mv $out/etc/udev/hwdb.bin $NIX_BUILD_TOP/hwdb.bin
+        rm -rf $out
+        mv $NIX_BUILD_TOP/hwdb.bin $out
       '';
 
   compressFirmware =


### PR DESCRIPTION
Fixes `hwdb.bin` changing hash when the same derivation is built under different directories.

`systemd-hwdb` v3 writes each source filename into the database. The builder used `--root=$(pwd)`, so those names included the Nix build directory (`/build`, `/tmp/nix-build-…`, …). Closures assembled from different builders then failed to import, as in #558933.

This generates the database under `$out` and then moves `hwdb.bin` to `$out`. `$out` is known before the build, so the stored names no longer depend on the temporary root.

On current master (systemd 261.2) the tool already stores paths relative to `--root` (`/etc/udev/hwdb.d/…`). The `$out` root still keeps the builder from relying on that. systemd 260.2, which the issue used, embeds the full `--root`.

Verified on x86_64-linux with a minimal NixOS eval of `environment.etc."udev/hwdb.bin".source`:

```
nix-build --check --no-out-link /nix/store/vawlixp47yy5bcpv3gzvhc80625j9py4-hwdb.bin.drv
```

The rebuild matched `/nix/store/1svqlksnv5wx4fjjl262b048bfrab3y9-hwdb.bin`.

Resolves #558933

## AI disclosure

Grok 4.6 using grok-build. I reviewed systemd `hwdb-util.c` (v260.2 vs v261.2), reproduced the filename embedding, and checked the rebuilt store path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. *(rebuilt `hwdb.bin` with `nix-build --check`; output matched)*
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy] (commits carry `Assisted-by:` trailers).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test