### PR TITLE
lmms: zynaddsubfx plugin missing

### DIFF
--- a/pkgs/by-name/lm/lmms/package.nix
+++ b/pkgs/by-name/lm/lmms/package.nix
@@ -21,6 +21,9 @@
   libsoundio,
   libsndfile,
   libvorbis,
+  libxinerama,
+  libxcursor,
+  libxft,
   lilv,
   lv2,
   perl5,
@@ -75,6 +78,9 @@ stdenv.mkDerivation (finalAttrs: {
     qt5.qttools
     pkg-config
     qt5.wrapQtAppsHook
+  ]
+  ++ lib.optionals withZyn [
+    fltk
   ];
 
   buildInputs = [
@@ -117,9 +123,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withSoundFont [
     fluidsynth
   ]
-  ++ lib.optionals withZyn [
-    fltk
-  ]
   ++ lib.optionals (withSWH || withSID) [
     perl5
     perl5Packages.ListMoreUtils
@@ -139,6 +142,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withWine [
     glibc_multi
     winePackages
+  ]
+  ++ lib.optionals withZyn [
+    libxinerama
+    libxcursor
+    libxft
   ];
 
   patches = [


### PR DESCRIPTION
The current lmms has the instrument plugin missing, this adds it back in.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
