### PR TITLE
parallel-disk-usage: 0.21.1 -> 0.24.0

### DIFF
--- a/pkgs/by-name/pa/parallel-disk-usage/package.nix
+++ b/pkgs/by-name/pa/parallel-disk-usage/package.nix
@@ -2,19 +2,40 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  installShellFiles,
+  versionCheckHook,
 }:
+
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "parallel-disk-usage";
-  version = "0.21.1";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "KSXGitHub";
     repo = "parallel-disk-usage";
-    rev = finalAttrs.version;
-    hash = "sha256-EYveK1p/OWvtY5Q0dDlZwFkVt7u/A0qY0BG/oLgwmfE=";
+    tag = finalAttrs.version;
+    hash = "sha256-fxEiZGdBUYmPcTPDpcwlB8xYcA/zC+HBspNAUpg0Rgg=";
   };
 
-  cargoHash = "sha256-r9lNOElOr4GjzaI1ZZFdc+1i2kC4YVl7n/XR05mdEJA=";
+  cargoHash = "sha256-goPN4O2HfSqyzfvJ8c6NqHSA3+S54tE8SgiYoAaeUW4=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkFlags = [
+    "--skip=cross_device_excludes_mount"
+  ];
+
+  postInstall = ''
+    installManPage exports/pdu.1
+
+    installShellCompletion --cmd pdu \
+      --bash exports/completion.bash \
+      --fish exports/completion.fish \
+      --zsh exports/completion.zsh
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Highly parallelized, blazing fast directory tree analyzer";


### PR DESCRIPTION
Bump `parallel-disk-usage` from 0.21.1 to 0.24.0

Added `versionCheckHook`
Added `checkFlags` to skip a test that requires the /dev dir Refactored to use `tag` attr instead of `rev` attr

Edit: Now also includes manpage and shell completion

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
