### PR TITLE
python3Packages.torchao: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
   replaceVars,
 
   # build-system
@@ -21,6 +20,7 @@
 
   # tests
   bitsandbytes,
+  datasets,
   expecttest,
   fire,
   pytest-xdist,
@@ -43,19 +43,15 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "torchao";
-  version = "0.17.0";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "ao";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Mry6jsZKkoC8dq3fYNsRyGbL4+S8ZYuHpkETNDy5qsg=";
+    hash = "sha256-szPyGqvvXSboDRcsLKAkXSBI+Kgx4Fganw/SlONimcY=";
   };
-
-  # AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting
-  # new attributes. Did you mean: '__reduce__'?
-  disabled = pythonAtLeast "3.14";
 
   patches = lib.optionals isAarch64Darwin [
     ./use-system-cpuinfo.patch
@@ -96,6 +92,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     bitsandbytes
+    datasets
     expecttest
     fire
     parameterized
@@ -302,10 +299,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTestPaths = [
-    # ImportError: cannot import name 'ToyLinearModel' from 'torchao.testing.model_architectures'
-    "benchmarks/microbenchmarks/test/test_benchmark_profiler.py"
-    "benchmarks/microbenchmarks/test/test_utils.py"
-
     # ImportError: cannot import name 'fp8_blockwise_weight_dequant' from 'torchao.kernel.blockwise_quantization'
     "test/kernel/test_blockwise_triton.py"
   ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pytorch/ao/compare/v0.17.0...v0.18.0
Changelog: https://github.com/pytorch/ao/releases/tag/v0.18.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
