### PR TITLE
bitcoin-knots: 29.3.knots20260508 -> 29.4.1.knots20260508

### DIFF
--- a/pkgs/by-name/bi/bitcoin-knots/package.nix
+++ b/pkgs/by-name/bi/bitcoin-knots/package.nix
@@ -36,12 +36,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = if withGui then "bitcoin-knots" else "bitcoind-knots";
-  version = "29.3.knots20260508";
+  version = "29.4.1.knots20260508";
 
   src = fetchurl {
     url = "https://bitcoinknots.org/files/29.x/${finalAttrs.version}/bitcoin-${finalAttrs.version}.tar.gz";
     # hash retrieved from signed SHA256SUMS
-    hash = "sha256-jjrr2sqzL29rZdkMmKGIlSVToSpXfgtY0TUlv9Wd1jA=";
+    hash = "sha256-2kPox5C+2djEMtB6ECcQhFN9vWHeO6D3vUn5Wa3Lm48=";
   };
 
   nativeBuildInputs = [
@@ -86,18 +86,18 @@ stdenv.mkDerivation (finalAttrs: {
       publicKeys = fetchFromGitHub {
         owner = "bitcoinknots";
         repo = "guix.sigs";
-        rev = "15113e2fe61b31354a6bcc3fddd17f759ce20c4a";
-        sha256 = "sha256-snbs2j88k9CBdv8+s3GaFoIXyJRVWlKoxiKA8R6ek9Y=";
+        rev = "5d1879a10e22934294944eebc2f5f925a29b5ebc";
+        sha256 = "sha256-5xZSk7BnZI8FOiAgONsHqDBztuKpyBHJVp8VpcXhJlo=";
       };
 
       checksums = fetchurl {
         url = "https://bitcoinknots.org/files/${majorVersion}.x/${finalAttrs.version}/SHA256SUMS";
-        hash = "sha256-vFfeObwXowk143DSv9WZ++u+KA0fuHexFU1NizrCiV4=";
+        hash = "sha256-r6vDK1Vu7pjVaJVlDoakOaIwMv5ZsyHPx0YULecAxnI=";
       };
 
       signatures = fetchurl {
         url = "https://bitcoinknots.org/files/${majorVersion}.x/${finalAttrs.version}/SHA256SUMS.asc";
-        hash = "sha256-8pVhrITphjs7rnJZrmxAU92GVgkjVPlkA54ne9iwiIs=";
+        hash = "sha256-2qInQ7g/YpXBgmHz7UtDf8Jherr2O1fIr+atVWBJVK4=";
       };
 
       verifyBuilderKeys =
@@ -149,7 +149,6 @@ stdenv.mkDerivation (finalAttrs: {
     # building with db48 (for legacy wallet support) is broken on Darwin
     (lib.cmakeBool "WITH_BDB" (withWallet && !stdenv.hostPlatform.isDarwin))
     (lib.cmakeBool "WITH_USDT" enableTracing)
-    (lib.cmakeFeature "RDTS_CONSENT" "RUNTIME_WARN")
   ]
   ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
     (lib.cmakeBool "BUILD_TESTS" false)


### PR DESCRIPTION
https://github.com/bitcoinknots/bitcoin/releases/tag/v29.4.1.knots20260508

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
