### PR TITLE
fastpotify: init at 0.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7405,6 +7405,12 @@
     githubId = 93157285;
     name = "Dmitrii Stepanidenko";
   };
+  DmitrySkibitsky = {
+    email = "dmitryskibitsky@gmail.com";
+    github = "DmitrySkibitsky";
+    githubId = 20288556;
+    name = "Dmitry Skibitsky";
+  };
   DmitryTsygankov = {
     email = "dmitry.tsygankov@gmail.com";
     github = "DmitryTsygankov";

--- a/pkgs/by-name/fa/fastpotify/package.nix
+++ b/pkgs/by-name/fa/fastpotify/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  makeWrapper,
+  writeShellScript,
+  alsa-lib,
+  libpulseaudio,
+  libGL,
+  libx11,
+  libxkbcommon,
+  wayland,
+  libxcursor,
+  libxi,
+  libxrandr,
+  apple-sdk_15,
+}:
+
+let
+  # projectm-sys expects CMake to install into lib/, while CMake defaults to
+  # lib64/ on NixOS. Wrap cmake to force it, matching upstream's flake.nix.
+  cmakeWithLibdir = writeShellScript "cmake-fastpotify" ''
+    if [[ "$1" == "--build" ]]; then
+      exec ${cmake}/bin/cmake "$@"
+    else
+      exec ${cmake}/bin/cmake "$@" -DCMAKE_INSTALL_LIBDIR=lib
+    fi
+  '';
+in
+rustPlatform.buildRustPackage rec {
+  pname = "fastpotify";
+  version = "0.7.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "crmne";
+    repo = "fastpotify";
+    tag = "v${version}";
+    hash = "sha256-RZEM1b7oj0dAIXKf+B4z5g8RaO9lArMk04/h++roGME=";
+  };
+
+  cargoHash = "sha256-DrwPRPGr2QBXpTKJmCSHLnOJAymwuN7SKKqEYlNTQHc=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    rustPlatform.bindgenHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      libpulseaudio
+      libGL
+      libx11
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
+
+  env.CMAKE = "${cmakeWithLibdir}";
+
+  # The GUI dlopens its Wayland, X11 and GL libraries at run time.
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/fastpotify \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libxkbcommon
+          wayland
+          libGL
+          libx11
+          libxcursor
+          libxi
+          libxrandr
+        ]
+      }
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -Dm644 packaging/applications/fastpotify.desktop \
+      $out/share/applications/fastpotify.desktop
+    install -Dm644 packaging/icons/fastpotify.svg \
+      $out/share/icons/hicolor/scalable/apps/fastpotify.svg
+  '';
+
+  meta = {
+    description = "Fast native Spotify client with local playback and Spotify Connect";
+    homepage = "https://fastpotify.rocks";
+    changelog = "https://github.com/crmne/fastpotify/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ DmitrySkibitsky ];
+    mainProgram = "fastpotify";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
Adds `fastpotify`, a fast native Spotify client with local playback and Spotify Connect, built with `librespot` and `egui`.

Upstream: https://github.com/crmne/fastpotify
License: MIT

**AI disclosure**: The package derivation and this PR description were drafted with assistance from Claude Code (Claude Sonnet 5). All generated output was manually reviewed, built, and tested by me before submission, per the [automation/AI policy].

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
