### PR TITLE
pprof: 0-unstable-2026-03-02 -> 0-unstable-2026-09-03

### DIFF
--- a/pkgs/by-name/pp/pprof/package.nix
+++ b/pkgs/by-name/pp/pprof/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule {
   pname = "pprof";
-  version = "0-unstable-2026-03-02";
+  version = "0-unstable-2026-09-03";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "pprof";
-    rev = "a15ffb7f9dccb95074ad153aef0f1fcbb01e61e3";
-    hash = "sha256-l+D7wbu+Nu8ePmDvhfDgOnu8jcn6mH9Wt3aUPOK+LsM=";
+    rev = "d6c3cb2f37ec22719bbaf5eb031d9a46635cb5b2";
+    hash = "sha256-2LflblPAds0JRZZPvxW986cgXCMV+R3qikLt9w+9vU0=";
   };
 
   nativeCheckInputs = [
@@ -51,6 +51,9 @@ buildGoModule {
       This is not an official Google product.
     '';
     mainProgram = "pprof";
-    maintainers = with lib.maintainers; [ hzeller ];
+    maintainers = with lib.maintainers; [
+      hzeller
+      lromor
+    ];
   };
 }


### PR DESCRIPTION
Update to head.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
