### PR TITLE
norgolith: 1.3.1 -> 1.4.0, norgolith-mcp: 1.1.0 -> 1.2.0, norgolith-plugin-sdk: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/by-name/no/norgolith-mcp/package.nix
+++ b/pkgs/by-name/no/norgolith-mcp/package.nix
@@ -6,17 +6,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "norgolith-mcp";
-  version = "1.1.0";
+  version = "1.2.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "norgolith";
     repo = "core";
     tag = "norgolith-mcp-v${finalAttrs.version}";
-    hash = "sha256-YaJ+VMtEZksiGvEaDUVrvOxtV/qxTUSQGDLiEBQ8OP8=";
+    hash = "sha256-XCcycFHAi3NAVGg7toCLMkVylV0kTAUb5CkLmvplR1w=";
   };
 
-  cargoHash = "sha256-dxWsMsOmTS5g8pKLw6Vtv5NyJtrRzkiPlBCq2WPRw/M=";
+  cargoHash = "sha256-i9noy9F/qitOKGbSCjxyey0rYzNOVNfWLPrdPOLZvGk=";
 
   cargoRoot = "norgolith-mcp";
   buildAndTestSubdir = "norgolith-mcp";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "MCP (Model Context Protocol) server for Norgolith documentation";
     homepage = "https://norgolith.dev";
-    changelog = "https://github.com/norgolith/core/releases/tag/norgolith-mcp-v${finalAttrs.version}";
+    changelog = "https://github.com/norgolith/core/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.Ladas552 ];
     mainProgram = "norgolith-mcp";

--- a/pkgs/by-name/no/norgolith-plugin-sdk/package.nix
+++ b/pkgs/by-name/no/norgolith-plugin-sdk/package.nix
@@ -6,17 +6,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "norgolith-plugin-sdk";
-  version = "1.1.1";
+  version = "1.2.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "norgolith";
     repo = "core";
     tag = "norgolith-plugin-sdk-v${finalAttrs.version}";
-    hash = "sha256-jL8Ajv3K70t1eXttqtrm9WoN9QRW6aucK380iJn3ACw=";
+    hash = "sha256-XCcycFHAi3NAVGg7toCLMkVylV0kTAUb5CkLmvplR1w=";
   };
 
-  cargoHash = "sha256-KhsNCVZAFDWVlxTzkpTdDT6RqE9j+nejTj0botqywvM=";
+  cargoHash = "sha256-zNch2yFswY9L9cYckYB7P5lV82XYbFY7Zct9Bw6hjd8=";
 
   cargoRoot = "sdk";
   buildAndTestSubdir = "sdk";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "SDK for building Norgolith plugins";
     homepage = "https://norgolith.dev";
-    changelog = "https://github.com/norgolith/core/releases/tag/norgolith-plugin-sdk-v${finalAttrs.version}";
+    changelog = "https://github.com/norgolith/core/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.Ladas552 ];
     mainProgram = "norgolith-plugin-sdk";

--- a/pkgs/by-name/no/norgolith/package.nix
+++ b/pkgs/by-name/no/norgolith/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "norgolith";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "norgolith";
     repo = "core";
     tag = "norgolith-v${finalAttrs.version}";
-    hash = "sha256-R74IUEQ7XkeC/YeEhKTOTPwnhRwDh+nAbAOstc9PzFk=";
+    hash = "sha256-XCcycFHAi3NAVGg7toCLMkVylV0kTAUb5CkLmvplR1w=";
   };
 
-  cargoHash = "sha256-Zy8IhQq5Fdnv7CkkEFHV/wxedEAmd6OfKw7BWbRoA7w=";
+  cargoHash = "sha256-sEC20LrVHOXTf9HJPxPiWlZ94Ev8aZq57k4gMR6VTNI=";
 
   nativeBuildInputs = [
     pkg-config
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "The monolithic Norg static site generator built with Rust";
     homepage = "https://norgolith.dev";
-    changelog = "https://github.com/norgolith/core/releases/tag/norgolith-v${finalAttrs.version}";
+    changelog = "https://github.com/norgolith/core/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.Ladas552 ];
     mainProgram = "lith";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Manually update packages, as r-ryantm did not  pick up latest releases in [norgolith repo](https://github.com/norgolith/core/releases). Also changing changelog to use `${finalAttrs.src.tag}` in case it fixes auto updates.

No breaking changes 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
