### PR TITLE
sessiond-hooks: init at 0.1.0

### DIFF
--- a/pkgs/by-name/se/sessiond-hooks/package.nix
+++ b/pkgs/by-name/se/sessiond-hooks/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchgit,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "sessiond-hooks";
+  version = "0.1.0";
+
+  cargoHash = "sha256-XD2g3nkV4iz9ZQlb0+0YDuJl+8XdMOdwbMcCnCjKGT8=";
+
+  src = fetchgit {
+    url = "https://tangled.org/did:plc:ujej26vte653yzllxk3q2dtf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zVEHxDNjF0xRydp2Y+oqM6O5KqM4zZTv0IqlHGXCgsA=";
+  };
+
+  meta = {
+    description = "Launch and supervise per-user session hooks with sessiond";
+    homepage = "https://tangled.org/did:plc:ujej26vte653yzllxk3q2dtf";
+    license = lib.licenses.gpl3Only;
+    maintainers = builtins.attrValues { inherit (lib.maintainers) r0chd; };
+    platforms = lib.platforms.linux;
+    mainProgram = "sessiond-hooks";
+  };
+})


### PR DESCRIPTION
[sessiond-hooks](https://tangled.org/r0chd.pl/sessiond-hooks) is a [sessiond](https://tangled.org/r0chd.pl/sessiond) client responsible for launching and supervising per-user hooks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
