### PR TITLE
filezilla: 3.70.6 -> 3.71.1, fzssh: 1.3.0 -> 1.4.0 and add myself as maintainer

### DIFF
--- a/pkgs/by-name/fi/filezilla/package.nix
+++ b/pkgs/by-name/fi/filezilla/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "filezilla";
-  version = "3.70.6";
+  version = "3.71.1";
 
   src = fetchurl {
     # Upstream download link was made unstable on purpose
     # See https://trac.filezilla-project.org/ticket/13186
     url = "https://sources.archlinux.org/other/filezilla/filezilla-${finalAttrs.version}.tar.xz";
-    hash = "sha256-PdJCWpf5bbjMiyEuG2BdeVEljj2jJ5yQEHq/SmqJyD8=";
+    hash = "sha256-Pfm5s+Wyw33G2ey4g1VKuhQKAuxHw9a1IzO/FzOvTaQ=";
   };
 
   configureFlags = [

--- a/pkgs/by-name/fz/fzssh/package.nix
+++ b/pkgs/by-name/fz/fzssh/package.nix
@@ -19,14 +19,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fzssh";
-  version = "1.3.0";
+  version = "1.4.0";
   __structuredAttrs = true;
 
   src = fetchurl {
     # Upstream download link was made unstable on purpose
     # See https://trac.filezilla-project.org/ticket/13186
     url = "https://sources.archlinux.org/other/packages/fzssh/fzssh-${finalAttrs.version}.tar.xz";
-    hash = "sha256-hkWCsgNyZYi1oW2GFB/5Wrd9I5l2L+u+H97ZLk8EeZY=";
+    hash = "sha256-DFMXgpg2RATh/kzj1QJnzxI45StBSmpTNWvEOzeBEzg=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/fz/fzssh/package.nix
+++ b/pkgs/by-name/fz/fzssh/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://lib.filezilla-project.org/";
     description = "SSH/SFTP library based on libfilezilla";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iedame ];
     pkgConfigModules = [ "libfzssh-client" ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Since https://github.com/NixOS/nixpkgs/pull/524601 `fzssh` was added to buildInputs so it is needed up-to-date to properly compile the latest `filezilla`.

This PR updates both `filezilla` and `fzssh` and adds myself as maintainer to be able to update it along filezilla.

Changelog: https://svn.filezilla-project.org/filezilla/FileZilla3/trunk/NEWS

closes https://github.com/NixOS/nixpkgs/pull/558515
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
