### PR TITLE
python3Packages.scaleway: 2.11.0 -> 2.12.0,   python3Packages.scaleway-core: 2.11.0 -> 2.12.0

### DIFF
--- a/pkgs/development/python-modules/scaleway-core/default.nix
+++ b/pkgs/development/python-modules/scaleway-core/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "scaleway-core";
-  version = "2.11.0";
+  version = "2.12.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
     owner = "scaleway";
     repo = "scaleway-sdk-python";
     tag = finalAttrs.version;
-    hash = "sha256-v/dN0vLXr+vCobcrH9E6wXS61qMHsESHyL5BEpsJPkM=";
+    hash = "sha256-JvlCCy0RrOUGuwWcWqQdvRfCVtooNvkjpIBxb6NPOSY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pname}";

--- a/pkgs/development/python-modules/scaleway/default.nix
+++ b/pkgs/development/python-modules/scaleway/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "scaleway";
-  version = "2.11.0";
+  version = "2.12.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -19,7 +19,7 @@ buildPythonPackage (finalAttrs: {
     owner = "scaleway";
     repo = "scaleway-sdk-python";
     tag = finalAttrs.version;
-    hash = "sha256-v/dN0vLXr+vCobcrH9E6wXS61qMHsESHyL5BEpsJPkM=";
+    hash = "sha256-JvlCCy0RrOUGuwWcWqQdvRfCVtooNvkjpIBxb6NPOSY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pname}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
