### PR TITLE
glibmm*: add explicit version suffix to attr, enable structuredAttrs and strictDeps

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -13,7 +13,7 @@
   gettext,
   ghostscript,
   glib,
-  glibmm,
+  glibmm_2_4,
   gobject-introspection,
   gsl,
   gspell,
@@ -153,7 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     gettext
     glib
-    glibmm
+    glibmm_2_4
     gsl
     gtkmm3
     gtksourceview4

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-mm-sms/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/purple-mm-sms/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  glibmm,
+  glibmm_2_4,
   pidgin,
   pkg-config,
   modemmanager,
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    glibmm
+    glibmm_2_4
     pidgin
     modemmanager
   ];

--- a/pkgs/by-name/ar/ardour/package.nix
+++ b/pkgs/by-name/ar/ardour/package.nix
@@ -21,7 +21,7 @@
   flac,
   fluidsynth,
   glibc,
-  glibmm,
+  glibmm_2_4,
   graphviz,
   harvid,
   hidapi,
@@ -142,7 +142,7 @@ let
       fftwSinglePrec
       flac
       fluidsynth
-      glibmm
+      glibmm_2_4
       hidapi
       itstool
       kissfft

--- a/pkgs/by-name/ar/ardour_8/package.nix
+++ b/pkgs/by-name/ar/ardour_8/package.nix
@@ -17,7 +17,7 @@
   flac,
   fluidsynth,
   glibc,
-  glibmm,
+  glibmm_2_4,
   graphviz,
   harvid,
   hidapi,
@@ -129,7 +129,7 @@ stdenv.mkDerivation (
       fftwSinglePrec
       flac
       fluidsynth
-      glibmm
+      glibmm_2_4
       hidapi
       itstool
       kissfft

--- a/pkgs/by-name/at/atkmm/package.nix
+++ b/pkgs/by-name/at/atkmm/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   atk,
-  glibmm,
+  glibmm_2_4,
   pkg-config,
   gnome,
   meson,
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [
     atk
-    glibmm
+    glibmm_2_4
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ca/cadabra2/package.nix
+++ b/pkgs/by-name/ca/cadabra2/package.nix
@@ -10,7 +10,7 @@
   nix-update-script,
 
   boost,
-  glibmm,
+  glibmm_2_4,
   gmpxx,
   gtkmm3,
   jsoncpp,
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     boost
-    glibmm
+    glibmm_2_4
     gmpxx
     jsoncpp
     onetbb

--- a/pkgs/by-name/ch/chatty/package.nix
+++ b/pkgs/by-name/ch/chatty/package.nix
@@ -11,7 +11,7 @@
   wrapGAppsHook4,
   evolution-data-server,
   feedbackd,
-  glibmm,
+  glibmm_2_4,
   libsecret,
   gnome-desktop,
   gspell,
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     evolution-data-server
     feedbackd
-    glibmm
+    glibmm_2_4
     libsecret
     gnome-desktop
     gspell

--- a/pkgs/by-name/ff/ffado/package.nix
+++ b/pkgs/by-name/ff/ffado/package.nix
@@ -5,7 +5,7 @@
   dbus,
   dbus_cplusplus,
   fetchurl,
-  glibmm,
+  glibmm_2_4,
   libavc1394,
   libconfig,
   libiec61883,
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     dbus
     dbus_cplusplus
-    glibmm
+    glibmm_2_4
     libavc1394
     libconfig
     libiec61883

--- a/pkgs/by-name/gl/glibmm_2_4/package.nix
+++ b/pkgs/by-name/gl/glibmm_2_4/package.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "glibmm";
   version = "2.66.8";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchurl {
     url = "mirror://gnome/sources/glibmm/${lib.versions.majorMinor finalAttrs.version}/glibmm-${finalAttrs.version}.tar.xz";
     hash = "sha256-ZPEdO5WiTiqNQWbs/1GHMPeezCciLvQfr3x+A0D8kyk=";

--- a/pkgs/by-name/gl/glibmm_2_4/package.nix
+++ b/pkgs/by-name/gl/glibmm_2_4/package.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "glibmm";
+      attrPath = "glibmm_2_4";
       versionPolicy = "odd-unstable";
       freeze = true;
     };

--- a/pkgs/by-name/gl/glibmm_2_68/package.nix
+++ b/pkgs/by-name/gl/glibmm_2_68/package.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "glibmm";
   version = "2.88.1";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/by-name/gt/gtkmm3/package.nix
+++ b/pkgs/by-name/gt/gtkmm3/package.nix
@@ -7,7 +7,7 @@
   ninja,
   python3,
   gtk3,
-  glibmm,
+  glibmm_2_4,
   cairomm_1_0,
   pangomm,
   atkmm,
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ libepoxy ];
 
   propagatedBuildInputs = [
-    glibmm
+    glibmm_2_4
     gtk3
     atkmm
     cairomm_1_0

--- a/pkgs/by-name/gt/gtksourceviewmm/package.nix
+++ b/pkgs/by-name/gt/gtksourceviewmm/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   pkg-config,
   gtkmm3,
-  glibmm,
+  glibmm_2_4,
   gtksourceview3,
   gnome,
 }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    glibmm
+    glibmm_2_4
     gtkmm3
     gtksourceview3
   ];

--- a/pkgs/by-name/gt/gtksourceviewmm4/package.nix
+++ b/pkgs/by-name/gt/gtksourceviewmm4/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   pkg-config,
   gtkmm3,
-  glibmm,
+  glibmm_2_4,
   gtksourceview4,
   gnome,
 }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [
-    glibmm
+    glibmm_2_4
     gtkmm3
     gtksourceview4
   ];

--- a/pkgs/by-name/gt/gtkspellmm/package.nix
+++ b/pkgs/by-name/gt/gtkspellmm/package.nix
@@ -5,7 +5,7 @@
   pkg-config,
   gtk3,
   glib,
-  glibmm,
+  glibmm_2_4,
   gtkmm3,
   gtkspell3,
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3
     glib
-    glibmm
+    glibmm_2_4
     gtkmm3
   ];
 

--- a/pkgs/by-name/gu/guitarix-vst/package.nix
+++ b/pkgs/by-name/gu/guitarix-vst/package.nix
@@ -7,7 +7,7 @@
   fftwFloat,
   freetype,
   glib,
-  glibmm,
+  glibmm_2_4,
   lib,
   libsndfile,
   libx11,
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     fftwFloat
     freetype
     glib
-    glibmm
+    glibmm_2_4
     libx11
     libxcursor
     libxext

--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -13,7 +13,7 @@
   gettext,
   glib,
   glib-networking,
-  glibmm,
+  glibmm_2_4,
   gperf,
   gtk3,
   gtkmm3,
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     glib
     glib-networking.out
-    glibmm
+    glibmm_2_4
     gtk3
     gtkmm3
     ladspa-header

--- a/pkgs/by-name/ja/jamesdsp/package.nix
+++ b/pkgs/by-name/ja/jamesdsp/package.nix
@@ -2,7 +2,7 @@
   copyDesktopItems,
   fetchFromGitHub,
   fetchpatch,
-  glibmm,
+  glibmm_2_4,
   gst_all_1,
   lib,
   libarchive,
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    glibmm
+    glibmm_2_4
     libarchive
     kdePackages.qtbase
     kdePackages.qtsvg

--- a/pkgs/by-name/li/libgdamm/package.nix
+++ b/pkgs/by-name/li/libgdamm/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   pkg-config,
-  glibmm,
+  glibmm_2_4,
   libgda5,
   libxml2,
   gnome,
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    glibmm
+    glibmm_2_4
     libxml2
   ];
   propagatedBuildInputs = [ gda ];

--- a/pkgs/by-name/li/libsigrok-sipeed/package.nix
+++ b/pkgs/by-name/li/libsigrok-sipeed/package.nix
@@ -11,7 +11,7 @@
   check,
   libserialport,
   doxygen,
-  glibmm,
+  glibmm_2_4,
   python3,
   hidapi,
   libieee1284,
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     libftdi1
     check
     libserialport
-    glibmm
+    glibmm_2_4
     hidapi
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/by-name/li/libsigrok/package.nix
+++ b/pkgs/by-name/li/libsigrok/package.nix
@@ -10,7 +10,7 @@
   check,
   libserialport,
   doxygen,
-  glibmm,
+  glibmm_2_4,
   python3,
   hidapi,
   libieee1284,
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
     libftdi1
     check
     libserialport
-    glibmm
+    glibmm_2_4
     hidapi
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/by-name/li/libxmlxx5/package.nix
+++ b/pkgs/by-name/li/libxmlxx5/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   libxml2,
-  glibmm,
+  glibmm_2_4,
   meson,
   ninja,
 }:
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
-  buildInputs = [ glibmm ];
+  buildInputs = [ glibmm_2_4 ];
 
   propagatedBuildInputs = [ libxml2 ];
 

--- a/pkgs/by-name/li/lightspark/package.nix
+++ b/pkgs/by-name/li/lightspark/package.nix
@@ -17,7 +17,7 @@
   xz,
   nasm,
   llvm,
-  glibmm,
+  glibmm_2_4,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     xz
     nasm
     llvm
-    glibmm
+    glibmm_2_4
   ];
 
   meta = {

--- a/pkgs/by-name/li/linthesia/package.nix
+++ b/pkgs/by-name/li/linthesia/package.nix
@@ -5,7 +5,7 @@
   SDL2_ttf,
   alsa-lib,
   fetchFromGitHub,
-  glibmm,
+  glibmm_2_4,
   gtk3,
   libGL,
   libGLU,
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libGLU
     alsa-lib
-    glibmm
+    glibmm_2_4
     sqlite
     SDL2
     SDL2_ttf

--- a/pkgs/by-name/pa/paprefs/package.nix
+++ b/pkgs/by-name/pa/paprefs/package.nix
@@ -7,7 +7,7 @@
   gettext,
   pkg-config,
   pulseaudioFull,
-  glibmm,
+  glibmm_2_4,
   gtkmm3,
   wrapGAppsHook3,
 }:
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     pulseaudioFull
-    glibmm
+    glibmm_2_4
     gtkmm3
   ];
 

--- a/pkgs/by-name/pe/performous/package.nix
+++ b/pkgs/by-name/pe/performous/package.nix
@@ -11,7 +11,7 @@
   fmt,
   gettext,
   glew,
-  glibmm,
+  glibmm_2_4,
   glm,
   icu,
   libepoxy,
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     ffmpeg
     fmt
     glew
-    glibmm
+    glibmm_2_4
     glm
     icu
     libepoxy

--- a/pkgs/by-name/po/powermode-indicator/package.nix
+++ b/pkgs/by-name/po/powermode-indicator/package.nix
@@ -5,7 +5,7 @@
   cmake,
   pkg-config,
   gtkmm3,
-  glibmm,
+  glibmm_2_4,
   libappindicator,
 }:
 stdenv.mkDerivation {
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   buildInputs = [
     libappindicator
     gtkmm3
-    glibmm
+    glibmm_2_4
   ];
 
   meta = {

--- a/pkgs/by-name/pu/pulseeffects-legacy/package.nix
+++ b/pkgs/by-name/pu/pulseeffects-legacy/package.nix
@@ -14,7 +14,7 @@
   pulseaudio,
   gtk3,
   glib,
-  glibmm,
+  glibmm_2_4,
   gtkmm3,
   lilv,
   lv2,
@@ -71,7 +71,7 @@ stdenv.mkDerivation {
   buildInputs = [
     pulseaudio
     glib
-    glibmm
+    glibmm_2_4
     gtk3
     gtkmm3
     gst_all_1.gstreamer

--- a/pkgs/by-name/pu/pulseview/package.nix
+++ b/pkgs/by-name/pu/pulseview/package.nix
@@ -12,7 +12,7 @@
   libzip,
   libftdi1,
   hidapi,
-  glibmm,
+  glibmm_2_4,
   python3,
   bluez,
   libsForQt5,
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     libzip
     libftdi1
     hidapi
-    glibmm
+    glibmm_2_4
     python3
     libsForQt5.qtsvg
   ]

--- a/pkgs/by-name/ra/radiotray-ng/package.nix
+++ b/pkgs/by-name/ra/radiotray-ng/package.nix
@@ -12,7 +12,7 @@
   libbsd,
   # GUI/Desktop
   dbus,
-  glibmm,
+  glibmm_2_4,
   gsettings-desktop-schemas,
   hicolor-icon-theme,
   libappindicator,
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     jsoncpp
     libbsd
-    glibmm
+    glibmm_2_4
     hicolor-icon-theme
     gsettings-desktop-schemas
     libappindicator

--- a/pkgs/by-name/rh/rhvoice/package.nix
+++ b/pkgs/by-name/rh/rhvoice/package.nix
@@ -5,7 +5,7 @@
   ensureNewerSourcesForZipFilesHook,
   pkg-config,
   scons,
-  glibmm,
+  glibmm_2_4,
   libpulseaudio,
   libao,
   speechd-minimal,
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    glibmm
+    glibmm_2_4
     libpulseaudio
     libao
     speechd-minimal

--- a/pkgs/by-name/sm/smuview/package.nix
+++ b/pkgs/by-name/sm/smuview/package.nix
@@ -11,7 +11,7 @@
   libzip,
   libftdi1,
   hidapi,
-  glibmm,
+  glibmm_2_4,
   python3,
   bluez,
   pcre2,
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     libzip
     libftdi1
     hidapi
-    glibmm
+    glibmm_2_4
     python3
     pcre2
     libsForQt5.qwt

--- a/pkgs/by-name/sy/synfigstudio/package.nix
+++ b/pkgs/by-name/sy/synfigstudio/package.nix
@@ -10,7 +10,7 @@
   cairo,
   ffmpeg,
   gettext,
-  glibmm,
+  glibmm_2_4,
   libmng,
   gtk3,
   gtkmm3,
@@ -79,7 +79,7 @@ let
     ];
     buildInputs = [
       ETL
-      glibmm
+      glibmm_2_4
       mlt
       libsigcxx
       libxmlxx
@@ -130,7 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
     ETL
     synfig
     cairo
-    glibmm
+    glibmm_2_4
     gtk3
     gtkmm3
     imagemagick

--- a/pkgs/by-name/sy/syshud/package.nix
+++ b/pkgs/by-name/sy/syshud/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  glibmm,
+  glibmm_2_4,
   gtk4-layer-shell,
   gtkmm4,
   libevdev,
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    glibmm
+    glibmm_2_4
     gtk4-layer-shell
     gtkmm4
     libevdev

--- a/pkgs/by-name/wo/workrave/package.nix
+++ b/pkgs/by-name/wo/workrave/package.nix
@@ -16,7 +16,7 @@
   libxtst,
   gobject-introspection,
   glib,
-  glibmm,
+  glibmm_2_4,
   gtkmm3,
   atk,
   pango,
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxscrnsaver
     libxtst
     glib
-    glibmm
+    glibmm_2_4
     gtkmm3
     atk
     pango

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   pkg-config,
   file,
-  glibmm,
+  glibmm_2_4,
   gst_all_1,
   gnome,
   apple-sdk_gstreamer,
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    glibmm
+    glibmm_2_4
     gst_all_1.gst-plugins-base
   ];
 

--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -4,7 +4,7 @@
   fetchurl,
   pkg-config,
   libxml2,
-  glibmm,
+  glibmm_2_4,
   perl,
   gnome,
 }:
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [
     libxml2
-    glibmm
+    glibmm_2_4
   ];
 
   passthru = {

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -4,7 +4,7 @@
   fetchurl,
   pkg-config,
   libxml2,
-  glibmm,
+  glibmm_2_4,
   perl,
   gnome,
   meson,
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     dblatex
   ];
 
-  buildInputs = [ glibmm ];
+  buildInputs = [ glibmm_2_4 ];
 
   propagatedBuildInputs = [ libxml2 ];
 

--- a/pkgs/development/libraries/pangomm/2.42.nix
+++ b/pkgs/development/libraries/pangomm/2.42.nix
@@ -7,7 +7,7 @@
   ninja,
   python3,
   pango,
-  glibmm,
+  glibmm_2_4,
   cairomm_1_0,
   gnome,
 }:
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ];
   propagatedBuildInputs = [
     pango
-    glibmm
+    glibmm_2_4
     cairomm_1_0
   ];
 

--- a/pkgs/development/libraries/pangomm/default.nix
+++ b/pkgs/development/libraries/pangomm/default.nix
@@ -7,7 +7,7 @@
   ninja,
   python3,
   pango,
-  glibmm,
+  glibmm_2_4,
   cairomm_1_0,
   gnome,
 }:
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   ];
   propagatedBuildInputs = [
     pango
-    glibmm
+    glibmm_2_4
     cairomm_1_0
   ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1001,6 +1001,7 @@ mapAliases {
   glew-egl = throw "'glew-egl' has been renamed to/replaced by 'glew'"; # Converted to throw 2025-10-27
   glfw-wayland = throw "'glfw-wayland' has been renamed to/replaced by 'glfw'"; # Converted to throw 2025-10-27
   glfw-wayland-minecraft = throw "'glfw-wayland-minecraft' has been renamed to/replaced by 'glfw3-minecraft'"; # Converted to throw 2025-10-27
+  glibmm = throw "'glibmm' attribute has been removed from nixpkgs. Use a 'glibmm_*' attribute with an explicit ABI version instead."; # Added 2026-09-04
   globalprotect-openconnect = throw "'globalprotect-openconnect' was removed because it was unmaintained in Nixpkgs and needed upgrading to the Tauri rewrite, as the old version depends on the removed Qt 5 WebEngine"; # Added 2026-04-26
   glom = throw "'glom' has been removed as it was archived upstream and depended on libsoup 2.4"; # Added 2026-06-07
   glxinfo = throw "'glxinfo' has been renamed to/replaced by 'mesa-demos'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
Having the older ABI version as the default seems odd and the different glibmm packages appear to be fundamentally incompatible, so drop the unsuffixed version similar to webkitgtk and as discussed in https://github.com/NixOS/nixpkgs/pull/543345#issuecomment-5199018730.

Enabling `__structuredAttrs` and `strictDeps` for `glibmm_2_4` because we have to (CI treats it as a new package), enabling both for `glibmm_2_68` as well while we're at it.

No build output differences for `glibmm_2_{4,68}` apart from store paths.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `glibmm_2_{4,68}`
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
