### PR TITLE
claude-code: 2.1.258 -> 2.1.259

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -21,22 +21,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-eIJB3cp3HeD5DGcr/mp4kjkY/gMFp9oam8cGKeKSOMc=";
+          hash = "sha256-AQPOmmxtDSwt7lq7L31hafqtu5X8myoYJ/DLaNc3WXk=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-SG5Mj3qd0VUOErXUtHiAHaPCWmDoCCNSnNoQBa4cBCw=";
+          hash = "sha256-yjsgeVeDbJGY1tGgkX1Hd7L7XJQGimu/IQIrZYw+vcE=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-gOOI6PqNdET7phteeqZ9ejcXTpstipMSGVTGxyf+od0=";
+          hash = "sha256-9BOjYrZ7njsfkC3mVj6Fp1HFTZ9P9wwZ7u2iFFl3b+k=";
         };
       };
     in
     {
       name = "claude-code";
       publisher = "anthropic";
-      version = "2.1.258";
+      version = "2.1.259";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/by-name/cl/claude-code/manifest.zst.json
+++ b/pkgs/by-name/cl/claude-code/manifest.zst.json
@@ -1,61 +1,60 @@
 {
-  "version": "2.1.258",
+  "version": "2.1.259",
   "manifestSignatureEnforcement": "flag",
-  "commit": "b3cd543a1f6fcdf4d8fabc0f5e5538d2ee7f38e1",
-  "buildDate": "2026-09-01T22:04:05Z",
+  "commit": "9b549c8d1c72e407ea9d3af3b9d5e50da794ec4d",
+  "buildDate": "2026-09-02T20:41:43Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude.zst",
-      "checksum": "ee83f6743e0e5f60ec1456ea813851c625051241f7bc55d607faafe44cf4bc82",
-      "size": 65811873,
+      "checksum": "e2afc0237a4ee7213730b3cf579a51f1c1a2b627b0f2d615ac3478433c4f9b9d",
+      "size": 66314944,
       "bundle": {
-        "checksum": "412f0b36da7cff5b20e7d856c939b449449583ee0971e9217c54972d1dfb4df3",
-        "size": 65814874
+        "checksum": "9a73fbc4c23cc04ba3ac0280cd6b7bf3941cd039099fad713be75b0010c7fc8b",
+        "size": 66313806
       }
     },
     "darwin-x64": {
       "binary": "claude.zst",
-      "checksum": "160aa9a06afcb80c293ecd4e42ea62adb67e471bed6b9a813504f26b96978034",
-      "size": 69876596,
+      "checksum": "bec7b01d0fccc8902b850cd9cf655024d0a484306e4da2104fb1bee6fb5334da",
+      "size": 70374909,
       "bundle": {
-        "checksum": "575203804ea01ddd3c12226c7c9cdcd068f1d039c732e22916297d438944510c",
-        "size": 69878203
+        "checksum": "ad45869201a4e81c882d7251c676a74a539d7378beeaaf13be044f4fa7d5397c",
+        "size": 70378257
       }
     },
     "linux-arm64": {
       "binary": "claude.zst",
-      "checksum": "31768a9f65e58e48a3cacf7fce069bb6d7bd707cdb49874af2cb19b9d05af671",
-      "size": 75035372
+      "checksum": "75b8227d2735398754aacc875866fee533e673d54199a16a7e5424f09feb21ad",
+      "size": 75526532
     },
     "linux-x64": {
       "binary": "claude.zst",
-      "checksum": "88207a58aee5a82e47db834ce81111200ad8fae9ea9abe2ff1ff9773d6a2100a",
-      "size": 75670149
+      "checksum": "3623df24e9be0ae1a92eb1103d11cdf44d04f6b589200952ce8e6853de8aa845",
+      "size": 76150824
     },
     "linux-arm64-musl": {
       "binary": "claude.zst",
-      "checksum": "6658622d769ad18dfbc1e70ea0056e34e88e258b15769e9c63c6c444cb83625a",
-      "size": 73516216
+      "checksum": "fcd70a9db4aaea51ff721fd0638faf9dc0b45f6e4d4489280801c4870b4bc642",
+      "size": 73995724
     },
     "linux-x64-musl": {
       "binary": "claude.zst",
-      "checksum": "d357e596364fb922923e5db2b3877d3d7ba4a1b9d2f44f44879efa103bf459a0",
-      "size": 74188445
+      "checksum": "7afb1ee29124e2884226215c85cfcde486da6fd31dc999810dffe8e9d8cda37d",
+      "size": 74670388
     },
     "win32-x64": {
       "binary": "claude.exe.zst",
-      "checksum": "94c7203fbeaa42f67dba3e7aabc544b1356dcec76bf830693948e99f4e4f21bc",
-      "size": 78074015
+      "checksum": "ae95350b7235bd1fc1fba12ca6b296205b505c4990af607ac18424746ad4ce37",
+      "size": 78555005
     },
     "win32-arm64": {
       "binary": "claude.exe.zst",
-      "checksum": "28eb7de6beb1adc3bc628426eada6aabd9592d42b66174cc419f64cb208f0127",
-      "size": 74810598
+      "checksum": "479df3648b599f4918d3305f909487103a4819cad574d14ef30441a8e48aec4f",
+      "size": 75294093
     }
   },
   "sdkCompat": {
     "testedWrapperVersions": [
-      "0.3.217",
       "0.3.218",
       "0.3.219",
       "0.3.220",


### PR DESCRIPTION
Prepared with the assistance of Claude Code (Claude Opus 5). Version and hash bumps were produced by the standard maintainers/scripts/update.nix script.

Routine version bump of `claude-code` (2.1.258 -> 2.1.259) and the matching `vscode-extensions.anthropic.claude-code` extension. All three extension arch hashes were refreshed by the updater.

Changelog: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

https://claude.ai/code/session_01HFnVGsYALyoURLfxzjPUcF
