### PR TITLE
plakar: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "plakar";
-  version = "1.1.4";
+  version = "1.1.5";
 
   # to avoid having all the Test(Get|Set|Validate)Service.* tests fail on darwin
   __darwinAllowLocalNetworking = true;
@@ -22,31 +22,20 @@ buildGoModule (finalAttrs: {
     owner = "PlakarKorp";
     repo = "plakar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Urj1BG3XGhSroaa9pl9NGiKj38J1P+H9sA7noGwIhdc=";
+    hash = "sha256-6uw20jqAtJnPEeNrMsK/jA7+stdY4tAEkPe+mov6UNo=";
   };
 
-  vendorHash = "sha256-6Y9wzK0NMG/iJMR0eQFu20x4hKidJjwFv3Yx+BVNMTg=";
+  vendorHash = "sha256-s/4vTHFFfOuGnVc3FK0B5aa9kRATr356/mGydw4cMng=";
 
   # Remove in next release
   patches = [
     (fetchpatch {
-      name = "fuse3-support.patch";
-      url = "https://github.com/PlakarKorp/plakar/commit/d21d74b653a84806af79129a634b97596cbb00d8.patch";
-      includes = [ "go.mod" ];
-      hash = "sha256-K/Y7DrJJsQaQpQiEpU9OnY8JOMVXnu79L4Qaxsi2xlc=";
+      name = "backup-allow-multiple-ignore-files.patch";
+      url = "https://github.com/PlakarKorp/plakar/commit/049603ba4db8086ceb9aadf6197751083821e699.patch";
+      includes = [ "subcommands/backup/backup.go" ];
+      hash = "sha256-9uxkXpuWs758xlu3afANB14hqhVut7agvIeOlcm+98k=";
     })
   ];
-
-  # Remove in next release
-  postPatch = ''
-    substituteInPlace go.sum \
-      --replace-fail \
-        "github.com/anacrolix/fuse v0.3.2 h1:ablJbmHt2BeYGnNrlfXkAcKN96mMMeXZN/ZAqo1AY/o=" \
-        "github.com/anacrolix/fuse v0.3.3-0.20260723023734-9e1272bc0085 h1:9cQ6o8Qv3jbLAJ0a8dQX8ZntDtWY2ESuI3DtqhqWxEs=" \
-      --replace-fail \
-        "github.com/anacrolix/fuse v0.3.2/go.mod h1:vN3X/6E+uHNjg5F8Oy9FD9I+pYxeDWeB8mNjIoxL5ds=" \
-        "github.com/anacrolix/fuse v0.3.3-0.20260723023734-9e1272bc0085/go.mod h1:V14Hqx/K8kb3e6beqqT6reYy25RPP+2Ps3c0vEXoNMA="
-  '';
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Diff : https://github.com/PlakarKorp/plakar/compare/v1.1.4...v1.1.5
Changelog : https://github.com/PlakarKorp/plakar/releases/tag/v1.1.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
