### PR TITLE
python3Packages.stdlibs: 2026.2.26 -> 2026.9.3

### DIFF
--- a/pkgs/development/python-modules/stdlibs/default.nix
+++ b/pkgs/development/python-modules/stdlibs/default.nix
@@ -3,32 +3,41 @@
   buildPythonPackage,
   fetchFromGitHub,
   flit-core,
+  moreorless,
+  unittestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stdlibs";
-  version = "2026.2.26";
+  version = "2026.9.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "omnilib";
     repo = "stdlibs";
-    tag = "v${version}";
-    hash = "sha256-5Brb214tglEEjsJXOvEhlaJgSYCUpOGPbHkmI9AWPoM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W2fj+hGZ5UA/XNO0CUyTbz/Wwhh3pr/2qB8Su5TdKPM=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "flit_core >=4,<5" "flit_core"
+  '';
 
   build-system = [ flit-core ];
 
-  # Module has no tests
-  doCheck = false;
+  nativeCheckInputs = [
+    moreorless
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [ "stdlibs" ];
 
   meta = {
     description = "Overview of the Python stdlib";
     homepage = "https://github.com/omnilib/stdlibs";
-    changelog = "https://github.com/omnilib/stdlibs/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/omnilib/stdlibs/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/omnilib/stdlibs/blob/v2026.9.3/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
