### PR TITLE
me3: fix game launches failing to exec steam-run

### DIFF
--- a/pkgs/by-name/me/me3/steam-run.patch
+++ b/pkgs/by-name/me/me3/steam-run.patch
@@ -1,6 +1,24 @@
---- a/crates/cli/src/commands/launch/strategy/compat_tool.rs
-+++ b/crates/cli/src/commands/launch/strategy/compat_tool.rs
-@@ -260,10 +260,10 @@
+--- a/crates/cli/src/commands/launch/strategy/compat_tool.rs    2026-09-03 14:05:16.759188723 -0400
++++ b/crates/cli/src/commands/launch/strategy/compat_tool.rs    2026-09-03 14:06:00.351497967 -0400
+@@ -206,17 +206,6 @@
+         command.env("STEAM_COMPAT_DATA_PATH", prefix_path);
+         command.env("STEAM_COMPAT_APP_ID", app_id.to_string());
+ 
+-        let mut ld_preload = steam
+-            .path()
+-            .join("ubuntu12_64/gameoverlayrenderer.so")
+-            .into_os_string();
+-
+-        if let Some(existing_ld_preload) = std::env::var_os("LD_PRELOAD") {
+-            ld_preload.push(" ");
+-            ld_preload.push(&existing_ld_preload);
+-        }
+-
+-        command.env("LD_PRELOAD", ld_preload);
+         Ok(())
+     }
+ }
+@@ -279,10 +268,23 @@
              tool = parent_tool;
          }
  
@@ -8,10 +26,24 @@
 -            args.pop_front()
 -                .ok_or_eyre("Compat Tool produced invalid command")?,
 -        );
-+        let program = args.pop_front()
++        let mut ld_preload = OsString::from("LD_PRELOAD=");
++        ld_preload.push(steam.path().join("ubuntu12_64/gameoverlayrenderer.so"));
++
++        if let Some(existing_ld_preload) = std::env::var_os("LD_PRELOAD") {
++            ld_preload.push(" ");
++            ld_preload.push(&existing_ld_preload);
++        }
++
++        let program = args
++            .pop_front()
 +            .ok_or_eyre("Compat Tool produced invalid command")?;
++
 +        let mut command = Command::new("@steamRun@");
++        command.env_remove("LD_PRELOAD");
++        command.arg("env");
++        command.arg(ld_preload);
 +        command.arg(program);
          command.args(args);
          command.arg(exe);
          command.arg("--");
+


### PR DESCRIPTION
`gameoverlayrenderer.so` is a generic-FHS shared object with "NEEDED libGL.so.1". This works fine on an FHS distro but for NixOS we have `steam-run.patch` to patch the loader to use `steam-run` . However, this causes the preload to only apply to the `steam-run` wrapper and not the sandboxed loader. This fixes the issue by passing the preload to `env(1)` on the far side of the sandbox boundary and clearing `LD_PRELOAD` from the wrapper's environment.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
