### PR TITLE
kubeseal: 0.38.4 -> 0.39.1

### DIFF
--- a/pkgs/by-name/ku/kubeseal/package.nix
+++ b/pkgs/by-name/ku/kubeseal/package.nix
@@ -2,20 +2,21 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "kubeseal";
-  version = "0.38.4";
+  version = "0.39.1";
 
   src = fetchFromGitHub {
     owner = "bitnami";
     repo = "sealed-secrets";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-cg9YEY78miw8BRX9CCIeWqdAeJDsFSr6VvgRJFYzREU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vmvKD6Rk/xCw0hpGmus9JOG2JBStqzTSl09QGYMcOjQ=";
   };
 
-  vendorHash = "sha256-1RATVZIeWZFceLttnqnDgXHyUsjRvkHAnsypABW/WDE=";
+  vendorHash = "sha256-JzBl9jOGYstoimv8bdy2t1DSvchFMl73zdxeY1Vagog=";
 
   subPackages = [ "cmd/kubeseal" ];
 
@@ -24,6 +25,9 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X main.VERSION=${finalAttrs.version}"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Kubernetes controller and tool for one-way encrypted Secrets";


### PR DESCRIPTION
Bump `kubeseal` from 0.38.4 to 0.39.1

The refactor part is kinda opinionated (not "modern") so do let me know if you just prefer the before, and I can change it back. 
Refactored `fetchFromGithub` attrs to use `tag` instead of `rev`, and `hash` instead of `sha256`
Added `versionCheckHook`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
