### PR TITLE
tuned: 2.27.0 -> 2.28.0

### DIFF
--- a/pkgs/by-name/tu/tuned/package.nix
+++ b/pkgs/by-name/tu/tuned/package.nix
@@ -16,7 +16,6 @@
   pkg-config,
   powertop,
   python3Packages,
-  tuna,
   util-linux,
   versionCheckHook,
   virt-what,
@@ -84,10 +83,8 @@ stdenv.mkDerivation (finalAttrs: {
     dbus-python
     pygobject3
     pyinotify
-    pyperf
     python-linux-procfs
     pyudev
-    tuna
   ];
 
   makeFlags = [

--- a/pkgs/by-name/tu/tuned/package.nix
+++ b/pkgs/by-name/tu/tuned/package.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tuned";
-  version = "2.27.0";
+  version = "2.28.0";
 
   outputs = [
     "out"
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "redhat-performance";
     repo = "tuned";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PlF2T+EpveFkKPMU/6ZMXDO0q8Efzol4HJ4CX0wsBoY=";
+    hash = "sha256-WBQgtmlCbSUkeEtfYfCgf7kCCA9G+IZiWArOX9i/OH8=";
   };
 
   patches = [
@@ -63,6 +63,10 @@ stdenv.mkDerivation (finalAttrs: {
       $(find profiles/ -type f -executable -name '*.sh') \
       --replace-warn "/usr/share" "$out/share" \
       --replace-warn "/usr/lib" "$out/lib"
+
+    substituteInPlace tests/unit/test_functions.py \
+      --replace-fail "/bin/bash" "${stdenv.shell}" \
+      --replace-fail '"/bin/" + command' "shutil.which(command)"
   '';
 
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Updated TuneD to 2.27.0 -> 2.28.0
   Added substitution for hard-coded bash, grep, ls, and sed calls in the new [upstream test](https://github.com/redhat-performance/tuned/blob/a4907c9af9ea0a29f208b8f024465af16a7c9cbf/tests/unit/test_functions.py) 
- Dropped unused `tuna` and `pyperf` dependencies

Changelog: https://github.com/redhat-performance/tuned/releases/tag/v2.28.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
