### PR TITLE
cdebug: init at 0.0.19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21193,6 +21193,12 @@
     github = "norpl";
     githubId = 98636020;
   };
+  northbymidwest = {
+    name = "Michael Bryniarski";
+    email = "michael.bryniarski@gmail.com";
+    github = "northbymidwest";
+    githubId = 856836;
+  };
   nosewings = {
     name = "Nicholas Coltharp";
     email = "coltharpnicholas@gmail.com";

--- a/pkgs/by-name/cd/cdebug/package.nix
+++ b/pkgs/by-name/cd/cdebug/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  buildPackages,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "cdebug";
+  version = "0.0.19";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "iximiuz";
+    repo = "cdebug";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-F2Bsn2dH49Jn72ddYHbCv4FHSF+coXwHTe5x1ITqUTU=";
+  };
+
+  vendorHash = "sha256-cpjpwL9w3PRcIoYYdfHLELMNRS9HjemMgvzWJWkb/7g=";
+
+  # ./ci is a separate Go module holding the Dagger CI pipeline
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-X=main.version=${finalAttrs.version}"
+  ];
+
+  # The only tests are end-to-end tests requiring a running Docker,
+  # containerd, or Kubernetes instance.
+  doCheck = false;
+
+  postInstall =
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/cdebug"
+        else
+          lib.getExe buildPackages.cdebug;
+    in
+    ''
+      installShellCompletion --cmd cdebug \
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Swiss army knife of container debugging";
+    homepage = "https://github.com/iximiuz/cdebug";
+    changelog = "https://github.com/iximiuz/cdebug/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ northbymidwest ];
+    mainProgram = "cdebug";
+  };
+})


### PR DESCRIPTION
Adds [cdebug](https://github.com/iximiuz/cdebug), a container debugging tool that starts a debugger shell in containers or pods lacking a shell, and forwards unpublished or localhost ports from Docker containers. Basically, it spins up a sidecar container with tools you need in it that may not be present in the actual target container (very useful for distroless containers).

This is my first package, so the first commit adds me to the maintainer list.

Disclosure: the package expression and commit messages were drafted with Claude Code (Claude Fable 5.1) and reviewed by me before submission, per the Automation/AI policy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
