### PR TITLE
python3Packages.tokenizers: 0.23.1 -> 0.23.2

### DIFF
--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -29,54 +29,33 @@
 }:
 
 let
-  # See https://github.com/huggingface/tokenizers/blob/main/bindings/python/tests/utils.py for details
-  # about URLs and file names
-  test-data = linkFarm "tokenizers-test-data" {
-    "roberta-base-vocab.json" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-vocab.json";
-      hash = "sha256-nn9jwtFdZmtS4h0lDS5RO4fJtxPPpph6gu2J5eblBlU=";
+  fetchTestData =
+    name: hash:
+    fetchurl {
+      url = "https://huggingface.co/datasets/hf-internal-testing/tokenizers-test-data/resolve/main/${name}";
+      inherit hash;
     };
-    "roberta-base-merges.txt" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/roberta-base-merges.txt";
-      hash = "sha256-HOFmR3PFDz4MyIQmGak+3EYkUltyixiKngvjO3cmrcU=";
-    };
-    "albert-base-v1-tokenizer.json" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/albert-base-v1-tokenizer.json";
-      hash = "sha256-biqj1cpMaEG8NqUCgXnLTWPBKZMfoY/OOP2zjOxNKsM=";
-    };
-    "bert-base-uncased-vocab.txt" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt";
-      hash = "sha256-B+ztN1zsFE0nyQAkHz4zlHjeyVj5L928VR8pXJkgOKM=";
-    };
-    "tokenizer-llama3.json" = fetchurl {
-      url = "https://huggingface.co/Narsil/llama-tokenizer/resolve/main/tokenizer.json";
-      hash = "sha256-eePlImNfMXEwCRO7QhRkqH3mIiGCoFcLmyzLoqlksrQ=";
-    };
-    "big.txt" = fetchurl {
-      url = "https://norvig.com/big.txt";
-      hash = "sha256-+gZsfUDw8gGsQUTmUqpiQw5YprOAXscGUPZ42lgE6Hs=";
-    };
-    "bert-wiki.json" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/anthony/doc-pipeline/tokenizer.json";
-      hash = "sha256-i533xC8J5CDMNxBjo+p6avIM8UOcui8RmGAmK0GmfBc=";
-    };
-    "tokenizer-wiki.json" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/anthony/doc-quicktour/tokenizer.json";
-      hash = "sha256-ipY9d5DR5nxoO6kj7rItueZ9AO5wq9+Nzr6GuEIfIBI=";
-    };
-    "openai-gpt-vocab.json" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/openai-gpt-vocab.json";
-      hash = "sha256-/fSbGefeI2hSCR2gm4Sno81eew55kWN2z0X2uBJ7gHg=";
-    };
-    "openai-gpt-merges.txt" = fetchurl {
-      url = "https://s3.amazonaws.com/models.huggingface.co/bert/openai-gpt-merges.txt";
-      hash = "sha256-Dqm1GuaVBzzYceA1j3AWMR1nGn/zlj42fVI2Ui8pRyU=";
-    };
-  };
+
+  # The test suite downloads those files from the `hf-internal-testing/tokenizers-test-data`
+  # dataset. See https://github.com/huggingface/tokenizers/blob/main/bindings/python/tests/utils.py
+  test-data = linkFarm "tokenizers-test-data" (
+    lib.mapAttrs fetchTestData {
+      "albert-base-v1-tokenizer.json" = "sha256-biqj1cpMaEG8NqUCgXnLTWPBKZMfoY/OOP2zjOxNKsM=";
+      "bert-base-uncased-vocab.txt" = "sha256-B+ztN1zsFE0nyQAkHz4zlHjeyVj5L928VR8pXJkgOKM=";
+      "bert-wiki.json" = "sha256-i533xC8J5CDMNxBjo+p6avIM8UOcui8RmGAmK0GmfBc=";
+      "big.txt" = "sha256-+gZsfUDw8gGsQUTmUqpiQw5YprOAXscGUPZ42lgE6Hs=";
+      "openai-gpt-merges.txt" = "sha256-Dqm1GuaVBzzYceA1j3AWMR1nGn/zlj42fVI2Ui8pRyU=";
+      "openai-gpt-vocab.json" = "sha256-/fSbGefeI2hSCR2gm4Sno81eew55kWN2z0X2uBJ7gHg=";
+      "roberta-base-merges.txt" = "sha256-HOFmR3PFDz4MyIQmGak+3EYkUltyixiKngvjO3cmrcU=";
+      "roberta-base-vocab.json" = "sha256-nn9jwtFdZmtS4h0lDS5RO4fJtxPPpph6gu2J5eblBlU=";
+      "small.txt" = "sha256-sE7qWm92PyCeBF5PYJDASlT7wkAOdmLtIegrGh2sQVc=";
+      "tokenizer-wiki.json" = "sha256-ipY9d5DR5nxoO6kj7rItueZ9AO5wq9+Nzr6GuEIfIBI=";
+    }
+  );
 in
 buildPythonPackage (finalAttrs: {
   pname = "tokenizers";
-  version = "0.23.1";
+  version = "0.23.2";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -84,7 +63,7 @@ buildPythonPackage (finalAttrs: {
     owner = "huggingface";
     repo = "tokenizers";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tY1pzbcCRQVxk3Qxd4FjFZTQJicm7Iwa0qRgjUrR+rk=";
+    hash = "sha256-liHx1YRFZC/PUNiv1MJyb9oAw7/xHbaRbFsn1n8gtuI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
@@ -94,7 +73,7 @@ buildPythonPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-JUhjjDyWsl9+hsRYIfNMX68b1GU+F++KS1tHEl6OzHA=";
+    hash = "sha256-AVmmOqyH1iX5agDjB58SpzHuk56aV2d1lvopVcR6u4s=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/bindings/python";
@@ -133,36 +112,30 @@ buildPythonPackage (finalAttrs: {
       ln -s ${test-data}/* $sourceRoot/tests/data/
     '';
 
+  postPatch =
+    # Read the test data from the local `tests/data` directory populated in `postUnpack`
+    # rather than downloading it from the Hugging Face Hub
+    ''
+      substituteInPlace tests/utils.py \
+        --replace-fail \
+          'return hf_hub_download(repo_id=HF_TEST_REPO, filename=filename, repo_type="dataset")' \
+          'return os.path.join(DATA_PATH, filename)'
+    '';
+
   pythonImportsCheck = [ "tokenizers" ];
 
   disabledTests = [
-    # Downloads data using the datasets module
+    # Downloads a dataset using the `datasets` module
     "TestTrainFromIterators"
-    "TestUnigram"
-    "test_encode_special_tokens"
-    "test_splitting"
 
-    # Require downloading from huggingface
-    # huggingface_hub.errors.LocalEntryNotFoundError
-    "test_async_methods_existence"
-    "test_basic_encoding"
-    "test_concurrency"
-    "test_decode"
+    # Require downloading models from the Hugging Face Hub
+    "TestAsyncTokenizer"
     "test_decode_skip_special_tokens"
     "test_decode_stream_fallback"
-    "test_encode"
-    "test_error_handling"
-    "test_large_batch"
-    "test_numpy_inputs"
-    "test_performance_comparison"
-    "test_various_input_formats"
-    "test_with_special_tokens"
-    "test_with_truncation_padding"
-
-    # Those tests require more data
+    "test_encode_special_tokens"
     "test_from_pretrained"
     "test_from_pretrained_revision"
-    "test_continuing_prefix_trainer_mistmatch"
+    "test_splitting"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/huggingface/tokenizers/compare/v0.23.1...v0.23.2
Changelog: https://github.com/huggingface/tokenizers/releases/tag/v0.23.2

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test