### PR TITLE
peertube: 8.2.3 -> 8.2.4; add update script

### DIFF
--- a/pkgs/by-name/pe/peertube/package.nix
+++ b/pkgs/by-name/pe/peertube/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchPnpmDeps,
+  nix-update-script,
 
   # build
   brotli,
@@ -21,7 +22,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "peertube";
-  version = "8.2.3";
+  version = "8.2.4";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -30,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Chocobozzz";
     repo = "PeerTube";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-w+mSFr+uobq1TtqfewRmakGMYlEjwLs0k39mWHMbq+Q=";
+    hash = "sha256-ixSa4VV11vgG607I8PJET+0eC060XpAXIFFqJSJNHvM=";
   };
 
   outputs = [
@@ -150,6 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     nodejs = nodejs_24;
     tests.peertube = nixosTests.peertube;
+    updateScript = nix-update-script { };
   };
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/Chocobozzz/PeerTube/compare/v8.2.3...v8.2.4
Changelog: https://github.com/Chocobozzz/PeerTube/blob/refs/tags/v8.2.4/CHANGELOG.md

> [!CAUTION]
> Critical security update

Apparently the Nixpkgs update bot [has never bumped peertube](https://github.com/NixOS/nixpkgs/issues?q=sort%3Aupdated-desc+is%3Apr+peertube+is%3Aclosed+author%3Ar-ryantm&page=1) even though [it should](https://github.com/nix-community/nixpkgs-update/blob/57f2db992e763f64e87e6f7173fd91f120be6380/doc/introduction.md?plain=1#L18-L21)? in any case, I'm adding an explicit update script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
