### PR TITLE
unsloth-desktop: init at 0.1.804-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22184,6 +22184,11 @@
     githubId = 47054801;
     name = "Parrot7483";
   };
+  parry-97 = {
+    github = "Parry-97";
+    githubId = 39216605;
+    name = "Parampal Singh";
+  };
   parth = {
     github = "parth";
     githubId = 821972;

--- a/pkgs/by-name/un/unsloth-desktop/package.nix
+++ b/pkgs/by-name/un/unsloth-desktop/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  cacert,
+  buildFHSEnv,
+  fetchurl,
+  dpkg,
+}:
+
+let
+  version = "0.1.804-beta";
+
+  unsloth-desktop-unwrapped = stdenv.mkDerivation {
+    pname = "unsloth-desktop-unwrapped";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/unslothai/unsloth/releases/download/v${version}/Unsloth-Desktop-Ubuntu.deb";
+      hash = "sha256-DrHbR7pGeTtvlPIDZD0SPO6pUf792Rskd1x1ANMmpfw=";
+    };
+
+    nativeBuildInputs = [ dpkg ];
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontStrip = true;
+    dontPatchELF = true;
+
+    installPhase = ''
+      runHook preInstall
+      dpkg-deb -x $src $out
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Unsloth Studio desktop payload from the upstream .deb (unwrapped)";
+      homepage = "https://unsloth.ai/";
+      license = lib.licenses.agpl3Only;
+      platforms = [ "x86_64-linux" ];
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
+  };
+in
+buildFHSEnv {
+  pname = "unsloth-desktop";
+  inherit version;
+
+  includeClosures = true;
+
+  targetPkgs =
+    pkgs: with pkgs; [
+      webkitgtk_4_1
+      gtk3
+      libsoup_3
+      glib-networking
+      gsettings-desktop-schemas
+      hicolor-icon-theme
+      shared-mime-info
+      libayatana-appindicator
+      libnghttp2
+      nodejs_24
+      cacert
+    ];
+
+  profile = ''
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+    export WEBKIT_DISABLE_DMABUF_RENDERER=1
+  '';
+
+  runScript = "${unsloth-desktop-unwrapped}/usr/bin/unsloth-studio";
+
+  extraInstallCommands = ''
+    install -Dm644 ${unsloth-desktop-unwrapped}/usr/share/applications/Unsloth.desktop \
+      $out/share/applications/unsloth-desktop.desktop
+    substituteInPlace $out/share/applications/unsloth-desktop.desktop \
+      --replace-fail "Exec=unsloth-studio" "Exec=unsloth-desktop"
+    install -Dm644 ${unsloth-desktop-unwrapped}/usr/share/icons/hicolor/128x128/apps/unsloth-studio.png \
+      $out/share/icons/hicolor/128x128/apps/unsloth-studio.png
+  '';
+
+  passthru = { inherit unsloth-desktop-unwrapped; };
+
+  meta = {
+    description = "Desktop application for running and training AI models locally";
+    homepage = "https://unsloth.ai/";
+    changelog = "https://github.com/unslothai/unsloth/releases";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ parry-97 ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "unsloth-desktop";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    longDescription = ''
+      Wraps the upstream Unsloth Desktop .deb in an FHS environment.
+
+      The app manages its own runtime in ~/.unsloth/studio: on first run it
+      bootstraps a uv venv, installs the unsloth PyPI backend and PyTorch
+      (CUDA wheels selected by GPU), and downloads prebuilt llama.cpp binaries.
+      These runtime components are not part of this package.
+
+      Note: the in-app self-updater cannot replace the read-only store binary;
+      update by rebuilding this package.
+    '';
+  };
+}


### PR DESCRIPTION

### Description

Adds [Unsloth Desktop](https://github.com/unslothai/unsloth) ([homepage](https://unsloth.ai/)), the official desktop application from Unsloth AI for running and fine-tuning open LLMs locally: a chat UI backed by llama.cpp, with fine-tuning via the unsloth Python library. App code is AGPL-3.0.

Packaging notes for reviewers:

- Wraps the upstream `Unsloth-Desktop-Ubuntu.deb` (`dpkg-deb -x`, no patchelf) in a `buildFHSEnv` bubblewrap environment. The payload is a prebuilt Tauri/WebKitGTK binary (`sourceProvenance = binaryNativeCode`).
- `includeClosures = true`: bare `buildFHSEnv` has no default library baseline, and the payload needs the full gtk3/webkitgtk_4_1 dependency closures at runtime.
- Managed runtime, documented in `longDescription`: on first run the app bootstraps its backend in `~/.unsloth/studio` — a uv venv with the `unsloth` PyPI package, PyTorch (CUDA wheels selected by GPU), and prebuilt llama.cpp binaries. These are not part of the package (precedent: steam and other apps with managed runtime).
- `nodejs_24` in `targetPkgs` satisfies the installer's system-node requirement (avoids an isolated node download); `SSL_CERT_FILE` points at `cacert` for the first-run Python tooling; `WEBKIT_DISABLE_DMABUF_RENDERER=1` for WebKitGTK on NVIDIA/Wayland.
- The in-app self-updater cannot replace the read-only store binary; updates happen by rebuilding the package. A `passthru.updateScript` can be added in a follow-up PR.
- x86_64-linux only: upstream Linux releases are amd64-only.
- I have added myself (`parry-97`) to `maintainers/maintainer-list.nix`.

**AI disclosure**: this contribution was prepared with LLM assistance (opencode CLI, model glm-5.3-flash), per the [automation/AI policy]. I reviewed all changes, ran `nixpkgs-review` locally (clean: 1 package built), and verified basic functionality on NixOS with an NVIDIA GPU: first-run install completes, and local-model chat inference runs on the GPU.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
