### PR TITLE
zvec-grep: init at 0.2.0

### DIFF
--- a/pkgs/by-name/zv/zvec-grep/package.nix
+++ b/pkgs/by-name/zv/zvec-grep/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs_22,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "zvec-grep";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "zvec-ai";
+    repo = "zvec-grep";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2o/6QWyeZqOy7O8ikO8puqMXmtvWdjS9Y1rNW/SD/Bc=";
+  };
+
+  nodejs = nodejs_22;
+
+  npmDepsHash = "sha256-NPFIAq618jy2wH7ikVg55LWLdPxjcU0OjniwZXPgEhk=";
+
+  # Keep npm rebuild offline; the CPU runtime is bundled and CUDA is optional.
+  env.ONNXRUNTIME_NODE_INSTALL_CUDA = "skip";
+
+  # Node.js already provides the compiler runtime libraries, and the native
+  # addons use $ORIGIN for their bundled shared-library dependencies.
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local-first hybrid workspace search for humans and AI agents";
+    homepage = "https://github.com/zvec-ai/zvec-grep";
+    changelog = "https://github.com/zvec-ai/zvec-grep/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "zg";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+    # @zvec/zvec publishes native bindings for these Linux architectures.
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
Add zvec-grep 0.2.0, a local-first hybrid workspace search CLI.

The upstream npm distribution bundles native Node addons for zvec, ONNX Runtime, llama.cpp, sharp, and reflink. Node.js already provides the compiler runtime libraries, while the bundled shared-library dependencies use `$ORIGIN`, so this derivation does not need `autoPatchelfHook`. The package is still marked with `binaryNativeCode` source provenance because these native binaries are distributed by npm.

The CUDA postinstall download is disabled so the dependency installation remains offline; the CPU runtime is bundled and CUDA is optional.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR; it is not available in the local environment.
- [x] Tested basic functionality of the CLI and all x86_64 native modules bundled by the package.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

AI assistance was used for research, implementation, and verification; the commit includes the required `Assisted-by: OpenAI Codex (GPT-5)` trailer. The contribution is submitted as a draft for responsible-person review.