### PR TITLE
espresso: 2.4 -> 2.5.1

### DIFF
--- a/pkgs/by-name/es/espresso/package.nix
+++ b/pkgs/by-name/es/espresso/package.nix
@@ -4,23 +4,22 @@
   cmake,
   stdenv,
   nix-update-script,
+  asciidoctor,
 }:
 stdenv.mkDerivation rec {
   pname = "espresso";
-  version = "2.4";
+  version = "2.5.1";
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "espresso";
     rev = "v${version}";
-    hash = "sha256-z5By57VbmIt4sgRgvECnLbZklnDDWUA6fyvWVyXUzsI=";
+    hash = "sha256-dZigbd4md8ffFawpPB/N/TccBQL6sbMKN2VdGu+fhKY=";
   };
 
-  postPatch = ''
-    substituteInPlace utility/port.h \
-      --replace-fail "VOID_HACK srandom();" "VOID_HACK srandom(unsigned int __seed);"
-  '';
-
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    asciidoctor
+  ];
 
   doCheck = true;
 
@@ -42,6 +41,7 @@ stdenv.mkDerivation rec {
       heuristic Boolean minimization.
     '';
     homepage = "https://github.com/chipsalliance/espresso";
+    changelog = "https://github.com/chipsalliance/espresso/releases/tag/v${version}";
     maintainers = with lib.maintainers; [ pineapplehunter ];
     mainProgram = "espresso";
     platforms = lib.platforms.all;


### PR DESCRIPTION
This PR updates espresso to the latest version.
Asciidoctor was added to the input to generate documentation.
Also adds the changelog link.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
