### PR TITLE
python3Packages.torchtitan: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/spmd-types/default.nix
+++ b/pkgs/development/python-modules/spmd-types/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonAtLeast,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  torch,
+
+  # tests
+  expecttest,
+  numpy,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "spmd-types";
+  version = "0.2.5";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "meta-pytorch";
+    repo = "spmd_types";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5N3EcZu9MsQM9Gzow+zt9GY89zd10Y8mpAgS/agGdpM=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        'version = "0.2.0"' \
+        'version = "${finalAttrs.version}"'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    # Not listed in dependencies, but required for `spmd_types` at import time
+    # https://github.com/meta-pytorch/spmd_types/blob/v0.2.5/spmd_types/_collectives.py#L13
+    torch
+  ];
+
+  pythonImportsCheck = [ "spmd_types" ];
+
+  nativeCheckInputs = [
+    expecttest
+    numpy
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Require internet access
+    "test_github_ci"
+
+    # SpmdTypeError not raised (type checking issues with raw distributed collectives)
+    "test_all_gather_into_tensor_wrong_input_context"
+    "test_factory_raw_collective_raises"
+    "test_raw_all_gather_into_tensor_v_to_i"
+    "test_raw_all_gather_into_tensor_wrong_input_type"
+    "test_raw_all_gather_into_tensor_wrong_output_type"
+    "test_raw_reduce_scatter_tensor_p_to_v"
+    "test_raw_reduce_scatter_tensor_wrong_input_type"
+    "test_strict_unknown_group_input_raises"
+    "test_strict_unknown_group_output_raises"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+
+    # Error message mismatch:
+    #   Expected: "'function' object does not support the context manager protocol"
+    #   Actual: "'function' object does not support the context manager protocol (missed __exit__ method)"
+    "test_context_form_rejects_types"
+  ];
+
+  meta = {
+    description = "Type system for distributed training code, based off of JAX's sharding in types, but adapted for the PyTorch ecosystem";
+    homepage = "https://github.com/meta-pytorch/spmd_types";
+    changelog = "https://github.com/meta-pytorch/spmd_types/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/torch-checkpointing/default.nix
+++ b/pkgs/development/python-modules/torch-checkpointing/default.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  numpy,
+  safetensors,
+  torch,
+  typing-extensions,
+
+  # tests
+  expecttest,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torch-checkpointing";
+  version = "0.1.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "meta-pytorch";
+    repo = "torch_checkpointing";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2D9iJVLPKUp5jAnqUHr/cdv0rb+mvWVr8AVkEM3qUjw=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    safetensors
+    torch
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "torch_checkpointing" ];
+
+  nativeCheckInputs = [
+    expecttest
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # RuntimeError: Unexpected response from worker process: Traceback (most recent call last):
+    # TypeError: timedout_subprocess_init_fn() takes 0 positional arguments but 2 were given
+    "test_subprocess_initialization_timeout"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_write_read_multiple_dtypes"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # AttributeError: module 'os' has no attribute 'O_DIRECT'. Did you mean: 'O_CREAT'?
+    "test_async_sequential_saves"
+    "test_atomic_stream_write_preserves_file_after_failure"
+    "test_atomic_stream_write_replaces_file_after_success"
+    "test_checkpoint_write_future_state_dict"
+    "test_checkpoint_write_sync_state_dict"
+    "test_consolidate_hf_safetensors_balances_default_mapping_across_ranks"
+    "test_consolidate_hf_safetensors_buffers_noncontiguous_destination_slices"
+    "test_consolidate_hf_safetensors_can_disable_tensor_metadata_validation"
+    "test_consolidate_hf_safetensors_converts_nested_path_at_hf_boundary"
+    "test_consolidate_hf_safetensors_defaults_single_fqn_to_one_file"
+    "test_consolidate_hf_safetensors_exports_plain_item_from_metadata"
+    "test_consolidate_hf_safetensors_exports_plain_only_item"
+    "test_consolidate_hf_safetensors_ignores_and_logs_mapping_fqns_not_in_checkpoint"
+    "test_consolidate_hf_safetensors_ignores_unused_rank_layout"
+    "test_consolidate_hf_safetensors_reads_contiguous_slices_into_output_buffer"
+    "test_consolidate_hf_safetensors_uses_rank_zero_for_single_output_file"
+    "test_consolidate_hf_safetensors_uses_replicated_metadata_for_plain_tensor"
+    "test_consolidate_hf_safetensors_uses_replicated_metadata_for_plain_tensor"
+    "test_consolidate_hf_safetensors_writes_to_separate_output_dir"
+    "test_load_basic"
+    "test_load_before_save_prepares_metadata"
+    "test_load_full_model_from_partial_checkpoint"
+    "test_load_returns_none"
+    "test_load_with_metadata_manager"
+    "test_make_async_checkpoint_saver"
+    "test_make_sync_checkpoint_saver"
+    "test_make_sync_checkpoint_saver_with_config_first"
+    "test_make_sync_checkpoint_saver_with_custom_config"
+    "test_metadata_cache_invalidation_on_structure_change"
+    "test_metadata_file_written"
+    "test_metadata_sent_once_to_subprocess"
+    "test_mixed_serialization_formats"
+    "test_multiple_saves_reuse_cached_metadata"
+    "test_nested_dict_partial_load"
+    "test_partial_load"
+    "test_save_and_load_basic"
+    "test_shared_memory_tensor_ipc"
+    "test_write_calls_callbacks"
+    "test_write_read_model_state_dict"
+    "test_write_read_multiple_dtypes"
+    "test_write_read_roundtrip_flat_tensors"
+    "test_write_read_roundtrip_list_of_tensors"
+    "test_write_read_roundtrip_nested_partial_target_reports_missing"
+    "test_write_read_roundtrip_nested_tensors_no_target_returns_flat"
+    "test_write_read_roundtrip_nested_tensors_with_target_renests"
+    "test_write_read_with_metadata"
+    "test_write_with_global_file_layout"
+    "test_write_with_layout_extra_keys"
+    "test_write_with_simple_layout"
+    "test_write_without_callbacks"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "High-performance asynchronous checkpointing for PyTorch";
+    homepage = "https://github.com/meta-pytorch/torch_checkpointing";
+    changelog = "https://github.com/meta-pytorch/torch_checkpointing/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/torchtitan/default.nix
+++ b/pkgs/development/python-modules/torchtitan/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -9,27 +10,31 @@
   # dependencies
   datasets,
   einops,
-  fsspec,
   pillow,
+  safetensors,
+  spmd-types,
   tensorboard,
   tokenizers,
-  tomli,
   torch,
+  torch-checkpointing,
   torchdata,
   transformers,
   tyro,
+  wandb,
 
   # tests
   expecttest,
+  flash-linear-attention,
   pytestCheckHook,
   tomli-w,
+  torchvision,
   triton,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "torchtitan";
-  version = "0.2.2";
+  version = "0.3.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -37,32 +42,39 @@ buildPythonPackage (finalAttrs: {
     owner = "pytorch";
     repo = "torchtitan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YXbbqNjmPBIFDRbvagHRIy5ph1pZmSerUxlqaF6f4cY=";
+    hash = "sha256-Wkhx1uGgzCLMiBDS2h7V6NVcaJYcSyDXkZkn2hUbgHE=";
   };
 
   build-system = [
     setuptools
   ];
 
+  pythonRelaxDeps = [
+    "spmd_types"
+  ];
   dependencies = [
     datasets
     einops
-    fsspec
     pillow
+    safetensors
+    spmd-types
     tensorboard
     tokenizers
-    tomli
     torch
+    torch-checkpointing
     torchdata
     tyro
+    wandb
   ];
 
   pythonImportsCheck = [ "torchtitan" ];
 
   nativeCheckInputs = [
     expecttest
+    flash-linear-attention
     pytestCheckHook
     tomli-w
+    torchvision
     transformers
     triton
     writableTmpDirAsHomeHook
@@ -71,6 +83,13 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # Require internet access
     "test_list_files"
+
+    # Require helion, but it is broken at the moment
+    "TestHelionRoPEOverride"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # torch._inductor.exc.InductorError: LoweringException: NotImplementedError: torch.compile on current platform is not supported for CPU.
+    "test_lora_forward"
   ];
 
   disabledTestPaths = [
@@ -80,6 +99,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "PyTorch native platform for training generative AI models";
+    changelog = "https://github.com/pytorch/torchtitan/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/pytorch/torchtitan";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20854,6 +20854,8 @@ self: super: with self; {
 
   torch-c-dlpack-ext = callPackage ../development/python-modules/torch-c-dlpack-ext { };
 
+  torch-checkpointing = callPackage ../development/python-modules/torch-checkpointing { };
+
   torch-cluster = callPackage ../development/python-modules/torch-cluster { };
 
   torch-einops-utils = callPackage ../development/python-modules/torch-einops-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19662,6 +19662,8 @@ self: super: with self; {
 
   splunk-sdk = callPackage ../development/python-modules/splunk-sdk { };
 
+  spmd-types = callPackage ../development/python-modules/spmd-types { };
+
   spotapi = callPackage ../development/python-modules/spotapi { };
 
   spotifyaio = callPackage ../development/python-modules/spotifyaio { };


### PR DESCRIPTION
## Things done

- **python3Packages.spmd-types: init at 0.2.5** (https://github.com/meta-pytorch/spmd_types)
- **python3Packages.torch-checkpointing: init at 0.1.0** (https://github.com/meta-pytorch/torch_checkpointing)
- **python3Packages.torchtitan: 0.2.2 -> 0.3.0** ([Diff](https://github.com/pytorch/torchtitan/compare/v0.2.2...v0.3.0), [Changelog](https://github.com/pytorch/torchtitan/releases/tag/v0.3.0))

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test