### PR TITLE
butane: 0.29.0 -> 2.27.0

### DIFF
--- a/pkgs/by-name/bu/butane/package.nix
+++ b/pkgs/by-name/bu/butane/package.nix
@@ -6,23 +6,23 @@
 
 buildGoModule (finalAttrs: {
   pname = "butane";
-  version = "0.29.0";
+  version = "2.27.0";
 
   src = fetchFromGitHub {
     owner = "coreos";
-    repo = "butane";
+    repo = "ignition";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lijMfxhUBopwbfEP4fEgszXh7zaRz7Xy1Y8PmatXXTE=";
+    hash = "sha256-CjYiBcUdbfrQWpMzvKjFG53SPVkQyxbQ/8coQt7BuH8=";
   };
 
   vendorHash = null;
 
   doCheck = false;
 
-  subPackages = [ "internal" ];
+  subPackages = [ "butane/internal" ];
 
   ldflags = [
-    "-X github.com/coreos/butane/internal/version.Raw=v${finalAttrs.version}"
+    "-X github.com/coreos/ignition/v2/butane/internal/version.Raw=v${finalAttrs.version}"
   ];
 
   postInstall = ''
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
     description = "Translates human-readable Butane configs into machine-readable Ignition configs";
     mainProgram = "butane";
     license = lib.licenses.asl20;
-    homepage = "https://github.com/coreos/butane";
+    homepage = "https://github.com/coreos/ignition";
     maintainers = with lib.maintainers; [
       elijahcaine
       ruuda


### PR DESCRIPTION
Upstream, Butane has been merged into the Ignition repository. This means that they now share a version number, every Ignition release is also a Butane release. This means a one-time big jump in version number.

[More information about the merge](https://github.com/coreos/ignition/issues/2307)

[Upstream release notes](https://github.com/coreos/ignition/releases/tag/v2.27.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. No AI used.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
