### PR TITLE
python3Packages.scikit-learn: backport fix for HTML repr performance

### DIFF
--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -48,6 +48,12 @@ buildPythonPackage (finalAttrs: {
     hatch-vcs
   ];
 
+  # nilearn excludes scikit-learn 1.9.0 due to a sluggish HTML repr bug,
+  # which is fixed by the patch applied to python3Packages.scikit-learn.
+  pythonRelaxDeps = [
+    "scikit-learn"
+  ];
+
   dependencies = [
     joblib
     nibabel

--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -3,6 +3,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
 
   # build-system
   cython,
@@ -34,6 +35,16 @@ buildPythonPackage rec {
     inherit version;
     hash = "sha256-iDMmaYnTpREBeKn64weDZ1Rgck0OHvsTsUkB0sZgxVc=";
   };
+
+  patches = [
+    # Fix HTML display performance when user has many features
+    # https://github.com/scikit-learn/scikit-learn/pull/34362
+    # TODO: remove when updating to the next release.
+    (fetchpatch {
+      url = "https://github.com/scikit-learn/scikit-learn/commit/aeadb51af96556dd0f884c0037c9dc9993449538.patch";
+      hash = "sha256-J7igLpK8pdcbgMwxFqaAGDEwm87VrLHb+ckg/pEh6IY=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace meson.build --replace-fail \


### PR DESCRIPTION
Backports scikit-learn/scikit-learn#34362, which fixes sluggish HTML representation of estimators with many features. The fix landed after the 1.9.0 release; drop it once we update to the version that includes it.

Also drop nilearn's !=1.9.0 scikit-learn exclusion, which was added specifically for this issue.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
