### PR TITLE
meh: Fix build for giflib 6

### DIFF
--- a/pkgs/by-name/me/meh/gif.patch
+++ b/pkgs/by-name/me/meh/gif.patch
@@ -1,0 +1,18 @@
+diff --git a/src/gif.c b/src/gif.c
+index 9d492c2..a1455a5 100644
+--- a/src/gif.c
++++ b/src/gif.c
+@@ -96,11 +96,11 @@ error:
+ 
+ void gif_close(struct image *img){
+ 	struct gif_t *g = (struct gif_t *)img;
+-#if defined(GIFLIB_MAJOR) && defined(GIFLIB_MINOR) && (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1)
++#if defined(GIFLIB_MAJOR) && defined(GIFLIB_MINOR) && ((GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1) || GIFLIB_MAJOR == 6)
+ 	int ret;
+ #endif
+ 
+-#if defined(GIFLIB_MAJOR) && defined(GIFLIB_MINOR) && (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1)
++#if defined(GIFLIB_MAJOR) && defined(GIFLIB_MINOR) && ((GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1) || GIFLIB_MAJOR == 6)
+ 	DGifCloseFile(g->gif,&ret);
+ 	if(ret != GIF_OK) {
+ #if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR >= 5

--- a/pkgs/by-name/me/meh/package.nix
+++ b/pkgs/by-name/me/meh/package.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation {
     giflib
   ];
 
+  patches = [ ./gif.patch ];
+
   meta = {
     description = "Minimal image viewer using raw XLib";
     homepage = "https://www.johnhawthorn.com/meh/";


### PR DESCRIPTION
This fixes `meh` so it works with GIFLIB version 6, in the same way it's handled for version 5.1.

The package however seems dead upstream (with a [PR open to fix a memory leak](https://github.com/jhawthorn/meh/pull/25/)), so maybe it makes more sense to drop it instead?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
