### PR TITLE
rdma-core: move perl scripts to scripts output

### DIFF
--- a/pkgs/by-name/rd/rdma-core/package.nix
+++ b/pkgs/by-name/rd/rdma-core/package.nix
@@ -25,12 +25,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Y0pCGkvCjZ1F9Ojouesozn2Lxj+x7/0ck6/9tJmdkWw=";
   };
 
+  __structuredAttrs = true;
   strictDeps = true;
 
   outputs = [
     "out"
     "man"
     "dev"
+    "scripts"
   ];
 
   nativeBuildInputs = [
@@ -61,15 +63,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     # cmake script is buggy, move file manually
-    mkdir -p $out/${perl.libPrefix}
-    mv $out/share/perl5/* $out/${perl.libPrefix}
+    mkdir -p $scripts/${perl.libPrefix}
+    mv $out/share/perl5/* $scripts/${perl.libPrefix}
   '';
 
   postFixup = ''
-    for pls in $out/bin/{ibfindnodesusing.pl,ibidsverify.pl}; do
+    for pls in ibfindnodesusing.pl ibidsverify.pl check_lft_balance.pl; do
       echo "wrapping $pls"
-      substituteInPlace $pls --replace \
-        "${perl}/bin/perl" "${perl}/bin/perl -I $out/${perl.libPrefix}"
+      substituteInPlace $out/bin/$pls \
+        --replace-fail "${perl}/bin/perl" "${perl}/bin/perl -I $scripts/${perl.libPrefix}"
+      moveToOutput bin/$pls "$scripts"
     done
   '';
 
@@ -78,6 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";
   };
+
+  outputChecks.out.disallowedRequisites = [
+    perl
+  ];
 
   meta = {
     description = "RDMA Core Userspace Libraries and Daemons";


### PR DESCRIPTION
This enables normal systems to be perlless again. rdma-core was added as a default dependency to libpcacp which is a dependency of iptables and thus by default in most systems.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
