### PR TITLE
corteza: 2024.9.9 -> 2024.9.10

### DIFF
--- a/pkgs/by-name/co/corteza/package.nix
+++ b/pkgs/by-name/co/corteza/package.nix
@@ -4,29 +4,18 @@
   buildGoModule,
   callPackage,
   fetchFromGitHub,
-  fetchpatch,
-  applyPatches,
   lib,
   nixosTests,
   stdenvNoCC,
 }:
 
 let
-  version = "2024.9.9";
-  src = applyPatches {
-    src = fetchFromGitHub {
-      owner = "cortezaproject";
-      repo = "corteza";
-      tag = version;
-      hash = "sha256-r6/z5yplkT2d1iEhA4S29C1LcbdEJQiOWr0JRP5Pvb0=";
-    };
-    patches = [
-      # CVE-2026-6093
-      (fetchpatch {
-        url = "https://github.com/cortezaproject/corteza/commit/64b58b9d7324e77248bacd183fb994ff338091ec.patch";
-        hash = "sha256-0Ume1zkksS3kwf6QS6T5lDXklAboZVlTt5ZJReqwu3w=";
-      })
-    ];
+  version = "2024.9.10";
+  src = fetchFromGitHub {
+    owner = "cortezaproject";
+    repo = "corteza";
+    tag = version;
+    hash = "sha256-Q80uFf3mb1yIfG6HrMKbMpi8pncnSKhg4Bgc8BLtSmM=";
   };
   meta = {
     description = "Low-code platform";
@@ -58,13 +47,13 @@ let
     };
 
   webApps = lib.mapAttrs mkWebApp {
-    admin = "sha256-fen4KxPbYpH0ikWco1w3Zr+4WeghFITdmsOqHMGa3gA=";
-    compose = "sha256-UHhyzCeSWTROgzULYkDKN/2hgZ25aDZ7roHTLkt466o=";
-    discovery = "sha256-GHmALrqLTBie0VTDmZz4zJ9Ls2JYsfV0A3VkRwCKSuQ=";
-    one = "sha256-GHCtouGYrFgghWlBVbF5rD9cXrAfleVVxVqZtuLOSr0=";
-    privacy = "sha256-PlmeAJZY/S+osdM650tpJI3XSOanc80WYuMQ6jsiJwQ=";
-    reporter = "sha256-4O6FEF7Ol4V0FxznKGISaIA0w68XL0E3HvQ8bbt2klE=";
-    workflow = "sha256-2vyx3lCxICtVlRFLPkpy0fzXZ9W4li9ESm9sJzInc8g=";
+    admin = "sha256-TjgdG+MNojJDmgv1oEb4lzP4EzHBMKbY+Ep0jrnxxKI=";
+    compose = "sha256-XxAjyYU/zlHNf+OKbMX3eGnXEI5/Fdz0rbjgsTqTTsk=";
+    discovery = "sha256-YN6co0Pixau6x2ulm32PYgmtGMpysHT2KnPcJMol3XU=";
+    one = "sha256-uTuQD2+PZ8NrG6rM7V8KiV/3+bY+xYsvhWJdHTHLhI4=";
+    privacy = "sha256-PsJnWW5D8a0O8zXwEtR6xhRxyJWJX/xrAC66Y27UG+0=";
+    reporter = "sha256-YZoVEsM6nlJbs+pIjIktQ6FYpSgs6GArUywZzUug/ZY=";
+    workflow = "sha256-4oM13BVvW/9hQozfqNCjANMZpSZhpDf+YvPZm8Yxj/c=";
   };
 
   server-webconsole = callPackage ./buildYarnDistOnly.nix {
@@ -79,7 +68,7 @@ let
     owner = "cortezaproject";
     repo = "corteza-locale";
     rev = "57b1f2403207c44055ebce19d95cedd5573f39df";
-    sha256 = "sha256-j+mfWG6tED8AACkUcRWpol2G05qknTxp8b+kwu7c2NA=";
+    hash = "sha256-j+mfWG6tED8AACkUcRWpol2G05qknTxp8b+kwu7c2NA=";
   };
 
   corteza-webapp = stdenvNoCC.mkDerivation (finalAttrs: {


### PR DESCRIPTION
Changelog: https://docs.cortezaproject.org/corteza-docs/2024.9/changelog/202409/index.html#_2024_9_10
Removes the need to pull the CVE patches, as they are now upstream.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
