### PR TITLE
nixos/redis: use replace-secret for sentinel auth-pass

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -622,13 +622,15 @@ in
                 fi
                 echo 'include "${redisConfStore}"' > "${redisConfRun}"
                 ${lib.optionalString (conf.requirePassFile != null) ''
-                  echo "requirepass $(cat ${lib.escapeShellArg conf.requirePassFile})" >> "${redisConfRun}"
+                  echo "requirepass @REQUIRE_PASS@" >> "${redisConfRun}"
+                  ${lib.getExe pkgs.replace-secret} '@REQUIRE_PASS@' ${lib.escapeShellArg conf.requirePassFile} "${redisConfRun}"
                 ''}
                 ${lib.optionalString (conf.masterUser != null) ''
                   echo "masteruser ${conf.masterUser}" >> "${redisConfRun}"
                 ''}
                 ${lib.optionalString (conf.masterAuthFile != null) ''
-                  echo "masterauth $(cat ${lib.escapeShellArg conf.masterAuthFile})" >> "${redisConfRun}"
+                  echo "masterauth @MASTER_AUTH@" >> "${redisConfRun}"
+                  ${lib.getExe pkgs.replace-secret} '@MASTER_AUTH@' ${lib.escapeShellArg conf.masterAuthFile} "${redisConfRun}"
                 ''}
                 ${lib.optionalString (conf.sentinelMasterHost != null) ''
                   sentinel_monitor_line="sentinel monitor ${conf.sentinelMasterName} ${conf.sentinelMasterHost} ${toString conf.sentinelMasterPort} ${toString conf.sentinelMasterQuorum}"

--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -649,13 +649,14 @@ in
                   fi
                 ''}
                 ${lib.optionalString (conf.sentinelAuthPassFile != null) ''
-                  sentinel_auth_pass_line="sentinel auth-pass ${conf.sentinelMasterName} $(cat ${lib.escapeShellArg conf.sentinelAuthPassFile})"
+                  sentinel_auth_pass_line="sentinel auth-pass ${conf.sentinelMasterName} @SENTINEL_AUTH_PASS@"
                   if grep -qE "^sentinel auth-pass ${conf.sentinelMasterName}\b" "${redisConfVar}"; then
                     sed -i \
                       "s|^sentinel auth-pass ${conf.sentinelMasterName}\b.*|$sentinel_auth_pass_line|" "${redisConfVar}"
                   else
                     echo "$sentinel_auth_pass_line" >> "${redisConfVar}"
                   fi
+                  ${lib.getExe pkgs.replace-secret} '@SENTINEL_AUTH_PASS@' ${lib.escapeShellArg conf.sentinelAuthPassFile} "${redisConfVar}"
                 ''}
               ''
             );


### PR DESCRIPTION
Fix sed escape issues like : 

`redis-sentinel-prep-conf[160725]: sed: -e expression #1, char 82: unknown option to 's'`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
