### PR TITLE
add colorir and zk-graph-view

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6717,6 +6717,12 @@
     githubId = 14032;
     name = "Daniel Brockman";
   };
+  dccabanas = {
+    email = "dccabanas-dev@tuta.com";
+    github = "dccabanas";
+    githubId = 156211504;
+    name = "Diogo C. Cabanas";
+  };
   DCsunset = {
     email = "DCsunset@protonmail.com";
     github = "DCsunset";

--- a/pkgs/by-name/zk/zk-graph-view/package.nix
+++ b/pkgs/by-name/zk/zk-graph-view/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "zk-graph-view";
+  version = "0.2.0";
+  __structuredAttrs = true;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cyberSapoPerro";
+    repo = "zk-graph-view";
+    rev = "75f8e519a3acd945e4629cc7789e967386473cf2";
+    hash = "sha256-mTC4eABtm3YecWE0euWmmRcN1wta0IaEcP0X0OhruCM=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    numpy
+    pyvis
+    scipy
+    matplotlib
+    colorir
+  ];
+
+  # typing is a deprecated dependency, as it is now part of the standard library.
+  # needs to be fixed upstream
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"typing",' ""
+  '';
+
+  meta = {
+    description = "Interactive visualization of Zettelkasten graphs generated with zk";
+    homepage = "https://github.com/cyberSapoPerro/zk-graph-view";
+    license = lib.licenses.mit;
+    mainProgram = "zk-graph-view";
+    maintainers = with lib.maintainers; [
+      dccabanas
+    ];
+  };
+}

--- a/pkgs/development/python-modules/colorir/default.nix
+++ b/pkgs/development/python-modules/colorir/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # build-system
+  setuptools,
+
+  # dependencies
+  colormath,
+  ipython,
+  kivy,
+  matplotlib,
+  numpy,
+  pillow,
+  plotly,
+  pygame,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "colorir";
+  version = "2.1.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "aleferna12";
+    repo = "colorir";
+    rev = "34d45e10ca2b575ac2fdcdadc53beed1ffd693c7";
+    hash = "sha256-mlsbcLYUl7iiCz33rTmMfld3LDZzBWM2mSIM9M18hDM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    colormath
+    ipython
+    kivy
+    matplotlib
+    numpy
+    pillow
+    plotly
+    pygame
+  ];
+
+  pythonImportsCheck = [
+    "colorir"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A python package for creation and management of color palettes";
+    homepage = "https://github.com/aleferna12/colorir";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dccabanas ];
+    mainProgram = "colorir";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3449,6 +3449,8 @@ self: super: with self; {
 
   colorful = callPackage ../development/python-modules/colorful { };
 
+  colorir = callPackage ../development/python-modules/colorir { };
+
   colorlog = callPackage ../development/python-modules/colorlog { };
 
   colorlover = callPackage ../development/python-modules/colorlover { };


### PR DESCRIPTION
Adds the [colorir](https://github.com/aleferna12/colorir) python package, which is a dependency of the, also added, [zk-graph-view](https://github.com/cyberSapoPerro/zk-graph-view) cli tool. The latter is a nice addition to the already present `zk` nixpkg.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
