### PR TITLE
lfsx: init at 1.14.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4303,6 +4303,12 @@
     githubId = 7560938;
     name = "Bas van den Wollenberg";
   };
+  bryanfrd = {
+    name = "Bryan Ferrando";
+    email = "bryanferrando59@gmail.com";
+    github = "BryanFRD";
+    githubId = 20824933;
+  };
   bryango = {
     name = "Bryan Lai";
     email = "bryanlais@gmail.com";

--- a/pkgs/by-name/lf/lfsx/package.nix
+++ b/pkgs/by-name/lf/lfsx/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lfsx";
+  version = "1.14.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "FerrLabs";
+    repo = "LFSX";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-muRfcKcc45cl7w9wy34xQh52McAzaCiO1liQ8rlSXwk=";
+  };
+
+  cargoHash = "sha256-wpGCB4nUJfJG/GahPBBlQrnVxPn2uF7hB852W53aKr4=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/lfsx";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast, lightweight, secure Git LFS server";
+    homepage = "https://lfsx.dev";
+    changelog = "https://github.com/FerrLabs/LFSX/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ bryanfrd ];
+    mainProgram = "lfsx-server";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
LFSX is a self-hosted Git LFS server written in Rust. Objects are stored once across
repositories, addressed by digest, with optional zstd compression and encryption at rest, file
locking, and permissions delegated to the upstream forge (GitHub, GitLab, Gitea, Forgejo).
https://lfsx.dev

The package builds two binaries, the server and the `lfsx` CLI.

`versionCheckProgram` points at `lfsx` because `lfsx-server` does not implement `--version` yet,
it starts serving instead (FerrLabs/LFSX#304).

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.
