### PR TITLE
nixos/btrfs: refactor autoScrub services

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -322,6 +322,9 @@
   Migrating sites to Grav 2 is a [manual process](https://learn.getgrav.org/20/migration/manual-migration) with this package since the migration plugin cannot modify the Nix store.
   The [`services.grav.package`](#opt-services.grav.package) option defaults to `pkgs.grav_2` if [`system.stateVersion`](#opt-system.stateVersion) >=26.11.
 
+- The implementation of [`services.btrfs.autoScrub`](#opt-services.btrfs.autoScrub.enable) has been refactored to use systemd templates.
+  As part of this change, mountpoints to be scrubbed are now automatically mounted (if not already mounted) when the unit is started.
+
 - `services.plausible` can now again seed an initial admin user declaratively via [`services.plausible.adminUser.email`](#opt-services.plausible.adminUser.email).
   This makes fully declarative deployments safer: Otherwise the user needed to either accept Plausible's unauthenticated "first launch" setup wizard, which lets anyone reaching the instance create the first admin account, or do more work (deploying with NixOS's default binding to `localhost` without exposing it publicly, going through the wizard, and then deploying Plausible exposed to the Internet).
   This option was previously removed with NixOS 25.05 due to an upstream Plausible change making declarative admin creation more difficult, but this change re-implements the admin creation directly.

--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -15,11 +15,12 @@ let
     mkIf
     optionals
     mkDefault
-    nameValuePair
-    listToAttrs
     filterAttrs
     mapAttrsToList
     foldl'
+    getExe
+    escape
+    versionOlder
     ;
 
   inInitrd = config.boot.initrd.supportedFilesystems.btrfs or false;
@@ -149,66 +150,84 @@ in
           )
         );
 
-      # TODO: Did not manage to do it via the usual btrfs-scrub@.timer/.service
-      # template units due to problems enabling the parameterized units,
-      # so settled with many units and templating via nix for now.
-      # https://github.com/NixOS/nixpkgs/pull/32496#discussion_r156527544
-      systemd.timers =
-        let
-          scrubTimer =
-            fs:
-            let
-              fs' = utils.escapeSystemdPath fs;
-            in
-            nameValuePair "btrfs-scrub-${fs'}" {
-              description = "regular btrfs scrub timer on ${fs}";
+      systemd.services."btrfs-scrub@" = {
+        description = "btrfs scrub on %f";
+        documentation = [ "man:btrfs-scrub(8)" ];
+        # scrub prevents suspend2ram or proper shutdown on linux < 6.19
+        conflicts = optionals (versionOlder config.boot.kernelPackages.kernel.version "6.19") [
+          "shutdown.target"
+          "sleep.target"
+        ];
+        before = optionals (versionOlder config.boot.kernelPackages.kernel.version "6.19") [
+          "shutdown.target"
+          "sleep.target"
+        ];
 
-              wantedBy = [ "timers.target" ];
-              timerConfig = {
-                OnCalendar = cfgScrub.interval;
-                AccuracySec = "1d";
-                Persistent = true;
-              };
-            };
-        in
-        listToAttrs (map scrubTimer cfgScrub.fileSystems);
+        unitConfig.RequiresMountsFor = "%f";
 
-      systemd.services =
-        let
-          scrubService =
-            fs:
-            let
-              fs' = utils.escapeSystemdPath fs;
-            in
-            nameValuePair "btrfs-scrub-${fs'}" {
-              description = "btrfs scrub on ${fs}";
-              documentation = [ "man:btrfs-scrub(8)" ];
-              # scrub prevents suspend2ram or proper shutdown on linux < 6.19
-              conflicts = lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.19") [
-                "shutdown.target"
-                "sleep.target"
-              ];
-              before = lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "6.19") [
-                "shutdown.target"
-                "sleep.target"
-              ];
+        serviceConfig =
+          let
+            btrfsCmd = getExe pkgs.btrfs-progs;
+            btrfsCancelCmd = pkgs.writers.writePython3 "btrfs-scrub-maybe-cancel" { } ''
+              import subprocess
+              import sys
 
-              serviceConfig = {
-                # simple and not oneshot, otherwise ExecStop is not used
-                Type = "simple";
-                Nice = 19;
-                IOSchedulingClass = "idle";
-                ExecStart = "${pkgs.btrfs-progs}/bin/btrfs scrub start -B ${
-                  lib.optionalString (cfgScrub.limit != null) "--limit ${cfgScrub.limit}"
-                } ${fs}";
-                # if the service is stopped before scrub end, cancel it
-                ExecStop = pkgs.writeShellScript "btrfs-scrub-maybe-cancel" ''
-                  (${pkgs.btrfs-progs}/bin/btrfs scrub status ${fs} | ${pkgs.gnugrep}/bin/grep finished) || ${pkgs.btrfs-progs}/bin/btrfs scrub cancel ${fs}
-                '';
-              };
-            };
-        in
-        listToAttrs (map scrubService cfgScrub.fileSystems);
+              btrfs = "${escape [ "\"" "\\" ] btrfsCmd}"
+              result = subprocess.run(
+                  [btrfs, "scrub", "cancel"] + sys.argv[1:],
+                  stderr=subprocess.PIPE,
+                  check=False,
+                  shell=False
+              )
+
+              # ignore errors if there was no running scrub to cancel
+              if result.returncode == 2:
+                  sys.exit(0)
+
+              sys.stderr.buffer.write(result.stderr)
+              sys.exit(result.returncode)
+            '';
+            additionalScrubArgs = optionals (cfgScrub.limit != null) [
+              "--limit"
+              cfgScrub.limit
+            ];
+          in
+          {
+            # simple and not oneshot, otherwise ExecStop is not used
+            Type = "simple";
+            Nice = 19;
+            CPUSchedulingPolicy = "idle";
+            IOSchedulingClass = "idle";
+            ExecStart = "${
+              utils.escapeSystemdExecArgs (
+                [
+                  btrfsCmd
+                  "scrub"
+                  "start"
+                  "-B"
+                ]
+                ++ additionalScrubArgs
+              )
+            } %f";
+            # if the service is stopped before scrub end, cancel it
+            ExecStop = "${utils.escapeSystemdExecArg btrfsCancelCmd} %f";
+          };
+      };
+
+      systemd.timers."btrfs-scrub@" = {
+        description = "Regular btrfs scrub on %f";
+        documentation = [ "man:btrfs-scrub(8)" ];
+
+        timerConfig = {
+          OnCalendar = cfgScrub.interval;
+          AccuracySec = "1d";
+          Persistent = true;
+        };
+      };
+
+      systemd.targets.timers.wants = map (
+        fs: "btrfs-scrub@${utils.escapeSystemdPath fs}.timer"
+      ) cfgScrub.fileSystems;
     })
   ];
 }

--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -163,6 +163,9 @@ in
           "sleep.target"
         ];
 
+        # prevent problems with MemoryDenyWriteExecute
+        environment.PYTHON_JIT = "0";
+
         unitConfig.RequiresMountsFor = "%f";
 
         serviceConfig =
@@ -211,6 +214,35 @@ in
             } %f";
             # if the service is stopped before scrub end, cancel it
             ExecStop = "${utils.escapeSystemdExecArg btrfsCancelCmd} %f";
+            # hardening
+            # required for starting/cancelling the scrub operation
+            CapabilityBoundingSet = [
+              "CAP_SYS_ADMIN"
+              "CAP_DAC_READ_SEARCH"
+            ];
+            NoNewPrivileges = true;
+            # no ProtectSystem/ProtectHome since the path to be scrubbed can refer to a device,
+            # which in turn might be mounted there and mounting it read-only prevents scrubbing
+            StateDirectory = "btrfs"; # contains progress information
+            PrivateNetwork = true;
+            ProtectHostname = true;
+            ProtectClock = true;
+            ProtectKernelModules = true;
+            ProtectKernelLogs = true;
+            ProtectControlGroups = true;
+            RestrictAddressFamilies = [ "AF_UNIX" ]; # used internally for communication
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            PrivateMounts = true;
+            SystemCallFilter = [
+              "@system-service"
+              "~@mount"
+            ];
+            SystemCallArchitectures = "native";
+            # no ProtectKernelTunables since /sys/fs/btrfs access is required
+            # no User= since written files have to be accessible by scrub commands run manually
           };
       };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -362,6 +362,7 @@ in
   btrbk-doas = runTest ./btrbk-doas.nix;
   btrbk-no-timer = runTest ./btrbk-no-timer.nix;
   btrbk-section-order = runTest ./btrbk-section-order.nix;
+  btrfs-autoscrub = runTest ./btrfs-autoscrub.nix;
   budgie = runTest ./budgie.nix;
   buildbot = runTest ./buildbot.nix;
   buildkite-agents = runTest ./buildkite-agents.nix;

--- a/nixos/tests/btrfs-autoscrub.nix
+++ b/nixos/tests/btrfs-autoscrub.nix
@@ -1,0 +1,69 @@
+{ ... }:
+{
+  name = "btrfs-autoscrub";
+
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.emptyDiskImages = [ 128 ];
+      # test sandbox permissiveness and command line escaping
+      virtualisation.fileSystems."/home/test/btrfs autoscrub test" = {
+        fsType = "btrfs";
+        device = "/dev/vdb";
+        autoFormat = true;
+        options = [ "X-mount.mkdir" ];
+      };
+      services.btrfs.autoScrub = {
+        enable = true;
+        # test that setting the limit works
+        limit = "1G";
+      };
+    };
+
+  testScript = ''
+    def run_scrub(fs):
+      machine.start_job(f"'btrfs-scrub@{fs}.service'")
+      machine.wait_until_fails(f"systemctl --quiet is-active 'btrfs-scrub@{fs}.service'")
+      machine.fail(f"systemctl is-failed 'btrfs-scrub@{fs}.service'")
+      invocation_id = machine.succeed(
+        f"systemctl show --value -p InvocationID 'btrfs-scrub@{fs}.service'"
+      )
+      output = machine.succeed(
+        f"journalctl --no-pager _SYSTEMD_INVOCATION_ID={invocation_id}"
+      )
+      t.assertNotRegex(output, "(?i)warning:|error:")
+
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    fs = "/home/test/btrfs autoscrub test"
+    escaped = r"home-test-btrfs\x20autoscrub\x20test"
+
+    with subtest("Verify that the configured timers and file systems are active"):
+      machine.require_unit_state(f"{escaped}.mount", "active")
+      machine.require_unit_state(f"btrfs-scrub@{escaped}.timer", "active")
+
+    # disable timers (and possible triggered services) to prevent them
+    # from interfering with the tests
+    machine.stop_job(f"'btrfs-scrub@{escaped}.timer'")
+    machine.stop_job(f"'btrfs-scrub@{escaped}.service'")
+
+    with subtest("Verify that scrubbing works"):
+      run_scrub(escaped)
+      result = machine.succeed(f"btrfs scrub status '{fs}'")
+      t.assertRegex(result, r"Status:\s*finished")
+
+    with subtest("Verify that scrubbing causes filesystems to be mounted"):
+      machine.stop_job(f"'{escaped}.mount'")
+      run_scrub(escaped)
+      machine.require_unit_state(f"{escaped}.mount", "active")
+
+    with subtest("Verify that the service can scrub private mountpoints"):
+      machine.succeed(f"chmod 000 '{fs}'")
+      machine.succeed("chmod 000 /home/test")
+      run_scrub(escaped)
+
+    with subtest("Verify that the service can scrub device files directly"):
+      run_scrub("dev-vdb")
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

After running `systemd-analyze security` I noticed that the services generated by `services.btrfs.autoScrub` have a very poor rating, which I want to improve.

I also implemented the following improvements:
- use systemd templates, which was attempted in #32496 but somehow did not work
- the `CPUSchedulingPolicy` is set to `idle`
- the filesystem to be scrubbed is automatically mounted when the unit is started
- fix possible race condition between cancellation and completion of a running scrub when stopping the service

I created some tests to ensure that the hardening did not break the service, but the last mentioned change creates a dependency on Python 3, which I am not sure is acceptable.
Maybe it is possible to implement the logic used in the script in Bash instead, but redirecting stderr without using temporary files is beyond my Bash knowledge.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
