### PR TITLE
whisper-cpp: fix ROCm support by using GGML_HIP cmake flag

### DIFF
--- a/pkgs/by-name/wh/whisper-cpp/package.nix
+++ b/pkgs/by-name/wh/whisper-cpp/package.nix
@@ -118,7 +118,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (cmakeBool "WHISPER_BUILD_EXAMPLES" true)
     (cmakeBool "GGML_CUDA" cudaSupport)
-    (cmakeBool "GGML_HIPBLAS" rocmSupport)
+    (cmakeBool "GGML_HIP" rocmSupport)
     (cmakeBool "GGML_VULKAN" vulkanSupport)
     (cmakeBool "WHISPER_SDL2" withSDL)
     (cmakeBool "GGML_LTO" true)


### PR DESCRIPTION
The GGML_HIPBLAS flag does not exist (anymore?) upstream in ggml-org/whisper-cpp. It is ignored and ROCm acceleration is not enabled. The GGML_HIP flag matches the whisper.cpp README documentation and correctly enables ROCm acceleration.

https://github.com/ggml-org/whisper.cpp/blob/master/README.md#amd-rocm-gpu-support

Tested locally with a Radeon RX 7900 XTX.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
