### PR TITLE
ci/github-script/check-target-branch-policy: add exemption for kernels

### DIFF
--- a/ci/github-script/check-target-branch-policy.test.ts
+++ b/ci/github-script/check-target-branch-policy.test.ts
@@ -161,7 +161,31 @@ const cases: Array<{
     expected: 'mass-rebuild',
   },
   {
-    name: 'kernel exemption suppresses a possible mass rebuild',
+    name: 'kernels-org exemption suppresses a possible mass rebuild',
+    facts: {
+      maxRebuildCount: 999,
+      onlyChangedFile: 'pkgs/os-specific/linux/kernel/kernels-org.json',
+    },
+    expected: 'dismiss',
+  },
+  {
+    name: 'kernels-org exemption suppresses a definite mass rebuild',
+    facts: {
+      maxRebuildCount: 1000,
+      onlyChangedFile: 'pkgs/os-specific/linux/kernel/kernels-org.json',
+    },
+    expected: 'dismiss',
+  },
+  {
+    name: 'kernels-org exemption suppresses a NixOS test rebuild',
+    facts: {
+      rebuildsAllTests: true,
+      onlyChangedFile: 'pkgs/os-specific/linux/kernel/kernels-org.json',
+    },
+    expected: 'dismiss',
+  },
+  {
+    name: 'xanmod kernel exemption suppresses a possible mass rebuild',
     facts: {
       maxRebuildCount: 999,
       onlyChangedFile: 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix',
@@ -169,7 +193,7 @@ const cases: Array<{
     expected: 'dismiss',
   },
   {
-    name: 'kernel exemption suppresses a definite mass rebuild',
+    name: 'xanmod kernel exemption suppresses a definite mass rebuild',
     facts: {
       maxRebuildCount: 1000,
       onlyChangedFile: 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix',
@@ -177,7 +201,7 @@ const cases: Array<{
     expected: 'dismiss',
   },
   {
-    name: 'kernel exemption suppresses a NixOS test rebuild',
+    name: 'xanmod kernel exemption suppresses a NixOS test rebuild',
     facts: {
       rebuildsAllTests: true,
       onlyChangedFile: 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix',

--- a/ci/github-script/check-target-branch-policy.ts
+++ b/ci/github-script/check-target-branch-policy.ts
@@ -62,9 +62,12 @@ export function evaluateTargetBranchPolicy({
     shouldCheckNixosRebuild,
   } = getTargetBranchPolicy({ base, head })
 
+  // https://github.com/NixOS/nixpkgs/pull/553786#issuecomment-5510286851
+  // kernels-org should go to staging-nixos (or master) and staging-nixos-xx.xx (or release-xx.xx) when backported
   // https://github.com/NixOS/nixpkgs/pull/521157
-  // These should go to master and release-xx.xx when backported
+  // xanmod should go to master and release-xx.xx when backported
   const isExemptKernelUpdate =
+    onlyChangedFile === 'pkgs/os-specific/linux/kernel/kernels-org.json' ||
     onlyChangedFile === 'pkgs/os-specific/linux/kernel/xanmod-kernels.nix'
 
   // https://github.com/NixOS/nixpkgs/pull/483194#issuecomment-3793393218


### PR DESCRIPTION
kernel updates go to staging-nixos, they shouldn't be flagged


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
