### PR TITLE
omnissa-horizon-client: 2605 -> 2606

### DIFF
--- a/pkgs/by-name/om/omnissa-horizon-client/package.nix
+++ b/pkgs/by-name/om/omnissa-horizon-client/package.nix
@@ -24,7 +24,7 @@ let
   # The downloaded archive also contains ARM binaries, but these have not been tested.
 
   # For USB support, ensure that /var/run/omnissa/<YOUR-UID>
-  # exists and is owned by you. Then run omnissa-usbarbitrator as root.
+  # exists and is owned by you. Then run horizon-eucusbarbitrator as root.
 
   mainProgram = "horizon-client";
 
@@ -185,7 +185,7 @@ stdenv.mkDerivation {
     runHook preInstall
     mkdir -p $out/bin
     ln -s ${omnissaFHSUserEnv "horizon-client"}/bin/horizon-client $out/bin/
-    ln -s ${omnissaFHSUserEnv "omnissa-usbarbitrator"}/bin/omnissa-usbarbitrator $out/bin/
+    ln -s ${omnissaFHSUserEnv "horizon-eucusbarbitrator"}/bin/horizon-eucusbarbitrator $out/bin/
     runHook postInstall
   '';
 

--- a/pkgs/by-name/om/omnissa-horizon-client/package.nix
+++ b/pkgs/by-name/om/omnissa-horizon-client/package.nix
@@ -14,7 +14,7 @@
   configText ? "",
 }:
 let
-  version = "2605";
+  version = "2606";
 
   sysArch =
     if stdenv.hostPlatform.system == "x86_64-linux" then
@@ -72,8 +72,8 @@ let
     pname = "omnissa-horizon-files";
     inherit version;
     src = fetchurl {
-      url = "https://download3.omnissa.com/software/CART27FQ1_LIN_2603_TARBALL/Omnissa-Horizon-Client-Linux-2603-8.18.0-24120621798.tar.gz";
-      hash = "sha256:acd30479cec91ee693bbd685880fa3834f3678f8dd336511bb9d732f134f71d7";
+      url = "https://download3.omnissa.com/software/CART27FQ2_LIN_2606_TARBALL/Omnissa-Horizon-Client-Linux-2606-8.19.0-32216036411.tar.gz";
+      hash = "sha256-5kpZAPeiY4R3a8WRLLjWLndWXGhqrg7rC4d6EBoC2Ao=";
     };
     nativeBuildInputs = [ makeWrapper ];
     installPhase = ''
@@ -119,10 +119,14 @@ let
           freetype
           gdk-pixbuf
           glib
+          gst_all_1.gst-plugins-base
+          gst_all_1.gstreamer
           gtk2
           gtk3-x11
           harfbuzz
           liberation_ttf
+          libgbm
+          libglvnd
           libjpeg
           libpng
           libpulseaudio
@@ -130,13 +134,11 @@ let
           libudev0-shim
           libuuid
           libv4l
-          pango
-          pcsclite
-          pixman
-          udev
-          omnissaHorizonClientFiles
+          libva
+          libvdpau
           libx11
           libxau
+          libxcb
           libxcursor
           libxext
           libxi
@@ -146,8 +148,12 @@ let
           libxrender
           libxscrnsaver
           libxtst
+          omnissaHorizonClientFiles
+          pango
+          pcsclite
+          pixman
+          udev
           zlib
-          libxml2_13
 
           (writeTextDir "etc/omnissa/config" configText)
         ];


### PR DESCRIPTION
Fixes #551571

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
