### PR TITLE
nixos/radicle-ci-broker: add setting logLevel

### DIFF
--- a/nixos/modules/services/continuous-integration/radicle/ci-broker.nix
+++ b/nixos/modules/services/continuous-integration/radicle/ci-broker.nix
@@ -56,6 +56,16 @@ in
       default = "/var/log/radicle-ci";
     };
 
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "info";
+      description = ''
+        Log level for radicle-ci-broker, set via the `RUST_LOG` environment variable. See
+        [RUST_LOG](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)
+        for the format.
+      '';
+    };
+
     enableHardening = lib.mkEnableOption "systemd hardening" // {
       default = true;
       example = false;
@@ -191,7 +201,10 @@ in
       bindsTo = [ "radicle-node.service" ];
       after = [ "radicle-node.service" ];
 
-      environment = { inherit RAD_HOME; };
+      environment = {
+        inherit RAD_HOME;
+        RUST_LOG = cfg.logLevel;
+      };
 
       serviceConfig = lib.mkMerge [
         {


### PR DESCRIPTION
Currently, the log level of the radicle ci broker can not be set easily and the default log level being `trace` is quite spammy.
Adding the `logLevel` setting allows easy adjustment of the log level.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
