### PR TITLE
nomacs: fix darwin build

### DIFF
--- a/pkgs/by-name/no/nomacs/package.nix
+++ b/pkgs/by-name/no/nomacs/package.nix
@@ -10,6 +10,7 @@
   opencv4,
   pkg-config,
   stdenv,
+  rsync,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "nomacs";
@@ -20,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "nomacs";
     repo = "nomacs";
     rev = finalAttrs.version;
-    fetchSubmodules = false; # We'll use our own
+    fetchSubmodules = false; # upstream no longer uses submodules
     inherit (finalAttrs) hash;
   };
 
@@ -36,6 +37,9 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     qt6.wrapQtAppsHook
     pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    rsync
   ];
 
   buildInputs = [
@@ -47,13 +51,21 @@ stdenv.mkDerivation (finalAttrs: {
     # see: https://github.com/NixOS/nixpkgs/pull/314186#issuecomment-2129974277
     (lib.getOutput "cxxdev" opencv4)
 
-    kdePackages.kimageformats
     qt6.qtbase
     qt6.qtimageformats
     qt6.qtsvg
     qt6.qttools
     kdePackages.quazip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # currently unsupported on darwin, and possibly unneeded?
+    kdePackages.kimageformats
   ];
+
+  prePatch = ''
+    substituteInPlace cmake/MacBuildTarget.cmake \
+      --replace-fail '/Applications' '${placeholder "out"}/Applications'
+  '';
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_OPENCV" true)
@@ -65,15 +77,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p $out/{Applications,lib}
-    mv $out/nomacs.app $out/Applications/nomacs.app
-    mv $out/libnomacsCore.dylib $out/lib/libnomacsCore.dylib
+    # prevent wrapping dylibs
+    find $out/Applications -type f -name "*.dylib" -exec chmod -x {} \;
   '';
+
   # FIXME:
   # why can't we have nomacs look in the "standard" plugin directory???
   # None of the wrap stuff worked...
   # Let's just instead move the plugin dir brute force
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     mv $out/lib/nomacs-plugins $out/bin/plugins
   '';
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fixes #556142

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
