### PR TITLE
nixos/home-assistant: allow access to cec devices for hdmi_cec component

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -283,6 +283,10 @@ let
     # Components that require access to input devices (/dev/input/*)
     "keyboard_remote"
   ];
+  componentsUsingCecDevices = [
+    # Components that require access to cec devices (/dev/cec*)
+    "hdmi_cec"
+  ];
 in
 {
   imports = [
@@ -1031,6 +1035,9 @@ in
             ]
             ++ optionals (any useComponent componentsUsingInputDevices) [
               "char-input rw"
+            ]
+            ++ optionals (any useComponent componentsUsingCecDevices) [
+              "char-cec rw"
             ];
           DevicePolicy = "closed";
           LockPersonality = true;
@@ -1082,6 +1089,9 @@ in
             ]
             ++ optionals (any useComponent componentsUsingInputDevices) [
               "input"
+            ]
+            ++ optionals (any useComponent componentsUsingCecDevices) [
+              "video"
             ];
           SystemCallArchitectures = "native";
           SystemCallFilter = [


### PR DESCRIPTION
Conditionally add `char-cec rw` to `DeviceAllow` and `video` to `SupplementaryGroups` inside `home-assistant` systemd service if `hdmi_cec` components is used. This is needed to expose access for `/dev/cec*` devices to `home-assistant` service. That is the first step towards fixing `hdmi_cec` component on NixOS, more details: https://github.com/NixOS/nixpkgs/issues/552855.

`stat /dev/cec0`
```
  File: /dev/cec0
  Size: 0               Blocks: 0          IO Block: 4096   character special file
Device: 0,6     Inode: 242         Links: 1     Device type: 246,0
Access: (0660/crw-rw----)  Uid: (    0/    root)   Gid: (   26/   video)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
