### PR TITLE
authelia: 4.39.20 -> 4.39.22

### DIFF
--- a/pkgs/by-name/au/authelia/package.nix
+++ b/pkgs/by-name/au/authelia/package.nix
@@ -6,7 +6,7 @@
   pnpmConfigHook,
   pnpm_11,
   fetchFromGitHub,
-  buildGo126Module,
+  buildGo127Module,
   installShellFiles,
   callPackage,
   nixosTests,
@@ -22,9 +22,7 @@
 }:
 
 let
-  pnpm = pnpm_11;
-
-  buildGoModule = buildGo126Module;
+  buildGoModule = buildGo127Module;
 
   inherit (import ./sources.nix { inherit fetchFromGitHub; })
     pname

--- a/pkgs/by-name/au/authelia/sources.nix
+++ b/pkgs/by-name/au/authelia/sources.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub }:
 rec {
   pname = "authelia";
-  version = "4.39.20";
+  version = "4.39.22";
 
   src = fetchFromGitHub {
     owner = "authelia";
     repo = "authelia";
     rev = "v${version}";
-    hash = "sha256-JjpfNQsqtmSKXj14fQUJsiTgfkAlSHDfqUC/x+bE+fc=";
+    hash = "sha256-6mKS+U0Leac2vcHRTMIAKfqr78NQUCMBiW76z4H/STw=";
   };
-  vendorHash = "sha256-dZjsYqw/ABEn1y6tZgSjbmqamO4U20Ljj/dQMFruVjU=";
-  pnpmDepsHash = "sha256-JeRolDKVf2EInZVAt/HpkurzgDcE592jF5stJ+qZY9U=";
+  vendorHash = "sha256-8ftsYIEMkoM3emW0d6E3cOv3hUQDLZcSBDEy8NvwNcY=";
+  pnpmDepsHash = "sha256-ngHVlFIQuUY+D54CDZ7FIlu13UjGr3zcdTvKryntVhQ=";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This bugfix release contains some important fixes for OAuth 2.0 Device Authorization Grant.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
