### PR TITLE
arti: 2.5.1 -> 2.6.0

### DIFF
--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -13,7 +13,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "arti";
-  version = "2.5.1";
+  version = "2.6.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -21,18 +21,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "core";
     repo = "arti";
     tag = "arti-v${finalAttrs.version}";
-    hash = "sha256-fPobYu2ADTeIwpeXyxQKh5yr1zw+yMQfqTkiZMMd8YY=";
+    hash = "sha256-ukGplnZz1O1Djh12COKk8FL/3rLmmWGyl0b816wRWBE=";
   };
 
   # Working around a bug in cargo that appears with cargo-auditable, see
   # https://github.com/rust-secure-code/cargo-auditable/issues/124.
   postPatch = ''
     substituteInPlace crates/arti/Cargo.toml \
+      --replace-fail '"http"' '"dep:http"' \
       --replace-fail '"tokio-util"' '"dep:tokio-util"'
   '';
 
   buildAndTestSubdir = "crates/arti";
-  cargoHash = "sha256-+JQ+SkRLyLl4RUq69nIUn1zJ/DmYpVEICQO5o85FsNw=";
+  cargoHash = "sha256-/7sWTLeVolqliggn1Qw+kxqAeWENHgbCR6hK5Th2z+g=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 


### PR DESCRIPTION
blog: https://blog.torproject.org/arti_2_6_0_released/
changelog: https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.6.0/CHANGELOG.md
diff: https://gitlab.torproject.org/tpo/core/arti/-/compare/arti-v2.5.1...arti-v2.6.0

tested:
- with `curl` as a socks5 proxy to connect to clearnet sites and onion services
- with `tor-browser` as a standalone proxy
- running a regular onion service
- running an onion service with restricted discovery/client authorization
- as a client in a test network as part of `nixosTests.tor`

marking for backport as this helps enable important features that can enhance general privacy/security properties (counter galois onion) and should be non-breaking for users of the binary (the only thing we distribute)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
