### PR TITLE
keycloakPlugins.keycloak-vikunja-team-mapper: init at 0-unstable-2026-08-11

### DIFF
--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -35,6 +35,7 @@
   keycloak-remember-me-authenticator = callPackage ./keycloak-remember-me-authenticator { };
   keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth { };
   keycloak-secrets-vault-provider = callPackage ./keycloak-secrets-vault-provider { };
+  keycloak-vikunja-team-mapper = callPackage ./keycloak-vikunja-team-mapper { };
 
   # junixsocket provides Unix domain socket support for JDBC connections,
   # which is required for connecting to PostgreSQL via Unix socket.

--- a/pkgs/by-name/ke/keycloak/keycloak-vikunja-team-mapper/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-vikunja-team-mapper/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  unstableGitUpdater,
+  gradle_8,
+}:
+
+let
+  gradle = gradle_8;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "keycloak-vikunja-team-mapper";
+  version = "0-unstable-2026-08-11";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    domain = "rechenknecht.net";
+    owner = "giz/keycloak";
+    repo = "vikunja-team-mapper";
+    rev = "d2e5ccc12c44ebfb2635bf55d6c7f5f5bf563930";
+    hash = "sha256-vhIZF47GE/KjROeT1BfXpGHIGztoBTq7CtitHAukR3s=";
+  };
+
+  nativeBuildInputs = [
+    gradle
+  ];
+
+  mitmCache = gradle.fetchDeps {
+    pkg = finalAttrs.finalPackage;
+    data = ./deps.json;
+  };
+
+  # this is required for using mitm-cache on Darwin
+  __darwinAllowLocalNetworking = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 -t "$out" build/libs/vikunja-team-mapper-1.0.0.jar
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Map Keycloak user groups to Vikunja teams";
+    homepage = "https://rechenknecht.net/giz/keycloak/vikunja-team-mapper";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ niklaskorz ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # mitm cache
+    ];
+  };
+})

--- a/pkgs/by-name/ke/keycloak/keycloak-vikunja-team-mapper/deps.json
+++ b/pkgs/by-name/ke/keycloak/keycloak-vikunja-team-mapper/deps.json
@@ -1,0 +1,1285 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://repo.maven.apache.org/maven2": {
+  "com/apicatalog#titanium-json-ld/1.3.3": {
+   "jar": "sha256-d53h2I8XNIbw6p8bS3d5lwrCGnrUmyoDcPX5m23+9yw=",
+   "pom": "sha256-VM++dai2e/vf/1mf+be016mun7h1GQHKu9f1+OTbxL0="
+  },
+  "com/fasterxml#oss-parent/56": {
+   "pom": "sha256-/UkfeIV0JBBtLj1gW815m1PTGlZc3IaEY8p+h120WlA="
+  },
+  "com/fasterxml#oss-parent/65": {
+   "pom": "sha256-2wuaUmqeMDxjuptYSWicYfs4kkf6cjEFS5DgvwC0MR4="
+  },
+  "com/fasterxml#oss-parent/69": {
+   "pom": "sha256-OFbVhKqhyOM86UxnJE9x9vcFOKJZ/+jngXYbn6qth18="
+  },
+  "com/fasterxml/jackson#jackson-base/2.19.0": {
+   "pom": "sha256-Noz4ykJkRni737F6sUfJC8QyWaWZUJfD8cT7au9Mdcg="
+  },
+  "com/fasterxml/jackson#jackson-base/2.19.2": {
+   "pom": "sha256-/779Z5U5lKd12QJsscFvkrqB0cHBMX7oorma4AnSYUM="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.16.1": {
+   "pom": "sha256-adi/myp9QsnPHXCtgr5C9qxv14iRim4ddXkuzcwRegs="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.19.0": {
+   "pom": "sha256-sR/LPvM6wH5oDObYXxfELWoz2waG+6z68OQ0j8Y5cbI="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.19.2": {
+   "pom": "sha256-IgBr5w/QGAmemcbCesCYIyDzoPPCzgU8VXA1eaXuowM="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.16": {
+   "pom": "sha256-i/YUKBIUiiq/aFCycvCvTD2P8RIe1gTEAvPzjJ5lRqs="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.19": {
+   "pom": "sha256-bNk0tNFdfz7hONl7I8y4Biqd5CJX7YelVs7k1NvvWxo="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.19.3": {
+   "pom": "sha256-I9GGyNjNBgFdAixxDHFUI9Zg1J4pc7FYcLApzCYBhoI="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.19.2": {
+   "jar": "sha256-5RZ0OjFtz4PFcv/Jy26MXowTSIDIxRVbAvezTpxdw88=",
+   "module": "sha256-MZtf0wd2wFk8yNxajX4ITkuQcJpDUGQYQqu9WfyByBU=",
+   "pom": "sha256-SVAWGuCtZsaze8Ku0S0hxleeF3ltv86Yixm40MIjpck="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.19.2": {
+   "jar": "sha256-qnfq8pKTqGjEc3IZT3xSh9d9k3CwTqJdP//B5JBLWIA=",
+   "module": "sha256-Ua8uZ3g6XXJETeajB8jj7ZMAklbNJ+ghkVVZohZcCUI=",
+   "pom": "sha256-gfatIwlG88U9gYwZ/l7hEcH6MxuRXEvajQGC5rT/1lA="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.19.2": {
+   "jar": "sha256-ChvU6bDWcOYy1A7oxiWtN2IzUC8DwvWIm66pXQJbR6c=",
+   "module": "sha256-xgFVg0SRj0CDS7bVg4EepsiDvwaigXmkx04voYswbGg=",
+   "pom": "sha256-2KebdQK2m/JQaEwZCpiCOJImaG1dlikGdW2BzVskO4I="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.19.0": {
+   "module": "sha256-qLWWRYzQPkdOAwOUJpAQeKzOtwMSau5jaUo0HpbWXoo=",
+   "pom": "sha256-p8eH3uN+tGj3MxtELbwPFUDxQnRveVmBu7YkgRY56K8="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.19.2": {
+   "jar": "sha256-RQ268UVD98LoE4cKousG/Nu3kxbYCzDMT32oMfNYLPM=",
+   "module": "sha256-tEgT9KJg3WOlW7Xcc9OsavHi+RwzrD8FfebYE6EiXeA=",
+   "pom": "sha256-o4vv9jT/C41ZaXIiP2tD7UtWatoxSBB5rwj9Hxn/mLs="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.19.2": {
+   "jar": "sha256-gKIT59mYJEkiq3vPCTjqA+t4aOiOLQWoQHxiKMiFo34=",
+   "module": "sha256-bpyu0tDwqryZNnVPNzN+Dxc2MdahWxjE2QRpVtZ1U24=",
+   "pom": "sha256-1UeZ1Ba/pn91wvGU3IgKE1dPvVXmQCqH45NImPebgM4="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.19.0": {
+   "pom": "sha256-D8yK4bXILDgeQPw9uULCgMHMSECz5sDekmOu9v4D0Zg="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.19.2": {
+   "pom": "sha256-z8A2j768TpMUNzf2pDHWjpLPPDXMlFmLo1U+1wYYEQk="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.19.2": {
+   "pom": "sha256-F5LLcfGWGg/nXi21/CckZovisBQX8LzHOee1AOIoFAE="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.19.2": {
+   "jar": "sha256-YFX+8QdW6L0bDogHqh2IEzjGPKldWSceHaSSK5oXWB4=",
+   "module": "sha256-cJMXXvltnjxoFL59n5uQeZzGsd/JDqi8ZUVP9byleEo=",
+   "pom": "sha256-u2kaYgtZPgNo7zrOifnc1dY3VtXlvAXdyay3ih/Ny+c="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.19.2": {
+   "jar": "sha256-lwn0Pg+lYlYz7mbbbAePsejHygIJJpa6lep4Xb8PpqE=",
+   "module": "sha256-HNFClAh9xmpIvf8+t1CZyHsK0paspR6AgMuc3yCRF6E=",
+   "pom": "sha256-sa5Nojzw/imhXWUC4XcpfAssYp3Nlpy2RFfVVLZacS8="
+  },
+  "com/fasterxml/jackson/jakarta/rs#jackson-jakarta-rs-base/2.19.2": {
+   "jar": "sha256-F/5iz/a/euqvdBNgCa9cS0mVSIxTe7bpKPcO2s7I4LA=",
+   "module": "sha256-1+OmfyY5twuE4/7bwZqTZKfMClnh7rl5lihDoARyjKg=",
+   "pom": "sha256-cuutsSEGvT1wp4JQT6g1ZL/R7oZHn5ZWPYMrnWt96rs="
+  },
+  "com/fasterxml/jackson/jakarta/rs#jackson-jakarta-rs-providers/2.19.2": {
+   "pom": "sha256-B2S/Gps0yugUzz8hO2oCKSBV4P0dxXOuixNfE/xre2M="
+  },
+  "com/fasterxml/jackson/jakarta/rs#jackson-jakarta-rs-yaml-provider/2.19.2": {
+   "jar": "sha256-zWNZeK73fG8NxbLTOhKhOo8HDmOjSVt9bCxrJRIwoSA=",
+   "module": "sha256-LLWfJRGJTBuWIQyhhK8LGvrXD+4HLMIfSo2OmEQe9wo=",
+   "pom": "sha256-JEYduYSE7ns8yTkLEKZyXfXp8JfN0XXnlwdnHCAmRcU="
+  },
+  "com/fasterxml/jackson/module#jackson-module-jakarta-xmlbind-annotations/2.19.2": {
+   "jar": "sha256-u69EflB7FOb/s/dVxLHmD1I5nHPzM4BfNK+6Z+8XWSs=",
+   "module": "sha256-HhkceCnIbeQvm7s6uph3Gdgcs49aDZdx5nQFHka3EDI=",
+   "pom": "sha256-mRKux2ADWIe3cb5/imHAWPOSt6WClRANzzqay8nAKec="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-base/2.19.2": {
+   "pom": "sha256-V6S5QhVKz4VVeikvO4O3cnMAfjxwJak5UDScL9GoYVo="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.19.2": {
+   "pom": "sha256-o8wywUW5Yr45UE+FNsrGISTry1rVAy2TC8ck/flOgqQ="
+  },
+  "com/github/ben-manes/caffeine#caffeine/3.1.8": {
+   "jar": "sha256-fdFfnfG+I4/6o2fOb1VnN6iAMd5ClNrRju9XxHTd8dM=",
+   "module": "sha256-SazUz4G+Hk6GgFTw00/PXHdWCEWVBzB86HjNuk/dTYQ=",
+   "pom": "sha256-Rj9PiWOKroLGVLPyhC6NA/eg1IGUxCYEbdnJXOBjJu4="
+  },
+  "com/github/jai-imageio#jai-imageio-core/1.4.0": {
+   "jar": "sha256-itPGjp7/+xCsh/+LxYmt9ksEpynFGUwHnv0GQ2B/1yo=",
+   "pom": "sha256-Ac0LjPRGoe4kVuyeg8Q11gRH0G6fVJBMTm/sCPfO8qw="
+  },
+  "com/github/ua-parser#uap-java/1.6.1": {
+   "jar": "sha256-/z4eudgH34vBl5UN5dVV0YkqfO7Q/f91s+sqp4u+UcU=",
+   "pom": "sha256-ZnXK/DBSoJQXycUnGv5owrSrpuu8ya8FUfh10k6r6ck="
+  },
+  "com/google/api/grpc#proto-google-common-protos/2.29.0": {
+   "jar": "sha256-7px1HwaxEukrN/deT3OhfQPvLDMCxujZhq28xyG2PLA=",
+   "pom": "sha256-buHqFliOzsn79BLXrRulV7xFbOCXUg3uXkzQiuYcJ4Q="
+  },
+  "com/google/code/gson#gson-parent/2.11.0": {
+   "pom": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
+  },
+  "com/google/code/gson#gson/2.11.0": {
+   "jar": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s=",
+   "pom": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
+  },
+  "com/google/errorprone#error_prone_annotations/2.30.0": {
+   "jar": "sha256-FE86771uJ9rsVdN1OyxrE8Gv2vDPBIFs21ZFiO2S8b0=",
+   "pom": "sha256-9xOEnCOzSVPoVFZdzoqnlcrgwUFmEbcgwhRhMix5X4Y="
+  },
+  "com/google/errorprone#error_prone_parent/2.30.0": {
+   "pom": "sha256-Xog0zMDl7Qxy8wbCULUY5q0Q0HWpt7kQz2lcuh7gKi0="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#failureaccess/1.0.2": {
+   "jar": "sha256-io+Bz5s1nj9t+mkaHndphcBh7y8iPJssgHU+G0WOgGQ=",
+   "pom": "sha256-GevG9L207bs9B7bumU+Ea1TvKVWCqbVjRxn/qfMdA7I="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/32.1.2-jre": {
+   "pom": "sha256-iOnLAHM1q1/bMUpuPJh3NOwjCMmgY/90fHRpGJ0Kkr8="
+  },
+  "com/google/guava#guava-parent/32.1.3-android": {
+   "pom": "sha256-QfwmRk+6irC1W0AmdrRTaeCqqbqOClpd7IBFKQisl+E="
+  },
+  "com/google/guava#guava-parent/33.3.1-android": {
+   "pom": "sha256-bhGYbqclC1H4RxV+Lck38yowaATfzgAHpegd25uVxXk="
+  },
+  "com/google/guava#guava/32.1.2-jre": {
+   "module": "sha256-5Azwhc7QWrGPnJTnx7wZfhzbaVvJOa/DRKskwUFNbH4=",
+   "pom": "sha256-PyCFltceCDmyU6SQr0mjbvf9tFG+kKQqsd+els/TFmA="
+  },
+  "com/google/guava#guava/32.1.3-android": {
+   "module": "sha256-+Kh873LA6AJ6b648vfAHKiQc5tjnYPlucIe3QqZgWmE=",
+   "pom": "sha256-SfgFUBXoaHd0z9iTm9aDx08J1rJLzA/CaEC82XoIhms="
+  },
+  "com/google/guava#guava/32.1.3-jre": {
+   "jar": "sha256-bU4rWhGKq2Lm5eKdGFoCJO7YLIXECsPTPPBKJww7N0Q="
+  },
+  "com/google/guava#guava/33.3.1-android": {
+   "module": "sha256-aXFhTd7uAD5U0racawyUzopbXrqYDRZFXIHfkImnrLc=",
+   "pom": "sha256-xyjbbycFyj6mo88s8SYNvv86RSQkmhsbkA7c/p1yFC8="
+  },
+  "com/google/guava#guava/33.3.1-jre": {
+   "jar": "sha256-S/Dixa+ORSXJbo/eF6T3MH+X+EePEcTI41oOMpiuTpA="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/j2objc#j2objc-annotations/2.8": {
+   "jar": "sha256-8CqV+hpele2z7YWf0Pt99wnRIaNSkO/4t03OKrf01u0=",
+   "pom": "sha256-N/h3mLGDhRE8kYv6nhJ2/lBzXvj6hJtYAMUZ1U2/Efg="
+  },
+  "com/google/j2objc#j2objc-annotations/3.0.0": {
+   "jar": "sha256-iCQVc0Z93KRP/U10qgTCu/0Rv3wX4MNCyUyd56cKfGQ=",
+   "pom": "sha256-I7PQOeForYndEUaY5t1744P0osV3uId9gsc6ZRXnShc="
+  },
+  "com/google/protobuf#protobuf-bom/3.25.1": {
+   "pom": "sha256-Q3hpcMGst8EZyWH1PqhWpLwL9r8M7/qwrSqE8mLPFlQ="
+  },
+  "com/google/protobuf#protobuf-java/3.25.1": {
+   "jar": "sha256-SKjlihqPgu/xQaejiNON/nfXpI1eV8kGbuN/GRR+IN8=",
+   "pom": "sha256-P/SnjWBeHWmR5RXFUDcmy0gEK4dOpVSkvIqHrp+Rv5U="
+  },
+  "com/google/protobuf#protobuf-parent/3.25.1": {
+   "pom": "sha256-zRvoNznwNkYrEptlN1n6hov61D+5U5xefR3irD2F3Oo="
+  },
+  "com/google/zxing#core/3.4.0": {
+   "jar": "sha256-ZQBIBqZpI0xpj74HVSWBADdfsB/pO1OEVfOQNxPUpQ0=",
+   "pom": "sha256-CzqlUO6bM9qDUwx7POCYVDQyNZew+ZXZrqEkbfeweDI="
+  },
+  "com/google/zxing#javase/3.4.0": {
+   "jar": "sha256-eu73RqVE7/zZ5JkhTZ8xXmnDqDXnyBq/twO+efhZptc=",
+   "pom": "sha256-zAE4wjA1fmStdZpAwONiuog3yf1PSr5kw1uz/VKhCno="
+  },
+  "com/google/zxing#zxing-parent/3.4.0": {
+   "pom": "sha256-6hqNZZr4nC3dRyfettWvEkddEsi4Rd/J11AT0I/xE+8="
+  },
+  "com/googlecode/owasp-java-html-sanitizer#java10-shim/20260101.1": {
+   "jar": "sha256-nCC++8cAOvTe45cP0fnQHyUtK+mDUjVQkDhBn8to2h0=",
+   "pom": "sha256-AkJQ+u/aQWrhRxG64pkHes+SfHIy5JG4SlIjUNebpck="
+  },
+  "com/googlecode/owasp-java-html-sanitizer#java8-shim/20260101.1": {
+   "jar": "sha256-tdWxCv0qsYmb2ahZ0de1m0nkONqxinyV2FrHHBMpkyo=",
+   "pom": "sha256-1DL8KSVzoBYOU/IZAupmBMuST25eGW3J4G+Q5z25uSk="
+  },
+  "com/googlecode/owasp-java-html-sanitizer#owasp-java-html-sanitizer/20260101.1": {
+   "jar": "sha256-8xPx1q6Emhj1Ei2++BJtw3nshs7y3PgZK0eBcMfq8VU=",
+   "pom": "sha256-LzARwOiu+gAb+dsZ+Mx+ts7bcvnoA/7wKGLvWlVa71s="
+  },
+  "com/googlecode/owasp-java-html-sanitizer#parent/20260101.1": {
+   "pom": "sha256-nk08oMDaG75sAV7RenMI6GNFrx2/BGBtZ9hx5CI7vMc="
+  },
+  "com/sun/activation#all/2.0.1": {
+   "pom": "sha256-ZI1dYrYVP0LxkM7S1ucMHmRCVQyc/rZvvuCWHGYWssw="
+  },
+  "com/sun/activation#jakarta.activation/2.0.1": {
+   "jar": "sha256-ueJLfdbgdJVWLqllMb4xMMltuk144d/Yitu96/QzKHE=",
+   "pom": "sha256-igaFktsI5oUyBP8LYlowFDjjw26l8a5lur/tIIUCeBo="
+  },
+  "com/webauthn4j#webauthn4j-core/0.29.3.RELEASE": {
+   "jar": "sha256-KwcixSJzMd6gy6hVyM06C0wu+d1SKN3HP7g9wV4ado4=",
+   "module": "sha256-LvUJKU66sFQfwNJLBbuUReNtMbveczzXFFsUtKujeYg=",
+   "pom": "sha256-mRqiEmv00c88ly/MiIKgb0F2Q17FlC1CT2+Ou6GGp2A="
+  },
+  "commons-codec#commons-codec/1.11": {
+   "jar": "sha256-5ZnVMY6Xqkj0ITaikn5t+k6Igd/w5sjjEJ3bv/Ude30=",
+   "pom": "sha256-wecUDR3qj981KLwePFRErAtUEpcxH0X5gGwhPsPumhA="
+  },
+  "io/grpc#grpc-api/1.65.0": {
+   "pom": "sha256-JD7d8N/78ktOlxt4m6NO0zUb0X85Y3k8JaiNJv98dDk="
+  },
+  "io/grpc#grpc-api/1.69.1": {
+   "jar": "sha256-qNPW3McfOrYT1miEIoK0iL3ZPT6ZoO9dyn7ub6c0woM=",
+   "pom": "sha256-vq8uR11cRdBjTU0yS/hNsqjWqSkilx5vfcJ+hRxCkH8="
+  },
+  "io/grpc#grpc-context/1.69.1": {
+   "jar": "sha256-Re+VuMFYqLW906y2e55oLvJUFLsUj0iOyEdDirZHFdQ=",
+   "pom": "sha256-beKbzqslob0L4R7qhGjQ4/HAxHbQpTMhW0/eHIKEtXA="
+  },
+  "io/grpc#grpc-core/1.69.1": {
+   "jar": "sha256-UTUsra7L+aSkqkLZP28fxyjx/QGwUWgDg+0J5WMf+9A=",
+   "pom": "sha256-loCY9KhFG7zT17iMaoq1t6dO+A397npgUvNS//eDssU="
+  },
+  "io/grpc#grpc-netty/1.65.0": {
+   "jar": "sha256-zukwf1gJhY/XtLwR1Sxqz/jamJ3yiCItDGir7Qm6SI0=",
+   "pom": "sha256-4WrvLiECuNN5SvCh9eEZmQFohMkR1LFeBJBmcp+u3gs="
+  },
+  "io/grpc#grpc-protobuf-lite/1.65.0": {
+   "jar": "sha256-lEZ52Y6pLvVkx+zOMKtpJRLcL/rllvTpqJQRMq+TcOg=",
+   "pom": "sha256-OslNjEdH7PHig5nrPaapmCJg/eAOV5Y/C6PQ3YdqFbg="
+  },
+  "io/grpc#grpc-protobuf/1.65.0": {
+   "jar": "sha256-r2l19WnK5PBaY2/cFXXi7ufMIJmrvFCvSKrGhJA0hD0=",
+   "pom": "sha256-3M03CJmNVXPgzZAWE0iNloomfnpXVTrrT32Hwh5dF4I="
+  },
+  "io/grpc#grpc-stub/1.65.0": {
+   "jar": "sha256-oZ+kxWQ060tyDt7JrdOJqKRCe/kYGMP0dwVxIS5b7iQ=",
+   "pom": "sha256-lzgLq7iK4WhKL8aUCfgkXn/507Myla47K6WuwOpWdXg="
+  },
+  "io/grpc#grpc-util/1.65.0": {
+   "jar": "sha256-aVtu9QQdECm9RyQHyMvdI11S+zJ0DZq8l64GDKggRxo=",
+   "pom": "sha256-iBzI5CKWjAreK+XJmBLu/82qMein8Sf9cquJgQgpgGE="
+  },
+  "io/netty#netty-bom/4.1.125.Final": {
+   "pom": "sha256-xKF8K1VcdW41xsJQz1dSjD0uyGAeReAOHEXTofHPAhY="
+  },
+  "io/netty#netty-bom/4.1.130.Final": {
+   "pom": "sha256-dqNTovsxFLYpJzr1qWcHRxN2khV8ppCUw43CNxPXCn4="
+  },
+  "io/netty#netty-buffer/4.1.130.Final": {
+   "jar": "sha256-AKUitn6jXLe03Zzyf4XGxY9eMGeFqgRTAuX2stSUSoc=",
+   "pom": "sha256-jaQLJhZvB3hj+MtuXbw10TURHGrVKknijzCrJnciqlM="
+  },
+  "io/netty#netty-codec-dns/4.1.130.Final": {
+   "jar": "sha256-gUv552SiqeTXrOcY9mHh8Z0qLMNbLTrABl1DBs/sNK0=",
+   "pom": "sha256-ldMIiSFrr3g8yiuvNHC2x8/y9A5HDHyUgTg1qOwbUv8="
+  },
+  "io/netty#netty-codec-haproxy/4.1.130.Final": {
+   "jar": "sha256-cZXOnU+wxGYXP+f7lWLGw+OA41EaIjVdFcFto0nGqjM=",
+   "pom": "sha256-BrtC9iJl0V1FFfncBYet+nlrFBmLDUqYcZhmG6gwE1E="
+  },
+  "io/netty#netty-codec-http/4.1.130.Final": {
+   "jar": "sha256-W2rdwd97M5ehk71lRKi/2xjsrJn9E77k7HWxeBpmTl4=",
+   "pom": "sha256-jbbaoGlvpMM9oWqFquh6y/5CO0bgXMAfQDVhObf4r4o="
+  },
+  "io/netty#netty-codec-http2/4.1.130.Final": {
+   "jar": "sha256-+P/bVQNo/V3ufH8Tk/pJVSUi8oDtjelq6/QmnKsNyPM=",
+   "pom": "sha256-PgUZZtGWr8BGhrrgs7lJlCiq5Peje7iJqGwc50m75Bg="
+  },
+  "io/netty#netty-codec-socks/4.1.130.Final": {
+   "jar": "sha256-m4+LL6slZBGTbd9TWMPraxhMSep7iwH0DUc/qU7XuSw=",
+   "pom": "sha256-8icDackWghoyGoFZ8Grv82Exufz9QvHfJDLqLw9QaH0="
+  },
+  "io/netty#netty-codec/4.1.130.Final": {
+   "jar": "sha256-UmNrwpvWISC5e75dHSHqubHLK++O+7VNIiHF8/oI2M0=",
+   "pom": "sha256-rZKn6ObQoFiFEMSUSkx+BzGlFdrZASC9dr38A+UzTmk="
+  },
+  "io/netty#netty-common/4.1.130.Final": {
+   "jar": "sha256-U5IfKN1aNSsb7Q4cvMVNAT3GD/6+rpsrHlPqvvMX5YE=",
+   "pom": "sha256-WIF1EzWJM3tbOtDZDFiyZ9EF0E4cDfyNZd07FYb3kDo="
+  },
+  "io/netty#netty-handler-proxy/4.1.130.Final": {
+   "jar": "sha256-M2VoddAAFYfupKl3jPIkK0GLyIftA7LTfvOWngt9O14=",
+   "pom": "sha256-yUlBQhCdbldb+La30IMs2g5UEWvoyHTMeZIhGvZDLUk="
+  },
+  "io/netty#netty-handler/4.1.130.Final": {
+   "jar": "sha256-mMeOwYfKMKS5d1v29jL1yZKdtr8Gpg5pcflFgTiAyg8=",
+   "pom": "sha256-WCbi2Q+csalMhnGlG7+zceZRN0Ur9XAP2Ld+REbo7c8="
+  },
+  "io/netty#netty-parent/4.1.130.Final": {
+   "pom": "sha256-/U4yGCQmXIdjUo79HG9Wy5Gz5iVW2OJpjcxoHPQeoJw="
+  },
+  "io/netty#netty-resolver-dns/4.1.130.Final": {
+   "jar": "sha256-u8TVzhgaIyKUG0gLG78B+qdSVO7k06jhRjFzFfYagoM=",
+   "pom": "sha256-ass9TqcHQYapt8zJ4nEeFrmQZo1/5RqbkMOUF8EfEr8="
+  },
+  "io/netty#netty-resolver/4.1.130.Final": {
+   "jar": "sha256-SMWyGKidGE4bYB1GQzlX9RX879tEZBgrE0i85PWhjzU=",
+   "pom": "sha256-xeGFNYp1FoMpbu5sqpLwLMWq8KB72k8y4k0o3soEzNY="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.130.Final": {
+   "jar": "sha256-z178QWhZfXzRRpW0aUGMrCoRNFM/mgyC7wU415b9OeE=",
+   "pom": "sha256-XwK+49pXj+xPWfASUUPjSX6JATXHrMAcXNq6I2CPiMs="
+  },
+  "io/netty#netty-transport/4.1.130.Final": {
+   "jar": "sha256-G/VzJm0nH4VnBamYTSVEnFah1zwCoWrxIDPOzP5VXbs=",
+   "pom": "sha256-t/og1TA1PCvYnzJgfefhojcQDT/7hTme4Sq8xDy84v8="
+  },
+  "io/opentelemetry#opentelemetry-api-incubator/1.44.1-alpha": {
+   "jar": "sha256-jb9FHOWA+gJS7pynczH9IXEHEMqbc1oTWSQerTvo6+U=",
+   "module": "sha256-4xVFUKMLo5DGJMsWRkRzAzGPseeQ2ocO2UGb1TcBvzQ=",
+   "pom": "sha256-hcOLlNH3DV4pzm2VhFaKae4m3X3nMZcCFsp0FHuxNlI="
+  },
+  "io/opentelemetry#opentelemetry-api/1.44.1": {
+   "jar": "sha256-CX4ucci4yBP0oTF2uq+7uxJLElP1yf/9EQvCrddKzpM=",
+   "module": "sha256-RbSspNj7Vc4bw+hkVvSTGQhRnvRJIb9+zLskhezCVeg=",
+   "pom": "sha256-KS4M34NNybob7DZvStv+UzZx9DZ3mlfBgshKTLU/PKQ="
+  },
+  "io/opentelemetry#opentelemetry-context/1.44.1": {
+   "jar": "sha256-AGs/fDiANWqG8CxA7t66Ek8iai8UX+kEzBt97wCIurA=",
+   "module": "sha256-h8s/2z9n8MpQ+C211ma7biS2jngCKKCXZD6JuXFQZGA=",
+   "pom": "sha256-zODnGGvOKSWMYdP68YUjTedaN3g81Lz++gr15YzkCWU="
+  },
+  "io/opentelemetry#opentelemetry-exporter-common/1.44.1": {
+   "jar": "sha256-JZtlrcHolpgEtCMlKb1Sy6qr+GBJxATyW841iYAjaWs=",
+   "module": "sha256-yW92+ff4JJk+mdYynDqOkJULe+ASlBrbPoo0jtK9gJo=",
+   "pom": "sha256-zBc+te2QVHVmGNUJFoMV9UiNn+doBox0QYX/3fBwFVI="
+  },
+  "io/opentelemetry#opentelemetry-exporter-otlp-common/1.44.1": {
+   "jar": "sha256-WJOFzt6Ol0oJJ1PXuvvFr9JujqrZcOl1+1EQZVe9rkE=",
+   "module": "sha256-K1ONCNGjdLY5Pj6Ucmzad+9FwSIDvt+g3HpEBSG5tRU=",
+   "pom": "sha256-/n6L61GdAJnLCzn8YmfP8rXdEgpSF92tJtJbvVI+IDg="
+  },
+  "io/opentelemetry#opentelemetry-exporter-otlp/1.44.1": {
+   "jar": "sha256-k4T6qDHwgt0QyksJ6xkG+izdiooP2/ylbrtPtNbiBew=",
+   "module": "sha256-aK04rzhflHG9FcXFzvj3ZWLTSO55JVXtaAMt9AGWP6I=",
+   "pom": "sha256-xEkzR+8x4M1O7083/BT7LDLOoOZ+kY+c5UZbuZtpKp4="
+  },
+  "io/opentelemetry#opentelemetry-sdk-common/1.44.1": {
+   "jar": "sha256-N3D8R37g+rIeeWu1WfCpltOMdE86Fwho0bO4W2O4J9A=",
+   "module": "sha256-GJDjyaKYoES0Wvc0EfKQ7GN7RLKHJReJ9jbHrWMmbic=",
+   "pom": "sha256-lSuXrrc9sdi6OocSdRPbY15F9Dy3jFqJY10DCmoyG/E="
+  },
+  "io/opentelemetry#opentelemetry-sdk-extension-autoconfigure-spi/1.44.1": {
+   "jar": "sha256-80eK+W5PL1/WAoNSJVPeTOmcA2BqFuRg0HvG7uEvn5U=",
+   "module": "sha256-RR2LypYXHnQYdi+k56TE+NaVsft0p9/2VcEvR1l0ACY=",
+   "pom": "sha256-0VY919SNjat3nNL+nHsvMUuDezLjJlT2yvvfvzQCCkw="
+  },
+  "io/opentelemetry#opentelemetry-sdk-extension-autoconfigure/1.44.1": {
+   "jar": "sha256-IsMSy/77GmqKsJc/P//oLDJpCJgmSqW6eUH77TM/Rrc=",
+   "module": "sha256-8Pp/J/HrRfuGKXzUhTVHWdCdSD4toO5+CM3+rJg8S50=",
+   "pom": "sha256-d8LvW3ZBR/ugGutAqaLHbH5BoVoWB31LRfYqywraQsM="
+  },
+  "io/opentelemetry#opentelemetry-sdk-logs/1.44.1": {
+   "jar": "sha256-ukqXlm3tKSfcqubpG/ChcHhn5EzD3Srkx++CFL342vc=",
+   "module": "sha256-WqzBloLcDuNB5WKaKCnrrdgQ2FlKOddardqk2bSD/Bc=",
+   "pom": "sha256-ZfhfVBB+2/csorRqovDFeVBl4sdD6nAi2WyWJm6PJb0="
+  },
+  "io/opentelemetry#opentelemetry-sdk-metrics/1.44.1": {
+   "jar": "sha256-PAlmipbx6UQ9KJSuRWZ0yMOLIhwJbDkfyBYW2qZyv2g=",
+   "module": "sha256-6rYDVYnMHynQbSW4JEa6175P6OqXdHjg35UhMe4e1Vo=",
+   "pom": "sha256-0aP1lEWdRQUX5k6D+dqjIj5RxSfouDGYLpfsDd7OjN8="
+  },
+  "io/opentelemetry#opentelemetry-sdk-trace/1.44.1": {
+   "jar": "sha256-/wE6uUVWfcy13eY496NmUZ3vvS0TjfE3CTboR+9gjIc=",
+   "module": "sha256-GbZ9F2m+2icA2wziDS5OMg+dGMHX3DW2iy2rq2e99M4=",
+   "pom": "sha256-Yhr6Z+8S2iKViUfNm8JR0vbCfSgzMOu+XKJv6fjscpo="
+  },
+  "io/opentelemetry#opentelemetry-sdk/1.44.1": {
+   "jar": "sha256-fGTzMOwZeh64gFm5fck3b9uYNmlQJ8lqDLTnTvkXzr4=",
+   "module": "sha256-l4xnOlg7C4VWdDijcn/JJ/uxB8zdniLEV27NQ1O8bto=",
+   "pom": "sha256-mSRNwYlhphYEI96Ks0Gg1cd5VcUrFHoFzLxxz75qrXU="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-instrumentation-annotations-support/2.10.0-alpha": {
+   "jar": "sha256-+M7F7I2nF9sluK0wctA0PmNvW1uHv/2T2wks+/2/SAI=",
+   "module": "sha256-SX5VTcazi7yAtwUGYkv4ZHL7gPsSRhBUX/wVCtyVQPM=",
+   "pom": "sha256-8NVbPyHN3//YXrGy4nd1BuIhLmQEB381sh/GlUJ+/4A="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-instrumentation-annotations/2.10.0": {
+   "jar": "sha256-kGuirHRxCeRUC9hyN2P8HQxRYAuf6iA7oidqQpWb9tM=",
+   "module": "sha256-W6mFKXlR/zMxayDtgRXkPLgnZc7N74ijq0y9i88sOuY=",
+   "pom": "sha256-6QM+fjTF3BegyTlR1hFKejiSr6JyVICuptsHYcgK4n0="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-instrumentation-api-incubator/2.10.0-alpha": {
+   "jar": "sha256-5q0LzuRnSZPxX9ZyACCQ97EI/+lf59otiCmJy+txmkw=",
+   "module": "sha256-4KjCBqOkKfT0rs73Fs6KntB0IMLRA51EPsvy88qeYDE=",
+   "pom": "sha256-NqfREgpfdEiRf0BB7HRejvP6aahhCNgmsY3ejoxyskI="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-instrumentation-api/2.10.0": {
+   "jar": "sha256-qxU1wp+S/Py3Vf35aQTTFxYcauJ9U4Xr6oyOOU0p5vY=",
+   "module": "sha256-1J2QILHe9JzH4Vp9AvoAIGLSd2/RZdyJ8SpL/hCXdGE=",
+   "pom": "sha256-KHIpdPydxrwV+ETuAhYEkhpVtI1aalZdmb7GQkuZ+D0="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-jdbc/2.10.0-alpha": {
+   "jar": "sha256-nO9Jvc7m0ndyWZUAQXQ2XXT7MV1zdDVbd00j1zvP8Hc=",
+   "module": "sha256-S643TODrEX09xYI5IBRQQf2wPLRz+TuEmrmODGsGuB8=",
+   "pom": "sha256-hchv5iiuk9gYQXQ5oVUtVUj4kMcfTS8KUsBvgq8gDLE="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-runtime-telemetry-java17/2.10.0-alpha": {
+   "jar": "sha256-eIoK0DsirJr24w+rkQNHCAd0Glqx8lrsAP1HQMSQ8cM=",
+   "module": "sha256-xqxvXJOqGGKNmG7KMw9YcLUPBQ4Wy5u8jt2Af0eoqSc=",
+   "pom": "sha256-1/247cE3DrnctSvBVqFlNRxYdeZZNYhWfzv39MrOues="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-runtime-telemetry-java8/2.10.0-alpha": {
+   "jar": "sha256-FlgPr5BTL2AXlnesGISpZjrecEf5UEqGcUbQrssyYyY=",
+   "module": "sha256-NoAo0AwQf6M46e3eyYXb284JzyAwkPpxldArDT4U/eM=",
+   "pom": "sha256-1S1lVTYZ50/4xiD9J4wPspBZChhRyVFrumhtKX4nadM="
+  },
+  "io/opentelemetry/semconv#opentelemetry-semconv-incubating/1.29.0-alpha": {
+   "jar": "sha256-KNFmd+YnvROgJJe63cUjX/86TcmJO25xDaXX7n+OkRs=",
+   "module": "sha256-UQnQAW3PUDYkHNqJFISYO+QYwmqPq4c3a6XprAIyxyo=",
+   "pom": "sha256-bGXZkzdvLC9hRrir8BYts2lbnWXteUOYnr1O5nlUHec="
+  },
+  "io/opentelemetry/semconv#opentelemetry-semconv/1.28.0-alpha": {
+   "module": "sha256-a+M8eGFUBbP+AKl/Kq/heNGT8/GXgbsMnS1BDKtMs/0=",
+   "pom": "sha256-WxMz4G1KPsra2LV6BJfZU4gLCL4fTBlKHR5ql2yE5VQ="
+  },
+  "io/opentelemetry/semconv#opentelemetry-semconv/1.29.0-alpha": {
+   "jar": "sha256-qV8a7X4/ZDU+xiXG3vcqDKrwa2xTlw9Xj91RPa/Zlf0=",
+   "module": "sha256-uCvms5s/HXFPu90Te+mLagSeocjD/bPSRP+4YlGYOmg=",
+   "pom": "sha256-ritWG/POdHQlww2QMVMJt1fV/Qn/GVykQE5XSadm8hs="
+  },
+  "io/perfmark#perfmark-api/0.27.0": {
+   "jar": "sha256-x7R4UD7FJOVd8ZtCTUbSfIporrgBZk+t1PBptx9S0PY=",
+   "module": "sha256-n2xOamK43v0UFzrNt9spPQhjU7Ikkj7vYpP1gWGJPMo=",
+   "pom": "sha256-IsF1wsGCNmdjDITnMiV2f1lwSS2ObL/7gaZXXbpHLSY="
+  },
+  "io/quarkus#quarkus-arc-parent/3.27.2": {
+   "pom": "sha256-ZN1sC5SBomcLjiXklPPqd5lvg8lbZx3rAYmT+DxwkU8="
+  },
+  "io/quarkus#quarkus-arc/3.27.2": {
+   "jar": "sha256-3WJPscRM/wxQtXBkTbb4YIHhLAkqtHbrHE2kK6wOlzA=",
+   "pom": "sha256-xJi6qIKKtexp7K/nflmF7w8Bfe9U44GLsmdfvTJArpg="
+  },
+  "io/quarkus#quarkus-bom/3.27.2": {
+   "pom": "sha256-uCpa4PEoCNpde29w0bYzFBncNExBaQTaZZwwzlHjRko="
+  },
+  "io/quarkus#quarkus-bootstrap-bom-test/3.27.2": {
+   "pom": "sha256-eT94gNFvx0C+hoU/28FAligiqKpQN5yEB2A4kBtDPyw="
+  },
+  "io/quarkus#quarkus-bootstrap-bom/3.27.2": {
+   "pom": "sha256-9QocTTHKP7qhFzBB5FwGVi910BTm2HtQA1qLavPLzIk="
+  },
+  "io/quarkus#quarkus-bootstrap-parent/3.27.2": {
+   "pom": "sha256-ybfqyQ0ZPTxTj9yaMRXCtnm0zTrwf088XSvW1h6zxts="
+  },
+  "io/quarkus#quarkus-bootstrap-runner/3.27.2": {
+   "jar": "sha256-cYVO8eyEAaxPbjnzY/qzqUG7OTup3joBeauPzRf4Fhw=",
+   "pom": "sha256-ShA4JoxiHRUnnDhZJmyyweKe9wlO7jxu7Pmt5SY2rSI="
+  },
+  "io/quarkus#quarkus-build-parent/3.27.2": {
+   "pom": "sha256-i9HhSp/08Fmrs/xZv5Ds82Y2StgQLgaxo5FKu0UQR4U="
+  },
+  "io/quarkus#quarkus-classloader-commons/3.27.2": {
+   "jar": "sha256-TmJmI9SQSpuFuR+eU7AGuLffnH3wofglBf/wtnpOOxs=",
+   "pom": "sha256-+psVZM1FZSjNri4jOqEIjmxwikQj/1PI1AV/ih+V0qI="
+  },
+  "io/quarkus#quarkus-core-parent/3.27.2": {
+   "pom": "sha256-iYVNwTYgWe2/lZw/lse7kd68b0rIBc9UTGKUfjVQwBE="
+  },
+  "io/quarkus#quarkus-core/3.27.2": {
+   "jar": "sha256-EvleLl1PoyrpfDpGaEGH1a48u6ScZ+oJnvGwdpS67u8=",
+   "pom": "sha256-PnDlM5kg6RU9qP+lG1RY73QZ/AAON+FCd3Wam6CO2Fw="
+  },
+  "io/quarkus#quarkus-credentials-parent/3.27.2": {
+   "pom": "sha256-bf8cILB/Li3Q3riQZB3pGufTUGw0dWRwIWhs11nddqU="
+  },
+  "io/quarkus#quarkus-credentials/3.27.2": {
+   "jar": "sha256-U32DJ8ZCxv/nIHVZgu8PVG+piDN1EsOkkvD+j3u0dtg=",
+   "pom": "sha256-RIT/cgQSNDUYXGRkiYB2+h91+rM5di3gqodizGt4B60="
+  },
+  "io/quarkus#quarkus-development-mode-spi/3.27.2": {
+   "jar": "sha256-QAabyGkx4dEWssH2WRW0lM/pRTPJoA89P7udt0bBG/U=",
+   "pom": "sha256-Q3Ge0N2V70MLVVzyQWoNZzlryykf/CZbY8lKwU6htFM="
+  },
+  "io/quarkus#quarkus-extensions-parent/3.27.2": {
+   "pom": "sha256-52+lOhj50/ubMS0XUdUPfbIgMuzv1UhhlookKTQKRg0="
+  },
+  "io/quarkus#quarkus-fs-util/1.1.0": {
+   "jar": "sha256-UVeS4sJh5wS1wFK+If2qnMQ6pf2FiN9Tzy7dBx/Z7iY=",
+   "pom": "sha256-b3vzqQRLngi5QKZ4aONBjJrTtaUw4L92iMJpTR4jYK4="
+  },
+  "io/quarkus#quarkus-grpc-common-parent/3.27.2": {
+   "pom": "sha256-DbNQTGuj/nOTvCh3H0IFnOHrF+iVadSYdKFzDaroWu4="
+  },
+  "io/quarkus#quarkus-grpc-common/3.27.2": {
+   "jar": "sha256-fTI23z9Kvkk9gilXfoMr6yCJ1Nk+jBY3hq5oaAN3q+I=",
+   "pom": "sha256-Xv2u7KMo0LSNU/C8mjXV+X/JA/glQuXplqYaoCyMzOQ="
+  },
+  "io/quarkus#quarkus-ide-launcher/3.27.2": {
+   "jar": "sha256-a56Bf5fXEpM1E8/cKOSOKje8uZzg0L5hcBw13VUvYQ0=",
+   "pom": "sha256-0G16iq7uBc207BFIR5/tPteQ1z5kDgGzGO7h6Qv3vkI="
+  },
+  "io/quarkus#quarkus-mutiny-parent/3.27.2": {
+   "pom": "sha256-7vxs39eImT06Y8797EQmyuINoumujbTkgO1V+ae4hAY="
+  },
+  "io/quarkus#quarkus-mutiny/3.27.2": {
+   "jar": "sha256-23LkxP1OdzBr61n+42YNKHTuOpWusjASwwrGcqIP2IE=",
+   "pom": "sha256-wWuPvfWbW0kEqRCfqBIB2RtpMxWMiKukJUFkui4PqwE="
+  },
+  "io/quarkus#quarkus-netty-parent/3.27.2": {
+   "pom": "sha256-UqswPn/A2FrMKh4u/xa7q+Apmwx0H/6lgsrwuvXbX/w="
+  },
+  "io/quarkus#quarkus-netty/3.27.2": {
+   "jar": "sha256-yIvb1lXIlszNzW3nk9kzb1VN7UOa9n8dz+tLMgws28o=",
+   "pom": "sha256-tJGwyteqLobgluqViQkCSF0f5ME7YczMYTbmBdDLOHA="
+  },
+  "io/quarkus#quarkus-opentelemetry-parent/3.27.2": {
+   "pom": "sha256-+2/SbHWY61vatlG76ui18iRoiXIckUEhdnW/vY3dQtc="
+  },
+  "io/quarkus#quarkus-opentelemetry/3.27.2": {
+   "jar": "sha256-Why2z3fuqciMyRR+6Qza1alex0Jk3IrXk7SS/Q8rZ+w=",
+   "pom": "sha256-D4V0GEKEY5qiVF5QM7C8qe9wCkGyumskDFt3aq7kFrY="
+  },
+  "io/quarkus#quarkus-parent/3.27.2": {
+   "pom": "sha256-Pwd9e2KmkQte/4FOUp0fEhjeIXZ73YNUBammK2N4M2Y="
+  },
+  "io/quarkus#quarkus-project/3.27.2": {
+   "pom": "sha256-I8QVOliUOuwUOOyHax8FfwmRwvVILQ1GLOT5+2fnPhM="
+  },
+  "io/quarkus#quarkus-security-parent/3.27.2": {
+   "pom": "sha256-fveBOaewaiJWlcj5o6m8Cs/bwaj2K0OljScLPVNS1jY="
+  },
+  "io/quarkus#quarkus-security-runtime-spi/3.27.2": {
+   "jar": "sha256-heNQsq5zQYO7va1wO92f1ZYNckPi9b3uLYb2g4zUm8U=",
+   "pom": "sha256-IbltL7Uw6c5pul5OdMtWAMHIDWV4thE/tE+Zfa0NYQw="
+  },
+  "io/quarkus#quarkus-smallrye-context-propagation-parent/3.27.2": {
+   "pom": "sha256-agXhJhhvFni3r0rlu1EVPY4V1BVofYJQQczZ41wMxDw="
+  },
+  "io/quarkus#quarkus-smallrye-context-propagation/3.27.2": {
+   "jar": "sha256-er+IbcLH8B3NuSFEx+BKRkOV7cWFllC1t7E2v3vtc04=",
+   "pom": "sha256-QvTAUkrfVHnhyM2u3Fv+n3VXW/USgTjRGaUGsFTrv1U="
+  },
+  "io/quarkus#quarkus-tls-registry-parent/3.27.2": {
+   "pom": "sha256-j5J2YX/3dvchP5gNju15kFo1m8iaHeM/0G+TsTN+3xw="
+  },
+  "io/quarkus#quarkus-tls-registry-spi/3.27.2": {
+   "jar": "sha256-yu3C5EhnolmYuEm2AIavxsD0SX7QZHQnmD+Dp+j9SMw=",
+   "pom": "sha256-KbGgsGcMhG6EWuiHzD6OateQVWNgBTmncbmYjvp86SQ="
+  },
+  "io/quarkus#quarkus-tls-registry/3.27.2": {
+   "jar": "sha256-2DJ0nc5/JSWz4OuyIsesYo0vugGVxsDv4ECM22xXJUo=",
+   "pom": "sha256-iFZQ4+bVrZFEpU8chKHqI+X1HA0k9UgT7BBia27QBbg="
+  },
+  "io/quarkus#quarkus-vertx-latebound-mdc-provider/3.27.2": {
+   "jar": "sha256-2fjExG5p5r2YToGWXdjKIGtcNsnjXFZoVb/0gQsav8I=",
+   "pom": "sha256-4rOy9mHiLCk7V2qm6u7J8t3P/ZyvglOfZ8QlKc5V7sA="
+  },
+  "io/quarkus#quarkus-vertx-parent/3.27.2": {
+   "pom": "sha256-Js+oDWq7FSUOJoo2YLGCLz5G6QWJcBNCTgx9GCNgyRo="
+  },
+  "io/quarkus#quarkus-vertx/3.27.2": {
+   "jar": "sha256-Wd9uuq+cYc9HzGIfJcwohNfK6UXDVfxUTpcq4BXwxJs=",
+   "pom": "sha256-DQc0HHk7/u2549tpvPlAIHpbNcOdtiQqQsdKoszs8/Q="
+  },
+  "io/quarkus#quarkus-virtual-threads-parent/3.27.2": {
+   "pom": "sha256-aosAAfXGCnm/EMwAXO1prOTyafZnJwrJ/7fqm3+mB4E="
+  },
+  "io/quarkus#quarkus-virtual-threads/3.27.2": {
+   "jar": "sha256-QR0bbzN4SxsUzkJsV1lgFR5cAcZr5FgTBYLfCJzo7ZM=",
+   "pom": "sha256-z1PJxizOzAXK655I5jo1I6/mTNq45Z9vsh8ROXi3TFs="
+  },
+  "io/quarkus#quarkus-websockets-next-parent/3.27.2": {
+   "pom": "sha256-6zYQ6JMbp4H+/J+qScWnqjCebBFAWEMAomSgQsy650w="
+  },
+  "io/quarkus#quarkus-websockets-next-spi/3.27.2": {
+   "jar": "sha256-hgMO6C8oJ1ctq+0b0efnAaR30SnHMSrrxZR1eUVYgZ8=",
+   "pom": "sha256-ud1bUUeqUPbtvuG7oQG6dMRmClbkXguz0MHobne5mNM="
+  },
+  "io/quarkus/arc#arc-parent/3.27.2": {
+   "pom": "sha256-0BMh7N6A+Nhp9+rfJx6LZPJJ/sFjM0svGyWlMHAiS1M="
+  },
+  "io/quarkus/arc#arc/3.27.2": {
+   "jar": "sha256-+QpanpsiR1IZKEZ7Ng+3v/coaiuvwn/vzpAeyjuVRcA=",
+   "pom": "sha256-+IhPcLclUD5iAutd12e50m3MCLZaY8ZyZAT6TPQiSJo="
+  },
+  "io/quarkus/platform#quarkus-bom/3.27.2": {
+   "pom": "sha256-85clb8J05naJHaO3CN1LUi7fNXf1ANKfFXOuzBkVPPw="
+  },
+  "io/quarkus/security#quarkus-security/2.2.1": {
+   "jar": "sha256-tQIPb8xQbS23HBesaFTMOpB4wLc5UpGASNHyy7Sn2Pg=",
+   "pom": "sha256-61QM6rzfhW8vhd1hzXDVDrIYSPb6mMFcSR/5ngWVZ+o="
+  },
+  "io/reactivex/rxjava3#rxjava/3.1.10": {
+   "jar": "sha256-6fJW+egFVy3V/UWxQNs2DX3ERNDDgwSbLT1+vwXYSqs=",
+   "module": "sha256-rwV/vBEyR6Pp/cYOWU+dh2xPW8oZy4sb2myBGP9ixpU=",
+   "pom": "sha256-EeldzI+ywwumAH/f9GxW+HF2/lwwLFGEQThZEk1Tq60="
+  },
+  "io/setl#rdf-urdna/1.1": {
+   "jar": "sha256-xXoq5VG9MB+E+vEBAlHZZRCkDisA2IPobN0tDfpvAa4=",
+   "pom": "sha256-A9Ntu7P+61HJhioDg6G/JMnvI/3MM+IaPi3iAxE/OF0="
+  },
+  "io/smallrye#smallrye-build-parent/41": {
+   "pom": "sha256-cMa/huHu5E1o5zmJYoghjLU6mtI+GNJHp5FBXKdyfGU="
+  },
+  "io/smallrye#smallrye-build-parent/42": {
+   "pom": "sha256-FBJFawNFSQ+NC00L5SnQSh1Y0Z1a2FvzHDdAwT+Q1t4="
+  },
+  "io/smallrye#smallrye-build-parent/45": {
+   "pom": "sha256-1vPL5JFUM6LZ9bmsEjjul17d+7En3yDbdpRpCKBMXys="
+  },
+  "io/smallrye#smallrye-build-parent/46": {
+   "pom": "sha256-FP8daINJaqcRP89+Fv5Whyr1hL2g2G16nreXQkW4zFE="
+  },
+  "io/smallrye#smallrye-build-parent/47": {
+   "pom": "sha256-1xrwHMwBPiiKiVx5tegErdaADy3r6NWXUSAaYsqt5Bk="
+  },
+  "io/smallrye#smallrye-build-parent/48": {
+   "pom": "sha256-mV9fXiCWxo9U/P2jCQ0SCSw/K0L6Q7EqSEsYBhseZJA="
+  },
+  "io/smallrye#smallrye-context-propagation-api/2.2.1": {
+   "jar": "sha256-oTFH8wXUh5B0wHOt/YYdBwdieLGPH4AQrNgf2KIfXLk=",
+   "pom": "sha256-Xv/VEJ3oz9ZYvhkePAgHx9ri8OOcFIZslJzY0JxalWk="
+  },
+  "io/smallrye#smallrye-context-propagation-parent/2.2.1": {
+   "pom": "sha256-5unin/Ow22Q+mTxqico0Edh7FxMlbOd/3yTn6hcIxps="
+  },
+  "io/smallrye#smallrye-context-propagation-storage/2.2.1": {
+   "jar": "sha256-OzR7tXyOyT7SN1rnjySQj6C1QaEQ3oCv22PzJaXIpwU=",
+   "pom": "sha256-Z5IMHn2OUknNWtW2siSG10hnnAYml6unH7a8YHPrRxg="
+  },
+  "io/smallrye#smallrye-context-propagation/2.2.1": {
+   "jar": "sha256-kfolPYvZA2cvMLm80DqX8DpzSZ9aftH9PQPQT1NIVJo=",
+   "pom": "sha256-THy3aKr/jqdJXTUy9VVqP9wjaRas02QbF3745PJs2OY="
+  },
+  "io/smallrye#smallrye-fault-tolerance-implementation-parent/6.9.3": {
+   "pom": "sha256-ZVqovQk90r2ER3clp+IuJFvrUzHhXUpuX9W4rhH66p8="
+  },
+  "io/smallrye#smallrye-fault-tolerance-parent/6.9.3": {
+   "pom": "sha256-r/x2bbL5uacuQnzsKg0tZn0Lq5CohWTmPxv62is8yGA="
+  },
+  "io/smallrye#smallrye-fault-tolerance-vertx/6.9.3": {
+   "jar": "sha256-QQh8osz5wPJY3zY59uT5WbeRFZbQ8XXulCeNWbxIhKA=",
+   "pom": "sha256-hhpJklfkS8MRa9DJANGSPAzHh8JI3RzG7YMm/4EvCXk="
+  },
+  "io/smallrye#smallrye-parent/41": {
+   "pom": "sha256-ioaQNk3oDebPDRAahYPpMb6E4Ej6OHw5i79upl8lrQw="
+  },
+  "io/smallrye#smallrye-parent/42": {
+   "pom": "sha256-EGQjW60r3LUZiEslMIbPyqQ0Ft20fExszkIVadt5ooU="
+  },
+  "io/smallrye#smallrye-parent/46": {
+   "pom": "sha256-SwaHf4gDT1Nv8tl97y0zlQq2ROCZFWOb6lOPasl+je4="
+  },
+  "io/smallrye#smallrye-parent/47": {
+   "pom": "sha256-5kq1jZ4QolJiHzARt1x+dbNHmlvOiBoiuO+msH4EhDI="
+  },
+  "io/smallrye/certs#smallrye-certificate-generator-parent/0.9.2": {
+   "pom": "sha256-8aCsVJaI1GhDzzDhM3F6Gck17ytxXVemI6lfpzyjG2c="
+  },
+  "io/smallrye/certs#smallrye-private-key-pem-parser/0.9.2": {
+   "jar": "sha256-S6mOku0gNZPYfjhKHgn6lsGMkBc6YXD+pxzyOhycUoY=",
+   "pom": "sha256-xGmWD+xR7AjjvWN3l2QsRK3yIAFI0x6DJCLmU6XN/o8="
+  },
+  "io/smallrye/common#smallrye-common-annotation/2.13.9": {
+   "pom": "sha256-SFvgX+ekxY65Ejs7GOv0QO5jwAHwaG65RJoQ9cRz6ek="
+  },
+  "io/smallrye/common#smallrye-common-annotation/2.14.0": {
+   "jar": "sha256-PH/erJDtes+XsD62PY4yhunw+mbIRQYT00U2RXJdsBA=",
+   "pom": "sha256-8hRfZJEp6csGb5KXpTyyHiCfNivdPExfOmXFJtwfXHY="
+  },
+  "io/smallrye/common#smallrye-common-bom/2.12.0": {
+   "pom": "sha256-KO214eRveaA0DEcf1MV3AV7+xXqcDC7wP+lNsuMh+vA="
+  },
+  "io/smallrye/common#smallrye-common-bom/2.13.7": {
+   "pom": "sha256-ONZLzK+YWJ7WHBXQo4w7Z6WQytJS/Hef5SZgk++Da7w="
+  },
+  "io/smallrye/common#smallrye-common-bom/2.13.9": {
+   "pom": "sha256-0HBc+5T145lqWx69/t6T9JGe86VS9nwcccsf0gbleRQ="
+  },
+  "io/smallrye/common#smallrye-common-bom/2.2.0": {
+   "pom": "sha256-qLCcNrWIuSXIMKhUV+75cVVOQk4H6wu+1GnGruoLiAk="
+  },
+  "io/smallrye/common#smallrye-common-bom/2.4.0": {
+   "pom": "sha256-puGY/JfU0KDHsxCSPhkTTjS6+jHmpG6CcmYDwLxeYow="
+  },
+  "io/smallrye/common#smallrye-common-classloader/2.13.7": {
+   "jar": "sha256-UauhPN7KCsXFLwPBgM+ovgm3BSYVM/9wKIxt8BpFeds=",
+   "pom": "sha256-PgSr+3GjSeEcYi8sYv5Ac2Nx7buorTcgLwf9JbnJN4k="
+  },
+  "io/smallrye/common#smallrye-common-constraint/2.13.9": {
+   "jar": "sha256-x11vzsuGdIAQbtFmB/A5MHiIOMT9lZ0R4FqRbl6uOgE=",
+   "pom": "sha256-atuj2SyHn4RCf3M5FqHGSvF4xjirIUVBd/kYMXPj0EI="
+  },
+  "io/smallrye/common#smallrye-common-cpu/2.12.0": {
+   "jar": "sha256-nR3X1CNMWNiRmNd3+hxretVTNm9fY1S4HNwjIE73cJA=",
+   "pom": "sha256-++jCL2Z7E7lT9AFC5AWZmMBunYdM9jxZweAlErHvBoQ="
+  },
+  "io/smallrye/common#smallrye-common-cpu/2.2.0": {
+   "pom": "sha256-0mGDziGlS1zTx9LyEZ18DDFLgs5OLXWsXHze+sQBK4M="
+  },
+  "io/smallrye/common#smallrye-common-expression/2.13.7": {
+   "jar": "sha256-QF4QVDL9FaTbTTzx+Q9bIRfSEohb4p4D5haG5NkZQPQ=",
+   "pom": "sha256-NEoEFG5anaEB6JLhnh4ThyxQvRAkKxudJX3/zkBXQa4="
+  },
+  "io/smallrye/common#smallrye-common-expression/2.2.0": {
+   "pom": "sha256-1uROh7ttspfOvjlga2s3qaLbDTShf2sLmZxAWDsNL1o="
+  },
+  "io/smallrye/common#smallrye-common-expression/2.4.0": {
+   "pom": "sha256-wBzAQOvkRjOSkKdFwFvU4nykStE1TbF/g9VpXEMeErk="
+  },
+  "io/smallrye/common#smallrye-common-function/2.12.0": {
+   "pom": "sha256-dYYLzV8fA29BYMyMqrNw55t2iend1Q0hDHey8gtBpDg="
+  },
+  "io/smallrye/common#smallrye-common-function/2.13.7": {
+   "jar": "sha256-xj4w9o6RJSiMT8DXcrpWHnKSjStsKiJYHM1GbfRaFz8=",
+   "pom": "sha256-8s3BlLdddMAJQzF6Kquv0cpz5w6XmX3qw5NZHRaq7N4="
+  },
+  "io/smallrye/common#smallrye-common-io/2.13.9": {
+   "jar": "sha256-YTJRL6HDLqY7nw2stfuF9dQY8ltwh9iNtu0pRWCoiOs=",
+   "pom": "sha256-qmB8FWWNw3VPNWFw0ChKzMv/Zrk3NxxXiVwVdoCN8EE="
+  },
+  "io/smallrye/common#smallrye-common-net/2.2.0": {
+   "pom": "sha256-Jamu9WCWh9aY0pXM6SMr+10GTXH80kb/I90yHXGFhas="
+  },
+  "io/smallrye/common#smallrye-common-net/2.4.0": {
+   "jar": "sha256-wwPBS2+Nz+u7O/IwwcKU5MP5kOBgtKLHDo/86jyabe4=",
+   "pom": "sha256-oLeuxpBtgIykODX1QIJb9Dr0HkNX3Me6dcvHfuWnqLM="
+  },
+  "io/smallrye/common#smallrye-common-os/2.13.9": {
+   "jar": "sha256-jeGEbKBnSimc1sN/ZpFM5yVpAZtXBiZ6o5Y85o/YezY=",
+   "pom": "sha256-/VEGxFrO4x3T4EHrCDwmAhplmKAwLqy2hnrGWOsiU0E="
+  },
+  "io/smallrye/common#smallrye-common-parent/2.12.0": {
+   "pom": "sha256-Lgu9gF58//pkt4GMZmEetxMSC/EiijO5MUeaFhw3VCs="
+  },
+  "io/smallrye/common#smallrye-common-parent/2.13.7": {
+   "pom": "sha256-HekbICMWPsNipJy1t+4sfdx0n5xJUZuvx9W4RnqWMxQ="
+  },
+  "io/smallrye/common#smallrye-common-parent/2.13.9": {
+   "pom": "sha256-98YjrNoF1DADFDNl04nV4UY8i1KmDv2uTvKzD2TSBfc="
+  },
+  "io/smallrye/common#smallrye-common-parent/2.14.0": {
+   "pom": "sha256-UZcefyokqgPu9JuY7+t0dJS/vs4YzRrp+ZYP/X/pZwI="
+  },
+  "io/smallrye/common#smallrye-common-parent/2.2.0": {
+   "pom": "sha256-JMv8O0a0/z97onRjG26HpkFt0rKzCLfu7JarZYHeBJc="
+  },
+  "io/smallrye/common#smallrye-common-parent/2.4.0": {
+   "pom": "sha256-snO2sOWvRzileVZ+dA4krJON7RD45EbT26GQ9xhkT+E="
+  },
+  "io/smallrye/common#smallrye-common-ref/2.2.0": {
+   "pom": "sha256-/Ix5ya3YlCcd7MU2ZM+mNevQV/XIZu7kqu9046VKC3o="
+  },
+  "io/smallrye/common#smallrye-common-ref/2.4.0": {
+   "jar": "sha256-uZAtmbUqRjzDhREF3d1Y1A9YBzUGSLmWrhYasUEjQnw=",
+   "pom": "sha256-wMVVPQElarUrmuLe57dismveONfMkHaddTWM8+Cpo4Y="
+  },
+  "io/smallrye/common#smallrye-common-vertx-context/2.13.9": {
+   "jar": "sha256-LwDDSoNFiipQVkJZNJnm4FxQlpTyMIcyr13ZFgrRBU0=",
+   "pom": "sha256-wCsRlq7H/o/kqsXkYgZXvgZXbiq55EjXZMw09N9Hh0w="
+  },
+  "io/smallrye/config#smallrye-config-common/3.13.4": {
+   "jar": "sha256-/T+28GCdLLldJhGZEhZfiQNhIDkv95yr4Lwkzbes2lE=",
+   "pom": "sha256-ri+qhPtc37XPeMq5BL7OtXC+zV6cZrno743VPOq7fL4="
+  },
+  "io/smallrye/config#smallrye-config-core/3.13.4": {
+   "jar": "sha256-sqxThIRLrnmLQMVwV/Ex63J1T7aDZvsJK9pdkT7ko1s=",
+   "pom": "sha256-WM2maEKhpej+6b1VbAsRFu2IOJlbvATOOpwTPiKQdrQ="
+  },
+  "io/smallrye/config#smallrye-config-parent/3.13.4": {
+   "pom": "sha256-O/t/MY3foMxv7MzAXEEYzA86wXVbDQRacvnfYb06AGc="
+  },
+  "io/smallrye/config#smallrye-config/3.13.4": {
+   "jar": "sha256-yo1vsLAg2HS3B/LEoT1kktYup//6lf4DwED1U/d5mPQ=",
+   "pom": "sha256-Ps7R2beSYvTpJIKLdp0T9bBzmDyR56XPLxpMBT66/Nw="
+  },
+  "io/smallrye/reactive#mutiny-bom/2.9.5": {
+   "pom": "sha256-fXWvERRq4a5zlsXsV2GOaue600OsxjqPJ6f26yd7yZA="
+  },
+  "io/smallrye/reactive#mutiny-project/2.9.5": {
+   "pom": "sha256-7d/eBJRqr5SzYVp4D+fNSxg9xAf9NB+fAD2zjxzYfqE="
+  },
+  "io/smallrye/reactive#mutiny-project/3.1.0": {
+   "pom": "sha256-x1R8JM2seRouh/4vpkjblf7/5FHxVfSNde+VXssIVXg="
+  },
+  "io/smallrye/reactive#mutiny-smallrye-context-propagation/2.9.5": {
+   "jar": "sha256-cxHvP49PQO/RuMKr/oecwoeojLahwz66bIGetDLLP+k=",
+   "pom": "sha256-f/QMyqIOqZ2jTbAKmH6RPRnICX2El3WtMeQxOMuMjZc="
+  },
+  "io/smallrye/reactive#mutiny/2.9.5": {
+   "pom": "sha256-cFbpIIxnrcli7KWljCsj7jk4tHMSHu6ZUbkMyaM0DQs="
+  },
+  "io/smallrye/reactive#mutiny/3.1.0": {
+   "jar": "sha256-MUvVlCyKI40Z7dAAMlsSzaVJFqQJ8sOvXE6eScOgjbM=",
+   "pom": "sha256-EtGoV9AwqH1ywlonHXHdK6yTMzVAuXjXhqi867lPy/o="
+  },
+  "io/smallrye/reactive#smallrye-mutiny-vertx-bindings-projects/3.21.3": {
+   "pom": "sha256-EwUgLy/xTeKo3oMtWQzLSce2jflf/dJh5H5IIT7aN/U="
+  },
+  "io/smallrye/reactive#smallrye-mutiny-vertx-core/3.21.3": {
+   "jar": "sha256-U2BsUtpsG5N7JEUysdjECuE64KeN8cs4CPz29wMshhY=",
+   "pom": "sha256-8xcu18vrwEm0M8KBLXmYKaey8FGM+zSNLaxxOMS2yMI="
+  },
+  "io/smallrye/reactive#smallrye-mutiny-vertx-runtime/3.21.3": {
+   "jar": "sha256-BHxUDW1LnmVWkEjZZFJfjTBtQ3JtaulCfdsDlcm0V7s=",
+   "pom": "sha256-x4+f7hSkHCFBIbq3XMWV+jHE7wGlXhMNOunMhNHR8Sc="
+  },
+  "io/smallrye/reactive#vertx-mutiny-clients/3.21.3": {
+   "pom": "sha256-C2u/h/+SstRFieOa/gk/idZQ+M8wQ7MeQa68GEm0lS4="
+  },
+  "io/smallrye/reactive#vertx-mutiny-generator/3.21.3": {
+   "jar": "sha256-qlP/KL2crwx8Msjr/+AloB2fXBiw50vlaQYNeXjh8Yc=",
+   "pom": "sha256-O75r6m6FnvPnmGdiBt7GYBUlu0Uw9bM5Sj64ZH56mfg="
+  },
+  "io/smallrye/testing#smallrye-testing-bom/2.3.1": {
+   "pom": "sha256-PXfwZzfjRWwgi9zmKzccfsRYz2+9vJgWQIPkiFC4Mf4="
+  },
+  "io/smallrye/testing#smallrye-testing-parent/2.3.1": {
+   "pom": "sha256-vxksWNysCIzuwC3riPu+eC7iNx4N8hZh6lXPR4kZNdE="
+  },
+  "io/vertx#vertx-codegen/4.5.23": {
+   "jar": "sha256-Td7zcrugTgGRyZ85VsY7+szFz0oSlmnE6Z+bAmMpiKY=",
+   "pom": "sha256-WMMFXMo4uyfUAJS0DfHw394NNXn2Zslw4u9vAw+0mbs="
+  },
+  "io/vertx#vertx-core/4.5.21": {
+   "pom": "sha256-AIylD5wQ4cMOKU0Yv+2Y7/CGiZwLS/n32Ns3RUBKbz0="
+  },
+  "io/vertx#vertx-core/4.5.23": {
+   "jar": "sha256-0RmrpQjojhpUvUSbryfVsinPMCX6nKkvn7hMOmPBFDs=",
+   "pom": "sha256-MlaTwuE0nLdLqwjLaQKjoU1f5yhwfIgNv66SHmBnWDI="
+  },
+  "io/vertx#vertx-dependencies/4.5.21": {
+   "pom": "sha256-RoNO1Vlj5RBbGeXMUF8j3MIvQpoVPxfpCAxSrIJi34s="
+  },
+  "io/vertx#vertx-dependencies/4.5.23": {
+   "pom": "sha256-zALhPY/GKyTnMBWP8tC7znMiI6TmhuhMwG/s3PEyH44="
+  },
+  "io/vertx#vertx-ext-parent/42": {
+   "pom": "sha256-VPvxEeodETa2f+Y4RC3Eezw7ecBZgtdJbcMSpeYtyQc="
+  },
+  "io/vertx#vertx-ext/42": {
+   "pom": "sha256-MNosN+ZU8G39XLc2XbuXawmGgNc4PtcVnmP5Ysbvoro="
+  },
+  "io/vertx#vertx-grpc-aggregator/4.5.23": {
+   "pom": "sha256-YGThFsdkljm7E3ClW2rKKKSPcTLu0fl3d/jJMJCaPZc="
+  },
+  "io/vertx#vertx-grpc-client/4.5.23": {
+   "jar": "sha256-kf0DtSpDyf7gm1u8JH6QqdI3UUo+gJF8qGSbjmil3Dc=",
+   "pom": "sha256-zw0+GE6tZ9jakLAHQzNXpn7vPxMbqd1qHM54Vqh7Rro="
+  },
+  "io/vertx#vertx-grpc-common/4.5.23": {
+   "jar": "sha256-ix3J+oT9y168s9YqSSspCFig6FuqCoK4XV1s+X6J5/g=",
+   "pom": "sha256-IGAkAooF7yiusFAui14f0gS9M8WTFsRROR3OjD5YUls="
+  },
+  "io/vertx#vertx-grpc-parent/4.5.23": {
+   "pom": "sha256-8Cgo8nISlXmhmS67ur7MU1ibROL4f6GJwBj96SZSDUQ="
+  },
+  "io/vertx#vertx-grpc-server/4.5.23": {
+   "jar": "sha256-XZDRnOFw2qbHJww7t1Jy7AgOnNwd/Qw01yxopJsLkIM=",
+   "pom": "sha256-mbl7pdzLzD23c/Jf08st/eP4sfW78ase7MhTU7YRFo4="
+  },
+  "io/vertx#vertx-grpc/4.5.23": {
+   "jar": "sha256-JQJF2JeSW24cINSZBeIzkA0/Gq8sG639gEu6+kjnVd4=",
+   "pom": "sha256-hZq6S4HbzWywyFD8lvBuFHjJdfCWekw2utjQIQ0wv84="
+  },
+  "io/vertx#vertx-parent/22": {
+   "pom": "sha256-0RFbFBZdLwS0RoW7RJhQ3l9Yd3EGWjGJWK/Iwvv9hv0="
+  },
+  "jakarta/activation#jakarta.activation-api/2.1.1": {
+   "pom": "sha256-aTJZ+O/tqXSHm/MFz3HPELZUjYxvZ6ufNYyWrUfnygA="
+  },
+  "jakarta/activation#jakarta.activation-api/2.1.3": {
+   "jar": "sha256-AbF21xihaSY+eCkGkfxHmXcYa8xrMzSHMlCE1lhvRic=",
+   "pom": "sha256-slSZQMF7aGWjT2E1t3Iu2Mv+9tC2wNs3LDDwNGvIzVg="
+  },
+  "jakarta/annotation#jakarta.annotation-api/3.0.0": {
+   "jar": "sha256-sB9VVSKEz7FJQR5k6rynXpQtJtLheGsykUJQ5DMK+qI=",
+   "pom": "sha256-n8Zqhzdd+EQ6umvcwdT/B/EmVCWDeFpIKpJioZv+jq4="
+  },
+  "jakarta/el#jakarta.el-api/6.0.0": {
+   "jar": "sha256-8z0L7PLVUWcwulzJmntaKx9imGvwozcCSc3/mi8XFQc=",
+   "pom": "sha256-JsZmqRV0htvE3C6xnzuAhWDdvAukVyVNY/JcjascZtA="
+  },
+  "jakarta/enterprise#jakarta.enterprise.cdi-api/4.1.0": {
+   "jar": "sha256-xCyAjxeSUSmggA9hj+vgUNlm4YGkxzhMil56AoPWhpk=",
+   "pom": "sha256-1GTYSDGOBh0SNkQit1NHz8i8vSlEfbZIDTbx0CWAmFw="
+  },
+  "jakarta/enterprise#jakarta.enterprise.cdi-parent/4.1.0": {
+   "pom": "sha256-4WQl8r2D3YcdpwRKpRQBb74SBdpfsVTl2tFEtrNjgvE="
+  },
+  "jakarta/enterprise#jakarta.enterprise.lang-model/4.1.0": {
+   "jar": "sha256-u1b1cfYNKGKyOH1UaP6PVUD4CUcnKD7ZkfiQgnCAle4=",
+   "pom": "sha256-/2xEh5kCTGlLrItSt97jsfJkoicYpeKvTdTV+0LJiwI="
+  },
+  "jakarta/inject#jakarta.inject-api/2.0.1": {
+   "jar": "sha256-99yYBi/M8UEmq7dRtk+rEsMSVm6MvchINZi//OqTr3w=",
+   "pom": "sha256-5/1yMuljB6V1sklMk2fWjPQ+yYJEqs48zCPhdz/6b9o="
+  },
+  "jakarta/interceptor#jakarta.interceptor-api/2.2.0": {
+   "jar": "sha256-0kDXK03Tii5DHIBAeYEAEMuXkDZ4+l+Yf7dDSHiwQ5g=",
+   "pom": "sha256-jOOOxhmprbgI0qjQay+mLYmkNC5/Fu125+m7uzcypvg="
+  },
+  "jakarta/json#jakarta.json-api/2.1.3": {
+   "jar": "sha256-vJNBQoBeodeU8UQFY5ZaOGGiqft0FOzT/kTyZQBzRBQ=",
+   "pom": "sha256-QWpzlxOFoL5D+dqKR3qmT0gUrFIYfYjz4k8hW3+J394="
+  },
+  "jakarta/mail#jakarta.mail-api/2.1.1": {
+   "pom": "sha256-LApZ7RKeEs7aDkiIohPfsaBthZGa/OzAzBwKPUNqIqA="
+  },
+  "jakarta/mail#jakarta.mail-api/2.1.3": {
+   "jar": "sha256-gFG1jXX5gvmluWOzdlQm6CSypkhl7wrxcgXkVbmNsFw=",
+   "pom": "sha256-/r52PsEKgXMh7LFdqGyx+8mVx+NS4cET8P01fku1eYA="
+  },
+  "jakarta/transaction#jakarta.transaction-api/2.0.1": {
+   "jar": "sha256-UMCnx2DBOubAQqzxgrKPAEdBPblbRjb7iHm8/6tbqHU=",
+   "pom": "sha256-X+NJmBwVb7viY4jVmUn9rBa7jXh57mGzTEnHtc4PLyM="
+  },
+  "jakarta/ws/rs#all/3.1.0": {
+   "pom": "sha256-1P3UF4DgZarNWsCZzQSQFxk3zFEi3CyO8biKh7PJQkw="
+  },
+  "jakarta/ws/rs#jakarta.ws.rs-api/3.1.0": {
+   "jar": "sha256-azs2KLi0rt2g0kwzVDNemFSX2O88UQuPMCjpINW4Zj0=",
+   "pom": "sha256-xpejA+n/wxlj6xwnW793pYOn1IKWWsTxuybckeWV/78="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api-parent/3.0.1": {
+   "pom": "sha256-nx+11KAun4/dYu876rlLj+p7gWQ3SMhvaKMfQPd0rVY="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api/3.0.1": {
+   "jar": "sha256-uPtL7j/1tcHvdxRNhBExYBjXu9Qfzx7eBkb3l4VGuGc=",
+   "pom": "sha256-onPayXQUEv2dzM6ZESmHBteJ5YLcs1GXB19v0qWw6+o="
+  },
+  "jakarta/xml/soap#jakarta.xml.soap-api/3.0.0": {
+   "jar": "sha256-MxJOmNcktp4Wc6YWdcIFtYw3JgX0JU1FWxKzc5ghmjc=",
+   "pom": "sha256-L2a6M+MGzpKyLnvPRW0S5klOepfRijqNS+rbt4Gdzdg="
+  },
+  "javax/annotation#javax.annotation-api/1.3.2": {
+   "jar": "sha256-4EulGVvNVV3JVlD3zGFNFR5LzVLSmhC4qiGX86uJq5s=",
+   "pom": "sha256-RqSiUcpAbnjkhT16K66DKChEpJkoUUOe6aHyNxbwa5c="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
+  },
+  "org/apache#apache/18": {
+   "pom": "sha256-eDEwcoX9R1u8NrIK4454gvEcMVOx1ZMPhS1E7ajzPBc="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache/commons#commons-collections4/4.4": {
+   "jar": "sha256-Hfi5QwtcjtFD14FeQD4z71NxskAKrb6b2giDdi4IRtE=",
+   "pom": "sha256-JxvWc4Oa9G5zr/lX4pGNS/lvWsT2xs9NW+k/0fEnHE0="
+  },
+  "org/apache/commons#commons-parent/42": {
+   "pom": "sha256-zTE0lMZwtIPsJWlyrxaYszDlmPgHACNU63ZUefYEsJw="
+  },
+  "org/apache/commons#commons-parent/48": {
+   "pom": "sha256-Hh996TcKe3kB8Sjx2s0UIr504/R/lViw954EwGN8oLQ="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.14": {
+   "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
+   "pom": "sha256-8YNVr0z4CopO8E69dCpH6Qp+rwgMclsgldvE/F2977c="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.14": {
+   "pom": "sha256-W60d5PEBRHZZ+J0ImGjMutZKaMxQPS1lQQtR9pBKoGE="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.16": {
+   "pom": "sha256-8tdaLC1COtGFOb8hZW1W+IpAkZRKZi/K8VnVrig9t/c="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/11": {
+   "pom": "sha256-qQH4exFcVQcMfuQ+//Y+IOewLTCvJEOuKSvx9OUy06o="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.16": {
+   "jar": "sha256-bJs90UKgncRo4jrTmq1vdaDyuFElEERp8CblKkdORk8=",
+   "pom": "sha256-PLrYSbNdrP5s7DGtraLGI8AmwyYRQbDSbux+OZxs1/o="
+  },
+  "org/checkerframework#checker-qual/3.43.0": {
+   "jar": "sha256-P7wumPBYVMPfFt+auqlVuRsVs+ysM2IyCO1kJGQO8PY=",
+   "module": "sha256-+BYzJyRauGJVMpSMcqkwVIzZfzTWw/6GD6auxaNNebQ=",
+   "pom": "sha256-kxO/U7Pv2KrKJm7qi5bjB5drZcCxZRDMbwIxn7rr7UM="
+  },
+  "org/crac#crac/1.5.0": {
+   "jar": "sha256-9EJuFkHI8PovAlpM18QMKFq68mWTDmcXrfyu8D0DSFA=",
+   "pom": "sha256-mW3NvEpNuqYmZ6d9nSoMlH7SeUpGuX5iG6nZpG4oxQ8="
+  },
+  "org/eclipse/angus#all/2.0.4": {
+   "pom": "sha256-/M1yMQnFQB6VNOZYBCnxNj/1yEa0sWkThqbx9zdcoQw="
+  },
+  "org/eclipse/angus#angus-activation-project/2.0.2": {
+   "pom": "sha256-r5GIoQy4qk61/+bTkfHuIVnx6kp/2JDuaYYj5vN52PY="
+  },
+  "org/eclipse/angus#angus-activation/2.0.2": {
+   "jar": "sha256-bdO8/8IrzoOwc3ag4uCU5JZKMZXUEY+0PjgO81Q2zB4=",
+   "pom": "sha256-deViGn3IWMmW7nDGtNiE2QHRh4Ns5sZxIMr5VH5vxXE="
+  },
+  "org/eclipse/angus#angus-mail/2.0.4": {
+   "jar": "sha256-hzAYZVhLrZFwZis+7vA1Cqr+pFIkg+OOVK6H3D3z6Vg=",
+   "pom": "sha256-hQ9aU/bgvIyFxRwmuDzkvVGEsbmC3zTRMfYIRO2T6zg="
+  },
+  "org/eclipse/ee4j#project/1.0.6": {
+   "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
+  },
+  "org/eclipse/ee4j#project/1.0.7": {
+   "pom": "sha256-IFwDmkLLrjVW776wSkg+s6PPlVC9db+EJg3I8oIY8QU="
+  },
+  "org/eclipse/ee4j#project/1.0.8": {
+   "pom": "sha256-DQx7blSjXq9sJG4QfrGox6yP8KC4TEibB6NXcTrfZ0s="
+  },
+  "org/eclipse/ee4j#project/1.0.9": {
+   "pom": "sha256-glN5k0oc8pJJ80ny0Yra95p7LLLb4jFRiXTh7nCUHBc="
+  },
+  "org/eclipse/microprofile#microprofile-parent/2.11": {
+   "pom": "sha256-Bh21mPB4vltnvh3qVKmYZPqaa6zH1AvPtWrArdpDdVc="
+  },
+  "org/eclipse/microprofile#microprofile-parent/2.8": {
+   "pom": "sha256-Jp6jTEQci09GlvduyeDGaE10K/13dicT+6ix5E2BI6k="
+  },
+  "org/eclipse/microprofile/config#microprofile-config-api/3.1": {
+   "jar": "sha256-3uJ3+B4e3+r9XkNYlEHs30NFAP5KMdA150uObY57/ZE=",
+   "pom": "sha256-GAJTRl9lUPjhlVSHJVZ5ZuUyS6NDkNGShL1V7tl+aWk="
+  },
+  "org/eclipse/microprofile/config#microprofile-config-parent/3.1": {
+   "pom": "sha256-ywzs7U528l0aYMvNPGfM9eOQKPYCTpM17fX6oPL2vhI="
+  },
+  "org/eclipse/microprofile/context-propagation#microprofile-context-propagation-api/1.3": {
+   "jar": "sha256-aczARIfod3nUlwqlDGc8w0qd8IDBwOjY6rLotG+CXPQ=",
+   "pom": "sha256-nvSA7RaoZ9Gux6gEH6/mDcPBdF0G68GN1d1o5sQ/qEQ="
+  },
+  "org/eclipse/microprofile/context-propagation#microprofile-context-propagation-parent/1.3": {
+   "pom": "sha256-tIsfWNtYIsWs6EQcbAymZoHUsETBbbXLDsrxMUtGeLQ="
+  },
+  "org/eclipse/microprofile/openapi#microprofile-openapi-api/4.0.2": {
+   "jar": "sha256-xvypkT1+y964AdXmyTWYghn2Sg64sX4jQ36g4B56EKk=",
+   "pom": "sha256-pHgztxGIuIUZs0nPLC2LTiaKn78OhbwsC0+D7VFpcwo="
+  },
+  "org/eclipse/microprofile/openapi#microprofile-openapi-parent/4.0.2": {
+   "pom": "sha256-xZ/HxL1loTq28ogYDbDT5M1n2+sINSNpqn4wu7dsKus="
+  },
+  "org/eclipse/parsson#parsson/1.1.6": {
+   "jar": "sha256-f4gAdNCe+vG3RDv9n5m1KZgTkuhFrZctu2kXNEuxOBU=",
+   "pom": "sha256-DZz9FQTUuOs3gmXoY4M5nPEJuYMtCQvI0OzOMiOIs9M="
+  },
+  "org/eclipse/parsson#project/1.1.6": {
+   "pom": "sha256-LuAauaenRjgO5vpjnCrxvJixnc/WCmWZZUu7uS/tftA="
+  },
+  "org/infinispan#infinispan-bom/15.0.19.Final": {
+   "pom": "sha256-EORmwd1rdMnBh9B5ZpN25naQJrlCWTpKu10NQ9W4XY8="
+  },
+  "org/infinispan#infinispan-build-configuration-parent/15.0.19.Final": {
+   "pom": "sha256-3jSEoQYRh1Y+i9Jj4xFRWs3i/Ie4GgrxZJ5s/TCsjJA="
+  },
+  "org/infinispan#infinispan-commons-parent/15.0.19.Final": {
+   "pom": "sha256-luIdP8U1wVS//6cWlsrHprgsUGVAqM3CA3QXqIAc0OI="
+  },
+  "org/infinispan#infinispan-commons/15.0.19.Final": {
+   "jar": "sha256-lnV1+9JTNIcr1J2hIA8sizIwXh68z3EJUhk30PRo920=",
+   "pom": "sha256-sJb5V+rLRJc1umczXOCq+0OvTm2ZNvN3VHPw6sBOlRI="
+  },
+  "org/infinispan#infinispan-parent/15.0.19.Final": {
+   "pom": "sha256-jmzA2m9nq4OgTPxDgVmhqKYYpzrxGAMT894ueE5F2f4="
+  },
+  "org/infinispan/protostream#parent/5.0.14.Final": {
+   "pom": "sha256-dd31FbFXy5YxbUl5TptinotZ9s+rTRpOmXtXRerEpBE="
+  },
+  "org/infinispan/protostream#protostream-processor/5.0.14.Final": {
+   "jar": "sha256-7YnsbRu2iKEmyYr+OmguOw4JVVfWye1iaWvs2rTDX5M=",
+   "pom": "sha256-DfassHZwHm5xRbfsowFX6442zcQK0q2FGflf2ZlQYPU="
+  },
+  "org/infinispan/protostream#protostream-types/5.0.14.Final": {
+   "jar": "sha256-Ff7P3AVs+AMw2yTAUge1e5mpKsiXHx9wmEkfvRXfOd0=",
+   "pom": "sha256-uFRu3De9CldOIkryjf2NtLkAasbheD0zTxBMsmbQGpI="
+  },
+  "org/infinispan/protostream#protostream/5.0.14.Final": {
+   "jar": "sha256-dcDm6an7B8faP85awaUBIqjAqcg8wDnYjHjAfyf9MRg=",
+   "pom": "sha256-Qd4D8E1bo2CzRxCoAWjT3uZnuldNChSG8PO+/bZy6Rk="
+  },
+  "org/jboss#jboss-parent/18": {
+   "pom": "sha256-cHWFSAOI9dIE/KZTz7/KCIVx61HCW70VLoXwfhg3tuQ="
+  },
+  "org/jboss#jboss-parent/39": {
+   "pom": "sha256-BN/wdaAAlLYwYa9AfSgW2c3mZ5WsrjdqBUvf6Lox5mQ="
+  },
+  "org/jboss#jboss-parent/42": {
+   "pom": "sha256-5BJ27+NQkFTLpBl7PWNgxR3Ve8ZA3eSM832vqkWgnDs="
+  },
+  "org/jboss#jboss-parent/43": {
+   "pom": "sha256-PDredvuIOs25qKAzVdHfQGb/ucjHjwmyGenA/Co/Qxc="
+  },
+  "org/jboss#jboss-parent/44": {
+   "pom": "sha256-zsr9kUYWSkIoy76TFkCzmGAmwC2D+U7fFrZJNPe2rcc="
+  },
+  "org/jboss#jboss-parent/47": {
+   "pom": "sha256-B0S14LJQm3uhe4W1r1RoCOovH4Oydl/R2MMztyzQW+Y="
+  },
+  "org/jboss#jboss-parent/48": {
+   "pom": "sha256-CO+EDZkz+WMjFsnLGysaql2oZynZSE5ZdQnRh43iv5s="
+  },
+  "org/jboss#jboss-parent/49": {
+   "pom": "sha256-LomePziWPgSk3fGSpaQFY6cAnEjYVjBAaHTMwVzbBpg="
+  },
+  "org/jboss#jboss-parent/51": {
+   "pom": "sha256-Lh91oQ4VgfMvj/1mKRQU5ZkMfJZruwedu1IVGEmpzM4="
+  },
+  "org/jboss/logging#commons-logging-jboss-logging/1.0.0.Final": {
+   "jar": "sha256-8SF2Jj6iX054u0+ks20zWilzjd5qgSPhttqJplXRUP8=",
+   "pom": "sha256-WNsZt6ci9K+a5CHQh0xaCkpCt/0VqO0m2FmnM1du5cw="
+  },
+  "org/jboss/logging#jboss-logging/3.6.1.Final": {
+   "jar": "sha256-XgiksJLchbM38JEKdAVx2HIM+lZfq9iAqMr5SmV8pBY=",
+   "pom": "sha256-J82Iq45ZRrinqpJkTrNzLjW+KBQ5qwevcfiYRT7nVA0="
+  },
+  "org/jboss/logging#logging-parent/1.0.3.Final": {
+   "pom": "sha256-mXLIlHSc2jVXZiF9Q97XAJse6ybgMBwwkUotslPdaFs="
+  },
+  "org/jboss/logmanager#jboss-logmanager/3.1.2.Final": {
+   "jar": "sha256-wefeaCpIcajk7vsmra8PzGPNCRNUPFCqa39G+l7BUf4=",
+   "pom": "sha256-W8Fhlm6f+EcDJamlXR0bT3zhyp9b6CsrfG90toW+mxI="
+  },
+  "org/jboss/shrinkwrap#shrinkwrap-bom/1.2.6": {
+   "pom": "sha256-HArIAaoxJb3l6IFrqHijJDJZw5bS845nbihSqcxVADY="
+  },
+  "org/jboss/slf4j#slf4j-jboss-logmanager/2.0.2.Final": {
+   "jar": "sha256-ukaal16dHnnzSouqGgr6iwG72M8IBTfA4ImUdtMduEs=",
+   "pom": "sha256-HOpvrl8FyRjwFlKElZ09+wraiPUeeFWmHwC8l7Dl6HQ="
+  },
+  "org/jboss/threads#jboss-threads/3.9.1": {
+   "jar": "sha256-068va5Qurmg/8t59/mhGf41XDLuo2zf+hYl3NJw78qo=",
+   "pom": "sha256-1c6ELJiUVKWGeA4ONoidMglfFdMneG72yIRJ+d743AI="
+  },
+  "org/jctools#jctools-core/4.0.5": {
+   "jar": "sha256-1l5fOLzQmE4m+HGHaH8fcN1SdAxNXgRvjRBOAatduV8=",
+   "pom": "sha256-ppiXuP8MIZi0uM19T5P95tQrjp2/yVVTWF4nWHsk4hE="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.10.2": {
+   "pom": "sha256-+vDGU45T3cBJmmNmTY52PCFlgLLhjnIsy98bQxpq/iY="
+  },
+  "org/junit#junit-bom/5.10.0": {
+   "module": "sha256-6z7mEnYIAQaUqJgFbnQH0RcpYAOrpfXbgB30MLmIf88=",
+   "pom": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
+  },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.10.3": {
+   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
+   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
+  },
+  "org/junit#junit-bom/5.11.0": {
+   "module": "sha256-9+2+Z/IgQnCMQQq8VHQI5cR29An1ViNqEXkiEnSi7S0=",
+   "pom": "sha256-5nRZ1IgkJKxjdPQNscj0ouiJRrNAugcsgL6TKivkZE0="
+  },
+  "org/junit#junit-bom/5.11.3": {
+   "module": "sha256-S/D1PO6nx5D9+9JNujyeBM3FGGQnnuv8V6qkc+vKA4A=",
+   "pom": "sha256-8T3y5Mrx/rzlZ2Z+fDeBAaAzHVPRMk1uLf467Psfd3Q="
+  },
+  "org/junit#junit-bom/5.11.4": {
+   "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
+   "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
+  },
+  "org/junit#junit-bom/5.13.4": {
+   "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
+   "pom": "sha256-16CKmbJQLwu2jNTh+YTwv2kySqogi9D3M2bAP8NUikI="
+  },
+  "org/keycloak#keycloak-common/26.5.5": {
+   "jar": "sha256-ZB+kMKp8p9vHNR93xdyeqduUMWgm4EgpZIkdWvSV6zo=",
+   "pom": "sha256-fBzWAHCdgClX9zUJ7+873BNWKX0N675MY1ixG3Ikjd4="
+  },
+  "org/keycloak#keycloak-config-api/26.5.5": {
+   "jar": "sha256-6Y/29Dv+AxvgcFmnlKWkhFlK6LYrnWKjUlEcvDTkI2M=",
+   "pom": "sha256-pSFTYJ6QpvrpahgTMpQP6bmcip0ptrvONctmV+NK1ok="
+  },
+  "org/keycloak#keycloak-core/26.5.5": {
+   "jar": "sha256-TS8bSJFDWJBuICGTs50F/kiHUaQuqmr1Ettu+7iwl0w=",
+   "pom": "sha256-PrPiJ8FyTzEWupBOI67LMjqPEvuS02FfTvrKWCTt+oM="
+  },
+  "org/keycloak#keycloak-model-pom/26.5.5": {
+   "pom": "sha256-ztl66h+sNbjiXK1fXelKZKLq0OvGfCCvYJoFjPvGt1E="
+  },
+  "org/keycloak#keycloak-model-storage-private/26.5.5": {
+   "jar": "sha256-mRi37SV3O6UU0gRf3QR+yulI4FEeg7wWzrPSSeqedoo=",
+   "pom": "sha256-JA2OS5+N7m5ik7Ivb+fZ+q4m9IXKh1x+tFNFEKmoEXo="
+  },
+  "org/keycloak#keycloak-model-storage/26.5.5": {
+   "jar": "sha256-PDwhdds2nS0NRJ7b7nyjvX8FWpxFnV6xANsnbBCwqRo=",
+   "pom": "sha256-+BC4Lo9pcjn20DtaqXLhk/pw7UPzoCXQZvh7ZWspf7M="
+  },
+  "org/keycloak#keycloak-parent/26.5.5": {
+   "pom": "sha256-2izuXQjSCwZobr6uQgXqCgVU7DjvZckLD6ojo6Ifx2w="
+  },
+  "org/keycloak#keycloak-quarkus-parent/26.5.5": {
+   "pom": "sha256-jF4esK2Mu32lTNkl7FNz8lNKdAB55x3z9HQrIIbZqb0="
+  },
+  "org/keycloak#keycloak-server-spi-private/26.5.5": {
+   "jar": "sha256-2z8z5wSOycpCpwcA/we7GYVkZy5dR9T+u8q6ifbrIZ0=",
+   "pom": "sha256-k8IXgIYmQDemJyufqsVwyynnFJ8ZCCf74i1m84jL8xk="
+  },
+  "org/keycloak#keycloak-server-spi/26.5.5": {
+   "jar": "sha256-y/9NXkSRAPw/fiYKLsj6dzR4bmL6NqC4+afn4y4NKK4=",
+   "pom": "sha256-kq07NxwM/3D53hdMap0VcTJYJEvLXK2pX21iXA23uBE="
+  },
+  "org/keycloak#keycloak-services/26.5.5": {
+   "jar": "sha256-c5cS8n50AQlRGP8+XZKU7c/y8EekqksDhbB2XMM0L4c=",
+   "pom": "sha256-+Y1l1m79jR0n4hdQ23t2O6QcIXikmJ3pNdF9PWGHIq0="
+  },
+  "org/mockito#mockito-bom/5.18.0": {
+   "pom": "sha256-BhfEyedxfwt421BQgYuxvvLYvEuzmDQiQfKwoaKruZg="
+  },
+  "org/ow2#ow2/1.5.1": {
+   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm/9.8": {
+   "jar": "sha256-h26raoPa7K1cpn65/KuwY8l7WuuM8fynqYns3hdSIFE=",
+   "pom": "sha256-wTZ8O7OD12Gef3l+ON91E4hfLu8ErntZCPaCImV7W6o="
+  },
+  "org/reactivestreams#reactive-streams/1.0.4": {
+   "jar": "sha256-91yll3ibPaxY9hhXuawuEDSmj6Zy2zUFWo+0UJ4yXyg=",
+   "pom": "sha256-VLoj2HotQ4VAyZ74eUoIVvxXOiVrSYZ4KDw8Z+8Yrag="
+  },
+  "org/slf4j#slf4j-api/2.0.17": {
+   "jar": "sha256-e3UdlSBhlU1av+1xgcH2RdM2CRtnmJFZHWMynGIuuDI=",
+   "pom": "sha256-FQxAKH987NwhuTgMqsmOkoxPM8Aj22s0jfHFrJdwJr8="
+  },
+  "org/slf4j#slf4j-bom/2.0.17": {
+   "pom": "sha256-940ntkK0uIbrg5/BArXNn+fzDzdZn/5oGFvk4WCQMek="
+  },
+  "org/slf4j#slf4j-parent/2.0.17": {
+   "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/testcontainers#testcontainers-bom/1.21.3": {
+   "pom": "sha256-LOcXIm0dZ7Wx35cH7ZgCKjZqyJLZ5JbF8Bc/GreKCWU="
+  },
+  "org/twitter4j#twitter4j-core/4.1.2": {
+   "jar": "sha256-cmAigcBtl+ksY86EvZPQB2QvoL/4UvY98S/RI7mQsfI=",
+   "module": "sha256-AQDT1GTl6gAdKXq4e4JQsslz2b9a2VFnltfHvnVrOCY=",
+   "pom": "sha256-VhhBMpQ6873BFPIRc7ieacjMqlj2GBo/vR1g9xJro0Y="
+  },
+  "org/wildfly/common#wildfly-common/2.0.1": {
+   "jar": "sha256-+kpxDbeuPlmKX0FjnrVOn3sJ3l/Q9Y9WvWBw8h2VY3Q=",
+   "pom": "sha256-yWySJJfCjJxm7brae4odGYJJJr1B/h1LEMJ7psZsZfM="
+  },
+  "org/yaml#snakeyaml/2.0": {
+   "pom": "sha256-Q8dh+StUnIsI+5kggCU+SfCpg+VE7wZjwfT51o61JhY="
+  },
+  "org/yaml#snakeyaml/2.4": {
+   "jar": "sha256-73ea9dKand6MxwzgNB9cb3c14j7f+Whc6qnTU1m3u38=",
+   "pom": "sha256-4VSjIxzWzeaKq/J0/RiWTUmpwaX16e079HHprnvfCOY="
+  }
+ }
+}


### PR DESCRIPTION
> A Keycloak Mapper that maps Keycloak groups to Vikunja teams. The mapper allows configuration of specific attributes on groups to configure whether
> 
> * Teams are public
> * How the teams are named
> * Which description teams have
> 
> This mapper is compatible with Vikunja 0.25 onwards.

This has been in steady development for over a year now, but they don't seem to do tagged releases.

Tested on my own instances of Keycloak and Vikunja.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
