### PR TITLE
pegasus-frontend: 2024-11-11 -> 2026-07-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12339,6 +12339,12 @@
     github = "Irgendeinwer";
     githubId = 175053643;
   };
+  irgolic = {
+    name = "Rafael Irgolič";
+    email = "hello@irgolic.com";
+    github = "irgolic";
+    githubId = 24586651;
+  };
   ironicbadger = {
     email = "alexktz@gmail.com";
     github = "ironicbadger";

--- a/pkgs/by-name/pe/pegasus-frontend/package.nix
+++ b/pkgs/by-name/pe/pegasus-frontend/package.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation {
   pname = "pegasus-frontend";
-  version = "0-unstable-2024-11-11";
+  version = "0-unstable-2026-07-18";
 
   src = fetchFromGitHub {
     owner = "mmatyas";
     repo = "pegasus-frontend";
-    rev = "54362976fd4c6260e755178d97e9db51f7a896af";
+    rev = "6b322063a036db60cba5810fda82a3ce38f1e62f";
     fetchSubmodules = true;
-    hash = "sha256-DqtkvDg0oQL9hGB+6rNXe3sDBywvnqy9N31xfyl6nbI=";
+    hash = "sha256-HsOli+iU9DjTrFSjBENiIURCXQcazB9QWrti7VszNvE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pe/pegasus-frontend/package.nix
+++ b/pkgs/by-name/pe/pegasus-frontend/package.nix
@@ -44,7 +44,10 @@ stdenv.mkDerivation {
     mainProgram = "pegasus-fe";
     homepage = "https://pegasus-frontend.org/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ tengkuizdihar ];
+    maintainers = with lib.maintainers; [
+      tengkuizdihar
+      irgolic
+    ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Bumps pegasus-frontend from 2024-11-11 to 2026-07-18. FYI pegasus-frontend do not make releases, best we can do is pin a commit like this.

In my own testing nothing breaks between these builds.

I've also added myself as a maintainer – the package only has one maintainer at the moment, who seems to be inactive.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
