### PR TITLE
home-assistant-custom-components.planta: init at 1.3.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/planta/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/planta/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  stringcase,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "natekspencer";
+  domain = "planta";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    inherit (finalAttrs) owner;
+    repo = "ha-planta";
+    tag = finalAttrs.version;
+    hash = "sha256-LqRBWeman+ZwkIwfSWGuAW2aCwgmLXIME0U6uz+IDVE=";
+  };
+
+  postPatch = ''
+    substituteInPlace custom_components/planta/manifest.json \
+      --replace-fail '"version": "0.0.0"' '"version": "${finalAttrs.version}"'
+  '';
+
+  dependencies = [ stringcase ];
+
+  meta = {
+    description = "Home Assistant integration for the Planta plant care app";
+    homepage = "https://github.com/natekspencer/ha-planta";
+    changelog = "https://github.com/natekspencer/ha-planta/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})


### PR DESCRIPTION
https://github.com/natekspencer/ha-planta

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
