### PR TITLE
mkosi: 26 -> 27

### DIFF
--- a/pkgs/by-name/mk/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
+++ b/pkgs/by-name/mk/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
@@ -16,7 +16,7 @@ diff --git a/mkosi/__init__.py b/mkosi/__init__.py
 index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c219890572652e3f350 100644
 --- a/mkosi/__init__.py
 +++ b/mkosi/__init__.py
-@@ -613,7 +613,7 @@ def finalize_host_scripts(
+@@ -639,7 +639,7 @@ def finalize_host_scripts(
          if context.config.find_binary(binary):
              scripts[binary] = (binary, "--root", "/buildroot")
      if ukify := context.config.find_binary("ukify"):
@@ -25,7 +25,7 @@ index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c2198905726
      return finalize_scripts(context.config, scripts | dict(helpers))
  
  
-@@ -755,7 +755,11 @@ def script_maybe_chroot_sandbox(
+@@ -788,7 +788,11 @@ def script_maybe_chroot_sandbox(
  
      helpers = {
          "mkosi-chroot": [
@@ -38,7 +38,7 @@ index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c2198905726
              "--bind", "/buildroot", "/",
              "--bind", "/var/tmp", "/var/tmp",
              *apivfs_options(root=Path("/")),
-@@ -1587,7 +1591,7 @@ def run_ukify(
+@@ -1610,7 +1614,7 @@ def run_ukify(
      sign: bool = True,
      json_out: bool = False,
  ) -> dict[str, Any]:
@@ -47,7 +47,7 @@ index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c2198905726
      if not ukify:
          die("Could not find ukify")
  
-@@ -1599,7 +1603,6 @@ def run_ukify(
+@@ -1622,7 +1626,6 @@ def run_ukify(
      (context.workspace / "cmdline").write_text(f"{' '.join(cmdline)}\x00")
  
      cmd = [
@@ -55,7 +55,7 @@ index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c2198905726
          ukify,
          "build",
          *arguments,
-@@ -1694,7 +1697,7 @@ def build_uki(
+@@ -1717,7 +1720,7 @@ def build_uki(
      profiles: Sequence[Path],
      output: Path,
  ) -> dict[str, Any]:
@@ -64,15 +64,16 @@ index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c2198905726
          die("Could not find ukify")
  
      json_out = False
-@@ -1755,7 +1758,6 @@ def build_uki(
+@@ -1776,7 +1779,7 @@ def build_uki(
+             "--pcr-banks", "sha256",
+         ]  # fmt: skip
  
-         if (
-             systemd_tool_version(
--                python_binary(context.config),
-                 ukify,
-                 sandbox=context.sandbox,
-             )
-@@ -1815,7 +1817,6 @@ def build_uki(
+-        ukify_version = systemd_tool_version(python_binary(context.config), ukify, sandbox=context.sandbox)
++        ukify_version = systemd_tool_version(ukify, sandbox=context.sandbox)
+ 
+         if ukify_version >= "258":
+             cert_parameter = "--pcr-certificate"
+@@ -1838,7 +1841,6 @@ def build_uki(
          # new .ucode section support?
          if (
              systemd_tool_version(
@@ -80,7 +81,7 @@ index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c2198905726
                  ukify,
                  sandbox=context.sandbox,
              )
-@@ -1883,7 +1884,7 @@ def want_uki(context: Context) -> bool:
+@@ -1906,7 +1908,7 @@ def want_uki(context: Context) -> bool:
          or (
              context.config.unified_kernel_images == UnifiedKernelImage.auto
              and systemd_stub_binary(context).exists()
@@ -89,7 +90,7 @@ index f4766ae71244a21caa5bcbf5b5376f617c706b33..e022c2e2e3ea267a78c69c2198905726
          )
      )
  
-@@ -2799,9 +2800,9 @@ def check_ukify(
+@@ -2844,9 +2846,9 @@ def check_ukify(
      reason: str,
      hint: Optional[str] = None,
  ) -> None:
@@ -105,7 +106,7 @@ diff --git a/mkosi/bootloader.py b/mkosi/bootloader.py
 index 7d434bb4776980c6fa58ae8f7795f3ffc319baeb..8960a6d17d153b06b029f9072a464a12f5cafe65 100644
 --- a/mkosi/bootloader.py
 +++ b/mkosi/bootloader.py
-@@ -316,8 +316,7 @@ def find_signed_grub_image(context: Context) -> Optional[Path]:
+@@ -315,8 +315,7 @@ def find_signed_grub_image(context: Context) -> Optional[Path]:
  def python_binary(config: Config) -> PathString:
      # If there's no tools tree, prefer the interpreter from MKOSI_INTERPRETER. If there is a tools
      # tree, just use the default python3 interpreter.
@@ -119,7 +120,7 @@ diff --git a/mkosi/run.py b/mkosi/run.py
 index 159b75c1af1b5d84e409426e566e098571086c8e..68572039cbeddcb1c32ffc1e2ba34c91dede52b0 100644
 --- a/mkosi/run.py
 +++ b/mkosi/run.py
-@@ -238,7 +238,11 @@ def spawn(
+@@ -352,7 +352,11 @@ def spawn(
              module = stack.enter_context(resource_path(sys.modules[__package__ or __name__]))
              prefix = [
                  *(["strace", "--detach-on=execve", "--string-limit=256"] if ARG_DEBUG_SANDBOX.get() else []),
@@ -132,16 +133,7 @@ index 159b75c1af1b5d84e409426e566e098571086c8e..68572039cbeddcb1c32ffc1e2ba34c91
                  *sbx,
              ]  # fmt: skip
  
-@@ -321,7 +325,7 @@ def finalize_path(
-         # Make sure that /usr/bin and /usr/sbin are always in $PATH.
-         path += [s for s in ("/usr/bin", "/usr/sbin") if s not in path]
-     else:
--        path += ["/usr/bin", "/usr/sbin"]
-+        path += ["/usr/bin", "/usr/sbin", "@NIX_PATH@"]
- 
-     if prefix_usr:
-         path = [os.fspath(root / s.lstrip("/")) if s in ("/usr/bin", "/usr/sbin") else s for s in path]
-@@ -690,7 +694,7 @@ def chroot_options() -> list[PathString]:
+@@ -805,7 +809,7 @@ def chroot_options() -> list[PathString]:
          "--unshare-ipc",
          "--setenv", "container", "mkosi",
          "--setenv", "HOME", "/",

--- a/pkgs/by-name/mk/mkosi/0002-Fix-library-resolving.patch
+++ b/pkgs/by-name/mk/mkosi/0002-Fix-library-resolving.patch
@@ -14,7 +14,7 @@ diff --git a/mkosi/sandbox.py b/mkosi/sandbox.py
 index 4a41f333a764bc41abbd36302bd9fe86baa45a3f..1f7f133912c022a9fb3258437f4ed09872d79dd4 100755
 --- a/mkosi/sandbox.py
 +++ b/mkosi/sandbox.py
-@@ -124,7 +124,7 @@ class cap_user_data_t(ctypes.Structure):
+@@ -158,7 +158,7 @@ class cap_user_data_t(ctypes.Structure):
      ]
  
  
@@ -23,7 +23,7 @@ index 4a41f333a764bc41abbd36302bd9fe86baa45a3f..1f7f133912c022a9fb3258437f4ed098
  
  libc.syscall.restype = ctypes.c_long
  libc.unshare.argtypes = (ctypes.c_int,)
-@@ -291,7 +291,7 @@ def seccomp_suppress(*, chown: bool = False, sync: bool = False) -> None:
+@@ -370,7 +370,7 @@ def seccomp_suppress(*, chown: bool = False, sync: bool = False) -> None:
      if not chown and not sync:
          return
  

--- a/pkgs/by-name/mk/mkosi/0003-Fix-QEMU-firmware-path.patch
+++ b/pkgs/by-name/mk/mkosi/0003-Fix-QEMU-firmware-path.patch
@@ -12,7 +12,7 @@ diff --git a/mkosi/qemu.py b/mkosi/qemu.py
 index 4d1bec15605ca36d66a05add0744afdfbdc4853d..d10007ed58ebc16271b313b1a846ca2c24d8ae81 100644
 --- a/mkosi/qemu.py
 +++ b/mkosi/qemu.py
-@@ -189,7 +189,7 @@ def find_ovmf_firmware(config: Config, firmware: Firmware) -> Optional[OvmfConfi
+@@ -192,7 +192,7 @@ def find_ovmf_firmware(config: Config, firmware: Firmware) -> Optional[OvmfConfi
      if not firmware.is_uefi():
          return None
  

--- a/pkgs/by-name/mk/mkosi/package.nix
+++ b/pkgs/by-name/mk/mkosi/package.nix
@@ -19,12 +19,6 @@
   # Optional dependencies
   withQemu ? false,
   qemu,
-
-  # Workaround for supporting providing additional package manager
-  # dependencies in the recursive use in the binary path.
-  # This can / should be removed once the `finalAttrs` pattern is
-  # available for Python packages.
-  extraDeps ? [ ],
 }:
 let
   # For systemd features used by mkosi, see
@@ -51,7 +45,6 @@ let
     systemdForMkosi
     util-linux
   ]
-  ++ extraDeps
   ++ lib.optionals withQemu [
     qemu
   ];

--- a/pkgs/by-name/mk/mkosi/package.nix
+++ b/pkgs/by-name/mk/mkosi/package.nix
@@ -23,15 +23,29 @@
 let
   # For systemd features used by mkosi, see
   # https://github.com/systemd/mkosi/blob/19bb5e274d9a9c23891905c4bcbb8f68955a701d/action.yaml#L64-L72
-  systemdForMkosi = systemd.override {
-    withRepart = true;
-    withBootloader = true;
-    withSysusers = true;
-    withFirstboot = true;
-    withEfi = true;
-    withUkify = true;
-    withKernelInstall = true;
-  };
+  systemdForMkosi =
+    (systemd.override {
+      withRepart = true;
+      withBootloader = true;
+      withSysusers = true;
+      withFirstboot = true;
+      withEfi = true;
+      withUkify = true;
+      withKernelInstall = true;
+    }).overrideAttrs
+      (prevAttrs: {
+        # Use the default PATH instead of the nix store path
+        postPatch = (prevAttrs.postPatch or "") + ''
+          substituteInPlace src/basic/path-util.h \
+            --replace-fail "\"$out/bin/\"" \
+            '"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"'
+        '';
+
+        # Use the FHS nologin path, not the nix store path
+        mesonFlags = (prevAttrs.mesonFlags or [ ]) ++ [
+          (lib.mesonOption "nologin-path" "/usr/sbin/nologin")
+        ];
+      });
 
   pythonWithPefile = python3Packages.python.withPackages (ps: [ ps.pefile ]);
 
@@ -51,7 +65,7 @@ let
 in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mkosi";
-  version = "26";
+  version = "27";
   pyproject = true;
 
   outputs = [
@@ -63,7 +77,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "systemd";
     repo = "mkosi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6DVIyFsEV2VkQ/kesn6cN+iH9MW+mmAZw5i0R5C4xaU=";
+    hash = "sha256-uUNPGFXrwTiSC6/EcYIxbAizjcS3Hqe1LABa5BmWGgw=";
   };
 
   patches = [
@@ -111,6 +125,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
   postInstall = ''
     mkdir -p $out/share/man/man1
     mv mkosi/resources/man/mkosi.1 $out/share/man/man1/
+  '';
+
+  # Workaround for https://github.com/NixOS/nixpkgs/issues/510068
+  postFixup = ''
+    rm -f "$out/bin/mkosi-sandbox" "$out/bin/.mkosi-sandbox-wrapped"
+    sed "1i#!${python3Packages.python.interpreter} -SI" \
+      "$out/${python3Packages.python.sitePackages}/mkosi/sandbox.py" \
+      > "$out/bin/mkosi-sandbox"
+    chmod +x "$out/bin/mkosi-sandbox"
   '';
 
   meta = {


### PR DESCRIPTION
Updates mkosi to the latest version (v27).

This also makes the following changes to the derivation:

1. mkosi now uses a systemd build which doesn't override certain NixOS-specific paths. This is important when using commands such as `mkosi shell`: `mkosi` isn't building NixOS images, its building FHS images.
2. The `extraDeps` input was removed, as `buildPythonApplication` supports finalAttrs.
3. The patch offsets were updated
4. `0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch` previously prevented the addition of `/usr/bin:/bin` to `PATH`: this is not desirable as the OS you're building follows the filesystem hierarchy, and `PATH` is otherwise maintained. This caused issues on NixOS where /usr/bin isn't otherwise on PATH.
5. `mkosi-sandbox` no longer uses the standard NixOS wrapping mechanism, as the file queries `__name__`. There aren't any dependencies, so we can just add the correct shebang.

Closes #510068

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
