### PR TITLE
Gnustep: drop toolchain closure

### DIFF
--- a/pkgs/by-name/so/sogo/package.nix
+++ b/pkgs/by-name/so/sogo/package.nix
@@ -58,6 +58,12 @@ clangStdenv.mkDerivation rec {
   patches = lib.optional enableActiveSync ./enable-activesync.patch;
 
   postPatch = ''
+    # Don't record the compile command line in .GCC.command.line sections of
+    # the installed binaries: it embeds the store paths of the whole toolchain
+    # and turns clang, llvm and gcc into runtime dependencies.
+    substituteInPlace general.make \
+      --replace-fail ' $(call cc-option,-frecord-gcc-switches)' ""
+
     # Exclude NIX_ variables
     sed -i 's/grep GNUSTEP_/grep ^GNUSTEP_/g' configure
 

--- a/pkgs/by-name/so/sope/package.nix
+++ b/pkgs/by-name/so/sope/package.nix
@@ -23,6 +23,14 @@ clangStdenv.mkDerivation rec {
     hash = "sha256-0G28qDXygDe/TJ2znNE+NVQry3bkqUO59jqtJm/t2S4=";
   };
 
+  postPatch = ''
+    # Don't record the compile command line in .GCC.command.line sections of
+    # the installed binaries: it embeds the store paths of the whole toolchain
+    # and turns clang, llvm and gcc into runtime dependencies.
+    substituteInPlace general.make \
+      --replace-fail ' $(call cc-option,-frecord-gcc-switches)' ""
+  '';
+
   nativeBuildInputs = lib.optional (libpq != null) libpq.pg_config;
   buildInputs = [
     gnustep-base

--- a/pkgs/by-name/wr/wrapGNUstepAppsHook/wrapGNUstepAppsHook.sh
+++ b/pkgs/by-name/wr/wrapGNUstepAppsHook/wrapGNUstepAppsHook.sh
@@ -4,6 +4,10 @@ if [[ -z "${__nix_wrapGNUstepAppsHook-}" ]]; then
     # Inherit arguments given in mkDerivation
     gnustepWrapperArgs=(${gnustepWrapperArgs-})
 
+    # NIX_GNUSTEP_SYSTEM_HEADERS is deliberately missing here: it only matters
+    # while compiling and gnustep-base ignores it at run time, so writing it
+    # into the installed config file would only pull the -dev outputs of every
+    # build input into the runtime closure.
     gnustepConfigVars+=(
         GNUSTEP_MAKEFILES
         NIX_GNUSTEP_SYSTEM_APPS
@@ -12,7 +16,6 @@ if [[ -z "${__nix_wrapGNUstepAppsHook-}" ]]; then
         NIX_GNUSTEP_SYSTEM_TOOLS
         NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS
         NIX_GNUSTEP_SYSTEM_LIBRARY
-        NIX_GNUSTEP_SYSTEM_HEADERS
         NIX_GNUSTEP_SYSTEM_LIBRARIES
         NIX_GNUSTEP_SYSTEM_DOC
         NIX_GNUSTEP_SYSTEM_DOC_MAN
@@ -38,17 +41,40 @@ if [[ -z "${__nix_wrapGNUstepAppsHook-}" ]]; then
             fi
         }
 
-        gsAddToIncludeSearchPath() {
-            local -n ref="$1"
+        # Without strictDeps, gnustep-make's environment hook also picks up
+        # native build inputs, so the NIX_GNUSTEP_* paths include the compiler
+        # wrapper and friends. Keeping those in the installed config file would
+        # make the whole toolchain a runtime dependency (~1.6 GB).
+        gsDropBuildOnlyPaths() {
+            local -n pathsRef="$1"
+            local -a kept=()
+            local entry prefix
+            local IFS=:
 
-            if [[ -d "$2" && "${ref-}" != *"$2"* ]]; then
-                if [[ "${ref-}" != "" ]]; then
-                    ref+=" "
-                fi
+            for entry in ${pathsRef-}; do
+                for prefix in "${gnustepRuntimePrefixes[@]}"; do
+                    if [[ "$entry" =~ ^"$prefix"(/|$) ]]; then
+                        kept+=("$entry")
+                        break
+                    fi
+                done
+            done
 
-                ref+="$2"
-            fi
+            pathsRef="${kept[*]}"
         }
+
+        gnustepRuntimePrefixes=()
+
+        for output in ${outputs:-out}; do
+            gnustepRuntimePrefixes+=("${!output}")
+        done
+
+        for pkg in \
+            ${pkgsHostHost+"${pkgsHostHost[@]}"} \
+            ${pkgsHostTarget+"${pkgsHostTarget[@]}"}
+        do
+            gnustepRuntimePrefixes+=("$pkg")
+        done
 
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_APPS "$out/lib/GNUstep/Applications"
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_APPS "$out/lib/GNUstep/Applications"
@@ -56,11 +82,17 @@ if [[ -z "${__nix_wrapGNUstepAppsHook-}" ]]; then
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_TOOLS "$out/bin"
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_ADMIN_TOOLS "$out/sbin"
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARY "$out/lib/GNUstep"
-        gsAddToIncludeSearchPath NIX_GNUSTEP_SYSTEM_HEADERS "$out/include"
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_LIBRARIES "$out/lib"
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_DOC "$out/share/GNUstep/Documentation"
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_DOC_MAN "$out/share/man"
         gsAddToSearchPath NIX_GNUSTEP_SYSTEM_DOC_INFO "$out/share/info"
+
+        for var in "${gnustepConfigVars[@]}"; do
+            # GNUSTEP_MAKEFILES is a single path pointing at gnustep-make
+            # rather than a search path assembled from the build environment.
+            [[ "$var" == NIX_GNUSTEP_* ]] || continue
+            gsDropBuildOnlyPaths "$var"
+        done
 
         for var in "${gnustepConfigVars[@]}"; do
             if [[ -n "${!var-}" ]]; then


### PR DESCRIPTION
Packages built with `gnustep-make` retain the full clang/llvm/gcc toolchain (~1.6–2.4 GB) as a runtime dependency, even though only `gcc-lib`/`gcc-libgcc` (and, for gnustep-base consumers, `compiler-rt-libc`) are actually linked against.

Two independent causes:

1. **`wrapGNUstepAppsHook`** writes the whole `NIX_GNUSTEP_*` build environment into the installed `$out/GNUstep.conf`. Without `strictDeps`, gnustep-make's environment hook also picks up native build inputs, so the compiler wrapper, pkg-config, patchelf, etc. end up as runtime references. `NIX_GNUSTEP_SYSTEM_HEADERS` is dropped from the config entirely, so writing it out only pulled in every build input's `-dev` output.
2. **`sogo`/`sope`** compile with `-frecord-gcc-switches` (`general.make`), which makes clang embed the full compile command line in a `.GCC.command.line` ELF section that `strip -S` does not remove.

Split into 3 commits: the hook fix first (fixes `gnustep-base`, `gnustep-gui`, `gnustep-back`, `gorm`, `gworkspace`, `owl-compositor`, `pikopixel`, `projectcenter`, `gnustep-systempreferences`), then `sope`, then `sogo` (which lndirs `sope`'s output into its own).

Resolves #551383

Disclosure: written with assistance from Claude Code, per the [automation/AI policy].

## Verification

### Before

```console
$ nix path-info -S --store https://cache.nixos.org \
    $(nix eval --raw nixpkgs#gnustep-base) \
    $(nix eval --raw nixpkgs#gnustep-gui) \
    $(nix eval --raw nixpkgs#gnustep-back) \
    $(nix eval --raw nixpkgs#gorm) \
    $(nix eval --raw nixpkgs#owl-compositor) \
    $(nix eval --raw nixpkgs#sope) \
    $(nix eval --raw nixpkgs#sogo)
/nix/store/iadnrgs97syvl3sn5g6hzpwsn78j3h0r-gnustep-base-1.29.0                          2139010944
/nix/store/1390f0lk4iabw56bx99bklaifvf2l7qv-gnustep-gui-0.32.0                           2152923536
/nix/store/3x0ddrafbxrcrc110vn1y42d7z2ps9hh-sope-5.12.9                                  2212537424
/nix/store/7zy8ksw993l7br5718cbw28x9f2wx679-gnustep-back-0.32.0                          2384899392
/nix/store/mlmjzvyikwdg8bva71i9ixs3kpkwfq2v-sogo-5.12.9                                  2441909336
/nix/store/pccl2v3ml748b9b2cv3yp5ksl6zylg63-owl-compositor-0-unstable-2021-11-10         2398571904
/nix/store/y2xhr47y80jvqlgxdmpd2wzbyk7mia94-gorm-1.4.0                                   2390053216

$ nix why-depends --precise --store https://cache.nixos.org \
    $(nix eval --raw nixpkgs#gnustep-gui) $(nix eval --raw nixpkgs#llvmPackages.clang-unwrapped.lib)
/nix/store/1390f0lk4iabw56bx99bklaifvf2l7qv-gnustep-gui-0.32.0
└───GNUstep.conf: …-patchelf-0.15.2/bin:/nix/store/w021fbcg4z6vxihnp6gb6vijyifl051f-clang-wrapper-21.1.8/bin:/nix/s…
    → /nix/store/w021fbcg4z6vxihnp6gb6vijyifl051f-clang-wrapper-21.1.8
    └───nix-support/cc-cflags: …0rkdag2-gcc-15.3.0 -B/nix/store/yc2a9854a2y2c8kci88piblc847iq1l4-clang-21.1.8-lib/lib ->
        → /nix/store/yc2a9854a2y2c8kci88piblc847iq1l4-clang-21.1.8-lib

$ nix why-depends --precise --store https://cache.nixos.org \
    $(nix eval --raw nixpkgs#sogo) $(nix eval --raw nixpkgs#llvmPackages.clang-unwrapped.lib)
/nix/store/mlmjzvyikwdg8bva71i9ixs3kpkwfq2v-sogo-5.12.9
└───bin/.sogo-ealarms-notify-wrapped: …rkdag2-gcc-15.3.0 -B /nix/store/yc2a9854a2y2c8kci88piblc847iq1l4-clang-21.1.8-li>
    → /nix/store/yc2a9854a2y2c8kci88piblc847iq1l4-clang-21.1.8-lib
```

### After

```console
$ nix path-info -S $(nix-build . -A gnustep-base -A gnustep-gui -A gnustep-back \
                                 -A gorm -A owl-compositor -A sope -A sogo --no-out-link)
/nix/store/kp15zssbrk6laxnlmq8w6cz8rjzrkymc-sope-5.12.9                                   160854680
/nix/store/4disygd9ap33f7353k26h4msg56fnlyf-sogo-5.12.9                                   243618776
/nix/store/rhykm1j8bz0sc0qccj1qsnw2r0jr4dvb-gnustep-base-1.29.0                           369917208
/nix/store/5r8hynnhxslcmqh26z03albnmp2fnhz8-gnustep-gui-0.32.0                            397226048
/nix/store/q4pjmfr1j48w6yvj6pwvfr9zjwn4x82w-gnustep-back-0.32.0                           629197896
/nix/store/6wnkgxab6kzyzq4j2192fb32if6nvn8k-owl-compositor-0-unstable-2021-11-10          642868184
/nix/store/7nsdk6yvb5jhh2088i3xcg3y6hviyg96-gorm-1.4.0                                    634349104
```

package | before | after |
| --- | --- | --- |
| `gnustep-base` | 2.14 GB | 370 MB |
| `gnustep-gui` | 2.15 GB | 397 MB |
| `sope` | 2.21 GB | 161 MB |
| `gnustep-back` | 2.38 GB | 629 MB |
| `sogo` | 2.44 GB | 244 MB |
| `owl-compositor` | 2.40 GB | 643 MB |
| `gorm` | 2.39 GB | 634 MB |

### Checks

```console
$ nix-build . -A nixosTests.sogo --no-out-link
/nix/store/9vvijadlmsprys1m8kng84sh2fgd1j8w-vm-test-run-sogo

$ nix log /nix/store/9vvijadlmsprys1m8kng84sh2fgd1j8w-vm-test-run-sogo | tail -8
sogo # [   19.599565] sogod[1026]: Sep 03 15:10:55 sogod [1026]: 127.0.0.1 "GET /SOGo/ HTTP/1.1" 200 2523/0 0.021 - - 384K - 11
sogo: (finished: must succeed: curl -sSfL http://sogo/SOGo, in 0.18 seconds)
(finished: run the VM test script, in 20.84 seconds)
test script finished in 20.90s
cleanup
kill QemuMachine (pid 46)
sogo # qemu-system-x86_64: terminating on signal 15 from pid 39 (/nix/store/b5bpi6zfajzzrwwpgba2q6li3nnya4bs-python3-3.14.7/bin/python3.14)
(finished: cleanup, in 0.16 seconds)
```

## Things done

`nixpkgs-review` failes with an unrelated issue in `datalad-next`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
