### PR TITLE
nixos/comfyui: add declarative model management

### DIFF
--- a/nixos/modules/services/misc/comfyui.nix
+++ b/nixos/modules/services/misc/comfyui.nix
@@ -9,6 +9,19 @@ let
 
   # By default a StateDirectory is used; anything else needs its own directory and a hole in the unit's mount namespace.
   isDefaultDataDir = cfg.dataDir == "/var/lib/comfyui";
+
+  modelDrvs = map (m: {
+    inherit m;
+    drv = pkgs.fetchurl (lib.filterAttrs (n: _: n == "name" || n == "url" || n == "hash") m);
+  }) cfg.models;
+
+  modelSymlinks = lib.concatMapStringsSep "\n" (
+    x:
+    lib.concatMapStringsSep "\n" (p: ''
+      mkdir -p ${lib.escapeShellArg "${cfg.dataDir}/models/${p}"}
+      ln -sn ${x.drv} ${lib.escapeShellArg "${cfg.dataDir}/models/${p}/${x.m.name}"}
+    '') x.m.installPaths
+  ) modelDrvs;
 in
 {
   options = {
@@ -67,6 +80,71 @@ in
           Flags set by the module are prepended with `lib.mkBefore`, so any user supplied flag wins over that.
         '';
       };
+
+      models = lib.mkOption {
+        type = lib.types.listOf (
+          lib.types.submodule {
+            options = {
+              name = lib.mkOption {
+                type = lib.types.str;
+                description = ''
+                  The model file name, used as the link name in `models/<installPath>/<name>`,
+                  and as the `fetchurl` derivation name.
+                  It must be unique within the same `<installPath>`,
+                  since the module creates one symlink per model there.
+                '';
+              };
+              url = lib.mkOption {
+                type = lib.types.str;
+                description = ''
+                  The download URL of the model file.
+                  Prefer a pinned-resolve URL (e.g. HuggingFace's `/resolve/<commit>/<file>`) so the hash stays stable.
+                '';
+              };
+              hash = lib.mkOption {
+                type = lib.types.str;
+                example = lib.fakeHash;
+                description = ''
+                  The SRI hash of the model file. Generate it with `nix-prefetch-url <url>`,
+                  or set this to `lib.fakeHash` and build once:
+                  the resulting error message reports the actual hash to replace it with.
+                '';
+              };
+              installPaths = lib.mkOption {
+                # A single directory name is upgraded to a one-element list; lists are merged by concatenation.
+                type = lib.types.coercedTo (lib.types.strMatching "[A-Za-z0-9_-]+") lib.singleton (
+                  lib.types.nonEmptyListOf (lib.types.strMatching "[A-Za-z0-9_-]+")
+                );
+                description = ''
+                  List of target subdirectory names below `models/`, such as `upscale_models`, `loras`, `checkpoints`.
+                  Write bare directory names (the module assembles them into `models/<installPath>`,
+                  one symlink per install path); a single string is also accepted and upgraded to a one-element list.
+                '';
+                example = [ "upscale_models" ];
+              };
+            };
+          }
+        );
+        default = [ ];
+        example = lib.literalExpression ''
+          [ {
+            name = "RealESRGAN_x4plus_anime_6B.pth";
+            url = "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth";
+            hash = "sha256-+HLYN9PJDtLgUie+1xGvVnGm/RyffX6RyRGmHxVemdo=";
+            installPaths = [ "upscale_models" ];
+          } ]
+        '';
+        description = ''
+          ComfyUI models to fetch and symlink into `<dataDir>/models/<installPath>/<name>`,
+          where `<dataDir>` is the directory set by `services.comfyui.dataDir`.
+          Models are fetched at build time via `pkgs.fetchurl` and are not members of the nixpkgs package set,
+          so they never enter the nixpkgs binary cache.
+          Regular files placed manually under `<dataDir>/models/<type>/` are left untouched;
+          only symlinks there are managed (removed and rebuilt at start).
+          A manually placed regular file with the same name as a declared model prevents the service from starting,
+          because the symlink cannot be created over it.
+        '';
+      };
     };
   };
 
@@ -98,6 +176,20 @@ in
             cp --no-preserve=all -r ${cfg.package}/share/comfyui/$d "${cfg.dataDir}/"
           fi
         done
+
+        # Remove all model symlinks pointing into /nix/store,
+        # then rebuild the managed ones below,
+        # so removed declarations no longer leave stale entries.
+        readarray -d "" stale < <(find "${cfg.dataDir}/models" \
+          -type l -print0)
+        for link in "''${stale[@]}"; do
+          if [[ "$(readlink "$link")" == ${lib.escapeShellArg builtins.storeDir}/* ]]; then
+            rm "$link"
+          fi
+        done
+
+        # Rebuild model symlinks
+        ${modelSymlinks}
       '';
 
       serviceConfig = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary

This is the first step of splitting the original single-commit #550095 into a set of incrementally mergeable commits, one feature per commit.

It introduces `services.comfyui.models`, a declarative interface for the model files that every ComfyUI setup currently downloads by hand.

```nix
services.comfyui.models = [{
  name = "RealESRGAN_x4plus_anime_6B.pth";
  url = "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth";
  hash = "sha256-…"; # nix-prefetch-url
  installPaths = [ "upscale_models" ];
}];
```

Models are fetched at build time with pkgs.fetchurl and symlinked into <dataDir>/models/<installPath>/<name> at service start. Each entry is hash-verified and reproducible. They are deliberately not members of the nixpkgs package set, so multi-GB model downloads never enter the official binary cache and stay local to the user's store.

Regular files placed manually under <dataDir>/models/<type>/ are left untouched. At service start, only the managed symlinks (those pointing into the store) are removed and rebuilt, so a removed declaration no longer leaves a stale entry. A manually-placed regular file with the same name as a declared model prevents the service from starting, because the symlink cannot be created over it.

> This PR uses AI-generated PR description.
> I have reviewed the generated text to ensure its accuracy and correctness.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
