### PR TITLE
typescript-go: switch to noembed build and bundle libs

### DIFF
--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -28,6 +28,13 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-q6dMb2ab4uZ3GTrcA7v2JzfmOM+ZzBcJN6gKOpLfM/k=";
 
+  tags = [
+    # Prevent LSP issues. In embed mode, "Go to Definition" fails for built-in types:
+    #   - https://github.com/microsoft/typescript-go/pull/4197
+    #   - https://github.com/microsoft/typescript-go/pull/3840
+    "noembed"
+  ];
+
   ldflags = [
     "-s"
     "-w"
@@ -39,8 +46,16 @@ buildGoModule (finalAttrs: {
     "cmd/tsgo"
   ];
 
+  # When built with the "noembed" tag, the executable must be under "lib/${pname}/" to resolve its paths.
   postInstall = ''
-    ln -s "$out/bin/tsgo" "$out/bin/tsc"
+    lib_dir="$out/lib/${finalAttrs.pname}"
+    mkdir -p "$lib_dir"
+    cp -r internal/bundled/libs/. "$lib_dir"
+
+    mv "$out/bin/tsgo" "$lib_dir/tsc"
+
+    ln -s "$lib_dir/tsc" "$out/bin/tsc"
+    ln -s "$lib_dir/tsc" "$out/bin/tsgo"
   '';
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The current package works as a compiler, and the "Go to Definition" LSP feature also works for user-defined or npm-installed types.
However, "Go to Definition" fails for built-in types. I confirmed this behavior in helix-editor with the following `slice`.

```typescript
const s = "string";
s.slice(0, 1);
```

```
2026-09-04T16:18:08.708 helix_term::commands::lsp [WARN] discarding invalid or unsupported URI: unsupported scheme 'bundled' in URL bundled:///libs/lib.es5.d.ts
```

This seems to be the same issue as reported in some upstream PRs.

 - https://github.com/microsoft/typescript-go/pull/4197
 - https://github.com/microsoft/typescript-go/pull/3840

@xuanduc987 @RyanCallahan312 Thanks for the investigation!

This PR might be a preparation part of #558890.
cc: @GIP2000

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
