### PR TITLE
nixos/wireguard: add endpointCommand option

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -326,6 +326,24 @@ let
         '';
       };
 
+      endpointCommand = mkOption {
+        default = null;
+        example = literalExpression ''
+          '''
+            echo "$(''${pkgs.dig}/bin/dig +short @1.1.1.1 example.org):51820"
+          ''''';
+        type = with types; nullOr str;
+        description = ''
+          A command that should return the peer endpoint.
+          The returned value should include the port e.g. 1.2.3.4:5432
+
+          This option can be used in advanced situations where the default
+          behaviour of resolving the peers endpoint through the systems dns
+          would not work. For example if the system has the peer configured as
+          the nameserver then dns queries would fail when the peer is down
+        '';
+      };
+
       dynamicEndpointRefreshSeconds = mkOption {
         default = null;
         defaultText = literalExpression "config.networking.wireguard.interfaces.<name>.dynamicEndpointRefreshSeconds";
@@ -505,6 +523,7 @@ let
             [ ''${wg} set ${interfaceName} peer "${peer.publicKey}"'' ]
             ++ optional (psk != null) ''preshared-key "${psk}"''
             ++ optional (peer.endpoint != null) ''endpoint "${peer.endpoint}"''
+            ++ optional (peer.endpointCommand != null) ''endpoint "$( ${peer.endpointCommand} )"''
             ++ optional (
               peer.persistentKeepalive != null
             ) ''persistent-keepalive "${toString peer.persistentKeepalive}"''
@@ -718,13 +737,16 @@ in
             message = "networking.wireguard.interfaces.${name}.generatePrivateKeyFile must not be set if networking.wireguard.interfaces.${name}.privateKey is set.";
           }) cfg.interfaces
         ))
-        ++ map (
-          { interfaceName, peer, ... }:
+        ++ concatMap ({ interfaceName, peer, ... }: [
           {
             assertion = (peer.presharedKey == null) || (peer.presharedKeyFile == null);
             message = "networking.wireguard.interfaces.${interfaceName} peer «${peer.publicKey}» has both presharedKey and presharedKeyFile set, but only one can be used.";
           }
-        ) all_peers;
+          {
+            assertion = (peer.endpoint == null) || (peer.endpointCommand == null);
+            message = "networking.wireguard.interfaces.${interfaceName} peer «${peer.publicKey}» has both endpoint and endpointCommand set, but only one can be used.";
+          }
+        ]) all_peers;
 
       boot.extraModulePackages =
         optional (usingWg && (versionOlder kernel.kernel.version "5.6")) kernel.wireguard


### PR DESCRIPTION
Allows using a custom command to determine the peers endpoint. 
This can be used for more advanced setups such as the network namespace approach described here https://www.wireguard.com/netns/

The current approach is not available when using the namespace setup, as currently all peer endpoints are resolved using the system nameserver in the namespace that contains the wireguard interface.
If all traffic is routed over the same peer we are trying to resolve the endpoint for, or this peer is used as a nameserver, this will always fail.

To solve the above issue using this option you can set it as in the example below, where it runs dig in a different namespace that has network connectivity outside wireguard, you could also specify the nameserver to dig instead of using the one configured in the namespaces /etc/resolv.conf.

This approach is fully flexible, as all you need is a command that returns a domain:port for wireguard to use as the endpoint, how one obtains the endpoint doesn't need to be through dns, it could be through any other method as long as the command returns a domain:port. 

Tested using namespace setup similar to the following config
```nix
networking.wireguard = {
  enable = true;
  interfaces."wg0" = {
    socketNamespace = "outside";
    interfaceNamespace = "init";
    privateKeyFile = "...";
    ips = ["..."];
    peers = [
      {
        publicKey = "...";
        endpointCommand = ''
          echo "$(ip netns exec outside ${pkgs.dig}/bin/dig +short example.com):51820"
        '';
        dynamicEndpointRefreshSeconds = 30;
        allowedIPs = [
          "0.0.0.0/0"
          "::/0"
        ];
      }
    ];
  };
};
```

When endpointCommand is not set, behaviour is identical as previous behaviour

Fixes #169128 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
