### PR TITLE
python3Packages.shap: 0.50.0 -> 0.52.0; python3Packages.slicer: cleanup, fix

### DIFF
--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -2,71 +2,79 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  python,
+
+  # build-system
+  cmake,
+  nanobind,
+  ninja,
+  numpy,
+  packaging,
+  scikit-build-core,
+  setuptools-scm,
+
+  # dependencies
+  cloudpickle,
+  llvmlite,
+  numba,
+  pandas,
+  scikit-learn,
+  scipy,
+  slicer,
+  tqdm,
+
   pytestCheckHook,
   writeText,
   catboost,
-  cloudpickle,
-  cython,
   ipython,
   lightgbm,
   lime,
   matplotlib,
-  numba,
-  numpy,
   opencv4,
-  pandas,
   pyspark,
   pytest-mpl,
-  scikit-learn,
-  scipy,
   sentencepiece,
-  setuptools,
-  setuptools-scm,
-  slicer,
-  tqdm,
   transformers,
   xgboost,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "shap";
-  version = "0.50.0";
+  version = "0.52.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "slundberg";
     repo = "shap";
-    tag = "v${version}";
-    hash = "sha256-sf9EYa15/5xEOtHSesuq97dFP4frtteoGSpHE8kGP9Q=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/U/FdJlsLcu4m1X4R5rr4S7Q79L57Q6MKIVQppW/LR0=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "cython>=3.0.11" cython \
-      --replace-fail "numpy>=2.0" "numpy"
-  '';
-
   build-system = [
-    cython
+    cmake
+    nanobind
+    ninja
     numpy
-    setuptools
+    packaging
+    scikit-build-core
     setuptools-scm
   ];
+  dontUseCmakeConfigure = true;
+
+  env.CMAKE_PREFIX_PATH = "${nanobind}/${python.sitePackages}/nanobind";
 
   dependencies = [
     cloudpickle
+    llvmlite
     numba
     numpy
+    packaging
     pandas
     scikit-learn
     scipy
     slicer
     tqdm
-  ];
-
-  pythonRelaxDeps = [
-    "numba"
-    "llvmlite"
   ];
 
   optional-dependencies = {
@@ -152,11 +160,11 @@ buildPythonPackage rec {
   meta = {
     description = "Unified approach to explain the output of any machine learning model";
     homepage = "https://github.com/slundberg/shap";
-    changelog = "https://github.com/slundberg/shap/releases/tag/${src.tag}";
+    changelog = "https://github.com/slundberg/shap/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       evax
       natsukium
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/slicer/default.nix
+++ b/pkgs/development/python-modules/slicer/default.nix
@@ -1,42 +1,54 @@
 {
   lib,
   buildPythonPackage,
-  dos2unix,
-  fetchPypi,
-  pytestCheckHook,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # tests
   pandas,
-  torch,
+  pytestCheckHook,
   scipy,
+  torch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "slicer";
   version = "0.0.8";
   pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-LnVTr3PwwMLTVfSvzD7Pl8byFW/PRZOVXD9Wz2xNbrc=";
+  src = fetchFromGitHub {
+    owner = "interpretml";
+    repo = "slicer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kmZQUIgePX1+PQZBA0JuJzjAfXqaOUGb0LLyhbybL18=";
   };
 
-  prePatch = ''
-    dos2unix slicer/*
-  '';
+  patches = [
+    # Fix pandas 3 compatibility
+    # https://github.com/interpretml/slicer/issues/10
+    ./pandas-3-compat.patch
+  ];
 
-  nativeBuildInputs = [ dos2unix ];
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "slicer" ];
 
   nativeCheckInputs = [
-    pytestCheckHook
     pandas
-    torch
+    pytestCheckHook
     scipy
+    torch
   ];
 
   meta = {
     description = "Wraps tensor-like objects and provides a uniform slicing interface via __getitem__";
     homepage = "https://github.com/interpretml/slicer";
+    changelog = "https://github.com/interpretml/slicer/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ evax ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/slicer/pandas-3-compat.patch
+++ b/pkgs/development/python-modules/slicer/pandas-3-compat.patch
@@ -1,0 +1,13 @@
+--- a/slicer/slicer_internal.py
++++ b/slicer/slicer_internal.py
+@@ -571,6 +571,10 @@
+         ("scipy.sparse.lil", "lil_matrix"): ArrayHandler,
+         ("pandas.core.frame", "DataFrame"): DataFrameHandler,
+         ("pandas.core.series", "Series"): SeriesHandler,
++        # pandas v3 reports the public "pandas" module for these types
++        # instead of their private location.
++        ("pandas", "DataFrame"): DataFrameHandler,
++        ("pandas", "Series"): SeriesHandler,
+     }
+ 
+     @classmethod


### PR DESCRIPTION
## Things done

- **python3Packages.shap: 0.50.0 -> 0.52.0**
- **python3Packages.slicer: cleanup, fix**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
