### PR TITLE
xeus-cpp: fix on darwin

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/xeus-cpp/xeus-cpp.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cpp/xeus-cpp.nix
@@ -106,6 +106,16 @@ stdenv.mkDerivation (finalAttrs: {
     curl
   ];
 
+  # xeus-cpp probes the host `c++` for its include search path and prepends the
+  # result, which shadows the hermetic paths we hand it (Xcode's libc++ and SDK
+  # win on any machine with Xcode). Skip the probe when those paths are supplied.
+  postPatch = ''
+    substituteInPlace src/xinterpreter.cpp --replace-fail \
+      "Cpp::DetectSystemCompilerIncludePaths(CxxSystemIncludes);" \
+      "if (const char* e = std::getenv(\"CPPINTEROP_EXTRA_INTERPRETER_ARGS\"); !e || !*e)
+    Cpp::DetectSystemCompilerIncludePaths(CxxSystemIncludes);"
+  '';
+
   cmakeFlags = [
     (lib.cmakeBool "XEUS_CPP_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     "-DXEUS_CPP_RESOURCE_DIR=${resourceDir}"

--- a/pkgs/by-name/cp/cpp-interop/package.nix
+++ b/pkgs/by-name/cp/cpp-interop/package.nix
@@ -1,15 +1,16 @@
 {
-  lib,
-  fetchFromGitHub,
-  cmake,
-  ninja,
-  python3,
-  llvmPackages_21,
+  apple-sdk,
   cling,
+  cmake,
+  fetchFromGitHub,
   gcc-unwrapped,
+  lib,
   libffi,
   libxml2,
+  llvmPackages_21,
   ncurses,
+  ninja,
+  python3,
   zlib,
   zstd,
 
@@ -46,20 +47,49 @@ let
       "${clingRoot}/lib/clang/20"
     else
       "${lib.getLib clang}/lib/clang/${lib.versions.major llvm.version}";
+
+  # These must precede the resource dir, because libc++ ships its own <stddef.h>
+  # that include_next's Clang's and errors out if reached second.
+  cxxIncludeArgs =
+    if stdenv.hostPlatform.isDarwin then
+      [
+        "-isystem"
+        "${lib.getDev llvmPackages.libcxx}/include/c++/v1"
+      ]
+    else
+      [
+        "-isystem"
+        "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}"
+        "-isystem"
+        "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}/${stdenv.hostPlatform.config}"
+      ];
+
+  libcIncludeArgs =
+    if stdenv.hostPlatform.isDarwin then
+      [
+        "-isystem"
+        "${apple-sdk.sdkroot}/usr/include"
+        "-iframework"
+        "${apple-sdk.sdkroot}/System/Library/Frameworks"
+      ]
+    else
+      [
+        "-isystem"
+        "${lib.getDev stdenv.cc.libc}/include"
+      ];
+
   interpreterArgs = [
     "-nostdinc"
     "-nostdinc++"
     "-resource-dir"
     resourceDir
+  ]
+  ++ cxxIncludeArgs
+  ++ [
     "-isystem"
     "${resourceDir}/include"
-    "-isystem"
-    "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}"
-    "-isystem"
-    "${gcc-unwrapped}/include/c++/${gcc-unwrapped.version}/${stdenv.hostPlatform.config}"
-    "-isystem"
-    "${lib.getDev stdenv.cc.libc}/include"
-  ];
+  ]
+  ++ libcIncludeArgs;
 in
 
 assert lib.assertOneOf "backend" backend [


### PR DESCRIPTION
`xeus-cpp` was broken on `aarch64-darwin`, as surfaced in #558639. This fixes it by passing appropriate Darwin-specific flags.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
