### PR TITLE
nixos/starship: add enable*Integration options

### DIFF
--- a/nixos/modules/programs/starship.nix
+++ b/nixos/modules/programs/starship.nix
@@ -38,6 +38,19 @@ in
 
     package = lib.mkPackageOption pkgs "starship" { };
 
+    enableBashIntegration = lib.mkEnableOption "Bash integration" // {
+      default = true;
+    };
+    enableFishIntegration = lib.mkEnableOption "Fish integration" // {
+      default = true;
+    };
+    enableZshIntegration = lib.mkEnableOption "zsh integration" // {
+      default = true;
+    };
+    enableXonshIntegration = lib.mkEnableOption "Xonsh integration" // {
+      default = true;
+    };
+
     interactiveOnly =
       lib.mkEnableOption ''
         starship only when the shell is interactive.
@@ -110,7 +123,7 @@ in
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
-    programs.bash.${initOption} = ''
+    programs.bash.${initOption} = lib.mkIf cfg.enableBashIntegration ''
       if [[ $TERM != "dumb" ]]; then
         # don't set STARSHIP_CONFIG automatically if there's a user-specified
         # config file.  starship appears to use a hardcoded config location
@@ -123,7 +136,7 @@ in
       fi
     '';
 
-    programs.fish.${initOption} = ''
+    programs.fish.${initOption} = lib.mkIf cfg.enableFishIntegration ''
       if test "$TERM" != "dumb"
         # don't set STARSHIP_CONFIG automatically if there's a user-specified
         # config file.  starship appears to use a hardcoded config location
@@ -148,7 +161,7 @@ in
       end
     '';
 
-    programs.zsh.${initOption} = ''
+    programs.zsh.${initOption} = lib.mkIf cfg.enableZshIntegration ''
       if [[ $TERM != "dumb" ]]; then
         # don't set STARSHIP_CONFIG automatically if there's a user-specified
         # config file.  starship appears to use a hardcoded config location
@@ -162,7 +175,7 @@ in
     '';
 
     # use `config` instead of `${initOption}` because `programs.xonsh` doesn't have `shellInit` or `promptInit`
-    programs.xonsh.config = ''
+    programs.xonsh.config = lib.mkIf cfg.enableXonshIntegration ''
       if $TERM != "dumb":
         # don't set STARSHIP_CONFIG automatically if there's a user-specified
         # config file.  starship appears to use a hardcoded config location


### PR DESCRIPTION
Matching other shell-specific options and the Home-Manager module, this adds `enable*Integration` options for each shell currently supported by Starship on NixOS. The default for each flag is `true`, matching the current behavior without introducing breaking changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
