### PR TITLE
go: enable strictDeps, structuredAttrs for bootstrap, use stdenvNoCC

### DIFF
--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor version}";

--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -4,6 +4,7 @@
   fetchurl,
   version,
   hashes,
+  bashNonInteractive,
 }:
 let
   platform = with stdenv.hostPlatform.go; "${GOOS}-${if GOARCH == "arm" then "armv6l" else GOARCH}";
@@ -16,8 +17,14 @@ stdenv.mkDerivation {
     sha256 = hashes.${platform} or (throw "Missing Go bootstrap hash for platform ${platform}");
   };
 
+  buildInputs = [
+    bashNonInteractive
+  ];
+
   # We must preserve the signature on Darwin
   dontStrip = stdenv.hostPlatform.isDarwin;
+
+  strictDeps = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -1,15 +1,17 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchurl,
   version,
   hashes,
   bashNonInteractive,
 }:
 let
-  platform = with stdenv.hostPlatform.go; "${GOOS}-${if GOARCH == "arm" then "armv6l" else GOARCH}";
+  platform =
+    with stdenvNoCC.hostPlatform.go;
+    "${GOOS}-${if GOARCH == "arm" then "armv6l" else GOARCH}";
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "go-${version}-${platform}-bootstrap";
 
   src = fetchurl {
@@ -22,7 +24,7 @@ stdenv.mkDerivation {
   ];
 
   # We must preserve the signature on Darwin
-  dontStrip = stdenv.hostPlatform.isDarwin;
+  dontStrip = stdenvNoCC.hostPlatform.isDarwin;
 
   strictDeps = true;
 


### PR DESCRIPTION
One of the last few changes needed to make everything up to and including the go compiler have strictDeps/structuredAttrs enabled... The other relevant PR is https://github.com/NixOS/nixpkgs/pull/559869 .

The change to `stdenvNoCC` is not necessary, but seemed like an improvement.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
