### PR TITLE
electrum{,-grs,-ltc}: use top-level callPackage

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -2,13 +2,12 @@
   lib,
   stdenv,
   fetchurl,
-  wrapQtAppsHook,
   python3,
   zbar,
   enableQt ? true,
+  qt5,
   enablePythonEcdsa ? false,
   callPackage,
-  qtwayland,
 
   writableTmpDirAsHomeHook,
 }:
@@ -38,9 +37,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     python3.pkgs.pythonRelaxDepsHook
   ]
   ++ lib.optionals enableQt [
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
   ];
-  buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qtwayland;
+  buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qt5.qtwayland;
 
   dependencies =
     with python3.pkgs;

--- a/pkgs/applications/misc/electrum/grs.nix
+++ b/pkgs/applications/misc/electrum/grs.nix
@@ -2,12 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  wrapQtAppsHook,
   python3,
   zbar,
   secp256k1,
   enableQt ? true,
-  qtwayland,
+  qt5,
 }:
 
 let
@@ -43,8 +42,8 @@ python3.pkgs.buildPythonApplication {
     sha256 = "1k078jg3bw4n3kcxy917m30x1skxm679w8hcw8mlxb94ikrjc66h";
   };
 
-  nativeBuildInputs = lib.optionals enableQt [ wrapQtAppsHook ];
-  buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qtwayland;
+  nativeBuildInputs = lib.optionals enableQt [ qt5.wrapQtAppsHook ];
+  buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qt5.qtwayland;
 
   propagatedBuildInputs =
     with python3.pkgs;

--- a/pkgs/applications/misc/electrum/ltc.nix
+++ b/pkgs/applications/misc/electrum/ltc.nix
@@ -3,12 +3,11 @@
   stdenv,
   fetchurl,
   fetchFromGitHub,
-  wrapQtAppsHook,
   python3,
   zbar,
   secp256k1,
   enableQt ? true,
-  qtwayland,
+  qt5,
 }:
 
 let
@@ -60,7 +59,7 @@ python3.pkgs.buildPythonApplication {
     cp -ar ${tests} $sourceRoot/electrum_ltc/tests
   '';
 
-  nativeBuildInputs = lib.optionals enableQt [ wrapQtAppsHook ];
+  nativeBuildInputs = lib.optionals enableQt [ qt5.wrapQtAppsHook ];
 
   propagatedBuildInputs =
     with python3.pkgs;
@@ -156,7 +155,7 @@ python3.pkgs.buildPythonApplication {
     pyaes
     pycryptodomex
   ];
-  buildInputs = lib.optional stdenv.hostPlatform.isLinux qtwayland;
+  buildInputs = lib.optional stdenv.hostPlatform.isLinux qt5.qtwayland;
 
   enabledTestPaths = [ "electrum_ltc/tests" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8396,7 +8396,7 @@ with pkgs;
 
   electrum = callPackage ../applications/misc/electrum { };
 
-  electrum-grs = libsForQt5.callPackage ../applications/misc/electrum/grs.nix { };
+  electrum-grs = callPackage ../applications/misc/electrum/grs.nix { };
 
   electrum-ltc = libsForQt5.callPackage ../applications/misc/electrum/ltc.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8398,7 +8398,7 @@ with pkgs;
 
   electrum-grs = callPackage ../applications/misc/electrum/grs.nix { };
 
-  electrum-ltc = libsForQt5.callPackage ../applications/misc/electrum/ltc.nix { };
+  electrum-ltc = callPackage ../applications/misc/electrum/ltc.nix { };
 
   inherit (recurseIntoAttrs (callPackage ../applications/editors/emacs { }))
     emacs31

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8394,7 +8394,7 @@ with pkgs;
 
   eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse { });
 
-  electrum = libsForQt5.callPackage ../applications/misc/electrum { };
+  electrum = callPackage ../applications/misc/electrum { };
 
   electrum-grs = libsForQt5.callPackage ../applications/misc/electrum/grs.nix { };
 


### PR DESCRIPTION
This PR drops another 3 explicit usages of `libsForQt5.callPackage` in Nixpkgs. Hopefully all usages in https://github.com/NixOS/nixpkgs/issues/180841#issuecomment-2423659515 could be migrated by the end of the year...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
