### PR TITLE
bytefetch: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7064,6 +7064,12 @@
     github = "Dev380";
     githubId = 49997896;
   };
+  devcheckra1n = {
+    email = "me@actavis.dev";
+    github = "devcheckra1n";
+    githubId = 97061690;
+    name = "mex";
+  };
   developer-guy = {
     name = "Batuhan Apaydın";
     email = "developerguyn@gmail.com";

--- a/pkgs/by-name/by/bytefetch/package.nix
+++ b/pkgs/by-name/by/bytefetch/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  testers,
+  bytefetch,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bytefetch";
+  version = "1.0.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "devcheckra1n";
+    repo = "bytefetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ikTzuu4JxQrASSwGH/FWlzWidTpdEnPeAcrUjmazpCE=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 bytefetch $out/bin/bytefetch
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion { package = bytefetch; };
+
+  meta = {
+    description = "Small, fast system information tool";
+    longDescription = ''
+      bytefetch prints the system information a fetch tool normally shows
+      without starting a subprocess, reading everything from sysctl,
+      IORegistry, /proc, /sys and getifaddrs and emitting it in a single
+      write. The output is configurable through ~/.config/bytefetch/config.
+    '';
+    homepage = "https://codeberg.org/devcheckra1n/bytefetch";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "bytefetch";
+    maintainers = with lib.maintainers; [ devcheckra1n ];
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
bytefetch is a small system information tool. It prints what a fetch tool
normally shows without starting a subprocess, reading from sysctl, IORegistry,
/proc, /sys and getifaddrs, and writing the output in a single write().

Homepage: https://codeberg.org/devcheckra1n/bytefetch

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

To be precise about what the boxes above do and do not claim: the package and its
`passthru.tests.version` were built on aarch64-darwin and the resulting binary was
run. No Linux build has been done through Nix, only a plain compile in a container,
so both Linux boxes are left unticked. `nixpkgs-review` was not run. There are no
NixOS module changes and no release note changes, so those are not applicable.

Disclosure per the automation/AI policy: the writing of this package and its Nix expression was assisted by Claude Code (claude-opus-5). I manually parsed / reviewed and tested the result before
submission.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
