### PR TITLE
[Backport release-26.05] firefox/wrapper: add appDataDir argument

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -72,6 +72,7 @@ let
       pkcs11Modules ? [ ],
       useGlvnd ? (!isDarwin),
       cfg ? config.${applicationName} or { },
+      appDataDir ? null,
 
       ## Following options are needed for extra prefs & policies
       # For more information about anti tracking (german website)
@@ -340,6 +341,11 @@ let
         "--set"
         "MOZ_ALLOW_DOWNGRADE"
         "1"
+      ]
+      ++ lib.optionals (appDataDir != null) [
+        "--set"
+        "MOZ_APP_DATA"
+        appDataDir
       ]
       ++ lib.optionals (!isDarwin) [
         "--suffix"


### PR DESCRIPTION
This is immediately helpful on MacOS 27+ where access to default datadir
is now restricted to apps that are signed by Mozilla.

Moving datadir to a new location implies a completely new profile will
be created, unless users migrate their datadirs from the default
location to the new one. Nixpkgs derivation cannot execute this
migration for the users, nor it includes any tools to help with it. For
this reason, users on 27+ will have to explicitly opt-in their firefox
to use a new location, potentially also migrating their existing
datadir beforehand.

I expect Home Manager programs.firefox module to allow to set the
argument to:

${cfg.home.homeDirectory}/Library/Application Support/org.nixos.firefox

Other package consumers are advised to use the same directory for
portability reasons.

Fixes #535123

(cherry picked from commit 2452ba690cfa131ce5bb55b2974b99a01ac94709)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
