### PR TITLE
dfdisk: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29840,6 +29840,12 @@
     matrix = "@ty:tjll.net";
     name = "Tyler Langlois";
   };
+  tylerstyle = {
+    email = "tylerstyle.de@gmail.com";
+    github = "tylerstyle";
+    githubId = 57803;
+    name = "Ronny Terhuerne";
+  };
   tylervick = {
     email = "nix@tylervick.com";
     github = "tylervick";

--- a/pkgs/by-name/df/dfdisk/package.nix
+++ b/pkgs/by-name/df/dfdisk/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  pkg-config,
+  libewf,
+  smartmontools,
+  ddrescue,
+  util-linux,
+  systemd,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dfdisk";
+  version = "0.1.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tylerstyle";
+    repo = "dfdisk";
+    rev = "v${version}";
+    hash = "sha256-dvcRwTGB0UsHlv7pUc3GXeYoUXrE49HtRUWs4tJyKX0=";
+  };
+
+  cargoHash = "sha256-sfJxgqm9MHZOC/xpE/8GcMBGKKFQRiWgYWZkN466OyI=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libewf
+    smartmontools
+    ddrescue
+    util-linux
+    systemd
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/dfdisk \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          libewf
+          smartmontools
+          ddrescue
+          util-linux
+          systemd
+        ]
+      }
+  '';
+
+  meta = with lib; {
+    description = "Modern forensic disk imaging, damaged media rescue and conversion CLI/TUI tool";
+    homepage = "https://github.com/tylerstyle/dfdisk";
+    changelog = "https://github.com/tylerstyle/dfdisk/releases/tag/v${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ tylerstyle ];
+    mainProgram = "dfdisk";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR adds `dfdisk` (v0.1.2), a modern forensic disk imaging, damaged media rescue, and format conversion CLI/TUI tool for Digital Forensics and Incident Response (DFIR).

- Homepage: https://github.com/tylerstyle/dfdisk
- Changelog: https://github.com/tylerstyle/dfdisk/releases/tag/v0.1.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
