### PR TITLE
lomiri.libusermetrics: Link against our qdjango build again

### DIFF
--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   testers,
   cmake,
@@ -40,6 +41,22 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
     "doc"
+  ];
+
+  patches = [
+    # Upstream switched to building qdjango statically so users don't have to build & install a dead project.
+    # Maybe https://gitlab.com/ubports/development/core/libusermetrics/-/merge_requests/24 will get rid of it for good.
+    # Until then, undo & link against our system-installed build.
+    (fetchpatch {
+      name = "0001-libusermetrics-revert-qdjango-vendoring.patch";
+      url = "https://gitlab.com/ubports/development/core/libusermetrics/-/commit/87f83dd4711bfb4e94fd87bc68403a9bd5cfef2a.patch";
+      revert = true;
+      includes = [
+        "CMakeLists.txt"
+        "src/usermetricsservice/CMakeLists.txt"
+      ];
+      hash = "sha256-OPTQPRr10I7bk7dQ/9x17mv42pKc8yIQUGEGak01Hic=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/559395#issuecomment-5526294317

> I'm aware that qdjango is dead, and so are the lomiri upstream devs. I'm waiting for https://gitlab.com/ubports/development/core/libusermetrics/-/merge_requests/24 to get finalised & merged so we can fully get rid of it in both of our trees.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
