### PR TITLE
python3Packages.pyscf: cleanup, re-enable on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -1,12 +1,12 @@
 {
-  buildPythonPackage,
   lib,
+  stdenv,
+  buildPythonPackage,
   fetchFromGitHub,
 
   # build-sysetm
   cmake,
   setuptools,
-  wheel,
 
   # build inputs
   blas,
@@ -23,6 +23,7 @@
   cppe,
 
   # tests
+  pytest-xdist,
   pytestCheckHook,
 }:
 
@@ -30,6 +31,7 @@ buildPythonPackage (finalAttrs: {
   pname = "pyscf";
   version = "2.14.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pyscf";
@@ -38,18 +40,18 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-9FyiN5VrFpZ6Q4JFvNn1gVQJq4KQysiL5Sz5E+fSC5U=";
   };
 
-  # setup.py calls Cmake and passes the arguments in CMAKE_CONFIGURE_ARGS to cmake.
-  build-system = [
-    setuptools
-    wheel
-    cmake
-  ];
-
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "cmake<4.0" "cmake"
   '';
+
+  # setup.py calls Cmake and passes the arguments in CMAKE_CONFIGURE_ARGS to cmake.
+  build-system = [
+    setuptools
+    cmake
+  ];
   dontUseCmakeConfigure = true;
+
   preConfigure = ''
     export CMAKE_CONFIGURE_ARGS="-DBUILD_LIBCINT=0 -DBUILD_LIBXC=0 -DBUILD_XCFUN=0"
     PYSCF_INC_DIR="${libcint}:${libxc}:${xcfun}";
@@ -73,67 +75,88 @@ buildPythonPackage (finalAttrs: {
   };
 
   nativeCheckInputs = [
+    pytest-xdist
     pytestCheckHook
   ]
   ++ finalAttrs.passthru.optional-dependencies.cppe;
   pythonImportsCheck = [ "pyscf" ];
-  preCheck = ''
+  preCheck =
     # Set config used by tests to ensure reproducibility
-    echo 'pbc_tools_pbc_fft_engine = "NUMPY"' > pyscf/pyscf_config.py
-    ulimit -s 20000
-    export PYSCF_CONFIG_FILE=$(pwd)/pyscf/pyscf_config.py
-  '';
+    ''
+      echo 'pbc_tools_pbc_fft_engine = "NUMPY"' > pyscf/pyscf_config.py
+      ulimit -s 20000
+      export PYSCF_CONFIG_FILE=$(pwd)/pyscf/pyscf_config.py
+    '';
 
-  # Numerically slightly off tests
   disabledTests = [
-    "test_rdm_trace"
-    "test_tdhf_singlet"
-    "test_ab_hf"
-    "test_ea"
-    "test_bz"
-    "h2o_vdz"
-    "test_mc2step_4o4e"
-    "test_ks_noimport"
-    "test_jk_hermi0"
-    "test_j_kpts"
-    "test_k_kpts"
-    "test_lda"
-    "high_cost"
-    "skip"
+    # Numerically slightly off tests
     "call_in_background"
+    "h2o_vdz"
+    "high_cost"
     "libxc_cam_beta_bug"
-    "test_finite_diff_rks_eph"
-    "test_finite_diff_uks_eph"
-    "test_finite_diff_roks_grad"
+    "skip"
+    "test_ab_hf"
+    "test_bz"
+    "test_collinear_kgks_gga"
+    "test_ea"
+    "test_ee_adc3"
     "test_finite_diff_df_roks_grad"
+    "test_finite_diff_rks_eph"
+    "test_finite_diff_roks_grad"
+    "test_finite_diff_uks_eph"
     "test_frac_particles"
     "test_gwac_pade_frozen"
+    "test_j_kpts"
+    "test_jk_hermi0"
+    "test_k_kpts"
+    "test_ks_noimport"
+    "test_lda"
+    "test_libxc_gga_deriv4"
+    "test_mc2step_4o4e"
+    "test_n3_cis_ewald"
     "test_nosymm_sa4_newton"
     "test_pipek"
-    "test_n3_cis_ewald"
-    "test_veff"
-    "test_collinear_kgks_gga"
-    "test_libxc_gga_deriv4"
+    "test_rdm_trace"
     "test_sacasscf_grad"
-    "test_sparse_dot"
     "test_set_param_named"
+    "test_sparse_dot"
+    "test_tdhf_singlet"
+    "test_veff"
+
+    # Flaky when using pytest-xdist:
+    #   NotImplementedError: Guess type not implemented
+    "test_ee_adc2x_cis"
+    #   AttributeError: 'UADCIP' object has no attribute 'f_ov'
+    "test_ee_adc2x"
+    #   BlockingIOError: [Errno 11] Unable to synchronously open file
+    "test_khf_newton"
+    "test_get_rho"
+    "test_init_guess_from_chkfile"
+    "test_kghf"
+    #   TypeError: '>' not supported between instances of 'list' and 'int'
+    "test_to_khf_with_chkfile"
+
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # Numerically slightly off tests
+    "test_ee_adc2x"
+    "test_vs_libxc_rks"
+    "test_vs_libxc_uks"
+    "test_xcfun_gga_deriv3"
   ];
 
   disabledTestPaths = [
-    "pyscf/pbc/tdscf"
-    "pyscf/pbc/gw"
-    "pyscf/nac/test/test_sacasscf.py"
     "pyscf/grad/test/test_casscf.py"
+    "pyscf/nac/test/test_sacasscf.py"
+    "pyscf/pbc/gw"
+    "pyscf/pbc/tdscf"
   ];
 
   meta = {
     description = "Python-based simulations of chemistry framework";
     homepage = "https://github.com/pyscf/pyscf";
+    changelog = "https://github.com/pyscf/pyscf/blob/${finalAttrs.src.rev}/CHANGELOG";
     license = lib.licenses.asl20;
-    platforms = [
-      "x86_64-linux"
-      "aarch64-darwin"
-    ];
     maintainers = [ lib.maintainers.sheepforce ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

As title.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
