### PR TITLE
dnsglobe: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5368,6 +5368,12 @@
     name = "Christian Kruse";
     keys = [ { fingerprint = "BC5D 9F4E F7FB 4382 6056  E834 B8E0 F342 A99A 9D73"; } ];
   };
+  cktiel = {
+    email = "tiel@tuta.io";
+    github = "cktiel";
+    githubId = 	2486916;
+    name = "Artur Cierocki"
+  };
   clacke = {
     email = "claes.wallin@greatsinodevelopment.com";
     github = "clacke";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5371,7 +5371,7 @@
   cktiel = {
     email = "tiel@tuta.io";
     github = "cktiel";
-    githubId = 	2486916;
+    githubId = 2486916;
     name = "Artur Cierocki";
   };
   clacke = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5372,7 +5372,7 @@
     email = "tiel@tuta.io";
     github = "cktiel";
     githubId = 	2486916;
-    name = "Artur Cierocki"
+    name = "Artur Cierocki";
   };
   clacke = {
     email = "claes.wallin@greatsinodevelopment.com";

--- a/pkgs/by-name/dn/dnsglobe/package.nix
+++ b/pkgs/by-name/dn/dnsglobe/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  libiconv,
+  pkg-config,
+  stdenv
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dnsglobe";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "514-labs";
+    repo = "dnsglobe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-c5H7i7ElWj4lbzDe4+l2av87HndvCHzr8QpQgcKDLGg=";
+  };
+
+  cargoHash = "sha256-1h8zBS81hNbnYyLiqyqTQRnAaiB5t0SFnqxasAPV6DQ=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  versionCheckProgram = [ "${placeholder "out"}/bin/dnsglobe" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
+  ];
+
+  meta = {
+    description = "Global DNS propagation checker TUI — watch a DNS record propagate across public resolvers worldwide, on a world map in your terminal";
+    homepage = "https://github.com/514-labs/dnsglobe";
+    changelog = "https://github.com/514-labs/dnsglobe/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [];
+    mainProgram = "dnsglobe";
+  };
+})

--- a/pkgs/by-name/dn/dnsglobe/package.nix
+++ b/pkgs/by-name/dn/dnsglobe/package.nix
@@ -11,6 +11,7 @@
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dnsglobe";
   version = "0.5.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "514-labs";
@@ -25,8 +26,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgram = [ "${placeholder "out"}/bin/dnsglobe" ];
-
   nativeBuildInputs = [ pkg-config ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
@@ -37,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/514-labs/dnsglobe";
     changelog = "https://github.com/514-labs/dnsglobe/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [];
+    maintainers = with lib.maintainers; [ cktiel ];
     mainProgram = "dnsglobe";
   };
 })

--- a/pkgs/by-name/dn/dnsglobe/package.nix
+++ b/pkgs/by-name/dn/dnsglobe/package.nix
@@ -5,7 +5,7 @@
   versionCheckHook,
   libiconv,
   pkg-config,
-  stdenv
+  stdenv,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {


### PR DESCRIPTION
Initialized dnsglobe, a TUI DNS propagation checker at 0.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
