### PR TITLE
rosec: fix wasm provider paths

### DIFF
--- a/nixos/tests/rosec.nix
+++ b/nixos/tests/rosec.nix
@@ -27,6 +27,7 @@ in
       services.rosec = {
         enable = true;
         pam.enable = true;
+        package = pkgs.rosecFull;
       };
 
       environment.systemPackages = [ pkgs.libsecret ];
@@ -70,6 +71,12 @@ in
           _, output = machine.systemctl("status rosecd --no-pager", "alice")
           assert "Active: active (running)" in output
           machine.succeed("su - alice -c 'busctl --user list | grep -q org.freedesktop.impl.portal.desktop.rosec'")
+
+      with subtest("rosecFull wasm providers are discovered"):
+          kinds = machine.succeed("su - alice -c 'rosec provider kinds'")
+          assert "bitwarden-pm" in kinds, "bitwarden-pm provider not discovered"
+          assert "bitwarden-sm" in kinds, "bitwarden-sm provider not discovered"
+          assert "gnome-keyring" in kinds, "gnome-keyring provider not discovered"
 
       with subtest("PAM is configured with pam_rosec"):
           login_pam = machine.succeed("cat /etc/pam.d/login")

--- a/pkgs/by-name/ro/rosec-bitwarden-pm/package.nix
+++ b/pkgs/by-name/ro/rosec-bitwarden-pm/package.nix
@@ -17,6 +17,11 @@ rustPlatform.buildRustPackage (finalAttrs: rec {
   env.RUSTFLAGS = "-C linker=wasm-ld";
   nativeBuildInputs = [ lld ];
 
+  postInstall = ''
+    mkdir -p $out/lib/rosec/providers
+    mv $out/bin/*.wasm $out/lib/rosec/providers/
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   __structuredAttrs = true;

--- a/pkgs/by-name/ro/rosec-bitwarden-sm/package.nix
+++ b/pkgs/by-name/ro/rosec-bitwarden-sm/package.nix
@@ -17,6 +17,11 @@ rustPlatform.buildRustPackage (finalAttrs: rec {
   env.RUSTFLAGS = "-C linker=wasm-ld";
   nativeBuildInputs = [ lld ];
 
+  postInstall = ''
+    mkdir -p $out/lib/rosec/providers
+    mv $out/bin/*.wasm $out/lib/rosec/providers/
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   __structuredAttrs = true;

--- a/pkgs/by-name/ro/rosec-gnome-keyring/package.nix
+++ b/pkgs/by-name/ro/rosec-gnome-keyring/package.nix
@@ -17,6 +17,11 @@ rustPlatform.buildRustPackage (finalAttrs: rec {
   env.RUSTFLAGS = "-C linker=wasm-ld";
   nativeBuildInputs = [ lld ];
 
+  postInstall = ''
+    mkdir -p $out/lib/rosec/providers
+    mv $out/bin/*.wasm $out/lib/rosec/providers/
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   __structuredAttrs = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes the installation path of wasm providers so rosec can pcik them up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
