### PR TITLE
cosmic-ext-applet-workspace-icons: init at 1.2.0

### DIFF
--- a/pkgs/by-name/co/cosmic-ext-applett-workspace-icons/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-applett-workspace-icons/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  libcosmicAppHook,
+  just,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-ext-applet-workspace-icons";
+  version = "1.2.0";
+
+  __structuredAttrs = true;
+  src = fetchFromGitHub {
+    owner = "crocodile";
+    repo = "cosmic-ext-applet-workspace-icons";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gJfT7GpTRVlSJVHnEm4ezaWmJpObVz3Sjkd0ELYZQU4=";
+  };
+
+  cargoHash = "sha256-fuCmcnGKY/AjovGSBbrnifXY6iiWyXaPM0YmSqn2P4E=";
+
+  nativeBuildInputs = [
+    libcosmicAppHook
+    just
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "targetdir"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Workspace Icons is a COSMIC panel applet that adds application icons to numbered workspaces.";
+    homepage = "https://github.com/crocodile/cosmic-ext-applet-workspace-icons";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "cosmic-ext-applet-workspace-icons";
+    maintainers = [ lib.maintainers.berrij ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [`cosmic-ext-applet-workspace-icons`](https://github.com/crocodile/cosmic-ext-applet-workspace-icons):

> Workspace Icons is a COSMIC panel applet that adds application icons to numbered workspaces. It helps you see which apps are open on each workspace and monitor without opening the workspace overview.

<img width="418" height="60" alt="image" src="https://github.com/user-attachments/assets/0dbce80b-1d3a-4487-9537-5edc378cc0df" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test