### PR TITLE
haskellPackages.extensions: default to GHC 9.12 compatible version

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -185,12 +185,11 @@ with haskellLib;
   # language extensions.
   extensions = doJailbreak (
     super.extensions.override {
-      Cabal =
-        if versionOlder self.ghc.version "9.10" then
-          self.Cabal_3_12_1_0
+      Cabal-syntax =
+        if versionOlder self.ghc.version "9.12" then
+          self.Cabal-syntax_3_14_2_0
         else
           # use GHC bundled version
-          # N.B. for GHC >= 9.12, extensions needs to be upgraded
           null;
     }
   );

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -69,12 +69,6 @@ with haskellLib;
   Win32 = null;
 
   #
-  # Hand pick versions that are compatible with ghc 9.12 and base 4.21
-  #
-
-  extensions = doDistribute self.extensions_0_1_1_0;
-
-  #
   # Jailbreaks
   #
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -29,7 +29,6 @@ default-package-overrides:
   - clash-lib-hedgehog < 1.9 # needs to match clash-lib from Stackage
   # 2025-12-26: Needs to match egison-pattern-src from Stackage LTS
   - egison-pattern-src-th-mode < 0.2.2
-  - extensions == 0.1.0.2 # matches Cabal 3.12 (GHC 9.10)
   # 2026-06-29: needs to match futhark-0.26.3
   - futhark-manifest == 1.8.0.0
   # 2026-01-30: Needs to match hasql from Stackage LTS 24

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -233124,68 +233124,6 @@ self: {
       mkDerivation,
       base,
       bytestring,
-      Cabal,
-      colourista,
-      containers,
-      directory,
-      filepath,
-      ghc-boot-th,
-      hedgehog,
-      hspec,
-      hspec-hedgehog,
-      optparse-applicative,
-      parsec,
-      text,
-    }:
-    mkDerivation {
-      pname = "extensions";
-      version = "0.1.0.2";
-      sha256 = "1ra1qfrsc3icv6lgm06pgrhv77shwb8r7ci2whgnj3hs692ld7gd";
-      revision = "5";
-      editedCabalFile = "04plmhvz94p8dhy5qfykv5p2z9g25mqjrmcdyz6fj3x2p9pfrscd";
-      isLibrary = true;
-      isExecutable = true;
-      libraryHaskellDepends = [
-        base
-        bytestring
-        Cabal
-        containers
-        directory
-        filepath
-        ghc-boot-th
-        parsec
-        text
-      ];
-      executableHaskellDepends = [
-        base
-        colourista
-        containers
-        directory
-        filepath
-        optparse-applicative
-        text
-      ];
-      testHaskellDepends = [
-        base
-        bytestring
-        containers
-        ghc-boot-th
-        hedgehog
-        hspec
-        hspec-hedgehog
-        text
-      ];
-      description = "Parse Haskell Language Extensions";
-      license = lib.meta.getLicenseFromSpdxId "MPL-2.0";
-      mainProgram = "extensions";
-    }
-  ) { };
-
-  extensions_0_1_1_0 = callPackage (
-    {
-      mkDerivation,
-      base,
-      bytestring,
       Cabal-syntax,
       colourista,
       containers,
@@ -233239,7 +233177,6 @@ self: {
       ];
       description = "Parse Haskell Language Extensions";
       license = lib.meta.getLicenseFromSpdxId "MPL-2.0";
-      hydraPlatforms = lib.platforms.none;
       mainProgram = "extensions";
     }
   ) { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
