### PR TITLE
rust: enable strictDeps / structuredAttrs in its build infrastructure

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -105,6 +105,8 @@ let
       outputHash = hash;
       outputHashAlgo = if hash == "" then "sha256" else null;
       outputHashMode = "recursive";
+
+      __structuredAttrs = true;
     }
     // removeAttrs args removedArgs
   );
@@ -117,6 +119,8 @@ runCommand "${name}-vendor"
       cargo
       replaceWorkspaceValues
     ];
+    strictDeps = true;
+    __structuredAttrs = true;
   }
   ''
     fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"

--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -49,6 +49,8 @@ runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}"
       unwrapped = rustc-unwrapped;
     };
 
+    __structuredAttrs = true;
+
     meta = rustc-unwrapped.meta // {
       description = "${rustc-unwrapped.meta.description} (wrapper script)";
       priority = 10;

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -176,6 +176,9 @@ rec {
     ]
     ++ lib.optional (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) gcc.cc.lib;
 
+    strictDeps = true;
+    __structuredAttrs = true;
+
     postPatch = ''
       patchShebangs .
     '';

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -48,6 +48,8 @@ rec {
     ++ lib.optional (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) gcc.cc.lib
     ++ lib.optional (!stdenv.hostPlatform.isDarwin) zlib;
 
+    strictDeps = true;
+
     postPatch = ''
       patchShebangs .
     '';
@@ -89,6 +91,8 @@ rec {
     dontStrip = true;
 
     setupHooks = ./setup-hook.sh;
+
+    __structuredAttrs = true;
 
     passthru = rec {
       targetPlatformsWithHostTools = [

--- a/pkgs/development/compilers/rust/cargo-auditable-cargo-wrapper.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable-cargo-wrapper.nix
@@ -14,6 +14,8 @@ else
     {
       nativeBuildInputs = [ makeBinaryWrapper ];
 
+      strictDeps = true;
+
       passthru.tests =
         runCommand "rust-audit-info-test"
           {
@@ -22,6 +24,8 @@ else
           ''
             rust-audit-info ${lib.getBin rust-audit-info}/bin/rust-audit-info > $out
           '';
+
+      __structuredAttrs = true;
 
       meta = cargo-auditable.meta // {
         mainProgram = "cargo";

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -116,6 +116,8 @@ rustPlatform.buildRustPackage.override
       rustPlatform.rust.rustc.unwrapped
     ];
 
+    __structuredAttrs = true;
+
     meta = {
       homepage = "https://crates.io";
       description = "Downloads your Rust project's dependencies and builds your project";

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -411,6 +411,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optional (!withBundledLLVM) llvmShared.lib
   ++ optional (useLLVM && !withBundledLLVM) llvmPackages.libunwind;
 
+  strictDeps = true;
+
   outputs = [
     "out"
     "man"


### PR DESCRIPTION
These are required changes to make everything up to and including the Rust compiler have strictDeps / structuredAttrs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
