### PR TITLE
flightdeck: init at 1.0.0

### DIFF
--- a/pkgs/by-name/fl/flightdeck/package.nix
+++ b/pkgs/by-name/fl/flightdeck/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  qt6,
+  caelestia-shell,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flightdeck";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "AstraSuite";
+    repo = "FlightDeck";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GXRHPCxjV5vQs/ZDJQDIULQqJu0WSSOJ1Iq5VX6NB8A=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+    qt6.qtshadertools
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtshadertools
+    qt6.qtsvg
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FLIGHTDECK_VERSION" finalAttrs.version)
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix QML2_IMPORT_PATH : "${caelestia-shell.plugin}/${qt6.qtbase.qtQmlPrefix}:${caelestia-shell.m3shapesModule}/${qt6.qtbase.qtQmlPrefix}"
+    )
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "QT_QPA_PLATFORM=offscreen flightdeck --version";
+    };
+  };
+
+  meta = {
+    description = "Hyprland configuration manager for Caelestia Shell";
+    homepage = "https://github.com/AstraSuite/FlightDeck";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ rachalaraj ];
+    mainProgram = "flightdeck";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[FlightDeck](https://github.com/AstraSuite/FlightDeck) is a graphical Hyprland configuration manager for Caelestia Shell built with Qt6.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test