### PR TITLE
gleam: move erlang to nativeCheckInputs

### DIFF
--- a/pkgs/by-name/gl/gleam/package.nix
+++ b/pkgs/by-name/gl/gleam/package.nix
@@ -30,12 +30,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    beamPackages.erlang
   ];
 
   nativeCheckInputs = [
     # used by several tests
     git
+
+    # erlang runtime is used for integration tests
+    beamPackages.erlang
 
     # js runtimes used for integration tests
     nodejs


### PR DESCRIPTION
Building Gleam only requires Erlang for tests, not at build time. By moving Erlang from `nativeBuildInputs` to `nativeCheckInputs` we avoid pulling in a substantial dependency unless we actually need it. This should have no effect on the runtime behaviour of the package.

Evidence Erlang is not required for build:
- The official [build documentation](https://gleam.run/install/linux/gleam/source/) does not mention Erlang
- Gleam's own CI for releases build Gleam before installing Erlang, which appears to be used only to run code with the built binary. See lines 71 and 193 of the [build_release action](https://github.com/gleam-lang/gleam/blob/fd41dd06b5eac97b559ee875dc3602d92cc8a6a8/.github/actions/build-release/action.yml) (ignore the step name at line 71, it appears to be incorrect)
- It builds successfully and the tests pass with this change applied.

It may also be worthwhile to replace the `beamPackages.erlang` dependency with `beamMinimalPackages.erlang` since we probably don't need Erlang's `wxWidgets` graphical support just to run some tests, but I haven't confirmed that and it is beyond the scope of this PR.

Motivated by the way building a simple Gleam project lead to me compiling `webkitgtk` unnecessarily :/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test