### PR TITLE
gexiv2*: add explicit version suffix to attr, enable structuredAttrs and strictDeps

### DIFF
--- a/pkgs/applications/graphics/gimp/2.0/default.nix
+++ b/pkgs/applications/graphics/gimp/2.0/default.nix
@@ -40,7 +40,7 @@
   libxpm,
   glib-networking,
   libmypaint,
-  gexiv2,
+  gexiv2_0_10,
   harfbuzz,
   mypaint-brushes1,
   libwebp,
@@ -182,7 +182,7 @@ stdenv.mkDerivation (finalAttrs: {
     gdk-pixbuf
     pango
     cairo
-    gexiv2
+    gexiv2_0_10
     harfbuzz
     isocodes
     freetype

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -57,7 +57,7 @@
   json-glib,
   libmypaint,
   llvmPackages,
-  gexiv2,
+  gexiv2_0_10,
   harfbuzz,
   makeFontsConf,
   mypaint-brushes,
@@ -158,7 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
     pango
     cairo
     libarchive
-    gexiv2
+    gexiv2_0_10
     harfbuzz
     isocodes
     freetype
@@ -220,7 +220,7 @@ stdenv.mkDerivation (finalAttrs: {
     gegl
     cairo
     pango
-    gexiv2
+    gexiv2_0_10
   ];
 
   strictDeps = true;

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -346,7 +346,7 @@ lib.makeScope pkgs.newScope (
         with pkgs;
         [
           lensfun
-          gexiv2
+          gexiv2_0_10
         ]
         ++ lib.optional stdenv.cc.isClang llvmPackages.openmp
       );

--- a/pkgs/by-name/en/entangle/package.nix
+++ b/pkgs/by-name/en/entangle/package.nix
@@ -15,7 +15,7 @@
   dbus,
   elfutils,
   libepoxy,
-  gexiv2,
+  gexiv2_0_10,
   glib,
   gobject-introspection,
   gst_all_1,
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     libepoxy
     elfutils
-    gexiv2
+    gexiv2_0_10
     glib
     lerc
     gst_all_1.gst-plugins-base

--- a/pkgs/by-name/ge/gegl/package.nix
+++ b/pkgs/by-name/ge/gegl/package.nix
@@ -26,7 +26,7 @@
   meson,
   ninja,
   libraw,
-  gexiv2,
+  gexiv2_0_10,
   libwebp,
   luajit,
   openexr,
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     libraw
     libwebp
-    gexiv2
+    gexiv2_0_10
     openexr
     suitesparse
     vala

--- a/pkgs/by-name/ge/gexiv2_0_10/package.nix
+++ b/pkgs/by-name/ge/gexiv2_0_10/package.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
+      attrPath = "gexiv2_0_10";
       packageName = pname;
       versionPolicy = "odd-unstable";
       freeze = true;

--- a/pkgs/by-name/ge/gexiv2_0_10/package.nix
+++ b/pkgs/by-name/ge/gexiv2_0_10/package.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation rec {
   pname = "gexiv2";
   version = "0.14.6";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/by-name/gr/gramps/package.nix
+++ b/pkgs/by-name/gr/gramps/package.nix
@@ -6,7 +6,7 @@
   python3Packages,
   glibcLocales,
   intltool,
-  gexiv2,
+  gexiv2_0_10,
   pango,
   gobject-introspection,
   wrapGAppsHook3,
@@ -75,7 +75,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   buildInputs = [
     gtk3
     pango
-    gexiv2
+    gexiv2_0_10
   ]
   # Map support
   ++ lib.optionals enableOSM [

--- a/pkgs/by-name/ra/rapid-photo-downloader/package.nix
+++ b/pkgs/by-name/ra/rapid-photo-downloader/package.nix
@@ -8,7 +8,7 @@
   gobject-introspection,
   libgudev,
   udisks,
-  gexiv2,
+  gexiv2_0_10,
   gst_all_1,
   libnotify,
   ifuse,
@@ -73,7 +73,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   buildInputs = [
     gdk-pixbuf
-    gexiv2
+    gexiv2_0_10
     gst_all_1.gst-libav
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good

--- a/pkgs/by-name/tu/tuba/package.nix
+++ b/pkgs/by-name/tu/tuba/package.nix
@@ -12,7 +12,7 @@
   gtk4,
   libadwaita,
   json-glib,
-  gexiv2,
+  gexiv2_0_10,
   glib,
   glib-networking,
   gnome,
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    gexiv2
+    gexiv2_0_10
     glib
     glib-networking
     gtksourceview5

--- a/pkgs/by-name/va/variety/package.nix
+++ b/pkgs/by-name/va/variety/package.nix
@@ -2,7 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  gexiv2,
+  gexiv2_0_10,
   gobject-introspection,
   gtk3,
   hicolor-icon-theme,
@@ -39,7 +39,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   buildInputs = [
-    gexiv2
+    gexiv2_0_10
     gtk3
     hicolor-icon-theme
     libnotify

--- a/pkgs/by-name/vi/viking/package.nix
+++ b/pkgs/by-name/vi/viking/package.nix
@@ -22,7 +22,7 @@
   withGeoClue ? true,
   geoclue2,
   withGeoTag ? true,
-  gexiv2,
+  gexiv2_0_10,
   withMagic ? true,
   file,
   withMapnik ? false,
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     xz # liblzma
   ]
   ++ lib.optional withGeoClue geoclue2
-  ++ lib.optional withGeoTag gexiv2
+  ++ lib.optional withGeoTag gexiv2_0_10
   ++ lib.optional withMagic file
   ++ lib.optional withMapnik mapnik
   ++ lib.optional withMBTiles sqlite

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
@@ -11,7 +11,7 @@
   libadwaita,
   libgee,
   granite7,
-  gexiv2,
+  gexiv2_0_10,
   gnome-settings-daemon,
   elementary-settings-daemon,
   gtk4,
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     elementary-settings-daemon
     gnome-settings-daemon
     gala
-    gexiv2
+    gexiv2_0_10
     glib
     granite7
     gtk4

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
@@ -13,7 +13,7 @@
   fwupd,
   gdk-pixbuf,
   geoclue2,
-  gexiv2,
+  gexiv2_0_10,
   glib,
   gnome-settings-daemon,
   gobject-introspection,
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     fwupd
     gdk-pixbuf
     geoclue2
-    gexiv2
+    gexiv2_0_10
     glib
     gnome-settings-daemon # org.gnome.settings-daemon.* gschema
     gtk3

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -964,6 +964,7 @@ mapAliases {
   geos_3_9 = throw "geos_3_9 has been removed from nixpkgs. Please use a more recent 'geos' instead."; # Added 2025-09-21
   gepetto-viewer = throw "'gepetto-viewer' has been removed, as authors and most users moved to viser"; # Added 2026-03-24
   gepetto-viewer-corba = throw "'gepetto-viewer-corba' has been removed, as authors and most users moved to viser"; # Added 2026-03-24
+  gexiv2 = throw "'gexiv2' attribute has been removed from nixpkgs. Use a 'gexiv2_*' attribute with an explicit ABI version instead."; # Added 2026-09-04
   gfie = throw "'gfie' has been removed as it depended on EOL qt5 webengine"; # Added 2026-04-17
   gfn-electron = throw "gfn-electron has been removed from Nixpkgs as it's abandoned upstream"; # Added 2025-11-05
   gfortran9 = throw "gfortran9 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08


### PR DESCRIPTION
Having the older ABI version as the default seems odd and the different gexiv2 packages appear to be fundamentally incompatible, so drop the unsuffixed version similar to webkitgtk and as discussed in https://github.com/NixOS/nixpkgs/pull/543345#issuecomment-5199018730.

Enabling `__structuredAttrs` and `strictDeps` for `gexiv2_0_10` because we have to (CI treats it as a new package).

No build output differences for `gexiv2_0_10` apart from store paths.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
