### PR TITLE
wdotool: init at 0.5.3

### DIFF
--- a/pkgs/by-name/wd/wdotool/package.nix
+++ b/pkgs/by-name/wd/wdotool/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  stdenv,
+  fetchFromGitHub,
+  libxkbcommon,
+  nix-update-script,
+  pkg-config,
+  versionCheckHook,
+  wayland,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wdotool";
+  version = "0.5.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cushycush";
+    repo = "wdotool";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kmEMkkU5cy2AqEzbpm4Dp+FzguzldzWqD5KSr7uskLE=";
+  };
+
+  cargoHash = "sha256-0sifatYl+aGX+on2mXlMJg7/zKjpORNV3pEv9ZcdZZI=";
+
+  cargoBuildFlags = [ "--package=wdotool" ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxkbcommon
+    wayland
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wayland-native input and window automation tool";
+    homepage = "https://github.com/cushycush/wdotool";
+    changelog = "https://github.com/cushycush/wdotool/releases/tag/v${finalAttrs.version}";
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
+    maintainers = with lib.maintainers; [ johnrichardrinehart ];
+    mainProgram = "wdotool";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add [wdotool](https://github.com/cushycush/wdotool), a Wayland-native input and window automation tool.

The package builds the upstream Rust workspace with Wayland and libxkbcommon. Native builds run the upstream test suite. Cross builds skip executable install checks because the build host cannot run target binaries.

The x86_64-linux package passed a native build and a live Niri smoke test. The aarch64-linux package passed a cross-build and a native build on an AArch64 host. The upstream suite reported 97 passed tests and 8 ignored tests on each native platform.

Automation disclosure: Oh My Pi using OpenAI Codex (GPT-5.6) assisted with code, tests, and this pull request summary.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
