### PR TITLE
gcr*: add explicit version suffix to attr, enable structuredAttrs

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -209,7 +209,7 @@ in
     };
 
     services.dbus.packages = mkIf (lib.elem "gnome3" (cfg.agent.pinentryPackage.flavors or [ ])) [
-      pkgs.gcr
+      pkgs.gcr_3
     ];
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/programs/nm-applet.nix
+++ b/nixos/modules/programs/nm-applet.nix
@@ -39,6 +39,6 @@ in
       serviceConfig.ExecStart = "${cfg.package}/bin/nm-applet ${lib.optionalString cfg.indicator "--indicator"}";
     };
 
-    services.dbus.packages = [ pkgs.gcr ];
+    services.dbus.packages = [ pkgs.gcr_3 ];
   };
 }

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -30,7 +30,7 @@ in
 
     services.dbus.packages = [
       pkgs.gnome-keyring
-      pkgs.gcr
+      pkgs.gcr_3
     ];
 
     xdg.portal.extraPortals = [ pkgs.gnome-keyring ];

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -24,7 +24,7 @@
   gnome-desktop,
   gnome-session,
   gnome-shell,
-  gcr,
+  gcr_3,
   pam,
   systemd,
   upower,
@@ -108,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     evolution-data-server
     pulseaudio
     modemmanager
-    gcr
+    gcr_3
     networkmanager
     polkit
     gmobile

--- a/pkgs/by-name/bu/budgie-control-center/package.nix
+++ b/pkgs/by-name/bu/budgie-control-center/package.nix
@@ -10,7 +10,7 @@
   cups,
   docbook-xsl-nons,
   fontconfig,
-  gcr,
+  gcr_3,
   gdk-pixbuf,
   gettext,
   glib,
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     colord
     colord-gtk
     fontconfig
-    gcr
+    gcr_3
     gdk-pixbuf
     glib
     glib-networking

--- a/pkgs/by-name/ci/cinnamon/package.nix
+++ b/pkgs/by-name/ci/cinnamon/package.nix
@@ -11,7 +11,7 @@
   evolution-data-server,
   fetchFromGitHub,
   fetchpatch,
-  gcr,
+  gcr_3,
   gdk-pixbuf,
   gettext,
   libgnomekbd,
@@ -104,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     cjs
     dbus
     evolution-data-server # for calendar-server
-    gcr
+    gcr_3
     gdk-pixbuf
     glib
     graphene

--- a/pkgs/by-name/gc/gcr_3/package.nix
+++ b/pkgs/by-name/gc/gcr_3/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gcr";
   version = "3.41.2";
 
+  __structuredAttrs = true;
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/by-name/gc/gcr_3/package.nix
+++ b/pkgs/by-name/gc/gcr_3/package.nix
@@ -107,6 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gnome.updateScript {
+      attrPath = "gcr_3";
       packageName = "gcr";
       freeze = true;
     };

--- a/pkgs/by-name/gc/gcr_4/package.nix
+++ b/pkgs/by-name/gc/gcr_4/package.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gcr";
   version = "4.4.0.1";
 
+  __structuredAttrs = true;
+
   outputs = [
     "out"
     "bin"

--- a/pkgs/by-name/ge/geary/package.nix
+++ b/pkgs/by-name/ge/geary/package.nix
@@ -21,7 +21,7 @@
   libxml2,
   gettext,
   sqlite,
-  gcr,
+  gcr_3,
   json-glib,
   itstool,
   libgee,
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     adwaita-icon-theme
     enchant
     folks
-    gcr
+    gcr_3
     glib-networking
     gmime3
     gnome-online-accounts

--- a/pkgs/by-name/gn/gnome-keyring/package.nix
+++ b/pkgs/by-name/gn/gnome-keyring/package.nix
@@ -12,7 +12,7 @@
   glib,
   libxslt,
   gettext,
-  gcr,
+  gcr_3,
   libcap_ng,
   libselinux,
   p11-kit,
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     pam
     libcap_ng
     libselinux
-    gcr
+    gcr_3
     p11-kit
   ];
 

--- a/pkgs/by-name/li/libcryptui/package.nix
+++ b/pkgs/by-name/li/libcryptui/package.nix
@@ -16,7 +16,7 @@
   gnupg,
   gpgme,
   dbus-glib,
-  gcr,
+  gcr_3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     gnupg
     gpgme
     dbus-glib
-    gcr
+    gcr_3
   ];
   propagatedBuildInputs = [ dbus-glib ];
 

--- a/pkgs/by-name/ne/nemo-seahorse/package.nix
+++ b/pkgs/by-name/ne/nemo-seahorse/package.nix
@@ -10,7 +10,7 @@
   nemo,
   dbus-glib,
   libcryptui,
-  gcr,
+  gcr_3,
   libnotify,
   gnupg,
   gpgme,
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     gpgme
     dbus-glib
     libcryptui
-    gcr
+    gcr_3
     libnotify
     gnupg
   ];
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
 
         services.desktopManager.gnome.extraGSettingsOverridePackages = with pkgs; [
           nemo
-          gcr
+          gcr_3
           libcryptui
           nemo-seahorse
         ];

--- a/pkgs/by-name/ne/networkmanager-openconnect/package.nix
+++ b/pkgs/by-name/ne/networkmanager-openconnect/package.nix
@@ -9,7 +9,7 @@
   intltool,
   pkg-config,
   networkmanager,
-  gcr,
+  gcr_3,
   libsecret,
   file,
   gtk3,
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     libnma
     libnma-gtk4
     gtk4
-    gcr
+    gcr_3
     libsecret
   ];
 

--- a/pkgs/by-name/pa/pan/package.nix
+++ b/pkgs/by-name/pa/pan/package.nix
@@ -18,7 +18,7 @@
   spellChecking ? true,
   gnomeSupport ? true,
   libsecret,
-  gcr,
+  gcr_3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals spellChecking [ gspell ]
   ++ lib.optionals gnomeSupport [
     libsecret
-    gcr
+    gcr_3
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/se/seahorse/package.nix
+++ b/pkgs/by-name/se/seahorse/package.nix
@@ -20,7 +20,7 @@
   gpgme,
   python3,
   openldap,
-  gcr,
+  gcr_3,
   libsecret,
   avahi,
   p11-kit,
@@ -59,14 +59,14 @@ stdenv.mkDerivation (finalAttrs: {
     openssh
     gnupg
     desktop-file-utils
-    gcr
+    gcr_3
   ];
 
   buildInputs = [
     gtk3
     glib
     glib-networking
-    gcr
+    gcr_3
     gsettings-desktop-schemas
     gpgme
     libsecret
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Add “org.gnome.crypto.pgp” GSettings schema to path
     # to make it available for “gpgme-backend” test.
     # It is used by Seahorse’s internal “common” library.
-    addToSearchPath XDG_DATA_DIRS "${glib.getSchemaDataDirPath gcr}"
+    addToSearchPath XDG_DATA_DIRS "${glib.getSchemaDataDirPath gcr_3}"
     # The same test also requires home directory so that it can store settings.
     export HOME=$TMPDIR
   '';
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
   preFixup = ''
     gappsWrapperArgs+=(
       # Pick up icons from Gcr
-      --prefix XDG_DATA_DIRS : "${gcr}/share"
+      --prefix XDG_DATA_DIRS : "${gcr_3}/share"
     )
   '';
 

--- a/pkgs/by-name/sh/shotwell/package.nix
+++ b/pkgs/by-name/sh/shotwell/package.nix
@@ -21,7 +21,7 @@
   glib,
   glib-networking,
   json-glib,
-  gcr,
+  gcr_3,
   libgee,
   gexiv2_0_16,
   gettext,
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib-networking
     gdk-pixbuf
     librsvg
-    gcr
+    gcr_3
     adwaita-icon-theme
     libsecret
     libportal-gtk3

--- a/pkgs/by-name/su/surf/package.nix
+++ b/pkgs/by-name/su/surf/package.nix
@@ -5,7 +5,7 @@
   pkg-config,
   wrapGAppsHook3,
   glib,
-  gcr,
+  gcr_3,
   glib-networking,
   gsettings-desktop-schemas,
   gtk3,
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   ];
   buildInputs = [
     glib
-    gcr
+    gcr_3
     glib-networking
     gsettings-desktop-schemas
     libsoup_3

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -12,7 +12,7 @@
   libsForQt5,
   qt6,
   ncurses,
-  gcr,
+  gcr_3,
   withLibsecret ? true,
   libsecret,
 }:
@@ -28,7 +28,7 @@ let
     };
     gnome3 = {
       flag = "gnome3";
-      buildInputs = [ gcr ];
+      buildInputs = [ gcr_3 ];
       nativeBuildInputs = [ wrapGAppsHook3 ];
     };
     qt5 = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -955,6 +955,7 @@ mapAliases {
   gcc12 = throw "gcc12 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gcc12Stdenv = throw "gcc12Stdenv has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gccgo12 = throw "gccgo12 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
+  gcr = throw "'gcr' attribute has been removed from nixpkgs. Use a 'gcr_*' attribute with an explicit ABI version instead."; # Added 2026-09-03
   gdc11 = throw "gdc11 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gdc = throw "gdc has been removed from Nixpkgs, as recent versions require complex bootstrapping"; # Added 2025-08-08
   gdmd = throw "gdmd has been removed from Nixpkgs, as it depends on GDC which was removed"; # Added 2025-08-08


### PR DESCRIPTION
Having the older ABI version as the default seems odd and the different gcr packages appear to be fundamentally incompatible, so drop the unsuffixed version similar to webkitgtk and as discussed in https://github.com/NixOS/nixpkgs/pull/543345#issuecomment-5199018730.

Enabling `__structuredAttrs` for `gcr_3` because we have to (CI treats it as a new package), enabling it for `gcr_4` as well while we're at it.

No build output differences for `gcr_{3,4}` apart from store paths.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `gcr_{3,4}`
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
