### PR TITLE
python3Packages.nethsm: 2.1.1 -> 3.0.0, add panicgh as maintainer

### DIFF
--- a/pkgs/development/python-modules/nethsm/default.nix
+++ b/pkgs/development/python-modules/nethsm/default.nix
@@ -56,6 +56,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Nitrokey/nethsm-sdk-py";
     changelog = "https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.panicgh ];
   };
 }

--- a/pkgs/development/python-modules/nethsm/default.nix
+++ b/pkgs/development/python-modules/nethsm/default.nix
@@ -7,21 +7,20 @@
   poetry-core,
   pycryptodome,
   pytestCheckHook,
-  python-dateutil,
   typing-extensions,
   urllib3,
 }:
 
 buildPythonPackage rec {
   pname = "nethsm";
-  version = "2.1.1";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nethsm-sdk-py";
     tag = "v${version}";
-    hash = "sha256-1bU3C8dlErDpHQIqsEabi92VPC91/wTNvZnx2dDHcmw=";
+    hash = "sha256-kOZ/kNvYlnKi/ojv4b4ZGmNZqARZPAT0g12xi6gw39E=";
   };
 
   pythonRelaxDeps = true;
@@ -31,7 +30,6 @@ buildPythonPackage rec {
   dependencies = [
     certifi
     cryptography
-    python-dateutil
     typing-extensions
     urllib3
   ];


### PR DESCRIPTION
## Things done

* https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/v2.1.2
* https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/v3.0.0
* Remove outdated dependency to python-dateutil
* Add myself as maintainer

Closes #536116

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6abeeda53beffc052ed71672bf2b4b9251bafda9`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 5 packages built:</summary>
  <ul>
    <li>pynitrokey</li>
    <li>python313Packages.nethsm</li>
    <li>python313Packages.pynitrokey</li>
    <li>python314Packages.nethsm</li>
    <li>python314Packages.pynitrokey</li>
  </ul>
</details>