### PR TITLE
various: fix meta.mainProgram

### DIFF
--- a/pkgs/by-name/ad/adcskiller/package.nix
+++ b/pkgs/by-name/ad/adcskiller/package.nix
@@ -41,6 +41,6 @@ python3.pkgs.buildPythonApplication {
     homepage = "https://github.com/grimlockx/ADCSKiller";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ exploitoverload ];
-    mainProgram = "ADCSKiller";
+    mainProgram = "adcskiller";
   };
 }

--- a/pkgs/by-name/ca/cano/package.nix
+++ b/pkgs/by-name/ca/cano/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Text Editor Written In C Using ncurses";
     homepage = "https://github.com/Cano-Projects/Cano";
     license = lib.licenses.asl20;
-    mainProgram = "Cano";
+    mainProgram = "cano";
     maintainers = with lib.maintainers; [ sigmanificient ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/e-/e-imzo-manager/package.nix
+++ b/pkgs/by-name/e-/e-imzo-manager/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://git.oss.uzinfocom.uz/xinux/e-imzo-manager";
-    mainProgram = "E-IMZO-Manager";
+    mainProgram = "e-imzo-manager";
     description = "GTK application for managing E-IMZO keys";
     license = lib.licenses.agpl3Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/go/gow/package.nix
+++ b/pkgs/by-name/go/gow/package.nix
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
   meta = {
     homepage = "https://github.com/mitranim/gow";
     description = "Missing watch mode for Go commands";
-    mainProgram = "gox";
+    mainProgram = "gow";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ baloo ];
   };

--- a/pkgs/by-name/ka/karlyriceditor/package.nix
+++ b/pkgs/by-name/ka/karlyriceditor/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       DPDmancul
     ];
-    mainProgram = "karlyricseditor";
+    mainProgram = "karlyriceditor";
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/nt/ntpstat/package.nix
+++ b/pkgs/by-name/nt/ntpstat/package.nix
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Print the ntpd or chronyd synchronisation status";
     homepage = "https://github.com/mlichvar/ntpstat";
     license = lib.licenses.mit;
-    mainProgram = "nptstat";
+    mainProgram = "ntpstat";
     maintainers = with lib.maintainers; [ hzeller ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/nu/nucleiparser/package.nix
+++ b/pkgs/by-name/nu/nucleiparser/package.nix
@@ -34,6 +34,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     changelog = "https://github.com/Sinkmanu/nucleiparser/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
-    mainProgram = "nparser";
+    mainProgram = "nparse";
   };
 })

--- a/pkgs/by-name/si/sidequest/package.nix
+++ b/pkgs/by-name/si/sidequest/package.nix
@@ -150,6 +150,6 @@ buildFHSEnv {
       rvolosatovs
     ];
     platforms = [ "x86_64-linux" ];
-    mainProgram = "SideQuest";
+    mainProgram = "sidequest";
   };
 }

--- a/pkgs/by-name/up/upgrade-assistant/package.nix
+++ b/pkgs/by-name/up/upgrade-assistant/package.nix
@@ -10,7 +10,7 @@ buildDotnetGlobalTool {
     description = "Tool to assist developers in upgrading .NET Framework applications to .NET 6 and beyond";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ khaneliman ];
-    mainProgram = "ugprade-assistant";
+    mainProgram = "upgrade-assistant";
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
These packages had some of their letters transposed, or incorrect capitalization.

Full inventory:
```
/nix/store/nrshw9z9q8yjf8k7ik73nvsmifh7rb9i-adcskiller-0-unstable-2024-05-19/bin/adcskiller
/nix/store/bgyxgs9r6wl5rwmj85fyaqll4xsbv106-cano-0.2.0-alpha/bin/cano
/nix/store/2njq0isjsdc11sbfqfcxcpam3wxxks0g-e-imzo-manager-1.3.0/bin/e-imzo-manager
/nix/store/sszb2rqqmncvy2591pampbf83kf9yhy4-gow-0-unstable-2025-08-13/bin/gow
/nix/store/vgh8c9x8mjb6mwal4kg918hi2djk2v28-karlyriceditor-4.1.2/bin/karlyriceditor
/nix/store/7rwrsaqyqhcban7cpklhdm8z1d91bmlf-ntpstat-0.6/bin/ntpstat
/nix/store/2zxf9mryhvhv8fgzlr22fdq3ap9z3gcb-nucleiparser-0.2.1/bin/nparse
/nix/store/wx0kdihf19slxsma5433w044zkd7rk7a-sidequest-0.10.42/bin/sidequest
/nix/store/7ivhr9985fr83gpg1lzxwyhfjm0ly360-upgrade-assistant-1.0.518/bin/upgrade-assistant
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
