### PR TITLE
rush-lyrics: add playerctl runtime dependency

### DIFF
--- a/pkgs/by-name/ru/rush-lyrics/package.nix
+++ b/pkgs/by-name/ru/rush-lyrics/package.nix
@@ -15,6 +15,7 @@
   libxtst,
   fontconfig,
   libxkbcommon,
+  playerctl,
 }:
 
 let
@@ -78,9 +79,10 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/rush-lyrics
     cp -r desktopApp/build/compose/binaries/main/app/Rush/* $out/share/rush-lyrics/
 
-    # Wrap runtime binary to prefix graphics libraries
+    # Wrap runtime binary to prefix graphics libraries and playerctl CLI
     makeWrapper $out/share/rush-lyrics/bin/Rush $out/bin/rush-lyrics \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
+      --prefix PATH : "${lib.makeBinPath [ playerctl ]}"
 
     # Install icon
     install -Dm644 fastlane/metadata/android/en-US/images/icon.png $out/share/icons/hicolor/512x512/apps/rush-lyrics.png


### PR DESCRIPTION
A simple fix for Rush at runtime: `rush-lyrics` relies on `playerctl` to get MPRIS metadata.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
