### PR TITLE
microkit: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5699,6 +5699,11 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  conao3 = {
+    github = "conao3";
+    githubId = 4703128;
+    name = "Naoya Yamashita";
+  };
   conduktorbot = {
     email = "automation@conduktor.io";
     github = "conduktorbot";

--- a/pkgs/by-name/mi/microkit/package.nix
+++ b/pkgs/by-name/mi/microkit/package.nix
@@ -1,0 +1,82 @@
+{
+  fetchurl,
+  lib,
+  stdenvNoCC,
+}:
+
+let
+  version = "2.3.0";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://github.com/seL4/microkit/releases/download/${version}/microkit-sdk-${version}-linux-x86-64.tar.gz";
+      hash = "sha256-4S5Qf3LIfL9cUU356bDGYQO0IpiFL0TARdVynqPeT4k=";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/seL4/microkit/releases/download/${version}/microkit-sdk-${version}-linux-aarch64.tar.gz";
+      hash = "sha256-mKGL1dkDhsenKlQQg6jhoxKa6DvyfXHGV1mzY0RxiEE=";
+    };
+  };
+
+  source =
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "microkit: unsupported platform ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "microkit";
+  inherit version;
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # bin/microkit is a static-pie executable. The ELF files under board/ are
+  # inputs the tool reads symbols from, not executables of this package.
+  dontPatchELF = true;
+  dontStrip = true;
+
+  # The SDK is used as one tree: build systems point MICROKIT_SDK at its root
+  # and reach board/<board>/<config>/{include,lib,elf} from there.
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r . $out/
+    chmod +x $out/bin/microkit
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/microkit --help > /dev/null
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "SDK for the seL4 Microkit operating system framework";
+    longDescription = ''
+      The seL4 Microkit is a framework for writing statically structured
+      systems on the seL4 microkernel. The SDK contains the microkit tool,
+      which turns a system description and a set of ELF files into a bootable
+      image, along with the seL4 kernel, libmicrokit and the linker scripts
+      for every supported board and build configuration.
+
+      Build systems locate the rest of the SDK through the MICROKIT_SDK
+      environment variable, which should point at this package's root.
+    '';
+    homepage = "https://docs.sel4.systems/projects/microkit/";
+    changelog = "https://github.com/seL4/microkit/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    mainProgram = "microkit";
+    maintainers = with lib.maintainers; [ conao3 ];
+    platforms = lib.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
The [seL4 Microkit](https://docs.sel4.systems/projects/microkit/) is a framework for building statically structured systems on the seL4 microkernel. Programs run in isolated protection domains that reach each other only through the channels and memory regions declared in a system description; the `microkit` tool turns that description plus a set of ELF files into a bootable image. It's the current generation of seL4 userspace tooling, replacing CAmkES, and is what [LionsOS](https://lionsos.org/) and the seL4 device driver framework are built on.

There's no seL4 or Microkit package in nixpkgs today, and no open issue asking for one. Everyone downloads the SDK tarball by hand and points `MICROKIT_SDK` at it.

The SDK is one tree rather than a set of loose binaries: alongside `bin/microkit` it carries the seL4 kernel image, `libmicrokit.a`, headers and a linker script for each of 28 boards times 3 to 6 build configurations. Build systems locate all of that through `MICROKIT_SDK`, so this package installs the tree at `$out` and the fixup phase moves `doc` to `share/doc`.

### Why the pre-built release rather than a source build

Upstream publishes signed release tarballs per host platform, and this packages the Linux ones. Building the SDK from source needs a pinned seL4 kernel checkout, a `rustc` carrying `rust-src` (Microkit 2.1.0 moved its initialiser to `rust-sel4`, which uses custom targets), and TeX Live for the manual, to arrive at the same artifact that upstream already ships.

[DLR-FT/seL4-nix-utils](https://github.com/DLR-FT/seL4-nix-utils) has a from-source derivation for Microkit 2.1.0 if that tradeoff is worth it to you. I went the other way to keep the closure small and a cold build under a minute, and flagged it with `sourceProvenance = [ binaryNativeCode ]`. Happy to switch if reviewers would rather have the source build in nixpkgs.

`dontPatchELF` and `dontStrip` are set because `bin/microkit` is a static-pie executable and the ELF files under `board/` are inputs the tool reads symbols from, not executables of this package.

### Testing

Beyond `--help`, I built and booted a real system with it: a protection domain cross-compiled against this package's `libmicrokit.a` for `qemu_virt_aarch64`, linked with the SDK's linker script, packed by this package's `microkit` tool, booted under `qemu-system-aarch64`.

```
LDR|INFO: loader for seL4 starting
...
Booting all finished, dropped to user space
INFO  [sel4_capdl_initializer::initialize] Starting CapDL initializer
MON|INFO: Microkit Monitor started!
hello, world from nix-sel4
```

The harness is a flake of mine ([nix-sel4](https://github.com/conao3/nix-sel4)) that also boots on `qemu_virt_aarch64_el1` and `qemu_virt_riscv64`, but nothing here depends on it; it's just what I used to exercise the SDK end to end.

`nixpkgs-review rev HEAD` on x86_64-linux reports 1 package added and 1 package built, with no rebuilds elsewhere.

### Note on the first commit

`maintainers: add conao3` duplicates the same commit in #523829, which is still open. Whichever lands first, I'll rebase the other.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Assisted-by: Claude Code:claude-opus-5
