### PR TITLE
dipc: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/di/dipc/package.nix
+++ b/pkgs/by-name/di/dipc/package.nix
@@ -2,20 +2,35 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  fetchpatch,
+  versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dipc";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "doprz";
     repo = "dipc";
-    rev = "b111b8cb997e3337974f861f44a73b557fb3c294";
-    hash = "sha256-qP7LRwNIM92p5xQeuvQ03kwBM/HnRH+BniiKeYoihKw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sK4wyrEr1RCdug6uDjFQvMlZzrhPAcXi6yTiiWiPQcc=";
   };
 
-  cargoHash = "sha256-F6EYnkquvTsw4C7rl28Y1h9i9ChGccwZGkYSVrsEhVk=";
+  cargoHash = "sha256-BCJXROjsaztzv6HWi1+i2GYCoeEgdXbYrEjpEdUvGFg=";
+
+  patches = [
+    # TODO: Remove it once it goes to the next version (>1.2.0)
+    # feat(theme): add Kanagawa theme (#45)
+    (fetchpatch {
+      name = "kanagawa-theme";
+      url = "https://github.com/doprz/dipc/commit/e5a7d851117ccef1250f2a7999ab05dfd9538c53.patch";
+      hash = "sha256-OteBFaRT+HdDtWNe5nLaoIgNjapzNOdZfAttOA7G+2E=";
+    })
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Convert your favorite images and wallpapers with your favorite color palettes/themes";
@@ -30,4 +45,4 @@ rustPlatform.buildRustPackage {
     ];
     mainProgram = "dipc";
   };
-}
+})


### PR DESCRIPTION
Bump `dipc` from 1.1.0 to 1.2.0

I know the Kangawa theme is not really a patch and out-of-scope, but how can you not have the Kanagawa theme!

Refactored to use `finalAttrs` pattern
Switched to `tag` attrs instead of `rev`
Added Kanagawa theme patch
Added `versionCheckHook`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
