### PR TITLE
wezterm: use system openssl

### DIFF
--- a/pkgs/by-name/we/wezterm/headless.nix
+++ b/pkgs/by-name/we/wezterm/headless.nix
@@ -32,4 +32,6 @@ rustPlatform.buildRustPackage {
     install -Dm644 assets/shell-integration/wezterm.sh -t $out/etc/profile.d
     install -Dm644 ${wezterm.passthru.terminfo}/share/terminfo/w/wezterm -t $out/share/terminfo/w
   '';
+
+  env.OPENSSL_NO_VENDOR = 1;
 }

--- a/pkgs/by-name/we/wezterm/package.nix
+++ b/pkgs/by-name/we/wezterm/package.nix
@@ -134,6 +134,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # notifications require that the app bundle be codesigned (beyond the linker-signing that happens automatically for the executable)
   postFixup = lib.optionalString stdenv.hostPlatform.isDarwin "rcodesign sign $out/Applications/WezTerm.app";
 
+  env.OPENSSL_NO_VENDOR = 1;
+
   passthru = {
     # the headless variant is useful when deploying wezterm's mux server on remote severs
     headless = import ./headless.nix {


### PR DESCRIPTION
fixes `nix-build -A pkgsMusl.wezterm`, regressed by https://github.com/wezterm/wezterm/pull/8028

before pull/8028, all linux targets used the system openssl. this is known to work on nixpkgs. the vendored openssl, on the other hand, introduced an implicit build-time dependency on `perl` which we don't provide. this new dependency went undetected precisely because it was specific only to one platform. only by not special-casing platforms can we generalize over them, which is the actual way to support every platform.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
