### PR TITLE
stowaway: init at 1.0.1

### DIFF
--- a/pkgs/by-name/st/stowaway/package.nix
+++ b/pkgs/by-name/st/stowaway/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  qt6,
+  quickshell,
+  cliphist,
+  wl-clipboard,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stowaway";
+  version = "1.0.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "AstraSuite";
+    repo = "Stowaway";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8IQvpDudoADAkdtPHuretEnTJDYqUDVvmj8bbH5Wj1M=";
+  };
+
+  postPatch = ''
+    substituteInPlace launcher/main.cpp \
+      --replace-fail '/etc/xdg/quickshell/astra-stowaway/shell.qml' "$out/etc/xdg/quickshell/astra-stowaway/shell.qml" \
+      --replace-fail '"/usr/lib/qt6/qml"' "\"$out/lib/qt6/qml\"" \
+      --replace-fail '"/usr/lib/qt6/qml/Astra/Stowaway"' "\"$out/lib/qt6/qml/Astra/Stowaway\""
+    substituteInPlace assets/stowaway.service \
+      --replace-fail 'ExecStart=stowaway' "ExecStart=$out/bin/stowaway"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "STOWAWAY_VERSION" finalAttrs.version)
+    (lib.cmakeFeature "INSTALL_QSCONFDIR" "${placeholder "out"}/etc/xdg/quickshell/astra-stowaway")
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix PATH : ${
+        lib.makeBinPath [
+          quickshell
+          cliphist
+          wl-clipboard
+        ]
+      }
+      --prefix QML2_IMPORT_PATH : "$out/lib/qt6/qml"
+    )
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "stowaway --version";
+    };
+  };
+
+  meta = {
+    description = "Modern Wayland clipboard manager and emoji picker overlay";
+    homepage = "https://github.com/AstraSuite/Stowaway";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "stowaway";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[Stowaway](https://github.com/AstraSuite/Stowaway) is a modern Wayland clipboard manager and emoji picker overlay built with Qt6 and Quickshell.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test