### PR TITLE
ffmpeg-full: enable libplacebo on darwin

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -123,7 +123,7 @@
   withOpenjpeg ? withHeadlessDeps, # JPEG 2000 de/encoder
   withOpenmpt ? withHeadlessDeps, # Tracked music files decoder
   withOpus ? withHeadlessDeps, # Opus de/encoder
-  withPlacebo ? withFullDeps && !stdenv.hostPlatform.isDarwin, # libplacebo video processing library
+  withPlacebo ? withFullDeps, # libplacebo video processing library
   withPulse ? withSmallDeps && stdenv.hostPlatform.isLinux, # Pulseaudio input support
   withQrencode ? withFullDeps && lib.versionAtLeast version "7", # QR encode generation
   withQuirc ? withFullDeps && lib.versionAtLeast version "7", # QR decoding
@@ -160,7 +160,7 @@
   withVorbis ? withHeadlessDeps, # Vorbis de/encoding, native encoder exists
   withVpl ? withFullDeps && stdenv.hostPlatform.isLinux, # Hardware acceleration via intel libvpl
   withVpx ? withHeadlessDeps && stdenv.buildPlatform == stdenv.hostPlatform, # VP8 & VP9 de/encoding
-  withVulkan ? withHeadlessDeps && !stdenv.hostPlatform.isDarwin,
+  withVulkan ? withHeadlessDeps && (!stdenv.hostPlatform.isDarwin || withFullDeps),
   withVvenc ? withFullDeps && lib.versionAtLeast version "7.1", # H.266/VVC encoding
   withWebp ? withHeadlessDeps, # WebP encoder
   withWhisper ? withFullDeps && lib.versionAtLeast version "8.0", # Whisper speech recognition
@@ -1059,7 +1059,7 @@ stdenv.mkDerivation (
         addDriverRunpath ${placeholder "lib"}/lib/libavutil.so
       ''
       # https://trac.ffmpeg.org/ticket/10809
-      + optionalString (versionAtLeast version "5.0" && withVulkan && !stdenv.hostPlatform.isMinGW) ''
+      + optionalString (versionAtLeast version "5.0" && withVulkan && stdenv.hostPlatform.isLinux) ''
         patchelf $lib/lib/libavcodec.so --add-needed libvulkan.so --add-rpath ${
           lib.makeLibraryPath [ vulkan-loader ]
         }


### PR DESCRIPTION
libplacebo was conservatively disabled on Darwin for ffmpeg-full, but it already works as a standalone package (via MoltenVK). This diff just removes the artificial restriction - tested on linux and Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
