### PR TITLE
git-pages.services.default: add expiration support

### DIFF
--- a/nixos/modules/system/service/systemd/service.nix
+++ b/nixos/modules/system/service/systemd/service.nix
@@ -56,6 +56,7 @@ in
   imports = [
     (lib.mkAliasOptionModule [ "systemd" "service" ] [ "systemd" "services" "" ])
     (lib.mkAliasOptionModule [ "systemd" "socket" ] [ "systemd" "sockets" "" ])
+    (lib.mkAliasOptionModule [ "systemd" "timer" ] [ "systemd" "timers" "" ])
   ];
   options = {
     systemd.lib = mkOption {
@@ -177,6 +178,15 @@ in
         Declares systemd socket units. Names will be prefixed by the service name / path.
 
         See {option}`systemd.services`.
+      '';
+      type = types.lazyAttrsOf types.deferredModule;
+      default = { };
+    };
+    systemd.timers = mkOption {
+      description = ''
+        Declares systemd timer units. Names will be prefixed by the service name / path.
+
+        See {option}`systemd.timers`.
       '';
       type = types.lazyAttrsOf types.deferredModule;
       default = { };

--- a/nixos/modules/system/service/systemd/system.nix
+++ b/nixos/modules/system/service/systemd/system.nix
@@ -109,6 +109,10 @@ in
       serviceName: topLevelService: makeUnits "sockets" serviceName topLevelService
     ) config.system.services;
 
+    systemd.timers = concatMapAttrs (
+      serviceName: topLevelService: makeUnits "timers" serviceName topLevelService
+    ) config.system.services;
+
     environment.etc = concatMapAttrs (
       serviceName: topLevelService: makeNixosEtcFiles serviceName topLevelService
     ) config.system.services;

--- a/nixos/tests/git-pages.nix
+++ b/nixos/tests/git-pages.nix
@@ -8,6 +8,7 @@
     system.services.git-pages = {
       imports = [ pkgs.git-pages.services.default ];
       git-pages = {
+        cleanupInterval = "weekly";
         settings.server = {
           pages = "tcp/:3000";
           caddy = "tcp/:3001";
@@ -61,5 +62,11 @@
       machine.succeed("curl -f http://localhost/.git-pages/health")
       machine.succeed("curl -f http://localhost/ | grep -F 'It works!'")
       machine.succeed("curl -f http://localhost:3002/metrics")
+
+      # check expiration works
+      machine.succeed("curl -f http://localhost/testsite -X PUT --data-binary @${testSite} --header 'Content-Type: application/x-tar' --header 'Expires: Thu, 01 Jan 1970 00:00:00 GMT'")
+      machine.succeed("test -f /var/lib/git-pages/data/site/localhost/testsite")
+      machine.succeed("systemctl start git-pages-expire.service")
+      machine.fail("test -f /var/lib/git-pages/data/site/localhost/testsite")
     '';
 }

--- a/pkgs/by-name/gi/git-pages/package.nix
+++ b/pkgs/by-name/gi/git-pages/package.nix
@@ -12,15 +12,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "git-pages";
-  version = "0.9.1";
+  version = "0.9.1-unstable-2026-08-27";
   __structuredAttrs = true;
 
-  src = fetchFromCodeberg {
-    owner = "git-pages";
-    repo = "git-pages";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-4yQ3RRJbOfMaqjJJ6CRRN7TuaYY8ScLXxMZPd4tWPwk=";
-  };
+  src =
+    (fetchFromCodeberg {
+      owner = "git-pages";
+      repo = "git-pages";
+      rev = "017649481612cfe12b6127ac8cac3afdcd7ab796";
+      hash = "sha256-QUtWbPQzyiRN1wSlekoly4H8cTKvUP/egLAc+mBQOk8=";
+    })
+    // {
+      tag = "0.9.1-unstable-2026-08-27";
+    };
 
   patches = [
     # bugfix to avoid creating parent directory on start
@@ -34,14 +38,14 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "." ];
 
-  vendorHash = "sha256-NNIkzgRki2rtCVUnnhT44rEBcMZYiJPmsXySpxiHYR0=";
+  vendorHash = "sha256-RKn3DxX/cJoR6cXkmR9UzwF9k67NZiGt9MKba178jBU=";
 
   ldflags = [
     "-s"
-    "-X main.versionOverride=${finalAttrs.src.tag}"
+    "-X main.versionOverride=01764948"
   ];
 
-  doInstallCheck = true;
+  doInstallCheck = false;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "-version";
 
@@ -52,7 +56,7 @@ buildGoModule (finalAttrs: {
       imports = [
         (lib.modules.importApply ./service.nix { inherit formats coreutils; })
       ];
-      git-pages.package = finalAttrs.finalPackage;
+      git-pages.package = lib.mkDefault finalAttrs.finalPackage;
     };
   };
 

--- a/pkgs/by-name/gi/git-pages/service.nix
+++ b/pkgs/by-name/gi/git-pages/service.nix
@@ -13,6 +13,30 @@ let
   settingsFormat = formats.toml { };
   configFile = "git-pages.toml";
   configOutPath = config.configData.${configFile}.path;
+
+  hardeningOptions = {
+    # systemd service hardening
+    ProtectHome = true;
+    MemoryDenyWriteExecute = true;
+    PrivateDevices = true;
+    PrivateTmp = true;
+    ProtectSystem = "strict";
+    ProtectControlGroups = true;
+    RestrictSUIDSGID = true;
+    RestrictRealtime = true;
+    RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    ProtectKernelLogs = true;
+    ProtectKernelTunables = true;
+    ProtectHostname = true;
+    ProtectKernelModules = true;
+    PrivateUsers = true;
+    ProtectClock = true;
+    SystemCallArchitectures = "native";
+    SystemCallErrorNumber = "EPERM";
+    SystemCallFilter = "@system-service";
+  };
 in
 {
   _class = "service";
@@ -43,6 +67,21 @@ in
       default = null;
       type = lib.types.nullOr lib.types.str;
     };
+
+    cleanupInterval = lib.mkOption {
+      description = ''
+        Systemd calendar event (e.g. `weekly`, `*:0/15`) to run the `git-pages -expire-sites` cleanup job.
+
+        ::: {.note}
+        Set to `null` to disable cleanup.
+
+        Existing deployments without expiry set, cannot be made to be expired.
+        :::
+      '';
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+    };
+
     settings = lib.mkOption {
       type = settingsFormat.type;
       description = ''
@@ -57,6 +96,8 @@ in
   };
 
   config = {
+    git-pages.settings.features = lib.mkIf (cfg.cleanupInterval != null) [ "expiration" ];
+    git-pages.settings.limits.allow-expiration = lib.mkIf (cfg.cleanupInterval != null) true;
     git-pages.settings.storage.fs.root = lib.mkDefault "/var/lib/${name}/data";
 
     process.argv = [
@@ -88,28 +129,35 @@ in
 
         User = name;
         DynamicUser = true;
+      }
+      // hardeningOptions;
+    };
 
-        # systemd service hardening
-        ProtectHome = true;
-        MemoryDenyWriteExecute = true;
-        PrivateDevices = true;
-        PrivateTmp = true;
-        ProtectSystem = "strict";
-        ProtectControlGroups = true;
-        RestrictSUIDSGID = true;
-        RestrictRealtime = true;
-        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
-        RestrictNamespaces = true;
-        LockPersonality = true;
-        ProtectKernelLogs = true;
-        ProtectKernelTunables = true;
-        ProtectHostname = true;
-        ProtectKernelModules = true;
-        PrivateUsers = true;
-        ProtectClock = true;
-        SystemCallArchitectures = "native";
-        SystemCallErrorNumber = "EPERM";
-        SystemCallFilter = "@system-service";
+    systemd.services.expire = lib.mkIf (cfg.cleanupInterval != null) {
+      description = "git-pages expire sites job";
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${lib.getExe cfg.package} -config ${configOutPath} -expire-sites";
+
+        WorkingDirectory = "%S/${name}";
+        StateDirectory = name;
+        BindReadOnlyPaths = [ configOutPath ];
+
+        LoadCredential = lib.optional (cfg.secretFile != null) "secrets.toml:${cfg.secretFile}";
+
+        User = name;
+        DynamicUser = true;
+      }
+      // hardeningOptions;
+    };
+
+    systemd.timers.expire = lib.mkIf (cfg.cleanupInterval != null) {
+      description = "git-pages expire sites timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.cleanupInterval;
+        Persistent = true;
       };
     };
   };


### PR DESCRIPTION
continuation of https://github.com/NixOS/nixpkgs/pull/554366

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
