### PR TITLE
panix: init at 0.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18847,6 +18847,11 @@
     githubId = 323199;
     name = "Mihai Maruseac";
   };
+  mihakrumpestar = {
+    name = "Miha Krumpestar";
+    github = "mihakrumpestar";
+    githubId = 70652456;
+  };
   mihnea-s = {
     email = "mihn.stn@gmail.com";
     github = "mihnea-s";

--- a/pkgs/by-name/pa/panix/package.nix
+++ b/pkgs/by-name/pa/panix/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule rec {
+  pname = "panix";
+  version = "0.9.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mihakrumpestar";
+    repo = "panix";
+    rev = "v${version}";
+    hash = "sha256-1dHxDPJ76LGxqm8/5qoC8d63J6faPvj//FiUlj8jisg=";
+  };
+
+  subPackages = [ "cmd/panix" ];
+
+  ldflags = [ "-s" ];
+
+  env.CGO_ENABLED = 0;
+
+  doCheck = false;
+
+  vendorHash = "sha256-c+Qjn/RTZdSOFeqCaANBLaJl3zFeJYe7lIAve35rDkQ=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd panix \
+      --bash <($out/bin/panix completion -c bash) \
+      --fish <($out/bin/panix completion -c fish) \
+      --zsh <($out/bin/panix completion -c zsh)
+  '';
+
+  meta = with lib; {
+    description = "Universal Nix Deployment Orchestrator";
+    homepage = "https://github.com/mihakrumpestar/panix";
+    changelog = "https://github.com/mihakrumpestar/panix/releases/tag/v${version}";
+    license = licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ mihakrumpestar ];
+    platforms = platforms.all;
+    mainProgram = "panix";
+  };
+}


### PR DESCRIPTION
**Panix** is a stateless, phase-oriented deployment orchestrator for Nix flake installables. One static Go binary and a single `panix.yml` cover the whole lifecycle of a fleet, from provisioning bare metal to activating running systems, with a real-time TUI for visibility.

Highlighted features:

- **Full lifecycle, one tool**: kexec into a NixOS installer, partition disks with disko (optional encryption), build, `nix copy` closures in parallel, activate, and roll back. Bootstrap and deploy are no longer separate workflows like with other tools.
- **Flake-agnostic**: zero modifications to the target flake. No required module, no required output.
- **Works across the ecosystem**: NixOS, home-manager, nix-darwin, system-manager and other installables out of the box, plus a custom `output_types` mechanism to deploy arbitrary flake outputs with their own build/activation semantics.
- **Fleet-scale builds**: closures are built once per installable and deduplicated across machines sharing it; remote builds on beefier or foreign-architecture targets are also supported.
- **Multi-flake, tag-filtered deployments**: machines from multiple repositories in one run, subset via `--tags`.
- **Secrets**: rsynced with configurable uid/gid/permissions, never entering the Nix store.
- **Auto-rollback**: when activation fails, machines revert to the pre-deploy generation captured during Inspect phase.
- **Operability**: per-machine, per-phase TUI; retry only failed phases; dry-run modes; snapshot and replay of workflow state; hooks (`waitForOnline`, `waitForOffline`, post-bootstrap); bash/fish/zsh completions.

Docs: https://panix.xyz
Source: https://github.com/mihakrumpestar/panix

## Re-submission

Supersedes #525489, closed pending project traction. Since then the project grew to 73 stars, kept active development and shipped multiple releases with CI, coverage, and e2e tests.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
