### PR TITLE
but: init at 0.22.3

### DIFF
--- a/pkgs/by-name/bu/but/package.nix
+++ b/pkgs/by-name/bu/but/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  nix-update-script,
+  openssl,
+  makeWrapper,
+  git,
+  dbus,
+  pkg-config,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "but";
+  version = "0.22.3";
+  src = fetchFromGitHub {
+    owner = "gitbutlerapp";
+    repo = "gitbutler";
+    tag = "release/${finalAttrs.version}";
+    hash = "sha256-nW3yCbpbIhawLQVV+DptzGYiFBSKcyAP89NtDWHJM+0=";
+  };
+
+  cargoHash = "sha256-XRc2yok9K7f/vRAqgO78JUq/U36XSiUeOINupfOOSjw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+  buildInputs = [
+    openssl
+    dbus
+  ];
+
+  nativeCheckInputs = [ git ];
+
+  postFixup = ''
+    wrapProgram $out/bin/${finalAttrs.pname} \
+      --prefix PATH : ${lib.makeBinPath [ git ]}
+  '';
+
+  env = {
+    OPENSSL_NO_VENDOR = true; # tell openssl-sys: use system OpenSSL, never vendor
+    VERSION = finalAttrs.version;
+  };
+
+  postPatch = ''
+    # gix-testtools execve's fixture scripts directly; their `#!/usr/bin/env bash`
+    # shebang can't resolve in the nix sandbox (no /usr/bin), so point them at
+    # the actual bash from the build environment.
+    patchShebangs crates/but/tests/fixtures/scenario/*.sh
+  '';
+
+  cargoBuildFlags = [
+    "-p"
+    "but"
+  ];
+  buildFeatures = [ "packaged-but-distribution" ];
+
+  cargoTestFlags = [
+    "-p"
+    "but"
+  ];
+  checkFlags = lib.concatMap (t: [ "--skip=${t}" ]) [
+    # TUI SVG snapshots resolve the system file-opener (xdg-open → desktop
+    # associations; e.g. Thunar on Xfce) instead of upstream's fixture opener.
+    "command::legacy::status::tui::tests::open_tests::"
+    # These tests rely on builtin programs that only exist in debug builds
+    # (#[cfg(debug_assertions)] in but-api/src/open/program.rs), while nixpkgs
+    # runs the test suite with --profile release (matching what ships).
+    "command::open::"
+  ];
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release/(.*)"
+    ];
+  };
+
+  meta = {
+    description = "GitButler CLI for virtual branches and stacked diffs";
+    homepage = "https://gitbutler.com";
+    changelog = "https://github.com/gitbutlerapp/gitbutler/releases/tag/release/${finalAttrs.version}";
+    license = lib.licenses.fsl11Mit;
+    mainProgram = "but";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ parry-97 ];
+  };
+})


### PR DESCRIPTION
Adds `but`, the GitButler CLI for virtual branches / stacked diffs, at `pkgs/by-name/bu/but/package.nix`. Scope is the CLI only — the desktop app (`gitbutler`) already exists. Upstream publishes neither crates nor release binaries for the CLI, so this builds the `but` crate from the `release/0.22.3` source tag.

The license is `lib.licenses.fsl11Mit`, the same FSL-1.1-MIT as the existing `gitbutler` package (unfree but redistributable).

Notable implementation details:

- **Test-suite shebang fix** (`postPatch`): gix-testtools executes fixture scenario scripts via direct `execve` and only falls back to bash on `EPERM` — not `ENOENT`. Their `#!/usr/bin/env bash` shebang therefore can't resolve in the nix sandbox (no `/usr/bin`), panicking 36 tests (`but-testsupport/src/sandbox.rs:128`, "os error 2"). A single `patchShebangs crates/but/tests/fixtures/scenario/*.sh` fixes all of them.
  - The desktop `gitbutler` package skips five tests with this exact error quoted in its comments (`Archive at 'tests/fixtures/generated-archives/[...].tar' not found [..] Error: No such file or directory (os error 2)`) — same root cause, same one-line fix applies there. Happy to follow up with that change.
  - Upstream candidate: gix-testtools could fall back to bash on `ENOENT` the way it already does on `EPERM`.
- **Self-updater disabled**: `buildFeatures = [ "packaged-but-distribution" ]` compiles the distribution variant (`but update install` refuses), per the "package managers update packages" policy.
- **Remaining test skips** (2, both documented inline): TUI snapshot tests resolve the desktop file-opener via xdg associations, and `command::open::` needs `#[cfg(debug_assertions)]`-gated builtin programs that don't exist in a release-profile test run.
- **Runtime PATH**: wrapped with `git`, which `but` shells out to.
- **Update automation**: `passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex" "release/(.*)" ]; }` — upstream tags are `release/X.Y.Z`.
- `maintainers` left empty; open to @getchoo / @techknowlogick (desktop-package maintainers) claiming it if they prefer.

Test evidence (x86_64-linux): `nix-build -A but` green; the upstream Rust suite runs during the build and is green apart from the two documented skip classes (`but` integration suite: `test result: ok. 681 passed; 0 failed; 2 ignored; 0 measured; 16 filtered out`; lib unit tests: `test result: ok. 881 passed; 0 failed; 1 ignored; 0 measured; 9 filtered out`). Basic functionality verified: `but --version` → `0.22.3`, `but status` against a scratch repo, `but update install` refuses, `ldd` shows system libdbus only (no vendored ssl/git).

Reviewer smoke test:

```bash
nix-build -A but
./result/bin/but --version   # but 0.22.3
```

*Transparency note (automation/AI policy): this package was developed with the assistance of an AI coding assistant; all commands, verification results, and the final expression were reviewed, executed, and validated by me.*

cc @getchoo @techknowlogick

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (not run — new leaf package with no reverse dependencies; `nix-build -A but` and `nixpkgs-vet` cover the CI checks)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
