### PR TITLE
ci/github-script/bot.js: make llm-assisted label sticky

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -397,11 +397,11 @@ export default async ({ github, context, core, dry }) => {
         per_page: 100,
       })
 
-      // label llm-assisted PRs accordingly
+      // label llm-assisted PRs accordingly, retaining it if manually set
       const assistedByPattern = /Assisted-by: (?!nix-init)/i
-      evalLabels['llm-assisted'] = prCommits.some((c) =>
-        assistedByPattern.test(c.commit.message),
-      )
+      if (prCommits.some((c) => assistedByPattern.test(c.commit.message))) {
+        evalLabels['llm-assisted'] = true
+      }
 
       const commitSubjects = prCommits.map(
         (c) => c.commit.message.split('\n')[0],


### PR DESCRIPTION
By popular demand, this patch lets folks manually label PRs with the
label and make it stick, even if auto-labeler wouldn't label it itself
(presumably because the author didn't mark their commits according to
automation policy).

Assisted-by: Codex gpt-5.6-sol medium

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
