### PR TITLE
perfetto-sdk: init at 58.3

### DIFF
--- a/pkgs/by-name/pe/perfetto-sdk/package.nix
+++ b/pkgs/by-name/pe/perfetto-sdk/package.nix
@@ -1,0 +1,7 @@
+{
+  perfetto,
+  ...
+}@args:
+
+# Alias to perfetto.sdk to improve discoverability
+(perfetto.override (removeAttrs args [ "perfetto" ])).sdk

--- a/pkgs/by-name/pe/perfetto/package.nix
+++ b/pkgs/by-name/pe/perfetto/package.nix
@@ -239,6 +239,10 @@ stdenv.mkDerivation (finalAttrs: {
           runHook postInstall
         '';
 
+        passthru = {
+          inherit (finalAttrs.passthru) updateScript tests;
+        };
+
         meta = {
           inherit (finalAttrs.meta)
             homepage


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/553888 introduced `perfetto`, packaging the end user focus executables; it also exposes a `sdk` attribute, as its name implies is for other derivation to consume. Although I stand by the decision to maintain both in the same file (they share the same source, most of the same deps, etc), I think it would be valuable for the SDK to have its own `by-name` entry so it appears on e.g. https://search.nixos.org/packages?channel=26.05&query=perfetto – because they do not have the same audiance, someone looking for one would not necessarily assume the other is also available.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
