### PR TITLE
slimbook_qc71_laptop: init at 0-unstable-2026-07-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15809,6 +15809,12 @@
     githubId = 27364685;
     name = "Lorenzo Pasqui";
   };
+  l12raptor = {
+    email = "l12raptor@proton.me";
+    github = "L12Raptor";
+    githubId = 84540018;
+    name = "Lowis";
+  };
   l1n = {
     github = "l1n";
     githubId = 1367322;

--- a/nixos/modules/hardware/slimbook-drivers.nix
+++ b/nixos/modules/hardware/slimbook-drivers.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.hardware.slimbook-drivers;
+  slimbook_qc71_laptop = config.boot.kernelPackages.slimbook_qc71_laptop;
+in
+{
+  options.hardware.slimbook-drivers = {
+    enable = lib.mkEnableOption "Linux kernel platform driver for QC71 based Slimbook laptops";
+    enableBatteryChargeLimit = lib.mkEnableOption "battery charge limit for QC71 based Slimbook laptops";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.extraModulePackages = [ slimbook_qc71_laptop ];
+    boot.kernelModules = [ "qc71_laptop" ];
+    boot.extraModprobeConfig = lib.mkIf cfg.enableBatteryChargeLimit ''
+      options qc71_laptop show_charge_limit=true
+    '';
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -111,6 +111,7 @@
   ./hardware/sensor/hddtemp.nix
   ./hardware/sensor/iio.nix
   ./hardware/sheep-net.nix
+  ./hardware/slimbook-drivers.nix
   ./hardware/steam-hardware.nix
   ./hardware/system-76.nix
   ./hardware/tenstorrent.nix

--- a/pkgs/os-specific/linux/slimbook_qc71_laptop/default.nix
+++ b/pkgs/os-specific/linux/slimbook_qc71_laptop/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qc71_laptop";
+  version = "0-unstable-2026-07-23";
+
+  src = fetchFromGitHub {
+    owner = "Slimbook-Team";
+    repo = "qc71_laptop";
+    rev = "7eaaeed9fab43c5852dc156532952ae891cc22d8";
+    hash = "sha256-ciLtofIm6UJhoQ195pKE2bPHupraSWP0x+l2kXH5SNY=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "VERSION=${version}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D qc71_laptop.ko -t $out/lib/modules/${kernel.modDirVersion}/extra
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Linux kernel platform driver for QC71 based Slimbook laptops";
+    homepage = "https://github.com/Slimbook-Team/qc71_laptop";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ l12raptor ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -626,6 +626,8 @@ in
 
         xpad-noone = callPackage ../os-specific/linux/xpad-noone { };
 
+        slimbook_qc71_laptop = callPackage ../os-specific/linux/slimbook_qc71_laptop { };
+
       }
       // lib.optionalAttrs config.allowAliases {
         zfs = throw "linuxPackages.zfs has been removed, use zfs_* instead, or linuxPackages.\${pkgs.zfs.kernelModuleAttribute}"; # added 2025-01-23


### PR DESCRIPTION
## Description of changes

Add a module for Slimbook laptop drivers. For now, I've only included the qc71_laptop kernel module from Slimbook-Team. I've also added a NixOS module to enable the drivers and activate the battery charge limit.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
