### PR TITLE
binaryninja-free: 5.2.8722 -> 6.0.10601

### DIFF
--- a/pkgs/by-name/bi/binaryninja-free/package.nix
+++ b/pkgs/by-name/bi/binaryninja-free/package.nix
@@ -1,11 +1,13 @@
 {
   autoPatchelfHook,
   copyDesktopItems,
+  curl,
   dbus,
   fetchurl,
   fontconfig,
   freetype,
   lib,
+  libdrm,
   libGLU,
   libxkbcommon,
   makeDesktopItem,
@@ -16,16 +18,28 @@
   libxcb-keysyms,
   libxcb-render-util,
   libxcb-wm,
-  libxml2,
 }:
+let
+  version = "6.0.10601";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://github.com/Vector35/binaryninja-api/releases/download/stable/${version}/binaryninja_free_linux.zip";
+      hash = "sha256-PoucWGGr5umwTIa1+cStLchs7ep5ty17Cu4f3PfOkdY=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/Vector35/binaryninja-api/releases/download/stable/${version}/binaryninja_free_linux-arm.zip";
+      hash = "sha256-G3gSWFa+Rh9zJMoA9QyH8XiIXsEK0YVXgHDtmR6X11o=";
+    };
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "binaryninja-free";
-  version = "5.2.8722";
+  inherit version;
 
-  src = fetchurl {
-    url = "https://github.com/Vector35/binaryninja-api/releases/download/stable/${finalAttrs.version}/binaryninja_free_linux.zip";
-    hash = "sha256-YlBr/Cdjev7LWY/VsKgv/i3zHj4YR49RX69zmhhie7U=";
-  };
+  src = fetchurl (
+    sources.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")
+  );
 
   icon = fetchurl {
     url = "https://raw.githubusercontent.com/Vector35/binaryninja-api/448f40be71dffa86a6581c3696627ccc1bdf74f2/docs/img/logo.png";
@@ -54,9 +68,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    curl
     dbus
     fontconfig
     freetype
+    libdrm
     libGLU
     libxkbcommon
     stdenv.cc.cc.lib
@@ -96,6 +112,9 @@ stdenv.mkDerivation (finalAttrs: {
       scoder12
       timschumi
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
   };
 })


### PR DESCRIPTION
https://binary.ninja/2026/09/03/binary-ninja-6.0-krypton.html

Adds support for aarch64-linux.

Supersedes #550630

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
