### PR TITLE
python3Packages.nh3: 0.3.2 -> 0.3.7

### DIFF
--- a/pkgs/development/python-modules/nh3/default.nix
+++ b/pkgs/development/python-modules/nh3/default.nix
@@ -1,37 +1,35 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
-  rustPlatform,
-  libiconv,
   fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
 }:
-let
+
+buildPythonPackage (finalAttrs: {
   pname = "nh3";
-  version = "0.3.2";
+  version = "0.3.7";
+  pyproject = true;
+
   src = fetchFromGitHub {
     owner = "messense";
     repo = "nh3";
-    rev = "v${version}";
-    hash = "sha256-2D8ZLmVRA+SuMqeUsSXyY+0zlgqp7TSRyQuJMjmRVFk=";
-  };
-in
-buildPythonPackage {
-  inherit pname version src;
-  pyproject = true;
-
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    hash = "sha256-dN6zdwMGh8stgDuGiO+T/ZZ3/3P9Wu/gUw5gHJ1pPGA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ta3si1wiRmKQbpbDiu7+WM2pa1AfK3pYSd+Hf8xL5ss=";
   };
 
-  nativeBuildInputs = with rustPlatform; [
-    cargoSetupHook
+  build-system = with rustPlatform; [
     maturinBuildHook
+    cargoSetupHook
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    libiconv
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-Fp8DaZp5LdaqPH9HUExxdjSJlM0IkkkZn0Owc4k4G0c=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "nh3" ];
@@ -39,7 +37,11 @@ buildPythonPackage {
   meta = {
     description = "Python binding to Ammonia HTML sanitizer Rust crate";
     homepage = "https://github.com/messense/nh3";
+    changelog = "https://github.com/messense/nh3/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ happysalada ];
+    maintainers = with lib.maintainers; [
+      happysalada
+      erictapen
+    ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/messense/nh3/compare/v0.3.2...v0.3.7

Required for #540351 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
