### PR TITLE
.github: disable npm ci audit

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -49,7 +49,7 @@ jobs:
             ci/github-script
 
       - name: Install dependencies
-        run: npm ci --package-lock-only=false @actions/artifact bottleneck
+        run: npm ci --package-lock-only=false --no-audit @actions/artifact bottleneck
         working-directory: ci/github-script
 
       # Use a GitHub App, because it has much higher rate limits: 12,500 instead of 5,000 req / hour.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
             ci/github-script
 
       - name: Install dependencies
-        run: npm ci --package-lock-only=false bottleneck
+        run: npm ci --package-lock-only=false --no-audit bottleneck
         working-directory: trusted/ci/github-script
 
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install dependencies to trusted/
         run: |
-          npm ci --package-lock-only=false
+          npm ci --package-lock-only=false --no-audit
           echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
         working-directory: nixpkgs/trusted/ci/github-script
 

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -38,7 +38,7 @@ jobs:
             maintainers/github-teams.json
 
       - name: Install dependencies
-        run: npm ci --package-lock-only=false bottleneck
+        run: npm ci --package-lock-only=false --no-audit bottleneck
         working-directory: ci/github-script
 
       - name: Synchronise teams


### PR DESCRIPTION
It's currently very slow and often times brings jobs past the 3min
limit. No one is reading these audit reports in ci output, and in slight
chance we care to stay on top of these CVE audit reports from npm, we
should have a dedicated procedure to monitor and bump lock file that
doesn't involve routinely executing it in every job.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
