### PR TITLE
wechat: 4.1.8.106-37335 -> 4.1.13.59-269627 for darwin; 4.1.1.4 -> 4.1.1.8 on linux

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15928,6 +15928,13 @@
     github = "langsjo";
     githubId = 104687438;
   };
+  larry0x = {
+    name = "Larry Engineer";
+    email = "nixpkgs@larry.engineer";
+    github = "larry0x";
+    githubId = 26318510;
+    keys = [ { fingerprint = "BF1C 46E2 93BB 3CC3 7155  56ED 5E02 19E0 2D70 E4E2"; } ];
+  };
   larsr = {
     email = "Lars.Rasmusson@gmail.com";
     github = "larsr";

--- a/pkgs/by-name/we/wechat/package.nix
+++ b/pkgs/by-name/we/wechat/package.nix
@@ -15,7 +15,10 @@ let
     downloadPage = "https://linux.weixin.qq.com/en";
     license = lib.licenses.unfree;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-    maintainers = with lib.maintainers; [ prince213 ];
+    maintainers = with lib.maintainers; [
+      larry0x
+      prince213
+    ];
     mainProgram = "wechat";
     platforms = [
       "aarch64-darwin"

--- a/pkgs/by-name/we/wechat/package.nix
+++ b/pkgs/by-name/we/wechat/package.nix
@@ -28,14 +28,14 @@ let
     # https://dldir1.qq.com/weixin/mac/mac-release.xml
     aarch64-darwin =
       let
-        version = "4.1.8.106-37335";
+        version = "4.1.13.59-269627";
         version' = lib.replaceString "-" "_" version;
       in
       {
         inherit version;
         src = fetchurl {
           url = "https://dldir1v6.qq.com/weixin/Universal/Mac/xWeChatMac_universal_${version'}.dmg";
-          hash = "sha256-lygjqWbNqh9fCnhbyfEhnRdKdfQ9MOwPv5unqwJJsvE=";
+          hash = "sha256-45zrtADGKikIfN+BQRMR74Pnmr4VHfXShamWEnOTdOk=";
         };
       };
     # use https://web.archive.org/save to archive the Linux versions

--- a/pkgs/by-name/we/wechat/package.nix
+++ b/pkgs/by-name/we/wechat/package.nix
@@ -42,17 +42,17 @@ let
     # add `if_` at the end of timestamps to avoid toolbar insertion
     # for a more complicated guide, see https://en.wikipedia.org/wiki/Help:Using_the_Wayback_Machine
     aarch64-linux = {
-      version = "4.1.1.4";
+      version = "4.1.1.8";
       src = fetchurl {
-        url = "https://web.archive.org/web/20260311102559if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_arm64.AppImage";
-        hash = "sha256-YlWJxT62tXDaNwYVpsPMC5elFH8fsbI1HjTQn6ePiPo=";
+        url = "https://web.archive.org/web/20260818044444if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_arm64.AppImage";
+        hash = "sha256-RLHhac3wSS1C9rx3GsA07Tp1EzxSf2LLBMyPtrECnUY=";
       };
     };
     x86_64-linux = {
-      version = "4.1.1.4";
+      version = "4.1.1.8";
       src = fetchurl {
-        url = "https://web.archive.org/web/20260311102439if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.AppImage";
-        hash = "sha256-XxAvFnlljqurGPDgRr+DnuCKbdVvgXBPh02DLHY3Oz8=";
+        url = "https://web.archive.org/web/20260818044436if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.AppImage";
+        hash = "sha256-RX26ArkbAxzdRBLu4HT7v/udnQax5Q/Bgi00hw4RSZA=";
       };
     };
   };


### PR DESCRIPTION
Bumps WeChat to the latest, and adds me as a maintainer.

- darwin: `4.1.8.106-37335` -> `4.1.13.59-269627`
- linux: `4.1.1.4` -> `4.1.1.8`

## Supersedes #519235

#519235 has been a draft since 2026-05-12, and targets an older version (`4.1.9.51-38789`). Once this PR is merged, it can be closed.

## Maintainership

WeChat has not been updated here for 4+ months. I am a user of the package, and would like to help keep it up to date.

## Automation/AI disclosure

Claude Code (claude-opus-5) assisted with these commits. I reviewed every change and every verification result, and I am accountable for all of it.

## Verification

- All three hashes were reproduced with `nix store prefetch-file`.
- The darwin URL that `package.nix` builds is byte-for-byte the `<enclosure>` URL in the Sparkle feed, and the feed reports `sparkle:shortVersionString` `4.1.13.59` with `sparkle:version` `269627`.
- The Linux version was read out of the payload, not inferred from the file name: both AppImages carry the string `4.1.1.8` in `opt/wechat/wechat`.
- Both Wayback captures are identical in size to the files currently served from `dldir1v6.qq.com`, so `4.1.1.8` is still the current Linux build.
- `nix-build lib/tests/maintainers.nix` succeeds, and `nixfmt` plus `keep-sorted` report no changes.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
