### PR TITLE
python3Packages.xml2rfc: 3.33.0 -> 3.34.0

### DIFF
--- a/pkgs/development/python-modules/xml2rfc/default.nix
+++ b/pkgs/development/python-modules/xml2rfc/default.nix
@@ -9,10 +9,12 @@
   intervaltree,
   jinja2,
   lxml,
+  natsort,
   platformdirs,
   pycairo,
   pycountry,
   pypdf,
+  pyprojectVersionPatchHook,
   pytestCheckHook,
   python-fontconfig,
   pyyaml,
@@ -23,15 +25,17 @@
 
 buildPythonPackage rec {
   pname = "xml2rfc";
-  version = "3.33.0";
+  version = "3.34.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ietf-tools";
     repo = "xml2rfc";
     tag = "v${version}";
-    hash = "sha256-eoTuA4OJjqJGRP+uRi2TMWfS3yrCCUPIKI2uNPnjqcA=";
+    hash = "sha256-O5S1jeNOa1Lrv1wJpqpexDjghFkEiQqI9tYGGlpbRi4=";
   };
+
+  pythonRelaxDeps = [ "lxml" ];
 
   postPatch = ''
     substituteInPlace Makefile \
@@ -41,7 +45,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  pythonRelaxDeps = [ "lxml" ];
+  nativeBuildInputs = [ pyprojectVersionPatchHook ];
 
   dependencies = [
     configargparse
@@ -50,6 +54,7 @@ buildPythonPackage rec {
     intervaltree
     jinja2
     lxml
+    natsort
     platformdirs
     pycountry
     pypdf

--- a/pkgs/development/python-modules/xml2rfc/default.nix
+++ b/pkgs/development/python-modules/xml2rfc/default.nix
@@ -23,7 +23,7 @@
   wcwidth,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xml2rfc";
   version = "3.34.0";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ietf-tools";
     repo = "xml2rfc";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-O5S1jeNOa1Lrv1wJpqpexDjghFkEiQqI9tYGGlpbRi4=";
   };
 
@@ -83,7 +83,7 @@ buildPythonPackage rec {
     description = "Tool generating IETF RFCs and drafts from XML sources";
     mainProgram = "xml2rfc";
     homepage = "https://github.com/ietf-tools/xml2rfc";
-    changelog = "https://github.com/ietf-tools/xml2rfc/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/ietf-tools/xml2rfc/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     # Well, parts might be considered unfree, if being strict; see:
     # http://metadata.ftp-master.debian.org/changelogs/non-free/x/xml2rfc/xml2rfc_2.9.6-1_copyright
     license = lib.licenses.bsd3;
@@ -92,4 +92,4 @@ buildPythonPackage rec {
       yrashk
     ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/ietf-tools/xml2rfc/blob/v3.34.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
