### PR TITLE
thonny: 4.1.7 -> 5.0.0, modernize

### DIFF
--- a/pkgs/by-name/th/thonny/package.nix
+++ b/pkgs/by-name/th/thonny/package.nix
@@ -10,14 +10,15 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "thonny";
-  version = "4.1.7";
+  version = "5.0.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "thonny";
     repo = "thonny";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RnjnXB5jU13uwRpL/Pn14QY7fRbRkq09Vopc3fv+z+Y=";
+    hash = "sha256-gvYf42QHoMHvowSb1nk2/VQmVWaXK+Cb89zqw0BWljo=";
   };
 
   nativeBuildInputs = [
@@ -39,8 +40,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     })
   ];
 
-  build-system = with python3.pkgs; [ setuptools ];
-
+  build-system = with python3.pkgs; [ uv-build ];
   dependencies =
     with python3.pkgs;
     (
@@ -54,6 +54,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
         pyperclip
         asttokens
         send2trash
+        setuptools
       ]
       ++ lib.optionals stdenv.hostPlatform.isLinux [
         dbus-next

--- a/pkgs/by-name/th/thonny/package.nix
+++ b/pkgs/by-name/th/thonny/package.nix
@@ -84,6 +84,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     '';
     homepage = "https://www.thonny.org/";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yvnth ];
     platforms = lib.platforms.unix;
     mainProgram = "thonny";
   };


### PR DESCRIPTION
Change log: https://github.com/thonny/thonny/releases/tag/v5.0.0
Also adding myself as this package maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
