### PR TITLE
trealla: 2.106.1 -> 3.9.39

### DIFF
--- a/pkgs/by-name/tr/trealla/package.nix
+++ b/pkgs/by-name/tr/trealla/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   libffi,
+  nix-update-script,
   openssl,
   readline,
   stdenv,
@@ -23,20 +24,20 @@ assert lib.elem lineEditingLibrary [
 ];
 stdenv.mkDerivation (finalAttrs: {
   pname = "trealla";
-  version = "2.106.1";
+  version = "3.9.39";
 
   src = fetchFromGitHub {
     owner = "trealla-prolog";
     repo = "trealla";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-21moIBYPAH9MF6NBfZRrnKMuQsFpLI+gxxe0kkoLDII=";
+    hash = "sha256-yfulQuwR3DgZk7ZUrVdqs09uZOcRmrTkZuU45Sw/f/o=";
   };
 
   postPatch = ''
-    substituteInPlace Makefile \
-      --replace '-I/usr/local/include' "" \
-      --replace '-L/usr/local/lib' "" \
-      --replace 'GIT_VERSION :=' 'GIT_VERSION ?='
+    substituteInPlace GNUmakefile \
+      --replace-fail '-I/usr/local/include' "" \
+      --replace-fail '-I/usr/local/opt/libffi/include' "" \
+      --replace-fail '-L/usr/local/lib' ""
   '';
 
   nativeBuildInputs = [ xxd ];
@@ -50,20 +51,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  env.LC_ALL = if stdenv.hostPlatform.isDarwin then "en_US.UTF-8" else "C.UTF-8";
+
   makeFlags = [
     "GIT_VERSION=\"v${finalAttrs.version}\""
+    "PREFIX=$(out)"
   ]
   ++ lib.optionals (lineEditingLibrary == "isocline") [ "ISOCLINE=1" ]
   ++ lib.optionals (!enableFFI) [ "NOFFI=1" ]
   ++ lib.optionals (!enableSSL) [ "NOSSL=1" ]
-  ++ lib.optionals enableThreads [ "THREADS=1" ];
+  ++ lib.optionals (!enableThreads) [ "NOTHREADS=1" ];
 
   enableParallelBuilding = true;
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 -t $out/bin tpl
-    runHook postInstall
+  postInstall = ''
+    find $out/share/trealla/library -type f \
+      \( -name '*.c' -o -name '*.d' -o -name '*.o' \) -delete
   '';
 
   doCheck = !valgrind.meta.broken;
@@ -71,6 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
   checkFlags = [ "test" ] ++ lib.optionals checkLeaks [ "leaks" ];
 
   passthru = {
+    updateScript = nix-update-script { };
+
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
