### PR TITLE
proxyauth: 1.0.3 -> 1.2.0

### DIFF
--- a/pkgs/by-name/pr/proxyauth/package.nix
+++ b/pkgs/by-name/pr/proxyauth/package.nix
@@ -14,17 +14,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "proxyauth";
-  version = "1.0.3";
+  version = "1.2.0";
 
   src = fetchFromForgejo {
     domain = "git.proxyauth.app";
     owner = "ProxyAuth";
     repo = "ProxyAuth";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hdLkDM1xNqQnaTKcBDRzLCc0hocHiIwLNPxIEU2MYIE=";
+    hash = "sha256-Im6BfBhzxrcbaZ0rvy0+dQ4Dx8L2NQz7zMc1SOY6xnY=";
   };
 
-  cargoHash = "sha256-IwIOlo5OyjvQBhgUZiRJy7fiNQshMgMHcl9MA6ju1h8=";
+  cargoHash = "sha256-q7goMwGtcBnnYXqhylmygQFTEGzTQG6IbgUhuKRiw+8=";
 
   nativeBuildInputs = [
     pkg-config
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Proxy Authentication Token - Fast authentication gateway for backend APIs";
+    description = "Edge reverse proxy for OIDC/API authentication and dashboards";
     homepage = "https://git.proxyauth.app/ProxyAuth/ProxyAuth";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ liberodark ];


### PR DESCRIPTION
Diff : https://git.proxyauth.app/ProxyAuth/ProxyAuth/compare/v1.0.3...v1.2.0
Changelog : https://git.proxyauth.app/ProxyAuth/ProxyAuth/releases/tag/v1.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
